### PR TITLE
Disables logging by default

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -76,7 +76,7 @@ module.exports = (function() {
       define: {},
       query: {},
       sync: {},
-      logging: console.log,
+      logging: false,
       omitNull: false,
       queue: true,
       native: false,


### PR DESCRIPTION
Logging like this (especially through console.log) should be for debugging purposes only and you would therefore assume it to be off by default.
