### PR TITLE
Update query-generator.js

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1228,7 +1228,7 @@ module.exports = (function() {
           _key = key
         } else {
           if(this.isAssociationFilter(key, dao, options)){
-            _key = key = this.getAssociationFilterColumn(key, dao, options);
+            _key = this.getAssociationFilterColumn(key, dao, options);
           } else {
             _key = this.quoteIdentifiers(key)
           }


### PR DESCRIPTION
Fixed issue where using un-escaped keys (extra assignment was causing it to fail)
