### PR TITLE
Fix #162

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -10,8 +10,11 @@ module.exports = (function() {
     this.migrator       = migrator
     this.path           = path
     this.filename       = Utils._.last(this.path.split('/'))
-    this.migrationId    = parseInt(this.filename.match(/(.*)-.*/)[1])
-    this.date           = Migration.stringToDate(this.filename)
+
+    var parsed          = Migration.parseFilename(this.filename)
+
+    this.migrationId    = parsed.id
+    this.date           = parsed.date;
     this.queryInterface = this.migrator.queryInterface
     this.undoneMethods  = 0
   }
@@ -20,20 +23,17 @@ module.exports = (function() {
   // static /////
   ///////////////
 
-  Migration.getFormattedDateString = function(s) {
-    var result = null
+  Migration.parseFilename = function(s) {
+    var matches = s.match(/^((\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2}))[-_].+/)
 
-    try {
-      result = s.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/).slice(1, 6).join('-')
-    } catch(e) {
-      throw new Error(s + ' is no valid migration timestamp format! Use YYYYMMDDHHmmss!')
+    if(matches === null) {
+      throw new Error(s + ' is not a valid migration name! Use YYYYMMDDHHmmss-migration-name format.')
     }
 
-    return result
-  }
-
-  Migration.stringToDate = function(s) {
-    return moment(Migration.getFormattedDateString(s), "YYYYMMDDHHmmss")
+    return {
+      id: parseInt(matches[1]),
+      date: moment(matches.slice(2, 8).join('-'), 'YYYYMMDDHHmmss')
+    }
   }
 
   Migration.migrationHasInterfaceCalls = function(func) {


### PR DESCRIPTION
- a migration timestamp can be separated with a dash or an underscore
  from its name
- match exactly 14 digits; previous regex matched greedily so in
  00000000000000-foo-bar.js it would take 00000000000000-foo as an ID
