### PR TITLE
Respecting `deletedAt` field of junction tables

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -362,7 +362,8 @@ module.exports = (function() {
     */
     selectQuery: function(tableName, options, factory) {
       var table = null,
-          joinQuery = ""
+          joinQuery = "",
+          tableJunctionWhereConditions = ""
 
       options            = options || {}
       options.table      = table = Array.isArray(tableName) ? tableName.map(function(t) { return this.quoteIdentifiers(t) }.bind(this)).join(", ") : this.quoteIdentifiers(tableName)
@@ -410,6 +411,14 @@ module.exports = (function() {
             var tableJunction     = include.association.connectorDAO.tableName
             joinQuery += " LEFT OUTER JOIN " + this.quoteIdentifier(tableJunction) + " ON " + this.quoteIdentifier(tableSource) + "." + this.quoteIdentifier(attrSource) + " = " + this.quoteIdentifier(tableJunction) + "." + this.quoteIdentifier(identSource)
             joinQuery += " LEFT OUTER JOIN " + this.quoteIdentifier(table) + " AS " + this.quoteIdentifier(as) + " ON " + this.quoteIdentifier(tableTarget) + "." + this.quoteIdentifier(attrTarget) + " = " + this.quoteIdentifier(tableJunction) + "." + this.quoteIdentifier(identTarget)
+
+            if (include.attributes.indexOf('deletedAt') !== -1) {
+              if (tableJunctionWhereConditions.length !== 0) {
+                tableJunctionWhereConditions += ' AND '
+              }
+
+              tableJunctionWhereConditions += this.quoteIdentifier(tableJunction) + "." + this.quoteIdentifier('deletedAt') + " IS NULL"
+            }
           }
         }.bind(this))
 
@@ -427,9 +436,21 @@ module.exports = (function() {
         query += joinQuery
       }
 
-      if (options.hasOwnProperty('where')) {
-        options.where = this.getWhereConditions(options.where, tableName, factory)
-        query += " WHERE " + options.where
+      if (options.hasOwnProperty('where') || (tableJunctionWhereConditions.length !== 0)) {
+        query += " WHERE "
+
+        if (options.hasOwnProperty('where')) {
+          options.where = this.getWhereConditions(options.where, tableName, factory)
+          query += options.where
+        }
+
+        if (tableJunctionWhereConditions.length !== 0) {
+          if (options.hasOwnProperty('where')) {
+            query += " AND "
+          }
+
+          query += tableJunctionWhereConditions
+        }
       }
 
       if (options.group) {


### PR DESCRIPTION
Eager loading ("include") feature should respect `deletedAt` field of junction tables. You probably don't want to see removed associations, do you? :) Here is basic implementation of this.
