### PR TITLE
Update mysql module notice

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -13,7 +13,7 @@ module.exports = (function() {
         mysql = require('mysql')
       }
     } catch (err) {
-      console.log('You need to install mysql package manually')
+      throw new Error('Please install mysql package manually')
     }
 
     this.sequelize = sequelize


### PR DESCRIPTION
The previous logged message wasn't a clear notice of what happened, since a stack trace for errors later in the code was thrown due to the mysql module not being defined.

Example: 

```
TypeError: Cannot call method 'createConnection' of undefined
    at module.exports.connect (/usr/lib/node_modules/sequelize/lib/dialects/mysql/connector-manager.js:306:28)
    at Object.pool.Pooling.Pool.create (/usr/lib/node_modules/sequelize/lib/dialects/mysql/connector-manager.js:131:19)
    at createResource (/usr/lib/node_modules/sequelize/node_modules/generic-pool/lib/generic-pool.js:258:13)
    at dispense (/usr/lib/node_modules/sequelize/node_modules/generic-pool/lib/generic-pool.js:250:9)
    at Object.me.acquire (/usr/lib/node_modules/sequelize/node_modules/generic-pool/lib/generic-pool.js:316:5)
    at null.fct (/usr/lib/node_modules/sequelize/lib/dialects/mysql/connector-manager.js:241:19)
    at null.<anonymous> (/usr/lib/node_modules/sequelize/lib/emitters/custom-event-emitter.js:24:18)
    at processImmediate [as _immediateCallback] (timers.js:330:15)
```

Throwing the custom error:

```
/usr/lib/node_modules/sequelize/lib/dialects/mysql/connector-manager.js:16
      throw new Error('Please install mysql package manually')
            ^
Error: Please install mysql package manually
    at new module.exports.ConnectorManager (/usr/lib/node_modules/sequelize/lib/dialects/mysql/connector-manager.js:16:13)
    at TransactionManager.getConnectorManager (/usr/lib/node_modules/sequelize/lib/transaction-manager.js:33:36)
    at TransactionManager.query (/usr/lib/node_modules/sequelize/lib/transaction-manager.js:52:15)
    at module.exports.Sequelize.query (/usr/lib/node_modules/sequelize/lib/sequelize.js:330:36)
    at null.fct (/usr/lib/node_modules/sequelize/lib/sequelize.js:410:10)
    at null.<anonymous> (/usr/lib/node_modules/sequelize/lib/emitters/custom-event-emitter.js:24:18)
    at processImmediate [as _immediateCallback] (timers.js:330:15)
```
