### PR TITLE
Postgres Delete Query problem w/o calling sync

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -243,6 +243,8 @@ module.exports = (function() {
       options = options || {}
       options.limit = options.limit || 1
 
+      primaryKeys[tableName] = primaryKeys[tableName] || [];
+
       var query = "DELETE FROM <%= table %> WHERE <%= primaryKeys %> IN (SELECT <%= primaryKeysSelection %> FROM <%= table %> WHERE <%= where %> LIMIT <%= limit %>)"
 
       var pks;


### PR DESCRIPTION
In a previous bug #177, there were issues with postgres on calling insert without calling "sync". This was addressed, however the deleteQuery aspect of the postgres query-generator is still broken. Calling delete w/o calling sync results in the following error. 

The code in question is trying to utilize the primaryKeys data structure legnth without checking it correctly. This pull request initializes the value if it does not exist.

This allows the delete to function w/o a sync, assuming that the primary field key is "id", since it will always fall through the the default in the deleteQuery clause.

```
    pks = addQuotes('id')
```

At least this gets delete working for most folks. To fully support all primary keys, the table data structure really needs to be build without "create table", so the query can populate non standard named primary keys correctly. This is a bit past me with regards to how to integrate. I just know I can't be calling "sync" on the model everytime i need to delete. Not only will I forget, but it calls "create table if not exists" on every delete.

Error.
 TypeError: Cannot read property 'length' of undefined
    at Object.module.exports.QueryGenerator.deleteQuery (/X/sequelize/lib/dialects/postgres/query-generator.js:254:44)
    at module.exports.QueryInterface.delete (/X/node_modules/sequelize/lib/query-interface.js:193:35)
    at module.exports.DAO.destroy (/mnt/users_home/robr/Peach-API/node_modules/sequelize/lib/dao.js:214:40)
    at exports.process.db.models.oauth_tokens.find.where.token (/X/lib/api/resources/oauth.js:220:16)
    at EventEmitter.emit (events.js:88:17)
    at module.exports.queryAndEmit (/X/sequelize/lib/query-interface.js:253:17)
    at EventEmitter.emit (events.js:115:20)
    at module.exports.Query.run.query.on.receivedError (/X/sequelize/lib/dialects/postgres/query.js:71:16)
    at EventEmitter.emit (events.js:88:17)
    at p.handleReadyForQuery (/X/pg/lib/query.js:80:8)
