### PR TITLE
Change joinTableName/joinTableModel/useJunctionTable option to one through option

### DIFF
--- a/lib/associations/has-many-double-linked.js
+++ b/lib/associations/has-many-double-linked.js
@@ -36,7 +36,7 @@ module.exports = (function() {
 
       where[through.tableName+"."+foreignKey] = {join: self.__factory.target.tableName+"."+foreignPrimary}
 
-      if (association.hasJoinTableModel) {
+      if (Object(association.through) === association.through) {
         queryOptions.hasJoinTableModel = true
         queryOptions.joinTableModel = through
 
@@ -102,8 +102,6 @@ module.exports = (function() {
       , options              = {}
       , unassociatedObjects;
 
-    console.log(":D")
-
     if ((defaultAttributes || {}).transaction instanceof Transaction) {
       options.transaction = defaultAttributes.transaction
       delete defaultAttributes.transaction
@@ -155,7 +153,7 @@ module.exports = (function() {
         attributes[self.__factory.identifier] = ((sourceKeys.length === 1) ? self.instance[sourceKeys[0]] : self.instance.id)
         attributes[foreignIdentifier] = ((targetKeys.length === 1) ? unassociatedObject[targetKeys[0]] : unassociatedObject.id)
 
-        if (association.hasJoinTableModel) {
+        if (Object(association.through) === association.through) {
           attributes = Utils._.defaults(attributes, unassociatedObject[association.through.name], defaultAttributes)
         }
 

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -1,6 +1,7 @@
 var Utils     = require("./../utils")
   , DataTypes = require('./../data-types')
   , Helpers   = require('./helpers')
+  , _         = require('lodash')
 
 var HasManySingleLinked = require("./has-many-single-linked")
   , HasManyMultiLinked  = require("./has-many-double-linked")
@@ -18,9 +19,13 @@ module.exports = (function() {
     if (this.through === undefined) {
       this.through = this.options.joinTableModel || this.options.joinTableName;
     }
+
     if (typeof this.through === "string") {
-      this.through = this.source.daoFactoryManager.sequelize.define(this.through, {}, this.options)
+      this.through = this.source.daoFactoryManager.sequelize.define(this.through, {}, _.extend(this.options, {
+        tableName: this.through
+      }))
     }
+
     if (this.through === undefined) {
       if (this.options.useJunctionTable === false) {
         this.through = null;
@@ -61,7 +66,7 @@ module.exports = (function() {
 
     // is there already a single sided association between the source and the target?
     // or is the association on the model itself?
-    if ((this.isSelfAssociation && this.useJunctionTable) || multiAssociation) {
+    if ((this.isSelfAssociation && this.through) || multiAssociation) {
       // remove the obsolete association identifier from the source
       if (this.isSelfAssociation) {
         this.foreignIdentifier = Utils._.underscoredIf((this.options.as || this.target.tableName) + 'Id', this.options.underscored)
@@ -114,8 +119,6 @@ module.exports = (function() {
       Helpers.addForeignKeyConstraints(newAttributes[this.identifier], this.source, this.target, this.options)
       Utils._.defaults(this.target.rawAttributes, newAttributes)
     }
-
-    this.connectorDAO = Object(this.through) === this.through ? this.through : null; // Lets not break EVERYTHING just yet
 
     // Sync attributes and setters/getters to DAO prototype
     this.target.refreshAttributes()

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -635,14 +635,14 @@ module.exports = (function() {
                   joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName)
                   joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.identifier)
                   joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.target.autoIncrementField)
-                } else if (association.connectorDAO){
-                  joinedTables[association.connectorDAO.tableName] = true;
-                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.connectorDAO.tableName)
+                } else if (Object(association.through) === association.through) {
+                  joinedTables[association.through.tableName] = true;
+                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.through.tableName)
                   joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.source.autoIncrementField)
-                  joins += ' = ' + self.quoteIdentifiers(association.connectorDAO.tableName + '.' + association.identifier)
+                  joins += ' = ' + self.quoteIdentifiers(association.through.tableName + '.' + association.identifier)
 
                   joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName)
-                  joins += ' ON ' + self.quoteIdentifiers(association.connectorDAO.tableName + '.' + association.foreignIdentifier)
+                  joins += ' ON ' + self.quoteIdentifiers(association.through.tableName + '.' + association.foreignIdentifier)
                   joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.target.autoIncrementField)
                 } else {
                   joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName)

--- a/test/associations/has-many.test.js
+++ b/test/associations/has-many.test.js
@@ -693,9 +693,9 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           expect(associationName).not.to.equal(this.User.tableName)
           expect(associationName).not.to.equal(this.Task.tableName)
 
-          var joinTableName = this.User.associations[associationName].options.joinTableName
-          if (typeof joinTableName !== 'undefined') {
-            expect(joinTableName).to.equal(associationName)
+          var through = this.User.associations[associationName].through
+          if (typeof through !== 'undefined') {
+            expect(through.tableName).to.equal(associationName)
           }
           var tableName = this.User.associations[associationName].options.tableName
           if (typeof tableName !== 'undefined') {


### PR DESCRIPTION
Instead of having joinTableName/joinTableModel/useJunctionTable options, we now have one through option with bc:

`A.hasMany(B, {through: 'AB'})`

```
AB = define()
A.hasMany(B, {through: AB})
```

`A.hasMany(A, {through: null})`
