### PR TITLE
This commit adds a new DAOFactory option called onNullError

### DIFF
--- a/lib/associations/has-many-single-linked.js
+++ b/lib/associations/has-many-single-linked.js
@@ -25,7 +25,7 @@ module.exports = (function() {
       options.where = where
     }
 
-    return this.__factory.target.all(options)
+    return this.__factory.target.all(options, {onNullError: false})
   }
 
   HasManySingleLinked.prototype.injectSetter = function(emitter, oldAssociations, newAssociations) {

--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -25,7 +25,8 @@ module.exports = (function() {
       schemaDelimiter: '',
       language: 'en',
       defaultScope: null,
-      scopes: null
+      scopes: null,
+      onNullError: false
     }, options || {})
 
     // error check options
@@ -339,9 +340,13 @@ module.exports = (function() {
       this.options.whereCollection = options.where || null
     }
 
+    var onNullError = (!!this.options && !!this.options.onNullError ? this.options.onNullError : false)
+    onNullError = (!!queryOptions && !!queryOptions.onNullError ? queryOptions.onNullError : onNullError)
+
     return this.QueryInterface.select(this, this.tableName, options, Utils._.defaults({
       type:    'SELECT',
-      hasJoin: hasJoin
+      hasJoin: hasJoin,
+      onNullError: onNullError
     }, queryOptions))
   }
 
@@ -432,10 +437,14 @@ module.exports = (function() {
 
     options.limit = 1
 
+    var onNullError = (!!this.options && !!this.options.onNullError ? this.options.onNullError : false)
+    onNullError = (!!queryOptions && !!queryOptions.onNullError ? queryOptions.onNullError : onNullError)
+
     return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
       plain: true,
       type: 'SELECT',
-      hasJoin: hasJoin
+      hasJoin: hasJoin,
+      onNullError: onNullError
     }, queryOptions))
   }
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -693,6 +693,10 @@ module.exports = (function() {
       emitter.query = query
 
       query.success(function(obj) {
+        if (Array.isArray(sqlOrQueryParams) && typeof sqlOrQueryParams[2] === "object" && typeof sqlOrQueryParams[2].onNullError === "string" && methodName === "select" && (obj === null || (Array.isArray(obj) && obj.length < 1))) {
+          return emitter.emit('error', sqlOrQueryParams[2].onNullError)
+        }
+
         options.success && options.success(obj)
         this.emit(methodName, null)
         emitter.emit('success', obj)

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -382,7 +382,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
                 , pad = function (number) {
                   if (number > 9) {
                     return number
-                  } 
+                  }
                   return '0' + number
                 }
               expect(user.year).to.equal(now.getFullYear() + '-' + pad(now.getMonth() + 1) + '-' + pad(now.getDate()))
@@ -2273,6 +2273,62 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         this.User.create({username: 'barfooz'}).success(function(user) {
           self.user = user
           done()
+        })
+      })
+
+      describe('should return an error when we declared onNullError to not equal false', function() {
+        describe('returns an error from the factory', function() {
+          beforeEach(function(done) {
+            this.User = this.sequelize.define('UserTest', {
+              username: Sequelize.STRING
+            }, {
+              onNullError: 'No users were found!'
+            })
+
+            this.User.sync({ force: true }).success(function() {
+              done()
+            })
+          })
+
+          it('on find', function(done) {
+            this.User.find({where: {username: ''}}).error(function(err) {
+              expect(err).to.equal('No users were found!')
+              done()
+            })
+          })
+
+          it('on all', function(done) {
+            this.User.all().error(function(err) {
+              expect(err).to.equal('No users were found!')
+              done()
+            })
+          })
+        })
+
+        describe('returns an error from the function options', function() {
+          beforeEach(function(done) {
+            this.User = this.sequelize.define('UserTest', {
+              username: Sequelize.STRING
+            })
+
+            this.User.sync({ force: true }).success(function() {
+              done()
+            })
+          })
+
+          it('on find', function(done) {
+            this.User.find({where: {username: ''}}, {onNullError: 'No users were found!'}).error(function(err) {
+              expect(err).to.equal('No users were found!')
+              done()
+            })
+          })
+
+          it('on all', function(done) {
+            this.User.all({}, {onNullError: 'No users were found!'}).error(function(err) {
+              expect(err).to.equal('No users were found!')
+              done()
+            })
+          })
         })
       })
 


### PR DESCRIPTION
This option allows you to emit an error whenever using .find or .findAll methods
and the records returned are null/length of zero. The error option is valid
under any value except a boolean false.

Example:

var Users = sequelize.define('User', { ...dataTypes... }, {onNullError: 'Users
not found!'})

Users.find({where: {username: 'Bob'}}).error(function(err) {
  // err would be Users not found!
})

This closes https://github.com/sequelize/sequelize/issues/272
