### PR TITLE
Added support for limit clause on update

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -1399,6 +1399,7 @@ module.exports = (function() {
    * @param  {Object}   [options]       
    * @param  {Boolean}  [options.validate=true] Should each row be subject to validation before it is inserted. The whole insert will fail if one row fails validation
    * @param  {Boolean}  [options.hooks=false]   Run before / after bulkUpdate hooks?
+   * @param  {Number}   [options.limit]         How many rows to update (only for mysql and mariadb)
    * @deprecated The syntax is due for change, in order to make `where` more consistent with the rest of the API
    *
    * @return {EventEmitter}

--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -7,6 +7,7 @@ AbstractDialect.prototype.supports = {
 	'DEFAULT': true,
 	'DEFAULT VALUES': false,
 	'VALUES ()': false,
+    'LIMIT ON UPDATE':false,
 	schemas: false
 }
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -204,6 +204,11 @@ module.exports = (function() {
         , values = []
 
       query = "UPDATE <%= table %> SET <%= values %> WHERE <%= where %>"
+
+      if(this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
+        query += " LIMIT "+this.escape(options.limit)+" "
+      }
+
       if (this._dialect.supports['RETURNING'] && (options.returning || options.returning === undefined)) {
         query += " RETURNING *"
       }

--- a/lib/dialects/mariadb/index.js
+++ b/lib/dialects/mariadb/index.js
@@ -6,7 +6,7 @@ var MariaDialect = function(sequelize) {
 }
 
 MariaDialect.prototype = _.defaults({
-
+    'LIMIT ON UPDATE':true
 }, MySQL.prototype)
 
 module.exports = MariaDialect

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -6,7 +6,8 @@ var MysqlDialect = function(sequelize) {
 }
 
 MysqlDialect.prototype.supports = _.defaults({
-	'VALUES ()': true
+	'VALUES ()': true,
+    'LIMIT ON UPDATE':true
 }, Abstract.prototype.supports)
 
 module.exports = MysqlDialect

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -806,6 +806,24 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         })
       })
     })
+
+    if(Support.dialectIsMySQL()) {
+      it('supports limit clause', function (done) {
+        var self = this
+          , data = [{ username: 'Peter', secretValue: '42' },
+                    { username: 'Peter', secretValue: '42' },
+                    { username: 'Peter', secretValue: '42' }]
+
+        this.User.bulkCreate(data).success(function () {
+          self.User.update({secretValue: '43'}, {username: 'Peter'}, {limit: 1}).done(function (err, affectedRows) {
+            expect(err).not.to.be.ok
+            expect(affectedRows).to.equal(1)
+            done()
+          })
+        })
+      })
+    }
+
   })
 
   describe('destroy', function() {


### PR DESCRIPTION
This PR adds <code>limit</code> option to Model.update (related to https://github.com/sequelize/sequelize/issues/1666)

It allows to make queries like this :
<code>UPDATE Resources SET userId = 1 WHERE userId IS NULL LIMIT 1</code>
via Model.update

Only mysql and mariadb support limit on update.
Postgres doesn't support it.
SQlite supports limit on update only if it is built with the SQLITE_ENABLE_UPDATE_DELETE_LIMIT compile-time option.
