### PR TITLE
Can't run raw UPDATE query with RETURNING statement  on postgresql

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -106,15 +106,7 @@ module.exports = (function() {
       }
     } else if (this.send('isShowOrDescribeQuery')) {
       this.emit('success', results)
-    } else if (this.send('isInsertQuery')) {
-      for (var key in rows[0]) {
-        if (rows[0].hasOwnProperty(key)) {
-          this.callee[key] = rows[0][key]
-        }
-      }
-
-      this.emit('success', this.callee)
-    } else if (this.send('isUpdateQuery')) {
+    } else if (this.send('isInsertQuery') || this.send('isUpdateQuery')) {
       if (this.callee) {
         for (var key in rows[0]) {
           if (rows[0].hasOwnProperty(key)) {


### PR DESCRIPTION
When running this:

`UPDATE stuff SET thing = 6 WHERE id = 10 RETURNING thing;`

The app crashes, returning a 500 error with message:

`"Cannot set property 'thing' of undefined"`

This happens because with a raw query `callee` is undefined in this line: https://github.com/sequelize/sequelize/blob/master/lib/dialects/postgres/query.js#L120

I'm trying to find a solution for this.
