### PR TITLE
Emit a save event on the model definition whenever an object succesfully 

### DIFF
--- a/lib/sequelize/model.js
+++ b/lib/sequelize/model.js
@@ -64,6 +64,9 @@ Model.prototype.save = function() {
       .on('success', function(obj) {
         obj.isNewRecord = false
         eventEmitter.emit('success', obj)
+
+        // Emit a save event for any post-save actions a consumer may want.
+        self.definition.emit('save', obj)
       })
       .on('failure', function(err) { eventEmitter.emit('failure', err) })
     })


### PR DESCRIPTION
Simply lets users add on save hooks. Now with less whitespace mangling.

For example:

var User = Sequelize.define('User');

User.on('save', function (user) {
    // Do some post-save handling.
    console.log('User ' + user.id + ' has been saved');
});
