### PR TITLE
Add Sequelize#model to fetch DAOFactory of previously defined model

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -195,6 +195,20 @@ module.exports = (function() {
     return factory
   }
 
+  /**
+   Fetch a DAO factory
+
+   @param {String} daoName The name of a model defined with Sequelize.define
+   @returns {DAOFactory} The DAOFactory for daoName
+   */
+  Sequelize.prototype.model = function(daoName) {
+    if(!this.isDefined(daoName)) {
+      throw new Error(daoName + ' has not been defined')
+    }
+
+    return this.daoFactoryManager.getDAO(daoName)
+  }
+
   Sequelize.prototype.isDefined = function(daoName) {
     var daos = this.daoFactoryManager.daos
     return (daos.filter(function(dao) { return dao.name === daoName }).length !== 0)

--- a/test/sequelize.test.js
+++ b/test/sequelize.test.js
@@ -51,6 +51,23 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
     })
   })
 
+  describe('model', function() {
+    it('throws an error if the dao being accessed is undefined', function() {
+      var self = this
+      expect(function() {
+        self.sequelize.model('Project')
+      }).to.throw(/project has not been defined/i)
+    })
+
+    it('returns the dao factory defined by daoName', function() {
+      var project = this.sequelize.define('Project', {
+        name: DataTypes.STRING
+      })
+
+      expect(this.sequelize.model('Project')).to.equal(project)
+    })
+  })
+
   describe('query', function() {
     afterEach(function(done) {
       this.sequelize.options.quoteIdentifiers = true


### PR DESCRIPTION
This provides some basic currying to the user for fetching `DAOFactory`s. I would update the docs too if I could figure out how they're generated.
