### PR TITLE
Update Postgres to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jasmine-node": "1.5.0",
     "sqlite3": "~2.1.5",
     "mysql": "~2.0.0-alpha7",
-    "pg": "~0.10.2",
+    "pg": "~1.3.0",
     "buster": "~0.6.3",
     "watchr": "~2.2.0",
     "yuidocjs": "~0.3.36"


### PR DESCRIPTION
Bringing pg up to date fixes the unit test errors, and is probably a good idea in general unless there are specific reasons not to.
