### PR TITLE
Updating migrator to properly test for coffee-script module

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -52,7 +52,7 @@ module.exports = (function() {
     get: function() {
       if (this.path.match(/\.coffee$/)) {
         try {
-          require('coffee-script/register')
+          require('coffee-script')
         } catch(e) {
           console.log("You have to add \"coffee-script\" to your package.json.")
           process.exit(1)


### PR DESCRIPTION
With CoffeeScript 1.6.3 register is not imported.  Should be checking for coffee-script with just require('coffee-script')
