### PR TITLE
'ORDER BY' should come after 'GROUP BY'

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -262,13 +262,6 @@ module.exports = (function() {
         query += " WHERE <%= where %>"
       }
 
-      if(options.order) {
-        options.order = options.order.replace(/([^ ]+)(.*)/, function(m, g1, g2) {
-          return QueryGenerator.addQuotes(g1) + g2
-        })
-        query += " ORDER BY <%= order %>"
-      }
-
       if(options.group) {
         if (Array.isArray(options.group)) {
           options.group = options.group.map(function(grp){
@@ -279,6 +272,13 @@ module.exports = (function() {
         }
 
         query += " GROUP BY <%= group %>"
+      }
+
+      if(options.order) {
+        options.order = options.order.replace(/([^ ]+)(.*)/, function(m, g1, g2) {
+          return QueryGenerator.addQuotes(g1) + g2
+        })
+        query += " ORDER BY <%= order %>"
       }
 
       if (!(options.include && (options.limit === 1))) {


### PR DESCRIPTION
otherwise it generate an error like this one: 

{ [Error: syntax error at or near "GROUP"]
  severity: 'ERROR',
  code: '42601',
  position: '558',
  file: 'scan.l',
  line: '1001',
  routine: 'scanner_yyerror' }
