### PR TITLE
Add support for typed arrays in SqlString.escape and SqlString.arrayToList

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -22,10 +22,10 @@ if (typeof ArrayBufferView === 'function') {
 
 SqlString.escapeId = function (val, forbidQualified) {
   if (forbidQualified) {
-    return '`' + val.replace(/`/g, '``') + '`';
+    return '`' + val.replace(/`/g, '``') + '`'
   }
-  return '`' + val.replace(/`/g, '``').replace(/\./g, '`.`') + '`';
-};
+  return '`' + val.replace(/`/g, '``').replace(/\./g, '`.`') + '`'
+}
 
 SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
   if (arguments.length === 1 && typeof arguments[0] === "object") {
@@ -89,10 +89,10 @@ SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
         case "\x1a": return "\\Z";
         default: return "\\"+s;
       }
-    });
+    })
   }
   return "'"+val+"'"
-};
+}
 
 SqlString.arrayToList = function(array, timeZone, dialect, field) {
   if (dialect === 'postgres') {
@@ -128,7 +128,7 @@ SqlString.arrayToList = function(array, timeZone, dialect, field) {
       return valstr.slice(0, -2)
     }
   }
-};
+}
 
 SqlString.format = function(sql, values, timeZone, dialect) {
   values = [].concat(values);
@@ -140,7 +140,7 @@ SqlString.format = function(sql, values, timeZone, dialect) {
 
     return SqlString.escape(values.shift(), false, timeZone, dialect)
   })
-};
+}
 
 SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
   return sql.replace(/\:(\w+)/g, function (value, key) {
@@ -149,8 +149,8 @@ SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
     } else {
       throw new Error('Named parameter "' + value + '" has no value in the given object.')
     }
-  });
-};
+  })
+}
 
 SqlString.dateToString = function(date, timeZone, dialect) {
   var dt = new Date(date)
@@ -170,7 +170,7 @@ SqlString.dateToString = function(date, timeZone, dialect) {
   }
 
   return moment(dt).format("YYYY-MM-DD HH:mm:ss")
-};
+}
 
 SqlString.bufferToString = function(buffer, dialect) {
   var hex = ''
@@ -189,7 +189,7 @@ SqlString.bufferToString = function(buffer, dialect) {
     return "E'\\\\x" + hex+ "'"
   }
   return "X'" + hex+ "'"
-};
+}
 
 SqlString.objectToValues = function(object, timeZone) {
   var values = []
@@ -203,7 +203,7 @@ SqlString.objectToValues = function(object, timeZone) {
   }
 
   return values.join(', ')
-};
+}
 
 function zeroPad(number) {
   return (number < 10) ? '0' + number : number

--- a/test/postgres/query-generator.test.js
+++ b/test/postgres/query-generator.test.js
@@ -17,6 +17,7 @@ if (dialect.match(/^postgres/)) {
       this.User = this.sequelize.define('User', {
         username: DataTypes.STRING,
         email: {type: DataTypes.ARRAY(DataTypes.TEXT)},
+        numbers: {type: DataTypes.ARRAY(DataTypes.FLOAT)},
         document: {type: DataTypes.HSTORE, defaultValue: '"default"=>"value"'}
       })
       this.User.sync({ force: true }).success(function() {
@@ -361,6 +362,9 @@ if (dialect.match(/^postgres/)) {
           arguments: ['myTable', {data: new Buffer('Sequelize') }],
           expectation: "INSERT INTO \"myTable\" (\"data\") VALUES (E'\\\\x53657175656c697a65') RETURNING *;"
         }, {
+          arguments: ['myTable', {name: 'foo', numbers: new Uint8Array([1,2,3])}],
+          expectation: "INSERT INTO \"myTable\" (\"name\",\"numbers\") VALUES ('foo',ARRAY[1,2,3]) RETURNING *;"
+        }, {
           arguments: ['myTable', {name: 'foo', foo: 1}],
           expectation: "INSERT INTO \"myTable\" (\"name\",\"foo\") VALUES ('foo',1) RETURNING *;"
         }, {
@@ -401,6 +405,10 @@ if (dialect.match(/^postgres/)) {
         }, {
           arguments: ['myTable', {name: 'foo', birthday: moment("2011-03-27 10:01:55 +0000", "YYYY-MM-DD HH:mm:ss Z").toDate()}],
           expectation: "INSERT INTO myTable (name,birthday) VALUES ('foo','2011-03-27 10:01:55.000 +00:00') RETURNING *;",
+          context: {options: {quoteIdentifiers: false}}
+        }, {
+          arguments: ['myTable', {name: 'foo', numbers: new Uint8Array([1,2,3])}],
+          expectation: "INSERT INTO myTable (name,numbers) VALUES ('foo',ARRAY[1,2,3]) RETURNING *;",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {name: 'foo', foo: 1}],
@@ -536,6 +544,9 @@ if (dialect.match(/^postgres/)) {
           arguments: ['myTable', {bar: 2}, {name: 'foo'}],
           expectation: "UPDATE \"myTable\" SET \"bar\"=2 WHERE \"name\"='foo' RETURNING *"
         }, {
+          arguments: ['myTable', {numbers: new Uint8Array([1,2,3])}, {name: 'foo'}],
+          expectation: "UPDATE \"myTable\" SET \"numbers\"=ARRAY[1,2,3] WHERE \"name\"='foo' RETURNING *"
+        }, {
           arguments: ['myTable', {name: "foo';DROP TABLE myTable;"}, {name: 'foo'}],
           expectation: "UPDATE \"myTable\" SET \"name\"='foo'';DROP TABLE myTable;' WHERE \"name\"='foo' RETURNING *"
         }, {
@@ -573,6 +584,10 @@ if (dialect.match(/^postgres/)) {
         }, {
           arguments: ['myTable', {bar: 2}, {name: 'foo'}],
           expectation: "UPDATE myTable SET bar=2 WHERE name='foo' RETURNING *",
+          context: {options: {quoteIdentifiers: false}}
+        }, {
+          arguments: ['myTable', {numbers: new Uint8Array([1,2,3])}, {name: 'foo'}],
+          expectation: "UPDATE myTable SET numbers=ARRAY[1,2,3] WHERE name='foo' RETURNING *",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {name: "foo';DROP TABLE myTable;"}, {name: 'foo'}],


### PR DESCRIPTION
When doing something like

``` javascript
setDataValue("position", new Float32Array([1.23, 4.2]))
```

Sequelize has stringified the typed array for database usage and by that broke the query.

With this commit typed arrays are handled like arrays, and can be saved to the database.
