### PR TITLE
Fixes Postgres' ability to search within functions.

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -526,7 +526,7 @@ module.exports = (function() {
 
       if (Utils.isHash(smth)) {
         smth = Utils.prependTableNameToHash(tableName, smth)
-        result = this.hashToWhereConditions(smth)
+        result = this.hashToWhereConditions(smth, factory)
       } else if (typeof smth === 'number') {
         var primaryKeys = !!factory ? Object.keys(factory.primaryKeys) : []
         if (primaryKeys.length > 0) {
@@ -549,7 +549,7 @@ module.exports = (function() {
       return result
     },
 
-    hashToWhereConditions: function(hash) {
+    hashToWhereConditions: function(hash, factory) {
       var result = []
 
       for (var key in hash) {
@@ -561,9 +561,20 @@ module.exports = (function() {
 
         if (Array.isArray(value)) {
           if (value.length === 0) { value = [null] }
-          _value = "(" + value.map(this.escape).join(',') + ")"
 
-          result.push([_key, _value].join(" IN "))
+          // Special conditions for searching within an array column type
+          var _realKey = key.split('.').pop()
+          if (!!factory && !!factory.rawAttributes[_realKey]) {
+            var col = factory.rawAttributes[_realKey]
+
+            if ((!!col.type && col.type.match(/\[\]$/) !== null) || (col.toString().match(/\[\]$/) !== null)) {
+              _value = 'ARRAY[' + value.map(this.escape).join(',') + ']::' + (!!col.type ? col.type : col.toString())
+              result.push([_key, _value].join(" && "))
+            }
+          } else {
+            _value = "(" + value.map(this.escape).join(',') + ")"
+            result.push([_key, _value].join(" IN "))
+          }
         }
         else if ((value) && (typeof value === "object")) {
           if (!!value.join) {


### PR DESCRIPTION
This is a pure and simple fix for searching with a Postgres' array column type.
This commit changes hashToWhereConditions by adding a second argument of sending
the factory's details over and checking for column type if the hash/value/first
argument is an array. For the actual search we just utilize a simple overlap &&
boolean search.
