### PR TITLE
Fix CustomEventEmitter

### DIFF
--- a/lib/emitters/custom-event-emitter.js
+++ b/lib/emitters/custom-event-emitter.js
@@ -36,12 +36,26 @@ module.exports = (function() {
       // No error listener
       var er = arguments[1];
 
+      // If error argument is an object but no error,
+      // boil it down to the value of the first key
+      // (probably an Array in most cases)
+      if (Utils._.isObject(er) && !(er instanceof Error)) {
+        er = er[Object.keys(er)[0]]
+      }
+
       // If error argument is an array, make sure we
       // pass only the first error to the original
       // .emit() function of EventEmitter
       if (er instanceof Array) {
-        arguments[1] = Utils._.flatten(er)[0]
+        er = Utils._.flatten(er)[0]
       }
+
+      // We don't want to throw strings. Make them Errors!
+      if (typeof er === "string") {
+        er = new Error(er)
+      }
+
+      arguments[1] = er
     }
 
     EventEmitter.prototype.emit.apply(this, arguments);

--- a/test/dao.test.js
+++ b/test/dao.test.js
@@ -710,7 +710,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
       })
     })
 
-    it("gets triggered if everything was ok", function(done) {
+    it("gets triggered if everything was ok", function(done) {
       this.User.count().complete(function(err, result) {
         expect(err).to.be.null
         expect(result).to.exist
@@ -795,7 +795,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
       // timeout is needed, in order to check the update of the timestamp
       var build = function(callback) {
         user      = User.build({ username: 'user' })
-  
+
         var save = user.save()
 
         save.success(function() {

--- a/test/emitters/custom-event-emitter.test.js
+++ b/test/emitters/custom-event-emitter.test.js
@@ -102,4 +102,22 @@ describe(Support.getTestDialectTeaser("CustomEventEmitter"), function () {
       })
     })
   })
+
+  describe("when emitting an error event with a hash containing arrays of error strings", function() {
+    describe("if no error handler is given", function() {
+      it("should throw an error with the first error string", function(done) {
+        var emitter = new CustomEventEmitter()
+        var errors = {
+          myValidation: [ "Invalid Length" ],
+          someOtherValidation: [ "Naah don't like that value!", "It's weird, u know?" ]
+        }
+
+        expect(function () {
+          emitter.emit("error", errors)
+        }).to.throw(errors.myValidation[0])
+
+        done()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Make sure that objects passed to CustomEventEmitter's `error` event
are boiled down to real Error instances so that node's EventEmitter
does not give us this nasty "Uncaught, unspecified error" thing.
