### PR TITLE
Add event hooks for update, create, save, and destroy to the model definition

### DIFF
--- a/lib/sequelize/model.js
+++ b/lib/sequelize/model.js
@@ -51,27 +51,37 @@ Model.prototype.query = function() {
   return s.query.apply(s, args)
 }
 
-Model.prototype.save = function() {
+Model.prototype.save = function(flags) {
+  var self = this
   var attr = this.options.underscored ? 'updated_at' : 'updatedAt'
-  
+  flags = flags || {}
+
   if(this.hasOwnProperty(attr))
     this[attr] = new Date()
-  
-  if(this.isNewRecord) {
-    var self = this
-    var eventEmitter = new Utils.CustomEventEmitter(function() {
-      self.query(QueryGenerator.insertQuery(self.definition.tableName, self.values))
-      .on('success', function(obj) {
-        obj.isNewRecord = false
-        eventEmitter.emit('success', obj)
-      })
-      .on('failure', function(err) { eventEmitter.emit('failure', err) })
+
+  var eventEmitter = new Utils.CustomEventEmitter(function() {
+    self.query(eventEmitter.sql).on('success', function(obj) {
+      var created = obj.isNewRecord;
+      obj.isNewRecord = false
+
+      eventEmitter.emit('success', obj)
+
+      self.definition.emit('save', obj)
+      if (created)
+        self.definition.emit('create', obj)
+      else
+        self.definition.emit('update', obj)
     })
-    return eventEmitter.run()
-  } else {
-    var identifier = this.options.hasPrimaryKeys ? this.primaryKeyValues : this.id
-    return this.query(QueryGenerator.updateQuery(this.definition.tableName, this.values, identifier))
-  }
+    .on('failure', function(err) { eventEmitter.emit('failure', err) })
+  })
+
+  // Attach the sql to the event emitter so the tests can get at sql
+  var identifier = this.options.hasPrimaryKeys ? this.primaryKeyValues : this.id
+  eventEmitter.sql = this.isNewRecord
+      ? QueryGenerator.insertQuery(this.definition.tableName, this.values, flags.ignore)
+      : QueryGenerator.updateQuery(this.definition.tableName, this.values, identifier)
+
+  return eventEmitter.run()
 }
 
 Model.prototype.updateAttributes = function(updates) {
@@ -95,13 +105,27 @@ Model.prototype.updateAttributes = function(updates) {
 }
 
 Model.prototype.destroy = function() {
-  if(this.options.timestamps && this.options.paranoid) {
-    this[this.options.underscored ? 'deleted_at' : 'deletedAt'] = new Date()
-    return this.save()
-  } else {
-    var identifier = this.options.hasPrimaryKeys ? this.primaryKeyValues : this.id
-    return this.query(QueryGenerator.deleteQuery(this.definition.tableName, identifier))
-  }
+  var self = this
+
+  var eventEmitter = new Utils.CustomEventEmitter(function() {
+    var query
+
+    if(self.options.timestamps && self.options.paranoid) {
+      self[self.options.underscored ? 'deleted_at' : 'deletedAt'] = new Date()
+      query = self.save()
+    } else {
+      var identifier = self.options.hasPrimaryKeys ? self.primaryKeyValues : self.id
+      query = self.query(QueryGenerator.deleteQuery(self.definition.tableName, identifier))
+    }
+
+    query.on('success', function (obj) {
+      eventEmitter.emit('success', obj)
+      self.definition.emit('destroy', obj)
+    })
+    .on('failure', function(err) { eventEmitter.emit('failure', err) })
+  })
+
+  return eventEmitter.run()
 }
 
 Model.prototype.__defineGetter__("identifiers", function() {

--- a/test/Model/create.js
+++ b/test/Model/create.js
@@ -48,5 +48,15 @@ module.exports = {
         exit(function(){})
       })
     })
+  },
+  'save should call the create event on a new item': function(exit) {
+    var User = sequelize.define('User' + config.rand(), { name: Sequelize.STRING, bio: Sequelize.TEXT })
+    User.on('create', function (obj) {
+      assert.eql(obj.name, 'hallo')
+      exit(function(){})
+    })
+    User.sync({force: true}).on('success', function() {
+      var u = User.build({name: 'hallo', bio: 'welt'}).save()
+    })
   }
 }

--- a/test/Model/destroy.js
+++ b/test/Model/destroy.js
@@ -31,5 +31,18 @@ module.exports = {
         })
       })
     })
+  },
+  'destroy should call the destroy event': function(exit) {
+    var User = sequelize.define('User' + config.rand(), { name: Sequelize.STRING, bio: Sequelize.TEXT })
+    User.on('destroy', function (obj) {
+      assert.eql(obj.name, 'hallo')
+      exit(function(){})
+    })
+    User.sync({force: true}).on('success', function() {
+      User.create({name: 'hallo', bio: 'asd'}).on('success', function(u) {
+        assert.eql(u.name, 'hallo')
+        u.destroy()
+      })
+    })
   }
 }

--- a/test/Model/save.js
+++ b/test/Model/save.js
@@ -40,5 +40,15 @@ module.exports = {
         }, 100)
       }, 100)
     })
+  },
+  'save should call the save event': function(exit) {
+    var User = sequelize.define('User' + config.rand(), { name: Sequelize.STRING, bio: Sequelize.TEXT })
+    User.on('save', function (obj) {
+      assert.eql(obj.name, 'hallo')
+      exit(function(){})
+    })
+    User.sync({force: true}).on('success', function() {
+      var u = User.build({name: 'hallo', bio: 'welt'}).save()
+    })
   }
 }

--- a/test/Model/update-attributes.js
+++ b/test/Model/update-attributes.js
@@ -57,5 +57,18 @@ module.exports = {
         exit(function(){})
       })
     })
+  },
+  'update should call the update event': function(exit) {
+    var User = sequelize.define('User' + config.rand(), { name: Sequelize.STRING, bio: Sequelize.TEXT })
+    User.on('update', function (obj) {
+      assert.eql(obj.name, 'hallothere')
+      exit(function(){})
+    })
+    User.sync({force: true}).on('success', function() {
+      User.create({name: 'hallo', bio: 'identifier'}).on('success', function(user) {
+        assert.eql(user.name, 'hallo')
+        user.updateAttributes({name: 'hallothere'})
+      })
+    })
   }
 }


### PR DESCRIPTION
Improved event hooks. Includes hooks for update, create, destroy, and save. Tests added for each.

Possibly a load event would be useful in addition, but it's not included in this changeset.
