### PR TITLE
Set insertId for non-default auto increment fields

### DIFF
--- a/lib/sequelize/model-definition.js
+++ b/lib/sequelize/model-definition.js
@@ -17,6 +17,7 @@ var ModelDefinition = module.exports = function(name, attributes, options) {
 
   this.addDefaultAttributes()
   this.addOptionalClassMethods()
+  this.findAutoIncrementField()
 }
 Utils.addEventEmitter(ModelDefinition)
 
@@ -41,6 +42,19 @@ ModelDefinition.prototype.addDefaultAttributes = function() {
 
   defaultAttributes = Utils.simplifyAttributes(defaultAttributes)
   Utils._.map(defaultAttributes, function(value, attr) { self.attributes[attr] = value })
+}
+
+ModelDefinition.prototype.findAutoIncrementField = function() {
+  var self = this;
+  this.autoIncrementField = null;
+  Utils._.map(this.attributes, function(definition, name) {
+    if (definition && definition.indexOf('auto_increment') >= 0) {
+      if (self.autoIncrementField) {
+        throw new Error('Invalid model definition. Only one autoincrement field allowed.')
+      }
+      self.autoIncrementField = name;
+    }
+  })
 }
 
 ModelDefinition.prototype.query = function() {

--- a/lib/sequelize/query.js
+++ b/lib/sequelize/query.js
@@ -34,8 +34,8 @@ Query.prototype.onSuccess = function(query, results, fields) {
     , self   = this
   
   // add the inserted row id to the instance
-  if (this.callee && !this.callee.options.hasPrimaryKeys && (query.indexOf('INSERT INTO') == 0) && (results.hasOwnProperty('insertId')))
-    this.callee.id = results.insertId
+  if (this.callee && (query.indexOf('INSERT INTO') == 0) && (results.hasOwnProperty('insertId')))
+    this.callee[this.callee.definition.autoIncrementField] = results.insertId
 
   // transform results into real model instances
   // return the first real model instance if options.plain is set (e.g. Model.find)

--- a/test/Model/create.js
+++ b/test/Model/create.js
@@ -37,5 +37,16 @@ module.exports = {
         })
       })
     })
+  },
+  'it should set the auto increment field to the insert id': function(exit) {
+    var User = sequelize.define('User' + config.rand(), {
+      userid: {type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true, allowNull: false}
+    })
+    User.sync({force:true}).on('success', function() {
+      User.create({}).on('success', function(user) {
+        assert.eql(user.userid, 1)
+        exit(function(){})
+      })
+    })
   }
 }

--- a/test/Sequelize/define.js
+++ b/test/Sequelize/define.js
@@ -75,5 +75,13 @@ module.exports = {
     
     assert.isDefined(User.build().makeItSo)
     assert.eql(User.build().makeItSo(), 2)
+  },
+  'it shouldn\'t allow two auto increment fields': function() {
+    assert.throws(function () {
+      var User = sequelize.define('User', {
+        userid: {type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true},
+        userscore: {type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true},
+      })
+    })
   }
 }

--- a/test/config.js
+++ b/test/config.js
@@ -1,6 +1,6 @@
 module.exports = {
     username: 'root'
-  , password: null
+  , password: 'password'
   , database: 'sequelize_test'
   , host: '127.0.0.1'
   , rand: function() {


### PR DESCRIPTION
Models with explicit auto increment primary keys wern't getting set to the insert id on INSERT queries.

The code now looks for any auto increment field and sets it to the insert id. Since mysql only allows one auto increment field, I also restrict model definitions to allow only one such field. This avoids any confusion about which field should get the insertId.
