### PR TITLE
Fix string escape with postgresql on raw SQL queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,4 @@ test*.js
 .DS_STORE
 node_modules
 npm-debug.log
-spec/config/config.js
-spec-jasmine/config/config.js
 *~

--- a/spec-jasmine/config/config.js
+++ b/spec-jasmine/config/config.js
@@ -18,8 +18,7 @@ module.exports = {
 
   postgres: {
     database: 'sequelize_test',
-    username: "root",
-    password: "toor",
+    username: "postgres",
     port: 5432,
     pool: { maxConnections: 5, maxIdleTime: 30}
   }

--- a/spec/config/config.js
+++ b/spec/config/config.js
@@ -24,8 +24,7 @@ module.exports = {
 
   postgres: {
     database: 'sequelize_test',
-    username: "root",
-    password: "toor",
+    username: "postgres",
     port: 5432,
     pool: { maxConnections: 5, maxIdleTime: 30}
   }


### PR DESCRIPTION
In raw SQL queries (sequelize.query) the string escape is \ but for postgre it's ' (http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS).

**example:**

``` javascript
var sql = 'UPDATE "test" SET "value"= ? WHERE id = 1';
sequelize.query(sql, {}, null, "isn't a good string escape" );
```

give into sql:

``` sql
UPDATE "test" SET "value"= 'isn\'t a good string escape' WHERE id = 1
```

this request emit an error on postgre.

the request should be:

``` sql
UPDATE "test" SET "value"= 'isn''t a good string escape' WHERE id = 1
```
