### PR TITLE
include all improvement

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -1593,6 +1593,7 @@ module.exports = (function() {
         // run recursively if nested
         if (nested) {
           addAllIncludes(model, thisInclude.include)
+          if (thisInclude.include.length == 0) delete thisInclude.include
         }
       })
       used.pop()


### PR DESCRIPTION
Small fix to include all code to prevent creation of empty include arrays.

Previously if used `include: {all: true, nested: true}`, where no associations were found empty include arrays were created. This fixes that.
