### PR TITLE
Refactor done() to apply args given, so as not to allways call with 2nd ...

### DIFF
--- a/lib/emitters/custom-event-emitter.js
+++ b/lib/emitters/custom-event-emitter.js
@@ -49,7 +49,11 @@ module.exports = (function() {
   function(fct) {
     fct = bindToProcess(fct);
     this.on('error', function(err) { fct(err, null) })
-        .on('success', function(arg0, arg1) { fct(null, arg0, arg1) })
+        .on('success', function() {
+          var args = Array.prototype.slice.call(arguments);
+          args.unshift(null);
+          fct.apply(fct, args);
+        })
     return this
   }
 


### PR DESCRIPTION
...param, as this messes with async.js auto.

Before the fix to pass on a 2nd parameter sequelize would work perfectly well with async.js
However know, atleast if using a custom event emitter inside an auto call, the result will come out [result, undefined] instead of just result, which is undesireable.
