### PR TITLE
2.0.0. Do not modify validator Array argument on validation

### DIFF
--- a/lib/dao-validator.js
+++ b/lib/dao-validator.js
@@ -108,6 +108,8 @@ var prepareValidationOfAttribute = function(value, details, validatorType, optio
 
     if (!Array.isArray(validatorArgs)) {
       validatorArgs = [validatorArgs]
+    } else {
+      validatorArgs = validatorArgs.slice(0);
     }
 
     // extract the error msg

--- a/spec/dao.validations.spec.js
+++ b/spec/dao.validations.spec.js
@@ -368,5 +368,26 @@ describe(Helpers.getTestDialectTeaser("DaoValidator"), function() {
             })
         })
     })
+
+    it('validates model with a validator whose arg is an Array successfully twice in a row', function(done){
+      var Foo = this.sequelize.define('Foo' + Math.random(), {
+        bar: {
+          type: Sequelize.STRING,
+          validate: {
+            isIn: [['a', 'b']]
+          }
+        }
+      }), foo;
+
+      foo = Foo
+        .build({bar:'a'});
+      foo.validate().success(function(errors){
+        expect(errors).not.toBeDefined()
+        foo.validate().success(function(errors){
+          expect(errors).not.toBeDefined()
+          done();
+        });
+      });
+    });
   })
 })


### PR DESCRIPTION
Validating with a validator that has an array argument fails if validate() is called twice on the same model since `next` is prepended to the validator argument array.

These changes copy the argument array before prepending to it so it is not modified.
