### PR TITLE
A failing test to show that findAll does not work with include in the belongsTo/hasOne case.

### DIFF
--- a/spec/dao-factory.spec.js
+++ b/spec/dao-factory.spec.js
@@ -426,6 +426,7 @@ describe("[" + dialect.toUpperCase() + "] DAOFactory", function() {
 
         this.sequelize.sync({ force: true }).success(function() {
           this.User.create({ name: 'barfooz' }).success(function(user) {
+          this.User.create({ name: 'another user' }).success(function(another_user) {
             this.Task.create({ title: 'task' }).success(function(task) {
               user.setTask(task).success(function() {
                 this.Task.find({
@@ -438,6 +439,7 @@ describe("[" + dialect.toUpperCase() + "] DAOFactory", function() {
                 })
               }.bind(this)) //- setTask
             }.bind(this)) //- Task.create
+          }.bind(this)) //- User.create
           }.bind(this)) //- User.create
         }.bind(this)) //- sequelize.sync
       })


### PR DESCRIPTION
A failing test to show that findAll does not work with include in the belongsTo/hasOne case.

From cursory investigation, it's happening because at https://github.com/sdepold/sequelize/blob/master/lib/dialects/mysql/query-generator.js#L161, Utils.addTicks(table) returns the table name that references instead of the referent table. This line may not be the root cause, but I hope this helps.
