### PR TITLE
Fix postgres casting conflict in named parameters

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -143,7 +143,11 @@ SqlString.format = function(sql, values, timeZone, dialect) {
 }
 
 SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
-  return sql.replace(/\:(?!\d)(\w+)/g, function (value, key) {
+  return sql.replace(/\:+(?!\d)(\w+)/g, function (value, key) {
+    if ('postgres' === dialect && '::' === value.slice(0, 2)) {
+      return value
+    }
+
     if (values.hasOwnProperty(key)) {
       return SqlString.escape(values[key], false, timeZone, dialect)
     } else {

--- a/test/sequelize.test.js
+++ b/test/sequelize.test.js
@@ -390,6 +390,13 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
     })
 
     if (Support.getTestDialect() === 'postgres') {
+      it('replaces named parameters with the passed object and ignores casts', function(done) {
+        this.sequelize.query('select :one as foo, :two as bar, \'1000\'::integer as baz', null, { raw: true }, { one: 1, two: 2 }).success(function(result) {
+          expect(result).to.deep.equal([{ foo: 1, bar: 2, baz: 1000 }])
+          done()
+        })
+      })
+
       it('supports WITH queries', function(done) {
         this
           .sequelize


### PR DESCRIPTION
The following query will fail due to Sequelize's named parameter handling:

``` sql
Sequelize.query("SELECT '10'::int");
```

This PR only replaces parameters that do not start with double colons (for Postgres dialects only).
