### PR TITLE
Add override for logging option to provide custom logging function

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -7,7 +7,7 @@ module.exports = (function() {
     this.client = client
     this.callee = callee
     this.options = Utils._.extend({
-      logging: true,
+      logging: console.log,
       plain: false,
       raw: false
     }, options || {})
@@ -23,10 +23,8 @@ module.exports = (function() {
 
     bindClient.call(this)
 
-    if((this.options.logging) && (this.options.customLogger))
-      this.options.customLogger('Executing: ' + this.sql)
-    else if (this.options.logging)
-      console.log('Executing: ' + this.sql)
+    if(this.options.logging !== false)
+      this.options.logging('Executing: ' + this.sql)
 
     this.client.query(this.sql, function(err, results, fields) {
       self.emit('sql', self.sql)

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -5,7 +5,7 @@ module.exports = (function() {
     this.database = database
     this.callee = callee
     this.options = Utils._.extend({
-      logging: true,
+      logging: console.log,
       plain: false,
       raw: false
     }, options || {})
@@ -17,10 +17,8 @@ module.exports = (function() {
 
     this.sql = sql
 
-    if((this.options.logging) && (this.options.customLogger))
-      this.options.customLogger('Executing: ' + this.sql)
-    else if(this.options.logging)
-      console.log('Executing: ' + this.sql)
+    if(this.options.logging !== false)
+      this.options.logging('Executing: ' + this.sql)
 
     this.database.serialize(function() {
       var isInsertCommand = (self.sql.toLowerCase().indexOf('insert') == 0)

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -13,7 +13,7 @@ module.exports = (function() {
       path: __dirname + '/../migrations',
       from: null,
       to: null,
-      logging: true
+      logging: console.log
     }, options || {})
   }
 
@@ -46,16 +46,12 @@ module.exports = (function() {
           migrations.forEach(function(migration) {
             chainer.add(migration, 'execute', [options], {
               before: function(migration) {
-                if((self.options.logging) && (self.options.customLogger))
-                  self.options.customLogger('Executing migration: ' + migration.filename)
-                else if(self.options.logging)
-                  console.log('Executing migration: ' + migration.filename)
+                if(self.options.logging !== false)
+                  self.options.logging('Executing migration: ' + migration.filename)
               },
               after: function(migration) {
-                if ((self.options.logging) && (self.options.customLogger))
-                  self.options.customLogger('Executed migration: ' + migration.filename)
-                else if (self.options.logging)
-                  console.log('Executed migration: ' + migration.filename)
+                if(self.options.logging !== false)
+                  self.options.logging('Executed migration: ' + migration.filename)
               },
               success: function(migration, callback) {
                 if(options.method == 'down')

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -72,9 +72,7 @@ module.exports = (function() {
   Sequelize.prototype.query = function(sql, callee, options) {
     options = Utils._.extend(Utils._.clone(this.options.query), options || {})
     options = Utils._.extend(options, {
-      logging: this.options.hasOwnProperty('logging') ? this.options.logging : true,
-      customLogger: this.options.hasOwnProperty('customLogger') &&
-          typeof(this.options.customLogger) === 'function' ? this.options.customLogger : undefined
+      logging: this.options.hasOwnProperty('logging') ? this.options.logging : console.log
     })
 
     return this.connectorManager.query(sql, callee, options)


### PR DESCRIPTION
Adding an option on the sequelize constructor to provide a custom log function:

``` js
var log = require('logging').getLogger(__filename),
    Sequelize = require("sequelize"),
    sequelize = new Sequelize('mydb', 'myuser', 'asdf1234', {
        host: '10.0.2.15',
        logging: log.verbose
    });
```
