### PR TITLE
Add support for setting the timezone and emit connect/disconnect events

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -57,10 +57,8 @@ module.exports = (function() {
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
 
-    if(!this.isConnected && !this.pool) this.connect()
-
     var queueItem = {
-      query: new Query(this.client, callee, options || {}),
+      query: new Query(this, callee, options || {}),
       sql: sql
     }
 
@@ -69,31 +67,51 @@ module.exports = (function() {
     return queueItem.query
   }
 
-  ConnectorManager.prototype.connect = function() {
+  ConnectorManager.prototype.connect = function(done) {
     var self = this
     // in case database is slow to connect, prevent orphaning the client
-    if (this.isConnecting || this.pool) {
+    if (self.isConnecting) {
+      setTimeout(function() {
+        self.connect(done)
+      }, 10)
       return
     }
+    
+    if (self.isConnected) {
+      if (done)
+        done()
+      return
+    }
+    
     connect.call(self, function(err, client) {
       if (err) {
-        throw err;
+        if (done)
+          done(err)
+        else
+          throw err;
       }
       self.client = client
       self.emit('connect', self.client)
+      if (done)
+        done()
      return
     })
-    return
   }
 
-  ConnectorManager.prototype.disconnect = function() {
+  ConnectorManager.prototype.disconnect = function(done) {
     var self = this
-    if (self.client)
-      disconnect.call(self, self.client, function() {
-        self.emit('disconnect', self.client)
-        self.client = null
-      })
-    return
+    if (!self.client) {
+      if (done)
+        done()
+      return
+    }
+    
+    disconnect.call(self, self.client, function() {
+      self.emit('disconnect', self.client)
+      self.client = null
+      if (done)
+        done()
+    })
   }
 
 
@@ -122,6 +140,7 @@ module.exports = (function() {
 
   var connect = function(done) {
     var self = this
+    self.isConnecting = true
     var client = require("mysql").createClient({
       user: self.config.username,
       password: self.config.password,
@@ -130,7 +149,7 @@ module.exports = (function() {
       database: self.config.database
     })
     client.setMaxListeners(self.maxConcurrentQueries)
-    if (self.config.timezone != null) {
+    if (self.config.utcoffset != null) {
       client.query( "SET time_zone = '" + self.config.utcoffset + "'", function(error) {
         if (error) {
           done(error, client)

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -1,10 +1,10 @@
 var Utils = require("../../utils")
 
 module.exports = (function() {
-  var Query = function(client, callee, options) {
+  var Query = function(connectorManager, callee, options) {
     var self = this
 
-    this.client = client
+    this.connectorManager = connectorManager
     this.callee = callee
     this.options = Utils._.extend({
       logging: console.log,
@@ -31,15 +31,22 @@ module.exports = (function() {
 
     this.sql = sql
 
-    bindClient.call(this)
-
-    if(this.options.logging !== false)
-      this.options.logging('Executing: ' + this.sql)
-
-    this.client.query(this.sql, function(err, results, fields) {
-      self.emit('sql', self.sql)
-      err ? onFailure.call(self, err) : onSuccess.call(self, results, fields)
-    }).setMaxListeners(100)
+    this.connectorManager.connect( function(error) {
+      if (error) {
+        onFailure.call(self, error)
+        return
+      }
+      
+      bindClient.call(self)
+    
+      if(self.options.logging !== false)
+        self.options.logging('Executing: ' + self.sql)
+    
+      self.connectorManager.client.query(self.sql, function(err, results, fields) {
+        self.emit('sql', self.sql)
+        err ? onFailure.call(self, err) : onSuccess.call(self, results, fields)
+      }).setMaxListeners(100)
+    })
 
     return this
   }
@@ -47,11 +54,11 @@ module.exports = (function() {
   //private
 
   var bindClient = function() {
-    this.client.on('error', this.bindClientFunction)
+    this.connectorManager.client.on('error', this.bindClientFunction)
   }
 
   var unbindClient = function() {
-    this.client.removeListener('error', this.bindClientFunction)
+    this.connectorManager.client.removeListener('error', this.bindClientFunction)
   }
 
   var onSuccess = function(results, fields) {
@@ -89,7 +96,8 @@ module.exports = (function() {
   }
 
   var onFailure = function(err) {
-    unbindClient.call(this)
+    if (this.connectorManager.client)
+      unbindClient.call(this)
     this.emit('failure', err, this.callee)
   }
 

--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -1,9 +1,12 @@
 var Query   = require("./query")
   , Utils   = require("../../utils")
   , without = function(arr, elem) { return arr.filter(function(e) { return e != elem }) }
+  , util    = require("util")
+  , events  = require("events")
 
 module.exports = (function() {
   var ConnectorManager = function(sequelize, config) {
+    events.EventEmitter.call(this)
     this.sequelize = sequelize
     this.client = null
     this.config = config || {}
@@ -12,14 +15,14 @@ module.exports = (function() {
     this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50)
   }
   Utils._.extend(ConnectorManager.prototype, require("../connector-manager").prototype)
+  util.inherits(ConnectorManager, events.EventEmitter)
 
   var isConnecting = false
   var isConnected  = false
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
     var self = this
-    if (this.client == null) this.connect()
-    var query = new Query(this.client, callee, options || {})
+    var query = new Query(this, callee, options || {})
     self.pendingQueries += 1
     return query.run(sql)
       .success(function() { self.endQuery.call(self) })
@@ -36,43 +39,67 @@ module.exports = (function() {
     }
   }
 
-  ConnectorManager.prototype.connect = function() {
+  ConnectorManager.prototype.connect = function(done) {
     var self = this
 
+    if (self.isConnected) {
+      if (done)
+        done()
+      return
+    }
+
     // in case database is slow to connect, prevent orphaning the client
-    if (this.isConnecting) return
-    this.isConnecting = true
-    this.isConnected  = false
+    if (self.isConnecting) {
+      setTimeout(function() {
+        self.connect(done)
+      }, 10)
+      return
+    }
+
+    self.isConnecting = true
+    self.isConnected  = false
 
     var conStr = 'tcp://<%= user %>:<%= password %>@<%= host %>:<%= port %>/<%= database %>'
     conStr = Utils._.template(conStr)({
-      user: this.config.username,
-      password: this.config.password,
-      database: this.config.database,
-      host: this.config.host,
-      port: this.config.port
+      user: self.config.username,
+      password: self.config.password,
+      database: self.config.database,
+      host: self.config.host,
+      port: self.config.port
     })
 
     var pg = require("pg")
-    this.client = new pg.Client(conStr)
+    self.client = new pg.Client(conStr)
 
-    this.client.connect(function(err, client) {
+    self.client.connect(function(err, client) {
       self.isConnecting = false
-      if (!err && client) {
-        if (this.config.timezone != null) {
-          client.query("SET TIME ZONE INTERVAL '" + this.config.utcoffset + "' HOUR TO MINUTE")
-            .on('end', function() {
-              self.isConnected = true
-              this.client = client
-              self.emit('connect', this.client)
-            });
-        } else {
-          self.isConnected = true
-          this.client = client
-          self.emit('connect', this.client)
-        }
+
+      if (err || !client) {
+        self.client = null
+        if (done)
+          done(err ? err : 'Failed to create client.')
+        return
+      }
+
+      if (self.config.utcoffset != null) {
+        client.query("SET TIME ZONE INTERVAL '" + self.config.utcoffset + "' HOUR TO MINUTE")
+          .on('end', function() {
+            self.isConnected = true
+            self.client = client
+            self.emit('connect', this.client)
+            if (done)
+              done()
+          }).on('error', function(error) {
+            self.client = null;
+            if (done)
+              done(error)
+          });
       } else {
-        this.client = null
+        self.isConnected = true
+        self.client = client
+        self.emit('connect', this.client)
+        if (done)
+          done()
       }
     })
   }

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -1,10 +1,10 @@
 var Utils = require("../../utils")
 
 module.exports = (function() {
-  var Query = function(client, callee, options) {
+  var Query = function(connectorManager, callee, options) {
     var self = this
 
-    this.client = client
+    this.connectorManager = connectorManager
     this.callee = callee
     this.options = Utils._.extend({
       logging: true,
@@ -22,57 +22,65 @@ module.exports = (function() {
     var results = [];
     var receivedError = false;
 
-    var query = this.client.query(sql)
-    query.on('row', function(row) {
-      if (self.callee && (self.sql.indexOf('INSERT INTO') == 0 || self.sql.indexOf('UPDATE') == 0)) {
-        Utils._.forEach(row, function(value, key) {
-          self.callee[key] = value
-        })
-        results.push(self.callee)
-      }
-
-      if (self.sql.indexOf('SELECT table_name FROM information_schema.tables') == 0) {
-        results.push(Utils._.values(row))
-      } else if (self.sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') == 0) {
-        results.push(Utils._.values(row))
-      } else if (self.sql.indexOf('SELECT') == 0) {
-        // transform results into real model instances
-        // return the first real model instance if options.plain is set (e.g. Model.find)
-        if (self.options.raw) {
-          results.push(row);
-        } else {
-          results.push(self.callee.build(row, { isNewRecord: false }))
+    this.connectorManager.connect( function(error) {
+        if (error) {
+          self.emit('failure', error, self.callee)
+          return
         }
-      } else if((self.sql.indexOf('SHOW') == 0) || (self.sql.indexOf('DESCRIBE') == 0)) {
-        results.push(row)
-      }
-    });
 
-    query.on('end', function() {
-      self.emit('sql', self.sql)
-      if (receivedError) return;
-
-      if (self.sql.indexOf('SELECT') == 0) {
-        if (self.options.plain) {
-          self.emit('success', (results.length == 0) ? null : results[0])
-        } else {
-          self.emit('success', results)
-        }
-      } else if((self.sql.indexOf('SHOW') == 0) || (self.sql.indexOf('DESCRIBE') == 0)) {
-        self.emit('success', results)
-      } else if (self.sql.indexOf('INSERT INTO') == 0) {
-        self.emit('success', results[0])
-      } else if (self.sql.indexOf('UPDATE') == 0) {
-        self.emit('success', self.callee)
-      } else {
-        self.emit('success', results)
-      }
-    });
-
-    query.on('error', function(err) {
-      receivedError = true
-      self.emit('failure', err, self.callee)
-    });
+        var query = self.connectorManager.client.query(sql)
+        query.on('row', function(row) {
+          if (self.callee && (self.sql.indexOf('INSERT INTO') == 0 || self.sql.indexOf('UPDATE') == 0)) {
+            Utils._.forEach(row, function(value, key) {
+              self.callee[key] = value
+            })
+            results.push(self.callee)
+          }
+    
+          if (self.sql.indexOf('SELECT table_name FROM information_schema.tables') == 0) {
+            results.push(Utils._.values(row))
+          } else if (self.sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') == 0) {
+            results.push(Utils._.values(row))
+          } else if (self.sql.indexOf('SELECT') == 0) {
+            // transform results into real model instances
+            // return the first real model instance if options.plain is set (e.g. Model.find)
+            if (self.options.raw) {
+              results.push(row);
+            } else {
+              results.push(self.callee.build(row, { isNewRecord: false }))
+            }
+          } else if((self.sql.indexOf('SHOW') == 0) || (self.sql.indexOf('DESCRIBE') == 0)) {
+            results.push(row)
+          }
+        });
+    
+        query.on('end', function() {
+          self.emit('sql', self.sql)
+          if (receivedError) return;
+    
+          if (self.sql.indexOf('SELECT') == 0) {
+            if (self.options.plain) {
+              self.emit('success', (results.length == 0) ? null : results[0])
+            } else {
+              self.emit('success', results)
+            }
+          } else if((self.sql.indexOf('SHOW') == 0) || (self.sql.indexOf('DESCRIBE') == 0)) {
+            self.emit('success', results)
+          } else if (self.sql.indexOf('INSERT INTO') == 0) {
+            self.emit('success', results[0])
+          } else if (self.sql.indexOf('UPDATE') == 0) {
+            self.emit('success', self.callee)
+          } else {
+            self.emit('success', results)
+          }
+        });
+    
+        query.on('error', function(err) {
+          receivedError = true
+          self.emit('failure', err, self.callee)
+        });
+        
+    })
 
     return this
   }

--- a/lib/dialects/sqlite/connector-manager.js
+++ b/lib/dialects/sqlite/connector-manager.js
@@ -1,20 +1,30 @@
 var Utils   = require("../../utils")
   , sqlite3 = require('sqlite3').verbose()
   , Query   = require("./query")
+  , util    = require("util")
+  , events  = require("events")
 
 module.exports = (function() {
-  var ConnectorManager = function(sequelize) {
+  var ConnectorManager = function(sequelize, config) {
     events.EventEmitter.call(this)
     this.sequelize = sequelize
-    if ( config.timezone != null )
-      process.env[ 'TZ' ] = config.timezone
+    
+    // TODO: set the timezone based off the utcoffset we're given
+    //if ( config.utcoffset != null )
+      //process.env[ 'TZ' ] = config.utcoffset
       // TODO: verify that the TZ ends up being set
-    this.database  = new sqlite3.Database(sequelize.options.storage || ':memory:')
+    this.database = this.client = new sqlite3.Database(sequelize.options.storage || ':memory:')
+    this.isConnected = false
   }
   Utils._.extend(ConnectorManager.prototype, require("../connector-manager").prototype)
+  util.inherits(ConnectorManager, events.EventEmitter)
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
-    return new Query(this.database, callee, options).run(sql)
+    if (!this.isConnected) {
+      this.emit('connect', this.client)
+      this.isConnected = true
+    }
+    return new Query(this, callee, options).run(sql)
   }
 
   return ConnectorManager

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -1,8 +1,8 @@
 var Utils = require("../../utils")
 
 module.exports = (function() {
-  var Query = function(database, callee, options) {
-    this.database = database
+  var Query = function(connectorManager, callee, options) {
+    this.connectorManager = connectorManager
     this.callee = callee
     this.options = Utils._.extend({
       logging: console.log,
@@ -32,9 +32,9 @@ module.exports = (function() {
     }
 
     var columnTypes = {};
-    this.database.serialize(function() {
+    this.connectorManager.database.serialize(function() {
       var executeSql = function() {
-        self.database[databaseMethod](self.sql, function(err, results) {
+        self.connectorManager.database[databaseMethod](self.sql, function(err, results) {
            //allow clients to listen to sql to do their own logging or whatnot
           self.emit('sql', self.sql)
           this.columnTypes = columnTypes;
@@ -49,7 +49,7 @@ module.exports = (function() {
         var tableName = RegExp.$1;
         if (tableName !== 'sqlite_master') {
           // get the column types
-          self.database.all("PRAGMA table_info(" + tableName + ")", function(err, results) {
+          self.connectorManager.database.all("PRAGMA table_info(" + tableName + ")", function(err, results) {
             if (!err) {
               for (var i=0, l=results.length; i<l; i++) {
                 columnTypes[results[i].name] = results[i].type;

--- a/lib/query-chainer.js
+++ b/lib/query-chainer.js
@@ -99,7 +99,10 @@ module.exports = (function() {
         self.fails.push(err)
         finish.call(self)
       })
-      .on('sql', function(sql){ self.eventEmitter.emit('sql', sql) })
+      .on('sql', function(sql) {
+        if (self.eventEmitter)
+          self.eventEmitter.emit('sql', sql)
+      })
   }
 
   var finish = function() {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -4,6 +4,8 @@ var Utils          = require("./utils")
   , DAOFactoryManager   = require("./dao-factory-manager")
   , Migrator       = require("./migrator")
   , QueryInterface = require("./query-interface")
+  , events = require('events')
+  , util = require('util')
 
 if(parseFloat(process.version.replace('v', '')) < 0.6) {
   console.log("DEPRECATION WARNING: Support for Node.JS < v0.6 will be canceled in the next minor release.")
@@ -11,6 +13,9 @@ if(parseFloat(process.version.replace('v', '')) < 0.6) {
 
 module.exports = (function() {
   var Sequelize = function(database, username, password, options) {
+    events.EventEmitter.call(this)
+    var self = this
+
     this.options = Utils._.extend({
       dialect: 'mysql',
       host: 'localhost',
@@ -50,10 +55,17 @@ module.exports = (function() {
 
     this.daoFactoryManager = new DAOFactoryManager(this)
     this.connectorManager  = new ConnectorManager(this, this.config)
+    this.connectorManager.on('connect', function( client ) {
+      self.emit('connect', client)
+    })
+    this.connectorManager.on('disconnect', function( client ) {
+      self.emit('disconnect', client)
+    })
   }
 
   Sequelize.Utils = Utils
   Sequelize.Utils._.map(DataTypes, function(sql, accessor) { Sequelize[accessor] = sql})
+  util.inherits(Sequelize, events.EventEmitter)
 
   Sequelize.prototype.getQueryInterface = function() {
     this.queryInterface = this.queryInterface || new QueryInterface(this)

--- a/spec-jasmine/associations/belongs-to.spec.js
+++ b/spec-jasmine/associations/belongs-to.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('BelongsTo', function() {

--- a/spec-jasmine/associations/has-many.spec.js
+++ b/spec-jasmine/associations/has-many.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('HasMany', function() {
@@ -10,7 +10,7 @@ describe('HasMany', function() {
     , Helpers   = null
 
   var setup = function() {
-    sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+    sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { port: config.mysql.port, utcoffset: '+0:00', logging: false })
     Helpers   = new (require("../config/helpers"))(sequelize)
 
     Helpers.dropAllTables()

--- a/spec-jasmine/associations/has-one.spec.js
+++ b/spec-jasmine/associations/has-one.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('HasOne', function() {

--- a/spec-jasmine/config/config.js
+++ b/spec-jasmine/config/config.js
@@ -6,7 +6,7 @@ module.exports = {
   //make maxIdleTime small so that tests exit promptly
   mysql: {
     username: "root",
-    password: null,
+    password: process.env[ "SEQUELIZE_MYSQL_PASSWORD" ],
     database: 'sequelize_test',
     host: '127.0.0.1',
     port: 3306,
@@ -19,6 +19,7 @@ module.exports = {
   postgres: {
     database: 'sequelize_test',
     username: "postgres",
+    password: process.env[ "SEQUELIZE_POSTGRES_PASSWORD" ],
     port: 5432
   }
 }

--- a/spec-jasmine/config/helpers.js
+++ b/spec-jasmine/config/helpers.js
@@ -42,5 +42,7 @@ Helpers.prototype.async = function(fct) {
   runs(function() {
     fct(function() { return done = true })
   })
-  waitsFor(function(){ return done })
+  waitsFor(function(){
+    return done
+  })
 }

--- a/spec-jasmine/dao-factory.spec.js
+++ b/spec-jasmine/dao-factory.spec.js
@@ -13,7 +13,8 @@ describe('DAOFactory', function() {
             {
               logging: false,
               dialect: dialect,
-              port: config[dialect].port
+              port: config[dialect].port,
+              utcoffset: '+0:00'
             }
           )
         , Helpers   = new (require("./config/helpers"))(sequelize)
@@ -662,7 +663,7 @@ describe('DAOFactory', function() {
 
         it("fails with incorrect database credentials", function() {
           Helpers.async(function(done) {
-            var sequelize2 = new Sequelize('foo', 'bar', null, { logging: false })
+            var sequelize2 = new Sequelize('foo', 'bar', null, { utcoffset: '+0:00', logging: false })
               , User2      = sequelize2.define('User', { name: Sequelize.STRING, bio: Sequelize.TEXT })
 
             User2.sync().error(function(err) {

--- a/spec-jasmine/dao.spec.js
+++ b/spec-jasmine/dao.spec.js
@@ -13,7 +13,8 @@ describe('DAO', function() {
             {
               logging: false,
               dialect: dialect,
-              port: config[dialect].port
+              port: config[dialect].port,
+              utcoffset: '+0:00'
             }
           )
         , Helpers   = new (require("./config/helpers"))(sequelize)

--- a/spec-jasmine/migration.spec.js
+++ b/spec-jasmine/migration.spec.js
@@ -1,6 +1,6 @@
 var config    = require("./config/config")
   , Sequelize = require("../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("./config/helpers"))(sequelize)
   , Migrator  = require("../lib/migrator")
   , Migration = require("../lib/migration")

--- a/spec-jasmine/migrator.spec.js
+++ b/spec-jasmine/migrator.spec.js
@@ -1,6 +1,6 @@
 var config    = require("./config/config")
   , Sequelize = require("../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("./config/helpers"))(sequelize)
   , Migrator  = require("../lib/migrator")
   , _         = Sequelize.Utils._

--- a/spec-jasmine/mysql/associations.has-many.spec.js
+++ b/spec-jasmine/mysql/associations.has-many.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('HasMany', function() {

--- a/spec-jasmine/mysql/associations.spec.js
+++ b/spec-jasmine/mysql/associations.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('Associations', function() {

--- a/spec-jasmine/mysql/connector-manager.spec.js
+++ b/spec-jasmine/mysql/connector-manager.spec.js
@@ -3,7 +3,32 @@ var config    = require("../config/config")
   , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
+//////////////////
+// event testing
+
+var connected = false
+var connectedViaConnectorManager = false
+sequelize.on( 'connect', function() {
+  connected = true
+})
+sequelize.connectorManager.on( 'connect', function() {
+  connectedViaConnectorManager = true
+})
+
+var disconnected = false
+var disconnectedViaConnectorManager = false
+sequelize.on( 'disconnect', function() {
+  disconnected = true
+})
+sequelize.connectorManager.on( 'disconnect', function() {
+  disconnectedViaConnectorManager = true
+})  
+//
+//////////////////
+
+
 describe('ConnectorManager', function() {
+
   beforeEach(function() {
     Helpers.dropAllTables()
   })
@@ -21,6 +46,9 @@ describe('ConnectorManager', function() {
           User.count().on('success', function(count) {
             expect(count).toEqual(1)
             done()
+          }).on('error', function() {
+            expect(false).toEqual(true)
+            done()
           })
         })
       })
@@ -31,6 +59,9 @@ describe('ConnectorManager', function() {
         User.count().on('success', function(count) {
           expect(count).toEqual(1)
           done()
+        }).on('failure', function() {
+          expect(false).toEqual(true)
+          done()
         })
       }, 1000)
     })
@@ -39,8 +70,8 @@ describe('ConnectorManager', function() {
   it('emits a connect event', function() {
     Helpers.async(function(done) {
       setTimeout(function() {
-        expect(self.connected).toEqual(true)
-        expect(self.connectedViaConnectorManager).toEqual(true)
+        expect(connected).toEqual(true)
+        expect(connectedViaConnectorManager).toEqual(true)
         done()
       }, 1000)
     })
@@ -49,8 +80,8 @@ describe('ConnectorManager', function() {
   it('emits a disconnect event', function() {
     Helpers.async(function(done) {
       setTimeout(function() {
-        expect(self.disconnected).toEqual(true)
-        expect(self.disconnectedViaConnectorManager).toEqual(true)
+        expect(disconnected).toEqual(true)
+        expect(disconnectedViaConnectorManager).toEqual(true)
         done()
       }, 1000)
     })
@@ -58,23 +89,49 @@ describe('ConnectorManager', function() {
   
   it('properly set timezone', function() {
     Helpers.async(function(done) {
-      sequelize.connectorManager.client.query( "SELECT @@session.time_zone", function(error, result) {
-        expect(error).toEqual(null)
+      sequelize.query( "SELECT @@session.time_zone", null, {raw: true}).on('success', function( results ) {
 
-        var re = new RegExp( '(.)(\d+)\:(\d+)' )
+        expect(results.length).toEqual(1);
+        var result = results[0]        
+        var re = new RegExp( /(.)(\d+)\:(\d+)/ )
         var match = re.exec( result[ '@@session.time_zone' ] )
         expect(match).not.toBeNull()
+        if (!match) {
+          done()
+          return
+        }
+
+        expect(match.length).toEqual(4)
+        if (match.length != 4) {
+          done()
+          return
+        }
 
         var dbSign = match[1]
         var dbHours = parseInt(match[2])
         var dbMinutes = parseInt(match[3])
-        
+
         match = re.exec( sequelize.config.utcoffset )
-        var configSign = result[0];
-        var configHours = parseInt(result[1] + result[2], 10)
-        var configMinutes = parseInt(result[4] + result[5], 10)
+        expect(match).not.toBeNull()
+        if (!match) {
+          done()
+          return
+        }
+
+        expect(match.length).toEqual(4)
+        if (match.length != 4) {
+          done()
+          return
+        }
+
+        var configSign = match[1]
+        var configHours = parseInt(match[2]) 
+        var configMinutes = parseInt(match[3]) 
 
         expect(dbSign + dbHours + dbMinutes).toEqual(configSign + configHours + configMinutes)
+        done()
+      }).on( 'error', function() {
+        expect(true).toEqual(false);
         done()
       })
     })

--- a/spec-jasmine/mysql/dao-factory.spec.js
+++ b/spec-jasmine/mysql/dao-factory.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('DAOFactory', function() {

--- a/spec-jasmine/mysql/query-generator.spec.js
+++ b/spec-jasmine/mysql/query-generator.spec.js
@@ -1,6 +1,6 @@
 var config         = require("../config/config")
   , Sequelize      = require("../../index")
-  , sequelize      = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize      = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers        = new (require("../config/helpers"))(sequelize)
   , QueryGenerator = require("../../lib/dialects/mysql/query-generator")
   , util           = require("util")

--- a/spec-jasmine/postgres/associations.has-many.spec.js
+++ b/spec-jasmine/postgres/associations.has-many.spec.js
@@ -2,6 +2,7 @@ var config    = require("../config/config")
   , Sequelize = require("../../index")
   , sequelize = new Sequelize(config.postgres.database, config.postgres.username, config.postgres.password, {
       logging: false,
+      utcoffset: '+0:00',
       port: config.postgres.port,
       dialect: 'postgres'
     })

--- a/spec-jasmine/postgres/associations.spec.js
+++ b/spec-jasmine/postgres/associations.spec.js
@@ -2,6 +2,7 @@ var config    = require("../config/config")
   , Sequelize = require("../../index")
   , sequelize = new Sequelize(config.postgres.database, config.postgres.username, config.postgres.password, {
       logging: false,
+      utcoffset: '+0:00',
       port: config.postgres.port,
       dialect: 'postgres'
     })

--- a/spec-jasmine/postgres/query-generator.spec.js
+++ b/spec-jasmine/postgres/query-generator.spec.js
@@ -2,6 +2,7 @@ var config         = require("../config/config")
   , Sequelize      = require("../../index")
   , sequelize      = new Sequelize(config.postgres.database, config.postgres.username, config.postgres.password, {
       logging: false,
+      utcoffset: '+0:00',
       dialect: 'postgres',
       port: config.postgres.port
     })

--- a/spec-jasmine/query-interface.spec.js
+++ b/spec-jasmine/query-interface.spec.js
@@ -1,6 +1,6 @@
 var config         = require("./config/config")
   , Sequelize      = require("../index")
-  , sequelize      = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize      = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { port: config.mysql.port, utcoffset: '+0:00', logging: false })
   , Helpers        = new (require("./config/helpers"))(sequelize)
   , QueryInterface = require("../lib/query-interface")
 

--- a/spec-jasmine/sequelize.spec.js
+++ b/spec-jasmine/sequelize.spec.js
@@ -2,13 +2,16 @@ var config         = require("./config/config")
   , Sequelize      = require("../index")
   , QueryInterface = require("../lib/query-interface")
 
+// avoid warnings when we bind 'exit' from lots of these specs
+process.setMaxListeners( 50 );
+
 describe('Sequelize', function() {
   var sequelize = null
     , Helpers   = null
 
 
   var setup = function(options) {
-    options   = options || {utcoffset: '+0:00', logging: false}
+    options   = options || { port: config.mysql.port, utcoffset: '+0:00', logging: false }
     sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, options)
     Helpers   = new (require("./config/helpers"))(sequelize)
 
@@ -28,7 +31,7 @@ describe('Sequelize', function() {
     })
 
     it('should correctly set the host and the port', function() {
-      var options = setup({ host: '127.0.0.1', port: 1234 })
+      var options = setup({ host: '127.0.0.1', port: 1234, utcoffset: '+0:00' })
 
       expect(sequelize.config.host).toEqual(options.host)
       expect(sequelize.config.port).toEqual(options.port)

--- a/spec-jasmine/sqlite/dao-factory.spec.js
+++ b/spec-jasmine/sqlite/dao-factory.spec.js
@@ -14,7 +14,8 @@ describe('DAOFactory', function() {
         sequelize = new Sequelize(config.database, config.username, config.password, {
           logging: false,
           dialect: 'sqlite',
-          storage: storage
+          storage: storage,
+          utcoffset: '+0:00'
         })
 
         Helpers = new (require("../config/helpers"))(sequelize)


### PR DESCRIPTION
Hey, so this turned into a much bigger change than I expected.  But the changes are:
- Sequelize object emit connect/disconnect events
- ConnectorManager object emit connect/disconnect events (Sequelize listens for an passes these on)
- Allow for setting a 'utcoffset' in the options in the format +/-hh:mm
- Set the TZ per-connection
- Test setting the timezone

The tests all pass, but it doesn't exit at the end.  I am not sure where we might be hanging.

One issue that came up in this change is that connect is not synchronous anymore.  I believe I made all the necessary changes to handle that, but it's worth a second look.
