### PR TITLE
Added basic Express middleware

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -304,5 +304,45 @@ module.exports = (function() {
     }).run()
   }
 
+  Sequelize.express = function(database, username, password, options, models_callback) {
+    models_callback = arguments[arguments.length - 1]
+
+    // Since we don't want to pass too many arguments to the constructor, we need to be creative...
+    var sequelize
+    switch(arguments.length) {
+      case 1:
+        sequelize = new Sequelize();
+        break;
+      case 2:
+        sequelize = new Sequelize(database);
+        break;
+      case 3:
+        sequelize = new Sequelize(database, username);
+        break;
+      case 4:
+        sequelize = new Sequelize(database, username, password);
+        break;
+      case 5:
+        sequelize = new Sequelize(database, username, password, options);
+    }
+
+    // If we received a function as the models_callback, call it.
+    // If it's a string, treat it as a file to be imported.
+    var models
+    if (typeof(models_callback) == "function")
+      models = models_callback(sequelize, DataTypes)
+    else if (typeof(models_callback) == "string")
+      models = sequelize.import(models_callback)
+
+    return function(req, res, next) {
+      if(!req.hasOwnProperty('models'))
+        req.models = models
+      if(!req.hasOwnProperty('sequelize'))
+        req.sequelize = sequelize
+
+      next()
+    }
+  }
+
   return Sequelize
 })()


### PR DESCRIPTION
Needs work, but it's a start.

Usage:

``` javascript

Sequelize = require('sequelize')
app = require('express')()

app.use(Sequelize.express(my_connection_string, __dirname + "/models.js"))
```

Basically, `Sequelize.express` receives the same arguments as `new Sequelize`, with the addition of the last argument, called `models_callback`, which can be:
- A string representing the filename to pass on to the `import` method; or
- A function of the form `function(sequelize, dataTypes) {...}`

To use your DB connection in a request:

``` javascript

app.get('/posts/:id', function(req, res, next) {
    req.models.Post.find({where: {id: req.params.id}}).success(function(post) {
        res.render(...)
    }).error(function(err) {
        res.render(...)
    })
})
```

where `req.models` is the exact same value returned by the `models_callback` mentioned above.
