### PR TITLE
Fixed id=NULL collision when creating a new record

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -1,9 +1,12 @@
 var Utils     = require("./utils")
   , Mixin     = require("./associations/mixin")
+  , DataTypes = require("./data-types")
   , Validator = require("validator")
 
 module.exports = (function() {
   var DAO = function(values, options) {
+    var self = this
+
     this.attributes = []
     this.validators = {} // holds validation settings for each attribute
     this.__factory = null // will be set in DAO.build
@@ -29,7 +32,7 @@ module.exports = (function() {
   Object.defineProperty(DAO.prototype, 'isDeleted', {
     get: function() {
       var result = this.__options.timestamps && this.__options.paranoid
-      result = result && this[this.__options.underscored ? 'deleted_at' : 'deletedAt'] !== null
+      result = result && this[this.__options.underscored ? 'deleted_at' : 'deletedAt'] != null
 
       return result
     }
@@ -86,28 +89,33 @@ module.exports = (function() {
       , updatedAtAttr = this.__options.underscored ? 'updated_at' : 'updatedAt'
       , createdAtAttr = this.__options.underscored ? 'created_at' : 'createdAt'
 
-    if (fields) {
-      if (self.__options.timestamps) {
-        if (fields.indexOf(updatedAtAttr) === -1) {
+    if(fields) {
+      if(self.__options.timestamps) {
+        if(fields.indexOf(updatedAtAttr) === -1) {
           fields.push(updatedAtAttr)
         }
 
-        if (fields.indexOf(createdAtAttr) === -1) {
+        if(fields.indexOf(createdAtAttr) === -1) {
           fields.push(createdAtAttr)
         }
       }
+
       fields.forEach(function(field) {
-        if (self.values[field] !== undefined) {
+        if(self.values[field] !== undefined) {
           values[field] = self.values[field]
         }
       })
     }
 
+
     if(this.__options.timestamps && this.hasOwnProperty(updatedAtAttr)) {
-      this[updatedAtAttr] = values[updatedAtAttr] = new Date()
+      var now = new Date()
+      this[updatedAtAttr] = now
+      values[updatedAtAttr] = now
     }
 
     if(this.isNewRecord) {
+	  delete values.id;
       return this.QueryInterface.insert(this, this.__factory.tableName, values)
     } else {
       var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : this.id
@@ -256,12 +264,10 @@ module.exports = (function() {
   // private
 
   var initAttributes = function(values) {
+    var self = this
+
     // add all passed values to the dao and store the attribute names in this.attributes
-    for (var key in values) {
-      if (values.hasOwnProperty(key)) {
-        this.addAttribute(key, values[key])
-      }
-    }
+    Utils._.map(values, function(value, key) { self.addAttribute(key, value) })
 
     // set id to null if not passed as value
     // a newly created dao has no id
@@ -276,13 +282,11 @@ module.exports = (function() {
       }
     }
 
-    for (var attr in defaults) {
-      var value = defaults[attr]
-
-      if(!this.hasOwnProperty(attr)) {
-        this.addAttribute(attr, Utils.toDefaultValue(value))
+    Utils._.map(defaults, function(value, attr) {
+      if(!self.hasOwnProperty(attr)) {
+        self.addAttribute(attr, Utils.toDefaultValue(value))
       }
-    }
+    })
   }
 
   /* Add the instance methods to DAO */


### PR DESCRIPTION
When creating a new record Sequelize was setting id to NULL, which lead to failed SQL query.
