### PR TITLE
Issue #629: Attribute ambiguity issue when eagerly loading.

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -465,7 +465,6 @@ module.exports = (function() {
         result = QueryGenerator.hashToWhereConditions(smth)
       }
       else if (typeof smth === "number") {
-        smth = QueryGenerator.pgEscape(smth)
         smth = Utils.prependTableNameToHash(tableName, { id: smth })
         result = QueryGenerator.hashToWhereConditions(smth)
       }

--- a/spec-jasmine/postgres/query-generator.spec.js
+++ b/spec-jasmine/postgres/query-generator.spec.js
@@ -49,16 +49,16 @@ describe('QueryGenerator', function() {
         expectation: "SELECT \"id\", \"name\" FROM \"myTable\";"
       }, {
         arguments: ['myTable', {where: {id: 2}}],
-        expectation: "SELECT * FROM \"myTable\" WHERE \"id\"=2;"
+        expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"id\"=2;"
       }, {
         arguments: ['myTable', {where: {name: 'foo'}}],
-        expectation: "SELECT * FROM \"myTable\" WHERE \"name\"='foo';"
+        expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"name\"='foo';"
       }, {
         arguments: ['myTable', {where: {name: "foo';DROP TABLE myTable;"}}],
-        expectation: "SELECT * FROM \"myTable\" WHERE \"name\"='foo'';DROP TABLE myTable;';"
+        expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"name\"='foo'';DROP TABLE myTable;';"
       }, {
         arguments: ['myTable', {where: 2}],
-        expectation: "SELECT * FROM \"myTable\" WHERE \"id\"=2;"
+        expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"id\"=2;"
       }, {
         arguments: ['foo', { attributes: [['count(*)', 'count']] }],
         expectation: 'SELECT count(*) as \"count\" FROM \"foo\";'
@@ -92,7 +92,7 @@ describe('QueryGenerator', function() {
         expectation: "SELECT * FROM \"mySchema\".\"myTable\";"
       }, {
         arguments: ['mySchema.myTable', {where: {name: "foo';DROP TABLE mySchema.myTable;"}}],
-        expectation: "SELECT * FROM \"mySchema\".\"myTable\" WHERE \"name\"='foo'';DROP TABLE mySchema.myTable;';"
+        expectation: "SELECT * FROM \"mySchema\".\"myTable\" WHERE \"mySchema\".\"myTable\".\"name\"='foo'';DROP TABLE mySchema.myTable;';"
       }
     ],
 


### PR DESCRIPTION
I updated the postgres QueryGenerator to prepend table names to attributes in the where clause when doing a "select". This fixes the attribute ambiguity issue that you get when eager loading.
I followed the same pattern the MySQL QueryGenerator does to prepend the table name.

(I also removed to unneeded commas in the same file.)
