### PR TITLE
Postgres will now properly create hstore columns as it should, text is n...

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -183,7 +183,7 @@ module.exports = {
     }
 
     result.type = 'HSTORE'
-    result.toString = result.valueOf = function() { return 'TEXT' }
+    result.toString = result.valueOf = function() { return 'HSTORE' }
 
     return result
   }

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -117,7 +117,7 @@ module.exports = (function() {
         schema = 'public';
       }
 
-      var query = 'SELECT c.column_name as "Field", c.column_default as "Default", c.is_nullable as "Null", c.data_type as "Type", (SELECT array_agg(e.enumlabel) FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid=e.enumtypid WHERE t.typname=c.udt_name) AS "special" FROM information_schema.columns c WHERE table_name = <%= table %> AND table_schema = <%= schema %>'
+      var query = 'SELECT c.column_name as "Field", c.column_default as "Default", c.is_nullable as "Null", CASE WHEN c.udt_name = \'hstore\' THEN c.udt_name ELSE c.data_type END as "Type", (SELECT array_agg(e.enumlabel) FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid=e.enumtypid WHERE t.typname=c.udt_name) AS "special" FROM information_schema.columns c WHERE table_name = <%= table %> AND table_schema = <%= schema %>'
 
       return Utils._.template(query)({
         table: this.escape(tableName),

--- a/test/postgres/dao.test.js
+++ b/test/postgres/dao.test.js
@@ -2,7 +2,6 @@ var chai      = require('chai')
   , expect    = chai.expect
   , Support   = require(__dirname + '/../support')
   , dialect   = Support.getTestDialect()
-  , config    = require(__dirname + '/../config/config')
   , DataTypes = require(__dirname + "/../../lib/data-types")
 
 chai.Assertion.includeStack = true
@@ -24,6 +23,13 @@ if (dialect.match(/^postgres/)) {
     afterEach(function(done) {
       this.sequelize.options.quoteIdentifiers = true
       done()
+    })
+
+    it('describeTable should tell me that a column is hstore and not USER-DEFINED', function(done) {
+      this.sequelize.queryInterface.describeTable('Users').success(function(table) {
+        expect(table.document.type).to.equal('HSTORE')
+        done()
+      })
     })
 
     describe('integers', function() {

--- a/test/support.js
+++ b/test/support.js
@@ -116,6 +116,18 @@ var Support = {
 
 var sequelize = Support.createSequelizeInstance({ dialect: Support.getTestDialect() })
 
+// For Postgres' HSTORE functionality and to properly execute it's commands we'll need this...
+before(function(done) {
+  var dialect = Support.getTestDialect()
+  if (dialect !== "postgres" && dialect !== "postgres-native") {
+    return done()
+  }
+
+  sequelize.query('CREATE EXTENSION IF NOT EXISTS hstore', null, {raw: true}).success(function() {
+    done()
+  })
+})
+
 beforeEach(function(done) {
   this.sequelize = sequelize
   Support.clearDatabase(this.sequelize, function() {


### PR DESCRIPTION
...ot a suitable alternative. This also fixes a describeTable issue with returning the column's data type as USER-DEFINED instead of HSTORE which closes #671
