### PR TITLE
fixed Utils.addTicks

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -171,7 +171,6 @@ module.exports = (function() {
             return Utils.addTicks(grp);
           }).join(".");
         }
-        options.group = Array.isArray(options.group) ? options.group.map(function(grp){return Utils.addTicks(grp)}).join(', ') : Utils.addTicks(options.group)
         query += " GROUP BY <%= group %>"
       }
 


### PR DESCRIPTION
In previous version, Utils.addTicks method wraps parameter string around Utils.TICK_CHAR whether parameter string has dot (has table name) or not.
so now I fixed this problem. would you like to add this to your code?

before:

```
Foo.findAll({ group: "`foo`.`baz`"}) // => SELECT * FROM `foo` GROUP BY `foo.baz`
```

after (i fixed):

```
Foo.findAll({ group: "`foo`.`baz`"}) // => SELECT * FROM `foo` GROUP BY `foo`.`baz`
```

_edit by janmeier - code formatting_
