### PR TITLE
the attributes of a joined table should only be added to the query if no...

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -189,11 +189,13 @@ module.exports = (function() {
         var optAttributes = options.attributes === '*' ? [options.table + '.*'] : [options.attributes]
 
         options.include.forEach(function(include) {
-          var attributes = Object.keys(include.daoFactory.attributes).map(function(attr) {
-            return "`" + include.as + "`.`" + attr + "` AS `" + include.as + "." + attr + "`"
-          })
+          if (options.attributes === '*') {
+            var attributes = Object.keys(include.daoFactory.attributes).map(function(attr) {
+              return "`" + include.as + "`.`" + attr + "` AS `" + include.as + "." + attr + "`"
+            })
 
-          optAttributes = optAttributes.concat(attributes)
+            optAttributes = optAttributes.concat(attributes)
+          }
 
           var table = include.daoFactory.tableName
           var as = include.as

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -236,12 +236,14 @@ module.exports = (function() {
         var optAttributes = options.attributes === '*' ? [options.table + '.*'] : [options.attributes]
 
         options.include.forEach(function(include) {
-          var attributes = Object.keys(include.daoFactory.attributes).map(function(attr) {
-            var template = Utils._.template('"<%= as %>"."<%= attr %>" AS "<%= as %>.<%= attr %>"')
-            return template({ as: include.as, attr:  attr })
-          })
+          if (options.attributes === '*') {
+            var attributes = Object.keys(include.daoFactory.attributes).map(function(attr) {
+              var template = Utils._.template('"<%= as %>"."<%= attr %>" AS "<%= as %>.<%= attr %>"')
+              return template({ as: include.as, attr:  attr })
+            })
 
-          optAttributes = optAttributes.concat(attributes)
+            optAttributes = optAttributes.concat(attributes)
+          }
 
           var joinQuery = ' LEFT OUTER JOIN "<%= table %>" AS "<%= as %>" ON "<%= tableLeft %>"."<%= attrLeft %>" = "<%= tableRight %>"."<%= attrRight %>"'
 


### PR DESCRIPTION
... attributes were particulary defined

I'm pretty sure if someone makes the effort to define the attributes he wants to SELECT, he also wants to define the attributes of the joined table. This is why I 'deactivated' the mechanism if it's not selecting the asterisk (*). 
