### PR TITLE
Fix for #305

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -13,15 +13,23 @@ function addQuotes(s, quoteChar) {
   return s.split('.').map(function(e) { return quoteChar + String(e) + quoteChar }).join('.')
 }
 
-function pgEscape(s) {
-  s = Utils.escape(s)
-
-  if (typeof s == 'string') {
-    // http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
-    s = s.replace(/\\'/g, "''")
+function pgEscape(val) {
+  if (val === undefined || val === null) {
+    return 'NULL';
   }
 
-  return s
+  switch (typeof val) {
+    case 'boolean': return (val) ? 'true' : 'false';
+    case 'number': return val+'';
+  }
+
+  if (val instanceof Date) {
+    val = pgSqlDate(val);
+  }
+
+  // http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
+  val = val.replace(/'/g, "''");
+  return "'"+val+"'";
 }
 
 function padInt(i) {
@@ -264,7 +272,7 @@ module.exports = (function() {
         table: addQuotes(tableName),
         attributes: Utils._.keys(attrValueHash).map(function(attr){return addQuotes(attr)}).join(","),
         values: Utils._.values(attrValueHash).map(function(value){
-          return pgEscape((value instanceof Date) ? pgSqlDate(value) : value)
+          return pgEscape(value)
         }).join(",")
       }
 
@@ -279,7 +287,7 @@ module.exports = (function() {
 
       for (var key in attrValueHash) {
         var value = attrValueHash[key]
-        values.push(addQuotes(key) + "=" + pgEscape((value instanceof Date) ? pgSqlDate(value) : value))
+        values.push(addQuotes(key) + "=" + pgEscape(value))
       }
 
       var replacements = {

--- a/spec-jasmine/postgres/query-generator.spec.js
+++ b/spec-jasmine/postgres/query-generator.spec.js
@@ -119,6 +119,9 @@ describe('QueryGenerator', function() {
         arguments: ['mySchema.myTable', {name: 'foo'}],
         expectation: "INSERT INTO \"mySchema\".\"myTable\" (\"name\") VALUES ('foo') RETURNING *;"
       }, {
+        arguments: ['mySchema.myTable', {name: JSON.stringify({info: 'Look ma a " quote'})}],
+        expectation: "INSERT INTO \"mySchema\".\"myTable\" (\"name\") VALUES ('{\"info\":\"Look ma a \\\" quote\"}') RETURNING *;"
+      }, {
         arguments: ['mySchema.myTable', {name: "foo';DROP TABLE mySchema.myTable;"}],
         expectation: "INSERT INTO \"mySchema\".\"myTable\" (\"name\") VALUES ('foo'';DROP TABLE mySchema.myTable;') RETURNING *;"
       }


### PR DESCRIPTION
This fixes the quoting bug in #305.

Prior to this change the pg dialect was using mysql's quoting logic, which doesn't work with postgres.
I have added 2 tests - 1 for just postgres and one for all databases. In the latter I'd like to test with a more convoluted string, but that caused sqlite to fail and exit the suite immediately.
