### PR TITLE
Migrations - renameColumn: Unhandled error if field name doesn't exist

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -133,7 +133,7 @@ module.exports = (function() {
 
     return new Utils.CustomEventEmitter(function(emitter) {
       self.describeTable(tableName).success(function(data) {
-        data = data.filter(function(h) { return h.Field == attrNameBefore })[0]
+        data = data.filter(function(h) { return h.Field == attrNameBefore })[0] || {}
 
         var options =  {}
 


### PR DESCRIPTION
When trying to run a migration that includes a renameColumn call the sequelize binary throws a `TypeError: Cannot read property 'Type' of undefined` error on lib/query-interface.js:141. This is caused by the previous data.filter function not finding any match and so data becomes undefined. The renameColumn method should handle this case a little better.
