### PR TITLE
bulkCreate() now has a third argument which gives you the ability to validate each row before attempting to bulkInsert.

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -437,6 +437,7 @@ module.exports = (function() {
   DAOFactory.prototype.bulkCreate = function(records, fields, options) {
     options = options || {}
     options.validate = options.validate || false
+    fields = fields || []
 
     var self          = this
       , updatedAtAttr = self.options.underscored ? 'updated_at' : 'updatedAt'
@@ -445,7 +446,7 @@ module.exports = (function() {
       , daos          = records.map(function(v) {
                           var build = self.build(v)
                           if (options.validate === true) {
-                            var valid = build.validate({type: 'insert'})
+                            var valid = build.validate({skip: fields})
                             if (valid !== null) {
                               errors[errors.length] = {record: v, errors: valid}
                             }
@@ -458,8 +459,6 @@ module.exports = (function() {
         emitter.emit('error', errors)
       }).run()
     }
-
-    fields = fields || []
 
     // we will re-create from DAOs, which may have set up default attributes
     records = []
@@ -477,7 +476,7 @@ module.exports = (function() {
         values[updatedAtAttr] = Utils.now()
       }
 
-      records.push(values);
+      records.push(values)
     })
 
     // Validate enums

--- a/lib/dao-validator.js
+++ b/lib/dao-validator.js
@@ -1,8 +1,12 @@
 var Validator = require("validator")
   , Utils     = require("./utils")
 
-var DaoValidator = module.exports = function(model) {
+var DaoValidator = module.exports = function(model, options) {
+  options = options || {}
+  options.skip = options.skip || []
+
   this.model = model
+  this.options = options
 }
 
 DaoValidator.prototype.validate = function() {
@@ -32,17 +36,19 @@ var validateModel = function() {
 }
 
 var validateAttributes = function() {
-  var errors = {}
+  var self = this
+    , errors = {}
 
   // for each field and value
   Utils._.each(this.model.dataValues, function(value, field) {
-    var rawAttribute   = this.model.rawAttributes[field]
+    var rawAttribute   = self.model.rawAttributes[field]
       , hasAllowedNull = ((rawAttribute === undefined || rawAttribute.allowNull === true) && ((value === null) || (value === undefined)))
+      , isSkipped      = self.options.skip.length > 0 && self.options.skip.indexOf(field) === -1
 
-    if (this.model.validators.hasOwnProperty(field) && !hasAllowedNull) {
-      errors = Utils._.merge(errors, validateAttribute.call(this, value, field))
+    if (self.model.validators.hasOwnProperty(field) && !hasAllowedNull && !isSkipped) {
+      errors = Utils._.merge(errors, validateAttribute.call(self, value, field))
     }
-  }.bind(this)) // for each field
+  })
 
   return errors
 }

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -201,8 +201,8 @@ module.exports = (function() {
    *
    * @return null if and only if validation successful; otherwise an object containing { field name : [error msgs] } entries.
    */
-  DAO.prototype.validate = function() {
-    var validator = new DaoValidator(this)
+  DAO.prototype.validate = function(object) {
+    var validator = new DaoValidator(this, object)
       , errors    = validator.validate()
 
     return (Utils._.isEmpty(errors) ? null : errors)

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -750,6 +750,33 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
       })
     })
 
+    it("doesn't emit an error when validate is set to true but our selectedValues are fine", function(done) {
+      var Tasks = this.sequelize.define('Task', {
+        name: {
+          type: Sequelize.STRING,
+          validate: {
+            notNull: { args: true, msg: 'name cannot be null' }
+          }
+        },
+        code: {
+          type: Sequelize.STRING,
+          validate: {
+            len: [3, 10]
+          }
+        }
+      })
+
+      Tasks.sync({ force: true }).success(function() {
+        Tasks.bulkCreate([
+          {name: 'foo', code: '123'},
+          {code: '1234'}
+        ], ['code'], {validate: true}).success(function() {
+          // we passed!
+          done()
+        })
+      })
+    })
+
     describe('enums', function() {
       it('correctly restores enum values', function(done) {
         var self = this


### PR DESCRIPTION
bulkCreate was originally made to be a mainstream/fast way of inserting records, however, sometimes you want the luxury of being able to insert multiple rows at once without sacrificing model validations. I've added a third argument to bulkCreate which is an object and currently the only option is `{validate: true}` I actually need this for my workplace, so please do review the PR let me know what you don't like (if anything) etc.

The following code...

``` js
var Tasks = this.sequelize.define('Task', {
        name: {
          type: Sequelize.STRING,
          validate: {
            notNull: { args: true, msg: 'name cannot be null' }
          }
        },
        code: {
          type: Sequelize.STRING,
          validate: {
            len: [3, 10]
          }
        }
      })

      Tasks.sync({ force: true }).success(function() {
        Tasks.bulkCreate([
          {name: 'foo', code: '123'},
          {code: '1234'},
          {name: 'bar', code: '1'}
        ], null, {validate: true}).error(function(errors) {
          // console.log(errors)
        })
     })
```

Produces this errors object:

``` js
[
  {
    "record": {
      "code": "1234"
    },
    "errors": {
      "name": [
        "name cannot be null"
      ]
    }
  },
  {
    "record": {
      "name": "bar",
      "code": "1"
    },
    "errors": {
      "code": [
        "String is not in range: code"
      ]
    }
  }
]
```

Which would allow you to not only see the errors, but which records were the offenders. 
