### PR TITLE
Fixes error thrown when eager loading a hasMany relationship that has zero models

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -136,9 +136,12 @@ module.exports = (function() {
 
             // Unfortunately for MySQL CI collation we need to map/lowercase values again
             if (isEnum && isMySQL && ciCollation && (attrName in values)) {
-              var scopeIndex = (definition.values || []).map(function(d) { return d.toLowerCase() }).indexOf(values[attrName].toLowerCase())
+              if (values[attrName] != null) {
+                var scopeIndex = (definition.values || []).map(function(d) {
+                  return d.toLowerCase();
+                }).indexOf(values[attrName].toLowerCase())
+              }
               valueOutOfScope = scopeIndex === -1
-
               // We'll return what the actual case will be, since a simple SELECT query would do the same...
               if (!valueOutOfScope) {
                 values[attrName] = definition.values[scopeIndex]

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -341,6 +341,9 @@ module.exports = (function() {
       var daoInstance = associatedDaoFactory.build(data, { isNewRecord: false, isDirty: false })
         , isEmpty     = !Utils.firstValueOfHash(daoInstance.identifiers)
 
+      // if association is null, there are no records for that model
+      if (association == null) return;
+
       if (['BelongsTo', 'HasOne'].indexOf(association.associationType) > -1) {
         accessor = Utils.singularize(accessor, self.sequelize.language)
         dao[accessor] = isEmpty ? null : daoInstance


### PR DESCRIPTION
When a hasMany association is eagerly loaded, and there is 0 related models in the datastore, this gets thrown:

```
>> TypeError: Cannot read property 'associationType' of null
>>     at null.<anonymous> (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/abstract/query.js:331:54)
>>     at Array.forEach (native)
>>     at module.exports.buildAssociatedDaoInstances (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/abstract/query.js:327:21)
>>     at module.exports.transformRowWithEagerLoadingIntoDao (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/abstract/query.js:296:37)
>>     at null.<anonymous> (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/abstract/query.js:282:50)
>>     at Array.map (native)
>>     at module.exports.transformRowsWithEagerLoadingIntoDaos (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/abstract/query.js:281:58)
>>     at module.exports.handleSelectQuery (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/abstract/query.js:262:54)
>>     at module.exports.AbstractQuery.formatResults (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/abstract/query.js:68:34)
>>     at null.<anonymous> (/Users/michael/Projects/dearharry-server/node_modules/sequelize/lib/dialects/mysql/query.js:32:35)
```

This inserts a check to see if the association is null, and returns early.
