### PR TITLE
Adds an additional check for enum value before converting it toLowerCase

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -135,7 +135,7 @@ module.exports = (function() {
               , ciCollation     = !!self.daoFactory.options.collate && self.daoFactory.options.collate.match(/_ci$/i)
 
             // Unfortunately for MySQL CI collation we need to map/lowercase values again
-            if (isEnum && isMySQL && ciCollation && (attrName in values)) {
+            if (isEnum && isMySQL && ciCollation && (attrName in values) && values[attrName]) {
               var scopeIndex = (definition.values || []).map(function(d) { return d.toLowerCase() }).indexOf(values[attrName].toLowerCase())
               valueOutOfScope = scopeIndex === -1
 


### PR DESCRIPTION
Basically fixes an issue introduced with commit 2d298a3c9fca0a342251c665728cff04fc595a9b that causes conversion of undefined toLowerCase

TypeError: Cannot call method 'toLowerCase' of undefined
    at null.<anonymous> (/path/to/project/modules/elms/node_modules/sequelize/lib/dao.js:139:127)
    at EventEmitter.emit (events.js:95:17)
    at null.<anonymous> (/path/to/project/modules/elms/node_modules/sequelize/lib/dao-validator.js:45:17)
    at Hooks.runHooks (/path/to/project/modules/elms/node_modules/sequelize/lib/hooks.js:19:15)
    at null.<anonymous> (/path/to/project/modules/elms/node_modules/sequelize/lib/dao-validator.js:39:29)
    at Hooks.runHooks (/path/to/project/modules/elms/node_modules/sequelize/lib/hooks.js:19:15)
    at null.fct (/path/to/project/modules/elms/node_modules/sequelize/lib/dao-validator.js:26:27)
    at null.<anonymous> (/path/to/project/modules/elms/node_modules/sequelize/lib/emitters/custom-event-emitter.js:25:18)
    at processImmediate [as _immediateCallback](timers.js:330:15)
