### PR TITLE
Move validations earlier in save function

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -122,6 +122,14 @@ module.exports = (function() {
       })
     }
 
+    var errors = this.validate()
+
+    if (!!errors) {
+      return new Utils.CustomEventEmitter(function(emitter) {
+        emitter.emit('error', errors)
+      }).run()
+    }
+
     for (var attrName in this.daoFactory.rawAttributes) {
       if (this.daoFactory.rawAttributes.hasOwnProperty(attrName)) {
         var definition      = this.daoFactory.rawAttributes[attrName]
@@ -160,14 +168,7 @@ module.exports = (function() {
       this.dataValues[updatedAtAttr] = values[updatedAtAttr] = Utils.now(this.sequelize.options.dialect)
     }
 
-    var errors = this.validate()
-
-    if (!!errors) {
-      return new Utils.CustomEventEmitter(function(emitter) {
-        emitter.emit('error', errors)
-      }).run()
-    }
-    else if (this.isNewRecord) {
+    if (this.isNewRecord) {
       this.isDirty = false
       return this.QueryInterface.insert(this, this.QueryInterface.QueryGenerator.addSchema(this.__factory), values)
     } else {


### PR DESCRIPTION
Move the validation code to happen before the save funtion checks for enums being out of range.  This way the enum validators can catch the error and raise the event instead of throwing an error that breaks execution.
