### PR TITLE
Added results to the query chainer

### DIFF
--- a/lib/sequelize/query-chainer.js
+++ b/lib/sequelize/query-chainer.js
@@ -25,9 +25,16 @@ QueryChainer.prototype.observeEmitter = function(emitter) {
   var self = this
   emitter
     .on('success', function(res){
-      self.results.push(res);
+      var len = self.emitters.length;
+      for(var i=0;i< len;i++)
+      {
+          if(self.results[i] == undefined ) self.results[i]=[]
+          if(self.emitters[i] == emitter){
+              self.results[i] = res;
+           }
+      }
       self.finishedEmits++
-      self.finish(self.results)
+      self.finish( )
     })
     .on('failure', function(err){
       self.finishedEmits++
@@ -39,7 +46,7 @@ QueryChainer.prototype.finish = function(result) {
   this.finished = (this.finishedEmits == this.emitters.length)
   if(this.finished && this.runned) {
     var status = this.fails.length == 0 ? 'success' : 'failure'
-    result = this.fails.length == 0 ? result : this.fails
+    result = this.fails.length == 0 ? this.results : this.fails
     this.eventEmitter.emit(status, result)
   }
 }


### PR DESCRIPTION
With these changes, you can now use the chainer for select queries. The results are pushed into an array and then made available with the result event.

Example:
When you want to render an overview page, you might have to do this:

Project.getTasks()
Project.getTeam()

to get all the data, you will have to either nest methods, or keep track yourself. With the query chainer, you can now do the following:

```
var chainer = new Sequelize.Utils.QueryChainer
chainer.add(Project.getTasks());
chainer.add(Project.getTeam());
chainer.run().on('success', function(result){
    tasks = result[0];
    team = result[1];
}
```

I think this is a good addition to the framework. Let me know what you think.
