### PR TITLE
Localized optcpy in lib/dao-factory.js

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -95,7 +95,7 @@ module.exports = (function() {
 
   //right now, the caller (has-many-double-linked) is in charge of the where clause
   DAOFactory.prototype.findAllJoin = function(joinTableName, options) {
-    optcpy = Utils._.clone(options)
+    var optcpy = Utils._.clone(options)
     optcpy.attributes = optcpy.attributes || [Utils.addTicks(this.tableName)+".*"]
 
     return this.QueryInterface.select(this, [this.tableName, joinTableName], optcpy)


### PR DESCRIPTION
mocha was indicating that optcpy was defined globally and potentially causing memory leaks. optcpy was changed to a local variable to silence the warning. 
