### PR TITLE
Increment enumIdx as intended, fixes issue #1020 updated test

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -141,6 +141,7 @@ module.exports = (function() {
                     chainer2.add(self.sequelize.query(self.QueryGenerator.pgEnumAdd(getTableName, keys[i], value, options)))
                   }
                 })
+                enumIdx++
               }
             }
           }

--- a/test/postgres/dao.test.js
+++ b/test/postgres/dao.test.js
@@ -106,7 +106,11 @@ if (dialect.match(/^postgres/)) {
           // now sync one more time:
           DummyModel.sync({force: true}).done(function(err) {
             expect(err).not.to.be.ok
-            done();
+            // sync without dropping
+            DummyModel.sync().done(function(err) {
+              expect(err).not.to.be.ok
+              done();
+            })
           })
         })
       })


### PR DESCRIPTION
Fix b155910 did not effect the "not-force" sync where the same issue
occurred. Since the enumIdx was never incremented I assume that this commit
establishes the originally intended behavior.
