### PR TITLE
Ability to lowercase table name using lowerCase option, with tests

### DIFF
--- a/lib/model-factory.js
+++ b/lib/model-factory.js
@@ -14,10 +14,11 @@ module.exports = (function() {
       freezeTableName: false,
       underscored: false,
       paranoid: false
-    }, options || {})
+    }, options || {})
 
     this.name = name
     this.tableName = this.options.freezeTableName ? name : Utils.pluralize(name)
+    this.tableName = this.options.lowerCase ? this.tableName.toLowerCase() : this.tableName;
     this.rawAttributes = attributes
     this.modelManager = null // defined in init function
     this.associations = {}

--- a/spec/model-factory.spec.js
+++ b/spec/model-factory.spec.js
@@ -47,6 +47,16 @@ describe('ModelFactory', function() {
           expect(User.tableName).toEqual('Users')
         })
 
+        it("uses the lowercase model name as tablename if lowerCase", function() {
+          var User = sequelize.define('User', {}, {lowerCase: true})
+          expect(User.tableName).toEqual('users')
+        })
+
+        it("uses the lowercase passed model name as tablename if lowerCase and freezeTableName", function() {
+          var User = sequelize.define('User', {}, {freezeTableName: true, lowerCase: true})
+          expect(User.tableName).toEqual('user')
+        })
+
         it("attaches class and instance methods", function() {
           var User = sequelize.define('User', {}, {
             classMethods: { doSmth: function(){ return 1 } },


### PR DESCRIPTION
Use:
<code>var User = sequelize.define('User', {}, {lowerCase: true});</code>
to have your table name lowercase as: <strong>users</strong>

If used with freezeTableName:
<code>var User = sequelize.define('User', {}, {lowerCase: true, freezeTableName: true});</code>
your table name will be: <strong>user</strong>

The default value for lowerCase is <strong>false</strong> for back compatibility.
