### PR TITLE
Added support for short validate attribute syntax.

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -148,7 +148,7 @@ module.exports = (function() {
           // is it a validator module function?
           else {
             // extra args
-            fn_args = details.hasOwnProperty("args") ? details.args : []
+            fn_args = details.hasOwnProperty("args") ? details.args : details
             if (!Utils._.isArray(fn_args))
               fn_args = [fn_args]
             // error msg


### PR DESCRIPTION
The documentation (http://www.sequelizejs.com/#models-validations) shows a short validate syntax like this:

validate:
  len: [2,10]

But the code only accepts long syntax like this:

validate:
  len:
    args: [2,10]

This pull request fixes this issue.
