### PR TITLE
Make default migrations path relative to cwd.

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -76,7 +76,7 @@ if(program.migrate) {
     options = _.extend(options, { logging: false })
 
     var sequelize       = new Sequelize(config.database, config.username, config.password, options)
-      , migratorOptions = { path: __dirname + '/../migrations' }
+      , migratorOptions = { path: migrationsPath }
       , migrator        = sequelize.getMigrator(migratorOptions)
 
     if(program.undo) {


### PR DESCRIPTION
When running `./node_modules/.bin/sequelize -m` the following error occured:

```
fs.js:384
  return binding.readdir(path);
                 ^
Error: ENOENT, no such file or directory '/PATHTOAPP/node_modules/sequelize/bin/../migrations'
    at Object.readdirSync (fs.js:384:18)
    at [object Object].getUndoneMigrations (/PATHTOAPP/node_modules/sequelize/lib/migrator.js:80:29)
    at [object Object].fct (/PATHTOAPP/node_modules/sequelize/lib/migrator.js:34:12)
    at Object._onTimeout (/PATHTOAPP/node_modules/sequelize/lib/emitters/custom-event-emitter.js:15:16)
    at Timer.ontimeout (timers.js:84:39)
```

This change fixed my issue. Not sure if this will break other uses.
