### PR TITLE
Fix invalid "USING" order in Postgres query generator

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -435,8 +435,8 @@ module.exports = (function() {
 
       return Utils._.compact([
         "CREATE", options.indicesType, "INDEX", this.quoteIdentifiers(options.indexName),
-        (options.indexType ? ('USING ' + options.indexType) : undefined),
-        "ON", this.quoteIdentifiers(tableName), '(' + transformedAttributes.join(', ') + ')'
+        "ON", this.quoteIdentifiers(tableName), (options.indexType ? ('USING ' + options.indexType) : undefined),
+        '(' + transformedAttributes.join(', ') + ')'
       ]).join(' ')
     },
 


### PR DESCRIPTION
According to documentation (http://www.postgresql.org/docs/9.3/static/sql-createindex.html) USING parameter must follow ON, not vise-versa. You can reproduce this bug through migrations by adding index with custom indexType:

``` javascript
migration.addIndex('table', [ 'somefield' ], {
    indexType: 'hash'
});
```
