### PR TITLE
do not strip quites on addIndexQuery

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -329,7 +329,7 @@ module.exports = (function() {
     addIndexQuery: function(tableName, attributes, options) {
       var transformedAttributes = attributes.map(function(attribute) {
         if (typeof attribute === 'string') {
-          return this.quoteIdentifier(attribute)
+          return attribute
         } else {
           var result = ""
 


### PR DESCRIPTION
Allows the use of DESC in indexes such as

``` javascript
migration.addIndex(table, ['"updatedAt" DESC'])
```
