### PR TITLE
Fix toSQLDate Bug

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,12 +46,12 @@ var Utils = module.exports = {
     return s < 10 ? '0' + s : s
   },
   toSqlDate: function(date) {
-    return date.getUTCFullYear() + '-' +
-      this.pad(date.getUTCMonth()+1) + '-' +
-      this.pad(date.getUTCDate()) + ' ' +
-      this.pad(date.getUTCHours()) + ':' +
-      this.pad(date.getUTCMinutes()) + ':' +
-      this.pad(date.getUTCSeconds())
+    return date.getFullYear() + '-' +
+      this.pad(date.getMonth()+1) + '-' +
+      this.pad(date.getDate()) + ' ' +
+      this.pad(date.getHours()) + ':' +
+      this.pad(date.getMinutes()) + ':' +
+      this.pad(date.getSeconds())
   },
   argsArePrimaryKeys: function(args, primaryKeys) {
     var result = (args.length == Object.keys(primaryKeys).length)


### PR DESCRIPTION
This is probably a bug.

Using date.getUTCxxx produce wrong date-time string because Date() already UTC-ed (I guess).

``` javascript
new Date(): Mon Jul 22 2013 10:26:09 GMT+0700 (WIT)
CONVERTED DATE:  2013-07-22 03:26:09
```

Using date.getxxx produce correct date-time string.

``` javascript
new Date(): Mon Jul 22 2013 10:25:08 GMT+0700 (WIT)
CONVERTED DATE:  2013-07-22 10:25:08
```
