### PR TITLE
Parse dates properly when using includes in sqlite

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -442,13 +442,16 @@ module.exports = (function() {
 
   DAOFactory.prototype.findAll = function(options, queryOptions) {
     var hasJoin = false
+      , tableNames  = { }
+
+    tableNames[this.tableName] = true
 
     options = optClone(options)
     if (typeof options === 'object') {
       if (options.hasOwnProperty('include') && options.include) {
         hasJoin = true
 
-        validateIncludedElements.call(this, options)
+        validateIncludedElements.call(this, options, tableNames)
       }
 
       // whereCollection is used for non-primary key updates
@@ -459,7 +462,8 @@ module.exports = (function() {
 
     return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
       type:    QueryTypes.SELECT,
-      hasJoin: hasJoin
+      hasJoin: hasJoin,
+      tableNames: Object.keys(tableNames)
     }, queryOptions, { transaction: (options || {}).transaction }))
   }
 
@@ -498,6 +502,9 @@ module.exports = (function() {
     var primaryKeys = this.primaryKeys
       , keys        = Object.keys(primaryKeys)
       , keysLength  = keys.length
+      , tableNames  = { }
+
+    tableNames[this.tableName] = true
 
     // options is not a hash but an id
     if (typeof options === 'number') {
@@ -534,7 +541,7 @@ module.exports = (function() {
       if (options.hasOwnProperty('include') && options.include) {
         hasJoin = true
 
-        validateIncludedElements.call(this, options)
+        validateIncludedElements.call(this, options, tableNames)
       }
 
       // whereCollection is used for non-primary key updates
@@ -559,7 +566,8 @@ module.exports = (function() {
     return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
       plain: true,
       type: QueryTypes.SELECT,
-      hasJoin: hasJoin
+      hasJoin: hasJoin,
+      tableNames: Object.keys(tableNames)
     }, queryOptions, { transaction: (options || {}).transaction }))
   }
 
@@ -1328,13 +1336,14 @@ module.exports = (function() {
     }.bind(this))
   }
 
-  var validateIncludedElements = function(options) {
+  var validateIncludedElements = function(options, tableNames) {
+    tableNames = tableNames || {}
     options.includeNames = []
     options.includeMap = {}
     options.hasSingleAssociation = false
     options.hasMultiAssociation = false
     options.include = options.include.map(function(include) {
-      include = validateIncludedElement.call(this, include, options.daoFactory)
+      include = validateIncludedElement.call(this, include, options.daoFactory, tableNames)
 
       options.includeMap[include.as] = include
       options.includeNames.push(include.as)
@@ -1345,12 +1354,12 @@ module.exports = (function() {
 
       options.hasIncludeWhere = options.hasIncludeWhere || include.hasIncludeWhere || !!include.where
       options.hasIncludeRequired = options.hasIncludeRequired || include.hasIncludeRequired || !!include.required
-
+      
       return include
     }.bind(this))
   };
 
-  var validateIncludedElement = function(include, parent) {
+  var validateIncludedElement = function(include, parent, tableNames) {
     if (include instanceof DAOFactory) {
       include = { daoFactory: include }
     }
@@ -1369,6 +1378,8 @@ module.exports = (function() {
     } else if (!include.hasOwnProperty('daoFactory')) {
       throw new Error('Include malformed. Expected attributes: daoFactory, as!')
     }
+
+    tableNames[include.daoFactory.tableName] = true
 
     if (include.hasOwnProperty('attributes')) {
       var primaryKeys;
@@ -1389,7 +1400,7 @@ module.exports = (function() {
     if (include._pseudo) return include
 
     // check if the current daoFactory is actually associated with the passed daoFactory - or it's a pseudo include
-	var association = parent.getAssociation(include.daoFactory, include.as)
+    var association = parent.getAssociation(include.daoFactory, include.as)
     if (association) {
       include.association = association
       include.as = association.as
@@ -1409,6 +1420,7 @@ module.exports = (function() {
         }
 
         include.include.push(include.through)
+        tableNames[through.tableName] = true
       }
 
       if (include.required === undefined) {
@@ -1417,7 +1429,7 @@ module.exports = (function() {
 
       // Validate child includes
       if (include.hasOwnProperty('include')) {
-        validateIncludedElements(include)
+        validateIncludedElements(include, tableNames)
       }
 
       return include

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -35,7 +35,7 @@ module.exports = (function() {
     },
 
     createSchema: function() {
-      var query = "SELECT name FROM sqlite_master WHERE type='table' and name!='sqlite_sequence';"
+      var query = "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';"
       return Utils._.template(query)({})
     },
 
@@ -44,7 +44,7 @@ module.exports = (function() {
     },
 
     showSchemasQuery: function() {
-      return "SELECT name FROM sqlite_master WHERE type='table' and name!='sqlite_sequence';"
+      return "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';"
     },
 
     createTableQuery: function(tableName, attributes, options) {
@@ -169,7 +169,7 @@ module.exports = (function() {
     },
 
     showTablesQuery: function() {
-      return "SELECT name FROM sqlite_master WHERE type='table' and name!='sqlite_sequence';"
+      return "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';"
     },
 
     bulkInsertQuery: function(tableName, attrValueHashes, options) {

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -55,21 +55,34 @@ module.exports = (function() {
         }
       }
 
-      if ((getDatabaseMethod.call(self) === 'all') && /select\s.*?\sfrom\s+([^ ;]+)/i.test(self.sql)) {
-        var tableName = RegExp.$1;
+      if ((getDatabaseMethod.call(self) === 'all')) {
+        var tableNames = []
+        if (self.options && self.options.tableNames) {
+          tableNames = self.options.tableNames
+        } else if (/FROM `(.*?)`/i.exec(self.sql)) {
+          tableNames.push(/FROM `(.*?)`/i.exec(self.sql)[1])
+        }
 
-        if (tableName !== 'sqlite_master') {
-          // get the column types
-          self.database.all("PRAGMA table_info(" + tableName + ")", function(err, results) {
-            if (!err) {
-              for (var i=0, l=results.length; i<l; i++) {
-                columnTypes[results[i].name] = results[i].type
-              }
-            }
-            executeSql()
-          });
-        } else {
+        if (!tableNames.length) {
           executeSql()
+        } else {
+          var execute = Utils._.after(tableNames.length, executeSql)
+          
+          tableNames.forEach(function (tableName) {
+            if (tableName !== 'sqlite_master') {
+              // get the column types
+              self.database.all("PRAGMA table_info(" + tableName + ")", function(err, results) {
+                if (!err) {
+                  for (var i=0, l=results.length; i<l; i++) {
+                    columnTypes[tableName + '.' + results[i].name] = columnTypes[results[i].name] = results[i].type
+                  }
+                }
+                execute()
+              });
+            } else {
+              execute()
+            }
+          })
         }
       } else {
         executeSql()

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -5,12 +5,7 @@ var chai      = require('chai')
   , expect    = chai.expect
   , Support   = require(__dirname + '/support')
   , DataTypes = require(__dirname + "/../lib/data-types")
-  , dialect   = Support.getTestDialect()
-  , config    = require(__dirname + "/config/config")
-  , sinon     = require('sinon')
   , datetime  = require('chai-datetime')
-  , _         = require('lodash')
-  , moment    = require('moment')
   , async     = require('async')
 
 chai.use(datetime)
@@ -541,6 +536,38 @@ describe(Support.getTestDialectTeaser("Include"), function () {
               }).done(function (err, group) {
                 expect(err).not.to.be.ok
                 expect(group.outsourcingCompanies.length).to.equal(3)
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
+
+    it('should support including date fields, with the correct timeszone', function (done) {
+      var User = this.sequelize.define('user', {
+          dateField: Sequelize.DATE
+        }, {timestamps: false})
+        , Group = this.sequelize.define('group', {
+          dateField: Sequelize.DATE
+        }, {timestamps: false})
+
+      User.hasMany(Group)
+      Group.hasMany(User)
+
+      this.sequelize.sync().success(function () {
+        User.create({ dateField: Date.UTC(2014, 1, 20) }).success(function (user) {
+          Group.create({ dateField: Date.UTC(2014, 1, 20) }).success(function (group) {
+            user.addGroup(group).success(function () {
+              User.find({
+                where: {
+                  id: user.id
+                }, 
+                include: [Group]
+              }).success(function (user) {
+                expect(user.dateField.getTime()).to.equal(Date.UTC(2014, 1, 20))
+                expect(user.groups[0].dateField.getTime()).to.equal(Date.UTC(2014, 1, 20))
+                
                 done()
               })
             })

--- a/test/include/findAll.test.js
+++ b/test/include/findAll.test.js
@@ -1211,5 +1211,37 @@ describe(Support.getTestDialectTeaser("Include"), function () {
         })
       })
     })
+
+    it('should support including date fields, with the correct timeszone', function (done) {
+      var User = this.sequelize.define('user', {
+          dateField: Sequelize.DATE
+        }, {timestamps: false})
+        , Group = this.sequelize.define('group', {
+          dateField: Sequelize.DATE
+        }, {timestamps: false})
+
+      User.hasMany(Group)
+      Group.hasMany(User)
+
+      this.sequelize.sync().success(function () {
+        User.create({ dateField: Date.UTC(2014, 1, 20) }).success(function (user) {
+          Group.create({ dateField: Date.UTC(2014, 1, 20) }).success(function (group) {
+            user.addGroup(group).success(function () {
+              User.findAll({
+                where: {
+                  id: user.id
+                }, 
+                include: [Group]
+              }).success(function (users) {
+                expect(users[0].dateField.getTime()).to.equal(Date.UTC(2014, 1, 20))
+                expect(users[0].groups[0].dateField.getTime()).to.equal(Date.UTC(2014, 1, 20))
+                
+                done()
+              })
+            })
+          })
+        })
+      })
+    })
   })
 })


### PR DESCRIPTION
Closes #1355

As the only dialect, sqlite relies on querying the database to get the types of fields. However, this would break when using includes, because the regex used to identify table names in the sql didn't like includes. I've changed it so that the table names are collected while processing the includes, and these are then passed on to sqlite/query.js This is not a very pretty way to do it, but should suffix for the release of 1.7, until we can look more at a general up / down for datatypes in 2.0
