### PR TITLE
Let user can set node-mysql options

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -265,9 +265,9 @@ module.exports = (function() {
       timezone: 'Z'
     };
 
-    if (config.nodeMysql) {
-      Object.keys(config.nodeMysql).forEach(function (key) {
-        connectionConfig[key] = config.nodeMysql[key];
+    if (config.connectionOptions) {
+      Object.keys(config.connectionOptions).forEach(function (key) {
+        connectionConfig[key] = config.connectionOptions[key];
       });
     }
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -103,7 +103,8 @@ module.exports = (function() {
       native  : this.options.native,
       replication: this.options.replication,
       dialectModulePath: this.options.dialectModulePath,
-      maxConcurrentQueries: this.options.maxConcurrentQueries
+      maxConcurrentQueries: this.options.maxConcurrentQueries,
+      connectionOptions: this.options.connectionOptions,
     }
 
     try {

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -101,14 +101,23 @@ describe(Support.getTestDialectTeaser("Configuration"), function() {
     })
 
     it('should accept four parameters (database, username, password, options)', function(done) {
-      var sequelize = new Sequelize('dbname', 'root', 'pass', { port: 999 })
+      var sequelize = new Sequelize('dbname', 'root', 'pass', {
+        port: 999,
+        connectionOptions: {
+          supportBigNumbers: true,
+          bigNumberStrings: true
+        }
+      })
       var config = sequelize.config
 
       expect(config.database).to.equal('dbname')
       expect(config.username).to.equal('root')
       expect(config.password).to.equal('pass')
       expect(config.port).to.equal(999)
+      expect(config.connectionOptions.supportBigNumbers).to.be.true
+      expect(config.connectionOptions.bigNumberStrings).to.be.true
       done()
     })
   })
+
 })

--- a/test/support.js
+++ b/test/support.js
@@ -35,7 +35,8 @@ var Support = {
       logging: options.logging,
       dialect: options.dialect,
       port:    options.port || process.env.SEQ_PORT || config[options.dialect].port,
-      pool:    options.pool
+      pool:    options.pool,
+      connectionOptions: options.connectionOptions || {}
     }
 
     if (!!options.host) {


### PR DESCRIPTION
It seems difficult for user to set node-mysql options before, Like `supportBigNumbers` and `bigNumberStrings`, I edit some code to improve the problem.

```
var sequelize = new Sequelize('database', 'username', 'password', {
  nodeMysql: {
    supportBigNumbers: true,
    bigNumberStrings: true
  }
});
```
