### PR TITLE
Allows migrations to call access to emitted events. 

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -121,7 +121,7 @@ module.exports = (function() {
               (self.undoneMethods == 0) && callback && callback()
           })
 
-          self.queryInterface[_method].apply(self.queryInterface, args)
+          return self.queryInterface[_method].apply(self.queryInterface, args)
         }
       })(method)
     }


### PR DESCRIPTION
Exposes the underlying emitter in migrations. This allows users to register for event callbacks. Fixes issue#215.
