### PR TITLE
Import cache

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -73,9 +73,13 @@ module.exports = (function() {
     return factory
   }
 
+  var importCache = {};
   Sequelize.prototype.import = function(path) {
-    var defineCall = require(path)
-    return defineCall(this, DataTypes)
+    if (!importCache[path]) {
+      var defineCall = require(path)
+      importCache[path] = defineCall(this, DataTypes)
+    }
+    return importCache[path];
   }
 
   Sequelize.prototype.migrate = function(options) {


### PR DESCRIPTION
Just a small fix to provide caching in the import function.
An issue arose where if splitting defines between files and having a hasMany association, the one model would not receive the proper getters & setters.

I have no idea why it wants to commit the merges we did from your master to our master to keep the codebase up to date.

If you can let me know how, i'd be happy to fix the commit.
But all the code seems to be minor merges so don't think it should be an issue.
