### PR TITLE
Added deletedAt buster tests borrowed from @gustavpursche

### DIFF
--- a/spec-jasmine/dao-factory.spec.js
+++ b/spec-jasmine/dao-factory.spec.js
@@ -90,25 +90,6 @@ describe('DAOFactory', function() {
           })
         })
 
-        it('marks the database entry as deleted if dao is paranoid', function() {
-          Helpers.async(function(done) {
-            User = sequelize.define('User', {
-              name: Sequelize.STRING, bio: Sequelize.TEXT
-            }, { paranoid:true })
-            User.sync({ force: true }).success(done)
-          })
-
-          Helpers.async(function(done) {
-            User.create({ name: 'asd', bio: 'asd' }).success(function(u) {
-              expect(u.deletedAt).toBeNull()
-              u.destroy().success(function(u) {
-                expect(u.deletedAt).toBeTruthy()
-                done()
-              })
-            })
-          })
-        })
-
         it('allows sql logging of update statements', function() {
           Helpers.async(function(done) {
             User = sequelize.define('User', {

--- a/spec/dao.spec.js
+++ b/spec/dao.spec.js
@@ -31,10 +31,20 @@ describe(Helpers.getTestDialectTeaser("DAO"), function() {
           aNumber:   { type: DataTypes.INTEGER },
           aRandomId: { type: DataTypes.INTEGER }
         })
+
+        self.ParanoidUser = sequelize.define('ParanoidUser', {
+          username: { type: DataTypes.STRING }
+        }, {
+          paranoid: true
+        })
+
+        self.ParanoidUser.hasOne( self.ParanoidUser )
       },
       onComplete: function() {
         self.User.sync({ force: true }).success(function(){
-          self.HistoryLog.sync({ force: true }).success(done)
+          self.HistoryLog.sync({ force: true }).success(function(){
+            self.ParanoidUser.sync({force: true }).success(done)
+          })
         })
       }
     })
@@ -490,6 +500,51 @@ describe(Helpers.getTestDialectTeaser("DAO"), function() {
           expect(users[0].username).toBeDefined()
 
           done()
+        }.bind(this))
+      }.bind(this))
+    })
+
+    it("creates the deletedAt property, when defining paranoid as true", function(done) {
+      this.ParanoidUser.create({ username: 'fnord' }).success(function() {
+        this.ParanoidUser.findAll().success(function(users) {
+          expect(users[0].deletedAt).toBeDefined()
+          expect(users[0].deletedAt).toBe(null)
+          done()
+        }.bind(this))
+      }.bind(this))
+    })
+
+    it("sets deletedAt property to a specific date when deleting an instance", function(done) {
+      this.ParanoidUser.create({ username: 'fnord' }).success(function() {
+        this.ParanoidUser.findAll().success(function(users) {
+          users[0].destroy().success(function(user) {
+            expect(user.deletedAt.getMonth).toBeDefined()
+            done()
+          }.bind(this))
+        }.bind(this))
+      }.bind(this))
+    })
+
+    it("keeps the deletedAt-attribute with value null, when running updateAttributes", function(done) {
+      this.ParanoidUser.create({ username: 'fnord' }).success(function() {
+        this.ParanoidUser.findAll().success(function(users) {
+          users[0].updateAttributes({username: 'newFnord'}).success(function(user) {
+            expect(user.deletedAt).toBe(null)
+            done()
+          }.bind(this))
+        }.bind(this))
+      }.bind(this))
+    })
+
+    it("keeps the deletedAt-attribute with value null, when updating associations", function(done) {
+      this.ParanoidUser.create({ username: 'fnord' }).success(function() {
+        this.ParanoidUser.findAll().success(function(users) {
+          this.ParanoidUser.create({ username: 'linkedFnord' }).success(function( linkedUser ) {
+            users[0].setParanoidUser( linkedUser ).success(function(user) {
+              expect(user.deletedAt).toBe(null)
+              done()
+            }.bind(this))
+          }.bind(this))
         }.bind(this))
       }.bind(this))
     })


### PR DESCRIPTION
In connection with #545 @gustavpursche did a couple of extra tests for deletedAt. Basically just a copy-pasta from https://github.com/gustavpursche/sequelize/commit/13c98e6a8df1a58343ebc9ee540691948ffa06ec and deleted the corresponding jasmine test in a feeble attempt to reduce test duplication
