### PR TITLE
npm ignore coverage directories

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ README.md
 .watchr.js
 changelog.md
 Makefile
+coverage*


### PR DESCRIPTION
There's currently a `coverage-sqlite` folder in the release on npm.
