### PR TITLE
Refactor SqlString.escape's argument passing

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -600,8 +600,9 @@ module.exports = (function() {
       return identifiers.split('.').map(function(v) { return this.quoteIdentifier(v, force) }.bind(this)).join('.')
     },
 
-    escape: function(value) {
-      return SqlString.escape(value, false, null, "mysql")
+    escape: function(value, options) {
+      options = Utils._.defaults({}, options, {dialect: "mysql"})
+      return SqlString.escape(value, options)
     }
 
   }

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -307,7 +307,11 @@ module.exports = (function() {
 
       var rowValues = []
       Object.keys(attrValueHash).forEach(function(attr) {
-        rowValues[rowValues.length] = this.escape(attrValueHash[attr], (!!attributes && !!attributes[attr] ? attributes[attr] : undefined))
+        var options = {}
+        if (attributes && attributes[attr]) {
+          options.field = attributes[attr]
+        }
+        rowValues[rowValues.length] = this.escape(attrValueHash[attr], options)
       }.bind(this))
 
       var replacements  = {
@@ -774,8 +778,9 @@ module.exports = (function() {
       return identifiers.split('.').map(function(t) { return this.quoteIdentifier(t, force) }.bind(this)).join('.')
     },
 
-    escape: function(value, field) {
-      return SqlString.escape(value, false, null, "postgres", field)
+    escape: function(value, options) {
+      options = Utils._.defaults({}, options, {dialect: "postgres"})
+      return SqlString.escape(value, options)
     }
 
   }

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -453,8 +453,9 @@ module.exports = (function() {
       return identifiers.split('.').map(function(v) { return this.quoteIdentifier(v, force) }.bind(this)).join('.')
     },
 
-    escape: function(value) {
-      return SqlString.escape(value, false, null, "sqlite")
+    escape: function(value, options) {
+      options = Utils._.defaults({}, options, {dialect: "sqlite"})
+      return SqlString.escape(value, options)
     }
 
   }

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -1,4 +1,5 @@
-var moment = require("moment")
+var moment = require('moment')
+  , _ = require('lodash')
   , SqlString = exports;
 
 SqlString.escapeId = function (val, forbidQualified) {
@@ -8,22 +9,40 @@ SqlString.escapeId = function (val, forbidQualified) {
   return '`' + val.replace(/`/g, '``').replace(/\./g, '`.`') + '`';
 };
 
-SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
+// Escape a SQL query given some basic options:
+// - stringifyObjects: If true, call toString on any objects. If false, try to
+//   pull out key-value pairs.
+// - timeZone: Timezone to convert dates to in ISO 8601 format (defaults to UTC)
+// - dialect: One of the following: "mysql" (default), "postgres", or "sqlite"
+// - field: A marker representing the postgres datatype for any supplied arrays.
+//   If our value is an empty array, we'll expliclity mark a type using this.
+SqlString.escape = function(val, options) {
+  // Set default options
+  options = _.defaults({}, options || {}, {
+    stringifyObjects: false,
+    timeZone: 'Z',
+    dialect: 'mysql',
+    field: null // only needed by postgres for arrays
+  });
+
   if (val === undefined || val === null) {
     return 'NULL';
   }
 
   switch (typeof val) {
     case 'boolean':
-      // SQLite doesn't have true/false support. MySQL aliases true/false to 1/0
-      // for us. Postgres actually has a boolean type with true/false literals,
-      // but sequelize doesn't use it yet.
-      return dialect === 'sqlite' ? +!!val : ('' + !!val);
-    case 'number': return val+'';
+      switch (options.dialect) {
+        case 'mysql': // MySQL aliases true/false to 1/0 for us.
+        case 'postgres': // Postgres actually has boolean support
+          return ('' + !!val);
+        case 'sqlite': // SQLite doesn't have any true/false support
+          return +!!val
+      }
+    case 'number': return '' + val;
   }
 
   if (val instanceof Date) {
-    val = SqlString.dateToString(val, timeZone || "Z", dialect);
+    val = SqlString.dateToString(val, options);
   }
 
   if (Buffer.isBuffer(val)) {
@@ -31,56 +50,63 @@ SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
   }
 
   if (Array.isArray(val)) {
-    return SqlString.arrayToList(val, timeZone, dialect, field);
+    return SqlString.arrayToList(val, options);
   }
 
   if (typeof val === 'object') {
-    if (stringifyObjects) {
+    if (options.stringifyObjects) {
       val = val.toString();
     } else {
-      return SqlString.objectToValues(val, timeZone);
+      return SqlString.objectToValues(val, options);
     }
   }
 
-  if (dialect === 'postgres' || dialect === 'sqlite') {
-    // http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
-    // http://stackoverflow.com/q/603572/130598
-    val = val.replace(/'/g, "''");
-  } else {
-    val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
-      switch(s) {
-        case "\0": return "\\0";
-        case "\n": return "\\n";
-        case "\r": return "\\r";
-        case "\b": return "\\b";
-        case "\t": return "\\t";
-        case "\x1a": return "\\Z";
-        default: return "\\"+s;
+  switch(options.dialect) {
+    case 'postgres': // http://postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
+    case 'sqlite': // http://stackoverflow.com/q/603572/130598
+      val = val.replace(/'/g, "''");
+      break;
+    case 'mysql':
+      val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
+        switch(s) {
+          case '\0': return '\\0';
+          case '\n': return '\\n';
+          case '\r': return '\\r';
+          case '\b': return '\\b';
+          case '\t': return '\\t';
+          case '\x1a': return '\\Z';
+          default: return '\\' + s;
+        }
+      });
+      break;
+  }
+  return "'" + val + "'";
+};
+
+SqlString.arrayToList = function(array, options) {
+  options = _.extend({}, options || {}, {stringifyObjects: true});
+  _.defaults(options, {dialect: 'mysql', field: null});
+
+  switch(options.dialect) {
+    case 'postgres':
+      var ret = 'ARRAY[' + array.map(function(v) {
+        return SqlString.escape(v, options);
+      }).join(',') + ']';
+      if (!!options.field && !!options.field.type) {
+        ret += '::' + options.field.type.replace(/\(\d+\)/g, '');
       }
-    });
-  }
-  return "'"+val+"'";
-};
-
-SqlString.arrayToList = function(array, timeZone, dialect, field) {
-  if (dialect === 'postgres') {
-    var ret = 'ARRAY[' + array.map(function(v) {
-      return SqlString.escape(v, true, timeZone, dialect, field);
-    }).join(',') + ']';
-    if (!!field && !!field.type) {
-      ret += '::' + field.type.replace(/\(\d+\)/g, '');
-    }
-    return ret;
-  } else {
-    return array.map(function(v) {
-      if (Array.isArray(v))
-        return '(' + SqlString.arrayToList(v, timeZone, dialect) + ')';
-      return SqlString.escape(v, true, timeZone, dialect);
-    }).join(', ');
+      return ret;
+    case 'mysql':
+    case 'sqlite':
+      return array.map(function(v) {
+        if (Array.isArray(v))
+          return '(' + SqlString.arrayToList(v, options) + ')';
+        return SqlString.escape(v, options);
+      }).join(', ');
   }
 };
 
-SqlString.format = function(sql, values, timeZone, dialect) {
+SqlString.format = function(sql, values, options) {
   values = [].concat(values);
 
   return sql.replace(/\?/g, function(match) {
@@ -88,28 +114,33 @@ SqlString.format = function(sql, values, timeZone, dialect) {
       return match;
     }
 
-    return SqlString.escape(values.shift(), false, timeZone, dialect);
+    return SqlString.escape(values.shift(), options);
   });
 };
 
-SqlString.dateToString = function(date, timeZone, dialect) {
+SqlString.dateToString = function(date, options) {
+  options = _.defaults({}, options || {}, {
+    timeZone: 'Z',
+    dialect: 'mysql'
+  });
+
   var dt = new Date(date);
+ 
+  switch(options.dialect) {
+    case 'postgres': // TODO: Ideally all dialects would work a bit more like this
+      return moment(dt).format('YYYY-MM-DD HH:mm:ss.SSS Z');
+    case 'mysql':
+    case 'sqlite':
+      if (options.timeZone !== 'local') {
+        var tz = convertTimezone(options.timeZone);
 
-  // TODO: Ideally all dialects would work a bit more like this
-  if (dialect === "postgres") {
-    return moment(dt).format("YYYY-MM-DD HH:mm:ss.SSS Z");
+        dt.setTime(dt.getTime() + (dt.getTimezoneOffset() * 60000));
+        if (tz !== false) {
+          dt.setTime(dt.getTime() + (tz * 60000));
+        }
+      }
+      return moment(dt).format('YYYY-MM-DD HH:mm:ss');
   }
-
-  if (timeZone !== 'local') {
-    var tz = convertTimezone(timeZone);
-
-    dt.setTime(dt.getTime() + (dt.getTimezoneOffset() * 60000));
-    if (tz !== false) {
-      dt.setTime(dt.getTime() + (tz * 60000));
-    }
-  }
-
-  return moment(dt).format("YYYY-MM-DD HH:mm:ss");
 };
 
 SqlString.bufferToString = function(buffer) {
@@ -127,7 +158,8 @@ SqlString.bufferToString = function(buffer) {
   return "X'" + hex+ "'";
 };
 
-SqlString.objectToValues = function(object, timeZone) {
+SqlString.objectToValues = function(object, options) {
+  options = _.extend({}, options, {stringifyObjects: true});
   var values = [];
   for (var key in object) {
     var value = object[key];
@@ -135,7 +167,7 @@ SqlString.objectToValues = function(object, timeZone) {
       continue;
     }
 
-    values.push(this.escapeId(key) + ' = ' + SqlString.escape(value, true, timeZone));
+    values.push(this.escapeId(key) + ' = ' + SqlString.escape(value, options));
   }
 
   return values.join(', ');
@@ -146,11 +178,11 @@ function zeroPad(number) {
 }
 
 function convertTimezone(tz) {
-  if (tz == "Z") return 0;
+  if (tz === 'Z') return 0;
 
   var m = tz.match(/([\+\-\s])(\d\d):?(\d\d)?/);
   if (m) {
-    return (m[1] == '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
+    return (m[1] === '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
   }
   return false;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,8 +36,7 @@ var Utils = module.exports = {
     util.inherits(_class, require('events').EventEmitter)
   },
   format: function(arr, dialect) {
-    var timeZone = null;
-    return SqlString.format(arr.shift(), arr, timeZone, dialect)
+    return SqlString.format(arr.shift(), arr, {dialect: dialect})
   },
   isHash: function(obj) {
     return Utils._.isObject(obj) && !Array.isArray(obj);


### PR DESCRIPTION
With all the arguments that `SqlString.escape` must handle, it makes more sense to use an options argument (discussed in issue #700). Some other minor changes were made throughout `SqlString` with an aim to improve readability and consistency.

The code probably isn't ready to merge just yet. I just wanted to go ahead and open a pull request so that I could make Travis run the unit tests for me.
