### PR TITLE
allow running of [jasmine] tests against MySQL instance ...

### DIFF
--- a/spec-jasmine/associations/belongs-to.spec.js
+++ b/spec-jasmine/associations/belongs-to.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('BelongsTo', function() {

--- a/spec-jasmine/associations/has-many.spec.js
+++ b/spec-jasmine/associations/has-many.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('HasMany', function() {
@@ -10,7 +10,7 @@ describe('HasMany', function() {
     , Helpers   = null
 
   var setup = function() {
-    sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+    sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
     Helpers   = new (require("../config/helpers"))(sequelize)
 
     Helpers.dropAllTables()

--- a/spec-jasmine/associations/has-one.spec.js
+++ b/spec-jasmine/associations/has-one.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('HasOne', function() {

--- a/spec-jasmine/dao.spec.js
+++ b/spec-jasmine/dao.spec.js
@@ -13,7 +13,8 @@ describe('DAO', function() {
             {
               logging: false,
               dialect: dialect,
-              port: config[dialect].port
+              port: config[dialect].port,
+              host: config[dialect].host
             }
           )
         , Helpers   = new (require("./config/helpers"))(sequelize)

--- a/spec-jasmine/mysql/associations.has-many.spec.js
+++ b/spec-jasmine/mysql/associations.has-many.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('HasMany', function() {

--- a/spec-jasmine/mysql/associations.spec.js
+++ b/spec-jasmine/mysql/associations.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('Associations', function() {

--- a/spec-jasmine/mysql/connector-manager.spec.js
+++ b/spec-jasmine/mysql/connector-manager.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('ConnectorManager', function() {

--- a/spec-jasmine/mysql/dao-factory.spec.js
+++ b/spec-jasmine/mysql/dao-factory.spec.js
@@ -1,6 +1,6 @@
 var config    = require("../config/config")
   , Sequelize = require("../../index")
-  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers   = new (require("../config/helpers"))(sequelize)
 
 describe('DAOFactory', function() {

--- a/spec-jasmine/mysql/query-generator.spec.js
+++ b/spec-jasmine/mysql/query-generator.spec.js
@@ -1,6 +1,6 @@
 var config         = require("../config/config")
   , Sequelize      = require("../../index")
-  , sequelize      = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false })
+  , sequelize      = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, { pool: config.mysql.pool, logging: false, host: config.mysql.host, port: config.mysql.port })
   , Helpers        = new (require("../config/helpers"))(sequelize)
   , QueryGenerator = require("../../lib/dialects/mysql/query-generator")
   , util           = require("util")

--- a/spec-jasmine/sequelize.spec.js
+++ b/spec-jasmine/sequelize.spec.js
@@ -8,7 +8,17 @@ describe('Sequelize', function() {
 
 
   var setup = function(options) {
-    options   = options || {logging: false}
+    options   = options || {}
+
+    if (!options.hasOwnProperty('pool'))
+      options.pool = config.mysql.pool
+    if (!options.hasOwnProperty('logging'))
+      options.logging = false
+    if (!options.hasOwnProperty('host'))
+      options.host = config.mysql.host
+    if (!options.hasOwnProperty('port'))
+      options.port = config.mysql.port
+
     sequelize = new Sequelize(config.mysql.database, config.mysql.username, config.mysql.password, options)
     Helpers   = new (require("./config/helpers"))(sequelize)
 


### PR DESCRIPTION
... that is either not local or requires connection via a socket. 

the PR makes it possible to set the 'port' option to a socket path and have the jasmine tests work (i.e. the mysql 'port' and 'host' options in `spec-jasmine/config/config` are now honored)
