### PR TITLE
Fixing a bug in query generation where 'identifier' is being stored as the raw value of the 'id' rather than being wrapped in an object.

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -158,7 +158,7 @@ module.exports = (function() {
     else if (this.isNewRecord) {
       return this.QueryInterface.insert(this, this.QueryInterface.QueryGenerator.addSchema(this.__factory), values)
     } else {
-      var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : this.id;
+      var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : { id: this.id };
 
       if (identifier === null && this.__options.whereCollection !== null) {
         identifier = this.__options.whereCollection;


### PR DESCRIPTION
When the raw value of `id` is stored as `identifier` in `save()` an invalid query is returned from the `QueryGenerator`.

i.e. - Without the fix, an UPDATE query looks like this:
`UPDATE `Users` SET `gender`='male',`email`='updated@bar.com',`updatedAt`='2013-05-29 23:33:36',`createdAt`='2013-05-29 23:33:36' WHERE 2`  

The `WHERE 2` is not the desired behavior. If `id` is wrapped in an object then the correct query is generated:
`UPDATE `Users` SET `gender`='male',`email`='updated@bar.com',`updatedAt`='2013-05-29 23:33:36',`createdAt`='2013-05-29 23:33:36' WHERE `id`=2`
