### PR TITLE
add .npmignore, save 1.4mb

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+docs
+examples
+test
+README.md
+.watchr.js
+changelog.md
+Makefile


### PR DESCRIPTION
This `.npmignore` file will save 1.4mb for every `npm install` issued from here on...
