### PR TITLE
Support relative custom config paths

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -22,6 +22,15 @@ var relativeConfigFile = function() {
   return path.relative(process.cwd(), configuration.configFile)
 }
 
+// Taken from
+// http://stackoverflow.com/questions/15375544/how-can-i-robustly-detect-a-relative-path-in-node-js/17521358#17521358
+var isRelativePath = function(p) {
+  var normal = path.normalize(p)
+    , absolute = path.resolve(p);
+
+  return normal != absolute;
+}
+
 var writeDefaultConfig = function(config) {
   var configPath = path.dirname(configuration.configFile)
 
@@ -109,10 +118,10 @@ program
   .parse(process.argv)
 
 if(typeof program.config === 'string') {
-  if (program.config[0] === '/') {
-    configuration.configFile = program.config
-  } else {
+  if (isRelativePath(program.config)) {
     configuration.configFile = path.join(process.cwd(), program.config);
+  } else {
+    configuration.configFile = program.config
   }
 }
 


### PR DESCRIPTION
At the moment, you will need to specify the full path to the config
file for it to work:

```
sequelize --config /full/path/to/config.json
```

This path supports relative config paths:

```
sequelize --config relative/path/to/config.json
```
