### PR TITLE
Refactor data-types to use a common makeType factory function.

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -1,129 +1,45 @@
-var STRING = function(length, binary) {
-  if (this instanceof STRING) {
-    this._binary = !!binary
+var makeType = function(typeName, proto) {
+  var t = function() {
+    var self = this instanceof t ? this : Object.create(t.prototype)
+    self.construct.apply(self, Array.prototype.slice.apply(arguments))
+    return self
+  }
+  t._type = t
+  t._typeName = typeName
+
+  t.toString = function() {
+    return new this._type().toString()
+  }
+
+  Object.defineProperty(t, 'type', {
+    get: function() {
+      return new this._type().toString()
+    }
+  })
+
+  t.prototype = Object.create(proto, {
+    type: {
+      get: function() { return this.toString() }
+    },
+    _typeName: {
+      get: function() { return t._typeName }
+    }
+  })
+  t.prototype.constructor = t
+
+  return t
+}
+
+var numeric_proto = {
+  construct: function(length, decimals, unsigned, zerofill) {
+    this._unsigned = !!unsigned
+    this._zerofill = !!zerofill
     if (typeof length === 'number') {
       this._length = length
-    } else {
-      this._length = 255
     }
-  } else {
-    return new STRING(length, binary)
-  }
-}
-
-STRING.prototype = {
-  get BINARY() {
-    this._binary = true
-    return this
-  },
-  get type() {
-    return this.toString()
-  },
-  toString: function() {
-    return 'VARCHAR(' + this._length + ')' + ((this._binary) ? ' BINARY' : '')
-  }
-}
-
-Object.defineProperty(STRING, 'BINARY', {
-  get: function() {
-    return new STRING(undefined, true)
-  }
-})
-
-var INTEGER = function() {
-  return INTEGER.prototype.construct.apply(this, [INTEGER].concat(Array.prototype.slice.apply(arguments)))
-}
-
-var BIGINT = function() {
-  return BIGINT.prototype.construct.apply(this, [BIGINT].concat(Array.prototype.slice.apply(arguments)))
-}
-
-var FLOAT = function() {
-  return FLOAT.prototype.construct.apply(this, [FLOAT].concat(Array.prototype.slice.apply(arguments)))
-}
-
-var BLOB = function() {
-  return BLOB.prototype.construct.apply(this, [BLOB].concat(Array.prototype.slice.apply(arguments)))
-}
-
-FLOAT._type = FLOAT
-FLOAT._typeName = 'FLOAT'
-INTEGER._type = INTEGER
-INTEGER._typeName = 'INTEGER'
-BIGINT._type = BIGINT
-BIGINT._typeName = 'BIGINT'
-STRING._type = STRING
-STRING._typeName = 'VARCHAR'
-BLOB._type = BLOB
-BLOB._typeName = 'BLOB'
-
-BLOB.toString = STRING.toString = INTEGER.toString = FLOAT.toString = BIGINT.toString = function() {
-  return new this._type().toString()
-}
-
-BLOB.prototype = {
-
-  construct: function(RealType, length) {
-    if (this instanceof RealType) {
-      this._typeName = RealType._typeName
-      if (typeof length === 'string') {
-        this._length = length
-      } else {
-        this._length = ''
-      }
-    } else {
-      return new RealType(length)
+    if (typeof decimals === 'number') {
+      this._decimals = decimals
     }
-  },
-
-  get type() {
-    return this.toString()
-  },
-
-  toString: function() {
-    switch (this._length.toLowerCase()) {
-    case 'tiny':
-      return 'TINYBLOB'
-    case 'medium':
-      return 'MEDIUMBLOB'
-    case 'long':
-      return 'LONGBLOB'
-    default:
-      return this._typeName
-    }
-  }
-}
-
-FLOAT.prototype = BIGINT.prototype = INTEGER.prototype = {
-
-  construct: function(RealType, length, decimals, unsigned, zerofill) {
-    if (this instanceof RealType) {
-      this._typeName = RealType._typeName
-      this._unsigned = !!unsigned
-      this._zerofill = !!zerofill
-      if (typeof length === 'number') {
-        this._length = length
-      }
-      if (typeof decimals === 'number') {
-        this._decimals = decimals
-      }
-    } else {
-      return new RealType(length, decimals, unsigned, zerofill)
-    }
-  },
-
-  get type() {
-    return this.toString()
-  },
-
-  get UNSIGNED() {
-    this._unsigned = true
-    return this
-  },
-
-  get ZEROFILL() {
-    this._zerofill = true
-    return this
   },
 
   toString: function() {
@@ -142,8 +58,63 @@ FLOAT.prototype = BIGINT.prototype = INTEGER.prototype = {
       result += ' ZEROFILL'
     }
     return result
-  }
+  },
+
+  get UNSIGNED() {
+    this._unsigned = true
+    return this
+  },
+
+  get ZEROFILL() {
+    this._zerofill = true
+    return this
+  },
 }
+
+var INTEGER = makeType('INTEGER', numeric_proto)
+var BIGINT  = makeType('BIGINT', numeric_proto)
+var FLOAT   = makeType('FLOAT', numeric_proto)
+
+var BLOB    = makeType('BLOB', {
+  construct: function(length) {
+    this._length = (typeof length === 'string') ? length : ''
+  },
+
+  toString: function() {
+    switch (this._length.toLowerCase()) {
+    case 'tiny':
+      return 'TINYBLOB'
+    case 'medium':
+      return 'MEDIUMBLOB'
+    case 'long':
+      return 'LONGBLOB'
+    default:
+      return this._typeName
+    }
+  }
+})
+
+var STRING  = makeType('VARCHAR', {
+  construct: function(length, binary) {
+    this._length = (typeof length === 'number') ? length : 255
+    this._binary = !!binary
+  },
+
+  toString: function() {
+    return 'VARCHAR(' + this._length + ')' + (this._binary ? ' BINARY' : '')
+  },
+
+  get BINARY() {
+    this._binary = true
+    return this
+  }
+})
+
+Object.defineProperty(STRING, 'BINARY', {
+  get: function() {
+    return new STRING(undefined, true)
+  }
+})
 
 var unsignedDesc = {
   get: function() {
@@ -156,18 +127,6 @@ var zerofillDesc = {
     return new this._type(undefined, undefined, undefined, true)
   }
 }
-
-var typeDesc = {
-  get: function() {
-    return new this._type().toString()
-  }
-}
-
-Object.defineProperty(STRING,  'type', typeDesc)
-Object.defineProperty(INTEGER, 'type', typeDesc)
-Object.defineProperty(BIGINT,  'type', typeDesc)
-Object.defineProperty(FLOAT,   'type', typeDesc)
-Object.defineProperty(BLOB,    'type', typeDesc)
 
 Object.defineProperty(INTEGER, 'UNSIGNED', unsignedDesc)
 Object.defineProperty(BIGINT,  'UNSIGNED', unsignedDesc)


### PR DESCRIPTION
This patch refactors the data-type definitions to use a common `makeType` function. There should be no functional change.

The original motivation for this change was to make the type functions be able to sort of "bud" more specific variants of themselves. I thought it would be a good idea to start a dialog with a reasonably minor change before going off on a tangent. The basic change I'm proposing (beyond this minor cleanup) is to use a more formal prototypical inheritance to extend types. Here's an example use case:

``` javascript
var Project = sequelize.define('Project', {
  title: Sequelize.STRING.bud({ allowNull: false, unique: true })
  description: Sequelize.TEXT
})
```

A more useful application of this would be to define specialty types (maybe with validators, like a URL or Email type) that can be later extended further, and use them more than once in models. For instance:

``` javascript
var URL = Sequelize.STRING.bud({ validate: { isUrl: true }});

var Image = sequelize.define('Image', {
  url: URL.bud({ allowNull: false, unique: true })
  ...
})
```

Another option is to have two kinds of type classes, basic and compound, where basic types would map one-to-one to db types, and compound types would be as described above. Even just a better defined interface to the basic types would be helpful for someone (me) to create an external extension that does this. I'd appreciate any commentary on this.

Just to be clear, the particular change in this patch is only to clean up how data types are defined.
