### PR TITLE
Explicitly target ./docs folder for generate-docs script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test-buster-postgres": "DIALECT=postgres ./node_modules/.bin/buster-test",
     "test-buster-postgres-native": "DIALECT=postgres-native ./node_modules/.bin/buster-test",
     "test-buster-sqlite": "DIALECT=sqlite ./node_modules/.bin/buster-test",
-    "generate-docs": "node_modules/.bin/dox-foundation --source ./lib --title Sequelize"
+    "generate-docs": "node_modules/.bin/dox-foundation --source ./lib --target ./docs --title Sequelize"
   },
   "bin": {
     "sequelize": "bin/sequelize"


### PR DESCRIPTION
The current script for `generate-docs` doesn't explicitly set the target folder (it defaults to ./docs on most systems, but not in all cases). Small fix, but should help new users get the docs up and running with fewer steps.
