### PR TITLE
Association scopes

### DIFF
--- a/lib/associations/has-many-double-linked.js
+++ b/lib/associations/has-many-double-linked.js
@@ -12,70 +12,58 @@ module.exports = (function() {
 
   HasManyDoubleLinked.prototype.injectGetter = function(options) {
     var self = this
-      , _options = options
-      , smart
+      , through = self.association.through
+      , queryOptions = {}
+      , targetAssociation = self.association.targetAssociation
+      , instancePrimaryKey = self.instance.Model.primaryKeyAttribute
+      , foreignPrimaryKey = self.association.target.primaryKeyAttribute
 
-    var customEventEmitter = new Utils.CustomEventEmitter(function() {
-      var where = []
-        , through = self.association.through
-        , options = _options || {}
-        , queryOptions = {}
-        , targetAssociation = self.association.targetAssociation
+    options = this.association._injectAssociationScope(options || {})
 
-      //fully qualify
-      var instancePrimaryKey = self.instance.Model.primaryKeyAttribute
-        , foreignPrimaryKey = self.association.target.primaryKeyAttribute
-
-      options.where = new Utils.and([
-        new Utils.where(
-          through.rawAttributes[self.association.identifier],
-          self.instance[instancePrimaryKey]
-        ),
-        new Utils.where(
-          through.rawAttributes[self.association.foreignIdentifier], {
-            join: new Utils.literal([
-              self.QueryInterface.quoteTable(self.association.target.name),
-              self.QueryInterface.quoteIdentifier(foreignPrimaryKey)
-            ].join('.'))
-          }
-        ),
-        options.where
-      ])
-
-      if (Object(targetAssociation.through) === targetAssociation.through) {
-        queryOptions.hasJoinTableModel = true
-        queryOptions.joinTableModel = through
-
-        if (!options.attributes) {
-          options.attributes = [
-            self.QueryInterface.quoteTable(self.association.target.name)+".*"
-          ]
+    options.where = new Utils.and([
+      new Utils.where(
+        through.rawAttributes[self.association.identifier],
+        self.instance[instancePrimaryKey]
+      ),
+      new Utils.where(
+        through.rawAttributes[self.association.foreignIdentifier], {
+          join: new Utils.literal([
+            self.QueryInterface.quoteTable(self.association.target.name),
+            self.QueryInterface.quoteIdentifier(foreignPrimaryKey)
+          ].join('.'))
         }
+      ),
+      options.where
+    ])
 
-        if (options.joinTableAttributes) {
-          options.joinTableAttributes.forEach(function (elem) {
-            options.attributes.push(
-              self.QueryInterface.quoteTable(through.name) + '.' + self.QueryInterface.quoteIdentifier(elem) + ' as ' +
-              self.QueryInterface.quoteIdentifier(through.name + '.' + elem, true)
-            )
-          })
-        } else {
-          Utils._.forOwn(through.rawAttributes, function (elem, key) {
-            options.attributes.push(
-              self.QueryInterface.quoteTable(through.name) + '.' + self.QueryInterface.quoteIdentifier(key) + ' as ' +
-              self.QueryInterface.quoteIdentifier(through.name + '.' + key, true)
-            )
-          })
-        }
+    if (Object(targetAssociation.through) === targetAssociation.through) {
+      queryOptions.hasJoinTableModel = true
+      queryOptions.joinTableModel = through
+
+      if (!options.attributes) {
+        options.attributes = [
+          self.QueryInterface.quoteTable(self.association.target.name)+".*"
+        ]
       }
 
-      self.association.target.findAllJoin([through.getTableName(), through.name], options, queryOptions)
-        .on('success', function(objects) { customEventEmitter.emit('success', objects) })
-        .on('error', function(err){ customEventEmitter.emit('error', err) })
-        .on('sql', function(sql) { customEventEmitter.emit('sql', sql)})
-    })
+      if (options.joinTableAttributes) {
+        options.joinTableAttributes.forEach(function (elem) {
+          options.attributes.push(
+            self.QueryInterface.quoteTable(through.name) + '.' + self.QueryInterface.quoteIdentifier(elem) + ' as ' +
+            self.QueryInterface.quoteIdentifier(through.name + '.' + elem, true)
+          )
+        })
+      } else {
+        Utils._.forOwn(through.rawAttributes, function (elem, key) {
+          options.attributes.push(
+            self.QueryInterface.quoteTable(through.name) + '.' + self.QueryInterface.quoteIdentifier(key) + ' as ' +
+            self.QueryInterface.quoteIdentifier(through.name + '.' + key, true)
+          )
+        })
+      }
+    }
 
-    return customEventEmitter.run()
+    return self.association.target.findAllJoin([through.getTableName(), through.name], options, queryOptions)     
   }
 
   HasManyDoubleLinked.prototype.injectSetter = function(emitterProxy, oldAssociations, newAssociations, defaultAttributes) {
@@ -168,8 +156,7 @@ module.exports = (function() {
     chainer
       .run()
       .success(function() { emitterProxy.emit('success', newAssociations) })
-      .error(function(err) { emitterProxy.emit('error', err) })
-      .on('sql', function(sql) { emitterProxy.emit('sql', sql) })
+      .proxy(emitterProxy, { events: ['error', 'sql']})
   }
 
   HasManyDoubleLinked.prototype.injectAdder = function(emitterProxy, newAssociation, additionalAttributes, exists) {
@@ -201,10 +188,7 @@ module.exports = (function() {
     } else {
       attributes = Utils._.defaults(attributes, newAssociation[targetAssociation.through.name], additionalAttributes)
 
-      this.association.through.create(attributes, options)
-        .success(function() { emitterProxy.emit('success', newAssociation) })
-        .error(function(err) { emitterProxy.emit('error', err) })
-        .on('sql', function(sql) { emitterProxy.emit('sql', sql) })
+      this.association.through.create(attributes, options).proxy(emitterProxy)
     }
   }
 

--- a/lib/associations/has-many-single-linked.js
+++ b/lib/associations/has-many-single-linked.js
@@ -1,6 +1,6 @@
 var Utils       = require('./../utils')
   , Transaction = require('./../transaction')
-
+  
 module.exports = (function() {
   var HasManySingleLinked = function(association, instance) {
     this.__factory = association
@@ -11,13 +11,13 @@ module.exports = (function() {
   }
 
   HasManySingleLinked.prototype.injectGetter = function(options) {
-    options = options || {}
+    options = this.association._injectAssociationScope(options || {})
 
     options.where = new Utils.and([
       new Utils.where(
         this.target.rawAttributes[this.association.identifier],
-        this.instance[this.source.primaryKeyAttribute])
-      ,
+        this.instance[this.source.primaryKeyAttribute]
+      ),
       options.where
     ])
 
@@ -98,8 +98,7 @@ module.exports = (function() {
     chainer
       .run()
       .success(function() { emitter.emit('success', newAssociations) })
-      .error(function(err) { emitter.emit('error', err) })
-      .on('sql', function(sql) { emitter.emit('sql', sql) })
+      .proxy(emitter, { events: ['error', 'sql']})
   }
 
   HasManySingleLinked.prototype.injectAdder = function(emitterProxy, newAssociation, additionalAttributes) {
@@ -114,10 +113,7 @@ module.exports = (function() {
 
     newAssociation[this.__factory.identifier] = this.instance[primaryKey]
 
-    newAssociation.save(options)
-      .success(function() { emitterProxy.emit('success', newAssociation) })
-      .error(function(err) { emitterProxy.emit('error', err) })
-      .on('sql', function(sql) { emitterProxy.emit('sql', sql) })
+    newAssociation.save(options).proxy(emitterProxy)
   }
 
   return HasManySingleLinked

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -1,5 +1,4 @@
 var Utils      = require("./../utils")
-  , DataTypes  = require('./../data-types')
   , Helpers    = require('./helpers')
   , _          = require('lodash')
   , Transaction = require('../transaction')
@@ -109,6 +108,17 @@ module.exports = (function() {
       if (this.targetAssociation) {
         this.targetAssociation.through = this.through
       }
+    }
+
+    if (this.options.defaultScope) {
+      this.defaultScope = this.options.defaultScope
+    } else {
+      this.defaultScope = {}
+    }
+    if (this.options.scopes) {
+      this.scopes = this.options.scopes
+    } else {
+      this.scopes = {}
     }
 
     this.options.tableName = this.combinedName = (this.through === Object(this.through) ? this.through.tableName : this.through)
@@ -415,6 +425,32 @@ module.exports = (function() {
 
     return this
   };
+
+  HasMany.prototype._injectAssociationScope = function(options) {
+    var scope
+
+    if (options._scoped === true) {
+      return options // Don't apply scopes several times, e.g. if we're reloading
+    }
+    options._scoped = true
+
+    if (options.hasOwnProperty('scope')) {
+      scope = this.source.scope.call(this, options.scope).scopeObj
+    } else {
+      Utils.injectScope.call(this, this.defaultScope)
+      scope = this.scopeObj
+    }
+
+    // Special handling on where, since we can merge several clauses together
+    if (options.hasOwnProperty('where')) {
+      options.where = new Utils.and([options.where, scope.where])
+    } else {
+      options.where = scope.where
+    }
+    delete scope.where
+    // Everything else is just overwritten if it's already set in options
+    return Utils._.defaults(options, scope)
+  }
 
   /**
    * The method checks if it is ok to delete the previously defined foreign key.

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -46,7 +46,7 @@ Mixin.hasMany = function(associatedDAOFactory, options) {
   options.hooks = options.hooks === undefined ? false : Boolean(options.hooks)
   options.useHooks = options.hooks
 
-  options = Utils._.extend(options, Utils._.omit(this.options, ['hooks']))
+  options = Utils._.defaults(options, Utils._.omit(this.options, ['hooks']))
 
   // the id is in the foreign table or in a connecting table
   var association = new HasMany(this, associatedDAOFactory, options)

--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -1483,7 +1483,9 @@ module.exports = (function() {
     }
 
     // pseudo include just needed the attribute logic, return
-    if (include._pseudo) return include
+    if (include._pseudo) {
+      return include
+    }
 
     // check if the current daoFactory is actually associated with the passed daoFactory - or it's a pseudo include
     var association = this.getAssociation(include.daoFactory, include.as)
@@ -1491,9 +1493,15 @@ module.exports = (function() {
       include.association = association
       include.as = association.as
 
+      if (association.associationType === 'HasMany') {
+        association._injectAssociationScope(include)
+      }
+
       // If through, we create a pseudo child include, to ease our parsing later on
       if (Object(include.association.through) === include.association.through) {
-        if (!include.include) include.include = []
+        if (!include.include) {
+          include.include = []
+        }
         var through = include.association.through
 
         include.through = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -76,7 +76,7 @@ var Utils = module.exports = {
       return true
     }
 
-    if (typeof scope.order === "string") {
+    if (typeof scope.order === "string" || Array.isArray(scope.order)) {
       self.scopeObj.order = self.scopeObj.order || []
       self.scopeObj.order[self.scopeObj.order.length] = scope.order
     }

--- a/test/associations/scopes.test.js
+++ b/test/associations/scopes.test.js
@@ -1,0 +1,222 @@
+/* jshint camelcase: false */
+/* jshint expr: true */
+var chai      = require('chai')
+  , Sequelize = require('../../index')
+  , expect    = chai.expect
+  , Support   = require(__dirname + '/../support')
+  , _         = require('lodash')
+
+chai.config.includeStack = true
+
+
+// An abstraction layer on top of getter / includes. Makes sure we test all cases work for both includes and regular get calls
+var runSuite = function (description, fn) {
+  describe(description, function () {
+    describe('defaultScope', function () {
+      it("should be applied by default", function (done) {
+        fn.call(this, {}, function (projects) {
+            expect(projects.length).to.equal(1)
+            expect(projects[0].started).to.equal(true)
+            done()
+          }
+        )
+      })
+
+      it("should be possible to disable it", function (done) {
+        fn.call(this, { scope: null }, function (projects) {
+            expect(projects.length).to.equal(5)
+            done()
+          }
+        )
+      })
+
+      it('can combine default scope and provided where clauses', function (done) {
+        fn.call(this, { 
+            where: {
+              semiRandomNumber: 2
+            }
+          }, function (projects) {
+            expect(projects.length).to.equal(1)
+
+            expect(projects[0].semiRandomNumber).to.equal(2)
+            expect(projects[0].started).to.equal(true)
+                          
+            done()
+          }
+        )
+      })
+    })
+
+    describe('other scopes', function () {
+      (description === 'using includes' ? it.skip : it)('works with limit and order', function (done) {
+        // Order and limit does not work for includes in general
+        fn.call(this, { scope: 'recent2'}, function (projects) {
+            expect(projects.length).to.equal(2)
+
+            expect(projects[0].semiRandomNumber).to.equal(88)
+            expect(projects[1].semiRandomNumber).to.equal(54)             
+
+            done()
+          }
+        )
+      })
+      
+      it('can combine scopes and provided where clauses', function (done) {
+        fn.call(this, { 
+            scope: 'notStarted',
+            where: {
+              semiRandomNumber: 2
+            }
+          }, function (projects) {
+            expect(projects.length).to.equal(1)
+
+            expect(projects[0].semiRandomNumber).to.equal(2)
+            expect(projects[0].started).to.equal(false)
+                          
+            done()
+          }
+        )
+      })
+
+      it('works with scope functions', function (done) {
+        fn.call(this, { 
+            scope: [
+              {method: ['actualValue', 54]}
+            ]
+          }, function (projects) {
+            expect(projects.length).to.equal(1)
+
+            expect(projects[0].semiRandomNumber).to.equal(54)
+                          
+            done()
+          }
+        )
+      })
+    })
+  }) 
+}
+
+describe(Support.getTestDialectTeaser("Association"), function () {
+  describe('Scopes', function () {
+    beforeEach(function () {
+      this.User = this.sequelize.define('user', {})
+      this.Project = this.sequelize.define('project', {
+        started: Sequelize.BOOLEAN,
+        semiRandomNumber: Sequelize.INTEGER
+      })
+
+      this.User.hasMany(this.Project, {
+        defaultScope: {
+          where: {
+            started: true
+          }
+        }, 
+        scopes: {
+          recent2: {
+            limit: 2,
+            order: [['semiRandomNumber', 'DESC']]
+          },
+          notStarted: {
+            where: {
+              started: false
+            }
+          },
+          actualValue: function(value) {
+            return {
+              where: {
+                semiRandomNumber: value
+              }
+            }
+          },
+        }
+      })
+    })
+
+    describe('n:m', function () {
+      beforeEach(function (done) {
+        var self = this
+        this.Project.hasMany(this.User)
+
+        this.sequelize.sync({ force: true}).success(function () {
+          self.User.create({ id: 12 }).success(function (user) {
+            self.Project.bulkCreate([
+              { started: false, semiRandomNumber: 88},
+              { started: true,  semiRandomNumber: 2},
+              { started: false, semiRandomNumber: 2},
+              { started: false, semiRandomNumber: 54},
+              { started: false, semiRandomNumber: 15}
+            ]).success(function () {
+              self.Project.findAll().success(function (projects) {
+                user.setProjects(projects).success(function () {
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+
+      runSuite('using includes', function includes(where, assertions) {
+        this.User.find({
+          where: {
+            id: 12
+          },
+          include: [
+            _.defaults(where, { model: this.Project})
+          ]
+        }).success(function (user) {
+          assertions(user.projects)
+        })
+      })
+
+      runSuite('using regular getters', function regularGetter(where, assertions) {
+        this.User.find(12).success(function (user) {
+          user.getProjects(where).success(function (projects) {
+            assertions(projects)
+          })
+        })
+      })
+    })
+
+    describe('1:m', function () {
+      beforeEach(function (done) {
+        var self = this
+
+        this.sequelize.sync({ force: true}).success(function () {
+          self.User.create({ id: 12 }).success(function (user) {
+            self.Project.bulkCreate([
+              { started: false, userId: user.id, semiRandomNumber: 88},
+              { started: true,  userId: user.id, semiRandomNumber: 2},
+              { started: false, userId: user.id, semiRandomNumber: 2},
+              { started: false, userId: user.id, semiRandomNumber: 54},
+              { started: false, userId: user.id, semiRandomNumber: 15}
+            ]).success(function () {
+              done()
+            })
+          })
+        })
+      })
+
+      runSuite('using includes', function includes(where, assertions) {
+        this.User.find({
+          where: {
+            id: 12
+          },
+          include: [
+            _.defaults(where, { model: this.Project})
+          ]
+        }).success(function (user) {
+          assertions(user.projects)
+        })
+      })
+
+      runSuite('using regular getters', function regularGetter(where, assertions) {
+        this.User.find(12).success(function (user) {
+          user.getProjects(where).success(function (projects) {
+            assertions(projects)
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
The same functionality as scopes and defaultScope on DAO has been added to associations. 

It's called slightly differently, since i don't think it makes much sense to call something like `associationScope` before getting associations. 

This feature should be very useful for #1307 (polymorphic associations)
