### PR TITLE
mssql - query-generator isn't setting its dialect key

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -21,12 +21,12 @@ module.exports = (function() {
       return value
     }
 
-    return QueryGenerator.addQuotes(SqlString.escape(processedValue), "'")
+    return SqlString.escape(processedValue)
   }
 
   var QueryGenerator = {
     options: {},
-
+    dialect: 'mssql',
     addSchema: function(opts) {
       var tableName         = undefined
       var schema            = (!!opts.options && !!opts.options.schema ? opts.options.schema : undefined)


### PR DESCRIPTION
Unlike other dialects, mssql isn't setting:

```
dialect:  'mssql'
```

in its QueryGenerator definition.  This causes, for example, boolean values to be translated incorrectly.  Without this fix, bools become literal true/false values in the generated SQL queries, which mssql does not support.  With this fix, bools are correctly translated to 0/1 in the generated SQL.
