### PR TITLE
Fix where clause generation for models with explicit primary keys.

### DIFF
--- a/lib/sequelize/model.js
+++ b/lib/sequelize/model.js
@@ -69,7 +69,7 @@ Model.prototype.save = function() {
     })
     return eventEmitter.run()
   } else {
-    var identifier = this.options.hasPrimaryKeys ? this.definition.primaryKeys : this.id
+    var identifier = this.options.hasPrimaryKeys ? this.primaryKeyValues : this.id
     return this.query(QueryGenerator.updateQuery(this.definition.tableName, this.values, identifier))
   }
 }

--- a/lib/sequelize/query.js
+++ b/lib/sequelize/query.js
@@ -16,6 +16,9 @@ Query.prototype.run = function(query) {
     database: this.config.database
   })
 
+  // Save the query text for testing and debugging.
+  this.sql = query
+
   if(this.options.logging)
     console.log('Executing: ' + query)
 

--- a/test/Model/update-attributes.js
+++ b/test/Model/update-attributes.js
@@ -28,7 +28,7 @@ module.exports = {
     })
   },
   'it should not set primary keys or timestamps': function(exit) {
-    User = sequelize.define('User' + config.rand(), {
+    var User = sequelize.define('User' + config.rand(), {
       name: Sequelize.STRING, bio: Sequelize.TEXT, identifier: {type: Sequelize.STRING, primaryKey: true}
     })
 
@@ -42,6 +42,19 @@ module.exports = {
           assert.eql(user.identifier, oldIdentifier)
           exit(function(){})
         })
+      })
+    })
+  },
+  "it should use the primary keys in the where clause": function(exit) {
+    var User = sequelize.define('User' + config.rand(), {
+      name: Sequelize.STRING, bio: Sequelize.TEXT, identifier: {type: Sequelize.STRING, primaryKey: true}
+    })
+
+    User.sync({force:true}).on('success', function() {
+      User.create({name: 'snafu', identifier: 'identifier'}).on('success', function(user) {
+        var query = user.updateAttributes({name: 'foobar'})
+        assert.match(query.sql, /WHERE `identifier`..identifier./)
+        exit(function(){})
       })
     })
   }


### PR DESCRIPTION
The update query generation was creating queries with where clauses like:

WHERE `userId`='INTEGER autoincrement PRIMARY KEY'

I made a simple fix to have the query generation code path call the correct model property and added a test.

Previous pull request was attached to my master branch and was picking up the wrong commits.
