### PR TITLE
forward transaction to before/after create/update hook

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -700,7 +700,7 @@ module.exports = (function() {
 
   DAOFactory.prototype.bulkBuild = function(valueSets, options) {
     options = options || { isNewRecord: true, isDirty: true }
-    
+
     if (options.hasOwnProperty('include') && options.include && !options.includeValidated) {
       validateIncludedElements.call(this, options)
     }
@@ -872,7 +872,7 @@ module.exports = (function() {
 
     return new Utils.CustomEventEmitter(function(emitter) {
       var done = function() {
-        self.runHooks('afterBulkCreate', daos, options.fields, function(err, newRecords, newFields) {
+        self.runHooks('afterBulkCreate', daos, options.fields, options.transaction, function(err, newRecords, newFields) {
           if (!!err) {
             return emitter.emit('error', err)
           }
@@ -895,7 +895,7 @@ module.exports = (function() {
 
         var i = 0
         var iterate = function(i) {
-          self.runHooks('beforeCreate', daos[i], function(err, newValues) {
+          self.runHooks('beforeCreate', daos[i], options.transaction, function(err, newValues) {
             if (!!err) {
               return emitter.emit('error', err)
             }
@@ -904,7 +904,7 @@ module.exports = (function() {
             daos[i].save({ transaction: options.transaction }).error(function(err) {
               emitter.emit('error', err)
             }).success(function() {
-              self.runHooks('afterCreate', daos[i], function(err, newValues) {
+              self.runHooks('afterCreate', daos[i], options.transaction, function(err, newValues) {
                 if (!!err) {
                   return emitter.emit('error', err)
                 }
@@ -957,7 +957,7 @@ module.exports = (function() {
         })
       }
 
-      self.runHooks('beforeBulkCreate', daos, options.fields, function(err, newRecords, newFields) {
+      self.runHooks('beforeBulkCreate', daos, options.fields, options.transaction, function(err, newRecords, newFields) {
         if (!!err) {
           return emitter.emit('error', err)
         }
@@ -1026,7 +1026,7 @@ module.exports = (function() {
       , args  = []
 
     return new Utils.CustomEventEmitter(function(emitter) {
-      self.runHooks(self.options.hooks.beforeBulkDestroy, where, function(err, newWhere) {
+      self.runHooks(self.options.hooks.beforeBulkDestroy, where, options.transaction, function(err, newWhere) {
         if (!!err) {
           return emitter.emit('error', err)
         }
@@ -1061,7 +1061,7 @@ module.exports = (function() {
                 return emitter.emit('error', err)
               }
 
-              self.runHooks(self.options.hooks.afterBulkDestroy, where, function(err) {
+              self.runHooks(self.options.hooks.afterBulkDestroy, where, options.transaction, function(err) {
                 if (!!err) {
                   return emitter.emit('error', err)
                 }
@@ -1073,7 +1073,7 @@ module.exports = (function() {
             if (options && options.hooks === true) {
               var tick = 0
               var next = function(i) {
-                self.runHooks(self.options.hooks.afterDestroy, records[i], function(err, newValues) {
+                self.runHooks(self.options.hooks.afterDestroy, records[i], options.transaction, function(err, newValues) {
                   if (!!err) {
                     return finished(err)
                   }
@@ -1101,7 +1101,7 @@ module.exports = (function() {
           self.all({where: where}).error(function(err) { emitter.emit('error', err) })
           .success(function(records) {
             var next = function(i) {
-              self.runHooks(self.options.hooks.beforeDestroy, records[i], function(err, newValues) {
+              self.runHooks(self.options.hooks.beforeDestroy, records[i], options.transaction, function(err, newValues) {
                 if (!!err) {
                   return runQuery(err)
                 }
@@ -1150,7 +1150,7 @@ module.exports = (function() {
 
     return new Utils.CustomEventEmitter(function(emitter) {
       var runSave = function() {
-        self.runHooks(self.options.hooks.beforeBulkUpdate, attrValueHash, where, function(err, attributes, _where) {
+        self.runHooks(self.options.hooks.beforeBulkUpdate, attrValueHash, where, options.transaction, function(err, attributes, _where) {
           if (!!err) {
             return emitter.emit('error', err)
           }
@@ -1176,7 +1176,7 @@ module.exports = (function() {
                   return emitter.emit('error', err)
                 }
 
-                self.runHooks(self.options.hooks.afterBulkUpdate, attrValueHash, where, function(err) {
+                self.runHooks(self.options.hooks.afterBulkUpdate, attrValueHash, where, options.transaction, function(err) {
                   if (!!err) {
                     return emitter.emit('error', err)
                   }
@@ -1188,7 +1188,8 @@ module.exports = (function() {
               if (options && options.hooks === true && !!records && records.length > 0) {
                 var tick = 0
                 var next = function(i) {
-                  self.runHooks(self.options.hooks.afterUpdate, records[i], function(err, newValues) {
+
+                  self.runHooks(self.options.hooks.afterUpdate, records[i], options.transaction, function(err, newValues) {
                     if (!!err) {
                       return finished(err)
                     }
@@ -1219,7 +1220,7 @@ module.exports = (function() {
               }
 
               var next = function(i) {
-                self.runHooks(self.options.hooks.beforeUpdate, records[i], function(err, newValues) {
+                self.runHooks(self.options.hooks.beforeUpdate, records[i], options.transaction, function(err, newValues) {
                   if (!!err) {
                     return runQuery(err)
                   }
@@ -1640,13 +1641,13 @@ module.exports = (function() {
   var optClone = function (options) {
     return Utils._.cloneDeep(options, function (elem) {
       // The DAOFactories used for include are pass by ref, so don't clone them.
-      if (elem instanceof DAOFactory || 
-        elem instanceof Utils.col || 
-        elem instanceof Utils.literal ||  
-        elem instanceof Utils.cast || 
-        elem instanceof Utils.fn || 
-        elem instanceof Utils.and || 
-        elem instanceof Utils.or || 
+      if (elem instanceof DAOFactory ||
+        elem instanceof Utils.col ||
+        elem instanceof Utils.literal ||
+        elem instanceof Utils.cast ||
+        elem instanceof Utils.fn ||
+        elem instanceof Utils.and ||
+        elem instanceof Utils.or ||
         elem instanceof Transaction
       ) {
         return elem

--- a/lib/dao.js
+++ b/lib/dao.js
@@ -4,7 +4,7 @@ var Utils           = require("./utils")
   , DataTypes       = require("./data-types")
   , _               = require('lodash')
   , defaultsOptions = { raw: true }
-        
+
 
 module.exports = (function() {
   var DAO = function(values, options) {
@@ -161,7 +161,7 @@ module.exports = (function() {
       if (!options.raw) {
         originalValue = this.dataValues[key]
       }
-      
+
       // If not raw, and there's a customer setter
       if (!options.raw && this._customSetters[key]) {
         this._customSetters[key].call(this, value, key)
@@ -345,9 +345,9 @@ module.exports = (function() {
               && !!self.Model.rawAttributes[updatedAtAttr].defaultValue
             )
             ? self.Model.rawAttributes[updatedAtAttr].defaultValue
-            : Utils.now(self.sequelize.options.dialect))    
+            : Utils.now(self.sequelize.options.dialect))
         }
-        
+
         if (self.isNewRecord && createdAtAttr && !values[createdAtAttr]) {
           values[createdAtAttr] = (
             (
@@ -382,7 +382,7 @@ module.exports = (function() {
         self.dataValues = _.extend(self.dataValues, values)
 
         // Run the beforeCreate / beforeUpdate hook
-        self.Model.runHooks('before' + hook, self, function(err) {
+        self.Model.runHooks('before' + hook, self, options.transaction, function(err) {
           if (!!err) {
             return emitter.emit('error', err)
           }
@@ -423,8 +423,7 @@ module.exports = (function() {
               // Ensure new values are on DAO, and reset previousDataValues
               result.dataValues = _.extend(result.dataValues, values)
               result._previousDataValues = _.clone(result.dataValues)
-
-              self.Model.runHooks('after' + hook, result, function(err) {
+              self.Model.runHooks('after' + hook, result, options.transaction, function(err) {
                 if (!!err) {
                   return emitter.emit('error', err)
                 }
@@ -506,7 +505,7 @@ module.exports = (function() {
       , query = null
 
     return new Utils.CustomEventEmitter(function(emitter) {
-      self.Model.runHooks(self.Model.options.hooks.beforeDestroy, self, function(err) {
+      self.Model.runHooks(self.Model.options.hooks.beforeDestroy, self, options.transaction, function(err) {
         if (!!err) {
           return emitter.emit('error', err)
         }
@@ -526,7 +525,7 @@ module.exports = (function() {
           emitter.emit('error', err)
         })
         .success(function(results) {
-          self.Model.runHooks(self.Model.options.hooks.afterDestroy, self, function(err) {
+          self.Model.runHooks(self.Model.options.hooks.afterDestroy, self, options.transaction, function(err) {
             if (!!err) {
               return emitter.emit('error', err)
             }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -23,11 +23,12 @@ Hooks.replaceHookAliases = function(hooks) {
 }
 
 Hooks.runHooks = function() {
-  var self  = this
-    , tick  = 0
-    , hooks = arguments[0]
-    , args  = Array.prototype.slice.call(arguments, 1, arguments.length-1)
-    , fn    = arguments[arguments.length-1]
+
+  var self        = this
+    , tick        = 0
+    , hooks       = arguments[0]
+    , args        = Array.prototype.slice.call(arguments, 1, arguments.length-1)
+    , fn          = arguments[arguments.length-1]
 
   if (typeof hooks === "string") {
     hooks = this.options.hooks[hooks] || []


### PR DESCRIPTION
forwards given transaction to hooks to reuse it there. new order of operations ...

// (3) beforeBulkCreate(daos, fields, transaction, fn) / beforeBulkDestroy(daos, fields, transaction, fn) / beforeBulkUpdate(daos, fields, transaction, fn)

// (4) beforeCreate(dao, transaction, fn) / beforeDestroy(dao, transaction, fn) / beforeUpdate(dao, transaction, fn)

// (5) afterCreate(dao, transaction, fn) / aftreDestroy(dao, transaction, fn) / afterUpdate(dao, transaction, fn)

// (6) afterBulkCreate(daos, fields, transaction, fn) / afterBulkDestory(daos, fields, transaction, fn) / afterBulkUpdate(daos, fields, transaction, fn)
