### PR TITLE
Added field to custom validator functions

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -208,7 +208,7 @@ module.exports = (function() {
           // is it a custom validator function?
           if (Utils._.isFunction(details)) {
             is_custom_fn = true
-            fn_method = Utils._.bind(details, self, value)
+            fn_method = Utils._.bind(details, self, value, field)
           }
           // is it a validator module function?
           else {

--- a/spec/dao.validations.spec.js
+++ b/spec/dao.validations.spec.js
@@ -260,9 +260,9 @@ describe(Helpers.getTestDialectTeaser("DAO"), function() {
         name: {
           type: Sequelize.STRING,
           validate: {
-            customFn: function(val) {
+            customFn: function(val, field) {
               if (val !== "2") {
-                throw new Error("name should equal '2'")
+                throw new Error("Should equal '2': " + field)
               }
             }
           }
@@ -273,7 +273,7 @@ describe(Helpers.getTestDialectTeaser("DAO"), function() {
         , errors      = failingUser.validate()
 
       expect(errors).not.toBeNull(null)
-      expect(errors).toEqual({ name: ["name should equal '2'"] })
+      expect(errors).toEqual({ name: ["Should equal '2': name"] })
 
       var successfulUser = User.build({ name : "2" })
       expect(successfulUser.validate()).toBeNull()


### PR DESCRIPTION
When defining custom validators, the field is never added. This makes it difficult to return proper error messages, especially since [in the DAO](https://github.com/sequelize/sequelize/blob/master/lib/dao.js#L234-L235), it doesn't return the field if its a custom function:

``` javascript
if (!fn_msg && !is_custom_fn)
  err += ": " + field
```
