### PR TITLE
Fix deprecation warning

### DIFF
--- a/test/associations/belongs-to.test.js
+++ b/test/associations/belongs-to.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , DataTypes = require(__dirname + "/../../lib/data-types")
   , Sequelize = require('../../index')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("BelongsTo"), function() {
   describe("Model.associations", function () {

--- a/test/associations/has-many.test.js
+++ b/test/associations/has-many.test.js
@@ -8,7 +8,7 @@ var chai      = require('chai')
   , moment    = require('moment')
   , sinon     = require('sinon')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("HasMany"), function() {
   describe("Model.associations", function () {

--- a/test/associations/has-one.test.js
+++ b/test/associations/has-one.test.js
@@ -4,7 +4,7 @@ var chai      = require('chai')
   , Support   = require(__dirname + '/../support')
   , Sequelize = require('../../index')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("HasOne"), function() {
   describe("Model.associations", function () {

--- a/test/associations/multiple-level-filters.test.js
+++ b/test/associations/multiple-level-filters.test.js
@@ -4,7 +4,7 @@ var chai      = require('chai')
   , Support   = require(__dirname + '/../support')
   , DataTypes = require(__dirname + "/../../lib/data-types")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Multiple Level Filters"), function() {
   it('can filter through belongsTo', function(done) {

--- a/test/associations/self.test.js
+++ b/test/associations/self.test.js
@@ -4,7 +4,7 @@ var chai      = require('chai')
   , Support   = require(__dirname + '/../support')
   , DataTypes = require(__dirname + "/../../lib/data-types")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Self"), function() {
   it('supports freezeTableName', function (done) {

--- a/test/configuration.test.js
+++ b/test/configuration.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , dialect   = Support.getTestDialect()
   , Sequelize = require(__dirname + '/../index')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Configuration"), function() {
   describe('Connections problems should fail with a nice message', function() {

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -14,7 +14,7 @@ var chai      = require('chai')
   , async     = require('async')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAOFactory"), function () {
   beforeEach(function(done) {

--- a/test/dao-factory/and-or-where.test.js
+++ b/test/dao-factory/and-or-where.test.js
@@ -14,7 +14,7 @@ var chai      = require('chai')
   , async     = require('async')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAOFactory"), function () {
   beforeEach(function(done) {

--- a/test/dao-factory/create.test.js
+++ b/test/dao-factory/create.test.js
@@ -14,7 +14,7 @@ var chai      = require('chai')
   , async     = require('async')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAOFactory"), function () {
   beforeEach(function(done) {

--- a/test/dao-factory/find.test.js
+++ b/test/dao-factory/find.test.js
@@ -14,7 +14,7 @@ var chai      = require('chai')
   , async     = require('async')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAOFactory"), function () {
   beforeEach(function(done) {

--- a/test/dao-factory/findAll.test.js
+++ b/test/dao-factory/findAll.test.js
@@ -14,7 +14,7 @@ var chai      = require('chai')
   , async     = require('async')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAOFactory"), function () {
   beforeEach(function(done) {

--- a/test/dao-factory/scopes.test.js
+++ b/test/dao-factory/scopes.test.js
@@ -14,7 +14,7 @@ var chai      = require('chai')
   , async     = require('async')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAOFactory"), function () {
   beforeEach(function(done) {

--- a/test/dao.test.js
+++ b/test/dao.test.js
@@ -11,7 +11,7 @@ var chai      = require('chai')
   , _         = require('lodash')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAO"), function () {
   beforeEach(function(done) {

--- a/test/dao.validations.test.js
+++ b/test/dao.validations.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , Support   = require(__dirname + '/support')
   , config    = require(__dirname + '/config/config')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DaoValidator"), function() {
   describe('validations', function() {

--- a/test/dao/values.test.js
+++ b/test/dao/values.test.js
@@ -12,7 +12,7 @@ var chai      = require('chai')
   , _         = require('lodash')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("DAO"), function () {
   describe('Values', function () {

--- a/test/data-types.test.js
+++ b/test/data-types.test.js
@@ -3,7 +3,7 @@ var chai      = require('chai')
   , Sequelize = require(__dirname + '/../index')
   , Support   = require(__dirname + '/support')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser('DataTypes'), function() {
   it('should return false when comparing DECIMAL and DECIMAL(10,2)', function(done) {

--- a/test/emitters/custom-event-emitter.test.js
+++ b/test/emitters/custom-event-emitter.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , sinon     = require('sinon')
   , CustomEventEmitter = require("../../lib/emitters/custom-event-emitter")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("CustomEventEmitter"), function () {
   describe("proxy", function () {

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , Sequelize = Support.Sequelize
   // , sinon     = require('sinon')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Sequelize Errors"), function () {
   describe('API Surface', function() {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -7,7 +7,7 @@ var chai      = require('chai')
   , Sequelize = Support.Sequelize
   , sinon     = require('sinon')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Hooks"), function () {
   describe('#validate', function() {

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -10,7 +10,7 @@ var chai      = require('chai')
   , _         = require('lodash')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 var sortById = function(a, b) {
   return a.id < b.id ? -1 : 1

--- a/test/include/findAll.test.js
+++ b/test/include/findAll.test.js
@@ -14,7 +14,7 @@ var chai      = require('chai')
   , async     = require('async')
 
 chai.use(datetime)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 var sortById = function(a, b) {
   return a.id < b.id ? -1 : 1

--- a/test/language.test.js
+++ b/test/language.test.js
@@ -3,7 +3,7 @@ var chai      = require('chai')
   , Sequelize = require(__dirname + '/../index')
   , Support   = require(__dirname + '/support')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Language Util"), function() {
   beforeEach(function(done) {

--- a/test/migrator.test.js
+++ b/test/migrator.test.js
@@ -5,7 +5,7 @@ var chai         = require('chai')
   , DataTypes     = require("../lib/data-types")
   , dialect      = Support.getTestDialect()
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Migrator"), function() {
   beforeEach(function() {

--- a/test/mysql/associations.test.js
+++ b/test/mysql/associations.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , sinon     = require('sinon')
   , DataTypes = require(__dirname + "/../../lib/data-types")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (Support.dialectIsMySQL()) {
   describe('[MYSQL Specific] Associations', function() {

--- a/test/mysql/connector-manager.test.js
+++ b/test/mysql/connector-manager.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , sinon     = require('sinon')
   , DataTypes = require(__dirname + "/../../lib/data-types")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (Support.dialectIsMySQL()) {
   describe('[MYSQL Specific] Connector Manager', function() {

--- a/test/mysql/dao-factory.test.js
+++ b/test/mysql/dao-factory.test.js
@@ -6,7 +6,7 @@ var chai      = require('chai')
   , dialect   = Support.getTestDialect()
   , config    = require(__dirname + "/../config/config")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (Support.dialectIsMySQL()) {
   describe("[MYSQL Specific] DAOFactory", function () {

--- a/test/mysql/query-generator.test.js
+++ b/test/mysql/query-generator.test.js
@@ -7,7 +7,7 @@ var chai      = require('chai')
   , _         = require('lodash')
   , QueryGenerator = require("../../lib/dialects/mysql/query-generator")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (Support.dialectIsMySQL()) {
   describe("[MYSQL Specific] QueryGenerator", function () {

--- a/test/postgres/associations.test.js
+++ b/test/postgres/associations.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , config    = require(__dirname + '/../config/config')
   , DataTypes = require(__dirname + "/../../lib/data-types")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] associations', function() {

--- a/test/postgres/dao.test.js
+++ b/test/postgres/dao.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , DataTypes = require(__dirname + "/../../lib/data-types")
   , _         = require('lodash')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] DAO', function() {

--- a/test/postgres/hstore.test.js
+++ b/test/postgres/hstore.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , dialect   = Support.getTestDialect()
   , hstore    = require(__dirname + '/../../lib/dialects/postgres/hstore')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] hstore', function() {

--- a/test/postgres/query-generator.test.js
+++ b/test/postgres/query-generator.test.js
@@ -9,7 +9,7 @@ var chai            = require('chai')
   , util            = require("util")
   , _               = require('lodash')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] QueryGenerator', function() {

--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , dialect   = Support.getTestDialect()
   , _         = require('lodash')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Promise"), function () {
   beforeEach(function(done) {

--- a/test/query-chainer.test.js
+++ b/test/query-chainer.test.js
@@ -4,7 +4,7 @@ var chai      = require('chai')
   , QueryChainer       = require("../lib/query-chainer")
   , CustomEventEmitter = require("../lib/emitters/custom-event-emitter")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("QueryChainer"), function () {
   beforeEach(function(done) {

--- a/test/query-generator.test.js
+++ b/test/query-generator.test.js
@@ -6,7 +6,7 @@ var chai      = require('chai')
   , dialect   = Support.getTestDialect()
   , _         = require('lodash')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("QueryGenerators"), function () {
   describe("comments", function() {

--- a/test/query-interface.test.js
+++ b/test/query-interface.test.js
@@ -5,7 +5,7 @@ var chai      = require('chai')
   , dialect   = Support.getTestDialect()
   , _         = require('lodash')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("QueryInterface"), function () {
   beforeEach(function(done) {

--- a/test/sequelize.executable.test.js
+++ b/test/sequelize.executable.test.js
@@ -9,7 +9,7 @@ var chai      = require('chai')
   , path      = require('path')
   , os        = require('os')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (os.type().toLowerCase().indexOf('windows') === -1) {
   describe(Support.getTestDialectTeaser("Executable"), function() {

--- a/test/sequelize.test.js
+++ b/test/sequelize.test.js
@@ -12,7 +12,7 @@ var chai        = require('chai')
   , path        = require('path')
   , sinon       = require('sinon')
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 var qq = function(str) {
   if (dialect == 'postgres' || dialect == 'sqlite') {

--- a/test/sqlite/dao-factory.test.js
+++ b/test/sqlite/dao-factory.test.js
@@ -7,7 +7,7 @@ var chai      = require('chai')
   , dbFile    = __dirname + '/test.sqlite'
   , storages  = [dbFile]
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAOFactory', function() {

--- a/test/sqlite/dao.test.js
+++ b/test/sqlite/dao.test.js
@@ -4,7 +4,7 @@ var chai      = require('chai')
   , DataTypes = require(__dirname + "/../../lib/data-types")
   , dialect   = Support.getTestDialect()
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAO', function() {

--- a/test/sqlite/query-generator.test.js
+++ b/test/sqlite/query-generator.test.js
@@ -8,7 +8,7 @@ var chai      = require('chai')
   , moment    = require('moment')
   , QueryGenerator = require("../../lib/dialects/sqlite/query-generator")
 
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] QueryGenerator', function() {

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,7 +5,7 @@ var chai    = require('chai')
   , Support = require(__dirname + '/support')
 
 chai.use(spies)
-chai.Assertion.includeStack = true
+chai.config.includeStack = true
 
 describe(Support.getTestDialectTeaser("Utils"), function() {
   describe('removeCommentsFromFunctionString', function() {


### PR DESCRIPTION
Fixes the deprecation warning:
Assertion.includeStack is deprecated, use chai.config.includeStack instead.
