### PR TITLE
Fix postgres connection pooling

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -12,7 +12,7 @@ module.exports = (function() {
     // set pooling parameters if specified
     if (this.pooling) {
       pg.defaults.poolSize = this.config.pool.maxConnections || 10
-      pg.defaults.poolIdleTimeout = this.config.pool.maxIdleTime | 30000
+      pg.defaults.poolIdleTimeout = this.config.pool.maxIdleTime || 30000
     }
     this.disconnectTimeoutId = null
     this.pendingQueries = 0


### PR DESCRIPTION
I rewrote most of the connector manager for postgres.

Now supports connection pooling and max concurrent queries.

The structure is based on the mysql connector manager.

From my own experience, I get a huge speed improvement with the new connector manager.
