### PR TITLE
Attribute selection during find commands

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -200,6 +200,8 @@ module.exports = (function() {
 
     instance.isNewRecord = options.hasOwnProperty('isNewRecord') ? options.isNewRecord : true
 
+    instance.returned_values = values
+
     return instance
   }
 


### PR DESCRIPTION
In the 3rd example here: http://www.sequelizejs.com/#models-finders
It says "only select some attributes and rename one", when running similar queries with the attributes set. I see the sql statement select only the requested attributes. For example if I request attributes: attrib1 and attrib2, the sql looks like:

select attrib1, attrib2 from mytable

But when I get an instance back from my find call, the instance values still contain all of instance attributes, only the ones that were not requested are null. So if I had 4 fields on my table, my instance values returned from the request above would be:

{ attrib1: myval1, attrib2: myval2, attrib3: null, attrib4: null}

I see that all the default values are added in dao-factory.js would it be possible to return just the requested values, at a minimum in a new variable?
