### PR TITLE
Make available migrator helpers

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -233,7 +233,7 @@ module.exports = (function() {
 
   // private
 
-  var getLastMigrationFromDatabase = function() {
+  var getLastMigrationFromDatabase = Migrator.prototype.getLastMigrationFromDatabase = function() {
     var self = this
 
     return new Utils.CustomEventEmitter(function(emitter) {
@@ -255,7 +255,7 @@ module.exports = (function() {
     }).run()
   }
 
-  var getLastMigrationIdFromDatabase = function() {
+  var getLastMigrationIdFromDatabase = Migrator.prototype.getLastMigrationIdFromDatabase = function() {
     var self = this
 
     return new Utils.CustomEventEmitter(function(emitter) {
@@ -270,7 +270,7 @@ module.exports = (function() {
     }).run()
   }
 
-  var getFormattedDateString = function(s) {
+  var getFormattedDateString = Migrator.prototype.getFormattedDateString = function(s) {
     var result = null
 
     try {
@@ -282,11 +282,11 @@ module.exports = (function() {
     return result
   }
 
-  var stringToDate = function(s) {
+  var stringToDate = Migrator.prototype.stringToDate = function(s) {
     return moment(getFormattedDateString(s), "YYYYMMDDHHmmss")
   }
 
-  var saveSuccessfulMigration = function(from, to, callback) {
+  var saveSuccessfulMigration = Migrator.prototype.saveSuccessfulMigration = function(from, to, callback) {
     var self = this
 
     self.findOrCreateSequelizeMetaDAO().success(function(SequelizeMeta) {
@@ -296,7 +296,7 @@ module.exports = (function() {
     })
   }
 
-  var deleteUndoneMigration = function(from, to, callback) {
+  var deleteUndoneMigration = Migrator.prototype.deleteUndoneMigration = function(from, to, callback) {
     var self = this
 
     self.findOrCreateSequelizeMetaDAO().success(function(SequelizeMeta) {


### PR DESCRIPTION
This has been done so other tools can interact with the current migration state and more advanced tooling for migrating.
