### PR TITLE
Fixing 'identifier' being stored as the raw value of the 'id' rather than being wrapped in an object

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -247,13 +247,13 @@ module.exports = (function() {
       this.dataValues[attr] = new Date()
       return this.save()
     } else {
-      var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : this.id
+      var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : { id: this.id };
       return this.QueryInterface.delete(this, this.QueryInterface.QueryGenerator.addSchema(this.__factory.tableName, this.__factory.options.schema), identifier)
     }
   }
 
   DAO.prototype.increment = function(fields, count) {
-    var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : this.id,
+    var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : { id: this.id },
       values = {}
 
     if (count === undefined) count = 1;


### PR DESCRIPTION
Continuation of a fix outlined in [pull request 656](https://github.com/sequelize/sequelize/pull/656)
