### PR TITLE
custom timestamp fields format

### DIFF
--- a/lib/sequelize/Sequelize.js
+++ b/lib/sequelize/Sequelize.js
@@ -88,7 +88,14 @@ Sequelize.prototype = {
   define: function(name, attributes, options) {
     var SequelizeTable = require(__dirname + "/SequelizeTable").SequelizeTable
     var _attributes = {}
-    
+    var createdAt = "createdAt";
+    var updatedAt = "updatedAt";
+
+    if(options){
+      if(options.createdAt)createdAt = options.createdAt;
+      if(options.updatedAt)updatedAt = options.updatedAt;
+    }
+
     Sequelize.Helper.Hash.forEach(attributes, function(value, key) {
       if(typeof value == 'string')
         _attributes[key] = { type: value }
@@ -97,9 +104,9 @@ Sequelize.prototype = {
       else
         throw new Error("Please specify a datatype either by using Sequelize.* or pass a hash!")
     })
-    
-    _attributes.createdAt = { type: Sequelize.DATE, allowNull: false}
-    _attributes.updatedAt = { type: Sequelize.DATE, allowNull: false}
+
+    _attributes[createdAt] = { type: Sequelize.DATE, allowNull: false}
+    _attributes[updatedAt] = { type: Sequelize.DATE, allowNull: false}
     
     var table = new SequelizeTable(Sequelize, this, Sequelize.Helper.SQL.asTableName(name), _attributes, options)
     

--- a/lib/sequelize/SequelizeTable.js
+++ b/lib/sequelize/SequelizeTable.js
@@ -10,6 +10,13 @@ exports.SequelizeTable = function(Sequelize, sequelize, tableName, attributes, o
   options.classMethods = options.classMethods || {}
   options.instanceMethods = options.instanceMethods || {}
 
+  //for dinamic timestamp field names
+  var createdAt = "createdAt";
+  var updatedAt = "updatedAt";
+
+  if(options.createdAt)createdAt = options.createdAt;
+  if(options.updatedAt)updatedAt = options.updatedAt;
+
   var table = function(values) {
     var self = this,
         defaults = {}
@@ -292,7 +299,7 @@ exports.SequelizeTable = function(Sequelize, sequelize, tableName, attributes, o
           self    = this
 
       Sequelize.Helper.Hash.forEach(table.attributes, function(options, attribute) {
-        if(['createdAt', 'updatedAt'].indexOf(attribute) > -1) return
+        if([createdAt, updatedAt].indexOf(attribute) > -1) return
 
         var allowsNull = ((typeof options.allowNull == 'undefined') || (options.allowNull !== false))
         var hasDefault = (typeof options.default != 'undefined')
@@ -356,9 +363,9 @@ exports.SequelizeTable = function(Sequelize, sequelize, tableName, attributes, o
         throw new Error(errorText)
       }
 
-      this.updatedAt = new Date()
+      this[updatedAt] = new Date()
       if(this.isNewRecord) {
-        this.createdAt = new Date()
+        this[createdAt] = new Date()
 
         query = Sequelize.sqlQueryFor('insert', {
           table: table.tableName,


### PR DESCRIPTION
Allow to define timestamp fields names for example to make a nodejs-rails integration on the same database

<code>
sequelize.define("sitemap_url", {  
project_id: Sequelize.INTEGER,
title: Sequelize.STRING 
}, {  
createdAt:'created_at',  
updatedAt:'updated_at',... 
</code>
