### PR TITLE
pool settings are not transported down to replica connections

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -289,7 +289,7 @@ module.exports = (function() {
     connection.query("SET time_zone = '+0:00'");
     // client.setMaxListeners(self.maxConcurrentQueries)
     this.isConnecting = false
-    if ((config.pool != null && config.pool.handleDisconnects) {
+    if (config.pool != null && config.pool.handleDisconnects) {
       handleDisconnect(this.pool, connection)
     }
     done(null, connection)


### PR DESCRIPTION
Say you have a replica set like so:

``` javascript
{
  "dialect"     : "mysql",
  "port"        : 3306,
  "pool"        : {
    "maxConnections" : 20,
    "maxIdleTime"    : 30000
  },
  "replication" : {
    "write": {
      "host"     : "127.0.0.1", 
      "username" : "root", 
      "password" : ""
    },
    "read": [
      {
        "host"     : "127.0.0.1", 
        "username" : "root", 
        "password" : ""
      }
    ]
  }
}
```

Connecting to the DB will fail:

``` bash
    if (config.pool.handleDisconnects) {
                   ^
TypeError: Cannot read property 'handleDisconnects' of undefined
```

I don't know if you should be bringing my pool settings into the connection, but either way, it's not set.  This will at least get the application to boot :D
