### PR TITLE
Add a case for native pg client with different callback format

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -113,6 +113,11 @@ module.exports = (function() {
           self.client = client
           emitter.emit('success', done)
         })
+      } else if (self.config.native) {
+        self.client.query("SET TIME ZONE 'UTC'").on('end', function() {
+          self.isConnected = true
+          emitter.emit('success', done)
+        })
       } else {
         done && done()
         self.client = null


### PR DESCRIPTION
When using the native pg bindings, the `connectCallback` has no `client` argument passed to it. As a result, self.client should continue to be used here.

Resolves #1034
