### PR TITLE
Only load .js files from the migrations directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ test*.js
 .DS_STORE
 node_modules
 npm-debug.log
+*~

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -93,7 +93,9 @@ module.exports = (function() {
       callback && callback(null, result)
     }
 
-    var migrationFiles = fs.readdirSync(this.options.path)
+    var migrationFiles = fs.readdirSync(this.options.path).filter(function(file) {
+      return /\.js$/.test(file)
+    })
 
     var migrations = migrationFiles.map(function(file) {
       return new Migration(self, self.options.path + '/' + file)


### PR DESCRIPTION
For the record tests are failing, but they were failing when I forked the repo so it's not my fault. I tested migrations manually and this patch does indeed work as expected.
