### PR TITLE
Fix for Utils.isHash on null and objects with a user-defined length property + tests for Utils.isHash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,7 @@ var Utils = module.exports = {
     return client.format.apply(client, [query, replacements])
   },
   isHash: function(obj) {
-    return (typeof obj == 'object') && !obj.hasOwnProperty('length')
+    return Utils._.isObject(obj) && !Utils._.isArray(obj);
   },
   toSqlDate: function(date) {
     return [

--- a/spec-jasmine/utils.spec.js
+++ b/spec-jasmine/utils.spec.js
@@ -84,4 +84,32 @@ describe('Utils', function() {
       })
     })
   })
+  
+  describe('isHash', function() {
+    it('doesn\'t match arrays', function() {
+      expect(Utils.isHash([])).toBeFalsy();
+    });
+    it('doesn\'t match null', function() {
+      expect(Utils.isHash(null)).toBeFalsy();
+    });
+    it('matches plain objects', function() {
+    	var values = {
+    	  'name': {
+    	    'first': 'Foo',
+    	    'last': 'Bar'
+    	  }
+    	};
+      expect(Utils.isHash(values)).toBeTruthy();
+    });
+    it('matches plain objects with length property/key', function() {
+      var values = {
+    	  'name': {
+    	    'first': 'Foo',
+    	    'last': 'Bar'
+    	  },
+    	  'length': 1
+    	};
+    	expect(Utils.isHash(values)).toBeTruthy();
+    });
+  });
 })


### PR DESCRIPTION
Basically switch to using underscores built in isObject and isArray to check wether it's a hash.
The previous method of checking for isHash would throw an error on null and would fail if the hash had a length property.
