### PR TITLE
Bug in findAndCountAll if where contains ["name LIKE ?", "%search%"] condition

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -449,8 +449,9 @@ module.exports = (function() {
 
   DAOFactory.prototype.findAndCountAll = function(options) {
     var self  = this
+      , copts = Utils._.clone(options, true)
       // no limit, offset, order, attributes or include for the options given to count()
-      , copts = Utils._.omit(options || {}, ['offset', 'limit', 'order', 'include', 'attributes'])
+      , copts = Utils._.omit(copts || {}, ['offset', 'limit', 'order', 'include', 'attributes'])
 
     return new Utils.CustomEventEmitter(function (emitter) {
       var emit = {


### PR DESCRIPTION
Fixed findAndCountAll if where contains a condition of the form "name LIKE '%search%'"

options = {
   where: ["name LIKE ?", "%search%"]
}

Result query for counting:

SELECT count(*) as "count" FROM "Table" WHERE name LIKE '%search%';

in second sql query after counting, options where is ["%search%"] only
what causes an error in the second query

Result query for items:

SELECT \* FROM "Table" WHERE %search%
