### PR TITLE
Revert "Fix hstore parse number conversion"

### DIFF
--- a/lib/dialects/postgres/hstore.js
+++ b/lib/dialects/postgres/hstore.js
@@ -1,5 +1,3 @@
-var _ = require('lodash')
-
 module.exports = {
   stringifyPart: function(part) {
     switch(typeof part) {
@@ -32,7 +30,7 @@ module.exports = {
       case '[':
         return JSON.parse(part)
       default:
-        return _.isFinite(part) ? parseFloat(part) : part
+        return part
     }
   },
   parse: function(string) {

--- a/test/postgres/hstore.test.js
+++ b/test/postgres/hstore.test.js
@@ -116,7 +116,7 @@ if (dialect.match(/^postgres/)) {
       })
 
       it('should handle multiple keys with different types of values', function(done) {
-        expect(hstore.parse('"true"=>true,"false"=>false,"null"=>NULL,"undefined"=>NULL,"integer"=>1,"array"=>"[1,\\"2\\"]","object"=>"{\\"object\\":\\"value\\"}"')).to.deep.equal({ true: true, false: false, null: null, undefined: null, integer: 1, array: [1,'2'], object: { object: 'value' }})
+        expect(hstore.parse('"true"=>true,"false"=>false,"null"=>NULL,"undefined"=>NULL,"integer"=>1,"array"=>"[1,\\"2\\"]","object"=>"{\\"object\\":\\"value\\"}"')).to.deep.equal({ true: true, false: false, null: null, undefined: null, integer: "1", array: [1,'2'], object: { object: 'value' }})
         done()
       })
     })


### PR DESCRIPTION
This reverts commit 48e04c4de24462ec761852d0efd8949fd57579b4.

Unfortunately, after reviewing this with @fixe, we concluded that it is bad practice to parse all numbers as float, particularly if you're storing numbers with precision larger than the maximum supported.

Since `HSTORE` does not allow us to strongly-type a value (unlike `JSON`), it is not possible to reliably determine the data type that was originally stored. It is therefore our opinion that Sequelize should not assume that any value can be a number.

This issue will be somewhat mitigated when Postgres 9.4 arrives which will bring high-performance `JSON` support (which inherently strongly-types numbers).
