### PR TITLE
Add support for IN operator in WHERE clauses.

### DIFF
--- a/lib/sequelize/query-generator.js
+++ b/lib/sequelize/query-generator.js
@@ -168,10 +168,21 @@ var QueryGenerator = module.exports = {
   */
   hashToWhereConditions: function(hash) {
     return Utils._.map(hash, function(value, key) {
-      var _value = Utils.escape(value)
-        , _key   = Utils.addTicks(key)
+      var _value, _key, operator;
 
-      return (_value == 'NULL') ? _key + " IS NULL" : [_key, _value].join("=")
+      _key = Utils.addTicks(key)
+      if (Array.isArray(value)) {
+          _value = "(" + Utils._.map(value, function(subvalue) {
+              return Utils.escape(subvalue);
+          }).join(',') + ")"
+          operator = " IN "
+      }
+      else {
+          _value = Utils.escape(value);
+          operator = " = "
+      }
+
+      return (_value == 'NULL') ? _key + " IS NULL" : [_key, _value].join(operator)
     }).join(" AND ")
   }
 }


### PR DESCRIPTION
Add support for IN operator in WHERE clauses. If an array is sent as a value, the IN operator is used and the array values is escaped and comma delimited.

For example:

{where: {gender: ["", 'male']}} 

turns into

WHERE `gender` IN ('', 'male')
