### PR TITLE
Updated copy in docs for new DBs and Github URL

### DIFF
--- a/js/templates/documentation/index.html
+++ b/js/templates/documentation/index.html
@@ -6,7 +6,7 @@
         <small>A multi-dialect Object-Relational-Mapper for Node.JS</small>
       </h1>
       <p class="lead">
-        The Sequelize library provides easy access to a MySQL database by mapping database entries to objects and vice versa. To put it in a nutshell... it's an ORM (Object-Relational-Mapper). The library is written entirely in JavaScript and can be used in the Node.JS environment.
+        The Sequelize library provides easy access to MySQL, SQLite, and PostgreSQL databases by mapping database entries to objects and vice versa. To put it in a nutshell... it's an ORM (Object-Relational-Mapper). The library is written entirely in JavaScript and can be used in the Node.JS environment.
       </p>
     </div>
   </div>

--- a/js/templates/documentation/sections/installation.html
+++ b/js/templates/documentation/sections/installation.html
@@ -20,7 +20,7 @@
       <pre><code class="language-javascript">
         // Checkout the current code from the repository using the commandline
         cd path/to/lib
-        git clone git://github.com/sdepold/sequelize.git
+        git clone git://github.com/sequelize/sequelize.git
 
         // Then require the installed library in your application code:
         var Sequelize = require(__dirname + "/lib/sequelize/index")


### PR DESCRIPTION
As was spotted by @optilude, since we can now use SQLite and PostgreSQL they should be included in the docs. Also the Github URL was updated since it was included in the docs.

This fixes #570 
