### PR TITLE
On a one-to-many relationship without a join table, the foreign key identifier should always be on the many table.

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -154,11 +154,16 @@ module.exports = (function() {
               query += Utils.addTicks(dao.tableName) + '.'
               query += Utils.addTicks('id') + '='
               query += Utils.addTicks(association.connectorDAO.tableName) + '.' + Utils.addTicks(association.identifier)
+            } else if (association.associationType === 'BelongsTo') {
+              query += ' LEFT OUTER JOIN ' + Utils.addTicks(dao.tableName) + ' ON '
+              query += Utils.addTicks(dao.tableName) + '.'
+              query += Utils.addTicks(association.identifier) + '='
+              query += Utils.addTicks(tableName) + '.' + Utils.addTicks('id')
             } else {
               query += ' LEFT OUTER JOIN ' + Utils.addTicks(dao.tableName) + ' ON '
-              query += Utils.addTicks(association.associationType === 'BelongsTo' ? dao.tableName : tableName) + '.'
-              query += Utils.addTicks(association.identifier) + '='
-              query += Utils.addTicks(association.associationType === 'BelongsTo' ? tableName : dao.tableName) + '.' + Utils.addTicks('id')
+              query += Utils.addTicks(tableName) + '.'
+              query += Utils.addTicks('id') + '='
+              query += Utils.addTicks(dao.tableName) + '.' + Utils.addTicks(association.identifier)
             }
 
             var aliasAssoc = daoFactory.getAssociationByAlias(daoName)


### PR DESCRIPTION
On a one-to-many relationship without a join table, the foreign key identifier should always be on the many table. Alternative fix could be to look up the other association and grab the foreign key from there, but this works for now and seems appropriate.
