### PR TITLE
Added options when using connection string

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -47,7 +47,8 @@ module.exports = (function() {
     var urlParts
     options = options || {}
 
-    if (arguments.length === 1) {
+    if (arguments.length === 1 || (arguments.length === 2 && typeof username === 'object')) {
+      options = username || {}
       urlParts = url.parse(arguments[0])
       database = urlParts.path.replace(/^\//,  '')
       dialect = urlParts.protocol


### PR DESCRIPTION
Added options when using a connection string, like Heroku.
Based on #490 last comment, I had the same problem.

With this fix you can now configure sequelize options when using a connection string.
The second parameter will be validated as object to differentiate from a normal connection (db name, username).
