### PR TITLE
Update connector-manager.js

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -60,7 +60,9 @@ module.exports = (function() {
         var query = new Query(self.client, self.sequelize, callee, options || {})
 
         return query.run(sql)
-          .complete(function(err) { done && done(err) })
+          .complete(function(err) {
+            self.endQuery.call(self)
+            done && done(err) })
           .success(function(results) { self.endQuery.call(self) })
           .error(function(err) { self.endQuery.call(self) })
           .proxy(emitter)


### PR DESCRIPTION
That will fix the bug on 'error: sorry, too many clients already'
