### PR TITLE
Attribute selection during find commands

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -109,9 +109,9 @@ module.exports = (function() {
     }
 
     // options is not a hash but an id
-    if(typeof options == 'number')
+    if(typeof options === 'number') {
       options = { where: options }
-    else if (Utils.argsArePrimaryKeys(arguments, this.primaryKeys)) {
+    } else if (Utils.argsArePrimaryKeys(arguments, this.primaryKeys)) {
         var where = {}
           , self  = this
 
@@ -125,7 +125,7 @@ module.exports = (function() {
 
     options.limit = 1
 
-    return this.QueryInterface.select(this, this.tableName, options, {plain: true})
+    return this.QueryInterface.select(this, this.tableName, options, { plain: true })
   }
 
   DAOFactory.prototype.count = function(options) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -111,11 +111,16 @@ module.exports = (function() {
         options.where = QueryGenerator.getWhereConditions(options.where)
         query += " WHERE <%= where %>"
       }
-      if(options.order) query += " ORDER BY <%= order %>"
+
+      if(options.order) {
+        query += " ORDER BY <%= order %>"
+      }
+
       if(options.group) {
         options.group = Utils.addTicks(options.group)
         query += " GROUP BY <%= group %>"
       }
+
       if(options.limit) {
         if(options.offset) query += " LIMIT <%= offset %>, <%= limit %>"
         else query += " LIMIT <%= limit %>"
@@ -233,14 +238,15 @@ module.exports = (function() {
     getWhereConditions: function(smth) {
       var result = null
 
-      if(Utils.isHash(smth))
+      if(Utils.isHash(smth)) {
         result = QueryGenerator.hashToWhereConditions(smth)
-      else if(typeof smth == 'number')
+      } else if(typeof smth === 'number') {
         result = Utils.addTicks('id') + "=" + Utils.escape(smth)
-      else if(typeof smth == "string")
+      } else if(typeof smth === "string") {
         result = smth
-      else if(Array.isArray(smth))
+      } else if(Array.isArray(smth)) {
         result = Utils.format(smth)
+      }
 
       return result
     },


### PR DESCRIPTION
In the 3rd example here: http://www.sequelizejs.com/#models-finders
It says "only select some attributes and rename one", when running similar queries with the attributes set.  I see the sql statement select only the requested attributes.  For example if I request attributes: attrib1 and attrib2, the sql looks like:

select attrib1, attrib2 from mytable

But when I get an instance back from my find call, the instance values still contain all of instance attributes, only the ones that were not requested are null.  So if I had 4 fields on my table, my instance values returned from the request above would be:

{ attrib1: myval1, attrib2: myval2, attrib3: null, attrib4: null}

I see that all the default values are added in dao-factory.js would it be possible to return just the requested values, at a minimum in a new variable? 

I would be open to doing it another way as well.
