### PR TITLE
fix validators tests broken loop logic

### DIFF
--- a/test/dao.validations.test.js
+++ b/test/dao.validations.test.js
@@ -240,7 +240,6 @@ describe(Support.getTestDialectTeaser("DaoValidator"), function() {
             })
             var successfulUser = UserSuccess.build({ name: succeedingValue })
             successfulUser.validate().success( function() {
-              console.log('ARGS:', arguments);
               expect(arguments).to.have.length(0)
               done()
             }).error(function(err) {


### PR DESCRIPTION
The Validators test loop was broken, effectively running only the `isCreditCard` test on all loops.

This fixes the broken logic but now that the tests run for a very long time i had a few issues i will be marking on the diff
