### PR TITLE
Enable the override of the default attributes

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -481,7 +481,9 @@ module.exports = (function() {
     }
 
     Utils._.each(defaultAttributes, function(value, attr) {
-      self.rawAttributes[attr] = value
+      if (Utils._.isUndefined(self.rawAttributes[attr])) {
+        self.rawAttributes[attr] = value
+      }
     })
   }
 

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -726,9 +726,15 @@ module.exports = (function() {
       }
 
       if (Utils._.includes(dataType, 'SERIAL')) {
-        dataType = dataType.replace(/INTEGER/, '')
+        if (Utils._.includes(dataType, 'BIGINT')) {
+          dataType = dataType.replace(/SERIAL/, 'BIGSERIAL')
+          dataType = dataType.replace(/BIGINT/, '')
+          tables[tableName][attr] = 'bigserial'
+        } else {
+          dataType = dataType.replace(/INTEGER/, '')
+          tables[tableName][attr] = 'serial'
+        }
         dataType = dataType.replace(/NOT NULL/, '')
-        tables[tableName][attr] = 'serial'
       }
 
       if (dataType.match(/^ENUM\(/)) {

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -76,6 +76,10 @@ module.exports = (function() {
         if (attributes.hasOwnProperty(attr)) {
           var dataType = attributes[attr]
 
+          if (Utils._.includes(dataType, 'AUTOINCREMENT')) {
+            dataType = dataType.replace(/BIGINT/, 'INTEGER')
+          }
+
           if (Utils._.includes(dataType, 'PRIMARY KEY') && needsMultiplePrimaryKeys) {
             primaryKeys.push(attr)
             attrStr.push(Utils.addTicks(attr) + " " + dataType.replace(/PRIMARY KEY/, 'NOT NULL'))

--- a/spec/sequelize.spec.js
+++ b/spec/sequelize.spec.js
@@ -194,5 +194,29 @@ describe(Helpers.getTestDialectTeaser("Sequelize"), function() {
         })
       })
     })
+
+    describe('table', function() {
+      [
+        { id: { type: Helpers.Sequelize.BIGINT } },
+        { id: { type: Helpers.Sequelize.STRING, allowNull: true } },
+        { id: { type: Helpers.Sequelize.BIGINT, allowNull: false, primaryKey: true, autoIncrement: true } }
+      ].forEach(function(customAttributes) {
+
+        it('should be able to override options on the default attributes', function(done) {
+          var Picture = this.sequelize.define('picture', Helpers.Sequelize.Utils._.cloneDeep(customAttributes))
+          Picture.sync({ force: true }).success(function() {
+            Object.keys(customAttributes).forEach(function(attribute) {
+              Object.keys(customAttributes[attribute]).forEach(function(option) {
+                var optionValue = customAttributes[attribute][option];
+                expect(Picture.rawAttributes[attribute][option]).toBe(optionValue)
+              });
+            })
+            done()
+          })
+        })
+
+      })
+    })
+
   })
 })


### PR DESCRIPTION
From what I understood the DAO factory adds some default attributes. In that process it adds the _id_ column with options suited to a traditional PK along with the Integer data type.

I wanted my id to have a different datatype but when I do the following:

``` js
sequelize.define('picture', {
      id : Sequelize.BIGINT
})
```

it does nothing, due to the way the addition of the default attributes. So I made some changes to support that.

Let me know what you think.
Cheers
