### PR TITLE
Fix "Cannot call method 'toLowerCase' of undefined" error

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -135,7 +135,7 @@ module.exports = (function() {
               , ciCollation     = !!self.daoFactory.options.collate && self.daoFactory.options.collate.match(/_ci$/i)
 
             // Unfortunately for MySQL CI collation we need to map/lowercase values again
-            if (isEnum && isMySQL && ciCollation) {
+            if (isEnum && isMySQL && ciCollation && (attrName in values)) {
               var scopeIndex = (definition.values || []).map(function(d) { return d.toLowerCase() }).indexOf(values[attrName].toLowerCase())
               valueOutOfScope = scopeIndex === -1
 


### PR DESCRIPTION
```
sequelize/lib/dao.js:139
ap(function(d) { return d.toLowerCase() }).indexOf(values[attrName].toLowerCas
                                                                    ^
TypeError: Cannot call method 'toLowerCase' of undefined
```

Problem occurs when the MySQL enum field (attrName) is not being inserted or updated.
