### PR TITLE
BIGINT support

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -2,6 +2,7 @@ module.exports = {
   STRING: 'VARCHAR(255)',
   TEXT: 'TEXT',
   INTEGER: 'INTEGER',
+  BIGINT:  'BIGINT',
   DATE: 'DATETIME',
   BOOLEAN: 'TINYINT(1)',
   FLOAT: 'FLOAT',

--- a/spec/dao-factory.spec.js
+++ b/spec/dao-factory.spec.js
@@ -205,6 +205,19 @@ describe("[" + Helpers.getTestDialectTeaser() + "] DAOFactory", function() {
       })
     })
 
+    it('sets a 64 bit int in bigint', function(done) {
+      var User = this.sequelize.define('UserWithBigIntFields', {
+        big: Sequelize.BIGINT
+      })
+
+      User.sync({ force: true }).success(function() {
+        User.create({ big: '9223372036854775807' }).on('success', function(user) {
+          expect(user.big).toEqual( '9223372036854775807' )
+          done()
+        })
+      })
+    })
+
     it('sets auto increment fields', function(done) {
       var User = this.sequelize.define('UserWithAutoIncrementField', {
         userid: { type: Sequelize.INTEGER, autoIncrement: true, primaryKey: true, allowNull: false }


### PR DESCRIPTION
BIGINT support - 

BIGINT in postgres and mysql is 8 bytes.

Javascript stores numbers as a double, which does not have enough precision to represent an 8 byte integer value.

If you cast to/from a string you can store a large number successfully with patch. 

Not sure if this is the right way to go but I'm not doing math on these values, they are merely what I am receiving from a REST API (mailchimp) and I hated the idea of storing a 20 digit number as a VARCHAR when I'm only using it as an ID
