### PR TITLE
Keep milliseconds in timestamps for postgres

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -138,7 +138,7 @@ module.exports = (function() {
     }
 
     if (this.__options.timestamps && this.dataValues.hasOwnProperty(updatedAtAttr)) {
-      this.dataValues[updatedAtAttr] = values[updatedAtAttr] = Utils.now()
+      this.dataValues[updatedAtAttr] = values[updatedAtAttr] = Utils.now(this.sequelize.options.dialect)
     }
 
     var errors = this.validate()
@@ -369,8 +369,8 @@ module.exports = (function() {
       }
 
       if (this.__options.timestamps) {
-        defaults[this.__options.underscored ? 'created_at' : 'createdAt'] = Utils.now()
-        defaults[this.__options.underscored ? 'updated_at' : 'updatedAt'] = Utils.now()
+        defaults[this.__options.underscored ? 'created_at' : 'createdAt'] = Utils.now(this.sequelize.options.dialect)
+        defaults[this.__options.underscored ? 'updated_at' : 'updatedAt'] = Utils.now(this.sequelize.options.dialect)
 
         if (this.__options.paranoid) {
           defaults[this.__options.underscored ? 'deleted_at' : 'deletedAt'] = null

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,9 +164,9 @@ var Utils = module.exports = {
     return subClass;
   },
 
-  now: function() {
+  now: function(dialect) {
     var now = new Date()
-    now.setMilliseconds(0)
+    if(dialect != "postgres") now.setMilliseconds(0)
     return now
   },
 


### PR DESCRIPTION
Postgres timestamps have millisecond precision. This patch preserves the millisecond part of Utils.now when dialect is set to postgres.
