### PR TITLE
Small tweak to allow string ids as parameters to find().

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -109,7 +109,14 @@ module.exports = (function() {
     }
 
     // options is not a hash but an id
-    if(typeof options === 'number') {
+    if(typeof options === 'string') {
+      var parsedId = parseInt(options,10);
+      if (!Utils._.isFinite(parsedId)) {
+        throw new Error('Invalid argument to find(). Must be an id or an options object.')
+      }
+      options = { where: parsedId }
+    }
+    else if(typeof options === 'number') {
       options = { where: options }
     } else if (Utils.argsArePrimaryKeys(arguments, this.primaryKeys)) {
         var where = {}


### PR DESCRIPTION
Small tweak to allow string ids as parameters to find().  If a string is passed, and it cannot be parsed, an error is thrown.

If you have any questions or want me to tweak the solution at all, I'm happy to do so.

Great library!  We're using it as a part of our MVC framework.

Thanks,
Mike McNeil
512-913-1386
