### PR TITLE
Add ability to add behavior to a model

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -81,7 +81,16 @@ module.exports = (function() {
 
     this.DAO.addBehavior = function(behavior) {
       Utils._.each(behavior.prototype, function(fct, name) {
-        self.DAO.prototype[name] = fct
+        if (self.DAO.prototype[name]) {
+          var oldFunc = self.DAO.prototype[name];
+          self.DAO.prototype[name] = function() {
+            var args = Array.prototype.slice.call(arguments)
+            args.push(oldFunc)
+            return fct.apply(this, args)
+          }
+        } else {
+          self.DAO.prototype[name] = fct
+        }
       })
     }
 
@@ -130,7 +139,16 @@ module.exports = (function() {
     this.DAO.addBehavior(behavior);
     var self = this;
     Utils._.functions(behavior).forEach(function(name) {
-      self[name] = behavior[name];
+      if (self[name]) {
+        var oldFunc = self[name];
+        self[name] = function() {
+          var args = Array.prototype.slice.call(arguments)
+          args.push(oldFunc)
+          return behavior[name].apply(this, args)
+        }
+      } else {
+        self[name] = behavior[name];
+      }
     });
   }
 

--- a/spec/dao-factory.spec.js
+++ b/spec/dao-factory.spec.js
@@ -61,6 +61,9 @@ describe(Helpers.getTestDialectTeaser("DAOFactory"), function() {
       MyBehavior.prototype.bar = function() {
         return 'bar'
       }
+      MyBehavior.drop = function(oldDropFunction) {
+        return oldDropFunction;
+      }
       var User = this.sequelize.define('UserWithBehavior', {});
       User.addBehavior(MyBehavior);
 
@@ -70,6 +73,7 @@ describe(Helpers.getTestDialectTeaser("DAOFactory"), function() {
       expect(User.build().foo).toEqual(true)
       expect(User.build().bar).toBeDefined()
       expect(User.build().bar()).toEqual('bar')
+      expect(User.drop()).toBeFunction();
     })
 
     it("throws an error if 2 autoIncrements are passed", function() {


### PR DESCRIPTION
How to reuse code across several models? The fact that `classMethods` and `instanceMethods` get attached to the `DAO` during the call to `sequelize.define()` makes it very difficult. This commit allows to reuse methods from an object, as follows:

``` js
var User = this.sequelize.define('UserWithBehavior', {});

var myBehavior = function() {
  this.foo = true;
}
myBehavior.hello = function() {
  return "world";
}
myBehavior.prototype.bar = function() {
  return 'baz';
}

User.addBehavior(myBehavior);

User.hello(); // 'world'
var user = User.build();
user.foo; // true
user.bar(); // 'baz'
```
