### PR TITLE
use this.getTableName() in findAll

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -453,7 +453,7 @@ module.exports = (function() {
 
     options = paranoidClause.call(this, options)
 
-    return this.QueryInterface.select(this, this.tableName, options, Utils._.defaults({
+    return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
       type:    QueryTypes.SELECT,
       hasJoin: hasJoin
     }, queryOptions, { transaction: (options || {}).transaction }))
@@ -584,7 +584,7 @@ module.exports = (function() {
 
   DAOFactory.prototype.count = function(options) {
     options = Utils._.clone(options || {})
-    
+
     return new Utils.CustomEventEmitter(function (emitter) {
       var col = this.sequelize.col('*')
       if (options.include) {


### PR DESCRIPTION
It appears the findAll is not currently respecting "schema".  Small fix for that.
