### PR TITLE
Limit and Eager loading in findAll query

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -250,6 +250,8 @@ module.exports = (function() {
         } else {
           query += " LIMIT " + options.limit
         }
+      }else if (options.limit) {
+        query += " LIMIT " + options.limit
       }
 
       query += ";"


### PR DESCRIPTION
Was working on a project when I noticed I could not include and limit 1 a select query using MySQL. Not sure if there is some abstract reasoning on why this is currently not allowed however I have made a minor modification to allow this. In order to better grasp what the issue is I made this example

``` javascript
var Sequelize = require('sequelize')

var sequelize = new Sequelize('seqtest', 'root', 'root', {
    host:'localhost', 
    port:3306, 
    dialect:'mysql', 
}); 

var Student = sequelize.define('Student', {name:{type:Sequelize.STRING}});
var Class = sequelize.define('Class', {name:{type:Sequelize.STRING}});

Student.sync(); 
Class.sync(); 
Student.hasMany(Class); 
Class.hasMany(Student); 

var chainer = new Sequelize.Utils.QueryChainer

chainer.add(Student.create({name:'David'}))
chainer.add(Student.create({name:'Jerry'}))
chainer.add(Student.create({name:'Matt'}))

chainer.add(Class.create({name:'Discrete Structures'}))
chainer.add(Class.create({name:'Computer Science II'}))

chainer.run().success(function(results){
    results[0].setClasses([results[3], results[4]])
    results[1].setClasses([results[3]])
    results[2].setClasses([results[4]])
    main(); 
}); 

function main(){    
    Student.findAll({include:[Class], 
                     order:'Students.createdAt ASC', 
                     limit:1, 
                     where:{'Classes.id':1}}).success(function(student){
        console.log("+               Query_              +"); 
        console.log("+-----------------------------------"); 
    }); 
}
```

If you run this you will notice the limit 1 parameter in the student findAll query in main() doesn't work, I suppose I could also use the MIN keyword with the date which might accomplish the goal of this query however this is a valid query none the less. You may or may not use my patch however I though I should at least bring this to your guys attention and possibly get some clarification. 
