### PR TITLE
default is a key word

### DIFF
--- a/lib/sequelize/SequelizeTable.js
+++ b/lib/sequelize/SequelizeTable.js
@@ -16,7 +16,7 @@ exports.SequelizeTable = function(Sequelize, sequelize, tableName, attributes, o
 
     // read all default values ...
     Sequelize.Helper.Hash.forEach(table.attributes, function(options, key) {
-      if(typeof options.default != 'undefined') defaults[key] = options.default
+      if(typeof options.defaultValue != 'undefined') defaults[key] = options.defaultValue
     })
 
     // and merge them into the passed one
@@ -269,10 +269,10 @@ exports.SequelizeTable = function(Sequelize, sequelize, tableName, attributes, o
         if(['createdAt', 'updatedAt'].indexOf(attribute) > -1) return
 
         var allowsNull = ((typeof options.allowNull == 'undefined') || (options.allowNull !== false))
-        var hasDefault = (typeof options.default != 'undefined')
+        var hasDefault = (typeof options.defaultValue != 'undefined')
 
         if(!allowsNull && !hasDefault && (typeof self[attribute] == 'undefined'))
-          result.push({ field: attribute, reason: 'The field does not allow NULL values and has no default!'})
+          result.push({ field: attribute, reason: 'The field does not allow NULL values and has no default value!'})
       })
 
       return result


### PR DESCRIPTION
Hey,

My IDE kept spitting out errors when I started adding default to my fields in model definitions.  Turns out 'default' is a reserved word: http://javascript.about.com/library/blreserved.htm

Works in nodejs no problem, but this will cause issues with the likes of jslint
