### PR TITLE
Small fix for isDirty on setAttributes when using timestamps

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -308,9 +308,9 @@ module.exports = (function() {
       }
     })
 
-    // since we're updating the record, we should be updating the updatedAt column..
-    if (this.daoFactory.options.timestamps === true) {
-      isDirty = true
+    // since we're updating the record, we should be updating the updatedAt column,
+    // but only if at least one attribute changed
+    if (this.daoFactory.options.timestamps === true && isDirty) {
       self[Utils._.underscoredIf(this.daoFactory.options.updatedAt, this.daoFactory.options.underscored)] = new Date()
     }
 

--- a/test/dao.test.js
+++ b/test/dao.test.js
@@ -169,13 +169,13 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
       })
     })
 
-    it("returns true for bulk non-changed attribute + model with timestamps", function(done) {
+    it("returns false for bulk non-changed attribute + model with timestamps", function(done) {
       this.User.create({ username: 'user' }).success(function(user) {
         user.setAttributes({
           username: 'user'
         })
 
-        expect(user.isDirty).to.be.rue
+        expect(user.isDirty).to.be.false
         done()
       })
     })


### PR DESCRIPTION
Was setting `isDirty` to true whenever `setAttributes()` was called if using timestamps. A call to `setAttributes({})` (with the empty object) would set `isDirty` to true and `updatedAt` would be updated.
Modified to only update the column `updatedAt` if at least one attribute changed, so now you can call `setAttributes()` and `isDirty` will propertly indicate whether something changed.

I think there's a test missing for `setAttributes()`, to check that `updatedAt` is only updated if at least one attribute changed. But I couldn't find a block of tests for `setAttributes()` to add this one in.

The motivation behind it is that you can do something like:

``` javascript
current.setAttributes({ at1: 1, at2: 2 })
if (current.isDirty) {
  current.save().complete(function(err, result) {
    done(null, result)
  })
} else {
  done(null, null)
}
```

So you can use`isDirty` to decide if the model needs to be saved or not. Otherwise the application has to do it's own verification of `attrs`, replicating what is already done in Sequelize.
