### PR TITLE
Fix quotation escape in postgres where conditions

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -495,7 +495,7 @@ module.exports = (function() {
         result = smth
       }
       else if (Array.isArray(smth)) {
-        result = Utils.format(smth)
+        result = Utils.format(smth, "postgres")
       }
 
       return result


### PR DESCRIPTION
The postgres query generator needs to pass its dialect to Utils so that quotes can be escaped correctly.
