### PR TITLE
Fix for Issue #984 ([postgres] Eager loading when using 'include' statement fails when specifying 'schemaName.tableName')

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -262,7 +262,7 @@ module.exports = (function() {
             query += Utils._.template(joinQuery)({
               table:      this.quoteIdentifiers(include.daoFactory.tableName),
               as:         this.quoteIdentifier(include.as),
-              tableLeft:  this.quoteIdentifiers((include.association.associationType === 'BelongsTo') ? include.as : tableName),
+              tableLeft:  this.quoteIdentifier((include.association.associationType === 'BelongsTo') ? include.as : tableName),
               attrLeft:   this.quoteIdentifier(((primaryKeysLeft.length !== 1) ? 'id' : primaryKeysLeft[0])),
               tableRight: this.quoteIdentifiers((include.association.associationType === 'BelongsTo') ? tableName : include.as),
               attrRight:  this.quoteIdentifier(include.association.identifier)


### PR DESCRIPTION
I ran the tests for postgres only (because this is within the dialects/postgres directory) before and after this change - 18 tests were failing both before and after.
