### PR TITLE
Use spec as default reporter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-REPORTER ?= dot
+REPORTER ?= spec
 TESTS = $(shell find ./test/* -name "*.test.js")
 DIALECT ?= mysql
 


### PR DESCRIPTION
http://visionmedia.github.io/mocha/#reporters

I propose we change the default reporter to spec. I believe it to be a better reporter since you can immediately see what test fails and then cancel the test if need be.
