### PR TITLE
make config reading relative to cwd

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -79,8 +79,11 @@ var createMigrationsFolder = function(force) {
 
 var readConfig = function() {
   try {
-    var fullPath = path.join(process.cwd(), configuration.configFile)
-      , config   = require(fullPath);
+    var fullPath = configuration.configFile;
+    if(fullPath.charAt(0) !== '/') {
+      fullPath = path.join(process.cwd(), fullPath);
+    }
+    var config = require(fullPath);
   } catch(e) {
     throw new Error('Error reading "' + relativeConfigFile() + '".');
   }


### PR DESCRIPTION
Function `relativeConfigFile` indicates that config `require`-ing expected to be cwd-relative. But in real that is not true (bare `require` was used, so it is module-relative).

In this case it is not really possible to import config relative to the dir the "binary" running.
For now workaround is to use absolute path:

``` sh
CFG=`pwd`/cfg/database.json

./node_modules/.bin/sequelize --config ${CFG} --env dev --migrate
```

Instead of simple:

``` sh
./node_modules/.bin/sequelize --config ./cfg/database.json --env dev --migrate
```

Pull request fixes this issue.
