### PR TITLE
Support minConnections option for MySQL pooling

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -24,6 +24,9 @@ module.exports = (function() {
       if (!this.poolCfg.maxConnections) {
         this.poolCfg.maxConnections = 10
       }
+      if (!this.poolCfg.minConnections) {
+        this.poolCfg.minConnections = 0
+      }
       this.pool = Pooling.Pool({
         name: 'sequelize-mysql',
         create: function (done) {
@@ -33,6 +36,7 @@ module.exports = (function() {
             disconnect.call(self, client)
         },
         max: self.poolCfg.maxConnections,
+        min: self.poolCfg.minConnections,
         idleTimeoutMillis: self.poolCfg.maxIdleTime
       })
     }


### PR DESCRIPTION
It's a pretty small change, but maybe useful to someone other than me.

By default `minConnections` will be set to `0`.
