### PR TITLE
Added Model Table Name overrides

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -19,7 +19,11 @@ module.exports = (function() {
     }, options || {})
 
     this.name = name
-    this.tableName = this.options.freezeTableName ? name : Utils.pluralize(name)
+    if(!this.options.tableName) {
+      this.tableName = this.options.freezeTableName ? name : Utils.pluralize(name)
+    } else {
+      this.tableName = this.options.tableName
+    }
     this.rawAttributes = attributes
     this.daoFactoryManager = null // defined in init function
     this.associations = {}


### PR DESCRIPTION
Added a new optional variable within the model file called "tableName."  When this is used, the dao factory utilizes this name instead of trying to make the name itself.

```
if(!this.options.tableName) {
      this.tableName = this.options.freezeTableName ? name : Utils.pluralize(name)
} else {
      this.tableName = this.options.tableName
}
```
