### PR TITLE
Fix for CoffeeScript prior to breaking change in 1.7.x for compiler registration

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -58,7 +58,7 @@ module.exports = (function() {
           try {
             // Prior to 1.7.x compiler registration
             require('coffee-script')
-          } catch (e) {
+          } catch(e) {
             console.log("You have to add \"coffee-script\" to your package.json.")
             process.exit(1)
           }


### PR DESCRIPTION
Apologies for not attacking this correctly on the first PR
