### PR TITLE
allow users to specify config.native in order to use the native pg client

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -9,6 +9,9 @@ module.exports = (function() {
     this.client = null
     this.config = config || {}
     this.pooling = (this.config.poolCfg != null && this.config.poolCfg.maxConnections > 0)
+    if (this.config.native) {
+      pg = pg.native
+    }
     // set pooling parameters if specified
     if (this.pooling) {
       pg.defaults.poolSize = this.config.poolCfg.maxConnections

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -37,7 +37,8 @@ module.exports = (function() {
       sync: {},
       logging: console.log,
       omitNull: false,
-      queue: true
+      queue: true,
+      native: false
     }, options || {})
 
     if(this.options.logging === true) {
@@ -54,6 +55,7 @@ module.exports = (function() {
       pool    : this.options.pool,
       protocol: this.options.protocol,
       queue   : this.options.queue,
+      native  : this.options.native,
       maxConcurrentQueries: this.options.maxConcurrentQueries
     }
 


### PR DESCRIPTION
This allows users to user password logins which currently only work with the native client of the pg module due to this bug: https://github.com/brianc/node-postgres/issues/202
