### PR TITLE
Broken ConnectorManager

### DIFF
--- a/lib/sequelize/connector-manager.js
+++ b/lib/sequelize/connector-manager.js
@@ -39,6 +39,7 @@ ConnectorManager.prototype.query = function(sql, callee, options) {
 
 ConnectorManager.prototype.disconnect = function() {
   this.client.end(function() {})
+  this.client = null
 }
 
 ConnectorManager.prototype.reconnect = function() {


### PR DESCRIPTION
This is a fix for a bug where sequelize stops executing queries after an idle period.

More details:

When the ConnectorManager disconnects the mysql client (e.g. when running _disconnectIfNoConnections), it never cleans up the client object, and therefore is never aware that it is disconnected. As a result, subsequent queries just get queued up on a disconnected mysql client.
