### PR TITLE
Deep cloning the findOptions in findAndCountAll

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -614,7 +614,7 @@ module.exports = (function() {
   DAOFactory.prototype.findAndCountAll = function(findOptions, queryOptions) {
     var self  = this
       // no limit, offset, order, attributes for the options given to count()
-      , countOptions = Utils._.omit(findOptions || {}, ['offset', 'limit', 'order', 'attributes'])
+      , countOptions = Utils._.omit(findOptions ? Utils._.merge({}, findOptions) : {}, ['offset', 'limit', 'order', 'attributes'])
 
     return new Utils.CustomEventEmitter(function (emitter) {
       var emit = {


### PR DESCRIPTION
Since the ID was added automatically to the attributes, it caused duplicate fields in the generated queries on the findAll.

fixes #1372
