### PR TITLE
Option to change file type regex filter in Migrator instances

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -12,7 +12,8 @@ module.exports = (function() {
       path: __dirname + '/../migrations',
       from: null,
       to: null,
-      logging: console.log
+      logging: console.log,
+      filesFilter: /\.js$/
     }, options || {})
 
     if (this.options.logging === true) {
@@ -96,7 +97,7 @@ module.exports = (function() {
     }
 
     var migrationFiles = fs.readdirSync(this.options.path).filter(function(file) {
-      return /\.js$/.test(file)
+      return self.options.filesFilter.test(file)
     })
 
     var migrations = migrationFiles.map(function(file) {


### PR DESCRIPTION
Enables coffee-script files to be loaded in migrations when using the class programatically. 
