### PR TITLE
fix adding duplicate PK attributes in select query

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -537,13 +537,13 @@ module.exports = (function() {
 
       if (subQuery && mainAttributes) {
         if (factory.hasPrimaryKeys) {
-            factory.primaryKeyAttributes.forEach(function(keyAtt){
-                if(mainAttributes.indexOf(keyAtt) == -1){
-                    mainAttributes.push(keyAtt)
-                }
-            })
+          factory.primaryKeyAttributes.forEach(function(keyAtt){
+            if(mainAttributes.indexOf(keyAtt) == -1){
+              mainAttributes.push(keyAtt)
+            }
+          })
         } else {
-            mainAttributes.push("id")
+          mainAttributes.push("id")
         }          
       }
 


### PR DESCRIPTION
If there's a subquery and options.attributes is defined and contains PK field duplicate would be added.
