### PR TITLE
Do not modify input to findOrCreate

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -564,24 +564,24 @@ module.exports = (function() {
     }).run()
   }
 
-  DAOFactory.prototype.findOrCreate = function (params, defaults) {
+  DAOFactory.prototype.findOrCreate = function (where, defaults) {
     var self = this;
 
-    var where = {};
-    for (var attrname in params) {
-      where[attrname] = params[attrname]
+    var params = {};
+    for (var attrname in where) {
+      params[attrname] = where[attrname]
     }
 
     return new Utils.CustomEventEmitter(function (emitter) {
       self.find({
-        where: where
+        where: params
       }).success(function (instance) {
         if (instance === null) {
           for (var attrname in defaults) {
-            where[attrname] = defaults[attrname]
+            params[attrname] = defaults[attrname]
           }
 
-          self.create(where)
+          self.create(params)
             .success(function (instance) {
               emitter.emit('success', instance, true)
             })


### PR DESCRIPTION
This helps when making spy assertions about what arguments findOrCreate was called with.

Without this, it is not possible to know when was originally passed to findOrCreate using sinon-like spies.
