### PR TITLE
Refactored sequelize binary (adding specification of config file)

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-var path = require("path")
-  , fs = require("fs")
-  , program = require("commander")
+var path      = require("path")
+  , fs        = require("fs")
+  , program   = require("commander")
   , Sequelize = require(__dirname + '/../index')
-  , moment = require("moment")
-  , _ = Sequelize.Utils._
+  , moment    = require("moment")
+  , _         = Sequelize.Utils._
 
 var configuration = {
   configFile: process.cwd() + '/config/config.json',


### PR DESCRIPTION
- Now allows the specification of a configuration file:
  -  `sequelize -m --config banana.json`
- Make the default JSON config file output look neater with less code 
  - (plus added a newline at EOF)
- Tucked configuration vars into an object so the values could be accessed in helper functions through reference frozen in their closures
- Created helper functions where code was duplicated
- Use `path#dirname` to eliminate the need to maintain a `configPath`
- Got rid of `configPathExists` and `configFileExists` variables, the caching advantage (of a whopping one subsequent call per execution, I think) wasn't worth the awkwardness of maintaining them once the config file became parameterized.
- Sprinkled a few more output messages in there that I noticed as I tested it

I guess the controversial part of this PR is that you can specify a configuration file. It was mentioned in a few other issues / PRs (#552 I think most recently). This approach won't break backwards compatibility so that gives a little more flexibility.

There are also a lot of changes in here. There is no test suite for the binary. I ran through each of the commands in the menu and I was getting the expected results. But it would be nice to have the comfort test coverage.

Fixes #581
