### PR TITLE
debug wrong version output 

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -56,7 +56,7 @@ var readConfig = function() {
 }
 
 program
-  .version('1.3.0')
+  .version('1.4.1')
   .option('-i, --init', 'Initializes the project. Creates a config/config.json')
   .option('-m, --migrate', 'Runs undone migrations')
   .option('-u, --undo', 'Redo the last migration.')


### PR DESCRIPTION
At the moment, when calling `node node_modules/sequelize/bin/sequelize -V` the returned value is `1.3.0`. But the current version is 1.4.1, which should be the return value as well.
Edit: the last documented version is 1.4.1, the current version in fact seems to be 1.5.0 (as is stated here: https://npmjs.org/package/sequelize)
