### PR TITLE
Use ENGINE=InnoDB as the default for create table statements

### DIFF
--- a/lib/sequelize/query-generator.js
+++ b/lib/sequelize/query-generator.js
@@ -8,7 +8,7 @@ var QueryGenerator = module.exports = {
   createTableQuery: function(tableName, attributes, options) {
     options = options || {}
     
-    var query   = "CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>);"
+    var query   = "CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=InnoDB;"
       , primaryKeys = []
       , attrStr = Utils._.map(attributes, function(dataType, attr) {
           var dt = dataType


### PR DESCRIPTION
Seems like this would be a safe bet these days as the default... maybe it could be made an option?
