### PR TITLE
Closing postgres client properly

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -27,6 +27,7 @@ module.exports = (function() {
 
     this.disconnectTimeoutId = null
     this.pendingQueries = 0
+    this.clientDrained = true
     this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50)
 
     process.on('exit', function() {
@@ -51,6 +52,7 @@ module.exports = (function() {
     var self = this
 
     self.pendingQueries++
+    self.clientDrained = false
 
     return new Utils.CustomEventEmitter(function(emitter) {
       self.connect()
@@ -64,8 +66,6 @@ module.exports = (function() {
           .complete(function(err) {
             self.endQuery.call(self)
             done && done(err) })
-          .success(function(results) { self.endQuery.call(self) })
-          .error(function(err) { self.endQuery.call(self) })
           .proxy(emitter)
       })
     }).run()
@@ -152,6 +152,12 @@ module.exports = (function() {
         this.client.connect(function(err, client, done) {
           connectCallback(err, client || self.client, done)
         })
+
+        // Closes a client correctly even if we have backed up queries
+        // https://github.com/brianc/node-postgres/pull/346
+        this.client.on('drain', function() {
+          self.clientDrained = true
+        })
       }
     }
 
@@ -168,9 +174,9 @@ module.exports = (function() {
     }
 
     if (this.client) {
-      // Closes a client correctly even if we have backed up queries
-      // https://github.com/brianc/node-postgres/pull/346
-      this.client.on('drain', this.client.end.bind(this.client))
+      if (this.clientDrained) {
+        this.client.end()
+      }
       this.client = null
     }
 


### PR DESCRIPTION
This fixes a couple issues:
- Multiple decrements of `pendingQueries` for the same query. Since we
  have a `complete` handler in addition to `success` and `error`,
  `endQuery` gets called twice if it's a success or an error. This
  means that we will end up with `pendingQueries < 0` so the
  disconnect condition is never satisfied.
- We were hooking into pg's `drain` event during the disconnect step,
  this is already too late since most of the time, the drain event is
  already fired. We need to hook into the `drain` event on client
  creation. Sadly, we cannot close the connection on the `drain`
  event as it will break with the error,
  `Error: Stream unexpectedly ended during query execution`

Repro of the second issue with `sequelize` and `node-postgres` where `client.end` is never called.

```
var Sequelize = require('sequelize');
var sequelize = new Sequelize('some_db', 'user', 'password', {
  dialect: 'postgres',
  port: 5432
});

sequelize.query('SELECT 1').success(function(row) {
  console.log(row);
});
```
