### PR TITLE
Added option 'primaryKey' for HasOne options

### DIFF
--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -41,12 +41,13 @@ module.exports = (function() {
 
   HasOne.prototype.injectGetter = function(obj) {
     var self = this
+    var customPrimaryKey = !!this.options.primaryKey ? this.options.primaryKey : null
 
     obj[this.accessors.get] = function(params) {
-      var id    = this.id
+      var condition = !!customPrimaryKey ? this[customPrimaryKey] : this.id
         , where = {}
 
-      where[self.identifier] = id
+      where[self.identifier] = condition
 
       if (!Utils._.isUndefined(params)) {
         if (!Utils._.isUndefined(params.attributes)) {


### PR DESCRIPTION
If we are working with an existing database, it can happen when foreignKey does not depend on the 'id' column, but from a different column. This commit adds a key 'primaryKey' to options in .hasOne method.
If we add primaryKey option - value of the condition is not taken from the column 'id', but is taken from the specified column.
Using:
ObjectHistory.hasOne(ObjectInfo, {as: 'ObjectInfo', foreignKey: 'id', primaryKey: 'ObjectInfoID'});
