### PR TITLE
Add ability to use attributes in belongsTo and hasOne accessors

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -32,9 +32,16 @@ module.exports = (function() {
     var self     = this
       , accessor = Utils._.camelize('get_' + (this.options.as || Utils.singularize(this.target.tableName)))
 
-    obj[accessor] = function() {
-      var id = obj[self.identifier]
-      return self.target.find(id)
+    obj[accessor] = function(params) {
+      var id    = obj[self.identifier]
+      if(!Utils._.isUndefined(params)) {
+        if(!Utils._.isUndefined(params.attributes)) 
+          params = Utils._.extend({where: {id:id}}, params)
+      }
+      else 
+        params = id
+      
+      return self.target.find(params)
     }
 
     return this

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -37,12 +37,21 @@ module.exports = (function() {
   HasOne.prototype.injectGetter = function(obj) {
     var self = this
 
-    obj[this.accessors.get] = function() {
+    obj[this.accessors.get] = function(params) {
       var id    = obj.id
         , where = {}
 
       where[self.identifier] = id
-      return self.target.find({where: where})
+
+      if(!Utils._.isUndefined(params)) {
+        if(!Utils._.isUndefined(params.attributes)) {
+          params = Utils._.extend({where: where}, params)
+        }
+      }
+      else 
+        params = {where: where}
+
+      return self.target.find(params)
     }
 
     return this

--- a/spec-jasmine/associations/has-many.spec.js
+++ b/spec-jasmine/associations/has-many.spec.js
@@ -87,7 +87,11 @@ describe('HasMany', function() {
         user.setTasks([task1, task2]).success(function() {
           user.getTasks().success(function(tasks) {
             expect(tasks.length).toEqual(2)
-            done()
+            user.getTasks({attributes: ['title']}).success(function(tasks) {
+              expect(tasks[0].selectedValues.title).toEqual('task1')
+              expect(tasks[0].selectedValues.id).toEqual(null)
+              done()
+            })
           })
         })
       })

--- a/spec-jasmine/associations/has-one.spec.js
+++ b/spec-jasmine/associations/has-one.spec.js
@@ -88,7 +88,11 @@ describe('HasOne', function() {
       user.setTask(task).on('success', function() {
         user.getTask().on('success', function(task2) {
           expect(task.title).toEqual(task2.title)
-          done()
+          user.getTask({attributes: ['title']}).on('success', function(task2) {
+            expect(task2.selectedValues.title).toEqual('snafu')
+            expect(task2.selectedValues.id).toEqual(null)
+            done()
+          })
         })
       })
     })


### PR DESCRIPTION
This will allow you to put attributes into the accessor requests.
It also complements the newly added field selectedValues so you can get
the exact fields you requested when using associations.
