### PR TITLE
Please add this update to add missed line to the code

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -142,6 +142,7 @@ module.exports = (function() {
         , sql   = []
 
       for (var attributeName in attributes) {
+        var definition = attributes[attributeName]
         var attrSql = ''
 
         if (definition.indexOf('NOT NULL') > 0) {


### PR DESCRIPTION
Fix a bug 'definition is not defined' in changeColumn method for PostrgeSQL migrations
