### PR TITLE
Use configured pgModule to access required ConenctionParameters

### DIFF
--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -1,6 +1,5 @@
 var Query                = require("./query")
   , Utils                = require("../../utils")
-  , ConnectionParameters = require('pg/lib/connection-parameters')
 
 module.exports = (function() {
   var ConnectorManager = function(sequelize, config) {
@@ -20,6 +19,7 @@ module.exports = (function() {
     this.pendingQueries = 0
     this.clientDrained = true
     this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50)
+    this.ConnectionParameters = require(pgModule + '/lib/connection-parameters')
 
     this.onProcessExit = function () {
       this.disconnect()
@@ -83,7 +83,7 @@ module.exports = (function() {
     this.isConnected  = false
 
     var uri    = this.sequelize.getQueryInterface().QueryGenerator.databaseConnectionUri(this.config)
-      , config = new ConnectionParameters(uri)
+      , config = new this.ConnectionParameters(uri)
 
     // set pooling parameters if specified
     if (this.pooling) {


### PR DESCRIPTION
Implementation of #1454

Allows to use the `ConnectionParameters` of the configured `pgModule`.
