### PR TITLE
unit test for ENUM that breaks on postgres #1020

### DIFF
--- a/test/postgres/dao.test.js
+++ b/test/postgres/dao.test.js
@@ -224,6 +224,39 @@ if (dialect.match(/^postgres/)) {
           })
           .error(console.log)
       })
+
+      it("10.5.1 should handle enums properly when re-initializing", function(done) {
+        var DummyModel = this.sequelize.define('Dummy-pg', {
+          username: DataTypes.STRING,
+          theEnumOne: {
+            type: DataTypes.ENUM,
+            values:[
+              'one',
+              'two',
+              'three',
+            ]
+          },
+          theEnumTwo: {
+            type: DataTypes.ENUM,
+            values:[
+              'four',
+              'five',
+              'six',
+            ],
+          },
+
+        })
+        DummyModel.sync({ force: true })
+          .success(function() {
+            // now sync one more time:
+            DummyModel.sync({force: true}).success(function(){
+              done();
+            })
+            .error(done);
+          })
+          .error(done);
+      });
+
     })
 
     describe('[POSTGRES] Unquoted identifiers', function() {


### PR DESCRIPTION
This is a test case for #1020, unfortunately i could not bind this PR to the issue as there must be a bug in `hub` command... anyway, here it is.
