### PR TITLE
use bluebird as promise library

### DIFF
--- a/lib/emitters/custom-event-emitter.js
+++ b/lib/emitters/custom-event-emitter.js
@@ -1,6 +1,6 @@
 var util           = require("util")
   , EventEmitter   = require("events").EventEmitter
-  , Promise        = require("promise")
+  , Promise        = require("bluebird")
   , proxyEventKeys = ['success', 'error', 'sql']
   , tick           = (typeof setImmediate !== "undefined" ? setImmediate : process.nextTick)
   , Utils          = require('../utils')

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "dottie": "0.0.8-0",
     "toposort-class": "~0.2.0",
     "generic-pool": "2.0.4",
-    "promise": "~3.2.0",
+    "bluebird": "~0.11.5",
     "sql": "~0.28.0",
     "node-uuid": "~1.4.1"
   },


### PR DESCRIPTION
I would prefer bluebird for the following reason:
- It allows long stack traces. See below
- It is super fast (see http://spion.github.io/posts/why-i-am-switching-to-promises.html)
- It is de facto replacing Q and when as the standard promises library
- It has a good amount of additional functions, such as .catch(), .all(), .race(), etc.

The main reason here are definitely the support of long stack traces. After requiring bluebird, the developer can call `Promise.longStackTraces()` to go from this

```
Trace: [TypeError: Cannot read property 'executexxx' of undefined]
    at xxx\src\grabbers\index.coffee:43:16
    at Object._onImmediate (xxx\node_modules\sequelize\node_modules\promise\core.js:34:15)
    at processImmediate [as _immediateCallback] (timers.js:327:15)
```

to this

```
TypeError: Cannot read property 'executexxx' of undefined
    at module.exports.checkxxx (xxx\src\grabbers\IS24Grabber.coffee:31:27)
From previous event:
    at new Promise (xxx\node_modules\bluebird\js\main\promise.js:92:37)
    at module.exports.CustomEventEmitter.then (xxx\node_modules\sequelize\lib\emitters\custom-event-emitter.js:94:12)
    at Object.module.exports.findxxx (xxx\src\grabbers\index.coffee:67:5)
    at Object.module.exports.grabxxx (xxx\src\grabbers\index.coffee:47:7)
    at Object.xxx (xxx\src\app.coffee:36:11)
    at Object.xxx (xxx\src\app.coffee:1)
    at Module._compile (module.js:449:26)
    at Object.Module._extensions..js (module.js:467:10)
```

bluebird is of course compliant with the promises/A+ standard and the test suite passes just as before. I use it in all of my production code and would love to see it being use here, as well!
