### PR TITLE
Try to insert foreignKeyConstraints attributes when the attribute already exists

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -46,7 +46,11 @@ module.exports = (function() {
 
     newAttributes[this.identifier] = { type: this.options.keyType || keyType }
     Helpers.addForeignKeyConstraints(newAttributes[this.identifier], this.target, this.source, this.options)
-    Utils._.defaults(this.source.rawAttributes, newAttributes)
+    if(this.source.rawAttributes.hasOwnProperty(this.identifier) && Utils.isHash(this.source.rawAttributes[this.identifier])) {
+      Utils._.defaults(this.source.rawAttributes[this.identifier], newAttributes[this.identifier])
+    } else {
+      Utils._.defaults(this.source.rawAttributes, newAttributes)
+    }
 
     // Sync attributes and setters/getters to DAO prototype
     this.source.refreshAttributes()

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -192,7 +192,11 @@ module.exports = (function() {
       var newAttributes = {}
       newAttributes[this.identifier] = { type: this.options.keyType || DataTypes.INTEGER }
       Helpers.addForeignKeyConstraints(newAttributes[this.identifier], this.source, this.target, this.options)
-      Utils._.defaults(this.target.rawAttributes, newAttributes)
+      if(this.source.rawAttributes.hasOwnProperty(this.identifier) && Utils.isHash(this.source.rawAttributes[this.identifier])) {
+        Utils._.defaults(this.source.rawAttributes[this.identifier], newAttributes[this.identifier])
+      } else {
+        Utils._.defaults(this.source.rawAttributes, newAttributes)
+      }
     }
 
     // Sync attributes and setters/getters to DAO prototype


### PR DESCRIPTION
Currently when a model already has a field definition foreignKeyConstraint attributes don't get inserted into the field. This PR fixes that.
