### PR TITLE
Enum values can now be null

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -176,7 +176,7 @@ module.exports = (function() {
 
     this.DAO.prototype.__factory        = this
     this.DAO.prototype.hasDefaultValues = !Utils._.isEmpty(this.DAO.prototype.defaultValues)
-    
+
     return this
   }
 
@@ -422,7 +422,7 @@ module.exports = (function() {
         options = {where: parseInt(Number(options) || 0, 0)}
       }
     }
-    
+
     options.limit = 1
 
     return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
@@ -608,7 +608,7 @@ module.exports = (function() {
             , hasValue        = (typeof values[attrName] !== 'undefined')
             , valueOutOfScope = ((definition.values || []).indexOf(values[attrName]) === -1)
 
-          if (isEnum && hasValue && valueOutOfScope) {
+          if (isEnum && hasValue && valueOutOfScope && !(definition.allowNull === true && values[attrName] === null)) {
             throw new Error('Value "' + values[attrName] + '" for ENUM ' + attrName + ' is out of allowed scope. Allowed values: ' + definition.values.join(', '))
           }
         }

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -152,7 +152,7 @@ module.exports = (function() {
           valueOutOfScope = ((definition.values || []).indexOf(values[attrName]) === -1)
         }
 
-        if (isEnum && hasValue && valueOutOfScope) {
+        if (isEnum && hasValue && valueOutOfScope && !(definition.allowNull === true && values[attrName] === null)) {
           throw new Error('Value "' + values[attrName] + '" for ENUM ' + attrName + ' is out of allowed scope. Allowed values: ' + definition.values.join(', '))
         }
 

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -593,6 +593,23 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
           })
         })
       })
+
+      it('allows null values', function(done) {
+        var Enum = this.sequelize.define('Enum', {
+          state: {
+            type: Sequelize.ENUM,
+            values: ['happy', 'sad'],
+            allowNull: true
+          }
+        })
+
+        Enum.sync({ force: true }).success(function() {
+          Enum.create({state: null}).success(function(_enum) {
+            expect(_enum.state).to.be.null
+            done()
+          })
+        })
+      })
     })
   })
 


### PR DESCRIPTION
If the column allows null values, the validation for that column will be skipped
if the vale is null.

Closes https://github.com/sequelize/sequelize/issues/839
