### PR TITLE
Allow additional parameters to be passed to mysql.createConnection()

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -158,6 +158,8 @@ module.exports = (function() {
     // client.setMaxListeners(self.maxConcurrentQueries)
     this.isConnecting = false
 
+    if (this.config.postConnect) this.config.postConnect(connection);
+
     done(null, connection)
   }
 

--- a/lib/dialects/sqlite/connector-manager.js
+++ b/lib/dialects/sqlite/connector-manager.js
@@ -3,9 +3,10 @@ var Utils   = require("../../utils")
   , Query   = require("./query")
 
 module.exports = (function() {
-  var ConnectorManager = function(sequelize) {
+  var ConnectorManager = function(sequelize, config) {
     this.sequelize = sequelize
     this.database  = new sqlite3.Database(sequelize.options.storage || ':memory:')
+    if (config.postConnect) config.postConnect(this.database);
   }
   Utils._.extend(ConnectorManager.prototype, require("../connector-manager").prototype)
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -57,7 +57,8 @@ module.exports = (function() {
       queue   : this.options.queue,
       native  : this.options.native,
       maxConcurrentQueries: this.options.maxConcurrentQueries,
-      dialectConnectParams: this.options.dialectConnectParams || {}
+      dialectConnectParams: this.options.dialectConnectParams || {},
+      postConnect: this.options.postConnect
     }
 
     var ConnectorManager = require("./dialects/" + this.options.dialect + "/connector-manager")


### PR DESCRIPTION
Expose a new option, 'dialectConnectParams', which is passed to the dialect connect call in addition to the default parameters.  At the moment, this is written only with the mysql connector in mind.

My use case is that I require the parameter 'insecureAuth' set to true for the mysql.createConnection() call.  If I can't set this, I'm unable to use sequelize until my DB admin changes the settings of the database, which may not be able to happen.

If you don't like the naming of this config parameter, rename it, but I need some way of providing values to the mysql.createConnection() call.  I'm also interested in being able to set debug to true.
