### PR TITLE
Fix output of test arguments

### DIFF
--- a/test/mysql/query-generator.test.js
+++ b/test/mysql/query-generator.test.js
@@ -545,7 +545,7 @@ if (Support.dialectIsMySQL()) {
     _.each(suites, function(tests, suiteTitle) {
       describe(suiteTitle, function() {
         tests.forEach(function(test) {
-          var title = test.title || 'MySQL correctly returns ' + test.expectation + ' for ' + util.inspect(test.arguments)
+          var title = test.title || 'MySQL correctly returns ' + test.expectation + ' for ' + JSON.stringify(test.arguments)
           it(title, function(done) {
             // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly
             var context = test.context || {options: {}};

--- a/test/postgres/query-generator.test.js
+++ b/test/postgres/query-generator.test.js
@@ -948,7 +948,7 @@ if (dialect.match(/^postgres/)) {
         })
 
         tests.forEach(function(test) {
-          var title = test.title || 'Postgres correctly returns ' + test.expectation + ' for ' + util.inspect(test.arguments)
+          var title = test.title || 'Postgres correctly returns ' + test.expectation + ' for ' + JSON.stringify(test.arguments)
           it(title, function(done) {
             // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly
             var context = test.context || {options: {}};

--- a/test/sqlite/query-generator.test.js
+++ b/test/sqlite/query-generator.test.js
@@ -473,7 +473,7 @@ if (dialect === 'sqlite') {
     _.each(suites, function(tests, suiteTitle) {
       describe(suiteTitle, function() {
         tests.forEach(function(test) {
-          var title = test.title || 'SQLite correctly returns ' + test.expectation + ' for ' + util.inspect(test.arguments)
+          var title = test.title || 'SQLite correctly returns ' + test.expectation + ' for ' + JSON.stringify(test.arguments)
           it(title, function(done) {
             // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly
             var context = test.context || {options: {}};


### PR DESCRIPTION
This PR improves the legibility of the test arguments, which could appear to be the test description. Here is how it looked before:

![before](https://cloud.githubusercontent.com/assets/92085/2614807/ca19d886-bbee-11e3-8270-47e99a4882d4.png)

If we replace `util.inspect` by `JSON.stringify`, the output becomes much nicer:

![after](https://cloud.githubusercontent.com/assets/92085/2614808/ca1c7ff0-bbee-11e3-8cf7-af01f2deff1e.png)
