### PR TITLE
SQLite addQuotes is not correct

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -24,8 +24,17 @@ module.exports = (function() {
   var QueryGenerator = {
     options: {},
 
-    addQuotes: function(s, quoteChar) {
-      return Utils.addTicks(s, quoteChar)
+    removeQuotes: function (s, quoteChar) {
+      quoteChar = quoteChar || '`'
+      return s.replace(new RegExp(quoteChar, 'g'), '')
+    },
+
+    addQuotes: function (s, quoteChar) {
+      quoteChar = quoteChar || '`'
+      return QueryGenerator.removeQuotes(s, quoteChar)
+        .split('.')
+        .map(function(e) { return quoteChar + String(e) + quoteChar })
+        .join('.')
     },
 
     addSchema: function(opts) {
@@ -144,6 +153,74 @@ module.exports = (function() {
       }
 
       return Utils._.template(query)(replacements)
+    },
+    selectQuery: function(tableName, options) {
+      var table = null,
+          joinQuery = ""
+
+      options            = options || {}
+      options.table      = table = Array.isArray(tableName) ? tableName.map(function(tbl){ return QueryGenerator.addQuotes(tbl) }).join(", ") : QueryGenerator.addQuotes(tableName)
+      options.attributes = options.attributes && options.attributes.map(function(attr){
+        if(Array.isArray(attr) && attr.length == 2) {
+          return [attr[0], QueryGenerator.addQuotes(attr[1])].join(' as ')
+        } else {
+          return attr.indexOf(Utils.TICK_CHAR) < 0 ? QueryGenerator.addQuotes(attr) : attr
+        }
+      }).join(", ")
+      options.attributes = options.attributes || '*'
+
+      if (options.include) {
+        var optAttributes = options.attributes === '*' ? [options.table + '.*'] : [options.attributes]
+
+        options.include.forEach(function(include) {
+          var attributes = Object.keys(include.daoFactory.attributes).map(function(attr) {
+            return "`" + include.as + "`.`" + attr + "` AS `" + include.as + "." + attr + "`"
+          })
+
+          optAttributes = optAttributes.concat(attributes)
+
+          var table = include.daoFactory.tableName
+          var as = include.as
+          var tableLeft = ((include.association.associationType === 'BelongsTo') ? include.as : tableName)
+          var attrLeft = 'id'
+          var tableRight = ((include.association.associationType === 'BelongsTo') ? tableName : include.as)
+          var attrRight = include.association.identifier
+          joinQuery += " LEFT OUTER JOIN `" + table + "` AS `" + as + "` ON `" + tableLeft + "`.`" + attrLeft + "` = `" + tableRight + "`.`" + attrRight + "`"
+
+        })
+
+        options.attributes = optAttributes.join(', ')
+      }
+
+      var query = "SELECT " + options.attributes + " FROM " + options.table
+      query += joinQuery
+
+      if (options.hasOwnProperty('where')) {
+        options.where = this.getWhereConditions(options.where, tableName)
+        query += " WHERE " + options.where
+      }
+
+      if (options.group) {
+        options.group = Array.isArray(options.group) ? options.group.map(function(grp){return QueryGenerator.addQuotes(grp)}).join(', ') : QueryGenerator.addQuotes(options.group)
+        query += " GROUP BY " + options.group
+      }
+
+      if (options.order) {
+        query += " ORDER BY " + options.order
+      }
+
+
+      if (options.limit && !(options.include && (options.limit === 1))) {
+        if (options.offset) {
+          query += " LIMIT " + options.offset + ", " + options.limit
+        } else {
+          query += " LIMIT " + options.limit
+        }
+      }
+
+      query += ";"
+
+      return query
     },
 
     updateQuery: function(tableName, attrValueHash, where) {

--- a/spec/dao-factory.spec.js
+++ b/spec/dao-factory.spec.js
@@ -1116,7 +1116,7 @@ describe(Helpers.getTestDialectTeaser("DAOFactory"), function() {
 
           done();
         }.bind(this))
-      })  
+      })
 
       it("should return raw data when raw is true", function (done) {
         this.User.find({ where: { username: 'barfooz'}}, { raw: true }).done(function (err, user) {
@@ -1373,9 +1373,9 @@ describe(Helpers.getTestDialectTeaser("DAOFactory"), function() {
         it("should return a DAO when queryOptions are not set", function (done) {
           this.User.findAll({ where: { username: 'barfooz'}}).done(function (err, users) {
             users.forEach(function (user) {
-              expect(user).toHavePrototype(this.User.DAO.prototype)  
+              expect(user).toHavePrototype(this.User.DAO.prototype)
             }, this)
-            
+
 
             done();
           }.bind(this))
@@ -1384,17 +1384,17 @@ describe(Helpers.getTestDialectTeaser("DAOFactory"), function() {
         it("should return a DAO when raw is false", function (done) {
           this.User.findAll({ where: { username: 'barfooz'}}, { raw: false }).done(function (err, users) {
             users.forEach(function (user) {
-              expect(user).toHavePrototype(this.User.DAO.prototype)  
+              expect(user).toHavePrototype(this.User.DAO.prototype)
             }, this)
-            
+
             done();
           }.bind(this))
-        })  
+        })
 
         it("should return raw data when raw is true", function (done) {
           this.User.findAll({ where: { username: 'barfooz'}}, { raw: true }).done(function (err, users) {
             users.forEach(function (user) {
-              expect(user).not.toHavePrototype(this.User.DAO.prototype) 
+              expect(user).not.toHavePrototype(this.User.DAO.prototype)
               expect(users[0]).toBeObject()
             }, this)
 
@@ -1563,6 +1563,10 @@ describe(Helpers.getTestDialectTeaser("DAOFactory"), function() {
               expect(self.UserSpecialSync.getTableName()).toEqual('"special"."UserSpecials"');
               expect(UserSpecial.indexOf('INSERT INTO "special"."UserSpecials"')).toBeGreaterThan(-1)
               expect(UserPublic.indexOf('INSERT INTO "UserPublics"')).toBeGreaterThan(-1)
+            } else if (dialect === "sqlite") {
+              expect(self.UserSpecialSync.getTableName()).toEqual('`special`.`UserSpecials`');
+              expect(UserSpecial.indexOf('INSERT INTO `special.UserSpecials`')).toBeGreaterThan(-1)
+              expect(UserPublic.indexOf('INSERT INTO `UserPublics`')).toBeGreaterThan(-1)
             } else {
               expect(self.UserSpecialSync.getTableName()).toEqual('`special.UserSpecials`');
               expect(UserSpecial.indexOf('INSERT INTO `special.UserSpecials`')).toBeGreaterThan(-1)


### PR DESCRIPTION
I discovered this by doing the following query:

``` javascript
Task.findAll({
    attributes: [['SUM("reward")', 'points'], 'fulfillorId']
    , include: [{ model: Resident, as: 'Fulfillor' }]
    , where:
        ['"Tasks"."fulfillorId" IN (' + residentIds.join(',') + ') ' /*+
            'AND "Tasks"."fulfilledAt" >= ?', lastWeek*/]
    , group: ['Tasks.fulfillorId', 'Fulfillor.id']
    , order: '"points" DESC'
}, {'raw': true})
```

The groupBy Statement was incorrectly quoted in SQLite. Therefore it worked with Postgres, but not with SQLite.

I hence copied the `addQuotes()`/`removeQuotes()` from the postgres dialect and adapted it to use backticks. 
This initially didn't work because the inheritance of the mysql query-generator in sqlite doesn't seem to work as one would expect. Therefore the `selectQuery()` would still use the `addQuotes()`/`removeQuotes()` from the mysql query generator.

By changing this, I noticed that the tests don't run anymore for sqlite because the backticks are compared. I changed the test but I'm not 100% sure if this breaks anything or not. 

So, I guess this patch is not something which should be merged but maybe a starting point what to do here. 
Also, with a proper patch later, it should be possible to add a few more test cases for this. 

Please tell me what you think :)
- Michael
