### PR TITLE
make findOrCreate return additional flag so the callback knows if the re...

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -270,7 +270,7 @@ module.exports = (function() {
 
           self.create(params)
 	    .success(function (instance) {
-              emitter.emit('success', instance)
+              emitter.emit('success', instance, true)
             })
 	    .error( function (error) {
               emitter.emit('error', error)


### PR DESCRIPTION
currently there's no way to tell if a record is existing or newly created in the callback of findOrCreate 
