### PR TITLE
change column postgresql defaul, spacing bug

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -177,7 +177,7 @@ module.exports = (function() {
         if (definition.indexOf('DEFAULT') > 0) {
           attrSql += Utils._.template(query)({
             tableName: this.quoteIdentifiers(tableName),
-            query:     this.quoteIdentifier(attributeName) + ' SET DEFAULT' + definition.match(/DEFAULT ([^;]+)/)[1]
+            query:     this.quoteIdentifier(attributeName) + ' SET DEFAULT ' + definition.match(/DEFAULT ([^;]+)/)[1]
           })
 
           definition = definition.replace(/(DEFAULT[^;]+)/, '').trim()


### PR DESCRIPTION
When running migrations there is a bug with making query for changeColumn

this bug is also in 1.7.0

```
ALTER TABLE "Users" ALTER COLUMN "points" SET DEFAULT0
```
