### PR TITLE
fixing buffer rendering in where query clause in mysql

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -641,9 +641,9 @@ module.exports = (function() {
         var _key   = this.quoteIdentifiers(key)
           , _value = null
 
-        if (Array.isArray(value)) {
+        if (Array.isArray(value) && !Buffer.isBuffer(value)) {
           result.push(this.arrayValue(value, key, _key, dao))
-        } else if ((value) && (typeof value == 'object') && !(value instanceof Date)) {
+        } else if ((value) && (typeof value == 'object') && !(value instanceof Date) && !Buffer.isBuffer(value)) {
           if (!!value.join) {
             //using as sentinel for join column => value
             _value = this.quoteIdentifiers(value.join)


### PR DESCRIPTION
In mysql, blob types cannot be compared in where clauses. This fix uses the escape method properly in order to render a hexadecimal representation.
