### PR TITLE
renameColumn: non-null column can't default null

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -410,6 +410,11 @@ module.exports = (function() {
           defaultValue: data.defaultValue
         }
 
+        // fix: a not-null column cannot have null as default value
+        if (data.defaultValue === null && !data.allowNull) {
+          delete options[attrNameAfter].defaultValue;
+        }
+
         if (this.sequelize.options.dialect === 'sqlite') {
           // sqlite needs some special treatment as it cannot rename a column
           SQLiteQueryInterface.renameColumn.call(this, tableName, attrNameBefore, attrNameAfter, emitter, queryAndEmit)


### PR DESCRIPTION
This fixes a bug in `renameColumn()` of migration. If one tries to rename a column which was originally `NOT NULL` and doesn't have a default value set, it will incorrectly try to set the default value as `NULL` after renaming.

Code explanation:

``` javascript
// query-interface.js L391
      this.describeTable(tableName).success(function(data) {
        /*
         * describeTable() returns null for defaultValue,
         * even when no defaultValue is set
         */

        data = data[attrNameBefore] || {}

        var options =  {}

        options[attrNameAfter] = {
          attribute:    attrNameAfter,
          type:         data.type,
          allowNull:    data.allowNull,
          defaultValue: data.defaultValue
        }

        // fix: a not-null column cannot have null as default value
        if (data.defaultValue === null && !data.allowNull) {
          delete options[attrNameAfter].defaultValue;
        }
```
