### PR TITLE
Implement .spread in custom event emitter

### DIFF
--- a/lib/emitters/custom-event-emitter.js
+++ b/lib/emitters/custom-event-emitter.js
@@ -143,7 +143,7 @@ module.exports = (function() {
 
     return new Promise(function (resolve, reject) {
       self.on('error', reject)
-          .on('success', resolve);
+          .on('success', resolve)
     }).then(onFulfilled, onRejected)
   }
 
@@ -157,10 +157,10 @@ module.exports = (function() {
       self.on('error', reject)
           .on('success', function () {
             resolve(Array.prototype.slice.apply(arguments)) // Transform args to an array
-          });
+          })
     }).spread(onFulfilled, onRejected)
   }
 
-  return CustomEventEmitter;
+  return CustomEventEmitter
 })()
 

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -321,7 +321,7 @@ describe(Support.getTestDialectTeaser("Promise"), function () {
         .then(function(user) {
           expect(user.id).to.equal(1)
           expect(arguments.length).to.equal(1)
-          done();
+          done()
         })      
     })
 
@@ -333,7 +333,7 @@ describe(Support.getTestDialectTeaser("Promise"), function () {
             expect(user.id).to.equal(1)
             expect(created).to.equal(false)
             expect(arguments.length).to.equal(2)
-            done();
+            done()
           })      
       })
       it('user created', function (done) {
@@ -343,7 +343,7 @@ describe(Support.getTestDialectTeaser("Promise"), function () {
             expect(user.id).to.equal(2)
             expect(created).to.equal(true)
             expect(arguments.length).to.equal(2)
-            done();
+            done()
           })      
       })
       it('works for functions with only one return value', function (done) {
@@ -352,7 +352,7 @@ describe(Support.getTestDialectTeaser("Promise"), function () {
           .spread(function(user) {
             expect(user.id).to.equal(1)
             expect(arguments.length).to.equal(1)
-            done();
+            done()
           })    
       })
     })    


### PR DESCRIPTION
Closes #1268

The spread function is almost a direct copy of .then, except that it transforms the arguments into an array.

We could have changed so that then would return an array of values if there are multiple return values, but I don't like that idea. First, it would break BC, for people who rely on and only need the first argument, and secondly, the way i see the promise spec, a promise can only return a single value

Also - back in PR business - woo! Docs comming shortly
