### PR TITLE
Update postgres query-generator to not quote table names.

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -10,7 +10,7 @@ function removeQuotes(s, quoteChar) {
 
 function addQuotes(s, quoteChar) {
   quoteChar = quoteChar || '"'
-  return quoteChar + removeQuotes(s) + quoteChar
+  return s.split('.').map(function(e) { return quoteChar + String(e) + quoteChar }).join('.')
 }
 
 function pgEscape(s) {
@@ -310,9 +310,10 @@ module.exports = (function() {
         return (typeof attribute == 'string') ? attribute : attribute.attribute
       })
 
+      var indexTable = tableName.split('.')
       options = Utils._.extend({
         indicesType: null,
-        indexName: Utils._.underscored(tableName + '_' + onlyAttributeNames.join('_')),
+        indexName: Utils._.underscored(indexTable[indexTable.length-1] + '_' + onlyAttributeNames.join('_')),
         parser: null
       }, options || {})
 


### PR DESCRIPTION
Postgres does use double quotes to quote system identifiers, but this
poses limitation for table names, and should not be used as default.
Note that Database, table, field and columns names in PostgreSQL are
case-independent, unless you created them with double-quotes around
their name, in which case they are case-sensitive. In MySQL, table names
can be case-sensitive or not, depending on which operating system you
are using.

But to get to the real reason to not quote table names by default it is
because it will interfere with using postgres schemas (which mysql does
not have the concept of). If a schema name is given (for example, CREATE
TABLE myschema.mytable ...) then the table is created in the specified
schema. Otherwise it is created in the current schema (public by
default)
