### PR TITLE
Fixes issue with options file (--options-path) relative path not working.

### DIFF
--- a/bin/sequelize
+++ b/bin/sequelize
@@ -18,7 +18,7 @@ var configuration = {
 
 var loadDefaultOptions = function(pathToOptionsFile) {
   try {
-    var options = require(path.resolve(process.cwd(), '/', pathToOptionsFile))
+    var options = require(pathToOptionsFile);
 
     Object.keys(options).forEach(function(key) {
       program[key] = options[key]
@@ -194,7 +194,15 @@ program
   .parse(process.argv)
 
 if(typeof program.optionsPath === 'string') {
-  loadDefaultOptions(program.optionsPath);
+  var optionsFilesPath = null;
+
+  if (isRelativePath(program.optionsPath)) {
+    optionsFilePath = path.join(process.cwd(), program.optionsPath);
+  } else {
+    optionsFilePath = program.optionsPath;
+  }
+
+  loadDefaultOptions(optionsFilePath);
 }
 
 if(typeof program.config === 'string') {


### PR DESCRIPTION
Due to incorrect path resolve:

```
var options = require(path.resolve(process.cwd(), '/', pathToOptionsFile))
```

The options file is not being found, by consequence is not loaded and the CLI command fails.
