### PR TITLE
Performance improvements for MySQL query generator

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -213,7 +213,6 @@ module.exports = (function() {
       }
 
       query += ";"
-      // console.log(query)
 
       return query
     },
@@ -246,8 +245,7 @@ module.exports = (function() {
 
       var query = "UPDATE " + QueryGenerator.addQuotes(tableName) +
                   " SET " + values.join(",") +
-                  " WHERE " + QueryGenerator.getWhereConditions(where) +
-                  ";"
+                  " WHERE " + QueryGenerator.getWhereConditions(where)
 
       return query
     },


### PR DESCRIPTION
Change important MySQL query generator functions from using _.template to string concatenation. This has a large performance impact when doing many queries and having big result sets (attributesToSQL function).

We experienced a 20-30% performance boost when doing queries with large result sets in parallel.
