### PR TITLE
mssql - fix value quoting for values containing '.'

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -21,7 +21,7 @@ module.exports = (function() {
       return value
     }
 
-    return QueryGenerator.addQuotes(SqlString.escape(processedValue), "'")
+    return SqlString.escape(processedValue)
   }
 
   var QueryGenerator = {


### PR DESCRIPTION
Fixes issue where values containing periods are escaped incorrectly in
mssql (e.g. ‘john’.’doe’ instead of ‘john.doe’)
