### PR TITLE
Mutiple calls to define with the same daoName add duplicate factory entry

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -145,6 +145,11 @@ module.exports = (function() {
     }
     options.omitNull = globalOptions.omitNull
 
+    // if you call "define" multiple times for the same daoName, do not clutter the factory
+    if(this.isDefined(daoName)) {
+        this.daoFactoryManager.removeDAO(this.daoFactoryManager.getDAO(daoName))
+    }
+
     var factory = new DAOFactory(daoName, attributes, options)
     this.daoFactoryManager.addDAO(factory.init(this.daoFactoryManager))
     return factory

--- a/spec/dao-factory.spec.js
+++ b/spec/dao-factory.spec.js
@@ -36,6 +36,16 @@ describe(Helpers.getTestDialectTeaser("DAOFactory"), function() {
       expect(User.tableName).toEqual('SuperUsers')
     })
 
+    it("uses checks to make sure dao factory isnt leaking on multiple define", function() {
+      var User = this.sequelize.define('SuperUser', {}, { freezeTableName: false })
+      var factorySize = this.sequelize.daoFactoryManager.all.length
+
+      var User2 = this.sequelize.define('SuperUser', {}, { freezeTableName: false })   
+      var factorySize2 = this.sequelize.daoFactoryManager.all.length
+
+      expect(factorySize).toEqual(factorySize2)
+    })
+
     it("attaches class and instance methods", function() {
       var User = this.sequelize.define('UserWithClassAndInstanceMethods', {}, {
         classMethods: { doSmth: function(){ return 1 } },


### PR DESCRIPTION
This will stop the factory leaking DAO's if define is called more than once with the same name. Also included a new test to perform factory size comparisons.

I utilized existing defined methods, but this functionality could thrown deeper into dao-factory-manager. Let me know if there are any issues here, otherwise I'd love to get this little ditty into 1.6, since it's just leak protection.

All tests pass.
