### PR TITLE
Adds GitHub repository and issue tracking URLs to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,13 @@
       "email": "jam@innofluence.com"
     }
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sdepold/sequelize.git"
+  },
+  "bugs": {
+    "url": "https://github.com/sdepold/sequelize/issues"
+  },
   "dependencies": {
     "underscore": "~1.4.0",
     "underscore.string": "~2.3.0",


### PR DESCRIPTION
I just wanted the GitHub URL to appear on here:

https://npmjs.org/package/sequelize

Thanks,

Alex
