### PR TITLE
rawSelect does not bother to check whether it actually found a result before trying to access a result attribute ...

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -311,7 +311,7 @@ module.exports = (function() {
 
       qry
         .success(function(data) {
-          var result = data[attributeSelector]
+          var result = data ? data[attributeSelector] : null
 
           if (options && options.parseInt) {
             result = parseInt(result)


### PR DESCRIPTION
fixes a TypeError that occurs if a 'rawSelect' query does not return a row (data is null).

I discovered the problem trying perform a `Model.count()` in combination with a `group` option on a MySQL database,MySQL does not return a record for query such as this:

``` sql
SELECT 
    count(*) AS `count` 
FROM 
    `SomeTable` 
WHERE 
    `category_id` = 1
GROUP BY 
    `my_grouping_field`
```

In Sequelize the previous query would be done like so:

``` js
SomeTable.count({
  group: 'my_grouping_field',
  where: {
    category_id: 1
  }
});
```

assuming the `category_id` WHERE clause returns zero records you end up with the following TypeError:

``` bash
TypeError: Cannot read property 'count' of null
    at null.<anonymous> (some-project/node_modules/sequelize/lib/query-interface.js:314:28)
    at EventEmitter.emit (events.js:117:20)
    at null.<anonymous> (some-project/node_modules/sequelize/lib/dialects/mysql/query.js:32:14)
    at Query.Sequence.end (some-project/node_modules/mysql/lib/protocol/sequences/Sequence.js:66:24)
    at Query._handleFinalResultPacket (some-project/node_modules/mysql/lib/protocol/sequences/Query.js:139:8)
    at Query.EofPacket (some-project/node_modules/mysql/lib/protocol/sequences/Query.js:123:8)
    at Protocol._parsePacket (some-project/node_modules/mysql/lib/protocol/Protocol.js:169:24)
    at Parser.write (some-project/node_modules/mysql/lib/protocol/Parser.js:62:12)
    at Protocol.write (some-project/node_modules/mysql/lib/protocol/Protocol.js:36:16)
    at write (_stream_readable.js:557:24)
```
