### PR TITLE
Save DATE values in UTC/GMT timezone

### DIFF
--- a/lib/sequelize/sequelize.js
+++ b/lib/sequelize/sequelize.js
@@ -9,6 +9,11 @@ var Sequelize = module.exports = function(database, username, password, options)
 
   Utils._.reject(options, function(_, key) { return ["host", "port", "disableTableNameModification"].indexOf(key) > -1 })
 
+  // Save dates in utc?
+  if (options.utc_dates) {
+    Utils.config.utc_dates = true;
+  }
+
   this.options = options
   this.config = {
     database: database,

--- a/lib/sequelize/utils.js
+++ b/lib/sequelize/utils.js
@@ -1,5 +1,6 @@
 var client = new (require("mysql").Client)()
 var Utils = module.exports = {
+  config: {utc_dates: false},
   _: (function() {
     var _ = require("underscore")
 
@@ -75,8 +76,9 @@ var Utils = module.exports = {
     if(dataType.indexOf(DataTypes.INTEGER) > -1)
       return value
 
-    if(dataType.indexOf(DataTypes.DATE) > -1)
-      return ("'" + Utils.asSqlDate(value) + "'")
+    if(dataType.indexOf(DataTypes.DATE) > -1) {
+      return ("'" + Utils.toSqlDate(value) + "'")
+    }
 
     return ("'" + value + "'")
   },
@@ -106,14 +108,32 @@ var Utils = module.exports = {
     return result
   },
   toSqlDate: function(date) {
+    if (Utils.config.utc_dates) {
+      return Utils.toUtcSqlDate(date);
+    } else {
+      return [
+        [
+          date.getFullYear(),
+          ((date.getMonth() < 9 ? '0' : '') + (date.getMonth()+1)),
+          ((date.getDate() < 10 ? '0' : '') + date.getDate())
+        ].join("-"),
+        date.toLocaleTimeString()
+      ].join(" ");
+    }
+  },
+  toUtcSqlDate: function(date) {
     return [
       [
-        date.getFullYear(),
-        ((date.getMonth() < 9 ? '0' : '') + (date.getMonth()+1)),
-        ((date.getDate() < 10 ? '0' : '') + date.getDate())
+        date.getUTCFullYear(),
+        ((date.getUTCMonth() < 9 ? '0' : '') + (date.getUTCMonth()+1)),
+        ((date.getUTCDate() < 10 ? '0' : '') + date.getUTCDate())
       ].join("-"),
-      date.toLocaleTimeString()
-    ].join(" ")
+      [
+        ((date.getUTCHours() < 10 ? '0' : '') + date.getUTCHours()),
+        ((date.getUTCMinutes() < 10 ? '0' : '') + date.getUTCMinutes()),
+        ((date.getUTCSeconds() < 10 ? '0' : '') + date.getUTCSeconds())
+      ].join(":")
+    ].join(" ");
   },
   argsArePrimaryKeys: function(args, primaryKeys) {
     var result = (args.length == Utils._.keys(primaryKeys).length)


### PR DESCRIPTION
I have the need to make sure all dates saved by sequelize.js are stored in UTC instead of the local time zone.  I didn't see a clean and easy way to do this, so I settled on easy.  I added the ability to specify in the options hash the property utc_dates.  If this is defined and its value evaluates as true, the toSqlDate function in the Utils module will generate a UTC time string.  No test that weren't failing before fail with my changes.  Anyway, maybe it will give you an idea for a better implementation ...

Add configuration option utc_dates that stores any DATE column in UTC instead of locale time zone.
