### PR TITLE
fix postgres for non-pool users

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -145,6 +145,7 @@ module.exports = (function() {
       // Closes a client correctly even if we have backed up queries
       // https://github.com/brianc/node-postgres/pull/346
       this.client.on('drain', this.client.end.bind(this.client))
+      this.client = null
     }
 
     this.isConnecting = false


### PR DESCRIPTION
https://github.com/sequelize/sequelize/commit/97c50bee8504ae3e11a5ee6b3d6437feb07a5b32#diff-79f54f85f3430ebb98753af796ddcbe4L148

This commit appears to have broken postgres for non-pool users.
The reason this slipped through is probably because our getting started examples has pools and the testing config has pools.

Basically the problem is that if queries come in a slow secession, it will hit 0 and then disconnect, but never set client to null and allow a new client to connect.
