### PR TITLE
Association injections overwrite existing defined validations

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -22,7 +22,7 @@ module.exports = (function() {
 
     this.identifier = this.options.foreignKey || Utils._.underscoredIf(Utils.singularize(this.target.tableName) + "Id", this.source.options.underscored)
     newAttributes[this.identifier] = { type: DataTypes.INTEGER }
-    Utils._.extend(this.source.rawAttributes, newAttributes)
+    Utils._.defaults(this.source.rawAttributes, newAttributes)
     return this
   }
 

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -63,7 +63,7 @@ module.exports = (function() {
     } else {
       var newAttributes = {}
       newAttributes[this.identifier] = { type: DataTypes.INTEGER }
-      Utils._.extend(this.target.rawAttributes, newAttributes)
+      Utils._.defaults(this.target.rawAttributes, newAttributes)
     }
 
     return this

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -27,7 +27,7 @@ module.exports = (function() {
 
     this.identifier = this.options.foreignKey || Utils._.underscoredIf(Utils.singularize(this.source.tableName) + "Id", this.options.underscored)
     newAttributes[this.identifier] = { type: DataTypes.INTEGER }
-    Utils._.extend(this.target.rawAttributes, newAttributes)
+    Utils._.defaults(this.target.rawAttributes, newAttributes)
 
     return this
   }


### PR DESCRIPTION
Attribute Injection uses underscore's extend, which overwrites any validation (or other attributes) previously defined in the model.

The patch uses underscore's defaults command, which only overwrites the rawAttributes if the column is not already defined.

The reason for this change is validation. If we want to ensure that the field is required, we define the validation at time the rest of the structure is defined. After this fact, associations are added. Without this patch, the attribute will overwrite the property with just the definition of the name, stripping out all other attributes in the definition.

Re-requested from a close #258 since I did not use a topic branch to request pull.
