### PR TITLE
don't throw in a callback

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -46,6 +46,7 @@ module.exports = (function() {
 
   ConnectorManager.prototype.connect = function() {
     var self = this
+    var emitter = new (require('events').EventEmitter)()
 
     // in case database is slow to connect, prevent orphaning the client
     if (this.isConnecting) return
@@ -58,7 +59,7 @@ module.exports = (function() {
       self.isConnecting = false
 
       if (!!err) {
-        throw err
+        emitter.emit('error', err)
       } else if (client) {
         client.query("SET TIME ZONE 'UTC'")
           .on('end', function() {
@@ -78,6 +79,8 @@ module.exports = (function() {
       this.client = new this.pg.Client(uri)
       this.client.connect(connectCallback)
     }
+
+    return emitter
   }
 
   ConnectorManager.prototype.disconnect = function() {


### PR DESCRIPTION
`connect()` returns an event emitter which can be used to handle errors
gracefully rather than throwing an error in callback which would
terminate the entire node process

see my comments on a previous closed issue:
https://github.com/sdepold/sequelize/pull/329

I ran the postgres tests before and after my changes.  I'm getting the same errors on both ends (see below).

I'm guessing one might want to duplicate this behavior into the other dialects.

Thanks.

```
 npm run test-buster-postgres                           

> sequelize@1.6.0-beta4 test-buster-postgres /Users/bjohnson/1on1/sequelize
> DIALECT=postgres ./node_modules/.bin/buster-test

[POSTGRES] HasMany: .............
[POSTGRES] DAO: ..........
[POSTGRES] Migration: .......
[POSTGRES] Migrator: { [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T
[POSTGRES] DAOFactory: ......................F......................................
[POSTGRES] BelongsTo: { [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T
[POSTGRES] DAO: ....................................................................
[POSTGRES] HasOne: .
[POSTGRES] Mixin: .
[POSTGRES] QueryChainer: ..........
[POSTGRES] Sequelize: { [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T

Deferred: [POSTGRES] Migrator migrations addColumn adds a column to the user table

Timeout: [POSTGRES] Migrator migrations executions executes migration #20111117063700 and correctly creates the table
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations executions executes migration #20111117063700 and correctly adds isBetaMember
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations executions executes migration #20111117063700 correctly up (createTable) and downwards (dropTable)
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations executions executes the empty migration #20111130161100
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations renameTable executes migration #20111205064000 and renames a table
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations removeColumn removes the shopId column from user
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations changeColumn changes the signature column from user to default "signature" + notNull
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns no files if timestamps are after the files timestamp
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns only files between from and to
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns all files to options.to if no options.from is defined
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns exactly the migration which is defined in from and to
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns also the file which is exactly options.from or options.to
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns all files from last migration id stored in database
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator renameColumn renames the signature column from user to sig
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator as
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] BelongsTo setAssociation clears the association if null is passed
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize isDefined returns false if the dao wasn't defined before
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize isDefined returns true if the dao was defined before
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query executes a query the internal way
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query executes a query if only the sql is passed
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query executes select queries correctly
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query executes stored procedures
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query uses the passed DAOFactory
    -> setUp
    TimeoutError: Timed out after 1000ms

Failure: [POSTGRES] DAOFactory create stores the current date in createdAt
    [assert.equals] 271397866 expected to be equal to 271392826
    at before.User.create.username (./spec/dao-factory.spec.js:357:48)
    at EventEmitter.emit (events.js:96:17)
    at module.exports.queryAndEmit (./lib/query-interface.js:267:17)
    at EventEmitter.emit (events.js:126:20)
    at module.exports.onSuccess (./lib/dialects/postgres/query.js:76:12)
    at module.exports.Query.run (./lib/dialects/postgres/query.js:46:17)

11 test cases, 194 tests, 325 assertions, 1 failure, 0 errors, 23 timeouts, 1 deferred
Finished in 28.555s
npm ERR! sequelize@1.6.0-beta4 test-buster-postgres: `DIALECT=postgres ./node_modules/.bin/buster-test`
npm ERR! `sh "-c" "DIALECT=postgres ./node_modules/.bin/buster-test"` failed with 1
npm ERR! 
npm ERR! Failed at the sequelize@1.6.0-beta4 test-buster-postgres script.
npm ERR! This is most likely a problem with the sequelize package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     DIALECT=postgres ./node_modules/.bin/buster-test
npm ERR! You can get their info via:
npm ERR!     npm owner ls sequelize
npm ERR! There is likely additional logging output above.

npm ERR! System Darwin 12.2.0
npm ERR! command "/usr/local/Cellar/node/0.8.16/bin/node" "/usr/local/bin/npm" "run" "test-buster-postgres"
npm ERR! cwd /Users/bjohnson/1on1/sequelize
npm ERR! node -v v0.8.16
npm ERR! npm -v 1.1.69
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/bjohnson/1on1/sequelize/npm-debug.log
npm ERR! not ok code 0
╭─bjohnson@bjohnson-MBP  ~/1on1/sequelize  ‹master*› 
╰─$                                                                                                   1 ↵
╭─bjohnson@bjohnson-MBP  ~/1on1/sequelize  ‹master*› 
╰─$ git diff                                                                                          1 ↵
╭─bjohnson@bjohnson-MBP  ~/1on1/sequelize  ‹master*› 
╰─$ npm run test-buster-postgres

> sequelize@1.6.0-beta4 test-buster-postgres /Users/bjohnson/1on1/sequelize
> DIALECT=postgres ./node_modules/.bin/buster-test

[POSTGRES] DAO: ..........
[POSTGRES] HasOne: .
[POSTGRES] Sequelize: { [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T
[POSTGRES] QueryChainer: ..........
[POSTGRES] DAOFactory: ......................................................F......
[POSTGRES] HasMany: .............
[POSTGRES] DAO: ....................................................................
[POSTGRES] Migration: .......
[POSTGRES] Migrator: { [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T{ [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T
[POSTGRES] Mixin: .
[POSTGRES] BelongsTo: { [Error: ER_BAD_DB_ERROR: Unknown database 'sequelize_test'] code: 'ER_BAD_DB_ERROR', fatal: true }
T

Deferred: [POSTGRES] Migrator migrations addColumn adds a column to the user table

Timeout: [POSTGRES] Sequelize query executes a query the internal way
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query executes select queries correctly
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query executes a query if only the sql is passed
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query executes stored procedures
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize query uses the passed DAOFactory
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize isDefined returns false if the dao wasn't defined before
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Sequelize isDefined returns true if the dao was defined before
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns no files if timestamps are after the files timestamp
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns exactly the migration which is defined in from and to
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns only files between from and to
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns also the file which is exactly options.from or options.to
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns all files to options.to if no options.from is defined
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator getUndoneMigrations returns all files from last migration id stored in database
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations executions executes migration #20111117063700 and correctly creates the table
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations executions executes migration #20111117063700 and correctly adds isBetaMember
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations executions executes migration #20111117063700 correctly up (createTable) and downwards (dropTable)
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations executions executes the empty migration #20111130161100
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations renameTable executes migration #20111205064000 and renames a table
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations changeColumn changes the signature column from user to default "signature" + notNull
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator migrations removeColumn removes the shopId column from user
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator renameColumn renames the signature column from user to sig
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] Migrator as
    -> setUp
    TimeoutError: Timed out after 1000ms

Timeout: [POSTGRES] BelongsTo setAssociation clears the association if null is passed
    -> setUp
    TimeoutError: Timed out after 1000ms

Failure: [POSTGRES] DAOFactory create stores the current date in createdAt
    [assert.equals] 271397892 expected to be equal to 271392852
    at before.User.create.username (./spec/dao-factory.spec.js:357:48)
 + .g/COMMIT_EDITMSG                                                                                      
    at EventEmitter.emit (events.js:96:17)
    at module.exports.queryAndEmit (./lib/query-interface.js:267:17)
    at EventEmitter.emit (events.js:126:20)
    at module.exports.onSuccess (./lib/dialects/postgres/query.js:76:12)
    at module.exports.Query.run (./lib/dialects/postgres/query.js:46:17)

11 test cases, 194 tests, 316 assertions, 1 failure, 0 errors, 23 timeouts, 1 deferred
Finished in 28.256s
npm ERR! sequelize@1.6.0-beta4 test-buster-postgres: `DIALECT=postgres ./node_modules/.bin/buster-test`
npm ERR! `sh "-c" "DIALECT=postgres ./node_modules/.bin/buster-test"` failed with 1
npm ERR! 
npm ERR! Failed at the sequelize@1.6.0-beta4 test-buster-postgres script.
npm ERR! This is most likely a problem with the sequelize package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     DIALECT=postgres ./node_modules/.bin/buster-test
npm ERR! You can get their info via:
npm ERR!     npm owner ls sequelize
npm ERR! There is likely additional logging output above.

npm ERR! System Darwin 12.2.0
npm ERR! command "/usr/local/Cellar/node/0.8.16/bin/node" "/usr/local/bin/npm" "run" "test-buster-postgres"
npm ERR! cwd /Users/bjohnson/1on1/sequelize
npm ERR! node -v v0.8.16
npm ERR! npm -v 1.1.69
npm ERR! code ELIFECYCLE
npm ERR! 
npm ERR! Additional logging details can be found in:
npm ERR!     /Users/bjohnson/1on1/sequelize/npm-debug.log
npm ERR! not ok code 0
```
