### PR TITLE
Don't quote order columns that are functions 

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -269,7 +269,7 @@ module.exports = (function() {
 
       if(options.order) {
         options.order = options.order.replace(/([^ ]+)(.*)/, function(m, g1, g2) {
-          return this.quoteIdentifiers(g1) + g2
+          return ((g1.indexOf("(") > -1) ? g1 : this.quoteIdentifiers(g1)) + g2
         }.bind(this))
         query += " ORDER BY <%= order %>"
       }


### PR DESCRIPTION
Currently the order columns are quoted, which causes an error when trying to order results by a function. This quick fix resolves that problem for Postgres.
