### PR TITLE
Remove duplicate link to the changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ To install 2.x.x branch - which has a unstable API and will break backwards comp
 - [Getting Started](http://sequelizejs.com/articles/getting-started)
 - [Documentation](http://sequelizejs.com/docs)
 - [API Reference](https://github.com/sequelize/sequelize/wiki/API-Reference) *Work in progress*
-- [Changelog](https://github.com/sequelize/sequelize/blob/master/changelog.md)
 - [Collaboration and pull requests](https://github.com/sequelize/sequelize/wiki/Collaboration)
 - [Roadmap](https://github.com/sequelize/sequelize/wiki/Roadmap)
 - [Meetups](https://github.com/sequelize/sequelize/wiki/Meetups)


### PR DESCRIPTION
Two links to the changelog appeared in the "Resources" section of the README. This commit removes the second link to the changelog.
