### PR TITLE
Changes booleans to no longer return false, if they are in fact null

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -409,7 +409,7 @@ module.exports = (function() {
   }
 
   DAO.prototype.addAttribute = function(attribute, value) {
-    if (this.booleanValues.length && this.booleanValues.indexOf(attribute) !== -1 && value !== undefined) { // transform integer 0,1 into boolean
+    if (this.booleanValues.length && this.booleanValues.indexOf(attribute) !== -1 && value != null) { // transform integer 0,1 into boolean
       value = !!value
     }
 

--- a/test/dao.test.js
+++ b/test/dao.test.js
@@ -1114,6 +1114,25 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
         })
       })
     })
+    it("returns null for null, undefined, and unset boolean values", function(done) {
+      var Setting = this.sequelize.define('SettingHelper', {
+        setting_key: DataTypes.STRING,
+          bool_value: { type: DataTypes.BOOLEAN, allowNull: true },
+          bool_value2: { type: DataTypes.BOOLEAN, allowNull: true },
+          bool_value3: { type: DataTypes.BOOLEAN, allowNull: true }
+      }, { timestamps: false, logging: false })
+
+      Setting.sync({ force: true }).success(function() {
+        Setting.create({ setting_key: 'test', bool_value: null, bool_value2: undefined }).success(function() {
+          Setting.find({ where: { setting_key: 'test' } }).success(function(setting) {
+            expect(setting.bool_value).to.equal(null)
+            expect(setting.bool_value2).to.equal(null)
+            expect(setting.bool_value3).to.equal(null)
+            done()
+          })
+        })
+      })
+    })
   })
 
   describe('equals', function() {


### PR DESCRIPTION
I stumbled upon this issue, when I tried inserting null or undefined values and for some reason, they would always return a false value. The insertion to the table was correct, but when it fetched NULL-values from the database, it would convert them to false, which is weird behavior. This fixes that behavior.
