### PR TITLE
re-enable synchronous model validators

### DIFF
--- a/lib/dao-validator.js
+++ b/lib/dao-validator.js
@@ -73,6 +73,7 @@ var validateModel = function() {
 
     this.chainer.add(new Utils.CustomEventEmitter(function(emitter) {
       var next = function(err) {
+
         if (err) {
           var error = {}
           error[validatorType] = [err]
@@ -137,8 +138,33 @@ var prepareValidationOfAttribute = function(value, details, validatorType, optio
   if (typeof details === 'function') {
     // it is a custom validator function?
     isCustomValidator = true
+
+    var callArgs = []
+    var validatorArity = details.length
+
+    var omitValue = !!(options || {}).omitValue
+    if (!omitValue) {
+      callArgs.push(value)
+    }
+
+    // check if validator is async and requires a callback
+    var isAsync = omitValue && validatorArity === 1 ||
+      !omitValue && validatorArity === 2
+
     validatorFunction = function(next) {
-      details.apply(this.model, ((options || {}).omitValue) ? [next] : [value, next])
+      if (isAsync) {
+        callArgs.push(next)
+      }
+
+      try {
+        details.apply(this.model, callArgs)
+      } catch(ex) {
+        return next(ex.message)
+      }
+
+      if (!isAsync) {
+        next()
+      }
     }.bind(this)
   } else {
     // it is a validator module function?

--- a/test/dao.validations.test.js
+++ b/test/dao.validations.test.js
@@ -1,3 +1,4 @@
+/* jshint expr:true */
 var chai      = require('chai')
   , expect    = chai.expect
   , Sequelize = require(__dirname + '/../index')
@@ -549,6 +550,43 @@ describe(Support.getTestDialectTeaser("DaoValidator"), function() {
               done('xnor failed')
             } else {
               done()
+            }
+          }
+        }
+      })
+
+      Foo
+        .build({ field1: null, field2: null })
+        .validate()
+        .success(function(errors) {
+          expect(errors).not.to.be.null
+          expect(errors).to.deep.equal({ 'xnor': ['xnor failed'] })
+
+          Foo
+            .build({ field1: 33, field2: null })
+            .validate()
+            .success(function(errors) {
+              expect(errors).not.exist
+              done()
+            })
+        })
+    })
+
+    it('validates a model with no async callback', function(done) {
+      var Foo = this.sequelize.define('Foo' + config.rand(), {
+        field1: {
+          type: Sequelize.INTEGER,
+          allowNull: true
+        },
+        field2: {
+          type: Sequelize.INTEGER,
+          allowNull: true
+        }
+      }, {
+        validate: {
+          xnor: function() {
+            if ((this.field1 === null) === (this.field2 === null)) {
+              throw new Error('xnor failed')
             }
           }
         }


### PR DESCRIPTION
re-enables synchronous model validators. 

Unbreaks change with validators, now they are BC

`make all` passes all tests on local except for a mariadb test:

```
  1) [MARIADB] DAOFactory references emits an error event as the referenced table name is invalid:
     Uncaught AssertionError: expected 'Cannot add foreign key constraint' to match /Can\'t create table/
```
