### PR TITLE
Allows migrator.options.logging to be set to false

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -19,11 +19,11 @@ module.exports = (function() {
     if (this.options.logging === true) {
       console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log')
       this.options.logging = console.log
-    }
-
-    if (this.options.logging == console.log) {
+    } else if (this.options.logging === console.log) {
       // using just console.log will break in node < 0.6
       this.options.logging = function(s) { console.log(s) }
+    } else if (this.options.logging === false) {
+      this.options.logging = function() {};
     }
   }
 
@@ -63,9 +63,7 @@ module.exports = (function() {
 
             chainer.add(migration, 'execute', [options], {
               before: function(migration) {
-                if (self.options.logging !== false) {
-                  self.options.logging(migration.filename)
-                }
+                self.options.logging(migration.filename)
                 migrationTime = process.hrtime()
               },
 
@@ -73,9 +71,7 @@ module.exports = (function() {
                 migrationTime = process.hrtime(migrationTime)
                 migrationTime = Math.round( (migrationTime[0] * 1000) + (migrationTime[1] / 1000000));
 
-                if (self.options.logging !== false) {
-                  self.options.logging('Completed in ' + migrationTime + 'ms')
-                }
+                self.options.logging('Completed in ' + migrationTime + 'ms')
               },
 
               success: function(migration, callback) {


### PR DESCRIPTION
Previously, this would cause an exception to be thrown:

```
Uncaught TypeError: Property 'logging' of object #<Object> is not a function
      at module.exports.Migrator.migrate (sequelize/lib/migrator.js:58:26)
      at module.exports.Migrator.getUndoneMigrations (sequelize/lib/migrator.js:146:25)
      at EventEmitter.emit (events.js:88:17)
      at module.exports.CustomEventEmitter.emit (sequelize/lib/emitters/custom-event-emitter.js:61:33)
      at module.exports.Migrator.getLastMigrationIdFromDatabase (sequelize/lib/migrator.js:264:19)
      at EventEmitter.emit (events.js:88:17)
      at module.exports.CustomEventEmitter.emit (sequelize/lib/emitters/custom-event-emitter.js:61:33)
      at module.exports.Migrator.getLastMigrationFromDatabase (sequelize/lib/migrator.js:245:23)
      at EventEmitter.emit (events.js:88:17)
      at module.exports.CustomEventEmitter.emit (sequelize/lib/emitters/custom-event-emitter.js:61:33)
      at module.exports.QueryInterface.queryAndEmit (sequelize/lib/query-interface.js:974:19)
      at EventEmitter.emit (events.js:88:17)
      at module.exports.CustomEventEmitter.emit (sequelize/lib/emitters/custom-event-emitter.js:61:33)
      at module.exports.onSuccess (sequelize/lib/dialects/sqlite/query.js:180:10)
      at Statement.module.exports.Query.run.database.serialize.executeSql (sequelize/lib/dialects/sqlite/query.js:52:25)
  --> in Database#all('SELECT * FROM `SequelizeMeta` ORDER BY id DESC LIMIT 1;', [Function])
      at module.exports.Query.run.database.serialize.executeSql (sequelize/lib/dialects/sqlite/query.js:43:54)
      at funcs (sequelize/node_modules/lodash/dist/lodash.js:5143:23)
      at Statement.module.exports.Query.run (sequelize/lib/dialects/sqlite/query.js:80:17)
```
