### PR TITLE
Doing a deep clone on includes/dao objects can be very slow in findAndCountAll

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -354,15 +354,17 @@ module.exports = (function() {
 
   DAOFactory.prototype.findAndCountAll = function(options) {
     var self  = this
-      , opts  = Utils._.cloneDeep(options)
-      , copts = Utils._.extend({}, Utils._.cloneDeep(options) || {}, {
-          // no limit, offset, order or include for the options given to count()
-          offset   : 0,
-          limit    : 0,
-          order    : null,
-          include  : null
-      })
+    , copts = Utils._.omit(options, ['offset', 'limit', 'order', 'include', 'attributes'])
 
+    copts = Utils._.extend({}, Utils._.cloneDeep(copts) || {}, {
+        // no limit, offset, order, attributes or include for the options given to count()
+        offset   : 0,
+        limit    : 0,
+        order    : null,
+        include  : null,
+        attributes: [],
+    })
+    
     return new Utils.CustomEventEmitter(function (emitter) {
       var emit = {
           err  : function(e) {        // emit error


### PR DESCRIPTION
When running tests on the new findAndCountAll we found that when we had multiple includes in the options, the cloneDeep call could get very slow, like 5-10 seconds slow.  This keeps this from occurring, I believe all the options that can currently go into the count call are really the where and group queries.

I did not provide an extra test for this, the current tests cover the basic semantics.
