### PR TITLE
Fix issue with incorrect migrations in SequelizeMeta getting deleted when reverting

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -218,7 +218,7 @@ module.exports = (function() {
 
     self.findOrCreateSequelizeMetaDAO().success(function(SequelizeMeta) {
       SequelizeMeta
-        .find({ where: { from: from.migrationId, to: to.migrationId } })
+        .find({ where: { from: from.migrationId.toString(), to: to.migrationId.toString() } })
         .success(function(meta) {
           meta.destroy().success(callback)
         })


### PR DESCRIPTION
This fixes two scenarios (tested in PostgreSQL and SQLite):

1) When performing one off migrations using `sequelize -m` after each new migration if you revert a migration using `sequelize -m -u` the earliest record in the SequelizeMeta table gets deleted instead of the latest record (which corresponds to the reverted migration).

2) When performing multiple migrations using `sequelize -m` if you revert the multiple migrations using `sequelize -m -u` the earliest records in the SequelizeMeta table get deleted instead of the latest records (ie if 2 migrations were reverted the earliest 2 will be deleted instead of the last 2 corresponding to the reverted migrations).

Both of these scenarios are apparent when trying to run `sequelize -m` again after `sequelize -m -u`  to re-run the reverted migration(s) since the SequelizeMeta table shows the latest script has been run.
