### PR TITLE
Added downcaseAssociationsAccessors configuration option

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -319,8 +319,10 @@ module.exports = (function() {
 
     var accessor = Utils._.camelize(tableName)
 
-    // downcase the first char
-    accessor = accessor.slice(0,1).toLowerCase() + accessor.slice(1)
+    if (self.sequelize.options.downcaseAssociationsAccessors === true) {
+      // downcase the first char
+      accessor = accessor.slice(0,1).toLowerCase() + accessor.slice(1)
+    }
 
     associationData.forEach(function(data) {
       var daoInstance = associatedDaoFactory.build(data, { isNewRecord: false, isDirty: false })

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -28,6 +28,7 @@ module.exports = (function() {
       @param {Boolean} [options.replication=false] I have absolutely no idea.
       @param {Object} [options.pool={}] Something.
       @param {Boolean} [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.
+      @param {Boolean} [options.downcaseAssociationsAccessors=true] Set to `false` to make eagerloaded association accesors respect initial capitalization.
 
     @example
         // without password and options
@@ -82,7 +83,8 @@ module.exports = (function() {
       replication: false,
       pool: {},
       quoteIdentifiers: true,
-      language: 'en'
+      language: 'en',
+      downcaseAssociationsAccessors: true
     }, options || {})
 
     if (this.options.logging === true) {


### PR DESCRIPTION
Hello there, as i have already commented on this issue a few months ago ( http://github.com/sequelize/sequelize/issues/652 ), this is the second time where im facing this little issue regarding the default and not-configurable behavior of down casing the first letter on the associated models accessors when eager loading.
Example:
User.hasOne(Profile)

When including the Profile model in any query on the User model, all the profile data will be inside a 'profile' property, instead of the original 'Profile'.

I understand that this is a convention and/or default in SOME circumstances, however, when you have to deal with a currently working API, and the capitalization is important for the responses, having to create object reformatters is a little overkill when this behavior could just be disabled with a simple fix.

Ideally with this patch, you can have an result object that respects the capitalization of the associated models.

I would love this pull to be merged into master, please let me know if you think this is not possible as im currently using a custom patched version of sequelize in 2 projects because of this.

Thanks!
