### PR TITLE
honor maxConcurrentQueries option

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -51,7 +51,8 @@ module.exports = (function() {
       host    : this.options.host,
       port    : this.options.port,
       pool    : this.options.pool,
-      protocol: this.options.protocol
+      protocol: this.options.protocol,
+      maxConcurrentQueries: this.options.maxConcurrentQueries
     }
 
     var ConnectorManager = require("./dialects/" + this.options.dialect + "/connector-manager")


### PR DESCRIPTION
This change pulls that configuration option in from `options` in `sequelize.js`.  Otherwise we just always fall back to the default of 50.
