### PR TITLE
Use options to HasMany for creating connector models

### DIFF
--- a/lib/sequelize/associations/has-many.js
+++ b/lib/sequelize/associations/has-many.js
@@ -47,7 +47,7 @@ HasMany.prototype.injectAttributes = function() {
     combinedTableAttributes[this.identifier] = {type:DataTypes.INTEGER, primaryKey: true} 
     combinedTableAttributes[this.foreignIdentifier] = {type:DataTypes.INTEGER, primaryKey: true}
 
-    this.connectorModel = this.source.modelManager.sequelize.define(this.combinedName, combinedTableAttributes)
+    this.connectorModel = this.source.modelManager.sequelize.define(this.combinedName, combinedTableAttributes, this.options)
     if(!this.isSelfAssociation) this.target.associations[this.associationAccessor].connectorModel = this.connectorModel
     
     this.connectorModel.sync()

--- a/test/Model/has-many.js
+++ b/test/Model/has-many.js
@@ -57,6 +57,36 @@ module.exports = {
       }
     })
   },
+  'it should correctly add the default columns - bidirectional': function() {
+    var num = config.rand()
+    var User = sequelize.define('User' + num, { username: Sequelize.STRING })
+    var Task = sequelize.define('Task' + num, { title: Sequelize.STRING })
+    
+    Task.hasMany(User)
+    User.hasMany(Task)
+
+    sequelize.modelManager.models.forEach(function(model) {
+      if(model.tableName == (Task.tableName + User.tableName)) {
+        assert.isDefined(model.attributes['createdAt'])
+        assert.isDefined(model.attributes['updatedAt'])
+      }
+    })
+  },
+  'it should correctly add the default columns with underscore - bidirectional': function() {
+    var num = config.rand()
+    var User = sequelize.define('User' + num, { username: Sequelize.STRING }, {underscored: true})
+    var Task = sequelize.define('Task' + num, { title: Sequelize.STRING })
+    
+    Task.hasMany(User)
+    User.hasMany(Task)
+
+    sequelize.modelManager.models.forEach(function(model) {
+      if(model.tableName == (Task.tableName + User.tableName)) {
+        assert.isDefined(model.attributes['created_at'])
+        assert.isDefined(model.attributes['updated_at'])
+      }
+    })
+  },
   'it should correctly add the foreign id when defining the foreignkey as option - monodirectional': function() {
     var num = config.rand()
     var User = sequelize.define('User' + num, { username: Sequelize.STRING }, {underscored: true})


### PR DESCRIPTION
Use the options from the HasMany association when creating the connector model.  I did this because I would like the default column names (ie: created_at, updated_at) to be consistent in all tables.

The options were correctly being used to underscore the id columns.
