### PR TITLE
Allows us to define our own timestamp columns.

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -9,6 +9,10 @@ module.exports = (function() {
   var DAOFactory = function(name, attributes, options) {
     this.options = Utils._.extend({
       timestamps: true,
+      createdAt: 'createdAt',
+      updatedAt: 'updatedAt',
+      deletedAt: 'deletedAt',
+      touchedAt: 'touchedAt',
       instanceMethods: {},
       classMethods: {},
       validate: {},
@@ -176,7 +180,7 @@ module.exports = (function() {
 
     this.DAO.prototype.__factory        = this
     this.DAO.prototype.hasDefaultValues = !Utils._.isEmpty(this.DAO.prototype.defaultValues)
-    
+
     return this
   }
 
@@ -422,7 +426,7 @@ module.exports = (function() {
         options = {where: parseInt(Number(options) || 0, 0)}
       }
     }
-    
+
     options.limit = 1
 
     return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
@@ -560,8 +564,8 @@ module.exports = (function() {
     fields = fields || []
 
     var self          = this
-      , updatedAtAttr = self.options.underscored ? 'updated_at' : 'updatedAt'
-      , createdAtAttr = self.options.underscored ? 'created_at' : 'createdAt'
+      , updatedAtAttr = Utils._.underscoredIf(self.options.updatedAt, self.options.underscored)
+      , createdAtAttr = Utils._.underscoredIf(self.options.createdAt, self.options.underscored)
       , errors        = []
       , daos          = records.map(function(v) {
                           var build = self.build(v)
@@ -629,7 +633,7 @@ module.exports = (function() {
    */
   DAOFactory.prototype.destroy = function(where, options) {
     if (this.options.timestamps && this.options.paranoid) {
-      var attr = this.options.underscored ? 'deleted_at' : 'deletedAt'
+      var attr = Utils._.underscoredIf(this.options.deletedAt, this.options.underscored)
       var attrValueHash = {}
       attrValueHash[attr] = Utils.now()
       return this.QueryInterface.bulkUpdate(this.tableName, attrValueHash, where)
@@ -650,7 +654,7 @@ module.exports = (function() {
     options.validate = options.validate || true
 
     if(this.options.timestamps) {
-      var attr = this.options.underscored ? 'updated_at' : 'updatedAt'
+      var attr = Utils._.underscoredIf(this.options.updatedAt, this.options.underscored)
       attrValueHash[attr] = Utils.now()
     }
 
@@ -708,11 +712,11 @@ module.exports = (function() {
     }
 
     if (this.options.timestamps) {
-      defaultAttributes[Utils._.underscoredIf('createdAt', this.options.underscored)] = {type: DataTypes.DATE, allowNull: false}
-      defaultAttributes[Utils._.underscoredIf('updatedAt', this.options.underscored)] = {type: DataTypes.DATE, allowNull: false}
+      defaultAttributes[Utils._.underscoredIf(this.options.createdAt, this.options.underscored)] = {type: DataTypes.DATE, allowNull: false}
+      defaultAttributes[Utils._.underscoredIf(this.options.updatedAt, this.options.underscored)] = {type: DataTypes.DATE, allowNull: false}
 
       if (this.options.paranoid)
-        defaultAttributes[Utils._.underscoredIf('deletedAt', this.options.underscored)] = {type: DataTypes.DATE}
+        defaultAttributes[Utils._.underscoredIf(this.options.deletedAt, this.options.underscored)] = {type: DataTypes.DATE}
     }
 
     Utils._.each(defaultAttributes, function(value, attr) {

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -28,7 +28,7 @@ module.exports = (function() {
   Object.defineProperty(DAO.prototype, 'isDeleted', {
     get: function() {
       var result = this.__options.timestamps && this.__options.paranoid
-      result = result && this.dataValues[this.__options.underscored ? 'deleted_at' : 'deletedAt'] !== null
+      result = result && this.dataValues[Utils._.underscoredIf(this.__options.deletedAt, this.__options.underscored)] !== null
 
       return result
     }
@@ -99,8 +99,8 @@ module.exports = (function() {
   DAO.prototype.save = function(fields, options) {
     var self          = this
       , values        = fields ? {} : this.dataValues
-      , updatedAtAttr = this.__options.underscored ? 'updated_at' : 'updatedAt'
-      , createdAtAttr = this.__options.underscored ? 'created_at' : 'createdAt'
+      , updatedAtAttr = Utils._.underscoredIf(this.__options.updatedAt, this.__options.underscored)
+      , createdAtAttr = Utils._.underscoredIf(this.__options.createdAt, this.__options.underscored)
 
     if (fields) {
       if (self.__options.timestamps) {
@@ -244,17 +244,17 @@ module.exports = (function() {
     readOnlyAttributes.push('id')
 
     if (this.isNewRecord !== true) {
-      readOnlyAttributes.push(this.daoFactory.options.underscored === true ? 'created_at' : 'createdAt')
+      readOnlyAttributes.push(Utils._.underscoredIf(this.daoFactory.options.createdAt, this.daoFactory.options.underscored))
     }
     // readOnlyAttributes.push(this.daoFactory.options.underscored === true ? 'updated_at' : 'updatedAt')
-    readOnlyAttributes.push(this.daoFactory.options.underscored === true ? 'deleted_at' : 'deletedAt')
+    readOnlyAttributes.push(this.daoFactory.options.deletedAt, this.daoFactory.options.underscored)
 
     var isDirty = this.isDirty
 
     Utils._.each(updates, function(value, attr) {
       var updateAllowed = (
-        (readOnlyAttributes.indexOf(attr) == -1) &&
-        (readOnlyAttributes.indexOf(Utils._.underscored(attr)) == -1) &&
+        (readOnlyAttributes.indexOf(attr) === -1) &&
+        (readOnlyAttributes.indexOf(Utils._.underscored(attr)) === -1) &&
         (self.attributes.indexOf(attr) > -1)
       )
 
@@ -270,7 +270,7 @@ module.exports = (function() {
     // since we're updating the record, we should be updating the updatedAt column..
     if (this.daoFactory.options.timestamps === true) {
       isDirty = true
-      self[this.daoFactory.options.underscored === true ? 'updated_at' : 'updatedAt'] = new Date()
+      self[Utils._.underscoredIf(this.daoFactory.options.updatedAt, this.daoFactory.options.underscored)] = new Date()
     }
 
     this.isDirty = isDirty
@@ -278,7 +278,7 @@ module.exports = (function() {
 
   DAO.prototype.destroy = function() {
     if (this.__options.timestamps && this.__options.paranoid) {
-      var attr = this.__options.underscored ? 'deleted_at' : 'deletedAt'
+      var attr = Utils._.underscoredIf(this.__options.deletedAt, this.__options.underscored)
       this.dataValues[attr] = new Date()
       return this.save()
     } else {
@@ -371,9 +371,9 @@ module.exports = (function() {
       this.__defineSetter__(attribute, has.set || function(v) {
         if (Utils.hasChanged(this.dataValues[attribute], v)) {
           //Only dirty the object if the change is not due to id, touchedAt, createdAt or updatedAt being initiated
-          var updatedAtAttr = this.__options.underscored ? 'updated_at' : 'updatedAt'
-            , createdAtAttr = this.__options.underscored ? 'created_at' : 'createdAt'
-            , touchedAtAttr = this.__options.underscored ? 'touched_at' : 'touchedAt'
+          var updatedAtAttr = Utils._.underscoredIf(this.__options.updatedAt, this.__options.underscored)
+            , createdAtAttr = Utils._.underscoredIf(this.__options.createdAt, this.__options.underscored)
+            , touchedAtAttr = Utils._.underscoredIf(this.__options.touchedAt, this.__options.underscored)
 
           if (this.dataValues[attribute] || (attribute != 'id' && attribute != touchedAtAttr && attribute != createdAtAttr && attribute != updatedAtAttr)) {
             this.isDirty = true
@@ -419,11 +419,11 @@ module.exports = (function() {
       }
 
       if (this.__options.timestamps) {
-        defaults[this.__options.underscored ? 'created_at' : 'createdAt'] = Utils.now(this.sequelize.options.dialect)
-        defaults[this.__options.underscored ? 'updated_at' : 'updatedAt'] = Utils.now(this.sequelize.options.dialect)
+        defaults[Utils._.underscoredIf(this.__options.createdAt, this.__options.underscored)] = Utils.now(this.sequelize.options.dialect)
+        defaults[Utils._.underscoredIf(this.__options.updatedAt, this.__options.underscored)] = Utils.now(this.sequelize.options.dialect)
 
         if (this.__options.paranoid) {
-          defaults[this.__options.underscored ? 'deleted_at' : 'deletedAt'] = null
+          defaults[Utils._.underscoredIf(this.__options.deletedAt, this.__options.underscored)] = null
         }
       }
     }

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -107,6 +107,53 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
       }).to.throw(Error, 'A model validator function must not have the same name as a field. Model: Foo, field/validation name: field')
       done()
     })
+
+    it('should allow me to override updatedAt, createdAt, and deletedAt fields', function(done) {
+      var UserTable = this.sequelize.define('UserCol', {
+        aNumber: Sequelize.INTEGER
+      }, {
+        timestamps: true,
+        updatedAt: 'updatedOn',
+        createdAt: 'dateCreated',
+        deletedAt: 'deletedAtThisTime',
+        paranoid: true
+      })
+
+      UserTable.sync({force: true}).success(function() {
+        UserTable.create({aNumber: 4}).success(function(user) {
+          expect(user.updatedOn).to.exist
+          expect(user.dateCreated).to.exist
+          user.destroy().success(function(user) {
+            expect(user.deletedAtThisTime).to.exist
+            done()
+          })
+        })
+      })
+    })
+
+    it('should allow me to override updatedAt, createdAt, and deletedAt fields with underscored being true', function(done) {
+      var UserTable = this.sequelize.define('UserCol', {
+        aNumber: Sequelize.INTEGER
+      }, {
+        timestamps: true,
+        updatedAt: 'updatedOn',
+        createdAt: 'dateCreated',
+        deletedAt: 'deletedAtThisTime',
+        paranoid: true,
+        underscored: true
+      })
+
+      UserTable.sync({force: true}).success(function() {
+        UserTable.create({aNumber: 4}).success(function(user) {
+          expect(user.updated_on).to.exist
+          expect(user.date_created).to.exist
+          user.destroy().success(function(user) {
+            expect(user.deleted_at_this_time).to.exist
+            done()
+          })
+        })
+      })
+    })
   })
 
   describe('build', function() {


### PR DESCRIPTION
This commit allows the user to predefine their own timestamp columns which is
useful for databases that already exist. This also allows the user to have their
own naming conventions for the timestamp columns.

The following options have been added when defining a new table:
- createdAt (defaults to "createdAt")
- updatedAt (defaults to "updatedAt")
- deletedAt (defaults to "deletedAt")
- touchedAt (defaults to "touchedAt")

Note: The underscored option still remains useful since it's just a simple one
line option which allows flexibility for those rare cases in which people decide
to change the structure of their database from camelCase to under_score or
vice-versa.
