### PR TITLE
Fix missing foreign key attribute in BelongsTo.

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -27,7 +27,7 @@ module.exports = (function() {
     Utils._.defaults(this.source.rawAttributes, newAttributes)
 
     // Sync attributes to DAO proto each time a new assoc is added
-    this.target.DAO.prototype.attributes = Object.keys(this.target.DAO.prototype.rawAttributes);
+    this.source.DAO.prototype.attributes = Object.keys(this.source.DAO.prototype.rawAttributes);
 
     return this
   }


### PR DESCRIPTION
- the injectAttributes method should update the source DAO as that's
  where the foreign key is.
