### PR TITLE
Added the posibility to specify options when getting objects associated with hasMany

### DIFF
--- a/lib/associations/has-many-double-linked.js
+++ b/lib/associations/has-many-double-linked.js
@@ -6,11 +6,11 @@ module.exports = (function() {
     this.instance = instance
   }
 
-  HasManyDoubleLinked.prototype.injectGetter = function() {
-    var self = this
-
+  HasManyDoubleLinked.prototype.injectGetter = function(options) {
+    var self = this, _options = options
+    
     var customEventEmitter = new Utils.CustomEventEmitter(function() {
-      var where = {}
+      var where = {}, options = _options || {};
 
       //fully qualify
       where[self.__factory.connectorDAO.tableName+"."+self.__factory.identifier] = self.instance.id
@@ -19,7 +19,19 @@ module.exports = (function() {
         , foreignKey  = primaryKeys.filter(function(pk) { return pk != self.__factory.identifier })[0]
 
       where[self.__factory.connectorDAO.tableName+"."+foreignKey] = {join: self.__factory.target.tableName+".id"}
-      self.__factory.target.findAllJoin(self.__factory.connectorDAO.tableName, {where: where})
+
+      if (options.where) {
+        Utils._.each(options.where, function(value, index) {
+          delete options.where[index];
+          options.where[self.__factory.target.tableName+"."+index] = value;
+        });
+
+        options.where = options.where ? Utils.merge(options.where, where) : where
+      } else {
+        options.where = where;
+      }
+
+      self.__factory.target.findAllJoin(self.__factory.connectorDAO.tableName, options)
       .on('success', function(objects) { customEventEmitter.emit('success', objects) })
       .on('error', function(err){ customEventEmitter.emit('error', err) })
       .on('sql', function(sql) { customEventEmitter.emit('sql', sql)})

--- a/lib/associations/has-many-single-linked.js
+++ b/lib/associations/has-many-single-linked.js
@@ -6,11 +6,13 @@ module.exports = (function() {
     this.instance = instance
   }
 
-  HasManySingleLinked.prototype.injectGetter = function() {
-    var where = {}
+  HasManySingleLinked.prototype.injectGetter = function(options) {
+    var where = {}, options = options || {}
 
     where[this.__factory.identifier] = this.instance.id
-    return this.__factory.target.findAll({where: where})
+
+    options.where = options.where ? Utils.merge(options.where, where) : where
+    return this.__factory.target.findAll(options)
   }
 
   HasManySingleLinked.prototype.injectSetter = function(emitter, oldAssociations, newAssociations) {

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -72,9 +72,9 @@ module.exports = (function() {
   HasMany.prototype.injectGetter = function(obj) {
     var self = this
 
-    obj[this.accessors.get] = function() {
+    obj[this.accessors.get] = function(options) {
       var Class = self.connectorDAO ? HasManyMultiLinked : HasManySingleLinked
-      return new Class(self, this).injectGetter()
+      return new Class(self, this).injectGetter(options)
     }
 
    obj[this.accessors.hasAll] = function(objects) {


### PR DESCRIPTION
This adds the functionality as described in #205:

``` javascript
Playlist.find({
    where: {
        id: playlist_id
    }
}).success( function( playlist ){

    playlist.getItems({
        limit: 10,
        order: 'id DESC'
    }).success( function( items ){ ... });

});
```

getXX accepts all the same options as a regular get, that is where, limit, order and group
