### PR TITLE
MySQL: Fix how empty `where` param makes bogus WHERE syntax.

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -416,7 +416,7 @@ module.exports = (function() {
         result = Utils.format(smth)
       }
 
-      return result
+      return result ? result : '1=1'
     },
 
     hashToWhereConditions: function(hash) {

--- a/spec-jasmine/mysql/query-generator.spec.js
+++ b/spec-jasmine/mysql/query-generator.spec.js
@@ -166,6 +166,26 @@ describe('QueryGenerator', function() {
         arguments: ['myTable', {offset: 2}],
         expectation: "SELECT * FROM `myTable`;",
         context: QueryGenerator
+      }, {
+        title: 'multiple where arguments',
+        arguments: ['myTable', {where: {boat: 'canoe', weather: 'cold'}}],
+        expectation: "SELECT * FROM `myTable` WHERE `myTable`.`boat`='canoe' AND `myTable`.`weather`='cold';",
+        context: QueryGenerator
+      }, {
+        title: 'no where arguments (object)',
+        arguments: ['myTable', {where: {}}],
+        expectation: "SELECT * FROM `myTable` WHERE 1;",
+        context: QueryGenerator
+      }, {
+        title: 'no where arguments (string)',
+        arguments: ['myTable', {where: ''}],
+        expectation: "SELECT * FROM `myTable` WHERE 1;",
+        context: QueryGenerator
+      }, {
+        title: 'no where arguments (null)',
+        arguments: ['myTable', {where: null}],
+        expectation: "SELECT * FROM `myTable` WHERE 1;",
+        context: QueryGenerator
       }
     ],
 


### PR DESCRIPTION
With an empty `where` param, it would generate `''` as the where parameters, which is not valid SQL. Now it returns `1=1` if instead of the empty string, as suggested by @muka in #606 (which this PR fixes).

Added failing MySQL tests for SelectQuery when the `where` is all kinds of empty and because I felt generous :stuck_out_tongue: there's also a new test in here for when you have multiple tuples in the `where` property (that one passed right away).
