### PR TITLE
Emit a save event on the model definition whenever an object succesfully 

### DIFF
--- a/lib/sequelize/model.js
+++ b/lib/sequelize/model.js
@@ -1,14 +1,14 @@
 var Utils          = require("./utils")
   , Mixin          = require("./associations/mixin")
   , QueryGenerator = require("./query-generator")
-  
+
 var Model = module.exports = function(values, options) {
   var self = this
-  
+
   this.definition = null // will be set in Model.build
   this.attributes = []
   this.options = options || {}
-  
+
   // add all passed values to the model and store the attribute names in this.attributes
   Utils._.map(values, function(value, key) { self.addAttribute(key, value) })
 
@@ -46,17 +46,17 @@ Model.prototype.addAttribute = function(attribute, value) {
 Model.prototype.query = function() {
   var args = Utils._.map(arguments, function(arg, _) { return arg })
     , s    = this.definition.modelManager.sequelize
-      
+
   args.push(this)
   return s.query.apply(s, args)
 }
 
 Model.prototype.save = function() {
   var attr = this.options.underscored ? 'updated_at' : 'updatedAt'
-  
+
   if(this.hasOwnProperty(attr))
     this[attr] = new Date()
-  
+
   if(this.isNewRecord) {
     var self = this
     var eventEmitter = new Utils.CustomEventEmitter(function() {
@@ -64,6 +64,9 @@ Model.prototype.save = function() {
       .on('success', function(obj) {
         obj.isNewRecord = false
         eventEmitter.emit('success', obj)
+
+        // Emit a save event for any post-save actions a consumer may want.
+        self.definition.emit('save', obj)
       })
       .on('failure', function(err) { eventEmitter.emit('failure', err) })
     })
@@ -108,43 +111,43 @@ Model.prototype.__defineGetter__("identifiers", function() {
   var primaryKeys = Utils._.keys(this.definition.primaryKeys)
     , result      = {}
     , self        = this
-  
+
   if(!this.definition.hasPrimaryKeys)
     primaryKeys = ['id']
-  
+
   primaryKeys.forEach(function(identifier) {
     result[identifier] = self[identifier]
   })
-  
+
   return result
 })
 
 Model.prototype.__defineGetter__('isDeleted', function() {
   var result = this.options.timestamps && this.options.paranoid
   result = result && this[this.options.underscored ? 'deleted_at' : 'deletedAt'] != null
-  
+
   return result
 })
 
 Model.prototype.__defineGetter__('values', function() {
   var result = {}
     , self   = this
-    
+
   this.attributes.forEach(function(attr) {
     result[attr] = self[attr]
   })
-  
+
   return result
 })
 
 Model.prototype.__defineGetter__('primaryKeyValues', function() {
   var result = {}
     , self   = this
-    
+
   Utils._.each(this.definition.primaryKeys, function(_, attr) {
     result[attr] = self[attr]
   })
-  
+
   return result
 })
 
@@ -155,16 +158,16 @@ Model.prototype.equals = function(other) {
   Utils._.each(this.values, function(value, key) {
     result = result && (value == other[key])
   })
-  
+
   return result
 }
 
 Model.prototype.equalsOneOf = function(others) {
   var result = false
     , self   = this
-    
+
   others.forEach(function(other) { result = result || self.equals(other) })
-  
+
   return result
 }
 


### PR DESCRIPTION
Simply lets users add on save hooks.

For example:

var User = Sequelize.define('User');

User.on('save', function (user) {
    // Do some post-save handling.
    console.log('User ' + user.id + ' has been saved');
});
