### PR TITLE
Change underscore.string version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "mysql": "=0.9.4",
     "underscore": "=1.2.1",
-    "underscore.string": "=1.2.0",
+    "underscore.string": "=2.0.0",
     "lingo": "=0.0.4",
     "validator": "=0.3.5",
     "moment": "=1.1.1"


### PR DESCRIPTION
Change underscore.string version, because underscore.string version 1.2.0 was rereleased as 2.0.0 version, for reasons of backward compatibility.
