### PR TITLE
Allow multiple order by columns in pg

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -285,7 +285,9 @@ module.exports = (function() {
 
       if(options.order) {
         options.order = options.order.replace(/([^ ]+)(.*)/, function(m, g1, g2) {
-          return this.quoteIdentifiers(g1) + g2
+          return g1.split(',').map(function(f) {
+						return this.quoteIdentifiers(f)
+					}.bind(this)).join(',') + g2
         }.bind(this))
         query += " ORDER BY <%= order %>"
       }

--- a/test/postgres/query-generator.test.js
+++ b/test/postgres/query-generator.test.js
@@ -240,6 +240,9 @@ if (dialect.match(/^postgres/)) {
           arguments: ['myTable', {order: "id DESC"}],
           expectation: "SELECT * FROM \"myTable\" ORDER BY \"id\" DESC;"
         }, {
+          arguments: ['myTable', {order: "id,name DESC"}],
+          expectation: "SELECT * FROM \"myTable\" ORDER BY \"id\",\"name\" DESC;"
+        }, {
           arguments: ['myTable', {group: "name"}],
           expectation: "SELECT * FROM \"myTable\" GROUP BY \"name\";"
         }, {
@@ -302,6 +305,10 @@ if (dialect.match(/^postgres/)) {
         }, {
           arguments: ['myTable', {order: "id DESC"}],
           expectation: "SELECT * FROM myTable ORDER BY id DESC;",
+          context: {options: {quoteIdentifiers: false}}
+        }, {
+          arguments: ['myTable', {order: "id,name DESC"}],
+          expectation: "SELECT * FROM myTable ORDER BY id,name DESC;",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {group: "name"}],


### PR DESCRIPTION
This just simply allows you to add column separated fields to your order by where query in a find for pg.  Mysql just takes the string, but pg breaks up the pieces.
