### PR TITLE
PostgreSQL will no longer try to split regclass identifiers for default values.

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -96,7 +96,10 @@ module.exports = (function() {
             result[_result.Field].defaultValue = result[_result.Field].defaultValue.replace(/'/g, "")
 
             if (result[_result.Field].defaultValue.indexOf('::') > -1) {
-              result[_result.Field].defaultValue = result[_result.Field].defaultValue.split('::')[0]
+              var split = result[_result.Field].defaultValue.split('::');
+              if (split[1].toLowerCase() !== "regclass)") {
+                result[_result.Field].defaultValue = split[0]
+              }
             }
           }
         })


### PR DESCRIPTION
This would cause a problem when describing a table with the default of nextval('seq'::regclass) etc. (basically any SERIAL key).
