### PR TITLE
Fix package.json to reflect true dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   ],
   "dependencies": {
     "mysql": "~2.0.0-alpha3",
+    "sqlite3": "~2.1.5",
+    "pg": "~0.8.7",
     "underscore": "~1.4.0",
     "underscore.string": "~2.3.0",
     "lingo": "~0.0.5",
@@ -33,8 +35,6 @@
   },
   "devDependencies": {
     "jasmine-node": "1.0.17",
-    "sqlite3": "~2.1.5",
-    "pg": "~0.8.7",
     "buster": "~0.6.0",
     "dox-foundation": "~0.3.0",
     "watchr": "~2.2.0"


### PR DESCRIPTION
Even though sqlite and postgres may be considered experimental, if they are not included as actual dependencies in sequelize's package.json file, they will not get included as part of the dependency tree of a project using a package.json file + npm install.

Without them being declared properly, sequelize -m does not work, because it fails to find the modules. Therefore, they are not "only" being used for dev (like a test suite), but should instead be full dependencies (that a user may optionally use or not). 
