### PR TITLE
Custom event emitter uses setImmediate over process.nextTick if supported

### DIFF
--- a/lib/emitters/custom-event-emitter.js
+++ b/lib/emitters/custom-event-emitter.js
@@ -2,7 +2,7 @@ var util           = require("util")
   , EventEmitter   = require("events").EventEmitter
   , Promise        = require("promise")
   , proxyEventKeys = ['success', 'error', 'sql']
-
+  , tick           = (typeof setImmediate !== "undefined" ? setImmediate : process.nextTick)
 
 var bindToProcess = function(fct) {
   if (fct) {
@@ -21,7 +21,6 @@ module.exports = (function() {
   util.inherits(CustomEventEmitter, EventEmitter)
 
   CustomEventEmitter.prototype.run = function() {
-    var tick = (typeof setImmediate !== "undefined" ? setImmediate : process.nextTick)
     tick(function() {
       if (this.fct) {
         this.fct.call(this, this)


### PR DESCRIPTION
Closes https://github.com/sequelize/sequelize/issues/869
