### PR TITLE
escape strings containing ' in sqlite WHERE clauses

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -182,7 +182,7 @@ module.exports = (function() {
         }
       }
 
-      return hashToWhereConditions(hash)
+      return hashToWhereConditions(hash).replace(/\\'/g, "''");
     }
   }
 

--- a/spec/sqlite/dao.spec.js
+++ b/spec/sqlite/dao.spec.js
@@ -48,6 +48,20 @@ if (dialect === 'sqlite') {
             console.log(err)
           })
       })
+    it("escapes strings properly in where clauses", function(done) {
+      var self = this
+
+      this.User
+        .create({ username: "user'name" })
+        .success(function(user) {
+          self.User.findAll({
+            where: { username: "user'name" }
+          }).success(function(users) {
+            expect(users.length).toEqual(1)
+            done()
+          })
+        })
+      })
     })
   })
 }


### PR DESCRIPTION
I just ran across a bug where a string containing ' that ended up in a WHERE clause on a Sqlite3 db was getting escaped with \' (the MySQL way) instead of '' (the Sqlite3 way). I added something of a hack to fix this in the smallest place I could find, but if you know more about the overall code flow and can suggest a better fix, please let me know.

Also, as far as I can see, the new test is working. However, a number of tests are currently not working in trunk, so it's possible that this is breaking something that I'm not seeing. Please advise.
