### PR TITLE
Fixes issue with migrations not being found when relative path for the m...

### DIFF
--- a/lib/migration.js
+++ b/lib/migration.js
@@ -7,7 +7,7 @@ var moment         = require("moment")
 module.exports = (function() {
   var Migration = function(migrator, p) {
     this.migrator       = migrator
-    this.path           = path.normalize(p)
+    this.path           = path.resolve(p)
     this.filename       = Utils._.last(this.path.split(path.sep))
 
     var parsed          = Migration.parseFilename(this.filename)


### PR DESCRIPTION
...igrations folder is provided.

This is because:

```
this.path           = path.normalize(p)
```

Does not resolve the relative path correctly, we could use something like this:

```
optionsFilePath = path.join(process.cwd(), program.optionsPath)
```

Which is used in the `./bin/sequelize` CLI commands file, but:

```
this.path           = path.resolve(p)
```

Does the work for us and works with absolute and relative routes, also works correctly when no migrations directory path is specified.
