### PR TITLE
throw err for pg.connect

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -55,7 +55,9 @@ module.exports = (function() {
 
     var connectCallback = function(err, client) {
       self.isConnecting = false
-      if (!err && client) {
+      if (err) {
+        throw err
+      } else if (client) {
         client.query("SET TIME ZONE 'UTC'")
           .on('end', function() {
             self.isConnected = true


### PR DESCRIPTION
Currently when pg.connect fails no error is being reported
This pull request fixes this by throwing `err` when `err` is passed by pg.connect
