### PR TITLE
CustomEventEmitter: Remove setTimeout in favor of process.nextTick()

### DIFF
--- a/lib/emitters/custom-event-emitter.js
+++ b/lib/emitters/custom-event-emitter.js
@@ -1,12 +1,12 @@
 var util         = require("util")
-  , EventEmitter = require("events").EventEmitter
+  , EventEmitter = require("events").EventEmitter;
 
 module.exports = (function() {
   var CustomEventEmitter = function(fct) {
     this.fct = fct;
     var self = this;
   }
-  util.inherits(CustomEventEmitter, EventEmitter)
+  util.inherits(CustomEventEmitter, EventEmitter);
 
   CustomEventEmitter.prototype.run = function() {
     var self = this;
@@ -23,26 +23,26 @@ module.exports = (function() {
   CustomEventEmitter.prototype.success =
   CustomEventEmitter.prototype.ok =
   function(fct) {
-    this.on('success', fct)
-    return this
+    this.on('success', fct);
+    return this;
   }
 
   CustomEventEmitter.prototype.failure =
   CustomEventEmitter.prototype.fail =
   CustomEventEmitter.prototype.error =
   function(fct) {
-    this.on('error', fct)
-    return this
+    this.on('error', fct);
+    return this;
   }
 
   CustomEventEmitter.prototype.done =
   CustomEventEmitter.prototype.complete =
   function(fct) {
     this.on('error', function(err) { fct(err, null) })
-        .on('success', function(result) { fct(null, result) })
-    return this
+        .on('success', function(result) { fct(null, result) });
+    return this;
   }
 
 
-  return CustomEventEmitter
-})()
+  return CustomEventEmitter;
+})();


### PR DESCRIPTION
According to [process.nextTick() documentation](http://nodejs.org/api/process.html#process_process_nexttick_callback), using setTimeout is not recommended:

```
On the next loop around the event loop call this callback. This is not a simple alias to setTimeout(fn, 0), it's much more efficient.
```

I'm not sure why you didn't use `nextTick()` yet, so if it was intended, please close :)
I'm currently testing this change and it seems to work better than with setTimeout.

What I'm unsure is the run function - it's not needed anymore imho.
