### PR TITLE
Default dialect in sequelize generatec config

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -34,19 +34,22 @@ var writeDefaultConfig = function(config) {
         username: "root",
         password: null,
         database: 'database_development',
-        host: '127.0.0.1'
+        host: '127.0.0.1',
+        dialect: 'mysql'
       },
       test: {
         username: "root",
         password: null,
         database: 'database_test',
-        host: '127.0.0.1'
+        host: '127.0.0.1',
+        dialect: 'mysql'
       },
       production: {
         username: "root",
         password: null,
         database: 'database_production',
-        host: '127.0.0.1'
+        host: '127.0.0.1',
+        dialect: 'mysql'
       }
     }, undefined, 2) + "\n"
 


### PR DESCRIPTION
The config.json generated by sequelize -i does not supply a dialect
key/value pair when generating. It defaults to mysql so lets make this
clear by adding it to the config file
