### PR TITLE
Add the option of calling associations by their alias/name as String

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -1388,7 +1388,7 @@ module.exports = (function() {
         }
 
         // check if the current daoFactory is actually associated with the passed daoFactory - or it's a pseudo include
-        if (association && (association.options.as || (association.options.as === include.as))) {
+        if (association && (!association.options.as || (association.options.as === include.as))) {
           include.association = association
 
           // If through, we create a pseudo child include, to ease our parsing later on


### PR DESCRIPTION
I've read a lot of examples that said that we could use strings to include associated models, but it wasn't, and i dind't saw neither on sequelize docs. So i changed some lines to allow it, instead of doing `User.findAll({ include: [{ model: Tool, as: 'Instruments' }] })` we could do `User.findAll({ include: [ 'Instruments' ] })` (as association already was defined)
## Example:

```
M.User
    .hasMany( M.UserEmail, {
        as: 'Emails',
    })
    .hasMany( M.UserPassword, {
        as: 'Passwords',
    })
    .hasMany( M.Task )

    .find({
        include: [
            'Emails',
            'Tasks',
            'Passwords',
        ],
    })
```
