### PR TITLE
Adding the ability to use named parameters as the fourth parameter of query

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -215,7 +215,12 @@ module.exports = (function() {
 
   Sequelize.prototype.query = function(sql, callee, options, replacements) {
     if (arguments.length === 4) {
-      sql = Utils.format([sql].concat(replacements), this.options.dialect)
+      if (Array.isArray(replacements)) {
+        sql = Utils.format([sql].concat(replacements), this.options.dialect)
+      }
+      else {
+        sql = Utils.formatNamedParameters(sql, replacements, this.options.dialect)
+      }
     } else if (arguments.length === 3) {
       options = options
     } else if (arguments.length === 2) {

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -106,6 +106,17 @@ SqlString.format = function(sql, values, timeZone, dialect) {
   });
 };
 
+SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
+  return sql.replace(/\:(\w+)/g, function (value, key) {
+    if (values.hasOwnProperty(key)) {
+      return SqlString.escape(values[key], false, timeZone, dialect);
+    }
+    else {
+      throw new Error('Named parameter "' + value + '" as no value in the given object.');
+    }
+  });
+};
+
 SqlString.dateToString = function(date, timeZone, dialect) {
   var dt = new Date(date);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,6 +41,10 @@ var Utils = module.exports = {
     var timeZone = null;
     return SqlString.format(arr.shift(), arr, timeZone, dialect)
   },
+  formatNamedParameters: function(sql, parameters, dialect) {
+    var timeZone = null;
+    return SqlString.formatNamedParameters(sql, parameters, timeZone, dialect)
+  },
   // smartWhere can accept an array of {where} objects, or a single {where} object.
   // The smartWhere function breaks down the collection of where objects into a more
   // centralized object for each column so we can avoid duplicates

--- a/test/sequelize.test.js
+++ b/test/sequelize.test.js
@@ -177,6 +177,67 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
       })
     })
 
+    it('replaces named parameters with the passed object', function(done) {
+      this.sequelize.query('select :one as foo, :two as bar', null, { raw: true }, { one: 1, two: 2 }).success(function(result) {
+        expect(result).to.deep.equal([{ foo: 1, bar: 2 }])
+        done()
+      })
+    })
+
+    it('replaces named parameters with the passed object using the same key twice', function(done) {
+      this.sequelize.query('select :one as foo, :two as bar, :one as baz', null, { raw: true }, { one: 1, two: 2 }).success(function(result) {
+        expect(result).to.deep.equal([{ foo: 1, bar: 2, baz: 1 }])
+        done()
+      })
+    })
+
+    it('replaces named parameters with the passed object having a null property', function(done) {
+      this.sequelize.query('select :one as foo, :two as bar', null, { raw: true }, { one: 1, two: null }).success(function(result) {
+        expect(result).to.deep.equal([{ foo: 1, bar: null }])
+        done()
+      })
+    })
+
+    it('throw an exception when key is missing in the passed object', function(done) {
+      var self = this
+      expect(function() {
+        self.sequelize.query('select :one as foo, :two as bar, :three as baz', null, { raw: true }, { one: 1, two: 2 })
+      }).to.throw(Error, /Named parameter ":\w+" as no value in the given object\./g)
+      done()
+    })
+
+    it('throw an exception with the passed number', function(done) {
+      var self = this
+      expect(function() {
+        self.sequelize.query('select :one as foo, :two as bar', null, { raw: true }, 2)
+      }).to.throw(Error, /Named parameter ":\w+" as no value in the given object\./g)
+      done()
+    })
+
+    it('throw an exception with the passed empty object', function(done) {
+      var self = this
+      expect(function() {
+        self.sequelize.query('select :one as foo, :two as bar', null, { raw: true }, {})
+      }).to.throw(Error, /Named parameter ":\w+" as no value in the given object\./g)
+      done()
+    })
+
+    it('throw an exception with the passed string', function(done) {
+      var self = this
+      expect(function() {
+        self.sequelize.query('select :one as foo, :two as bar', null, { raw: true }, 'foobar')
+      }).to.throw(Error, /Named parameter ":\w+" as no value in the given object\./g)
+      done()
+    })
+
+    it('throw an exception with the passed date', function(done) {
+      var self = this
+      expect(function() {
+        self.sequelize.query('select :one as foo, :two as bar', null, { raw: true }, new Date())
+      }).to.throw(Error, /Named parameter ":\w+" as no value in the given object\./g)
+      done()
+    })
+
     it('handles AS in conjunction with functions just fine', function(done) {
       this.sequelize.query('SELECT ' + (dialect === "sqlite" ? 'date(\'now\')' : 'NOW()') + ' AS t').success(function(result) {
         expect(moment(result[0].t).isValid()).to.be.true


### PR DESCRIPTION
This PR fixes https://github.com/sequelize/sequelize/issues/510.

I have decided to use the fourth parameter of the `query()` method to implement this feature.
If the last parameter is an Array, the "?" notation will be used.
If the last parameter is an Object, the ":" notation will be used.

Keys can be used more than once in the sql statement.
Keys used in the sql statement but not defined as property of the given object will raise an exception.

So with this solution you have to choose one notation or another, we won't face mixed notation with "?" and ":".

Hope you will like it.

Cheers,
Antoine
