### PR TITLE
Update the generated migration skeleton for async

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -145,11 +145,11 @@ if(program.migrate) {
 
   var migrationContent = [
     "module.exports = {",
-    "  up: function(migration, DataTypes) {",
-    "    // add altering commands here",
+    "  up: function(migration, DataTypes, done) {",
+    "    // add altering commands here, calling 'done' when finished",
     "  },",
-    "  down: function(migration) {",
-    "    // add reverting commands here",
+    "  down: function(migration, DataTypes, done) {",
+    "    // add reverting commands here, calling 'done' when finished",
     "  }",
     "}"
   ].join('\n')


### PR DESCRIPTION
The auto-generated migrations don't mention done which is confusing if you're new to sequelize and you've got a background in Rails.

This branch changes the migration skeletons generated by the sequelize executable. Fixes issue #566.

Before it was:

```
module.exports = {
  up: function(migration, DataTypes) {
    // add altering commands here
  },
  down: function(migration) {
    // add reverting commands here
  }
}
```

and this change will make it:

```
module.exports = {
  up: function(migration, DataTypes, done) {
    // add altering commands here, calling 'done' when finished
  },
  down: function(migration, DataTypes, done) {
    // add reverting commands here, calling 'done' when finished
  }
}
```
