### PR TITLE
fix library style based on gslint and jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,4 @@
+/*
 {
     "globals": {
         "spyOn": false,
@@ -24,4 +25,42 @@
     "quotmark": false,
     "undef": true,
     "strict": false
+}
+*/
+
+{
+  "bitwise":false,
+  "boss":true,
+  "expr":true,
+  "camelcase":false,
+  "curly":false,
+  "eqeqeq":true,
+  "freeze":true,
+  "immed":true,
+  "indent":2,
+  "latedef":"nofunc",
+  "laxbreak":true,
+  "laxcomma":true,
+  "newcap":true,
+  "noarg":true,
+  "node":true,
+  "strict":true,
+  "trailing":true,
+  "undef":true,
+  "esnext":false,
+  "sub":true,
+
+  /* questionable */
+  "shadow":true,
+  "loopfunc":true,
+  "evil":true,
+  
+  "predef": [
+    "describe",
+    "it",
+    "before",
+    "beforeEach",
+    "after",
+    "afterEach"
+  ]
 }

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict';
 
-var Utils       = require("./../utils")
-  , Helpers     = require('./helpers')
-  , Transaction = require('../transaction')
-  
+var Utils = require('./../utils')
+  , Helpers = require('./helpers')
+  , Transaction = require('../transaction');
+
 module.exports = (function() {
   var BelongsTo = function(source, target, options) {
-    this.associationType      = 'BelongsTo'
-    this.source               = source
-    this.target               = target
-    this.options              = options
-    this.isSingleAssociation  = true
-    this.isSelfAssociation    = (this.source == this.target)
-    this.as                   = this.options.as
+    this.associationType = 'BelongsTo';
+    this.source = source;
+    this.target = target;
+    this.options = options;
+    this.isSingleAssociation = true;
+    this.isSelfAssociation = (this.source === this.target);
+    this.as = this.options.as;
 
     if (this.as) {
-      this.isAliased = true
+      this.isAliased = true;
     } else {
-      this.as = Utils.singularize(this.target.name, this.target.options.language)
+      this.as = Utils.singularize(this.target.name, this.target.options.language);
     }
 
     if (!this.options.foreignKey) {
@@ -25,111 +25,111 @@ module.exports = (function() {
         [
           Utils._.underscoredIf(this.as, this.source.options.underscored),
           this.target.primaryKeyAttribute
-        ].join("_"),
+        ].join('_'),
         !this.source.options.underscored
-      )
+      );
     }
 
-    this.identifier = this.options.foreignKey
-    this.targetIdentifier = this.target.primaryKeyAttribute
-    this.associationAccessor = this.as
-    this.options.useHooks = options.useHooks
+    this.identifier = this.options.foreignKey;
+    this.targetIdentifier = this.target.primaryKeyAttribute;
+    this.associationAccessor = this.as;
+    this.options.useHooks = options.useHooks;
 
     this.accessors = {
       get: Utils._.camelize('get_' + this.as),
       set: Utils._.camelize('set_' + this.as),
       create: Utils._.camelize('create_' + this.as)
-    }
-  }
+    };
+  };
 
   // the id is in the source table
   BelongsTo.prototype.injectAttributes = function() {
-    var newAttributes  = {}
+    var newAttributes = {};
 
-    newAttributes[this.identifier] = { type: this.options.keyType || this.target.rawAttributes[this.targetIdentifier].type }
+    newAttributes[this.identifier] = { type: this.options.keyType || this.target.rawAttributes[this.targetIdentifier].type };
     if (this.options.constraints !== false) {
-      this.options.onDelete = this.options.onDelete || 'SET NULL'
-      this.options.onUpdate = this.options.onUpdate || 'CASCADE'
+      this.options.onDelete = this.options.onDelete || 'SET NULL';
+      this.options.onUpdate = this.options.onUpdate || 'CASCADE';
     }
-    Helpers.addForeignKeyConstraints(newAttributes[this.identifier], this.target, this.source, this.options)
-    Utils._.defaults(this.source.rawAttributes, newAttributes)
+    Helpers.addForeignKeyConstraints(newAttributes[this.identifier], this.target, this.source, this.options);
+    Utils._.defaults(this.source.rawAttributes, newAttributes);
 
     // Sync attributes and setters/getters to DAO prototype
-    this.source.refreshAttributes()
+    this.source.refreshAttributes();
 
     if (this.source.rawAttributes.hasOwnProperty(this.as)) {
-      throw new Error("Naming collision between attribute '" + this.as + "' and association '" + this.as + "' on model " + this.source.name + ". To remedy this, change either foreignKey or as in your association definition")
+      throw new Error("Naming collision between attribute '" + this.as + "' and association '" + this.as + "' on model " + this.source.name + '. To remedy this, change either foreignKey or as in your association definition');
     }
 
-    return this
-  }
+    return this;
+  };
 
   // Add getAssociation method to the prototype of the model instance
   BelongsTo.prototype.injectGetter = function(instancePrototype) {
-    var association = this
+    var association = this;
 
     instancePrototype[this.accessors.get] = function(params) {
-      var where = {}
+      var where = {};
 
-      params = params || {}
-      params.where = (params.where && [params.where]) || []
+      params = params || {};
+      params.where = (params.where && [params.where]) || [];
 
-      where[association.targetIdentifier] = this.get(association.identifier)
-      params.where.push(where)
+      where[association.targetIdentifier] = this.get(association.identifier);
+      params.where.push(where);
 
-      params.where = new Utils.and(params.where)
+      params.where = new Utils.and(params.where);
 
-      return association.target.find(params)
-    }
+      return association.target.find(params);
+    };
 
-    return this
-  }
+    return this;
+  };
 
   // Add setAssociaton method to the prototype of the model instance
   BelongsTo.prototype.injectSetter = function(instancePrototype) {
-    var association = this
+    var association = this;
 
     instancePrototype[this.accessors.set] = function(associatedInstance, options) {
-      var value = associatedInstance
+      var value = associatedInstance;
       if (associatedInstance instanceof association.target.Instance) {
-        value = associatedInstance[association.targetIdentifier]
+        value = associatedInstance[association.targetIdentifier];
       }
-      
-      this.set(association.identifier, value)
+
+      this.set(association.identifier, value);
 
       options = Utils._.extend({
-        fields: [ association.identifier ],
-        allowNull: [association.identifier ],
+        fields: [association.identifier],
+        allowNull: [association.identifier],
         association: true
-      }, options)
+      }, options);
 
 
       // passes the changed field to save, so only that field get updated.
-      return this.save(options)
-    }
+      return this.save(options);
+    };
 
-    return this
-  }
+    return this;
+  };
 
   // Add createAssociation method to the prototype of the model instance
   BelongsTo.prototype.injectCreator = function(instancePrototype) {
-    var association = this
+    var association = this;
 
     instancePrototype[this.accessors.create] = function(values, fieldsOrOptions) {
       var instance = this
-        , options = {}
+        , options = {};
 
       if ((fieldsOrOptions || {}).transaction instanceof Transaction) {
-        options.transaction = fieldsOrOptions.transaction
+        options.transaction = fieldsOrOptions.transaction;
       }
 
       return association.target.create(values, fieldsOrOptions).then(function(newAssociatedObject) {
-        return instance[association.accessors.set](newAssociatedObject, options)
-      })
-    }
+        return instance[association.accessors.set](newAssociatedObject, options);
+      });
+    };
 
-    return this
-  }
+    return this;
+  };
 
-  return BelongsTo
-})()
+  return BelongsTo;
+})();

--- a/lib/associations/has-many-double-linked.js
+++ b/lib/associations/has-many-double-linked.js
@@ -1,25 +1,25 @@
-"use strict";
+'use strict';
 
-var Utils       = require('./../utils')
-  , Transaction = require('./../transaction')
+var Utils = require('./../utils')
+  , Transaction = require('./../transaction');
 
 module.exports = (function() {
   var HasManyDoubleLinked = function(association, instance) {
-    this.association = association
-    this.instance = instance
+    this.association = association;
+    this.instance = instance;
 
     // Alias the quoting methods for code brevity
-    this.QueryInterface = instance.QueryInterface
-  }
+    this.QueryInterface = instance.QueryInterface;
+  };
 
   HasManyDoubleLinked.prototype.injectGetter = function(options, queryOptions) {
     var self = this
       , through = self.association.through
-      , targetAssociation = self.association.targetAssociation
+      , targetAssociation = self.association.targetAssociation;
 
     //fully qualify
     var instancePrimaryKey = self.instance.Model.primaryKeyAttribute
-      , foreignPrimaryKey = self.association.target.primaryKeyAttribute
+      , foreignPrimaryKey = self.association.target.primaryKeyAttribute;
 
     options.where = new Utils.and([
       new Utils.where(
@@ -27,7 +27,7 @@ module.exports = (function() {
         self.instance[instancePrimaryKey]
       ),
       new Utils.where(
-        through.rawAttributes[self.association.foreignIdentifier], 
+        through.rawAttributes[self.association.foreignIdentifier],
         {
           join: new Utils.literal([
             self.QueryInterface.quoteTable(self.association.target.name),
@@ -36,68 +36,68 @@ module.exports = (function() {
         }
       ),
       options.where
-    ])
+    ]);
 
     if (Object(targetAssociation.through) === targetAssociation.through) {
-      queryOptions.hasJoinTableModel = true
-      queryOptions.joinTableModel = through
+      queryOptions.hasJoinTableModel = true;
+      queryOptions.joinTableModel = through;
 
       if (!options.attributes) {
         options.attributes = [
-          self.QueryInterface.quoteTable(self.association.target.name)+".*"
-        ]
+          self.QueryInterface.quoteTable(self.association.target.name) + '.*'
+        ];
       }
 
       if (options.joinTableAttributes) {
-        options.joinTableAttributes.forEach(function (elem) {
+        options.joinTableAttributes.forEach(function(elem) {
           options.attributes.push(
             self.QueryInterface.quoteTable(through.name) + '.' + self.QueryInterface.quoteIdentifier(elem) + ' as ' +
             self.QueryInterface.quoteIdentifier(through.name + '.' + elem, true)
-          )
-        })
+          );
+        });
       } else {
-        Utils._.forOwn(through.rawAttributes, function (elem, key) {
+        Utils._.forOwn(through.rawAttributes, function(elem, key) {
           options.attributes.push(
             self.QueryInterface.quoteTable(through.name) + '.' + self.QueryInterface.quoteIdentifier(key) + ' as ' +
             self.QueryInterface.quoteIdentifier(through.name + '.' + key, true)
-          )
-        })
+          );
+        });
       }
     }
 
-    return self.association.target.findAllJoin([through.getTableName(), through.name], options, queryOptions)
-  }
+    return self.association.target.findAllJoin([through.getTableName(), through.name], options, queryOptions);
+  };
 
   HasManyDoubleLinked.prototype.injectSetter = function(oldAssociations, newAssociations, defaultAttributes) {
-    var self                 = this
-      , targetAssociation    = self.association.targetAssociation
-      , foreignIdentifier    = self.association.foreignIdentifier
-      , sourceKeys           = Object.keys(self.association.source.primaryKeys)
-      , targetKeys           = Object.keys(self.association.target.primaryKeys)
+    var self = this
+      , targetAssociation = self.association.targetAssociation
+      , foreignIdentifier = self.association.foreignIdentifier
+      , sourceKeys = Object.keys(self.association.source.primaryKeys)
+      , targetKeys = Object.keys(self.association.target.primaryKeys)
       , obsoleteAssociations = []
-      , changedAssociations  = []
-      , options              = {}
-      , promises             = []
+      , changedAssociations = []
+      , options = {}
+      , promises = []
       , unassociatedObjects;
 
     if ((defaultAttributes || {}).transaction instanceof Transaction) {
-      options.transaction = defaultAttributes.transaction
-      delete defaultAttributes.transaction
+      options.transaction = defaultAttributes.transaction;
+      delete defaultAttributes.transaction;
     }
 
-    unassociatedObjects = newAssociations.filter(function (obj) {
-      return !Utils._.find(oldAssociations, function (old) {
-        return (!!obj[foreignIdentifier] && !!old[foreignIdentifier] ? obj[foreignIdentifier] === old[foreignIdentifier] : obj.id === old.id)
-      })
-    })
+    unassociatedObjects = newAssociations.filter(function(obj) {
+      return !Utils._.find(oldAssociations, function(old) {
+        return (!!obj[foreignIdentifier] && !!old[foreignIdentifier] ? obj[foreignIdentifier] === old[foreignIdentifier] : obj.id === old.id);
+      });
+    });
 
-    oldAssociations.forEach(function (old) {
-      var newObj = Utils._.find(newAssociations, function (obj) {
-        return (!!obj[foreignIdentifier] && !!old[foreignIdentifier] ? obj[foreignIdentifier] === old[foreignIdentifier] : obj.id === old.id)
-      })
+    oldAssociations.forEach(function(old) {
+      var newObj = Utils._.find(newAssociations, function(obj) {
+        return (!!obj[foreignIdentifier] && !!old[foreignIdentifier] ? obj[foreignIdentifier] === old[foreignIdentifier] : obj.id === old.id);
+      });
 
       if (!newObj) {
-        obsoleteAssociations.push(old)
+        obsoleteAssociations.push(old);
       } else if (Object(targetAssociation.through) === targetAssociation.through) {
         var throughAttributes = newObj[self.association.through.name];
         // Quick-fix for subtle bug when using existing objects that might have the through model attached (not as an attribute object)
@@ -108,88 +108,88 @@ module.exports = (function() {
         var changedAssociation = {
           where: {},
           attributes: Utils._.defaults({}, throughAttributes, defaultAttributes)
-        }
+        };
 
-        changedAssociation.where[self.association.identifier] = self.instance[self.association.identifier] || self.instance.id
-        changedAssociation.where[foreignIdentifier] = newObj[foreignIdentifier] || newObj.id
+        changedAssociation.where[self.association.identifier] = self.instance[self.association.identifier] || self.instance.id;
+        changedAssociation.where[foreignIdentifier] = newObj[foreignIdentifier] || newObj.id;
 
         if (Object.keys(changedAssociation.attributes).length) {
-          changedAssociations.push(changedAssociation)
+          changedAssociations.push(changedAssociation);
         }
       }
-    })
+    });
 
     if (obsoleteAssociations.length > 0) {
-      var foreignIds = obsoleteAssociations.map(function (associatedObject) {
-        return ((targetKeys.length === 1) ? associatedObject[targetKeys[0]] : associatedObject.id)
-      })
+      var foreignIds = obsoleteAssociations.map(function(associatedObject) {
+        return ((targetKeys.length === 1) ? associatedObject[targetKeys[0]] : associatedObject.id);
+      });
 
-      var where = {}
+      var where = {};
 
-      where[self.association.identifier] = ((sourceKeys.length === 1) ? self.instance[sourceKeys[0]] : self.instance.id)
-      where[foreignIdentifier] = foreignIds
+      where[self.association.identifier] = ((sourceKeys.length === 1) ? self.instance[sourceKeys[0]] : self.instance.id);
+      where[foreignIdentifier] = foreignIds;
 
-      promises.push(self.association.through.destroy(where, options))
+      promises.push(self.association.through.destroy(where, options));
     }
 
     if (unassociatedObjects.length > 0) {
       var bulk = unassociatedObjects.map(function(unassociatedObject) {
-        var attributes = {}
+        var attributes = {};
 
-        attributes[self.association.identifier] = ((sourceKeys.length === 1) ? self.instance[sourceKeys[0]] : self.instance.id)
-        attributes[foreignIdentifier] = ((targetKeys.length === 1) ? unassociatedObject[targetKeys[0]] : unassociatedObject.id)
+        attributes[self.association.identifier] = ((sourceKeys.length === 1) ? self.instance[sourceKeys[0]] : self.instance.id);
+        attributes[foreignIdentifier] = ((targetKeys.length === 1) ? unassociatedObject[targetKeys[0]] : unassociatedObject.id);
 
         if (Object(targetAssociation.through) === targetAssociation.through) {
-          attributes = Utils._.defaults(attributes, unassociatedObject[targetAssociation.through.name], defaultAttributes)
+          attributes = Utils._.defaults(attributes, unassociatedObject[targetAssociation.through.name], defaultAttributes);
         }
 
-        return attributes
-      })
+        return attributes;
+      });
 
-      promises.push(self.association.through.bulkCreate(bulk, options))
+      promises.push(self.association.through.bulkCreate(bulk, options));
     }
 
     if (changedAssociations.length > 0) {
-      changedAssociations.forEach(function (assoc) {
-        promises.push(self.association.through.update(assoc.attributes, assoc.where, options))
-      })
+      changedAssociations.forEach(function(assoc) {
+        promises.push(self.association.through.update(assoc.attributes, assoc.where, options));
+      });
     }
 
-    return Utils.Promise.all(promises)
-  }
+    return Utils.Promise.all(promises);
+  };
 
   HasManyDoubleLinked.prototype.injectAdder = function(newAssociation, additionalAttributes, exists) {
-    var attributes          = {}
-      , targetAssociation   = this.association.targetAssociation
-      , foreignIdentifier   = targetAssociation.identifier
-      , options = {}
+    var attributes = {}
+      , targetAssociation = this.association.targetAssociation
+      , foreignIdentifier = targetAssociation.identifier
+      , options = {};
 
     var sourceKeys = Object.keys(this.association.source.primaryKeys);
     var targetKeys = Object.keys(this.association.target.primaryKeys);
 
     if ((additionalAttributes || {}).transaction instanceof Transaction) {
-      options.transaction = additionalAttributes.transaction
-      delete additionalAttributes.transaction
+      options.transaction = additionalAttributes.transaction;
+      delete additionalAttributes.transaction;
     }
 
-    attributes[this.association.identifier] = ((sourceKeys.length === 1) ? this.instance[sourceKeys[0]] : this.instance.id)
-    attributes[foreignIdentifier] = ((targetKeys.length === 1) ? newAssociation[targetKeys[0]] : newAssociation.id)
+    attributes[this.association.identifier] = ((sourceKeys.length === 1) ? this.instance[sourceKeys[0]] : this.instance.id);
+    attributes[foreignIdentifier] = ((targetKeys.length === 1) ? newAssociation[targetKeys[0]] : newAssociation.id);
 
     if (exists) {
-      var where = attributes
-      attributes = Utils._.defaults({}, newAssociation[targetAssociation.through.name], additionalAttributes)
+      var where = attributes;
+      attributes = Utils._.defaults({}, newAssociation[targetAssociation.through.name], additionalAttributes);
 
       if (Object.keys(attributes).length) {
-        return targetAssociation.through.update(attributes, where)
+        return targetAssociation.through.update(attributes, where);
       } else {
-        return Utils.Promise.resolve()
+        return Utils.Promise.resolve();
       }
     } else {
-      attributes = Utils._.defaults(attributes, newAssociation[targetAssociation.through.name], additionalAttributes)
+      attributes = Utils._.defaults(attributes, newAssociation[targetAssociation.through.name], additionalAttributes);
 
-      return this.association.through.create(attributes, options)
+      return this.association.through.create(attributes, options);
     }
-  }
+  };
 
-  return HasManyDoubleLinked
-})()
+  return HasManyDoubleLinked;
+})();

--- a/lib/associations/has-many-single-linked.js
+++ b/lib/associations/has-many-single-linked.js
@@ -1,16 +1,16 @@
-"use strict";
+'use strict';
 
-var Utils       = require('./../utils')
-  , Transaction = require('./../transaction')
+var Utils = require('./../utils')
+  , Transaction = require('./../transaction');
 
 module.exports = (function() {
   var HasManySingleLinked = function(association, instance) {
-    this.__factory = association
-    this.association = association
-    this.instance = instance
-    this.target = this.association.target
-    this.source = this.association.source
-  }
+    this.__factory = association;
+    this.association = association;
+    this.instance = instance;
+    this.target = this.association.target;
+    this.source = this.association.source;
+  };
 
   HasManySingleLinked.prototype.injectGetter = function(options, queryOptions) {
     options.where = new Utils.and([
@@ -19,99 +19,99 @@ module.exports = (function() {
         this.instance[this.source.primaryKeyAttribute])
       ,
       options.where
-    ])
+    ]);
 
-    return this.association.target.all(options, queryOptions)
-  }
+    return this.association.target.all(options, queryOptions);
+  };
 
   HasManySingleLinked.prototype.injectSetter = function(oldAssociations, newAssociations, defaultAttributes) {
-    var self                 = this
-      , associationKeys      = Object.keys((oldAssociations[0] || newAssociations[0] || {Model: {primaryKeys: {}}}).Model.primaryKeys || {})
-      , associationKey       = (associationKeys.length === 1) ? associationKeys[0] : 'id'
-      , options              = {}
-      , promises             = []
-      , obsoleteAssociations = oldAssociations.filter(function (old) {
-          return !Utils._.find(newAssociations, function (obj) {
-            return obj[associationKey] === old[associationKey]
-          })
+    var self = this
+      , associationKeys = Object.keys((oldAssociations[0] || newAssociations[0] || {Model: {primaryKeys: {}}}).Model.primaryKeys || {})
+      , associationKey = (associationKeys.length === 1) ? associationKeys[0] : 'id'
+      , options = {}
+      , promises = []
+      , obsoleteAssociations = oldAssociations.filter(function(old) {
+          return !Utils._.find(newAssociations, function(obj) {
+            return obj[associationKey] === old[associationKey];
+          });
         })
-      , unassociatedObjects  = newAssociations.filter(function (obj) {
-          return !Utils._.find(oldAssociations, function (old) {
-            return obj[associationKey] === old[associationKey]
-          })
+      , unassociatedObjects = newAssociations.filter(function(obj) {
+          return !Utils._.find(oldAssociations, function(old) {
+            return obj[associationKey] === old[associationKey];
+          });
         })
-      , update
+      , update;
 
     if ((defaultAttributes || {}).transaction instanceof Transaction) {
-      options.transaction = defaultAttributes.transaction
-      delete defaultAttributes.transaction
+      options.transaction = defaultAttributes.transaction;
+      delete defaultAttributes.transaction;
     }
 
     if (obsoleteAssociations.length > 0) {
       // clear the old associations
       var obsoleteIds = obsoleteAssociations.map(function(associatedObject) {
-        associatedObject[self.__factory.identifier] = (newAssociations.length < 1 ? null : self.instance.id)
-        return associatedObject[associationKey]
-      })
+        associatedObject[self.__factory.identifier] = (newAssociations.length < 1 ? null : self.instance.id);
+        return associatedObject[associationKey];
+      });
 
-      update = {}
-      update[self.__factory.identifier] = null
+      update = {};
+      update[self.__factory.identifier] = null;
 
       var primaryKeys = Object.keys(this.__factory.target.primaryKeys)
-        , primaryKey  = primaryKeys.length === 1 ? primaryKeys[0] : 'id'
-        , updateWhere = {}
+        , primaryKey = primaryKeys.length === 1 ? primaryKeys[0] : 'id'
+        , updateWhere = {};
 
-      updateWhere[primaryKey] = obsoleteIds
+      updateWhere[primaryKey] = obsoleteIds;
       promises.push(this.__factory.target.update(
         update,
         updateWhere,
         Utils._.extend(options, { allowNull: [self.__factory.identifier] })
-      ))
+      ));
     }
 
     if (unassociatedObjects.length > 0) {
       // For the self.instance
-      var pkeys       = Object.keys(self.instance.Model.primaryKeys)
-        , pkey        = pkeys.length === 1 ? pkeys[0] : 'id'
+      var pkeys = Object.keys(self.instance.Model.primaryKeys)
+        , pkey = pkeys.length === 1 ? pkeys[0] : 'id'
         // For chainer
         , primaryKeys = Object.keys(this.__factory.target.primaryKeys)
-        , primaryKey  = primaryKeys.length === 1 ? primaryKeys[0] : 'id'
-        , updateWhere = {}
+        , primaryKey = primaryKeys.length === 1 ? primaryKeys[0] : 'id'
+        , updateWhere = {};
 
       // set the new associations
       var unassociatedIds = unassociatedObjects.map(function(associatedObject) {
-        associatedObject[self.__factory.identifier] = self.instance[pkey] || self.instance.id
-        return associatedObject[associationKey]
-      })
+        associatedObject[self.__factory.identifier] = self.instance[pkey] || self.instance.id;
+        return associatedObject[associationKey];
+      });
 
-      update                            = {}
-      update[self.__factory.identifier] = (newAssociations.length < 1 ? null : self.instance[pkey] || self.instance.id)
-      updateWhere[primaryKey]           = unassociatedIds
+      update = {};
+      update[self.__factory.identifier] = (newAssociations.length < 1 ? null : self.instance[pkey] || self.instance.id);
+      updateWhere[primaryKey] = unassociatedIds;
 
       promises.push(this.__factory.target.update(
         update,
         updateWhere,
         Utils._.extend(options, { allowNull: [self.__factory.identifier] })
-      ))
+      ));
     }
 
-    return Utils.Promise.all(promises)
-  }
+    return Utils.Promise.all(promises);
+  };
 
   HasManySingleLinked.prototype.injectAdder = function(newAssociation, additionalAttributes) {
     var primaryKeys = Object.keys(this.instance.Model.primaryKeys)
       , primaryKey = primaryKeys.length === 1 ? primaryKeys[0] : 'id'
-      , options = {}
+      , options = {};
 
     if ((additionalAttributes || {}).transaction instanceof Transaction) {
-      options.transaction = additionalAttributes.transaction
-      delete additionalAttributes.transaction
+      options.transaction = additionalAttributes.transaction;
+      delete additionalAttributes.transaction;
     }
 
-    newAssociation[this.__factory.identifier] = this.instance[primaryKey]
+    newAssociation[this.__factory.identifier] = this.instance[primaryKey];
 
-    return newAssociation.save(options)
-  }
+    return newAssociation.save(options);
+  };
 
-  return HasManySingleLinked
-})()
+  return HasManySingleLinked;
+})();

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -1,32 +1,32 @@
-"use strict";
+'use strict';
 
-var Utils      = require("./../utils")
-  , Helpers    = require('./helpers')
-  , _          = require('lodash')
-  , Transaction = require('../transaction')
+var Utils = require('./../utils')
+  , Helpers = require('./helpers')
+  , _ = require('lodash')
+  , Transaction = require('../transaction');
 
-var HasManySingleLinked = require("./has-many-single-linked")
-  , HasManyDoubleLinked  = require("./has-many-double-linked")
+var HasManySingleLinked = require('./has-many-single-linked')
+  , HasManyDoubleLinked = require('./has-many-double-linked');
 
 module.exports = (function() {
   var HasMany = function(source, target, options) {
-    var self = this
+    var self = this;
 
-    this.associationType = 'HasMany'
-    this.source = source
-    this.target = target
-    this.targetAssociation = null
-    this.options = options
-    this.sequelize = source.daoFactoryManager.sequelize
-    this.through = options.through
-    this.isMultiAssociation = true
-    this.isSelfAssociation = this.source === this.target
-    this.doubleLinked = false
-    this.as = this.options.as
+    this.associationType = 'HasMany';
+    this.source = source;
+    this.target = target;
+    this.targetAssociation = null;
+    this.options = options;
+    this.sequelize = source.daoFactoryManager.sequelize;
+    this.through = options.through;
+    this.isMultiAssociation = true;
+    this.isSelfAssociation = this.source === this.target;
+    this.doubleLinked = false;
+    this.as = this.options.as;
     this.combinedTableName = Utils.combineTableNames(
       this.source.tableName,
       this.isSelfAssociation ? (this.as || this.target.tableName) : this.target.tableName
-    )
+    );
 
     /*
      * Map joinTableModel/Name to through for BC
@@ -50,14 +50,14 @@ module.exports = (function() {
      * Determine associationAccessor, especially for include options to identify the correct model
      */
 
-    this.associationAccessor = this.as
+    this.associationAccessor = this.as;
     if (!this.associationAccessor) {
       if (typeof this.through === 'string') {
-        this.associationAccessor = this.through
+        this.associationAccessor = this.through;
       } else if (Object(this.through) === this.through) {
-        this.associationAccessor = this.through.tableName
+        this.associationAccessor = this.through.tableName;
       } else {
-        this.associationAccessor = this.combinedTableName
+        this.associationAccessor = this.combinedTableName;
       }
     }
 
@@ -67,64 +67,64 @@ module.exports = (function() {
     if (this.isSelfAssociation) {
       // check 'as' is defined for many-to-many self-association
       if (this.through && this.through !== true && !this.as) {
-        throw new Error('\'as\' must be defined for many-to-many self-associations')
+        throw new Error('\'as\' must be defined for many-to-many self-associations');
       }
 
-      this.targetAssociation = this
+      this.targetAssociation = this;
     }
 
     /*
      * Else find partner DAOFactory if present, to identify double linked association
      */
     if (this.through) {
-      _.each(this.target.associations, function (association, accessor) {
+      _.each(this.target.associations, function(association, accessor) {
         if (self.source === association.target) {
-          var paired
+          var paired;
 
           // If through is default, we determine pairing by the accesor value (i.e. DAOFactory's using as won't pair, but regular ones will)
           if (self.through === true) {
-            paired = accessor === self.associationAccessor
+            paired = accessor === self.associationAccessor;
           }
           // If through is not default, determine pairing by through value (model/string)
           else {
-            paired = self.options.through === association.options.through
+            paired = self.options.through === association.options.through;
           }
           // If paired, set properties identifying both associations as double linked, and allow them to each eachtoerh
           if (paired) {
-            self.doubleLinked = true
-            association.doubleLinked = true
+            self.doubleLinked = true;
+            association.doubleLinked = true;
 
-            self.targetAssociation = association
-            association.targetAssociation = self
+            self.targetAssociation = association;
+            association.targetAssociation = self;
           }
         }
-      })
+      });
     }
 
     /*
      * If we are double linked, and through is either default or a string, we create the through model and set it on both associations
      */
     if (this.doubleLinked && this.through === true) {
-      this.through = this.combinedTableName
+      this.through = this.combinedTableName;
     }
 
-    if (typeof this.through === "string") {
+    if (typeof this.through === 'string') {
       this.through = this.sequelize.define(this.through, {}, _.extend(this.options, {
         tableName: this.through,
         paranoid: false  // A paranoid join table does not make sense
-      }))
+      }));
 
       if (this.targetAssociation) {
-        this.targetAssociation.through = this.through
+        this.targetAssociation.through = this.through;
       }
     }
 
-    this.options.tableName = this.combinedName = (this.through === Object(this.through) ? this.through.tableName : this.through)
+    this.options.tableName = this.combinedName = (this.through === Object(this.through) ? this.through.tableName : this.through);
 
     if (this.as) {
-      this.isAliased = true
+      this.isAliased = true;
     } else {
-      this.as = Utils.pluralize(this.target.name, this.target.options.language)
+      this.as = Utils.pluralize(this.target.name, this.target.options.language);
     }
 
     this.accessors = {
@@ -136,23 +136,23 @@ module.exports = (function() {
       remove: Utils._.camelize(Utils.singularize('remove_' + this.as, this.target.options.language)),
       hasSingle: Utils._.camelize(Utils.singularize('has_' + this.as, this.target.options.language)),
       hasAll: Utils._.camelize('has_' + this.as)
-    }
-  }
+    };
+  };
 
   // the id is in the target table
   // or in an extra table which connects two tables
   HasMany.prototype.injectAttributes = function() {
-    var doubleLinked      = this.doubleLinked
-      , self              = this
-      , primaryKeyDeleted = false
+    var doubleLinked = this.doubleLinked
+      , self = this
+      , primaryKeyDeleted = false;
 
     this.identifier = this.options.foreignKey || Utils._.camelizeIf(
       [
         Utils._.underscoredIf(Utils.singularize(this.source.name, this.source.options.language), this.source.options.underscored),
         this.source.primaryKeyAttribute
-      ].join("_"),
+      ].join('_'),
       !this.source.options.underscored
-    )
+    );
 
     // is there already a single sided association between the source and the target?
     // or is the association on the model itself?
@@ -169,290 +169,290 @@ module.exports = (function() {
         }
       }
 
-      this.foreignIdentifier = this.targetAssociation.identifier
-      this.targetAssociation.foreignIdentifier = this.identifier
+      this.foreignIdentifier = this.targetAssociation.identifier;
+      this.targetAssociation.foreignIdentifier = this.identifier;
 
       if (isForeignKeyDeletionAllowedFor.call(this, this.source, this.foreignIdentifier)) {
-        delete this.source.rawAttributes[this.foreignIdentifier]
+        delete this.source.rawAttributes[this.foreignIdentifier];
       }
 
       if (this.isSelfAssociation && this.foreignIdentifier === this.identifier) {
         this.foreignIdentifier = Utils._.camelizeIf(
-          [Utils.singularize(this.as, this.source.options.language), this.source.primaryKeyAttribute].join("_"),
+          [Utils.singularize(this.as, this.source.options.language), this.source.primaryKeyAttribute].join('_'),
           !this.source.options.underscored
-        )
+        );
 
         if (doubleLinked) {
-          this.targetAssociation.identifier = this.foreignIdentifier
+          this.targetAssociation.identifier = this.foreignIdentifier;
         }
       }
 
       // remove any PKs previously defined by sequelize
       Utils._.each(this.through.rawAttributes, function(attribute, attributeName) {
         if (attribute.primaryKey === true && attribute._autoGenerated === true) {
-          delete self.through.rawAttributes[attributeName]
-          primaryKeyDeleted = true
+          delete self.through.rawAttributes[attributeName];
+          primaryKeyDeleted = true;
         }
-      })
+      });
 
       // define a new model, which connects the models
       var sourceKeyType = this.source.rawAttributes[this.source.primaryKeyAttribute].type
         , targetKeyType = this.target.rawAttributes[this.target.primaryKeyAttribute].type
         , sourceAttribute = { type: sourceKeyType }
-        , targetAttribute = { type: targetKeyType }
+        , targetAttribute = { type: targetKeyType };
 
       if (this.options.constraints !== false) {
-        sourceAttribute.references = this.source.getTableName()
-        sourceAttribute.referencesKey = this.source.primaryKeyAttribute
-        sourceAttribute.onDelete = this.options.onDelete || 'CASCADE'
-        sourceAttribute.onUpdate = this.options.onUpdate || 'CASCADE'
+        sourceAttribute.references = this.source.getTableName();
+        sourceAttribute.referencesKey = this.source.primaryKeyAttribute;
+        sourceAttribute.onDelete = this.options.onDelete || 'CASCADE';
+        sourceAttribute.onUpdate = this.options.onUpdate || 'CASCADE';
       }
       if (this.targetAssociation.options.constraints !== false) {
-        targetAttribute.references = this.target.getTableName()
-        targetAttribute.referencesKey = this.target.primaryKeyAttribute
-        targetAttribute.onDelete = this.targetAssociation.options.onDelete || 'CASCADE'
-        targetAttribute.onUpdate = this.targetAssociation.options.onUpdate || 'CASCADE'
+        targetAttribute.references = this.target.getTableName();
+        targetAttribute.referencesKey = this.target.primaryKeyAttribute;
+        targetAttribute.onDelete = this.targetAssociation.options.onDelete || 'CASCADE';
+        targetAttribute.onUpdate = this.targetAssociation.options.onUpdate || 'CASCADE';
       }
 
       if (primaryKeyDeleted) {
-        targetAttribute.primaryKey = sourceAttribute.primaryKey = true
+        targetAttribute.primaryKey = sourceAttribute.primaryKey = true;
       } else {
-        var uniqueKey = [this.through.tableName, this.identifier, this.foreignIdentifier, 'unique'].join('_')
-        targetAttribute.unique = sourceAttribute.unique = uniqueKey
+        var uniqueKey = [this.through.tableName, this.identifier, this.foreignIdentifier, 'unique'].join('_');
+        targetAttribute.unique = sourceAttribute.unique = uniqueKey;
       }
 
       if (!this.through.rawAttributes[this.identifier]) {
         this.through.rawAttributes[this.identifier] = {
           _autoGenerated: true
-        }
+        };
       }
 
       if (!this.through.rawAttributes[this.foreignIdentifier]) {
         this.through.rawAttributes[this.foreignIdentifier] = {
           _autoGenerated: true
-        }
+        };
       }
 
       this.through.rawAttributes[this.identifier] = Utils._.extend(this.through.rawAttributes[this.identifier], sourceAttribute);
       this.through.rawAttributes[this.foreignIdentifier] = Utils._.extend(this.through.rawAttributes[this.foreignIdentifier], targetAttribute);
 
-      this.through.init(this.through.daoFactoryManager)
+      this.through.init(this.through.daoFactoryManager);
     } else {
-      var newAttributes = {}
-      var constraintOptions = _.clone(this.options) // Create a new options object for use with addForeignKeyConstraints, to avoid polluting this.options in case it is later used for a n:m
-      newAttributes[this.identifier] = { type: this.options.keyType || this.source.rawAttributes[this.source.primaryKeyAttribute].type }
+      var newAttributes = {};
+      var constraintOptions = _.clone(this.options); // Create a new options object for use with addForeignKeyConstraints, to avoid polluting this.options in case it is later used for a n:m
+      newAttributes[this.identifier] = { type: this.options.keyType || this.source.rawAttributes[this.source.primaryKeyAttribute].type };
 
       if (this.options.constraints !== false) {
-        constraintOptions.onDelete = constraintOptions.onDelete || 'SET NULL'
-        constraintOptions.onUpdate = constraintOptions.onUpdate || 'CASCADE'
+        constraintOptions.onDelete = constraintOptions.onDelete || 'SET NULL';
+        constraintOptions.onUpdate = constraintOptions.onUpdate || 'CASCADE';
       }
-      Helpers.addForeignKeyConstraints(newAttributes[this.identifier], this.source, this.target, constraintOptions)
-      Utils._.defaults(this.target.rawAttributes, newAttributes)
+      Helpers.addForeignKeyConstraints(newAttributes[this.identifier], this.source, this.target, constraintOptions);
+      Utils._.defaults(this.target.rawAttributes, newAttributes);
     }
 
     // Sync attributes and setters/getters to DAO prototype
-    this.target.refreshAttributes()
-    this.source.refreshAttributes()
+    this.target.refreshAttributes();
+    this.source.refreshAttributes();
 
     if (this.source.rawAttributes.hasOwnProperty(this.as)) {
-      throw new Error("Naming collision between attribute '" + this.as + "' and association '" + this.as + "' on model " + this.source.name + ". To remedy this, change either foreignKey or as in your association definition")
+      throw new Error("Naming collision between attribute '" + this.as + "' and association '" + this.as + "' on model " + this.source.name + '. To remedy this, change either foreignKey or as in your association definition');
     }
 
-    return this
-  }
+    return this;
+  };
 
   HasMany.prototype.injectGetter = function(obj) {
-    var association = this
+    var association = this;
 
     obj[this.accessors.get] = function(options, queryOptions) {
-      options = options || {}
-      queryOptions = queryOptions || {}
-      var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked
-      return new Class(association, this).injectGetter(options, queryOptions)
-    }
+      options = options || {};
+      queryOptions = queryOptions || {};
+      var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked;
+      return new Class(association, this).injectGetter(options, queryOptions);
+    };
 
     obj[this.accessors.hasAll] = function(instances, options) {
       var instance = this
-        , where
+        , where;
 
-      options = options || {}
-      
-      instances.forEach(function (instance) {
+      options = options || {};
+
+      instances.forEach(function(instance) {
         if (instance instanceof association.target.Instance) {
-          where = new Utils.or([where, instance.primaryKeyValues])
+          where = new Utils.or([where, instance.primaryKeyValues]);
         } else {
-          var _where = {}
-          _where[association.target.primaryKeyAttribute] = instance
-          where = new Utils.or([where, _where])
+          var _where = {};
+          _where[association.target.primaryKeyAttribute] = instance;
+          where = new Utils.or([where, _where]);
         }
-      })
+      });
 
       options.where = new Utils.and([
         where,
         options.where
-      ])
+      ]);
 
       return instance[association.accessors.get](
         options,
         { raw: true }
       ).then(function(associatedObjects) {
-        return associatedObjects.length === instances.length
-      })
-    }
+        return associatedObjects.length === instances.length;
+      });
+    };
 
     obj[this.accessors.hasSingle] = function(param, options) {
       var instance = this
-        , where
+        , where;
 
-      options = options || {}
+      options = options || {};
 
       if (param instanceof association.target.Instance) {
-        where = param.primaryKeyValues
+        where = param.primaryKeyValues;
       } else {
-        where = {}
-        where[association.target.primaryKeyAttribute] = param
+        where = {};
+        where[association.target.primaryKeyAttribute] = param;
       }
 
       options.where = new Utils.and([
         where,
         options.where
-      ])
+      ]);
 
       return instance[association.accessors.get](
         options,
         { raw: true }
       ).then(function(associatedObjects) {
-        return associatedObjects.length !== 0
-      })
-    }
-    return this
-  }
+        return associatedObjects.length !== 0;
+      });
+    };
+    return this;
+  };
 
   HasMany.prototype.injectSetter = function(obj) {
     var association = this
-      , primaryKeyAttribute = association.target.primaryKeyAttribute
+      , primaryKeyAttribute = association.target.primaryKeyAttribute;
 
-    obj[this.accessors.set] = function (newAssociatedObjects, additionalAttributes) {
+    obj[this.accessors.set] = function(newAssociatedObjects, additionalAttributes) {
       if (newAssociatedObjects === null) {
-        newAssociatedObjects = []
+        newAssociatedObjects = [];
       } else {
-        newAssociatedObjects = newAssociatedObjects.map(function (newAssociatedObject) {
+        newAssociatedObjects = newAssociatedObjects.map(function(newAssociatedObject) {
           if (!(newAssociatedObject instanceof association.target.Instance)) {
-            var tmpInstance = {}
-            tmpInstance[primaryKeyAttribute] = newAssociatedObject
+            var tmpInstance = {};
+            tmpInstance[primaryKeyAttribute] = newAssociatedObject;
             return association.target.build(tmpInstance, {
               isNewRecord: false
-            })
+            });
           }
-          return newAssociatedObject
-        })
+          return newAssociatedObject;
+        });
       }
 
-      var instance = this
+      var instance = this;
 
       return instance[association.accessors.get]({
         transaction: (additionalAttributes || {}).transaction
       }).then(function(oldAssociatedObjects) {
-        var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked
-        return new Class(association, instance).injectSetter(oldAssociatedObjects, newAssociatedObjects, additionalAttributes)
-      })
-    }
+        var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked;
+        return new Class(association, instance).injectSetter(oldAssociatedObjects, newAssociatedObjects, additionalAttributes);
+      });
+    };
 
-    obj[this.accessors.add] = function (newInstance, additionalAttributes) {
+    obj[this.accessors.add] = function(newInstance, additionalAttributes) {
       var instance = this
-        , primaryKeyAttribute = association.target.primaryKeyAttribute
-        
+        , primaryKeyAttribute = association.target.primaryKeyAttribute;
+
       if (!(newInstance instanceof association.target.Instance)) {
-        var tmpInstance = {}
-        tmpInstance[primaryKeyAttribute] = newInstance
+        var tmpInstance = {};
+        tmpInstance[primaryKeyAttribute] = newInstance;
         newInstance = association.target.build(tmpInstance, {
           isNewRecord: false
-        })
+        });
       }
 
       if (Array.isArray(newInstance)) {
-        return obj[association.accessors.addMultiple](newInstance, additionalAttributes)
+        return obj[association.accessors.addMultiple](newInstance, additionalAttributes);
       } else {
         return instance[association.accessors.get]({
           where: newInstance.primaryKeyValues,
           transaction: (additionalAttributes || {}).transaction
         }).then(function(currentAssociatedObjects) {
           if (currentAssociatedObjects.length === 0 || Object(association.through) === association.through) {
-            var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked
-            return new Class(association, instance).injectAdder(newInstance, additionalAttributes, !!currentAssociatedObjects.length)
+            var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked;
+            return new Class(association, instance).injectAdder(newInstance, additionalAttributes, !!currentAssociatedObjects.length);
           } else {
-            return Utils.Promise.resolve(currentAssociatedObjects[0])
+            return Utils.Promise.resolve(currentAssociatedObjects[0]);
           }
-        })
+        });
       }
-    }
+    };
 
-    obj[this.accessors.addMultiple] = function (newInstances, additionalAttributes) {
-      var primaryKeyAttribute = association.target.primaryKeyAttribute
+    obj[this.accessors.addMultiple] = function(newInstances, additionalAttributes) {
+      var primaryKeyAttribute = association.target.primaryKeyAttribute;
 
-      newInstances = newInstances.map(function (newInstance) {
+      newInstances = newInstances.map(function(newInstance) {
         if (!(newInstance instanceof association.target.Instance)) {
-          var tmpInstance = {}
-          tmpInstance[primaryKeyAttribute] = newInstance
+          var tmpInstance = {};
+          tmpInstance[primaryKeyAttribute] = newInstance;
           return association.target.build(tmpInstance, {
             isNewRecord: false
-          })
+          });
         }
-        return newInstance
-      })
+        return newInstance;
+      });
 
-      var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked
-      return new Class(association, this).injectSetter([], newInstances, additionalAttributes)
-    }
+      var Class = Object(association.through) === association.through ? HasManyDoubleLinked : HasManySingleLinked;
+      return new Class(association, this).injectSetter([], newInstances, additionalAttributes);
+    };
 
 
-    obj[this.accessors.remove] = function (oldAssociatedObject, options) {
-      var instance = this
+    obj[this.accessors.remove] = function(oldAssociatedObject, options) {
+      var instance = this;
       return instance[association.accessors.get]({
         transaction: (options || {}).transaction
       }).then(function(currentAssociatedObjects) {
-        var newAssociations = []
-          
+        var newAssociations = [];
+
         currentAssociatedObjects.forEach(function(association) {
           if (!Utils._.isEqual(oldAssociatedObject.identifiers, association.identifiers)) {
-            newAssociations.push(association)
+            newAssociations.push(association);
           }
-        })
+        });
 
-        return instance[association.accessors.set](newAssociations)
-      })
-    }
+        return instance[association.accessors.set](newAssociations);
+      });
+    };
 
-    return this
-  }
+    return this;
+  };
 
   HasMany.prototype.injectCreator = function(obj) {
-    var association = this
+    var association = this;
 
     obj[this.accessors.create] = function(values, fieldsOrOptions) {
       var instance = this
-        , options = {}
+        , options = {};
 
       if (values === undefined) {
-        values = {}
+        values = {};
       }
 
       if ((fieldsOrOptions || {}).transaction instanceof Transaction) {
-        options.transaction = fieldsOrOptions.transaction
+        options.transaction = fieldsOrOptions.transaction;
       }
 
       if (Object(association.through) === association.through) {
         // Create the related model instance
         return association.target.create(values, fieldsOrOptions).then(function(newAssociatedObject) {
-          return instance[association.accessors.add](newAssociatedObject, options).return(newAssociatedObject)
-        })
+          return instance[association.accessors.add](newAssociatedObject, options).return (newAssociatedObject);
+        });
       } else {
         values[association.identifier] = instance.get(association.source.primaryKeyAttribute);
-        return association.target.create(values, fieldsOrOptions)
+        return association.target.create(values, fieldsOrOptions);
       }
-    }
+    };
 
-    return this
+    return this;
   };
 
   /**
@@ -465,17 +465,17 @@ module.exports = (function() {
    * @return {Boolean}                Whether or not the deletion of the foreign key is ok.
    */
   var isForeignKeyDeletionAllowedFor = function(daoFactory, identifier) {
-    var isAllowed        = true
-      , associationNames = Utils._.without(Object.keys(daoFactory.associations), this.associationAccessor)
+    var isAllowed = true
+      , associationNames = Utils._.without(Object.keys(daoFactory.associations), this.associationAccessor);
 
     associationNames.forEach(function(associationName) {
       if (daoFactory.associations[associationName].identifier === identifier) {
-        isAllowed = false
+        isAllowed = false;
       }
-    })
+    });
 
-    return isAllowed
-  }
+    return isAllowed;
+  };
 
-  return HasMany
-})()
+  return HasMany;
+})();

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict';
 
-var Utils       = require("./../utils")
-  , Helpers     = require("./helpers")
-  , Transaction = require("../transaction")
+var Utils = require('./../utils')
+  , Helpers = require('./helpers')
+  , Transaction = require('../transaction');
 
 module.exports = (function() {
   var HasOne = function(srcDAO, targetDAO, options) {
-    this.associationType      = 'HasOne'
-    this.source               = srcDAO
-    this.target               = targetDAO
-    this.options              = options
-    this.isSingleAssociation  = true
-    this.isSelfAssociation    = (this.source == this.target)
-    this.as                   = this.options.as
+    this.associationType = 'HasOne';
+    this.source = srcDAO;
+    this.target = targetDAO;
+    this.options = options;
+    this.isSingleAssociation = true;
+    this.isSelfAssociation = (this.source === this.target);
+    this.as = this.options.as;
 
     if (this.as) {
-      this.isAliased = true
+      this.isAliased = true;
     } else {
-      this.as = Utils.singularize(this.target.name, this.target.options.language)
+      this.as = Utils.singularize(this.target.name, this.target.options.language);
     }
 
     if (!this.options.foreignKey) {
@@ -25,119 +25,119 @@ module.exports = (function() {
         [
           Utils._.underscoredIf(Utils.singularize(this.source.name, this.target.options.language), this.target.options.underscored),
           this.source.primaryKeyAttribute
-        ].join("_"),
+        ].join('_'),
         !this.source.options.underscored
-      )
+      );
     }
 
-    this.identifier = this.options.foreignKey
-    this.sourceIdentifier = this.source.primaryKeyAttribute
-    this.associationAccessor = this.as
-    this.options.useHooks = options.useHooks
+    this.identifier = this.options.foreignKey;
+    this.sourceIdentifier = this.source.primaryKeyAttribute;
+    this.associationAccessor = this.as;
+    this.options.useHooks = options.useHooks;
 
     this.accessors = {
       get: Utils._.camelize('get_' + this.as),
       set: Utils._.camelize('set_' + this.as),
       create: Utils._.camelize('create_' + this.as)
-    }
-  }
+    };
+  };
 
   // the id is in the target table
   HasOne.prototype.injectAttributes = function() {
     var newAttributes = {}
-      , keyType       = this.source.rawAttributes[this.sourceIdentifier].type
+      , keyType = this.source.rawAttributes[this.sourceIdentifier].type;
 
-    newAttributes[this.identifier] = { type: this.options.keyType || keyType }
-    Utils._.defaults(this.target.rawAttributes, newAttributes)
+    newAttributes[this.identifier] = { type: this.options.keyType || keyType };
+    Utils._.defaults(this.target.rawAttributes, newAttributes);
 
     if (this.options.constraints !== false) {
-      this.options.onDelete = this.options.onDelete || 'SET NULL'
-      this.options.onUpdate = this.options.onUpdate || 'CASCADE'
+      this.options.onDelete = this.options.onDelete || 'SET NULL';
+      this.options.onUpdate = this.options.onUpdate || 'CASCADE';
     }
-    Helpers.addForeignKeyConstraints(this.target.rawAttributes[this.identifier], this.source, this.target, this.options)
+    Helpers.addForeignKeyConstraints(this.target.rawAttributes[this.identifier], this.source, this.target, this.options);
 
     // Sync attributes and setters/getters to DAO prototype
-    this.target.refreshAttributes()
+    this.target.refreshAttributes();
 
     if (this.source.rawAttributes.hasOwnProperty(this.as)) {
-      throw new Error("Naming collision between attribute '" + this.as + "' and association '" + this.as + "' on model " + this.source.name + ". To remedy this, change either foreignKey or as in your association definition")
+      throw new Error("Naming collision between attribute '" + this.as + "' and association '" + this.as + "' on model " + this.source.name + '. To remedy this, change either foreignKey or as in your association definition');
     }
 
-    return this
-  }
+    return this;
+  };
 
   HasOne.prototype.injectGetter = function(instancePrototype) {
-    var association = this
+    var association = this;
 
     instancePrototype[this.accessors.get] = function(params) {
-      var where = {}
+      var where = {};
 
-      params = params || {}
-      params.where = (params.where && [params.where]) || []
+      params = params || {};
+      params.where = (params.where && [params.where]) || [];
 
-      where[association.identifier] = this.get(association.sourceIdentifier)
-      params.where.push(where)
+      where[association.identifier] = this.get(association.sourceIdentifier);
+      params.where.push(where);
 
-      params.where = new Utils.and(params.where)
+      params.where = new Utils.and(params.where);
 
-      return association.target.find(params)
-    }
+      return association.target.find(params);
+    };
 
-    return this
-  }
+    return this;
+  };
 
   HasOne.prototype.injectSetter = function(instancePrototype) {
-    var association = this
+    var association = this;
 
     instancePrototype[this.accessors.set] = function(associatedInstance, options) {
-      var instance     = this
+      var instance = this;
 
       return instance[association.accessors.get](options).then(function(oldInstance) {
         if (oldInstance) {
-          oldInstance[association.identifier] = null
+          oldInstance[association.identifier] = null;
           return oldInstance.save(Utils._.extend({}, options, {
-            fields:    [association.identifier],
+            fields: [association.identifier],
             allowNull: [association.identifier],
             association: true
-          }))
+          }));
         }
-      }).then(function () {
+      }).then(function() {
         if (associatedInstance) {
           if (!(associatedInstance instanceof association.target.Instance)) {
-              var tmpInstance = {}
-              tmpInstance[association.target.primaryKeyAttribute] = associatedInstance
+              var tmpInstance = {};
+              tmpInstance[association.target.primaryKeyAttribute] = associatedInstance;
               associatedInstance = association.target.build(tmpInstance, {
                 isNewRecord: false
-              })
+              });
           }
-          associatedInstance.set(association.identifier, instance.get(association.sourceIdentifier))
-          return associatedInstance.save(options)
+          associatedInstance.set(association.identifier, instance.get(association.sourceIdentifier));
+          return associatedInstance.save(options);
         }
         return null;
-      })
-    }
+      });
+    };
 
-    return this
-  }
+    return this;
+  };
 
   HasOne.prototype.injectCreator = function(instancePrototype) {
-    var association = this
+    var association = this;
 
     instancePrototype[this.accessors.create] = function(values, fieldsOrOptions) {
       var instance = this
-        , options = {}
+        , options = {};
 
       if ((fieldsOrOptions || {}).transaction instanceof Transaction) {
-        options.transaction = fieldsOrOptions.transaction
+        options.transaction = fieldsOrOptions.transaction;
       }
 
       return association.target.create(values, fieldsOrOptions).then(function(associationInstance) {
-        return instance[association.accessors.set](associationInstance, options)
-      })   
-    }
+        return instance[association.accessors.set](associationInstance, options);
+      });
+    };
 
-    return this
+    return this;
   };
 
-  return HasOne
-})()
+  return HasOne;
+})();

--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-var Utils = require("./../utils")
+var Utils = require('./../utils');
 
 module.exports = {
 
@@ -12,8 +12,8 @@ module.exports = {
 
       // Find primary keys: composite keys not supported with this approach
       var primaryKeys = Utils._.filter(Utils._.keys(source.rawAttributes), function(key) {
-        return source.rawAttributes[key].primaryKey
-      })
+        return source.rawAttributes[key].primaryKey;
+      });
 
       if (primaryKeys.length === 1) {
         if (!!source.options.schema) {
@@ -23,16 +23,16 @@ module.exports = {
               schema: source.options.schema,
               schemaDelimiter: source.options.schemaDelimiter
             }
-          })
+          });
         } else {
-          newAttribute.references = source.tableName
+          newAttribute.references = source.tableName;
         }
 
-        newAttribute.referencesKey = primaryKeys[0]
-        newAttribute.onDelete = options.onDelete
-        newAttribute.onUpdate = options.onUpdate
+        newAttribute.referencesKey = primaryKeys[0];
+        newAttribute.onDelete = options.onDelete;
+        newAttribute.onUpdate = options.onUpdate;
       }
     }
   }
 
-}
+};

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -1,14 +1,14 @@
-"use strict";
+'use strict';
 
-var Utils     = require("./../utils")
-  , HasOne    = require('./has-one')
-  , HasMany   = require("./has-many")
-  , BelongsTo = require("./belongs-to")
+var Utils = require('./../utils')
+  , HasOne = require('./has-one')
+  , HasMany = require('./has-many')
+  , BelongsTo = require('./belongs-to');
 
-/** 
+/**
  * Creating assocations in sequelize is done by calling one of the belongsTo / hasOne / hasMany functions
  * on a model (the source), and prodiving another model as the first argument to the function (the target).
- * 
+ *
  * * hasOne - adds a foreign key to target
  * * belongsTo - add a foreign key to source
  * * hasMany - adds a foreign key to target, unless you also specifiy that target hasMany source, in which case a junction table is created with sourceId and targetId
@@ -35,35 +35,35 @@ var Utils     = require("./../utils")
  *     { model: Picture, as: 'ProfilePicture' }, // load the profile picture. Notice that the spelling must be the exact same as the one in the association
  *   ]
  * })
- * ``` 
+ * ```
  *
  * When getting associated models, you can limit your query to only load some models. These queries are written in the same way as queries to `find`/`findAll`. To only get pictures in JPG, you can do:
  *
- * ```js 
+ * ```js
  * user.getPictures({
  *   where: {
  *     format: 'jpg'
  *   }
  * })
  * ```
- * 
+ *
  * There are several methods to update and add new assoications. Continuing with our example of users and pictures:
  * ```js
  * user.addPicture(p) // Add a single picture
  * user.setPictures([p1, p2]) // Associate user with ONLY these two picture, all other associations will be deleted
- * user.addPictures([p1, p2]) // Associate user with these two pictures, but don't touch any current associations 
- * ``` 
- * 
+ * user.addPictures([p1, p2]) // Associate user with these two pictures, but don't touch any current associations
+ * ```
+ *
  * You don't have to pass in a complete object to the association functions, if your associated model has a single primary key:
- * 
+ *
  * ```js
  * user.addPicture(req.query.pid) // Here pid is just an integer, representing the primary key of the picture
- * ``` 
+ * ```
  *
  * In the example above we have specified that a user belongs to his profile picture. Conceptually, this might not make sense,
  * but since we want to add the foreign key to the user model this is the way to do it.
  * Note how we also specified `constraints: false` for profile picture. This is because we add a foreign key from
- * user to picture (profilePictureId), and from picture to user (userId). If we were to add foreign keys to both, it would 
+ * user to picture (profilePictureId), and from picture to user (userId). If we were to add foreign keys to both, it would
  * create a cyclic dependency, and sequelize would not know which table to create first, since user depends on picture, and picture
  * depends on user. These kinds of problems are detected by sequelize before the models are synced to the database, and you will
  * get an error along the lines of `Error: Cyclic dependency found. 'users' is dependent of itself`. If you encounter this,
@@ -71,21 +71,21 @@ var Utils     = require("./../utils")
  *
  * @mixin Associations
  */
-var Mixin = module.exports = function(){}
+var Mixin = module.exports = function() {};
 
 /**
- * Creates an association between this (the source) and the provided target. The foreign key is added on the target. 
- * 
+ * Creates an association between this (the source) and the provided target. The foreign key is added on the target.
+ *
  * Example: `User.hasOne(Profile)`. This will add userId to the profile table.
  *
  * The following methods are injected on the source:
- * 
+ *
  * * get[AS] - for example getProfile(finder). The finder object is passed to `target.find`.
  * * set[AS] - for example setProfile(instance, options). Options are passed to `target.save`
  * * create[AS] - for example createProfile(value, options). Builds and saves a new instance of the associated model. Values and options are passed on to `target.create`
  *
  * All methods return a promise
- * 
+ *
  * @param {Model} target
  * @param {object}     [options]
  * @param {boolean}    [options.hooks=false] Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade. For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking any hooks
@@ -96,37 +96,37 @@ var Mixin = module.exports = function(){}
  * @param {boolean}    [options.constraints=true] Should on update and on delete constraints be enabled on the foreign key.
  */
 Mixin.hasOne = function(targetModel, options) {
-  var sourceModel = this
+  var sourceModel = this;
 
   // Since this is a mixin, we'll need a unique variable name for hooks (since Model will override our hooks option)
-  options = options || {}
-  options.hooks = options.hooks === undefined ? false : Boolean(options.hooks)
-  options.useHooks = options.hooks
+  options = options || {};
+  options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
+  options.useHooks = options.hooks;
 
   // the id is in the foreign table
-  var association = new HasOne(sourceModel, targetModel, Utils._.extend(options, sourceModel.options))
-  sourceModel.associations[association.associationAccessor] = association.injectAttributes()
+  var association = new HasOne(sourceModel, targetModel, Utils._.extend(options, sourceModel.options));
+  sourceModel.associations[association.associationAccessor] = association.injectAttributes();
 
   association.injectGetter(sourceModel.Instance.prototype);
   association.injectSetter(sourceModel.Instance.prototype);
   association.injectCreator(sourceModel.Instance.prototype);
 
-  return association
-}
+  return association;
+};
 
 /**
- * Creates an association between this (the source) and the provided target. The foreign key is added on the source. 
- * 
+ * Creates an association between this (the source) and the provided target. The foreign key is added on the source.
+ *
  * Example: `Profile.belongsTo(User)`. This will add userId to the profile table.
- * 
+ *
  * The following methods are injected on the source:
- * 
+ *
  * * get[AS] - for example getUser(finder). The finder object is passed to `target.find`.
  * * set[AS] - for example setUser(instance, options). Options are passed to this.save
  * * create[AS] - for example createUser(value, options). Builds and saves a new instance of the associated model. Values and options are passed on to target.create
  *
  * All methods return a promise
- * 
+ *
  * @param {Model} target
  * @param {object}     [options]
  * @param {boolean}    [options.hooks=false] Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade. For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking any hooks
@@ -137,26 +137,26 @@ Mixin.hasOne = function(targetModel, options) {
  * @param {boolean}    [options.constraints=true] Should on update and on delete constraints be enabled on the foreign key.
  */
 Mixin.belongsTo = function(targetModel, options) {
-  var sourceModel = this
+  var sourceModel = this;
 
   // Since this is a mixin, we'll need a unique variable name for hooks (since Model will override our hooks option)
-  options = options || {}
-  options.hooks = options.hooks === undefined ? false : Boolean(options.hooks)
-  options.useHooks = options.hooks
+  options = options || {};
+  options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
+  options.useHooks = options.hooks;
 
   // the id is in this table
-  var association = new BelongsTo(sourceModel, targetModel, Utils._.extend(options, sourceModel.options))
-  sourceModel.associations[association.associationAccessor] = association.injectAttributes()
+  var association = new BelongsTo(sourceModel, targetModel, Utils._.extend(options, sourceModel.options));
+  sourceModel.associations[association.associationAccessor] = association.injectAttributes();
 
-  association.injectGetter(sourceModel.Instance.prototype)
-  association.injectSetter(sourceModel.Instance.prototype)
-  association.injectCreator(sourceModel.Instance.prototype)
+  association.injectGetter(sourceModel.Instance.prototype);
+  association.injectSetter(sourceModel.Instance.prototype);
+  association.injectCreator(sourceModel.Instance.prototype);
 
-  return association
-}
+  return association;
+};
 
 /**
- * Create an association that is either 1:m or n:m. 
+ * Create an association that is either 1:m or n:m.
  *
  * ```js
  * // Create a 1:m association between user and project
@@ -170,15 +170,15 @@ Mixin.belongsTo = function(targetModel, options) {
  * By default, the name of the join table will be source+target, so in this case projectsusers. This can be overridden by providing either a string or a Model as `through` in the options.
 
  * The following methods are injected on the source:
- * 
+ *
  * * get[AS] - for example getPictures(finder). The finder object is passed to `target.find`.
  * * set[AS] - for example setPictures(instances, defaultAttributes|options). Update the associations. All currently associated models that are not in instances will be removed.
  * * add[AS] - for example addPicture(instance, defaultAttributes|options). Add another associated object.
  * * add[AS] [plural] - for example addPictures([instance1, instance2], defaultAttributes|options). Add some more associated objects.
- * * create[AS] - for example createPicture(values, options). Build and save a new association. 
+ * * create[AS] - for example createPicture(values, options). Build and save a new association.
  * * remove[AS] - for example removePicture(instance). Remove a single association
  * * has[AS] - for example hasPicture(instance). Is source associated to this target?
- * * has[AS] [plural] - for example hasPictures(instances). Is source associated to all these targets? 
+ * * has[AS] [plural] - for example hasPictures(instances). Is source associated to all these targets?
  *
  * All methods return a promise
  *
@@ -212,11 +212,11 @@ Mixin.belongsTo = function(targetModel, options) {
  *   p1.userprojects.started // Is this project started yet?
  * })
  * ```
- * 
+ *
  * @param {Model}             target
  * @param {object}            [options]
  * @param {boolean}           [options.hooks=false] Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade. For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking any hooks
- * @param {Model|string}      [options.through] The name of the table that is used to join source and target in n:m associations. Can also be a sequelize model if you want to define the junction table yourself and add extra attributes to it. 
+ * @param {Model|string}      [options.through] The name of the table that is used to join source and target in n:m associations. Can also be a sequelize model if you want to define the junction table yourself and add extra attributes to it.
  * @param {string}            [options.as] The alias of this model. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the assocition, you should provide the same alias when eager loading and when getting assocated models. Defaults to the singularized version of target.name
  * @param {string}            [options.foreignKey] The name of the foreign key in the target table / join table. Defaults to the name of source + primary key of source
  * @param {string}            [options.onDelete='SET&nbsp;NULL|CASCADE'] Cascade if this is a n:m, and set null if it is a 1:m
@@ -224,50 +224,50 @@ Mixin.belongsTo = function(targetModel, options) {
  * @param {boolean}           [options.constraints=true] Should on update and on delete constraints be enabled on the foreign key.
  */
 Mixin.hasMany = function(targetModel, options) {
-  var sourceModel = this
+  var sourceModel = this;
 
   // Since this is a mixin, we'll need a unique variable name for hooks (since Model will override our hooks option)
-  options = options || {}
-  options.hooks = options.hooks === undefined ? false : Boolean(options.hooks)
-  options.useHooks = options.hooks
+  options = options || {};
+  options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
+  options.useHooks = options.hooks;
 
-  options = Utils._.extend(options, Utils._.omit(sourceModel.options, ['hooks']))
+  options = Utils._.extend(options, Utils._.omit(sourceModel.options, ['hooks']));
 
   // the id is in the foreign table or in a connecting table
-  var association = new HasMany(sourceModel, targetModel, options)
-  sourceModel.associations[association.associationAccessor] = association.injectAttributes()
+  var association = new HasMany(sourceModel, targetModel, options);
+  sourceModel.associations[association.associationAccessor] = association.injectAttributes();
 
-  association.injectGetter(sourceModel.Instance.prototype)
-  association.injectSetter(sourceModel.Instance.prototype)
-  association.injectCreator(sourceModel.Instance.prototype)
+  association.injectGetter(sourceModel.Instance.prototype);
+  association.injectSetter(sourceModel.Instance.prototype);
+  association.injectCreator(sourceModel.Instance.prototype);
 
-  return association
-}
+  return association;
+};
 
 Mixin.getAssociation = function(target, alias) {
   for (var associationName in this.associations) {
     if (this.associations.hasOwnProperty(associationName)) {
-      var association = this.associations[associationName]
+      var association = this.associations[associationName];
 
       if (association.target === target && (alias === undefined ? !association.isAliased : association.as === alias)) {
-        return association
+        return association;
       }
     }
   }
 
-  return null
-}
+  return null;
+};
 
 Mixin.getAssociationByAlias = function(alias) {
   for (var associationName in this.associations) {
     if (this.associations.hasOwnProperty(associationName)) {
-      var association = this.associations[associationName]
+      var association = this.associations[associationName];
 
       if (association.as === alias) {
-        return association
+        return association;
       }
     }
   }
 
-  return null
-}
+  return null;
+};

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -1,280 +1,280 @@
-"use strict";
+'use strict';
 
 var STRING = function(length, binary) {
   if (this instanceof STRING) {
-    this._binary = !!binary
+    this._binary = !!binary;
     if (typeof length === 'number') {
-      this._length = length
+      this._length = length;
     } else {
-      this._length = 255
+      this._length = 255;
     }
   } else {
-    return new STRING(length, binary)
+    return new STRING(length, binary);
   }
-}
+};
 
-var CHAR = function (length, binary) {
+var CHAR = function(length, binary) {
   if (this instanceof CHAR) {
-    this._binary = !!binary
+    this._binary = !!binary;
     if (typeof length === 'number') {
-      this._length = length
+      this._length = length;
     } else {
-      this._length = 255
+      this._length = 255;
     }
   } else {
-    return new CHAR(length, binary)
+    return new CHAR(length, binary);
   }
-}
+};
 
 STRING.prototype = {
   get BINARY() {
-    this._binary = true
-    return this
+    this._binary = true;
+    return this;
   },
   get type() {
-    return this.toString()
+    return this.toString();
   },
   toString: function() {
-    return 'VARCHAR(' + this._length + ')' + ((this._binary) ? ' BINARY' : '')
+    return 'VARCHAR(' + this._length + ')' + ((this._binary) ? ' BINARY' : '');
   }
-}
+};
 
 CHAR.prototype = {
   get BINARY() {
-    this._binary = true
-    return this
+    this._binary = true;
+    return this;
   },
   get type() {
-    return this.toString()
+    return this.toString();
   },
   toString: function() {
-    return 'CHAR(' + this._length + ')' + ((this._binary) ? ' BINARY' : '')
+    return 'CHAR(' + this._length + ')' + ((this._binary) ? ' BINARY' : '');
   }
-}
+};
 
 Object.defineProperty(STRING, 'BINARY', {
   get: function() {
-    return new STRING(undefined, true)
+    return new STRING(undefined, true);
   }
-})
+});
 
 Object.defineProperty(CHAR, 'BINARY', {
   get: function() {
-    return new CHAR(undefined, true)
+    return new CHAR(undefined, true);
   }
-})
+});
 
 var INTEGER = function() {
-  return INTEGER.prototype.construct.apply(this, [INTEGER].concat(Array.prototype.slice.apply(arguments)))
-}
+  return INTEGER.prototype.construct.apply(this, [INTEGER].concat(Array.prototype.slice.apply(arguments)));
+};
 
 var BIGINT = function() {
-  return BIGINT.prototype.construct.apply(this, [BIGINT].concat(Array.prototype.slice.apply(arguments)))
-}
+  return BIGINT.prototype.construct.apply(this, [BIGINT].concat(Array.prototype.slice.apply(arguments)));
+};
 
 var FLOAT = function() {
-  return FLOAT.prototype.construct.apply(this, [FLOAT].concat(Array.prototype.slice.apply(arguments)))
-}
+  return FLOAT.prototype.construct.apply(this, [FLOAT].concat(Array.prototype.slice.apply(arguments)));
+};
 
 var BLOB = function() {
-  return BLOB.prototype.construct.apply(this, [BLOB].concat(Array.prototype.slice.apply(arguments)))
-}
+  return BLOB.prototype.construct.apply(this, [BLOB].concat(Array.prototype.slice.apply(arguments)));
+};
 
 var DECIMAL = function() {
-  return DECIMAL.prototype.construct.apply(this, [DECIMAL].concat(Array.prototype.slice.apply(arguments)))
-}
+  return DECIMAL.prototype.construct.apply(this, [DECIMAL].concat(Array.prototype.slice.apply(arguments)));
+};
 
 var VIRTUAL = function() {
 
 };
 
-FLOAT._type = FLOAT
-FLOAT._typeName = 'FLOAT'
-INTEGER._type = INTEGER
-INTEGER._typeName = 'INTEGER'
-BIGINT._type = BIGINT
-BIGINT._typeName = 'BIGINT'
-STRING._type = STRING
-STRING._typeName = 'VARCHAR'
-CHAR._type = CHAR
-CHAR._typeName = 'CHAR'
-BLOB._type = BLOB
-BLOB._typeName = 'BLOB'
-DECIMAL._type = DECIMAL
-DECIMAL._typeName = 'DECIMAL'
+FLOAT._type = FLOAT;
+FLOAT._typeName = 'FLOAT';
+INTEGER._type = INTEGER;
+INTEGER._typeName = 'INTEGER';
+BIGINT._type = BIGINT;
+BIGINT._typeName = 'BIGINT';
+STRING._type = STRING;
+STRING._typeName = 'VARCHAR';
+CHAR._type = CHAR;
+CHAR._typeName = 'CHAR';
+BLOB._type = BLOB;
+BLOB._typeName = 'BLOB';
+DECIMAL._type = DECIMAL;
+DECIMAL._typeName = 'DECIMAL';
 
 
 BLOB.toString = STRING.toString = CHAR.toString = INTEGER.toString = FLOAT.toString = BIGINT.toString = DECIMAL.toString = function() {
-  return new this._type().toString()
-}
+  return new this._type().toString();
+};
 
 BLOB.prototype = {
 
   construct: function(RealType, length) {
     if (this instanceof RealType) {
-      this._typeName = RealType._typeName
+      this._typeName = RealType._typeName;
       if (typeof length === 'string') {
-        this._length = length
+        this._length = length;
       } else {
-        this._length = ''
+        this._length = '';
       }
     } else {
-      return new RealType(length)
+      return new RealType(length);
     }
   },
 
   get type() {
-    return this.toString()
+    return this.toString();
   },
 
   toString: function() {
     switch (this._length.toLowerCase()) {
     case 'tiny':
-      return 'TINYBLOB'
+      return 'TINYBLOB';
     case 'medium':
-      return 'MEDIUMBLOB'
+      return 'MEDIUMBLOB';
     case 'long':
-      return 'LONGBLOB'
+      return 'LONGBLOB';
     default:
-      return this._typeName
+      return this._typeName;
     }
   }
-}
+};
 
 FLOAT.prototype = BIGINT.prototype = INTEGER.prototype = {
 
   construct: function(RealType, length, decimals, unsigned, zerofill) {
     if (this instanceof RealType) {
-      this._typeName = RealType._typeName
-      this._unsigned = !!unsigned
-      this._zerofill = !!zerofill
+      this._typeName = RealType._typeName;
+      this._unsigned = !!unsigned;
+      this._zerofill = !!zerofill;
       if (typeof length === 'number') {
-        this._length = length
+        this._length = length;
       }
       if (typeof decimals === 'number') {
-        this._decimals = decimals
+        this._decimals = decimals;
       }
     } else {
-      return new RealType(length, decimals, unsigned, zerofill)
+      return new RealType(length, decimals, unsigned, zerofill);
     }
   },
 
   get type() {
-    return this.toString()
+    return this.toString();
   },
 
   get UNSIGNED() {
-    this._unsigned = true
-    return this
+    this._unsigned = true;
+    return this;
   },
 
   get ZEROFILL() {
-    this._zerofill = true
-    return this
+    this._zerofill = true;
+    return this;
   },
 
   toString: function() {
-    var result = this._typeName
+    var result = this._typeName;
     if (this._length) {
-      result += '(' + this._length
+      result += '(' + this._length;
       if (typeof this._decimals === 'number') {
-        result += ',' + this._decimals
+        result += ',' + this._decimals;
       }
-      result += ')'
+      result += ')';
     }
     if (this._unsigned) {
-      result += ' UNSIGNED'
+      result += ' UNSIGNED';
     }
     if (this._zerofill) {
-      result += ' ZEROFILL'
+      result += ' ZEROFILL';
     }
-    return result
+    return result;
   }
-}
+};
 
 DECIMAL.prototype = {
 
   construct: function(RealType, precision, scale) {
     if (this instanceof RealType) {
-      this._typeName = RealType._typeName
+      this._typeName = RealType._typeName;
       if (typeof precision === 'number') {
-        this._precision = precision
+        this._precision = precision;
       } else {
-        this._precision = 0
+        this._precision = 0;
       }
       if (typeof scale === 'number') {
-        this._scale = scale
+        this._scale = scale;
       } else {
-        this._scale = 0
+        this._scale = 0;
       }
     } else {
-      return new RealType(precision, scale)
+      return new RealType(precision, scale);
     }
   },
 
   get type() {
-    return this.toString()
+    return this.toString();
   },
 
   get PRECISION() {
-    return this._precision
+    return this._precision;
   },
 
   get SCALE() {
-    return this._scale
+    return this._scale;
   },
 
   toString: function() {
     if (this._precision || this._scale) {
-      return 'DECIMAL(' + this._precision + ',' + this._scale + ')'
+      return 'DECIMAL(' + this._precision + ',' + this._scale + ')';
     }
 
-    return 'DECIMAL'
+    return 'DECIMAL';
   }
-}
+};
 
 var unsignedDesc = {
   get: function() {
-    return new this._type(undefined, undefined, true)
+    return new this._type(undefined, undefined, true);
   }
-}
+};
 
 var zerofillDesc = {
   get: function() {
-    return new this._type(undefined, undefined, undefined, true)
+    return new this._type(undefined, undefined, undefined, true);
   }
-}
+};
 
 var typeDesc = {
   get: function() {
-    return new this._type().toString()
+    return new this._type().toString();
   }
-}
+};
 
 var decimalDesc = {
   get: function() {
-    return new this._type(undefined, undefined, undefined)
+    return new this._type(undefined, undefined, undefined);
   }
-}
+};
 
-Object.defineProperty(STRING,  'type', typeDesc)
-Object.defineProperty(CHAR,    'type', typeDesc)
-Object.defineProperty(INTEGER, 'type', typeDesc)
-Object.defineProperty(BIGINT,  'type', typeDesc)
-Object.defineProperty(FLOAT,   'type', typeDesc)
-Object.defineProperty(BLOB,    'type', typeDesc)
-Object.defineProperty(DECIMAL, 'type', typeDesc)
+Object.defineProperty(STRING, 'type', typeDesc);
+Object.defineProperty(CHAR, 'type', typeDesc);
+Object.defineProperty(INTEGER, 'type', typeDesc);
+Object.defineProperty(BIGINT, 'type', typeDesc);
+Object.defineProperty(FLOAT, 'type', typeDesc);
+Object.defineProperty(BLOB, 'type', typeDesc);
+Object.defineProperty(DECIMAL, 'type', typeDesc);
 
-Object.defineProperty(INTEGER, 'UNSIGNED', unsignedDesc)
-Object.defineProperty(BIGINT,  'UNSIGNED', unsignedDesc)
-Object.defineProperty(FLOAT,   'UNSIGNED', unsignedDesc)
+Object.defineProperty(INTEGER, 'UNSIGNED', unsignedDesc);
+Object.defineProperty(BIGINT, 'UNSIGNED', unsignedDesc);
+Object.defineProperty(FLOAT, 'UNSIGNED', unsignedDesc);
 
-Object.defineProperty(INTEGER, 'ZEROFILL', zerofillDesc)
-Object.defineProperty(BIGINT,  'ZEROFILL', zerofillDesc)
-Object.defineProperty(FLOAT,   'ZEROFILL', zerofillDesc)
+Object.defineProperty(INTEGER, 'ZEROFILL', zerofillDesc);
+Object.defineProperty(BIGINT, 'ZEROFILL', zerofillDesc);
+Object.defineProperty(FLOAT, 'ZEROFILL', zerofillDesc);
 
-Object.defineProperty(DECIMAL, 'PRECISION', decimalDesc)
-Object.defineProperty(DECIMAL, 'SCALE', decimalDesc)
+Object.defineProperty(DECIMAL, 'PRECISION', decimalDesc);
+Object.defineProperty(DECIMAL, 'SCALE', decimalDesc);
 
 module.exports = {
   STRING: STRING,
@@ -282,7 +282,7 @@ module.exports = {
 
   TEXT: 'TEXT',
   INTEGER: INTEGER,
-  BIGINT:  BIGINT,
+  BIGINT: BIGINT,
   DATE: 'DATETIME',
   BOOLEAN: 'TINYINT(1)',
   FLOAT: FLOAT,
@@ -301,29 +301,29 @@ module.exports = {
       return {
         type: 'ENUM',
         values: Array.prototype.slice.call(arguments).reduce(function(result, element) {
-          return result.concat(Array.isArray(element) ? element : [ element ])
+          return result.concat(Array.isArray(element) ? element : [element]);
         }, []),
         toString: result.toString
-      }
-    }
+      };
+    };
 
-    result.toString = result.valueOf = function() { return 'ENUM' }
+    result.toString = result.valueOf = function() { return 'ENUM'; };
 
-    return result
+    return result;
   },
 
-  ARRAY: function(type) { return type + '[]' },
+  ARRAY: function(type) { return type + '[]'; },
 
   get HSTORE() {
     var result = function() {
       return {
         type: 'HSTORE'
-      }
-    }
+      };
+    };
 
-    result.type = 'HSTORE'
-    result.toString = result.valueOf = function() { return 'HSTORE' }
+    result.type = 'HSTORE';
+    result.toString = result.valueOf = function() { return 'HSTORE'; };
 
-    return result
+    return result;
   }
-}
+};

--- a/lib/dialects/abstract/connector-manager.js
+++ b/lib/dialects/abstract/connector-manager.js
@@ -1,36 +1,36 @@
-"use strict";
+'use strict';
 
-module.exports = (function(){
+module.exports = (function() {
   var ConnectorManager = function(sequelize, config) {
-    throw new Error('Define the constructor!')
-  }
+    throw new Error('Define the constructor!');
+  };
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
-    throw new Error('Define the query method!')
-  }
+    throw new Error('Define the query method!');
+  };
 
   ConnectorManager.prototype.afterTransactionSetup = function(callback) {
-    callback()
-  }
+    callback();
+  };
 
   ConnectorManager.prototype.connect = function() {
-    throw new Error('Define the connect method!')
-  }
+    throw new Error('Define the connect method!');
+  };
 
   ConnectorManager.prototype.disconnect = function() {
-    throw new Error('Define the disconnect method!')
-  }
+    throw new Error('Define the disconnect method!');
+  };
 
   ConnectorManager.prototype.reconnect = function() {
-    this.disconnect()
-    this.connect()
-  }
+    this.disconnect();
+    this.connect();
+  };
 
   ConnectorManager.prototype.cleanup = function() {
     if (this.onProcessExit) {
-      process.removeListener('exit', this.onProcessExit)
+      process.removeListener('exit', this.onProcessExit);
     }
-  }
+  };
 
-  return ConnectorManager
-})()
+  return ConnectorManager;
+})();

--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -1,16 +1,16 @@
-"use strict";
+'use strict';
 
 var AbstractDialect = function() {
-  
-}
+
+};
 
 AbstractDialect.prototype.supports = {
   'RETURNING': false,
   'DEFAULT': true,
   'DEFAULT VALUES': false,
   'VALUES ()': false,
-  'LIMIT ON UPDATE':false,
+  'LIMIT ON UPDATE': false,
   schemas: false
-}
+};
 
-module.exports = AbstractDialect
+module.exports = AbstractDialect;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1,16 +1,16 @@
-"use strict";
+'use strict';
 
-var Utils = require("../../utils")
-  , SqlString = require("../../sql-string")
-  , Model = require("../../model")
-  , _ = require('lodash')
+var Utils = require('../../utils')
+  , SqlString = require('../../sql-string')
+  , Model = require('../../model')
+  , _ = require('lodash');
 
 module.exports = (function() {
   var QueryGenerator = {
     addSchema: function(param) {
       var self = this
-        , schema           = (param.options && param.options.schema ? param.options.schema : undefined)
-        , schemaDelimiter  = (param.options && param.options.schemaDelimiter ? param.options.schemaDelimiter : undefined)
+        , schema = (param.options && param.options.schema ? param.options.schema : undefined)
+        , schemaDelimiter = (param.options && param.options.schemaDelimiter ? param.options.schemaDelimiter : undefined);
 
       if (!schema) return param.tableName || param;
 
@@ -21,9 +21,9 @@ module.exports = (function() {
         schema: schema,
         delimiter: schemaDelimiter || '.',
         toString: function() {
-          return self.quoteTable(this)
+          return self.quoteTable(this);
         }
-      }
+      };
     },
 
     /*
@@ -38,10 +38,10 @@ module.exports = (function() {
                    Defaults: { engine: 'InnoDB', charset: null }
     */
     createTableQuery: function(tableName, attributes, options) {
-      throwMethodUndefined('createTableQuery')
+      throwMethodUndefined('createTableQuery');
     },
 
-    describeTableQuery: function (tableName, schema, schemaDelimiter) {
+    describeTableQuery: function(tableName, schema, schemaDelimiter) {
       var table = this.quoteTable(
         this.addSchema({
           tableName: tableName,
@@ -50,22 +50,22 @@ module.exports = (function() {
             schemaDelimiter: schemaDelimiter
           }
         })
-      )
+      );
 
-      return 'DESCRIBE ' + table + ';'
+      return 'DESCRIBE ' + table + ';';
     },
 
     /*
       Returns a query for dropping a table.
     */
     dropTableQuery: function(tableName, options) {
-      options = options || {}
+      options = options || {};
 
-      var query = "DROP TABLE IF EXISTS <%= table %>;"
+      var query = 'DROP TABLE IF EXISTS <%= table %>;';
 
       return Utils._.template(query)({
         table: this.quoteTable(tableName)
-      })
+      });
     },
 
     /*
@@ -75,18 +75,18 @@ module.exports = (function() {
         - futureTableName: Name of the table after execution.
     */
     renameTableQuery: function(before, after) {
-      var query = "ALTER TABLE <%= before %> RENAME TO <%= after %>;"
+      var query = 'ALTER TABLE <%= before %> RENAME TO <%= after %>;';
       return Utils._.template(query)({
         before: this.quoteTable(before),
         after: this.quoteTable(after)
-      })
+      });
     },
 
     /*
       Returns a query, which gets all available table names in the database.
     */
     showTablesQuery: function() {
-      throwMethodUndefined('showTablesQuery')
+      throwMethodUndefined('showTablesQuery');
     },
 
     /*
@@ -101,7 +101,7 @@ module.exports = (function() {
             - allowNull: Boolean
     */
     addColumnQuery: function(tableName, attributes) {
-      throwMethodUndefined('addColumnQuery')
+      throwMethodUndefined('addColumnQuery');
     },
 
     /*
@@ -111,7 +111,7 @@ module.exports = (function() {
         - attributeName: Name of the obsolete attribute.
     */
     removeColumnQuery: function(tableName, attributeName) {
-      throwMethodUndefined('removeColumnQuery')
+      throwMethodUndefined('removeColumnQuery');
     },
 
     /*
@@ -126,7 +126,7 @@ module.exports = (function() {
             - allowNull: Boolean
     */
     changeColumnQuery: function(tableName, attributes) {
-      throwMethodUndefined('changeColumnQuery')
+      throwMethodUndefined('changeColumnQuery');
     },
 
     /*
@@ -137,7 +137,7 @@ module.exports = (function() {
         - attrNameAfter: The name of the attribute, after renaming.
     */
     renameColumnQuery: function(tableName, attrNameBefore, attrNameAfter) {
-      throwMethodUndefined('renameColumnQuery')
+      throwMethodUndefined('renameColumnQuery');
     },
 
     /*
@@ -145,16 +145,16 @@ module.exports = (function() {
     */
     insertQuery: function(table, valueHash, modelAttributes) {
       var query
-        , valueQuery          = "INSERT INTO <%= table %> (<%= attributes %>) VALUES (<%= values %>)"
-        , emptyQuery          = "INSERT INTO <%= table %>"
-        , fields              = []
-        , values              = []
+        , valueQuery = 'INSERT INTO <%= table %> (<%= attributes %>) VALUES (<%= values %>)'
+        , emptyQuery = 'INSERT INTO <%= table %>'
+        , fields = []
+        , values = []
         , key
         , value
-        , modelAttributeMap   = {}
+        , modelAttributeMap = {};
 
       if (modelAttributes) {
-        Utils._.each(modelAttributes, function (attribute, key) {
+        Utils._.each(modelAttributes, function(attribute, key) {
           modelAttributeMap[key] = attribute;
           if (attribute.field) {
             modelAttributeMap[attribute.field] = attribute;
@@ -163,52 +163,52 @@ module.exports = (function() {
       }
 
       if (this._dialect.supports['DEFAULT VALUES']) {
-        emptyQuery += " DEFAULT VALUES"
+        emptyQuery += ' DEFAULT VALUES';
       } else if (this._dialect.supports['VALUES ()']) {
-        emptyQuery += " VALUES ()"
+        emptyQuery += ' VALUES ()';
       }
 
       if (this._dialect.supports['RETURNING']) {
-        valueQuery += " RETURNING *"
-        emptyQuery += " RETURNING *"
+        valueQuery += ' RETURNING *';
+        emptyQuery += ' RETURNING *';
       }
 
-      valueHash = Utils.removeNullValuesFromHash(valueHash, this.options.omitNull)
+      valueHash = Utils.removeNullValuesFromHash(valueHash, this.options.omitNull);
 
       for (key in valueHash) {
         if (valueHash.hasOwnProperty(key)) {
-          value = valueHash[key]
-          fields.push(this.quoteIdentifier(key))
+          value = valueHash[key];
+          fields.push(this.quoteIdentifier(key));
 
           // SERIALS' can't be NULL in postgresql, use DEFAULT where supported
           if (modelAttributeMap && modelAttributeMap[key] && modelAttributeMap[key].autoIncrement === true && !value) {
             if (this._dialect.supports['DEFAULT']) {
-              values.push('DEFAULT')
+              values.push('DEFAULT');
             } else {
-              values.push(this.escape(null))
+              values.push(this.escape(null));
             }
           } else {
-            values.push(this.escape(value, (modelAttributeMap && modelAttributeMap[key]) || undefined))
+            values.push(this.escape(value, (modelAttributeMap && modelAttributeMap[key]) || undefined));
           }
         }
       }
 
-      var replacements  = {
-        table:      this.quoteTable(table),
-        attributes: fields.join(","),
-        values:     values.join(",")
-      }
+      var replacements = {
+        table: this.quoteTable(table),
+        attributes: fields.join(','),
+        values: values.join(',')
+      };
 
-      query = (replacements.attributes.length ? valueQuery : emptyQuery) + ";"
+      query = (replacements.attributes.length ? valueQuery : emptyQuery) + ';';
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
     /*
       Returns an insert into command for multiple values.
       Parameters: table name + list of hashes of attribute-value-pairs.
     */
     bulkInsertQuery: function(tableName, attrValueHashes) {
-      throwMethodUndefined('bulkInsertQuery')
+      throwMethodUndefined('bulkInsertQuery');
     },
 
     /*
@@ -222,35 +222,35 @@ module.exports = (function() {
                    If you use a string, you have to escape it on your own.
     */
     updateQuery: function(tableName, attrValueHash, where, options, attributes) {
-      options = options || {}
+      options = options || {};
 
-      attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull, options)
+      attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull, options);
 
       var query
-        , values = []
+        , values = [];
 
-      query = "UPDATE <%= table %> SET <%= values %> WHERE <%= where %>"
+      query = 'UPDATE <%= table %> SET <%= values %> WHERE <%= where %>';
 
-      if(this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
-        query += " LIMIT "+this.escape(options.limit)+" "
+      if (this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
+        query += ' LIMIT ' + this.escape(options.limit) + ' ';
       }
 
       if (this._dialect.supports['RETURNING'] && (options.returning || options.returning === undefined)) {
-        query += " RETURNING *"
+        query += ' RETURNING *';
       }
 
       for (var key in attrValueHash) {
-        var value = attrValueHash[key]
-        values.push(this.quoteIdentifier(key) + "=" + this.escape(value, (!!attributes && !!attributes[key] ? attributes[key] : undefined)))
+        var value = attrValueHash[key];
+        values.push(this.quoteIdentifier(key) + '=' + this.escape(value, (!!attributes && !!attributes[key] ? attributes[key] : undefined)));
       }
 
       var replacements = {
-        table:  this.quoteTable(tableName),
-        values: values.join(","),
-        where:  this.getWhereConditions(where)
-      }
+        table: this.quoteTable(tableName),
+        values: values.join(','),
+        where: this.getWhereConditions(where)
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     /*
@@ -270,7 +270,7 @@ module.exports = (function() {
                                 Note that truncate must ignore limit and where
     */
     deleteQuery: function(tableName, where, options) {
-      throwMethodUndefined('deleteQuery')
+      throwMethodUndefined('deleteQuery');
     },
 
     /*
@@ -284,34 +284,34 @@ module.exports = (function() {
                    If you use a string, you have to escape it on your own.
     */
     incrementQuery: function(tableName, attrValueHash, where, options) {
-      attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull)
+      attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull);
 
       var query
-        , values = []
+        , values = [];
 
-      query = "UPDATE <%= table %> SET <%= values %> WHERE <%= where %>"
+      query = 'UPDATE <%= table %> SET <%= values %> WHERE <%= where %>';
       if (this._dialect.supports['RETURNING']) {
-        query += " RETURNING *"
+        query += ' RETURNING *';
       }
 
       for (var key in attrValueHash) {
-        var value = attrValueHash[key]
-        values.push(this.quoteIdentifier(key) + "=" + this.quoteIdentifier(key) + " + " + this.escape(value))
+        var value = attrValueHash[key];
+        values.push(this.quoteIdentifier(key) + '=' + this.quoteIdentifier(key) + ' + ' + this.escape(value));
       }
 
-      options = options || {}
+      options = options || {};
       for (var key in options) {
         var value = options[key];
-        values.push(this.quoteIdentifier(key) + "=" + this.escape(value))
+        values.push(this.quoteIdentifier(key) + '=' + this.escape(value));
       }
 
       var replacements = {
-        table:  this.quoteIdentifiers(tableName),
-        values: values.join(","),
-        where:  this.getWhereConditions(where)
-      }
+        table: this.quoteIdentifiers(tableName),
+        values: values.join(','),
+        where: this.getWhereConditions(where)
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     /*
@@ -330,7 +330,7 @@ module.exports = (function() {
           - parser
     */
     addIndexQuery: function(tableName, attributes, options) {
-      throwMethodUndefined('addIndexQuery')
+      throwMethodUndefined('addIndexQuery');
     },
 
     /*
@@ -341,7 +341,7 @@ module.exports = (function() {
           - database: Name of the database.
     */
     showIndexQuery: function(tableName, options) {
-      throwMethodUndefined('showIndexQuery')
+      throwMethodUndefined('showIndexQuery');
     },
 
     /*
@@ -351,7 +351,7 @@ module.exports = (function() {
         - indexNameOrAttributes: The name of the index as string or an array of attribute names.
     */
     removeIndexQuery: function(tableName, indexNameOrAttributes) {
-      throwMethodUndefined('removeIndexQuery')
+      throwMethodUndefined('removeIndexQuery');
     },
 
     /*
@@ -359,14 +359,14 @@ module.exports = (function() {
       sql attribute definition.
     */
     attributesToSQL: function(attributes) {
-      throwMethodUndefined('attributesToSQL')
+      throwMethodUndefined('attributesToSQL');
     },
 
     /*
       Returns all auto increment fields of a factory.
     */
     findAutoIncrementField: function(factory) {
-      throwMethodUndefined('findAutoIncrementField')
+      throwMethodUndefined('findAutoIncrementField');
     },
 
 
@@ -374,34 +374,34 @@ module.exports = (function() {
       var table = '';
 
       if (as === true) {
-        as = param.as || param.name || param
+        as = param.as || param.name || param;
       }
 
       if (_.isObject(param)) {
         if (this._dialect.supports.schemas) {
           if (param.schema) {
-            table += this.quoteIdentifier(param.schema) + '.'
+            table += this.quoteIdentifier(param.schema) + '.';
           }
 
-          table += this.quoteIdentifier(param.tableName)
+          table += this.quoteIdentifier(param.tableName);
         } else {
           if (param.schema) {
-            table += param.schema + param.delimiter
+            table += param.schema + param.delimiter;
           }
 
-          table += param.tableName
-          table = this.quoteIdentifier(table)
+          table += param.tableName;
+          table = this.quoteIdentifier(table);
         }
 
-        
+
       } else {
-        table = this.quoteIdentifier(param)
+        table = this.quoteIdentifier(param);
       }
 
       if (as) {
-        table += " AS " + this.quoteIdentifier(as)
+        table += ' AS ' + this.quoteIdentifier(as);
       }
-      return table
+      return table;
     },
 
     /*
@@ -427,60 +427,60 @@ module.exports = (function() {
     */
     quote: function(obj, parent, force) {
       if (Utils._.isString(obj)) {
-        return this.quoteIdentifiers(obj, force)
+        return this.quoteIdentifiers(obj, force);
       } else if (Array.isArray(obj)) {
         // loop through array, adding table names of models to quoted
         // (checking associations to see if names should be singularised or not)
         var tableNames = []
           , parentAssociation
-          , len = obj.length
+          , len = obj.length;
         for (var i = 0; i < len - 1; i++) {
-          var item = obj[i]
+          var item = obj[i];
           if (item._modelAttribute || Utils._.isString(item) || item._isSequelizeMethod || 'raw' in item) {
-            break
+            break;
           }
 
-          var model, as
+          var model, as;
           if (item instanceof Model) {
-            model = item
+            model = item;
           } else {
-            model = item.model
-            as = item.as
+            model = item.model;
+            as = item.as;
           }
 
           // check if model provided is through table
-          var association
+          var association;
           if (!as && parentAssociation && parentAssociation.through === model) {
-            association = {as: Utils.singularize(model.tableName, model.options.language)}
+            association = {as: Utils.singularize(model.tableName, model.options.language)};
           } else {
             // find applicable association for linking parent to this model
-            association = parent.getAssociation(model, as)
+            association = parent.getAssociation(model, as);
           }
 
           if (association) {
-            tableNames[i] = association.as
-            parent = model
-            parentAssociation = association
+            tableNames[i] = association.as;
+            parent = model;
+            parentAssociation = association;
           } else {
-            tableNames[i] = model.tableName
-            throw new Error('\'' + tableNames.join('.') + '\' in order / group clause is not valid association')
+            tableNames[i] = model.tableName;
+            throw new Error('\'' + tableNames.join('.') + '\' in order / group clause is not valid association');
           }
         }
 
         // add 1st string as quoted, 2nd as unquoted raw
-        var sql = (i > 0 ? this.quoteIdentifier(tableNames.join('.')) + '.' : '') + this.quote(obj[i], parent, force)
+        var sql = (i > 0 ? this.quoteIdentifier(tableNames.join('.')) + '.' : '') + this.quote(obj[i], parent, force);
         if (i < len - 1) {
-          sql += ' ' + obj[i + 1]
+          sql += ' ' + obj[i + 1];
         }
-        return sql
+        return sql;
       } else if (obj._modelAttribute) {
-        return this.quoteTable(obj.Model.name)+'.'+obj.fieldName
+        return this.quoteTable(obj.Model.name) + '.' + obj.fieldName;
       } else if (obj._isSequelizeMethod) {
-        return obj.toString(this)
+        return obj.toString(this);
       } else if (Utils._.isObject(obj) && 'raw' in obj) {
-        return obj.raw
+        return obj.raw;
       } else {
-        throw new Error('Unknown structure passed to order / group: ' + JSON.stringify(obj))
+        throw new Error('Unknown structure passed to order / group: ' + JSON.stringify(obj));
       }
     },
 
@@ -489,49 +489,49 @@ module.exports = (function() {
      */
     createTrigger: function(tableName, triggerName, timingType, fireOnArray, functionName, functionParams,
         optionsArray) {
-      throwMethodUndefined('createTrigger')
+      throwMethodUndefined('createTrigger');
     },
 
     /*
      Drop a trigger
      */
     dropTrigger: function(tableName, triggerName) {
-      throwMethodUndefined('dropTrigger')
+      throwMethodUndefined('dropTrigger');
     },
 
     /*
      Rename a trigger
      */
     renameTrigger: function(tableName, oldTriggerName, newTriggerName) {
-      throwMethodUndefined('renameTrigger')
+      throwMethodUndefined('renameTrigger');
     },
 
     /*
      Create a function
      */
     createFunction: function(functionName, params, returnType, language, body, options) {
-      throwMethodUndefined('createFunction')
+      throwMethodUndefined('createFunction');
     },
 
     /*
      Drop a function
      */
     dropFunction: function(functionName, params) {
-      throwMethodUndefined('dropFunction')
+      throwMethodUndefined('dropFunction');
     },
 
     /*
      Rename a function
      */
     renameFunction: function(oldFunctionName, params, newFunctionName) {
-      throwMethodUndefined('renameFunction')
+      throwMethodUndefined('renameFunction');
     },
 
     /*
       Escape an identifier (e.g. a table or attribute name)
     */
     quoteIdentifier: function(identifier, force) {
-      throwMethodUndefined('quoteIdentifier')
+      throwMethodUndefined('quoteIdentifier');
     },
 
     /*
@@ -539,11 +539,11 @@ module.exports = (function() {
     */
     quoteIdentifiers: function(identifiers, force) {
       if (identifiers.indexOf('.') !== -1) {
-        identifiers = identifiers.split('.')
-        return this.quoteIdentifier(identifiers.slice(0, identifiers.length - 1).join('.')) + '.' + this.quoteIdentifier(identifiers[identifiers.length - 1])
+        identifiers = identifiers.split('.');
+        return this.quoteIdentifier(identifiers.slice(0, identifiers.length - 1).join('.')) + '.' + this.quoteIdentifier(identifiers[identifiers.length - 1]);
       } else {
-        return this.quoteIdentifier(identifiers)
-      }      
+        return this.quoteIdentifier(identifiers);
+      }
     },
 
     /*
@@ -551,9 +551,9 @@ module.exports = (function() {
     */
     escape: function(value, field) {
       if (value && value._isSequelizeMethod) {
-        return value.toString(this)
+        return value.toString(this);
       } else {
-        return SqlString.escape(value, false, null, this.dialect, field)
+        return SqlString.escape(value, false, null, this.dialect, field);
       }
     },
 
@@ -565,7 +565,7 @@ module.exports = (function() {
      * @return {String}            The generated sql query.
      */
     getForeignKeysQuery: function(tableName, schemaName) {
-      throwMethodUndefined('getForeignKeysQuery')
+      throwMethodUndefined('getForeignKeysQuery');
     },
 
     /**
@@ -576,7 +576,7 @@ module.exports = (function() {
      * @return {String}            The generated sql query.
      */
     dropForeignKeyQuery: function(tableName, foreignKey) {
-      throwMethodUndefined('dropForeignKeyQuery')
+      throwMethodUndefined('dropForeignKeyQuery');
     },
 
 
@@ -597,240 +597,239 @@ module.exports = (function() {
     selectQuery: function(tableName, options, model) {
       // Enter and change at your own peril -- Mick Hansen
 
-      options = options || {}
+      options = options || {};
 
-      var table               = null
-        , self                = this
+      var table = null
+        , self = this
         , query
-        , limit               = options.limit
-        , mainQueryItems      = []
-        , mainAttributes      = options.attributes && options.attributes.slice(0)
-        , mainJoinQueries     = []
+        , limit = options.limit
+        , mainQueryItems = []
+        , mainAttributes = options.attributes && options.attributes.slice(0)
+        , mainJoinQueries = []
         // We'll use a subquery if we have hasMany associations and a limit and a filtered/required association
-        , subQuery            = limit && (options.hasIncludeWhere || options.hasIncludeRequired || options.hasMultiAssociation)
-        , subQueryItems       = []
-        , subQueryAttributes  = null
-        , subJoinQueries      = []
-        , mainTableAs             = null
-        
+        , subQuery = limit && (options.hasIncludeWhere || options.hasIncludeRequired || options.hasMultiAssociation)
+        , subQueryItems = []
+        , subQueryAttributes = null
+        , subJoinQueries = []
+        , mainTableAs = null;
+
       if (!Array.isArray(tableName) && model) {
-        options.tableAs = mainTableAs = this.quoteTable(model.name)
+        options.tableAs = mainTableAs = this.quoteTable(model.name);
       }
       options.table = table = !Array.isArray(tableName) ? this.quoteTable(tableName) : tableName.map(function(t) {
         if (Array.isArray(t)) {
-          return this.quoteTable(t[0], t[1])
+          return this.quoteTable(t[0], t[1]);
         }
-        return this.quoteTable(t, true)
-      }.bind(this)).join(", ")
+        return this.quoteTable(t, true);
+      }.bind(this)).join(', ');
 
       if (subQuery && mainAttributes) {
         if (model.hasPrimaryKeys) {
-          model.primaryKeyAttributes.forEach(function(keyAtt){
-            if(mainAttributes.indexOf(keyAtt) == -1){
-              mainAttributes.push(keyAtt)
+          model.primaryKeyAttributes.forEach(function(keyAtt) {
+            if (mainAttributes.indexOf(keyAtt) === -1) {
+              mainAttributes.push(keyAtt);
             }
-          })
+          });
         } else {
-          mainAttributes.push("id")
-        }          
+          mainAttributes.push('id');
+        }
       }
 
       // Escape attributes
-      mainAttributes = mainAttributes && mainAttributes.map(function(attr){
-        var addTable = true
+      mainAttributes = mainAttributes && mainAttributes.map(function(attr) {
+        var addTable = true;
 
         if (attr instanceof Utils.literal) {
-          return attr.toString(this)
+          return attr.toString(this);
         }
 
         if (attr instanceof Utils.fn || attr instanceof Utils.col) {
-          return attr.toString(self)
+          return attr.toString(self);
         }
 
-        if(Array.isArray(attr) && attr.length == 2) {
+        if (Array.isArray(attr) && attr.length === 2) {
           if (attr[0] instanceof Utils.fn || attr[0] instanceof Utils.col) {
-            attr[0] = attr[0].toString(self)
-            addTable = false
+            attr[0] = attr[0].toString(self);
+            addTable = false;
           } else {
             if (attr[0].indexOf('(') === -1 && attr[0].indexOf(')') === -1) {
-              attr[0] = this.quoteIdentifier(attr[0])
+              attr[0] = this.quoteIdentifier(attr[0]);
             }
           }
-          attr = [attr[0], this.quoteIdentifier(attr[1])].join(' as ')
+          attr = [attr[0], this.quoteIdentifier(attr[1])].join(' as ');
         } else {
-          attr = attr.indexOf(Utils.TICK_CHAR) < 0 && attr.indexOf('"') < 0 ? this.quoteIdentifiers(attr) : attr
+          attr = attr.indexOf(Utils.TICK_CHAR) < 0 && attr.indexOf('"') < 0 ? this.quoteIdentifiers(attr) : attr;
         }
 
         if (options.include && attr.indexOf('.') === -1 && addTable) {
-          attr = mainTableAs + '.' + attr
+          attr = mainTableAs + '.' + attr;
         }
-        return attr
-      }.bind(this))
+        return attr;
+      }.bind(this));
 
       // If no attributes specified, use *
-      mainAttributes = mainAttributes || (options.include ? [mainTableAs+'.*'] : ['*'])
+      mainAttributes = mainAttributes || (options.include ? [mainTableAs + '.*'] : ['*']);
 
       // If subquery, we ad the mainAttributes to the subQuery and set the mainAttributes to select * from subquery
       if (subQuery) {
         // We need primary keys
-        subQueryAttributes = mainAttributes
-        mainAttributes = [mainTableAs+'.*']
+        subQueryAttributes = mainAttributes;
+        mainAttributes = [mainTableAs + '.*'];
       }
 
       if (options.include) {
         var generateJoinQueries = function(include, parentTable) {
-          var table         = include.model.getTableName()
-            , as            = include.as
-            , joinQueryItem = ""
+          var table = include.model.getTableName()
+            , as = include.as
+            , joinQueryItem = ''
             , joinQueries = {
               mainQuery: [],
               subQuery: []
             }
             , attributes
-            , association   = include.association
-            , through       = include.through
-            , joinType      = include.required ? ' INNER JOIN ' : ' LEFT OUTER JOIN '
-            , includeWhere  = {}
-            , whereOptions  = Utils._.clone(options)
+            , association = include.association
+            , through = include.through
+            , joinType = include.required ? ' INNER JOIN ' : ' LEFT OUTER JOIN '
+            , includeWhere = {}
+            , whereOptions = Utils._.clone(options);
 
-          whereOptions.keysEscaped = true
+          whereOptions.keysEscaped = true;
 
           if (tableName !== parentTable && mainTableAs !== parentTable) {
-            as = parentTable+'.'+include.as
+            as = parentTable + '.' + include.as;
           }
 
           // includeIgnoreAttributes is used by aggregate functions
           if (options.includeIgnoreAttributes !== false) {
-            attributes  = include.attributes.map(function(attr) {
+            attributes = include.attributes.map(function(attr) {
               var attrAs = attr;
 
-              if (Array.isArray(attr) && attr.length == 2) {
-                attr = attr.map(function ($attr) {
+              if (Array.isArray(attr) && attr.length === 2) {
+                attr = attr.map(function($attr) {
                   return $attr._isSequelizeMethod ? $attr.toString(self) : $attr;
-                })
-                
+                });
+
                 attrAs = attr[1];
                 attr = attr[0];
               }
-              return self.quoteIdentifier(as) + "." + self.quoteIdentifier(attr) + " AS " + self.quoteIdentifier(as + "." + attrAs);
-            })
+              return self.quoteIdentifier(as) + '.' + self.quoteIdentifier(attr) + ' AS ' + self.quoteIdentifier(as + '.' + attrAs);
+            });
 
             if (include.subQuery && subQuery) {
-              subQueryAttributes = subQueryAttributes.concat(attributes)
+              subQueryAttributes = subQueryAttributes.concat(attributes);
             } else {
-              mainAttributes = mainAttributes.concat(attributes)
+              mainAttributes = mainAttributes.concat(attributes);
             }
           }
 
           if (through) {
-            var throughTable      = through.model.getTableName()
-              , throughAs         = as + "." + through.as
+            var throughTable = through.model.getTableName()
+              , throughAs = as + '.' + through.as
               , throughAttributes = through.attributes.map(function(attr) {
-                return self.quoteIdentifier(throughAs) + "." + self.quoteIdentifier(attr) + " AS " + self.quoteIdentifier(throughAs + "." + attr)
+                return self.quoteIdentifier(throughAs) + '.' + self.quoteIdentifier(attr) + ' AS ' + self.quoteIdentifier(throughAs + '.' + attr);
               })
               , primaryKeysSource = association.source.primaryKeyAttributes
-              , tableSource       = parentTable
-              , identSource       = association.identifier
-              , attrSource        = primaryKeysSource[0]
+              , tableSource = parentTable
+              , identSource = association.identifier
+              , attrSource = primaryKeysSource[0]
               , where
 
               , primaryKeysTarget = association.target.primaryKeyAttributes
-              , tableTarget       = as
-              , identTarget       = association.foreignIdentifier
-              , attrTarget        = primaryKeysTarget[0]
+              , tableTarget = as
+              , identTarget = association.foreignIdentifier
+              , attrTarget = primaryKeysTarget[0]
 
               , sourceJoinOn
               , targetJoinOn
-              , targetWhere
+              , targetWhere;
 
             if (options.includeIgnoreAttributes !== false) {
               // Through includes are always hasMany, so we need to add the attributes to the mainAttributes no matter what (Real join will never be executed in subquery)
-              mainAttributes = mainAttributes.concat(throughAttributes)
+              mainAttributes = mainAttributes.concat(throughAttributes);
             }
 
             // Filter statement for left side of through
             // Used by both join and subquery where
-            sourceJoinOn = self.quoteTable(tableSource) + "." + self.quoteIdentifier(attrSource) + " = "
-              sourceJoinOn += self.quoteIdentifier(throughAs) + "." + self.quoteIdentifier(identSource)
+            sourceJoinOn = self.quoteTable(tableSource) + '.' + self.quoteIdentifier(attrSource) + ' = ';
+            sourceJoinOn += self.quoteIdentifier(throughAs) + '.' + self.quoteIdentifier(identSource);
 
             // Filter statement for right side of through
             // Used by both join and subquery where
-            targetJoinOn = self.quoteIdentifier(tableTarget) + "." + self.quoteIdentifier(attrTarget) + " = "
-              targetJoinOn += self.quoteIdentifier(throughAs) + "." + self.quoteIdentifier(identTarget)
+            targetJoinOn = self.quoteIdentifier(tableTarget) + '.' + self.quoteIdentifier(attrTarget) + ' = ';
+            targetJoinOn += self.quoteIdentifier(throughAs) + '.' + self.quoteIdentifier(identTarget);
 
             // Generate join SQL for left side of through
-            joinQueryItem += joinType + self.quoteTable(throughTable, throughAs) + " ON "
-              joinQueryItem += sourceJoinOn
+            joinQueryItem += joinType + self.quoteTable(throughTable, throughAs) + ' ON ';
+            joinQueryItem += sourceJoinOn;
 
             // Generate join SQL for right side of through
-            joinQueryItem += joinType + self.quoteTable(table, as) + " ON "
-              joinQueryItem += targetJoinOn
-
+            joinQueryItem += joinType + self.quoteTable(table, as) + ' ON ';
+            joinQueryItem += targetJoinOn;
 
             if (include.where) {
-              targetWhere = self.getWhereConditions(include.where, self.sequelize.literal(self.quoteIdentifier(as)), include.model, whereOptions)
-              joinQueryItem += " AND "+ targetWhere
+              targetWhere = self.getWhereConditions(include.where, self.sequelize.literal(self.quoteIdentifier(as)), include.model, whereOptions);
+              joinQueryItem += ' AND ' + targetWhere;
               if (subQuery) {
-                if (!options.where) options.where = {}
+                if (!options.where) options.where = {};
 
                 // Creating the as-is where for the subQuery, checks that the required association exists
-                options.where["__"+throughAs] = self.sequelize.asIs([ '(',
+                options.where['__' + throughAs] = self.sequelize.asIs(['(',
 
-                  "SELECT " + self.quoteIdentifier(throughAs) + "." + self.quoteIdentifier(identSource) + " FROM " + self.quoteTable(throughTable, throughAs),
-                  ! include.required && joinType + self.quoteTable(association.source.tableName, tableSource) + " ON " + sourceJoinOn || '',
-                  joinType + self.quoteTable(table, as) + " ON " + targetJoinOn,
-                  "WHERE " + ( ! include.required && targetWhere || sourceJoinOn + " AND " + targetWhere ),
-                  "LIMIT 1",
+                  'SELECT ' + self.quoteIdentifier(throughAs) + '.' + self.quoteIdentifier(identSource) + ' FROM ' + self.quoteTable(throughTable, throughAs),
+                  ! include.required && joinType + self.quoteTable(association.source.tableName, tableSource) + ' ON ' + sourceJoinOn || '',
+                  joinType + self.quoteTable(table, as) + ' ON ' + targetJoinOn,
+                  'WHERE ' + (! include.required && targetWhere || sourceJoinOn + ' AND ' + targetWhere),
+                  'LIMIT 1',
 
-                ')', 'IS NOT NULL'].join(' '))
+                ')', 'IS NOT NULL'].join(' '));
               }
             }
           } else {
             var primaryKeysLeft = association.associationType === 'BelongsTo' ? association.target.primaryKeyAttributes : include.association.source.primaryKeyAttributes
-              , tableLeft       = association.associationType === 'BelongsTo' ? as : parentTable
-              , attrLeft        = primaryKeysLeft[0]
-              , tableRight      = association.associationType === 'BelongsTo' ? parentTable : as
-              , attrRight       = association.identifier
-              , joinOn
+              , tableLeft = association.associationType === 'BelongsTo' ? as : parentTable
+              , attrLeft = primaryKeysLeft[0]
+              , tableRight = association.associationType === 'BelongsTo' ? parentTable : as
+              , attrRight = association.identifier
+              , joinOn;
 
             // Filter statement
             // Used by both join and subquery where
             joinOn =
               // Left side
               (
-                ( subQuery && !include.subQuery && include.parent.subQuery && !( include.hasParentRequired && include.hasParentWhere ) ) && self.quoteIdentifier(tableLeft + "." + attrLeft) ||
-                self.quoteTable(tableLeft) + "." + self.quoteIdentifier(attrLeft)
+                (subQuery && !include.subQuery && include.parent.subQuery && !(include.hasParentRequired && include.hasParentWhere)) && self.quoteIdentifier(tableLeft + '.' + attrLeft) ||
+                self.quoteTable(tableLeft) + '.' + self.quoteIdentifier(attrLeft)
               )
 
-              + " = " +
+              + ' = ' +
 
               // Right side
               (
-                ( subQuery && !include.subQuery && include.parent.subQuery && ( include.hasParentRequired && include.hasParentWhere ) ) && self.quoteIdentifier(tableRight + "." + attrRight) ||
-                self.quoteTable(tableRight) + "." + self.quoteIdentifier(attrRight)
-              )
+                (subQuery && !include.subQuery && include.parent.subQuery && (include.hasParentRequired && include.hasParentWhere)) && self.quoteIdentifier(tableRight + '.' + attrRight) ||
+                self.quoteTable(tableRight) + '.' + self.quoteIdentifier(attrRight)
+              );
 
             if (include.where) {
-              joinOn += " AND " + self.getWhereConditions(include.where, self.sequelize.literal(self.quoteIdentifier(as)), include.model, whereOptions)
+              joinOn += ' AND ' + self.getWhereConditions(include.where, self.sequelize.literal(self.quoteIdentifier(as)), include.model, whereOptions);
 
               // If its a multi association we need to add a where query to the main where (executed in the subquery)
               if (subQuery && association.isMultiAssociation && include.required) {
-                if (!options.where) options.where = {}
+                if (!options.where) options.where = {};
 
                 // Creating the as-is where for the subQuery, checks that the required association exists
-                options.where["__"+as] = self.sequelize.asIs([ '(',
+                options.where['__' + as] = self.sequelize.asIs(['(',
 
-                  "SELECT " + self.quoteIdentifier(attrRight),
-                  "FROM " + self.quoteTable(table, as),
-                  "WHERE " + joinOn,
-                  "LIMIT 1",
+                  'SELECT ' + self.quoteIdentifier(attrRight),
+                  'FROM ' + self.quoteTable(table, as),
+                  'WHERE ' + joinOn,
+                  'LIMIT 1',
 
-                ')', 'IS NOT NULL'].join(' '))
+                ')', 'IS NOT NULL'].join(' '));
               }
             }
 
             // Generate join SQL
-            joinQueryItem += joinType + self.quoteTable(table, as) + " ON " + joinOn
+            joinQueryItem += joinType + self.quoteTable(table, as) + ' ON ' + joinOn;
 
           }
 
@@ -842,73 +841,72 @@ module.exports = (function() {
 
           if (include.include) {
             include.include.forEach(function(childInclude) {
-              if (childInclude._pseudo) return
-              var childJoinQueries = generateJoinQueries(childInclude, as)
+              if (childInclude._pseudo) return;
+              var childJoinQueries = generateJoinQueries(childInclude, as);
 
               if (childInclude.subQuery && subQuery) {
-                joinQueries.subQuery = joinQueries.subQuery.concat(childJoinQueries.subQuery)
+                joinQueries.subQuery = joinQueries.subQuery.concat(childJoinQueries.subQuery);
               } else {
-                joinQueries.mainQuery = joinQueries.mainQuery.concat(childJoinQueries.mainQuery)
+                joinQueries.mainQuery = joinQueries.mainQuery.concat(childJoinQueries.mainQuery);
               }
-            }.bind(this))
+            }.bind(this));
           }
-          return joinQueries
-        }
+          return joinQueries;
+        };
 
         // Loop through includes and generate subqueries
         options.include.forEach(function(include) {
-          var joinQueries = generateJoinQueries(include, options.tableAs)
+          var joinQueries = generateJoinQueries(include, options.tableAs);
 
-          subJoinQueries = subJoinQueries.concat(joinQueries.subQuery)
-          mainJoinQueries = mainJoinQueries.concat(joinQueries.mainQuery)
-        }.bind(this))
+          subJoinQueries = subJoinQueries.concat(joinQueries.subQuery);
+          mainJoinQueries = mainJoinQueries.concat(joinQueries.mainQuery);
+        }.bind(this));
       }
 
       // If using subQuery select defined subQuery attributes and join subJoinQueries
       if (subQuery) {
-        subQueryItems.push("SELECT " + subQueryAttributes.join(', ') + " FROM " + options.table)
+        subQueryItems.push('SELECT ' + subQueryAttributes.join(', ') + ' FROM ' + options.table);
         if (mainTableAs) {
-          subQueryItems.push(" AS "+mainTableAs)
+          subQueryItems.push(' AS ' + mainTableAs);
         }
-        subQueryItems.push(subJoinQueries.join(''))
+        subQueryItems.push(subJoinQueries.join(''));
 
       // Else do it the reguar way
       } else {
-        mainQueryItems.push("SELECT " + mainAttributes.join(', ') + " FROM " + options.table)
+        mainQueryItems.push('SELECT ' + mainAttributes.join(', ') + ' FROM ' + options.table);
         if (mainTableAs) {
-          mainQueryItems.push(" AS "+mainTableAs)
+          mainQueryItems.push(' AS ' + mainTableAs);
         }
-        mainQueryItems.push(mainJoinQueries.join(''))
+        mainQueryItems.push(mainJoinQueries.join(''));
       }
 
       // Add WHERE to sub or main query
       if (options.hasOwnProperty('where')) {
-
-        options.where = this.getWhereConditions(options.where, mainTableAs || tableName, model, options)
+        options.where = this.getWhereConditions(options.where, mainTableAs || tableName, model, options);
         if (subQuery) {
-          subQueryItems.push(" WHERE " + options.where)
+          subQueryItems.push(' WHERE ' + options.where);
         } else {
-          mainQueryItems.push(" WHERE " + options.where)
+          mainQueryItems.push(' WHERE ' + options.where);
         }
       }
 
       // Add GROUP BY to sub or main query
       if (options.group) {
-        options.group = Array.isArray(options.group) ? options.group.map(function (t) { return this.quote(t, model) }.bind(this)).join(', ') : options.group
+        options.group = Array.isArray(options.group) ? options.group.map(function(t) { return this.quote(t, model); }.bind(this)).join(', ') : options.group;
         if (subQuery) {
-          subQueryItems.push(" GROUP BY " + options.group)
+          subQueryItems.push(' GROUP BY ' + options.group);
         } else {
-          mainQueryItems.push(" GROUP BY " + options.group)
+          mainQueryItems.push(' GROUP BY ' + options.group);
         }
       }
-      
+
       // Add HAVING to sub or main query
       if (options.hasOwnProperty('having')) {
-        options.having = this.getWhereConditions(options.having, tableName, model, options, false)
+        options.having = this.getWhereConditions(options.having, tableName, model, options, false);
         if (subQuery) {
-          subQueryItems.push(" HAVING " + options.having)
+          subQueryItems.push(' HAVING ' + options.having);
         } else {
-          mainQueryItems.push(" HAVING " + options.having)
+          mainQueryItems.push(' HAVING ' + options.having);
         }
       }
 
@@ -918,57 +916,57 @@ module.exports = (function() {
         var subQueryOrder = [];
 
         if (Array.isArray(options.order)) {
-          options.order.forEach(function (t) {
+          options.order.forEach(function(t) {
             if (subQuery && !(t[0] instanceof Model) && !(t[0].model instanceof Model)) {
-              subQueryOrder.push(this.quote(t, model))
+              subQueryOrder.push(this.quote(t, model));
             }
-            mainQueryOrder.push(this.quote(t, model))
-          }.bind(this))
+            mainQueryOrder.push(this.quote(t, model));
+          }.bind(this));
         } else {
-          mainQueryOrder.push(options.order)
+          mainQueryOrder.push(options.order);
         }
-        
+
         if (mainQueryOrder.length) {
-          mainQueryItems.push(" ORDER BY " + mainQueryOrder.join(', '))
+          mainQueryItems.push(' ORDER BY ' + mainQueryOrder.join(', '));
         }
         if (subQueryOrder.length) {
-          subQueryItems.push(" ORDER BY " + subQueryOrder.join(', '))
+          subQueryItems.push(' ORDER BY ' + subQueryOrder.join(', '));
         }
       }
 
-      var limitOrder = this.addLimitAndOffset(options, query)
+      var limitOrder = this.addLimitAndOffset(options, query);
 
       // Add LIMIT, OFFSET to sub or main query
       if (limitOrder) {
         if (subQuery) {
-          subQueryItems.push(limitOrder)
+          subQueryItems.push(limitOrder);
         } else {
-          mainQueryItems.push(limitOrder)
+          mainQueryItems.push(limitOrder);
         }
       }
 
       // If using subQuery, select attributes from wrapped subQuery and join out join tables
       if (subQuery) {
-        query = "SELECT " + mainAttributes.join(', ') + " FROM ("
-          query += subQueryItems.join('')
-        query += ") AS "+options.tableAs
-        query += mainJoinQueries.join('')
-        query += mainQueryItems.join('')
+        query = 'SELECT ' + mainAttributes.join(', ') + ' FROM (';
+        query += subQueryItems.join('');
+        query += ') AS ' + options.tableAs;
+        query += mainJoinQueries.join('');
+        query += mainQueryItems.join('');
       } else {
-        query = mainQueryItems.join('')
+        query = mainQueryItems.join('');
       }
 
       if (options.lock && this._dialect.supports.lock) {
         if (options.lock === 'SHARE') {
-          query += ' ' + this._dialect.supports.forShare
+          query += ' ' + this._dialect.supports.forShare;
         } else {
-          query += ' FOR UPDATE'
+          query += ' FOR UPDATE';
         }
       }
 
-      query += ";";
+      query += ';';
 
-      return query
+      return query;
     },
 
     /**
@@ -978,11 +976,11 @@ module.exports = (function() {
      * @return {String}        The generated sql query.
      */
     setAutocommitQuery: function(value) {
-      return "SET autocommit = " + (!!value ? 1 : 0) + ";"
+      return 'SET autocommit = ' + (!!value ? 1 : 0) + ';';
     },
 
     setIsolationLevelQuery: function(value) {
-      return "SET SESSION TRANSACTION ISOLATION LEVEL " + value + ";"
+      return 'SET SESSION TRANSACTION ISOLATION LEVEL ' + value + ';';
     },
 
     /**
@@ -992,7 +990,7 @@ module.exports = (function() {
      * @return {String}         The generated sql query.
      */
     startTransactionQuery: function(options) {
-      return "START TRANSACTION;"
+      return 'START TRANSACTION;';
     },
 
     /**
@@ -1002,7 +1000,7 @@ module.exports = (function() {
      * @return {String}         The generated sql query.
      */
     commitTransactionQuery: function(options) {
-      return "COMMIT;"
+      return 'COMMIT;';
     },
 
     /**
@@ -1012,19 +1010,19 @@ module.exports = (function() {
      * @return {String}         The generated sql query.
      */
     rollbackTransactionQuery: function(options) {
-      return "ROLLBACK;"
+      return 'ROLLBACK;';
     },
 
     addLimitAndOffset: function(options, query) {
-      query = query || ""
+      query = query || '';
 
       if (options.offset && !options.limit) {
-        query += " LIMIT " + options.offset + ", " + 10000000000000;
+        query += ' LIMIT ' + options.offset + ', ' + 10000000000000;
       } else if (options.limit) {
         if (options.offset) {
-          query += " LIMIT " + options.offset + ", " + options.limit
+          query += ' LIMIT ' + options.offset + ', ' + options.limit;
         } else {
-          query += " LIMIT " + options.limit
+          query += ' LIMIT ' + options.limit;
         }
       }
       return query;
@@ -1035,145 +1033,145 @@ module.exports = (function() {
     */
     getWhereConditions: function(smth, tableName, factory, options, prepend) {
       var result = null
-        , where  = {}
-        , self   = this
+        , where = {}
+        , self = this;
 
       if (Array.isArray(tableName)) {
-        tableName = tableName[0]
+        tableName = tableName[0];
         if (Array.isArray(tableName)) {
-          tableName = tableName[1]
+          tableName = tableName[1];
         }
       }
 
-      options = options || {}
+      options = options || {};
 
       if (typeof prepend === 'undefined') {
-        prepend = true
+        prepend = true;
       }
 
       if ((smth instanceof Utils.and) || (smth instanceof Utils.or)) {
-        var connector = (smth instanceof Utils.and) ? ' AND ' : ' OR '
+        var connector = (smth instanceof Utils.and) ? ' AND ' : ' OR ';
 
-        result = smth.args.filter(function (arg) {
-          return arg !== undefined
+        result = smth.args.filter(function(arg) {
+          return arg !== undefined;
         }).map(function(arg) {
-          return self.getWhereConditions(arg, tableName, factory, options, prepend)
-        }).join(connector)
+          return self.getWhereConditions(arg, tableName, factory, options, prepend);
+        }).join(connector);
 
-        result = "(" + result + ")"
+        result = '(' + result + ')';
       } else if (smth instanceof Utils.where) {
         var value = smth.logic
-          , key = this.quoteTable(smth.attribute.Model.name)+'.'+this.quoteIdentifier(smth.attribute.fieldName)
+          , key = this.quoteTable(smth.attribute.Model.name) + '.' + this.quoteIdentifier(smth.attribute.fieldName)
           , logic
           , _result = []
-          , _value
+          , _value;
 
         if (_.isObject(value)) {
           if (value.join) {
             //using as sentinel for join column => value
-            result = [key, value.join].join("=")
+            result = [key, value.join].join('=');
           } else {
             for (logic in value) {
-              _result.push([key, this.escape(value[logic])].join(' ' + Utils.getWhereLogic(logic, value[logic]) + ' '))
+              _result.push([key, this.escape(value[logic])].join(' ' + Utils.getWhereLogic(logic, value[logic]) + ' '));
             }
 
-            result = _result.join(" AND ")
+            result = _result.join(' AND ');
           }
         } else {
           if (typeof value === 'boolean') {
             value = this.booleanValue(value);
           } else {
-            value = this.escape(value)
+            value = this.escape(value);
           }
 
-          result = (value == 'NULL') ? key + " IS NULL" : [key, value].join("=")
+          result = (value === 'NULL') ? key + ' IS NULL' : [key, value].join('=');
         }
       } else if (Utils.isHash(smth)) {
         if (prepend) {
-          if (tableName) options.keysEscaped = true
-          smth = this.prependTableNameToHash(tableName, smth)
+          if (tableName) options.keysEscaped = true;
+          smth = this.prependTableNameToHash(tableName, smth);
         }
 
-        result = this.hashToWhereConditions(smth, factory, options)
+        result = this.hashToWhereConditions(smth, factory, options);
       } else if (typeof smth === 'number') {
-        var primaryKeys = !!factory ? Object.keys(factory.primaryKeys) : []
+        var primaryKeys = !!factory ? Object.keys(factory.primaryKeys) : [];
 
         if (primaryKeys.length > 0) {
           // Since we're just a number, assume only the first key
-          primaryKeys = primaryKeys[0]
+          primaryKeys = primaryKeys[0];
         } else {
-          primaryKeys = 'id'
+          primaryKeys = 'id';
         }
 
-        where[primaryKeys] = smth
+        where[primaryKeys] = smth;
 
-        if (tableName) options.keysEscaped = true
-        smth   = this.prependTableNameToHash(tableName, where)
-        result = this.hashToWhereConditions(smth)
-      } else if (typeof smth === "string") {
-        result = smth
+        if (tableName) options.keysEscaped = true;
+        smth = this.prependTableNameToHash(tableName, where);
+        result = this.hashToWhereConditions(smth);
+      } else if (typeof smth === 'string') {
+        result = smth;
       } else if (Buffer.isBuffer(smth)) {
-        result = this.escape(smth)
+        result = this.escape(smth);
       } else if (Array.isArray(smth)) {
         var treatAsAnd = smth.reduce(function(treatAsAnd, arg) {
           if (treatAsAnd) {
-            return treatAsAnd
+            return treatAsAnd;
           } else {
-            return !(arg instanceof Date) && ((arg instanceof Utils.and) || (arg instanceof Utils.or) || Utils.isHash(arg))
+            return !(arg instanceof Date) && ((arg instanceof Utils.and) || (arg instanceof Utils.or) || Utils.isHash(arg));
           }
-        }, false)
+        }, false);
 
         if (treatAsAnd) {
-          var _smth = self.sequelize.and.apply(null, smth)
-          result = self.getWhereConditions(_smth, tableName, factory, options, prepend)
+          var _smth = self.sequelize.and.apply(null, smth);
+          result = self.getWhereConditions(_smth, tableName, factory, options, prepend);
         } else {
-          result = Utils.format(smth, this.dialect)
+          result = Utils.format(smth, this.dialect);
         }
       }
 
-      return result ? result : '1=1'
+      return result ? result : '1=1';
     },
 
     prependTableNameToHash: function(tableName, hash) {
       if (tableName) {
-        var _hash = {}
+        var _hash = {};
 
         for (var key in hash) {
           if (key.indexOf('.') === -1) {
             if (tableName instanceof Utils.literal) {
-              _hash[tableName + '.' + this.quoteIdentifier(key)] = hash[key]
+              _hash[tableName + '.' + this.quoteIdentifier(key)] = hash[key];
             } else {
-              _hash[this.quoteTable(tableName) + '.' + this.quoteIdentifier(key)] = hash[key]
+              _hash[this.quoteTable(tableName) + '.' + this.quoteIdentifier(key)] = hash[key];
             }
           } else {
-            _hash[this.quoteIdentifiers(key)] = hash[key]
+            _hash[this.quoteIdentifiers(key)] = hash[key];
           }
         }
 
-        return _hash
+        return _hash;
       } else {
-        return hash
+        return hash;
       }
     },
 
-    findAssociation: function(attribute, dao){
+    findAssociation: function(attribute, dao) {
       var associationToReturn;
 
-      Object.keys(dao.associations).forEach(function(key){
-        if(!dao.associations[key]) return;
+      Object.keys(dao.associations).forEach(function(key) {
+        if (!dao.associations[key]) return;
 
 
         var association = dao.associations[key]
-          , associationName
+          , associationName;
 
         if (association.associationType === 'BelongsTo') {
           associationName = Utils.singularize(association.associationAccessor[0].toLowerCase() + association.associationAccessor.slice(1));
         } else {
-          associationName = association.accessors.get.replace('get', '')
+          associationName = association.accessors.get.replace('get', '');
           associationName = associationName[0].toLowerCase() + associationName.slice(1);
         }
 
-        if(associationName === attribute){
+        if (associationName === attribute) {
           associationToReturn = association;
         }
       });
@@ -1181,21 +1179,21 @@ module.exports = (function() {
       return associationToReturn;
     },
 
-    getAssociationFilterDAO: function(filterStr, dao){
+    getAssociationFilterDAO: function(filterStr, dao) {
       var associationParts = filterStr.split('.')
-        , self = this
+        , self = this;
 
-      associationParts.pop()
+      associationParts.pop();
 
-      associationParts.forEach(function (attribute) {
+      associationParts.forEach(function(attribute) {
         dao = self.findAssociation(attribute, dao).target;
       });
 
       return dao;
     },
 
-    isAssociationFilter: function(filterStr, dao, options){
-      if(!dao){
+    isAssociationFilter: function(filterStr, dao, options) {
+      if (!dao) {
         return false;
       }
 
@@ -1204,9 +1202,9 @@ module.exports = (function() {
 
       var associationParts = filterStr.split('.')
         , attributePart = associationParts.pop()
-        , self = this
+        , self = this;
 
-      return associationParts.every(function (attribute) {
+      return associationParts.every(function(attribute) {
         var association = self.findAssociation(attribute, dao);
         if (!association) return false;
         dao = association.target;
@@ -1214,62 +1212,62 @@ module.exports = (function() {
       }) && dao.rawAttributes.hasOwnProperty(attributePart);
     },
 
-    getAssociationFilterColumn: function(filterStr, dao, options){
+    getAssociationFilterColumn: function(filterStr, dao, options) {
       var associationParts = filterStr.split('.')
         , attributePart = associationParts.pop()
         , self = this
         , association
-        , keyParts = []
+        , keyParts = [];
 
-      associationParts.forEach(function (attribute) {
-        association = self.findAssociation(attribute, dao)
+      associationParts.forEach(function(attribute) {
+        association = self.findAssociation(attribute, dao);
         dao = association.target;
         if (options.include) {
-          keyParts.push(association.as || association.options.as || dao.tableName)
+          keyParts.push(association.as || association.options.as || dao.tableName);
         }
-      })
+      });
 
       if (options.include) {
-        return this.quoteIdentifier(keyParts.join('.')) + '.' + this.quoteIdentifiers(attributePart)
+        return this.quoteIdentifier(keyParts.join('.')) + '.' + this.quoteIdentifiers(attributePart);
       }
-      return this.quoteIdentifiers(dao.tableName + '.' + attributePart)
+      return this.quoteIdentifiers(dao.tableName + '.' + attributePart);
     },
 
-    getConditionalJoins: function(options, originalDao){
+    getConditionalJoins: function(options, originalDao) {
       var joins = ''
         , self = this
-        , joinedTables = {}
+        , joinedTables = {};
 
       if (Utils.isHash(options.where)) {
-        Object.keys(options.where).forEach(function(filterStr){
+        Object.keys(options.where).forEach(function(filterStr) {
           var associationParts = filterStr.split('.')
             , attributePart = associationParts.pop()
-            , dao = originalDao
+            , dao = originalDao;
 
           if (self.isAssociationFilter(filterStr, dao, options)) {
-            associationParts.forEach(function (attribute) {
+            associationParts.forEach(function(attribute) {
               var association = self.findAssociation(attribute, dao);
 
-              if(!joinedTables[association.target.tableName]){
+              if (!joinedTables[association.target.tableName]) {
                 joinedTables[association.target.tableName] = true;
 
-                if(association.associationType === 'BelongsTo'){
-                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName)
-                  joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.identifier)
-                  joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.target.autoIncrementField)
+                if (association.associationType === 'BelongsTo') {
+                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName);
+                  joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.identifier);
+                  joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.target.autoIncrementField);
                 } else if (Object(association.through) === association.through) {
                   joinedTables[association.through.tableName] = true;
-                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.through.tableName)
-                  joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.source.autoIncrementField)
-                  joins += ' = ' + self.quoteIdentifiers(association.through.tableName + '.' + association.identifier)
+                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.through.tableName);
+                  joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.source.autoIncrementField);
+                  joins += ' = ' + self.quoteIdentifiers(association.through.tableName + '.' + association.identifier);
 
-                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName)
-                  joins += ' ON ' + self.quoteIdentifiers(association.through.tableName + '.' + association.foreignIdentifier)
-                  joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.target.autoIncrementField)
+                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName);
+                  joins += ' ON ' + self.quoteIdentifiers(association.through.tableName + '.' + association.foreignIdentifier);
+                  joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.target.autoIncrementField);
                 } else {
-                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName)
-                  joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.source.autoIncrementField)
-                  joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.identifier)
+                  joins += ' LEFT JOIN ' + self.quoteIdentifiers(association.target.tableName);
+                  joins += ' ON ' + self.quoteIdentifiers(association.source.tableName + '.' + association.source.autoIncrementField);
+                  joins += ' = ' + self.quoteIdentifiers(association.target.tableName + '.' + association.identifier);
                 }
               }
               dao = association.target;
@@ -1281,12 +1279,12 @@ module.exports = (function() {
       return joins;
     },
 
-    arrayValue: function(value, key, _key, factory, logicResult){
+    arrayValue: function(value, key, _key, factory, logicResult) {
         var _value = null;
 
-        if (value.length === 0) { value = [null] }
-        _value = "(" + value.map(function(v) { return this.escape(v) }.bind(this)).join(',') + ")"
-        return [_key, _value].join(" " + logicResult + " ")
+        if (value.length === 0) { value = [null]; }
+        _value = '(' + value.map(function(v) { return this.escape(v); }.bind(this)).join(',') + ')';
+        return [_key, _value].join(' ' + logicResult + ' ');
     },
 
     /*
@@ -1294,52 +1292,52 @@ module.exports = (function() {
       The values are transformed by the relevant datatype.
     */
     hashToWhereConditions: function(hash, dao, options) {
-      var result = []
+      var result = [];
 
-      options = options || {}
+      options = options || {};
 
       // Closures are nice
-      Utils._.each(hash, function (value, key) {
+      Utils._.each(hash, function(value, key) {
         var _key
-          , _value = null
+          , _value = null;
 
         if (value instanceof Utils.asIs) {
-          result.push(value.toString(this))
-          return
+          result.push(value.toString(this));
+          return;
         }
 
         if (options.keysEscaped) {
-          _key = key
+          _key = key;
         } else {
-          if(this.isAssociationFilter(key, dao, options)){
+          if (this.isAssociationFilter(key, dao, options)) {
             _key = key = this.getAssociationFilterColumn(key, dao, options);
           } else {
-            _key = this.quoteIdentifiers(key)
+            _key = this.quoteIdentifiers(key);
           }
         }
 
         if (Array.isArray(value)) {
-          result.push(this.arrayValue(value, key, _key, dao, "IN"))
-        } else if ((value) && (typeof value == 'object') && !(value instanceof Date) && !Buffer.isBuffer(value)) {
+          result.push(this.arrayValue(value, key, _key, dao, 'IN'));
+        } else if ((value) && (typeof value === 'object') && !(value instanceof Date) && !Buffer.isBuffer(value)) {
           if (!!value.join) {
             //using as sentinel for join column => value
-            _value = this.quoteIdentifiers(value.join)
-            result.push([_key, _value].join("="))
+            _value = this.quoteIdentifiers(value.join);
+            result.push([_key, _value].join('='));
           } else {
             for (var logic in value) {
               var logicResult = Utils.getWhereLogic(logic, hash[key][logic]);
-              if (logicResult === "IN" || logicResult === "NOT IN") {
-                var values = Array.isArray(value[logic]) ? value[logic] : [value[logic]]
-                result.push(this.arrayValue(values, key, _key, dao, logicResult))
+              if (logicResult === 'IN' || logicResult === 'NOT IN') {
+                var values = Array.isArray(value[logic]) ? value[logic] : [value[logic]];
+                result.push(this.arrayValue(values, key, _key, dao, logicResult));
               }
-              else if (logicResult === "BETWEEN" || logicResult === "NOT BETWEEN") {
-                _value = this.escape(value[logic][0])
-                var _value2 = this.escape(value[logic][1])
+              else if (logicResult === 'BETWEEN' || logicResult === 'NOT BETWEEN') {
+                _value = this.escape(value[logic][0]);
+                var _value2 = this.escape(value[logic][1]);
 
-                result.push(' (' + _key + ' ' + logicResult + ' ' + _value + ' AND ' + _value2 + ') ')
+                result.push(' (' + _key + ' ' + logicResult + ' ' + _value + ' AND ' + _value2 + ') ');
               } else {
-                _value = this.escape(value[logic])
-                result.push([_key, _value].join(' ' + logicResult + ' '))
+                _value = this.escape(value[logic]);
+                result.push([_key, _value].join(' ' + logicResult + ' '));
               }
             }
           }
@@ -1347,25 +1345,25 @@ module.exports = (function() {
           if (typeof value === 'boolean') {
             _value = this.booleanValue(value);
           } else {
-            _value = this.escape(value)
+            _value = this.escape(value);
           }
 
-          result.push((_value == 'NULL') ? _key + " IS NULL" : [_key, _value].join("="))
+          result.push((_value === 'NULL') ? _key + ' IS NULL' : [_key, _value].join('='));
         }
-      }.bind(this))
+      }.bind(this));
 
-      return result.join(" AND ")
+      return result.join(' AND ');
     },
 
-    booleanValue: function(value){
+    booleanValue: function(value) {
       return value;
     }
-  }
+  };
 
   var throwMethodUndefined = function(methodName) {
-    throw new Error('The method "' + methodName + '" is not defined! Please add it to your sql dialect.')
-  }
+    throw new Error('The method "' + methodName + '" is not defined! Please add it to your sql dialect.');
+  };
 
-  return QueryGenerator
-})()
+  return QueryGenerator;
+})();
 

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict';
 
-var Utils              = require('../../utils')
-  , CustomEventEmitter = require("../../emitters/custom-event-emitter")
-  , Promise            = require("../../promise")
-  , Dot                = require('dottie')
-  , _                  = require('lodash')
-  , QueryTypes         = require('../../query-types')
+var Utils = require('../../utils')
+  , CustomEventEmitter = require('../../emitters/custom-event-emitter')
+  , Promise = require('../../promise')
+  , Dot = require('dottie')
+  , _ = require('lodash')
+  , QueryTypes = require('../../query-types');
 
 module.exports = (function() {
-  var AbstractQuery = function(database, sequelize, callee, options) {}
+  var AbstractQuery = function(database, sequelize, callee, options) {};
 
   /**
     Inherit from CustomEventEmitter
   */
-  Utils.inherit(AbstractQuery, CustomEventEmitter)
+  Utils.inherit(AbstractQuery, CustomEventEmitter);
 
   /**
    * Execute the passed sql query.
@@ -26,8 +26,8 @@ module.exports = (function() {
    * @api public
    */
   AbstractQuery.prototype.run = function(sql) {
-    throw new Error("The run method wasn't overwritten!")
-  }
+    throw new Error("The run method wasn't overwritten!");
+  };
 
   /**
    * Check the logging option of the instance and print deprecation warnings.
@@ -36,15 +36,15 @@ module.exports = (function() {
    */
   AbstractQuery.prototype.checkLoggingOption = function() {
     if (this.options.logging === true) {
-      console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log')
-      this.options.logging = console.log
+      console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
+      this.options.logging = console.log;
     }
 
     if (this.options.logging === console.log) {
       // using just console.log will break in node < 0.6
-      this.options.logging = function(s) { console.log(s) }
+      this.options.logging = function(s) { console.log(s); };
     }
-  }
+  };
 
   /**
    * High level function that handles the results of a query execution.
@@ -63,48 +63,48 @@ module.exports = (function() {
    * @param {Array} data - The result of the query execution.
    */
   AbstractQuery.prototype.formatResults = function(data) {
-    var result  = this.callee
+    var result = this.callee;
 
     if (isInsertQuery.call(this, data)) {
-      handleInsertQuery.call(this, data)
+      handleInsertQuery.call(this, data);
     }
 
     if (isSelectQuery.call(this)) {
-      result = handleSelectQuery.call(this, data)
+      result = handleSelectQuery.call(this, data);
     } else if (isShowTableQuery.call(this)) {
-      result = handleShowTableQuery.call(this, data)
+      result = handleShowTableQuery.call(this, data);
     } else if (isShowOrDescribeQuery.call(this)) {
-      result = data
+      result = data;
 
       if (this.sql.toLowerCase().indexOf('describe') === 0) {
-        result = {}
+        result = {};
 
         data.forEach(function(_result) {
           result[_result.Field] = {
-            type:         _result.Type.toUpperCase(),
-            allowNull:    (_result.Null === 'YES'),
+            type: _result.Type.toUpperCase(),
+            allowNull: (_result.Null === 'YES'),
             defaultValue: _result.Default
-          }
-        })
+          };
+        });
       } else if (this.sql.toLowerCase().indexOf('show index from') === 0) {
         result = Utils._.uniq(result.map(function(result) {
           return {
-            name:       result.Key_name,
-            tableName:  result.Table,
-            unique:     (result.Non_unique !== 1)
-          }
+            name: result.Key_name,
+            tableName: result.Table,
+            unique: (result.Non_unique !== 1)
+          };
         }), false, function(row) {
-          return row.name
-        })
+          return row.name;
+        });
       }
     } else if (isCallQuery.call(this)) {
-      result = data[0]
+      result = data[0];
     } else if (isBulkUpdateQuery.call(this) || isBulkDeleteQuery.call(this)) {
-      result = data.affectedRows
+      result = data.affectedRows;
     }
 
-    return result
-  }
+    return result;
+  };
 
   /**
    * This function is a wrapper for private methods.
@@ -113,9 +113,9 @@ module.exports = (function() {
    *
    */
   AbstractQuery.prototype.send = function(fctName/*, arg1, arg2, arg3, ...*/) {
-    var args = Array.prototype.slice.call(arguments).slice(1)
-    return eval(fctName).apply(this, args)
-  }
+    var args = Array.prototype.slice.call(arguments).slice(1);
+    return eval(fctName).apply(this, args);
+  };
 
   /**
    * Get the attributes of an insert query, which contains the just inserted id.
@@ -123,8 +123,8 @@ module.exports = (function() {
    * @return {String} The field name.
    */
   AbstractQuery.prototype.getInsertIdField = function() {
-    return 'insertId'
-  }
+    return 'insertId';
+  };
 
   /////////////
   // private //
@@ -139,97 +139,97 @@ module.exports = (function() {
    */
   var findTableNameInAttribute = function(attribute) {
     if (!this.options.include) {
-      return null
+      return null;
     }
     if (!this.options.includeNames) {
       this.options.includeNames = this.options.include.map(function(include) {
-        return include.as
-      })
+        return include.as;
+      });
     }
 
     var tableNames = this.options.includeNames.filter(function(include) {
-      return attribute.indexOf(include + '.') === 0
-    })
+      return attribute.indexOf(include + '.') === 0;
+    });
 
     if (tableNames.length === 1) {
-      return tableNames[0]
+      return tableNames[0];
     } else {
-      return null
+      return null;
     }
-  }
+  };
 
   var isInsertQuery = function(results, metaData) {
-    var result = true
+    var result = true;
 
     // is insert query if sql contains insert into
-    result = result && (this.sql.toLowerCase().indexOf('insert into') === 0)
+    result = result && (this.sql.toLowerCase().indexOf('insert into') === 0);
 
     // is insert query if no results are passed or if the result has the inserted id
-    result = result && (!results || results.hasOwnProperty(this.getInsertIdField()))
+    result = result && (!results || results.hasOwnProperty(this.getInsertIdField()));
 
     // is insert query if no metadata are passed or if the metadata has the inserted id
-    result = result && (!metaData || metaData.hasOwnProperty(this.getInsertIdField()))
+    result = result && (!metaData || metaData.hasOwnProperty(this.getInsertIdField()));
 
-    return result
-  }
+    return result;
+  };
 
   var handleInsertQuery = function(results, metaData) {
     if (this.callee) {
       // add the inserted row id to the instance
       var autoIncrementField = this.callee.Model.autoIncrementField
-        , id                 = null
+        , id = null;
 
-      id = id || (results && results[this.getInsertIdField()])
-      id = id || (metaData && metaData[this.getInsertIdField()])
+      id = id || (results && results[this.getInsertIdField()]);
+      id = id || (metaData && metaData[this.getInsertIdField()]);
 
-      this.callee[autoIncrementField] = id
+      this.callee[autoIncrementField] = id;
     }
-  }
+  };
 
   var isShowTableQuery = function() {
-    return (this.sql.toLowerCase().indexOf('show tables') === 0)
-  }
+    return (this.sql.toLowerCase().indexOf('show tables') === 0);
+  };
 
   var handleShowTableQuery = function(results) {
     return Utils._.flatten(results.map(function(resultSet) {
-      return Utils._.values(resultSet)
-    }))
-  }
+      return Utils._.values(resultSet);
+    }));
+  };
 
   var isSelectQuery = function() {
-    return this.options.type === QueryTypes.SELECT
-  }
-  
+    return this.options.type === QueryTypes.SELECT;
+  };
+
   var isBulkUpdateQuery = function() {
-    return this.options.type === QueryTypes.BULKUPDATE
-  }
+    return this.options.type === QueryTypes.BULKUPDATE;
+  };
 
   var isBulkDeleteQuery = function() {
-    return this.options.type === QueryTypes.BULKDELETE
-  }
+    return this.options.type === QueryTypes.BULKDELETE;
+  };
 
   var isUpdateQuery = function() {
-    return (this.sql.toLowerCase().indexOf('update') === 0)
-  }
+    return (this.sql.toLowerCase().indexOf('update') === 0);
+  };
 
   var handleSelectQuery = function(results) {
-    var result = null
+    var result = null;
 
     // Raw queries
     if (this.options.raw) {
       result = results.map(function(result) {
-        var o = {}
+        var o = {};
 
         for (var key in result) {
           if (result.hasOwnProperty(key)) {
-            o[key] = result[key]
+            o[key] = result[key];
           }
         }
 
-        return o
-      })
+        return o;
+      });
 
-      result = result.map(Dot.transform)
+      result = result.map(Dot.transform);
 
     // Queries with include
     } else if (this.options.hasJoin === true) {
@@ -239,33 +239,33 @@ module.exports = (function() {
         includeNames: this.options.includeNames
       }, {
         checkExisting: this.options.hasMultiAssociation
-      })
+      });
 
       result = this.callee.bulkBuild(results, {
         isNewRecord: false,
         isDirty: false,
-        include:this.options.include,
+        include: this.options.include,
         includeNames: this.options.includeNames,
         includeMap: this.options.includeMap,
         includeValidated: true,
         attributes: this.options.originalAttributes || this.options.attributes,
         raw: true
-      })
+      });
     } else if (this.options.hasJoinTableModel === true) {
       result = results.map(function(result) {
-        result = Dot.transform(result)
+        result = Dot.transform(result);
 
         var joinTableData = result[this.options.joinTableModel.name]
           , joinTableDAO = this.options.joinTableModel.build(joinTableData, { isNewRecord: false, isDirty: false })
-          , mainDao
+          , mainDao;
 
-        delete result[this.options.joinTableModel.name]
+        delete result[this.options.joinTableModel.name];
 
-        mainDao = this.callee.build(result, { isNewRecord: false, isDirty: false })
-        mainDao[this.options.joinTableModel.name] = joinTableDAO
+        mainDao = this.callee.build(result, { isNewRecord: false, isDirty: false });
+        mainDao[this.options.joinTableModel.name] = joinTableDAO;
 
-        return mainDao
-      }.bind(this))
+        return mainDao;
+      }.bind(this));
 
     // Regular queries
     } else {
@@ -274,33 +274,33 @@ module.exports = (function() {
         isDirty: false,
         raw: true,
         attributes: this.options.attributes
-      })
+      });
     }
 
     // return the first real model instance if options.plain is set (e.g. Model.find)
     if (this.options.plain) {
-      result = (result.length === 0) ? null : result[0]
+      result = (result.length === 0) ? null : result[0];
     }
 
-    return result
-  }
+    return result;
+  };
 
   var isShowOrDescribeQuery = function() {
-    var result = false
+    var result = false;
 
-    result = result || (this.sql.toLowerCase().indexOf('show') === 0)
-    result = result || (this.sql.toLowerCase().indexOf('describe') === 0)
+    result = result || (this.sql.toLowerCase().indexOf('show') === 0);
+    result = result || (this.sql.toLowerCase().indexOf('describe') === 0);
 
-    return  result
-  }
+    return result;
+  };
 
   var isCallQuery = function() {
-    var result = false
+    var result = false;
 
-    result = result || (this.sql.toLowerCase().indexOf('call') === 0)
+    result = result || (this.sql.toLowerCase().indexOf('call') === 0);
 
-    return result
-  }
+    return result;
+  };
 
 
   /**
@@ -349,85 +349,86 @@ module.exports = (function() {
       , child
       , calleeDataIgnore = ['__children']
       , parseChildren = function(result) {
-        _.each(result.__children, function (children, key) {
-          result[key] = groupJoinData(children, (includeOptions.includeMap && includeOptions.includeMap[key]), options)
-        })
-        delete result.__children
-      },
-      primaryKeyAttribute,
-      primaryKeyMap = {}
+        _.each(result.__children, function(children, key) {
+          result[key] = groupJoinData(children, (includeOptions.includeMap && includeOptions.includeMap[key]), options);
+        });
+
+        delete result.__children;
+      }
+      , primaryKeyAttribute
+      , primaryKeyMap = {};
 
     // Ignore all include keys on main data
     if (includeOptions.includeNames) {
-      calleeDataIgnore = calleeDataIgnore.concat(includeOptions.includeNames)
+      calleeDataIgnore = calleeDataIgnore.concat(includeOptions.includeNames);
     }
     if (includeOptions.model.primaryKeyAttributes.length === 1) {
-      primaryKeyAttribute = includeOptions.model.primaryKeyAttribute
+      primaryKeyAttribute = includeOptions.model.primaryKeyAttribute;
     }
 
     data.forEach(function parseRow(row) {
-      row = Dot.transform(row)
-      calleeData = row
+      row = Dot.transform(row);
+      calleeData = row;
 
       // If there are :M associations included we need to see if the main result of the row has already been identified
       if (options.checkExisting) {
         if (primaryKeyAttribute) {
           // If we can, detect equality on the singular primary key
-          existingResult = primaryKeyMap[calleeData[primaryKeyAttribute]]
+          existingResult = primaryKeyMap[calleeData[primaryKeyAttribute]];
         } else {
           // If we can't identify on a singular primary key, do a full row equality check
-          existingResult = _.find(results, function (result) {
-            return Utils._.isEqual(_.omit(result, calleeDataIgnore), calleeData)
-          })
+          existingResult = _.find(results, function(result) {
+            return Utils._.isEqual(_.omit(result, calleeDataIgnore), calleeData);
+          });
         }
       } else {
-        existingResult = null
+        existingResult = null;
       }
 
       if (!existingResult) {
-        results.push(existingResult = calleeData)
+        results.push(existingResult = calleeData);
         if (options.checkExisting && primaryKeyAttribute) {
-          primaryKeyMap[existingResult[primaryKeyAttribute]] = existingResult
+          primaryKeyMap[existingResult[primaryKeyAttribute]] = existingResult;
         }
       }
 
       for (var attrName in row) {
         if (row.hasOwnProperty(attrName)) {
           // Child if object, and is an child include
-          child = Object(row[attrName]) === row[attrName] && includeOptions.includeMap && includeOptions.includeMap[attrName]
+          child = Object(row[attrName]) === row[attrName] && includeOptions.includeMap && includeOptions.includeMap[attrName];
 
           if (child) {
             // Make sure nested object is available
             if (!existingResult.__children) {
-              existingResult.__children = {}
+              existingResult.__children = {};
             }
             if (!existingResult.__children[attrName]) {
-              existingResult.__children[attrName] = []
+              existingResult.__children[attrName] = [];
             }
 
-            existingResult.__children[attrName].push(row[attrName])
+            existingResult.__children[attrName].push(row[attrName]);
 
             // Remove from main
-            delete existingResult[attrName]
+            delete existingResult[attrName];
           }
         }
       }
 
       // parseChildren in same loop if no duplicate values are possible
       if (!options.checkExisting) {
-        parseChildren(existingResult)
+        parseChildren(existingResult);
       }
-    })
-    
+    });
+
     // parseChildren after row parsing if duplicate values are possible
     if (options.checkExisting) {
-      results.forEach(parseChildren)
+      results.forEach(parseChildren);
     }
 
-    return results
-  }
+    return results;
+  };
 
   AbstractQuery.$groupJoinData = groupJoinData;
 
-  return AbstractQuery
-})()
+  return AbstractQuery;
+})();

--- a/lib/dialects/mariadb/connector-manager.js
+++ b/lib/dialects/mariadb/connector-manager.js
@@ -1,49 +1,49 @@
-"use strict";
+'use strict';
 
 var mariadb
   , Pooling = require('generic-pool')
-  , Query   = require("./query")
-  , Utils   = require("../../utils")
-  , without = function(arr, elem) { return arr.filter(function(e) { return e != elem }) }
+  , Query = require('./query')
+  , Utils = require('../../utils')
+  , without = function(arr, elem) { return arr.filter(function(e) { return e !== elem; }); };
 
 module.exports = (function() {
   var ConnectorManager = function(sequelize, config) {
     try {
       if (config.dialectModulePath) {
-        mariadb = require(config.dialectModulePath)
+        mariadb = require(config.dialectModulePath);
       } else {
-        mariadb = require('mariasql')
+        mariadb = require('mariasql');
       }
     } catch (err) {
-      console.log('You need to install mariasql package manually')
+      console.log('You need to install mariasql package manually');
     }
 
-    this.sequelize = sequelize
-    this.client = null
-    this.config = config || {}
-    this.config.port = this.config.port || 3306
-    this.disconnectTimeoutId = null
-    this.queue = []
-    this.activeQueue = []
-    this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50)
+    this.sequelize = sequelize;
+    this.client = null;
+    this.config = config || {};
+    this.config.port = this.config.port || 3306;
+    this.disconnectTimeoutId = null;
+    this.queue = [];
+    this.activeQueue = [];
+    this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50);
     this.poolCfg = Utils._.defaults(this.config.pool, {
       maxConnections: 10,
       minConnections: 0,
       maxIdleTime: 1000,
       handleDisconnects: false,
       validate: function(client) {
-        return client && client.connected
+        return client && client.connected;
       }
-    })
-    this.pendingQueries = 0
-    this.useReplicaton = !!config.replication
-    this.useQueue = config.queue !== undefined ? config.queue : true
+    });
+    this.pendingQueries = 0;
+    this.useReplicaton = !!config.replication;
+    this.useQueue = config.queue !== undefined ? config.queue : true;
 
-    var self = this
+    var self = this;
 
     if (this.useReplicaton) {
       var reads = 0
-        , writes = 0
+        , writes = 0;
 
       // Init configs with options from config if not present
       for (var i in config.replication.read) {
@@ -53,7 +53,7 @@ module.exports = (function() {
           username: this.config.username,
           password: this.config.password,
           database: this.config.database
-        })
+        });
       }
       config.replication.write = Utils._.defaults(config.replication.write, {
         host: this.config.host,
@@ -61,46 +61,46 @@ module.exports = (function() {
         username: this.config.username,
         password: this.config.password,
         database: this.config.database
-      })
+      });
 
       // I'll make my own pool, with blackjack and hookers!
       this.pool = {
-        release: function (client) {
-          if (client.queryType == 'read') {
-            return this.read.release(client)
+        release: function(client) {
+          if (client.queryType === 'read') {
+            return this.read.release(client);
           } else {
-            return this.write.release(client)
+            return this.write.release(client);
           }
         },
-        acquire: function (callback, priority, queryType) {
-          if (queryType == 'SELECT') {
-            this.read.acquire(callback, priority)
+        acquire: function(callback, priority, queryType) {
+          if (queryType === 'SELECT') {
+            this.read.acquire(callback, priority);
           } else {
-            this.write.acquire(callback, priority)
+            this.write.acquire(callback, priority);
           }
         },
-        drain: function () {
-          this.read.drain()
-          this.write.drain()
+        drain: function() {
+          this.read.drain();
+          this.write.drain();
         },
         read: Pooling.Pool({
           name: 'sequelize-read',
-          create: function (done) {
+          create: function(done) {
             if (reads >= self.config.replication.read.length) {
-              reads = 0
+              reads = 0;
             }
-            var config = self.config.replication.read[reads++]
+            var config = self.config.replication.read[reads++];
 
-            connect.call(self, function (err, connection) {
+            connect.call(self, function(err, connection) {
               if (connection) {
-                connection.queryType = 'read'
+                connection.queryType = 'read';
               }
 
-              done(err, connection)
-            }, config)
+              done(err, connection);
+            }, config);
           },
           destroy: function(client) {
-            disconnect.call(self, client)
+            disconnect.call(self, client);
           },
           validate: self.poolCfg.validate,
           max: self.poolCfg.maxConnections,
@@ -109,17 +109,17 @@ module.exports = (function() {
         }),
         write: Pooling.Pool({
           name: 'sequelize-write',
-          create: function (done) {
-            connect.call(self, function (err, connection) {
+          create: function(done) {
+            connect.call(self, function(err, connection) {
               if (connection) {
-                connection.queryType = 'write'
+                connection.queryType = 'write';
               }
 
-              done(err, connection)
-            }, self.config.replication.write)
+              done(err, connection);
+            }, self.config.replication.write);
           },
           destroy: function(client) {
-            disconnect.call(self, client)
+            disconnect.call(self, client);
           },
           validate: self.poolCfg.validate,
           max: self.poolCfg.maxConnections,
@@ -131,39 +131,39 @@ module.exports = (function() {
       //the user has requested pooling, so create our connection pool
       this.pool = Pooling.Pool({
         name: 'sequelize-mariadb',
-        create: function (done) {
-          connect.call(self, done)
+        create: function(done) {
+          connect.call(self, done);
         },
         destroy: function(client) {
-          disconnect.call(self, client)
+          disconnect.call(self, client);
         },
         max: self.poolCfg.maxConnections,
         min: self.poolCfg.minConnections,
         validate: self.poolCfg.validate,
         idleTimeoutMillis: self.poolCfg.maxIdleTime
-      })
+      });
     }
 
-    this.onProcessExit = function () {
+    this.onProcessExit = function() {
       //be nice & close our connections on exit
       if (self.pool) {
-        self.pool.drain()
+        self.pool.drain();
       } else if (self.client) {
-        disconnect(self.client)
+        disconnect(self.client);
       }
 
-      return
+      return;
     }.bind(this);
 
-    process.on('exit', this.onProcessExit)
-  }
+    process.on('exit', this.onProcessExit);
+  };
 
-  Utils._.extend(ConnectorManager.prototype, require("../abstract/connector-manager").prototype)
+  Utils._.extend(ConnectorManager.prototype, require('../abstract/connector-manager').prototype);
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
-    var self = this
+    var self = this;
 
-    options = options || {}
+    options = options || {};
 
     if (this.useQueue) {
       // If queueing we'll let the execQueueItem method handle connecting
@@ -172,43 +172,43 @@ module.exports = (function() {
         sql: sql
       };
 
-      queueItem.query.options.uuid = this.config.uuid
-      enqueue.call(this, queueItem, options)
-      return queueItem.query.promise.finally(function () {
-        afterQuery.call(self, queueItem)
-      })
+      queueItem.query.options.uuid = this.config.uuid;
+      enqueue.call(this, queueItem, options);
+      return queueItem.query.promise.finally(function() {
+        afterQuery.call(self, queueItem);
+      });
     }
 
     var query = new Query(null, this.sequelize, callee, options);
     this.pendingQueries++;
 
-    query.options.uuid = this.config.uuid
+    query.options.uuid = this.config.uuid;
 
-    return this.getConnection(options).then(function (client) {
-      query.client = client
-      return query.run(sql).finally(function () {
+    return this.getConnection(options).then(function(client) {
+      query.client = client;
+      return query.run(sql).finally (function() {
         self.pendingQueries--;
         if (self.pool) {
           self.pool.release(query.client);
         } else {
           if (self.pendingQueries === 0) {
             setTimeout(function() {
-              if (self.pendingQueries === 0){
+              if (self.pendingQueries === 0) {
                 self.disconnect.call(self);
               }
             }, 100);
           }
         }
       });
-    })
+    });
   };
-  
+
   ConnectorManager.prototype.getConnection = function(options) {
     var self = this;
 
-    options = options || {}
+    options = options || {};
 
-    return new Utils.Promise(function (resolve, reject) {
+    return new Utils.Promise(function(resolve, reject) {
       if (!self.pool) {
         // Regular client caching
         if (self.client) {
@@ -216,7 +216,7 @@ module.exports = (function() {
         } else {
           // Cache for concurrent queries
           if (self._getConnection) {
-            return resolve(self._getConnection)
+            return resolve(self._getConnection);
           }
 
           // Set cache and acquire connection
@@ -241,65 +241,65 @@ module.exports = (function() {
           resolve(client);
         }, options.priority, options.type);
       }
-    })
+    });
   };
 
   ConnectorManager.prototype.connect = function() {
-    var self = this
+    var self = this;
     // in case database is slow to connect, prevent orphaning the client
     if (this.isConnecting || this.pool) {
-      return
+      return;
     }
     connect.call(self, function(err, client) {
-      self.client = client
-      return
-    })
-    return
-  }
+      self.client = client;
+      return;
+    });
+    return;
+  };
 
   ConnectorManager.prototype.disconnect = function() {
     if (this.client) {
-      disconnect.call(this, this.client)
+      disconnect.call(this, this.client);
     }
-    return
-  }
+    return;
+  };
 
   // private
   var disconnect = function(client) {
     if (!client) {
-      return // TODO possible orphaning of clients?
+      return; // TODO possible orphaning of clients?
     }
 
-    var self = this
+    var self = this;
     if (!this.useQueue) {
-      this.client = null
-      client.end()
-      return
+      this.client = null;
+      client.end();
+      return;
     }
 
-    var intervalObj = null
-    var cleanup = function () {
+    var intervalObj = null;
+    var cleanup = function() {
       // make sure to let queued items be finish before calling end
       if (self && self.hasQueuedItems) {
-        return
+        return;
       }
-      client.end()
+      client.end();
       if (self && self.client) {
-        self.client = null
+        self.client = null;
       }
-      clearInterval(intervalObj)
-    }
-    intervalObj = setInterval(cleanup, 10)
-    cleanup()
-  }
+      clearInterval(intervalObj);
+    };
+    intervalObj = setInterval(cleanup, 10);
+    cleanup();
+  };
 
   var connect = function(done, config) {
-    config = config || this.config
-    
-    var self = this
-      , client
+    config = config || this.config;
 
-    this.isConnecting = true
+    var self = this
+      , client;
+
+    this.isConnecting = true;
     var connectionConfig = {
       host: config.host,
       port: config.port,
@@ -307,12 +307,12 @@ module.exports = (function() {
       password: config.password,
       db: config.database,
       metadata: true
-    }
+    };
 
     if (config.dialectOptions) {
-      Object.keys(config.dialectOptions).forEach(function (key) {
+      Object.keys(config.dialectOptions).forEach(function(key) {
         connectionConfig[key] = config.dialectOptions[key];
-      })
+      });
     }
 
     if (connectionConfig.unixSocket) {
@@ -320,115 +320,115 @@ module.exports = (function() {
       delete connectionConfig.port;
     }
 
-    client = new mariadb()
-    client.connect(connectionConfig)
+    client = new mariadb();
+    client.connect(connectionConfig);
     client
-      .on('error', function (err) {
-        self.isConnecting = false
+      .on('error', function(err) {
+        self.isConnecting = false;
 
-        done(err)
+        done(err);
       })
-      .on('connect', function () {
-        client.query("SET time_zone = '+0:00'").on('result', function (res) {
-          res.on('end', function () {
-            client.setMaxListeners(self.maxConcurrentQueries)
-            self.isConnecting = false
+      .on('connect', function() {
+        client.query("SET time_zone = '+0:00'").on('result', function(res) {
+          res.on('end', function() {
+            client.setMaxListeners(self.maxConcurrentQueries);
+            self.isConnecting = false;
             if (config.pool.handleDisconnects) {
-              handleDisconnect(self.pool, client)
+              handleDisconnect(self.pool, client);
             }
-            done(null, client)
-          })
-        })
+            done(null, client);
+          });
+        });
       })
       .on('close', function() {
-        disconnect.call(self, client)
-      })
-  }
+        disconnect.call(self, client);
+      });
+  };
 
   var handleDisconnect = function(pool, client) {
     client.on('error', function(err) {
       if (err.code !== 'PROTOCOL_CONNECTION_LOST') {
-        throw err
+        throw err;
       }
-      pool.destroy(client)
-    })
-  }
+      pool.destroy(client);
+    });
+  };
 
   var enqueue = function(queueItem, options) {
-    options = options || {}
+    options = options || {};
     if (this.activeQueue.length < this.maxConcurrentQueries) {
-      this.activeQueue.push(queueItem)
+      this.activeQueue.push(queueItem);
       if (this.pool) {
-        var self = this
+        var self = this;
         this.pool.acquire(function(err, client) {
           if (err) {
-            queueItem.query.reject(err)
-            return
+            queueItem.query.reject(err);
+            return;
           }
           //we set the client here, asynchronously, when getting a pooled connection
           //allowing the ConnectorManager.query method to remain synchronous
-          queueItem.query.client = client
-          queueItem.client = client
-          execQueueItem.call(self, queueItem)
-          return
-        }, undefined, options.type)
+          queueItem.query.client = client;
+          queueItem.client = client;
+          execQueueItem.call(self, queueItem);
+          return;
+        }, undefined, options.type);
       } else {
-        execQueueItem.call(this, queueItem)
+        execQueueItem.call(this, queueItem);
       }
     } else {
-      this.queue.push(queueItem)
+      this.queue.push(queueItem);
     }
-  }
+  };
 
   var dequeue = function(queueItem) {
     //return the item's connection to the pool
     if (this.pool) {
-      this.pool.release(queueItem.client)
+      this.pool.release(queueItem.client);
     }
-    this.activeQueue = without(this.activeQueue, queueItem)
-  }
+    this.activeQueue = without(this.activeQueue, queueItem);
+  };
 
   var transferQueuedItems = function(count) {
-    for(var i = 0; i < count; i++) {
-      var queueItem = this.queue.shift()
+    for (var i = 0; i < count; i++) {
+      var queueItem = this.queue.shift();
       if (queueItem) {
-        enqueue.call(this, queueItem)
+        enqueue.call(this, queueItem);
       }
     }
-  }
+  };
 
   var afterQuery = function(queueItem) {
-    dequeue.call(this, queueItem)
-    transferQueuedItems.call(this, this.maxConcurrentQueries - this.activeQueue.length)
-    disconnectIfNoConnections.call(this)
-  }
+    dequeue.call(this, queueItem);
+    transferQueuedItems.call(this, this.maxConcurrentQueries - this.activeQueue.length);
+    disconnectIfNoConnections.call(this);
+  };
 
 
   var execQueueItem = function(queueItem) {
-    queueItem.query.run(queueItem.sql, queueItem.client)
-  }
+    queueItem.query.run(queueItem.sql, queueItem.client);
+  };
 
   ConnectorManager.prototype.__defineGetter__('hasQueuedItems', function() {
-    return (this.queue.length > 0) || (this.activeQueue.length > 0) || (this.client && this.client._queue && (this.client._queue.length > 0))
-  })
+    return (this.queue.length > 0) || (this.activeQueue.length > 0) || (this.client && this.client._queue && (this.client._queue.length > 0));
+  });
 
   // legacy
   ConnectorManager.prototype.__defineGetter__('hasNoConnections', function() {
-    return !this.hasQueuedItems
-  })
+    return !this.hasQueuedItems;
+  });
 
   ConnectorManager.prototype.__defineGetter__('isConnected', function() {
-    return this.client != null
-  })
+    return this.client !== null;
+  });
 
   var disconnectIfNoConnections = function() {
-    var self = this
+    var self = this;
 
-    this.disconnectTimeoutId && clearTimeout(this.disconnectTimeoutId)
+    this.disconnectTimeoutId && clearTimeout(this.disconnectTimeoutId);
     this.disconnectTimeoutId = setTimeout(function() {
-      self.isConnected && !self.hasQueuedItems && self.disconnect()
-    }, 100)
-  }
+      self.isConnected && !self.hasQueuedItems && self.disconnect();
+    }, 100);
+  };
 
-  return ConnectorManager
-})()
+  return ConnectorManager;
+})();

--- a/lib/dialects/mariadb/index.js
+++ b/lib/dialects/mariadb/index.js
@@ -1,14 +1,14 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
-  , MySQL = require('../mysql')
+  , MySQL = require('../mysql');
 
 var MariaDialect = function(sequelize) {
-  this.sequelize = sequelize
-}
+  this.sequelize = sequelize;
+};
 
 MariaDialect.prototype = _.defaults({
-    'LIMIT ON UPDATE':true
-}, MySQL.prototype)
+    'LIMIT ON UPDATE': true
+}, MySQL.prototype);
 
-module.exports = MariaDialect
+module.exports = MariaDialect;

--- a/lib/dialects/mariadb/query-generator.js
+++ b/lib/dialects/mariadb/query-generator.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-var Utils     = require("../../utils")
+var Utils = require('../../utils');
 
 module.exports = (function() {
   var QueryGenerator = {
@@ -9,16 +9,16 @@ module.exports = (function() {
       code: 1062,
       map: function(str) {
         // we're manually remvoving uniq_ here for a future capability of defining column names explicitly
-        var match = str.replace('uniq_', '').match(/Duplicate entry .* for key '(.*?)'$/)
+        var match = str.replace('uniq_', '').match(/Duplicate entry .* for key '(.*?)'$/);
         if (match === null || match.length < 2) {
-          return false
+          return false;
         }
 
-        return match[1].split('_')
+        return match[1].split('_');
       }
-    },
-  }
+    }
+  };
   // "MariaDB is a drop-in replacement for MySQL." - so thats exactly what we do, drop in the mysql query generator
 
-  return Utils._.extend(Utils._.clone(require("../mysql/query-generator")), QueryGenerator)
-})()
+  return Utils._.extend(Utils._.clone(require('../mysql/query-generator')), QueryGenerator);
+})();

--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -1,137 +1,137 @@
-"use strict";
+'use strict';
 
-var Utils         = require("../../utils")
-  , AbstractQuery = require('../abstract/query')
+var Utils = require('../../utils')
+  , AbstractQuery = require('../abstract/query');
 
 module.exports = (function() {
   var Query = function(client, sequelize, callee, options) {
-    this.client    = client
-    this.callee    = callee
-    this.sequelize = sequelize
-    this.options   = Utils._.extend({
+    this.client = client;
+    this.callee = callee;
+    this.sequelize = sequelize;
+    this.options = Utils._.extend({
       logging: console.log,
       plain: false,
       raw: false
-    }, options || {})
+    }, options || {});
 
-    var self = this
-    this.checkLoggingOption()
-    this.promise = new Utils.Promise(function (resolve, reject) {
-      self.resolve = resolve
-      self.reject = reject
-    })
-  }
+    var self = this;
+    this.checkLoggingOption();
+    this.promise = new Utils.Promise(function(resolve, reject) {
+      self.resolve = resolve;
+      self.reject = reject;
+    });
+  };
 
-  Utils.inherit(Query, AbstractQuery)
+  Utils.inherit(Query, AbstractQuery);
   Query.prototype.run = function(sql) {
-    this.sql = sql
+    this.sql = sql;
 
     if (this.options.logging !== false) {
-      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql)
+      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql);
     }
 
     var resultSet = [],
         errorDetected = false,
         alreadyEnded = false, // This is needed because CALL queries emit 'end' twice...
-        self = this
+        self = this;
 
     this.client.query(this.sql)
       .on('result', function(results) {
         results
           .on('row', function(row, metadata) {
-            var type
+            var type;
 
             for (var prop in row) {
               if (row.hasOwnProperty(prop)) {
                 if (row[prop] === null) {
-                  continue
+                  continue;
                 }
 
-                type = metadata.types[prop]
+                type = metadata.types[prop];
 
                 switch (type) {
-                case "TINYINT":
-                case "SMALLINT":
-                case "INTEGER":
-                case "MEDIUMINT":
-                case "BIGINT":
-                case "YEAR":
-                  row[prop] = parseInt(row[prop], 10)
-                  break
-                case "DECIMAL":
-                case "FLOAT":
-                case "DOUBLE":
-                  row[prop] = parseFloat(row[prop])
-                  break
-                case "DATE":
-                case "TIMESTAMP":
-                case "DATETIME":
-                  row[prop] = new Date(row[prop] + 'Z')
-                  break
-                case "BIT":
-                case "BLOB":
-                case "TINYBLOB":
-                case "MEDIUMBLOB":
-                case "LONGBLOB":
+                case 'TINYINT':
+                case 'SMALLINT':
+                case 'INTEGER':
+                case 'MEDIUMINT':
+                case 'BIGINT':
+                case 'YEAR':
+                  row[prop] = parseInt(row[prop], 10);
+                  break;
+                case 'DECIMAL':
+                case 'FLOAT':
+                case 'DOUBLE':
+                  row[prop] = parseFloat(row[prop]);
+                  break;
+                case 'DATE':
+                case 'TIMESTAMP':
+                case 'DATETIME':
+                  row[prop] = new Date(row[prop] + 'Z');
+                  break;
+                case 'BIT':
+                case 'BLOB':
+                case 'TINYBLOB':
+                case 'MEDIUMBLOB':
+                case 'LONGBLOB':
                   if (metadata.charsetNrs[prop] === 63) { // binary
-                    row[prop] = new Buffer(row[prop])
+                    row[prop] = new Buffer(row[prop]);
                   }
-                  break
-                case "TIME":
-                case "CHAR":
-                case "VARCHAR":
-                case "SET":
-                case "ENUM":
-                case "GEOMETRY":
-                case "NULL":
-                  break
+                  break;
+                case 'TIME':
+                case 'CHAR':
+                case 'VARCHAR':
+                case 'SET':
+                case 'ENUM':
+                case 'GEOMETRY':
+                case 'NULL':
+                  break;
                 default:
                   // blank
                 }
               }
             }
-            resultSet.push(row)
+            resultSet.push(row);
           })
           .on('error', function(err) {
-            errorDetected = true
-            self.promise.emit('sql', self.sql)
-            err.sql = sql
-            self.reject(err)
+            errorDetected = true;
+            self.promise.emit('sql', self.sql);
+            err.sql = sql;
+            self.reject(err);
           })
           .on('end', function(info) {
             if (alreadyEnded || errorDetected) {
-              return
+              return;
             }
-            alreadyEnded = true
+            alreadyEnded = true;
 
-            self.promise.emit('sql', self.sql)
+            self.promise.emit('sql', self.sql);
             // we need to figure out whether to send the result set
             // or info depending upon the type of query
             if (/^call/.test(self.sql.toLowerCase())) {
-              self.resolve(resultSet)
-            } else if( /^show/.test(self.sql.toLowerCase()) ||
+              self.resolve(resultSet);
+            } else if (/^show/.test(self.sql.toLowerCase()) ||
                 /^select/.test(self.sql.toLowerCase()) ||
               /^describe/.test(self.sql.toLowerCase())) {
-              self.resolve(self.formatResults(resultSet))
+              self.resolve(self.formatResults(resultSet));
             } else {
-              self.resolve(self.formatResults(info))
+              self.resolve(self.formatResults(info));
             }
-          })
+          });
       })
       .on('error', function(err) {
         if (errorDetected) {
-          return
+          return;
         }
-        errorDetected = true
-        self.promise.emit('sql', self.sql)
-        self.reject(err)
+        errorDetected = true;
+        self.promise.emit('sql', self.sql);
+        self.reject(err);
       })
-      .setMaxListeners(100)
+      .setMaxListeners(100);
 
-    return this.promise
-  }
+    return this.promise;
+  };
 
-  return Query
-})()
+  return Query;
+})();
 
 

--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -1,31 +1,31 @@
-"use strict";
+'use strict';
 
 var mysql
   , Pooling = require('generic-pool')
-  , Query   = require("./query")
-  , Utils   = require("../../utils")
-  , without = function(arr, elem) { return arr.filter(function(e) { return e.query.uuid != elem.query.uuid }) }
+  , Query = require('./query')
+  , Utils = require('../../utils')
+  , without = function(arr, elem) { return arr.filter(function(e) { return e.query.uuid !== elem.query.uuid; }); };
 
 module.exports = (function() {
   var ConnectorManager = function(sequelize, config) {
     try {
       if (config.dialectModulePath) {
-        mysql = require(config.dialectModulePath)
+        mysql = require(config.dialectModulePath);
       } else {
-        mysql = require('mysql')
+        mysql = require('mysql');
       }
     } catch (err) {
-      throw new Error('Please install mysql package manually')
+      throw new Error('Please install mysql package manually');
     }
 
-    this.sequelize = sequelize
-    this.client = null
-    this.config = config || {}
-    this.config.port = this.config.port || 3306
-    this.disconnectTimeoutId = null
-    this.queue = []
-    this.activeQueue = []
-    this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50)
+    this.sequelize = sequelize;
+    this.client = null;
+    this.config = config || {};
+    this.config.port = this.config.port || 3306;
+    this.disconnectTimeoutId = null;
+    this.queue = [];
+    this.activeQueue = [];
+    this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50);
     this.poolCfg = Utils._.defaults(this.config.pool, {
       maxConnections: 10,
       minConnections: 0,
@@ -37,7 +37,7 @@ module.exports = (function() {
     this.useReplicaton = !!config.replication;
     this.useQueue = config.queue !== undefined ? config.queue : true;
 
-    var self = this
+    var self = this;
 
     if (this.useReplicaton) {
       var reads = 0
@@ -63,42 +63,42 @@ module.exports = (function() {
 
       // I'll make my own pool, with blackjack and hookers!
       this.pool = {
-        release: function (client) {
-          if (client.queryType == 'read') {
+        release: function(client) {
+          if (client.queryType === 'read') {
             return this.read.release(client);
           } else {
             return this.write.release(client);
           }
         },
-        acquire: function (callback, priority, queryType) {
-          if (queryType == 'SELECT') {
+        acquire: function(callback, priority, queryType) {
+          if (queryType === 'SELECT') {
             this.read.acquire(callback, priority);
           } else {
             this.write.acquire(callback, priority);
           }
         },
-        drain: function () {
+        drain: function() {
           this.read.drain();
           this.write.drain();
         },
         read: Pooling.Pool({
           name: 'sequelize-read',
-          create: function (done) {
+          create: function(done) {
             if (reads >= self.config.replication.read.length) {
-              reads = 0
+              reads = 0;
             }
             var config = self.config.replication.read[reads++];
 
-            connect.call(self, function (err, connection) {
+            connect.call(self, function(err, connection) {
               if (connection) {
-                connection.queryType = 'read'
+                connection.queryType = 'read';
               }
 
-              done(err, connection)
+              done(err, connection);
             }, config);
           },
           destroy: function(client) {
-            disconnect.call(self, client)
+            disconnect.call(self, client);
           },
           validate: self.poolCfg.validate,
           max: self.poolCfg.maxConnections,
@@ -107,17 +107,17 @@ module.exports = (function() {
         }),
         write: Pooling.Pool({
           name: 'sequelize-write',
-          create: function (done) {
-            connect.call(self, function (err, connection) {
+          create: function(done) {
+            connect.call(self, function(err, connection) {
               if (connection) {
-                connection.queryType = 'write'
+                connection.queryType = 'write';
               }
 
-              done(err, connection)
+              done(err, connection);
             }, self.config.replication.write);
           },
           destroy: function(client) {
-            disconnect.call(self, client)
+            disconnect.call(self, client);
           },
           validate: self.poolCfg.validate,
           max: self.poolCfg.maxConnections,
@@ -129,42 +129,42 @@ module.exports = (function() {
       //the user has requested pooling, so create our connection pool
       this.pool = Pooling.Pool({
         name: 'sequelize-mysql',
-        create: function (done) {
-          connect.call(self, function (err, connection) {
+        create: function(done) {
+          connect.call(self, function(err, connection) {
             // This has to be nested for some reason, else the error won't propagate correctly
             done(err, connection);
-          })
+          });
         },
         destroy: function(client) {
-          disconnect.call(self, client)
+          disconnect.call(self, client);
         },
         max: self.poolCfg.maxConnections,
         min: self.poolCfg.minConnections,
         validate: self.poolCfg.validate,
         idleTimeoutMillis: self.poolCfg.maxIdleTime
-      })
+      });
     }
 
-    this.onProcessExit = function () {
+    this.onProcessExit = function() {
       //be nice & close our connections on exit
       if (self.pool) {
-        self.pool.drain()
+        self.pool.drain();
       } else if (self.client) {
-        disconnect(self.client)
+        disconnect(self.client);
       }
 
-      return
+      return;
     }.bind(this);
 
-    process.on('exit', this.onProcessExit)
-  }
+    process.on('exit', this.onProcessExit);
+  };
 
-  Utils._.extend(ConnectorManager.prototype, require("../abstract/connector-manager").prototype);
+  Utils._.extend(ConnectorManager.prototype, require('../abstract/connector-manager').prototype);
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
-    var self = this
+    var self = this;
 
-    options = options || {}
+    options = options || {};
 
     if (this.useQueue) {
       // If queueing we'll let the execQueueItem method handle connecting
@@ -173,43 +173,43 @@ module.exports = (function() {
         sql: sql
       };
 
-      queueItem.query.options.uuid = this.config.uuid
-      enqueue.call(this, queueItem, options)
-      return queueItem.query.promise.finally(function () {
-        afterQuery.call(self, queueItem)
-      })
+      queueItem.query.options.uuid = this.config.uuid;
+      enqueue.call(this, queueItem, options);
+      return queueItem.query.promise.finally(function() {
+        afterQuery.call(self, queueItem);
+      });
     }
 
     var query = new Query(null, this.sequelize, callee, options);
     this.pendingQueries++;
 
-    query.options.uuid = this.config.uuid
+    query.options.uuid = this.config.uuid;
 
-    return this.getConnection(options).then(function (client) {
-      query.client = client
-      return query.run(sql).finally(function () {
+    return this.getConnection(options).then(function(client) {
+      query.client = client;
+      return query.run(sql).finally (function() {
         self.pendingQueries--;
         if (self.pool) {
           self.pool.release(query.client);
         } else {
           if (self.pendingQueries === 0) {
             setTimeout(function() {
-              if (self.pendingQueries === 0){
+              if (self.pendingQueries === 0) {
                 self.disconnect.call(self);
               }
             }, 100);
           }
         }
       });
-    })
+    });
   };
 
   ConnectorManager.prototype.getConnection = function(options) {
     var self = this;
 
-    options = options || {}
+    options = options || {};
 
-    return new Utils.Promise(function (resolve, reject) {
+    return new Utils.Promise(function(resolve, reject) {
       if (!self.pool) {
         // Regular client caching
         if (self.client) {
@@ -217,7 +217,7 @@ module.exports = (function() {
         } else {
           // Cache for concurrent queries
           if (self._getConnection) {
-            return resolve(self._getConnection)
+            return resolve(self._getConnection);
           }
 
           // Set cache and acquire connection
@@ -243,14 +243,14 @@ module.exports = (function() {
           resolve(client);
         }, options.priority, options.type);
       }
-    })
+    });
   };
 
   ConnectorManager.prototype.disconnect = function() {
     if (this.client) {
-      disconnect.call(this, this.client)
+      disconnect.call(this, this.client);
     }
-    return
+    return;
   };
 
   // private
@@ -259,7 +259,7 @@ module.exports = (function() {
     this.client = null;
 
     if (!client) {
-      return // TODO possible orphaning of clients?
+      return; // TODO possible orphaning of clients?
     }
 
     client.end(function() {
@@ -267,24 +267,24 @@ module.exports = (function() {
         return client.destroy();
       }
 
-      var intervalObj = null
-      var cleanup = function () {
+      var intervalObj = null;
+      var cleanup = function() {
         // make sure to let client finish before calling destroy
         if (client._queue && (client._queue.length > 0)) {
-          return
+          return;
         }
         // needed to prevent mysql connection leak
-        client.destroy()
-        clearInterval(intervalObj)
-      }
-      intervalObj = setInterval(cleanup, 10)
-      cleanup()
-      return
-    })
-  }
+        client.destroy();
+        clearInterval(intervalObj);
+      };
+      intervalObj = setInterval(cleanup, 10);
+      cleanup();
+      return;
+    });
+  };
 
   var connect = function(done, config) {
-    config = config || this.config
+    config = config || this.config;
 
     var connectionConfig = {
       host: config.host,
@@ -296,7 +296,7 @@ module.exports = (function() {
     };
 
     if (config.dialectOptions) {
-      Object.keys(config.dialectOptions).forEach(function (key) {
+      Object.keys(config.dialectOptions).forEach(function(key) {
         connectionConfig[key] = config.dialectOptions[key];
       });
     }
@@ -304,16 +304,16 @@ module.exports = (function() {
     var connection = mysql.createConnection(connectionConfig);
     connection.connect(function(err) {
       if (err) {
-        switch(err.code) {
+        switch (err.code) {
         case 'ECONNREFUSED':
         case 'ER_ACCESS_D2ENIED_ERROR':
-          done('Failed to authenticate for MySQL. Please double check your settings.')
-          break
+          done('Failed to authenticate for MySQL. Please double check your settings.');
+          break;
         case 'ENOTFOUND':
         case 'EHOSTUNREACH':
         case 'EINVAL':
-          done('Failed to find MySQL server. Please double check your settings.')
-          break
+          done('Failed to find MySQL server. Please double check your settings.');
+          break;
         default:
           done(err);
           break;
@@ -323,97 +323,97 @@ module.exports = (function() {
       }
 
       done(null, connection);
-    })
+    });
 
     connection.query("SET time_zone = '+0:00'");
     // client.setMaxListeners(self.maxConcurrentQueries)
-    this.isConnecting = false
+    this.isConnecting = false;
     if (config.pool !== null && config.pool.handleDisconnects) {
-      handleDisconnect(this.pool, connection)
+      handleDisconnect(this.pool, connection);
     }
-  }
+  };
 
   var handleDisconnect = function(pool, client) {
     client.on('error', function(err) {
       if (err.code !== 'PROTOCOL_CONNECTION_LOST') {
-        throw err
+        throw err;
       }
-      pool.destroy(client)
-    })
-  }
+      pool.destroy(client);
+    });
+  };
 
   var validateConnection = function(client) {
-    return client && client.state !== 'disconnected'
-  }
+    return client && client.state !== 'disconnected';
+  };
 
   var enqueue = function(queueItem, options) {
-    options = options || {}
+    options = options || {};
     if (this.activeQueue.length < this.maxConcurrentQueries) {
-      this.activeQueue.push(queueItem)
-      execQueueItem.call(this, queueItem)
+      this.activeQueue.push(queueItem);
+      execQueueItem.call(this, queueItem);
     } else {
-      this.queue.push(queueItem)
+      this.queue.push(queueItem);
     }
-  }
+  };
 
   var dequeue = function(queueItem) {
     //return the item's connection to the pool
     if (this.pool) {
-      this.pool.release(queueItem.client)
+      this.pool.release(queueItem.client);
     }
-    this.activeQueue = without(this.activeQueue, queueItem)
-  }
+    this.activeQueue = without(this.activeQueue, queueItem);
+  };
 
   var transferQueuedItems = function(count) {
-    for(var i = 0; i < count; i++) {
+    for (var i = 0; i < count; i++) {
       var queueItem = this.queue.shift();
       if (queueItem) {
-        enqueue.call(this, queueItem)
+        enqueue.call(this, queueItem);
       }
     }
-  }
+  };
 
   var afterQuery = function(queueItem) {
-    dequeue.call(this, queueItem)
-    transferQueuedItems.call(this, this.maxConcurrentQueries - this.activeQueue.length)
-    disconnectIfNoConnections.call(this)
-  }
+    dequeue.call(this, queueItem);
+    transferQueuedItems.call(this, this.maxConcurrentQueries - this.activeQueue.length);
+    disconnectIfNoConnections.call(this);
+  };
 
   var execQueueItem = function(queueItem) {
     this.getConnection({
       priority: queueItem.query.options.priority,
       type: queueItem.query.options.type
-    }).then(function (connection) {
-      queueItem.query.client = connection
-      queueItem.client = connection
+    }).then(function(connection) {
+      queueItem.query.client = connection;
+      queueItem.client = connection;
 
-      queueItem.query.run(queueItem.sql)
-    }, function (err) {
-      queueItem.query.reject(err)
-    })
-  }
+      queueItem.query.run(queueItem.sql);
+    }, function(err) {
+      queueItem.query.reject(err);
+    });
+  };
 
   ConnectorManager.prototype.__defineGetter__('hasQueuedItems', function() {
-    return (this.queue.length > 0) || (this.activeQueue.length > 0) || (this.client && this.client._queue && (this.client._queue.length > 0))
-  })
+    return (this.queue.length > 0) || (this.activeQueue.length > 0) || (this.client && this.client._queue && (this.client._queue.length > 0));
+  });
 
   // legacy
   ConnectorManager.prototype.__defineGetter__('hasNoConnections', function() {
-    return !this.hasQueuedItems
-  })
+    return !this.hasQueuedItems;
+  });
 
   ConnectorManager.prototype.__defineGetter__('isConnected', function() {
-    return this.client !== null
-  })
+    return this.client !== null;
+  });
 
   var disconnectIfNoConnections = function() {
-    var self = this
+    var self = this;
 
-    this.disconnectTimeoutId && clearTimeout(this.disconnectTimeoutId)
+    this.disconnectTimeoutId && clearTimeout(this.disconnectTimeoutId);
     this.disconnectTimeoutId = setTimeout(function() {
-      self.isConnected && !self.hasQueuedItems && self.disconnect()
-    }, 100)
-  }
+      self.isConnected && !self.hasQueuedItems && self.disconnect();
+    }, 100);
+  };
 
-  return ConnectorManager
-})()
+  return ConnectorManager;
+})();

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -1,17 +1,17 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
-  , Abstract = require('../abstract')
+  , Abstract = require('../abstract');
 
 var MysqlDialect = function(sequelize) {
-  this.sequelize = sequelize
-}
+  this.sequelize = sequelize;
+};
 
 MysqlDialect.prototype.supports = _.defaults({
   'VALUES ()': true,
-  'LIMIT ON UPDATE':true,
+  'LIMIT ON UPDATE': true,
   lock: true,
   forShare: 'LOCK IN SHARE MODE'
-}, Abstract.prototype.supports)
+}, Abstract.prototype.supports);
 
-module.exports = MysqlDialect
+module.exports = MysqlDialect;

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -1,388 +1,388 @@
-"use strict";
+'use strict';
 
-var Utils     = require("../../utils")
-  , DataTypes = require("../../data-types")
-  , util      = require("util")
+var Utils = require('../../utils')
+  , DataTypes = require('../../data-types')
+  , util = require('util');
 
 module.exports = (function() {
   var QueryGenerator = {
     dialect: 'mysql',
 
     createSchema: function() {
-      var query = "SHOW TABLES"
-      return Utils._.template(query)({})
+      var query = 'SHOW TABLES';
+      return Utils._.template(query)({});
     },
 
     dropSchema: function(tableName, options) {
-      return QueryGenerator.dropTableQuery(tableName, options)
+      return QueryGenerator.dropTableQuery(tableName, options);
     },
 
     showSchemasQuery: function() {
-      return "SHOW TABLES"
+      return 'SHOW TABLES';
     },
 
     createTableQuery: function(tableName, attributes, options) {
       options = Utils._.extend({
         engine: 'InnoDB',
         charset: null
-      }, options || {})
+      }, options || {});
 
       var self = this;
 
-      var query   = "CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>)<%= comment %> ENGINE=<%= engine %> <%= charset %> <%= collation %>"
+      var query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>)<%= comment %> ENGINE=<%= engine %> <%= charset %> <%= collation %>'
         , primaryKeys = []
         , foreignKeys = {}
-        , attrStr = []
+        , attrStr = [];
 
       for (var attr in attributes) {
         if (attributes.hasOwnProperty(attr)) {
-          var dataType = this.mysqlDataTypeMapping(tableName, attr, attributes[attr])
+          var dataType = this.mysqlDataTypeMapping(tableName, attr, attributes[attr]);
 
           if (Utils._.includes(dataType, 'PRIMARY KEY')) {
-            primaryKeys.push(attr)
+            primaryKeys.push(attr);
 
-            if (Utils._.includes(dataType, 'REFERENCES')) { 
+            if (Utils._.includes(dataType, 'REFERENCES')) {
                // MySQL doesn't support inline REFERENCES declarations: move to the end
-              var m = dataType.match(/^(.+) (REFERENCES.*)$/)
-              attrStr.push(this.quoteIdentifier(attr) + " " + m[1].replace(/PRIMARY KEY/, ''))
-              foreignKeys[attr] = m[2]
+              var m = dataType.match(/^(.+) (REFERENCES.*)$/);
+              attrStr.push(this.quoteIdentifier(attr) + ' ' + m[1].replace(/PRIMARY KEY/, ''));
+              foreignKeys[attr] = m[2];
             } else {
-              attrStr.push(this.quoteIdentifier(attr) + " " + dataType.replace(/PRIMARY KEY/, ''))
-            }            
+              attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType.replace(/PRIMARY KEY/, ''));
+            }
           } else if (Utils._.includes(dataType, 'REFERENCES')) {
             // MySQL doesn't support inline REFERENCES declarations: move to the end
-            var m = dataType.match(/^(.+) (REFERENCES.*)$/)
-            attrStr.push(this.quoteIdentifier(attr) + " " + m[1])
-            foreignKeys[attr] = m[2]
+            var m = dataType.match(/^(.+) (REFERENCES.*)$/);
+            attrStr.push(this.quoteIdentifier(attr) + ' ' + m[1]);
+            foreignKeys[attr] = m[2];
           } else {
-            attrStr.push(this.quoteIdentifier(attr) + " " + dataType)
+            attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
           }
         }
       }
 
       var values = {
         table: this.quoteTable(tableName),
-        attributes: attrStr.join(", "),
-        comment: options.comment && Utils._.isString(options.comment) ? " COMMENT " + this.escape(options.comment) : "",
+        attributes: attrStr.join(', '),
+        comment: options.comment && Utils._.isString(options.comment) ? ' COMMENT ' + this.escape(options.comment) : '',
         engine: options.engine,
-        charset: (options.charset ? "DEFAULT CHARSET=" + options.charset : ""),
-        collation: (options.collate ? "COLLATE " + options.collate : "")
+        charset: (options.charset ? 'DEFAULT CHARSET=' + options.charset : ''),
+        collation: (options.collate ? 'COLLATE ' + options.collate : '')
       }
-      , pkString = primaryKeys.map(function(pk) { return this.quoteIdentifier(pk) }.bind(this)).join(", ")
+      , pkString = primaryKeys.map(function(pk) { return this.quoteIdentifier(pk); }.bind(this)).join(', ');
 
       if (!!options.uniqueKeys) {
         Utils._.each(options.uniqueKeys, function(columns) {
-          values.attributes += ", UNIQUE uniq_" + tableName + '_' + columns.fields.join('_') + " (" + Utils._.map(columns.fields, self.quoteIdentifier).join(", ") + ")";
-        })
+          values.attributes += ', UNIQUE uniq_' + tableName + '_' + columns.fields.join('_') + ' (' + Utils._.map(columns.fields, self.quoteIdentifier).join(', ') + ')';
+        });
       }
 
       if (pkString.length > 0) {
-        values.attributes += ", PRIMARY KEY (" + pkString + ")"
+        values.attributes += ', PRIMARY KEY (' + pkString + ')';
       }
 
       for (var fkey in foreignKeys) {
-        if(foreignKeys.hasOwnProperty(fkey)) {
-          values.attributes += ", FOREIGN KEY (" + this.quoteIdentifier(fkey) + ") " + foreignKeys[fkey]
+        if (foreignKeys.hasOwnProperty(fkey)) {
+          values.attributes += ', FOREIGN KEY (' + this.quoteIdentifier(fkey) + ') ' + foreignKeys[fkey];
         }
       }
 
-      return Utils._.template(query)(values).trim() + ";"
+      return Utils._.template(query)(values).trim() + ';';
     },
 
     showTablesQuery: function() {
-      return 'SHOW TABLES;'
+      return 'SHOW TABLES;';
     },
 
     uniqueConstraintMapping: {
       code: 'ER_DUP_ENTRY',
       map: function(str) {
         // we're manually remvoving uniq_ here for a future capability of defining column names explicitly
-        var match = str.replace('uniq_', '').match(/Duplicate entry .* for key '(.*?)'$/)
+        var match = str.replace('uniq_', '').match(/Duplicate entry .* for key '(.*?)'$/);
         if (match === null || match.length < 2) {
-          return false
+          return false;
         }
 
-        return match[1].split('_')
+        return match[1].split('_');
       }
     },
 
     addColumnQuery: function(tableName, attributes) {
-      var query      = "ALTER TABLE `<%= tableName %>` ADD <%= attributes %>;"
-        , attrString = []
+      var query = 'ALTER TABLE `<%= tableName %>` ADD <%= attributes %>;'
+        , attrString = [];
 
       for (var attrName in attributes) {
-        var definition = attributes[attrName]
+        var definition = attributes[attrName];
 
         attrString.push(Utils._.template('`<%= attrName %>` <%= definition %>')({
           attrName: attrName,
           definition: this.mysqlDataTypeMapping(tableName, attrName, definition)
-        }))
+        }));
       }
 
-      return Utils._.template(query)({ tableName: tableName, attributes: attrString.join(', ') })
+      return Utils._.template(query)({ tableName: tableName, attributes: attrString.join(', ') });
     },
 
     removeColumnQuery: function(tableName, attributeName) {
-      var query = "ALTER TABLE `<%= tableName %>` DROP `<%= attributeName %>`;"
-      return Utils._.template(query)({ tableName: tableName, attributeName: attributeName })
+      var query = 'ALTER TABLE `<%= tableName %>` DROP `<%= attributeName %>`;';
+      return Utils._.template(query)({ tableName: tableName, attributeName: attributeName });
     },
 
     changeColumnQuery: function(tableName, attributes) {
-      var query      = "ALTER TABLE `<%= tableName %>` CHANGE <%= attributes %>;"
-      var attrString = []
+      var query = 'ALTER TABLE `<%= tableName %>` CHANGE <%= attributes %>;';
+      var attrString = [];
 
       for (var attrName in attributes) {
-        var definition = attributes[attrName]
+        var definition = attributes[attrName];
 
         attrString.push(Utils._.template('`<%= attrName %>` `<%= attrName %>` <%= definition %>')({
           attrName: attrName,
           definition: definition
-        }))
+        }));
       }
 
-      return Utils._.template(query)({ tableName: tableName, attributes: attrString.join(', ') })
+      return Utils._.template(query)({ tableName: tableName, attributes: attrString.join(', ') });
     },
 
     renameColumnQuery: function(tableName, attrBefore, attributes) {
-      var query      = "ALTER TABLE `<%= tableName %>` CHANGE <%= attributes %>;"
-      var attrString = []
+      var query = 'ALTER TABLE `<%= tableName %>` CHANGE <%= attributes %>;';
+      var attrString = [];
 
       for (var attrName in attributes) {
-        var definition = attributes[attrName]
+        var definition = attributes[attrName];
 
         attrString.push(Utils._.template('`<%= before %>` `<%= after %>` <%= definition %>')({
           before: attrBefore,
           after: attrName,
           definition: definition
-        }))
+        }));
       }
 
-      return Utils._.template(query)({ tableName: tableName, attributes: attrString.join(', ') })
+      return Utils._.template(query)({ tableName: tableName, attributes: attrString.join(', ') });
     },
 
     bulkInsertQuery: function(tableName, attrValueHashes, options) {
-      var query = "INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %>;"
+      var query = 'INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %>;'
         , tuples = []
-        , allAttributes = []
+        , allAttributes = [];
 
       Utils._.forEach(attrValueHashes, function(attrValueHash, i) {
         Utils._.forOwn(attrValueHash, function(value, key, hash) {
-          if (allAttributes.indexOf(key) === -1) allAttributes.push(key)
-        })
-      })
+          if (allAttributes.indexOf(key) === -1) allAttributes.push(key);
+        });
+      });
 
       Utils._.forEach(attrValueHashes, function(attrValueHash, i) {
-        tuples.push("(" +
-          allAttributes.map(function (key) {
-            return this.escape(attrValueHash[key])
-          }.bind(this)).join(",") +
-        ")")
-      }.bind(this))
+        tuples.push('(' +
+          allAttributes.map(function(key) {
+            return this.escape(attrValueHash[key]);
+          }.bind(this)).join(',') +
+        ')');
+      }.bind(this));
 
-      var replacements  = {
+      var replacements = {
         ignoreDuplicates: options && options.ignoreDuplicates ? ' IGNORE' : '',
         table: this.quoteTable(tableName),
-        attributes: allAttributes.map(function(attr){
-                      return this.quoteIdentifier(attr)
-                    }.bind(this)).join(","),
+        attributes: allAttributes.map(function(attr) {
+                      return this.quoteIdentifier(attr);
+                    }.bind(this)).join(','),
         tuples: tuples
-      }
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     deleteQuery: function(tableName, where, options) {
-      options = options || {}
+      options = options ||  {};
 
-      var table = this.quoteTable(tableName)
+      var table = this.quoteTable(tableName);
       if (options.truncate === true) {
         // Truncate does not allow LIMIT and WHERE
-        return "TRUNCATE " + table
+        return 'TRUNCATE ' + table;
       }
 
-      where = this.getWhereConditions(where)
-      var limit = ""
+      where = this.getWhereConditions(where);
+      var limit = '';
 
-      if(Utils._.isUndefined(options.limit)) {
+      if (Utils._.isUndefined(options.limit)) {
         options.limit = 1;
       }
 
-      if(!!options.limit) {
-        limit = " LIMIT " + this.escape(options.limit)
+      if (!!options.limit) {
+        limit = ' LIMIT ' + this.escape(options.limit);
       }
 
-      return "DELETE FROM " + table + " WHERE " + where + limit
+      return 'DELETE FROM ' + table + ' WHERE ' + where + limit;
     },
 
     addIndexQuery: function(tableName, attributes, options) {
       var transformedAttributes = attributes.map(function(attribute) {
-        if(typeof attribute === 'string') {
-          return this.quoteIdentifier(attribute)
+        if (typeof attribute === 'string') {
+          return this.quoteIdentifier(attribute);
         } else {
-          var result = ""
+          var result = '';
 
           if (!attribute.attribute) {
-            throw new Error('The following index attribute has no attribute: ' + util.inspect(attribute))
+            throw new Error('The following index attribute has no attribute: ' + util.inspect(attribute));
           }
 
-          result += this.quoteIdentifier(attribute.attribute)
+          result += this.quoteIdentifier(attribute.attribute);
 
           if (attribute.length) {
-            result += '(' + attribute.length + ')'
+            result += '(' + attribute.length + ')';
           }
 
           if (attribute.order) {
-            result += ' ' + attribute.order
+            result += ' ' + attribute.order;
           }
 
-          return result
+          return result;
         }
-      }.bind(this))
+      }.bind(this));
 
       var onlyAttributeNames = attributes.map(function(attribute) {
-        return (typeof attribute === 'string') ? attribute : attribute.attribute
-      }.bind(this))
+        return (typeof attribute === 'string') ? attribute : attribute.attribute;
+      }.bind(this));
 
       options = Utils._.extend({
         indicesType: null,
         indexName: Utils._.underscored(tableName + '_' + onlyAttributeNames.join('_')),
         parser: null
-      }, options || {})
+      }, options || {});
 
       return Utils._.compact([
-        "CREATE", options.indicesType, "INDEX", options.indexName,
+        'CREATE', options.indicesType, 'INDEX', options.indexName,
         (options.indexType ? ('USING ' + options.indexType) : undefined),
-        "ON", tableName, '(' + transformedAttributes.join(', ') + ')',
-        (options.parser ? "WITH PARSER " + options.parser : undefined)
-      ]).join(' ')
+        'ON', tableName, '(' + transformedAttributes.join(', ') + ')',
+        (options.parser ? 'WITH PARSER ' + options.parser : undefined)
+      ]).join(' ');
     },
 
     showIndexQuery: function(tableName, options) {
-      var sql = "SHOW INDEX FROM `<%= tableName %>`<%= options %>"
+      var sql = 'SHOW INDEX FROM `<%= tableName %>`<%= options %>';
       return Utils._.template(sql)({
         tableName: tableName,
         options: (options || {}).database ? ' FROM `' + options.database + '`' : ''
-      })
+      });
     },
 
     removeIndexQuery: function(tableName, indexNameOrAttributes) {
-      var sql       = "DROP INDEX <%= indexName %> ON <%= tableName %>"
-        , indexName = indexNameOrAttributes
+      var sql = 'DROP INDEX <%= indexName %> ON <%= tableName %>'
+        , indexName = indexNameOrAttributes;
 
       if (typeof indexName !== 'string') {
-        indexName = Utils._.underscored(tableName + '_' + indexNameOrAttributes.join('_'))
+        indexName = Utils._.underscored(tableName + '_' + indexNameOrAttributes.join('_'));
       }
 
-      return Utils._.template(sql)({ tableName: tableName, indexName: indexName })
+      return Utils._.template(sql)({ tableName: tableName, indexName: indexName });
     },
 
     attributesToSQL: function(attributes) {
-      var result = {}
+      var result = {};
 
       for (var name in attributes) {
-        var dataType = attributes[name]
+        var dataType = attributes[name];
 
         if (Utils.isHash(dataType)) {
-          var template
+          var template;
 
           if (dataType.type.toString() === DataTypes.ENUM.toString()) {
             if (Array.isArray(dataType.values) && (dataType.values.length > 0)) {
-              template = "ENUM(" + Utils._.map(dataType.values, function(value) {
-                return this.escape(value)
-              }.bind(this)).join(", ") + ")"
+              template = 'ENUM(' + Utils._.map(dataType.values, function(value) {
+                return this.escape(value);
+              }.bind(this)).join(', ') + ')';
             } else {
-              throw new Error('Values for ENUM haven\'t been defined.')
+              throw new Error('Values for ENUM haven\'t been defined.');
             }
           } else {
             template = dataType.type.toString();
           }
 
           if (dataType.hasOwnProperty('allowNull') && (!dataType.allowNull)) {
-            template += " NOT NULL"
+            template += ' NOT NULL';
           }
 
           if (dataType.autoIncrement) {
-            template += " auto_increment"
+            template += ' auto_increment';
           }
 
           // Blobs/texts cannot have a defaultValue
-          if (dataType.type !== "TEXT" && dataType.type._binary !== true && Utils.defaultValueSchemable(dataType.defaultValue)) {
-            template += " DEFAULT " + this.escape(dataType.defaultValue)
+          if (dataType.type !== 'TEXT' && dataType.type._binary !== true && Utils.defaultValueSchemable(dataType.defaultValue)) {
+            template += ' DEFAULT ' + this.escape(dataType.defaultValue);
           }
 
           if (dataType.unique === true) {
-            template += " UNIQUE"
+            template += ' UNIQUE';
           }
 
           if (dataType.primaryKey) {
-            template += " PRIMARY KEY"
+            template += ' PRIMARY KEY';
           }
 
           if (dataType.comment && Utils._.isString(dataType.comment) && dataType.comment.length) {
-            template += " COMMENT " + this.escape(dataType.comment)
+            template += ' COMMENT ' + this.escape(dataType.comment);
           }
 
-          if(dataType.references) {
-            template += " REFERENCES " + this.quoteTable(dataType.references)
+          if (dataType.references) {
+            template += ' REFERENCES ' + this.quoteTable(dataType.references);
 
-            if(dataType.referencesKey) {
-              template += " (" + this.quoteIdentifier(dataType.referencesKey) + ")"
+            if (dataType.referencesKey) {
+              template += ' (' + this.quoteIdentifier(dataType.referencesKey) + ')';
             } else {
-              template += " (" + this.quoteIdentifier('id') + ")"
+              template += ' (' + this.quoteIdentifier('id') + ')';
             }
 
-            if(dataType.onDelete) {
-              template += " ON DELETE " + dataType.onDelete.toUpperCase()
+            if (dataType.onDelete) {
+              template += ' ON DELETE ' + dataType.onDelete.toUpperCase();
             }
 
-            if(dataType.onUpdate) {
-              template += " ON UPDATE " + dataType.onUpdate.toUpperCase()
+            if (dataType.onUpdate) {
+              template += ' ON UPDATE ' + dataType.onUpdate.toUpperCase();
             }
 
           }
 
-          result[name] = template
+          result[name] = template;
         } else {
-          result[name] = dataType
+          result[name] = dataType;
         }
       }
 
-      return result
+      return result;
     },
 
     findAutoIncrementField: function(factory) {
-      var fields = []
+      var fields = [];
 
       for (var name in factory.attributes) {
         if (factory.attributes.hasOwnProperty(name)) {
-          var definition = factory.attributes[name]
+          var definition = factory.attributes[name];
 
           if (definition && definition.autoIncrement) {
-            fields.push(name)
+            fields.push(name);
           }
         }
       }
 
-      return fields
+      return fields;
     },
 
-    addLimitAndOffset: function(options, query){
-      query = query || ""
+    addLimitAndOffset: function(options, query) {
+      query = query || '';
       if (options.offset && !options.limit) {
-        query += " LIMIT " + options.offset + ", " + 18440000000000000000;
+        query += ' LIMIT ' + options.offset + ', ' + 18440000000000000000;
       } else if (options.limit) {
         if (options.offset) {
-          query += " LIMIT " + options.offset + ", " + options.limit
+          query += ' LIMIT ' + options.offset + ', ' + options.limit;
         } else {
-          query += " LIMIT " + options.limit
+          query += ' LIMIT ' + options.limit;
         }
       }
       return query;
     },
 
     quoteIdentifier: function(identifier, force) {
-      if (identifier === '*') return identifier
-      return Utils.addTicks(identifier, "`")
+      if (identifier === '*') return identifier;
+      return Utils.addTicks(identifier, '`');
     },
     /**
      * Generates an SQL query that returns all foreign keys of a table.
@@ -392,7 +392,7 @@ module.exports = (function() {
      * @return {String}            The generated sql query.
      */
     getForeignKeysQuery: function(tableName, schemaName) {
-      return "SELECT CONSTRAINT_NAME as constraint_name FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE where TABLE_NAME = '" + tableName + "' AND CONSTRAINT_NAME!='PRIMARY' AND CONSTRAINT_SCHEMA='" + schemaName + "' AND REFERENCED_TABLE_NAME IS NOT NULL;"
+      return "SELECT CONSTRAINT_NAME as constraint_name FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE where TABLE_NAME = '" + tableName + "' AND CONSTRAINT_NAME!='PRIMARY' AND CONSTRAINT_SCHEMA='" + schemaName + "' AND REFERENCED_TABLE_NAME IS NOT NULL;";
     },
 
     /**
@@ -403,17 +403,17 @@ module.exports = (function() {
      * @return {String}            The generated sql query.
      */
     dropForeignKeyQuery: function(tableName, foreignKey) {
-      return 'ALTER TABLE ' + this.quoteTable(tableName) + ' DROP FOREIGN KEY ' + this.quoteIdentifier(foreignKey) + ';'
+      return 'ALTER TABLE ' + this.quoteTable(tableName) + ' DROP FOREIGN KEY ' + this.quoteIdentifier(foreignKey) + ';';
     },
 
     mysqlDataTypeMapping: function(tableName, attr, dataType) {
       if (Utils._.includes(dataType, 'UUID')) {
-        dataType = dataType.replace(/UUID/, 'CHAR(36) BINARY')
+        dataType = dataType.replace(/UUID/, 'CHAR(36) BINARY');
       }
 
-      return dataType
+      return dataType;
     }
-  }
+  };
 
-  return Utils._.extend(Utils._.clone(require("../abstract/query-generator")), QueryGenerator)
-})()
+  return Utils._.extend(Utils._.clone(require('../abstract/query-generator')), QueryGenerator);
+})();

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -1,52 +1,52 @@
-"use strict";
+'use strict';
 
-var Utils         = require("../../utils")
+var Utils = require('../../utils')
   , AbstractQuery = require('../abstract/query')
-  , uuid          = require('node-uuid')
+  , uuid = require('node-uuid');
 
 module.exports = (function() {
   var Query = function(client, sequelize, callee, options) {
-    this.client    = client
-    this.callee    = callee
-    this.sequelize = sequelize
-    this.uuid      = uuid.v4()
-    this.options   = Utils._.extend({
+    this.client = client;
+    this.callee = callee;
+    this.sequelize = sequelize;
+    this.uuid = uuid.v4();
+    this.options = Utils._.extend({
       logging: console.log,
       plain: false,
       raw: false
-    }, options || {})
+    }, options || {});
 
-    var self = this
-    this.checkLoggingOption()
-    this.promise = new Utils.Promise(function (resolve, reject) {
-      self.resolve = resolve
-      self.reject = reject
-    })
-  }
+    var self = this;
+    this.checkLoggingOption();
+    this.promise = new Utils.Promise(function(resolve, reject) {
+      self.resolve = resolve;
+      self.reject = reject;
+    });
+  };
 
-  Utils.inherit(Query, AbstractQuery)
+  Utils.inherit(Query, AbstractQuery);
   Query.prototype.run = function(sql) {
-    var self = this
-    this.sql = sql
+    var self = this;
+    this.sql = sql;
 
     if (this.options.logging !== false) {
-      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql)
+      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql);
     }
-    
+
     self.client.query(self.sql, function(err, results, fields) {
-      self.promise.emit('sql', self.sql, self.options.uuid)
+      self.promise.emit('sql', self.sql, self.options.uuid);
 
       if (err) {
-        err.sql = sql
+        err.sql = sql;
 
-        self.reject(err)
+        self.reject(err);
       } else {
-        self.resolve(self.formatResults(results))
+        self.resolve(self.formatResults(results));
       }
-    }).setMaxListeners(100)
+    }).setMaxListeners(100);
 
-    return this.promise
-  }
+    return this.promise;
+  };
 
-  return Query
-})()
+  return Query;
+})();

--- a/lib/dialects/postgres/connector-manager.js
+++ b/lib/dialects/postgres/connector-manager.js
@@ -1,191 +1,191 @@
-"use strict";
+'use strict';
 
-var Query                = require("./query")
-  , Utils                = require("../../utils")
+var Query = require('./query')
+  , Utils = require('../../utils');
 
 module.exports = (function() {
   var ConnectorManager = function(sequelize, config) {
-    var pgModule = config.dialectModulePath || 'pg'
+    var pgModule = config.dialectModulePath || 'pg';
 
-    this.sequelize = sequelize
-    this.client         = null
-    this.config         = config || {}
-    this.config.port    = this.config.port || 5432
-    this.pooling        = (!!this.config.pool && (this.config.pool.maxConnections > 0))
-    this.pg             = this.config.native ? require(pgModule).native : require(pgModule)
+    this.sequelize = sequelize;
+    this.client = null;
+    this.config = config || {};
+    this.config.port = this.config.port || 5432;
+    this.pooling = (!!this.config.pool && (this.config.pool.maxConnections > 0));
+    this.pg = this.config.native ? require(pgModule).native : require(pgModule);
     // Better support for BigInts
     // https://github.com/brianc/node-postgres/issues/166#issuecomment-9514935
     this.pg.types.setTypeParser(20, String);
 
-    this.disconnectTimeoutId = null
-    this.pendingQueries = 0
-    this.clientDrained = true
-    this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50)
-    this.ConnectionParameters = require(pgModule + '/lib/connection-parameters')
+    this.disconnectTimeoutId = null;
+    this.pendingQueries = 0;
+    this.clientDrained = true;
+    this.maxConcurrentQueries = (this.config.maxConcurrentQueries || 50);
+    this.ConnectionParameters = require(pgModule + '/lib/connection-parameters');
 
-    this.onProcessExit = function () {
-      this.disconnect()
+    this.onProcessExit = function() {
+      this.disconnect();
     }.bind(this);
 
-    process.on('exit', this.onProcessExit)
-  }
-  Utils._.extend(ConnectorManager.prototype, require("../abstract/connector-manager").prototype)
+    process.on('exit', this.onProcessExit);
+  };
+  Utils._.extend(ConnectorManager.prototype, require('../abstract/connector-manager').prototype);
 
   ConnectorManager.prototype.endQuery = function() {
-    var self = this
+    var self = this;
 
-    self.pendingQueries--
+    self.pendingQueries--;
 
     if (!self.pooling && self.pendingQueries === 0) {
       setTimeout(function() {
-        self.pendingQueries === 0 && self.disconnect.call(self)
-      }, 100)
+        self.pendingQueries === 0 && self.disconnect.call(self);
+      }, 100);
     }
-  }
+  };
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
-    var self = this
+    var self = this;
 
-    self.pendingQueries++
-    self.clientDrained = false
+    self.pendingQueries++;
+    self.clientDrained = false;
 
     return self.connect().then(function(done) {
-      var query = new Query(self.client, self.sequelize, callee, options || {})
+      var query = new Query(self.client, self.sequelize, callee, options || {});
 
       // We return the query regardless of error or success in the query
-      return query.run(sql).finally(function () {
+      return query.run(sql).finally (function() {
         self.endQuery.call(self);
         done && done();
       });
     });
-  }
+  };
 
   ConnectorManager.prototype.afterTransactionSetup = function(callback) {
-    this.setTimezone(this.client, 'UTC', callback)
-  }
+    this.setTimezone(this.client, 'UTC', callback);
+  };
 
   ConnectorManager.prototype.connect = function(callback) {
-    var self = this
+    var self = this;
 
-    return new Utils.Promise(function (resolve, reject) {
+    return new Utils.Promise(function(resolve, reject) {
       // in case database is slow to connect, prevent orphaning the client
       // TODO: We really need some sort of queue/flush/drain mechanism
       if (this.isConnecting && !this.pooling && this.client === null) {
-        return resolve()
+        return resolve();
       }
 
-      this.isConnecting = true
-      this.isConnected  = false
+      this.isConnecting = true;
+      this.isConnected = false;
 
-      var uri    = this.sequelize.getQueryInterface().QueryGenerator.databaseConnectionUri(this.config)
-        , config = new this.ConnectionParameters(uri)
+      var uri = this.sequelize.getQueryInterface().QueryGenerator.databaseConnectionUri(this.config)
+        , config = new this.ConnectionParameters(uri);
 
       // set pooling parameters if specified
       if (this.pooling) {
-        config.poolSize           = this.config.pool.maxConnections || 10
-        config.poolIdleTimeout    = this.config.pool.maxIdleTime    || 30000
-        config.reapIntervalMillis = this.config.pool.reapInterval   || 1000
-        config.uuid               = this.config.uuid
+        config.poolSize = this.config.pool.maxConnections || 10;
+        config.poolIdleTimeout = this.config.pool.maxIdleTime || 30000;
+        config.reapIntervalMillis = this.config.pool.reapInterval || 1000;
+        config.uuid = this.config.uuid;
       }
       var connectCallback = function(err, client, done) {
         var timezoneCallback = function() {
-            self.isConnected = true
-            self.client = client
-            resolve(done)
-          }
+            self.isConnected = true;
+            self.client = client;
+            resolve(done);
+          };
 
-        self.isConnecting = false
+        self.isConnecting = false;
 
         if (!!err) {
           // release the pool immediately, very important.
-          done && done(err)
-          self.client = null
+          done && done(err);
+          self.client = null;
 
           if (err.code) {
-            switch(err.code) {
+            switch (err.code) {
             case 'ECONNREFUSED':
-              reject(new Error("Failed to authenticate for PostgresSQL. Please double check your settings."))
-              break
+              reject(new Error('Failed to authenticate for PostgresSQL. Please double check your settings.'));
+              break;
             case 'ENOTFOUND':
             case 'EHOSTUNREACH':
             case 'EINVAL':
-              reject(new Error("Failed to find PostgresSQL server. Please double check your settings."))
-              break
+              reject(new Error('Failed to find PostgresSQL server. Please double check your settings.'));
+              break;
             default:
-              reject(err)
-              break
+              reject(err);
+              break;
             }
           } else {
-            reject(new Error(err.message))
+            reject(new Error(err.message));
           }
         } else if (client) {
           if (self.config.keepDefaultTimezone) {
-            timezoneCallback()
+            timezoneCallback();
           } else {
-            self.setTimezone(client, 'UTC', timezoneCallback)
+            self.setTimezone(client, 'UTC', timezoneCallback);
           }
         } else if (self.config.native) {
           if (self.config.keepDefaultTimezone) {
-            timezoneCallback()
+            timezoneCallback();
           } else {
-            self.setTimezone(self.client, 'UTC', timezoneCallback)  
-          }          
+            self.setTimezone(self.client, 'UTC', timezoneCallback);
+          }
         } else {
-          done && done()
-          self.client = null
-          resolve()
+          done && done();
+          self.client = null;
+          resolve();
         }
-      }
+      };
 
       if (this.pooling) {
         // acquire client from pool
-        this.pg.connect(config, connectCallback)
+        this.pg.connect(config, connectCallback);
       } else {
         if (!!this.client) {
-          connectCallback(null, this.client)
+          connectCallback(null, this.client);
         } else {
           //create one-off client
 
-          var responded = false
+          var responded = false;
 
-          this.client = new this.pg.Client(config)
+          this.client = new this.pg.Client(config);
           this.client.connect(function(err, client, done) {
-            responded = true
-            connectCallback(err, client || self.client, done)
-          })
+            responded = true;
+            connectCallback(err, client || self.client, done);
+          });
 
           // If we didn't ever hear from the client.connect() callback the connection timeout, node-postgres does not treat this as an error since no active query was ever emitted
-          this.client.on('end', function () {
+          this.client.on('end', function() {
             if (!responded) {
-              connectCallback(new Error('Connection timed out'))
+              connectCallback(new Error('Connection timed out'));
             }
-          })
+          });
 
           // Closes a client correctly even if we have backed up queries
           // https://github.com/brianc/node-postgres/pull/346
           this.client.on('drain', function() {
-            self.clientDrained = true
-          })
+            self.clientDrained = true;
+          });
         }
       }
-    }.bind(this))
-  }
+    }.bind(this));
+  };
 
   ConnectorManager.prototype.setTimezone = function(client, timezone, callback) {
-    client.query("SET TIME ZONE '" + (timezone || "UTC") + "'").on('end', callback)
-  }
+    client.query("SET TIME ZONE '" + (timezone ||  'UTC') + "'").on('end', callback);
+  };
 
   ConnectorManager.prototype.disconnect = function() {
     if (this.client) {
       if (this.clientDrained) {
-        this.client.end()
+        this.client.end();
       }
-      this.client = null
+      this.client = null;
     }
 
-    this.isConnecting = false
-    this.isConnected  = false
-  }
+    this.isConnecting = false;
+    this.isConnected = false;
+  };
 
-  return ConnectorManager
-})()
+  return ConnectorManager;
+})();

--- a/lib/dialects/postgres/hstore.js
+++ b/lib/dialects/postgres/hstore.js
@@ -1,69 +1,69 @@
-"use strict";
+'use strict';
 
 module.exports = {
   stringifyPart: function(part) {
-    switch(typeof part) {
+    switch (typeof part) {
       case 'boolean':
       case 'number':
-        return String(part)
+        return String(part);
       case 'string':
-        return '"' + part.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+        return '"' + part.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
       case 'undefined':
-        return 'NULL'
+        return 'NULL';
       default:
         if (part === null)
-          return 'NULL'
+          return 'NULL';
         else
-          return '"' + JSON.stringify(part).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"'
+          return '"' + JSON.stringify(part).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
     }
   },
   stringify: function(data) {
-    var self = this
+    var self = this;
 
     return Object.keys(data).map(function(key) {
-      return self.stringifyPart(key) + '=>' + self.stringifyPart(data[key])
-    }).join(',')
+      return self.stringifyPart(key) + '=>' + self.stringifyPart(data[key]);
+    }).join(',');
   },
   parsePart: function(part) {
-    part = part.replace(/\\\\/g, '\\').replace(/\\"/g, '"')
+    part = part.replace(/\\\\/g, '\\').replace(/\\"/g, '"');
 
-    switch(part[0]) {
+    switch (part[0]) {
       case '{':
       case '[':
-        return JSON.parse(part)
+        return JSON.parse(part);
       default:
-        return part
+        return part;
     }
   },
   parse: function(string) {
     var self = this,
-        object = { }
+        object = { };
 
     if (('string' !== typeof string) || (0 === string.length)) {
       return object;
     }
-    
-    var rx = /\"((?:\\\"|[^"])*)\"\s*\=\>\s*((?:true|false|NULL|\d+|\d+\.\d+|\"((?:\\\"|[^"])*)\"))/g
+
+    var rx = /\"((?:\\\"|[^"])*)\"\s*\=\>\s*((?:true|false|NULL|\d+|\d+\.\d+|\"((?:\\\"|[^"])*)\"))/g;
 
     string = string || '';
 
     string.replace(rx, function(match, key, value, innerValue) {
-      switch(value) {
+      switch (value) {
         case 'true':
-          object[self.parsePart(key)] = true
-          break
+          object[self.parsePart(key)] = true;
+          break;
         case 'false':
-          object[self.parsePart(key)] = false
-          break
+          object[self.parsePart(key)] = false;
+          break;
         case 'NULL':
-          object[self.parsePart(key)] = null
-          break
+          object[self.parsePart(key)] = null;
+          break;
         default:
-          object[self.parsePart(key)] = self.parsePart(innerValue || value)
-          break
+          object[self.parsePart(key)] = self.parsePart(innerValue || value);
+          break;
       }
-    })
+    });
 
     return object;
   }
-}
+};

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -1,18 +1,18 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
-  , Abstract = require('../abstract')
+  , Abstract = require('../abstract');
 
 var PostgresDialect = function(sequelize) {
-  this.sequelize = sequelize
-}
+  this.sequelize = sequelize;
+};
 
 PostgresDialect.prototype.supports = _.defaults({
   'RETURNING': true,
   'DEFAULT VALUES': true,
   schemas: true,
   lock: true,
-  forShare: 'FOR SHARE',
-}, Abstract.prototype.supports)
+  forShare: 'FOR SHARE'
+}, Abstract.prototype.supports);
 
-module.exports = PostgresDialect
+module.exports = PostgresDialect;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -1,12 +1,12 @@
-"use strict";
+'use strict';
 
-var Utils       = require("../../utils")
-  , hstore      = require('./hstore')
-  , util        = require("util")
-  , DataTypes   = require("../../data-types")
-  , SqlString   = require("../../sql-string")
-  , tables      = {}
-  , primaryKeys = {}
+var Utils = require('../../utils')
+  , hstore = require('./hstore')
+  , util = require('util')
+  , DataTypes = require('../../data-types')
+  , SqlString = require('../../sql-string')
+  , tables = {}
+  , primaryKeys = {};
 
 module.exports = (function() {
   var QueryGenerator = {
@@ -14,82 +14,82 @@ module.exports = (function() {
     dialect: 'postgres',
 
     createSchema: function(schema) {
-      var query = "CREATE SCHEMA <%= schema%>;"
-      return Utils._.template(query)({schema: schema})
+      var query = 'CREATE SCHEMA <%= schema%>;';
+      return Utils._.template(query)({schema: schema});
     },
 
     dropSchema: function(schema) {
-      var query = "DROP SCHEMA <%= schema%> CASCADE;"
-      return Utils._.template(query)({schema: schema})
+      var query = 'DROP SCHEMA <%= schema%> CASCADE;';
+      return Utils._.template(query)({schema: schema});
     },
 
     showSchemasQuery: function() {
-      return "SELECT schema_name FROM information_schema.schemata WHERE schema_name <> 'information_schema' AND schema_name != 'public' AND schema_name !~ E'^pg_';"
+      return "SELECT schema_name FROM information_schema.schemata WHERE schema_name <> 'information_schema' AND schema_name != 'public' AND schema_name !~ E'^pg_';";
     },
 
     createTableQuery: function(tableName, attributes, options) {
-      var self = this
+      var self = this;
 
       options = Utils._.extend({
-      }, options || {})
+      }, options || {});
 
-      primaryKeys[tableName] = []
-      tables[tableName] = {}
+      primaryKeys[tableName] = [];
+      tables[tableName] = {};
 
-      var query   = "CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>)<%= comments %>"
-        , comments = ""
+      var query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>)<%= comments %>'
+        , comments = ''
         , attrStr = []
-        , i
+        , i;
 
       if (options.comment && Utils._.isString(options.comment)) {
-        comments += "; COMMENT ON TABLE <%= table %> IS " + this.escape(options.comment)
+        comments += '; COMMENT ON TABLE <%= table %> IS ' + this.escape(options.comment);
       }
 
       for (var attr in attributes) {
         if ((i = attributes[attr].indexOf('COMMENT')) !== -1) {
           // Move comment to a seperate query
-          comments += "; " + attributes[attr].substring(i)
-          attributes[attr] = attributes[attr].substring(0, i)
+          comments += '; ' + attributes[attr].substring(i);
+          attributes[attr] = attributes[attr].substring(0, i);
         }
 
-        var dataType = this.pgDataTypeMapping(tableName, attr, attributes[attr])
-        attrStr.push(this.quoteIdentifier(attr) + " " + dataType)
+        var dataType = this.pgDataTypeMapping(tableName, attr, attributes[attr]);
+        attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
       }
 
-      var values  = {
+      var values = {
         table: this.quoteTable(tableName),
-        attributes: attrStr.join(", "),
+        attributes: attrStr.join(', '),
         comments: Utils._.template(comments, { table: this.quoteTable(tableName)})
-      }
+      };
 
       if (!!options.uniqueKeys) {
         Utils._.each(options.uniqueKeys, function(columns) {
-          values.attributes += ", UNIQUE (" + columns.fields.map(function(f) { return self.quoteIdentifiers(f) }).join(', ') + ")"
-        })
+          values.attributes += ', UNIQUE (' + columns.fields.map(function(f) { return self.quoteIdentifiers(f); }).join(', ') + ')';
+        });
       }
 
-      var pks = primaryKeys[tableName].map(function(pk){
-        return this.quoteIdentifier(pk)
-      }.bind(this)).join(",")
+      var pks = primaryKeys[tableName].map(function(pk) {
+        return this.quoteIdentifier(pk);
+      }.bind(this)).join(',');
 
       if (pks.length > 0) {
-        values.attributes += ", PRIMARY KEY (" + pks + ")"
+        values.attributes += ', PRIMARY KEY (' + pks + ')';
       }
 
-      return Utils._.template(query)(values).trim() + ";"
+      return Utils._.template(query)(values).trim() + ';';
     },
 
     dropTableQuery: function(tableName, options) {
-      options = options || {}
-      var query = "DROP TABLE IF EXISTS <%= table %><%= cascade %>;"
+      options = options || {};
+      var query = 'DROP TABLE IF EXISTS <%= table %><%= cascade %>;';
       return Utils._.template(query)({
         table: this.quoteTable(tableName),
-        cascade: options.cascade? " CASCADE" : ""
-      })
+        cascade: options.cascade ? ' CASCADE' : ''
+      });
     },
 
     showTablesQuery: function() {
-      return "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';"
+      return "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public';";
     },
 
     describeTableQuery: function(tableName, schema) {
@@ -97,419 +97,419 @@ module.exports = (function() {
         schema = 'public';
       }
 
-      var query = 'SELECT c.column_name as "Field", c.column_default as "Default", c.is_nullable as "Null", CASE WHEN c.udt_name = \'hstore\' THEN c.udt_name ELSE c.data_type END as "Type", (SELECT array_agg(e.enumlabel) FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid=e.enumtypid WHERE t.typname=c.udt_name) AS "special" FROM information_schema.columns c WHERE table_name = <%= table %> AND table_schema = <%= schema %>'
+      var query = 'SELECT c.column_name as "Field", c.column_default as "Default", c.is_nullable as "Null", CASE WHEN c.udt_name = \'hstore\' THEN c.udt_name ELSE c.data_type END as "Type", (SELECT array_agg(e.enumlabel) FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid=e.enumtypid WHERE t.typname=c.udt_name) AS "special" FROM information_schema.columns c WHERE table_name = <%= table %> AND table_schema = <%= schema %>';
 
       return Utils._.template(query)({
         table: this.escape(tableName),
         schema: this.escape(schema)
-      })
+      });
     },
 
     uniqueConstraintMapping: {
       code: '23505',
       map: function(str) {
-        var match = str.match(/duplicate key value violates unique constraint "(.*?)_key"/)
+        var match = str.match(/duplicate key value violates unique constraint "(.*?)_key"/);
         if (match === null || match.length < 2) {
-          return false
+          return false;
         }
 
-        return match[1].split('_').splice(1)
+        return match[1].split('_').splice(1);
       }
     },
 
     addColumnQuery: function(tableName, attributes) {
-      var query      = "ALTER TABLE <%= tableName %> ADD COLUMN <%= attributes %>;"
-        , attrString = []
+      var query = 'ALTER TABLE <%= tableName %> ADD COLUMN <%= attributes %>;'
+        , attrString = [];
 
       for (var attrName in attributes) {
-        var definition = attributes[attrName]
+        var definition = attributes[attrName];
 
         attrString.push(Utils._.template('<%= attrName %> <%= definition %>')({
-          attrName:   this.quoteIdentifier(attrName),
+          attrName: this.quoteIdentifier(attrName),
           definition: this.pgDataTypeMapping(tableName, attrName, definition)
-        }))
+        }));
 
         if (definition.match(/^ENUM\(/)) {
-          query = this.pgEnum(tableName, attrName, definition) + query
+          query = this.pgEnum(tableName, attrName, definition) + query;
         }
       }
 
       return Utils._.template(query)({
-        tableName:  this.quoteTable(tableName),
-        attributes: attrString.join(', ') 
-      })
+        tableName: this.quoteTable(tableName),
+        attributes: attrString.join(', ')
+      });
     },
 
-    arrayValue: function(value, key, _key, factory, logicResult){
-      var col      = null
-        , coltype  = null
+    arrayValue: function(value, key, _key, factory, logicResult) {
+      var col = null
+        , coltype = null
         , _realKey = key.split('.').pop().replace(/"/g, '')
-        , _value
+        , _value;
 
-      if (value.length === 0) { value = [null] }
+      if (value.length === 0) { value = [null]; }
 
       // Special conditions for searching within an array column type
       if (!!factory && !!factory.rawAttributes[_realKey]) {
-        col = factory.rawAttributes[_realKey]
-        coltype = col.type
-        if(coltype && !(typeof coltype == 'string')) {
+        col = factory.rawAttributes[_realKey];
+        coltype = col.type;
+        if (coltype && typeof coltype !== 'string') {
           coltype = coltype.toString();
         }
       }
 
-      if ( col && ((!!coltype && coltype.match(/\[\]$/) !== null) || (col.toString().match(/\[\]$/) !== null))) {
-        _value = 'ARRAY[' + value.map(this.escape.bind(this)).join(',') + ']::' + (!!col.type ? col.type : col.toString())
-        return [_key, _value].join(" && ")
+      if (col && ((!!coltype && coltype.match(/\[\]$/) !== null) || (col.toString().match(/\[\]$/) !== null))) {
+        _value = 'ARRAY[' + value.map(this.escape.bind(this)).join(',') + ']::' + (!!col.type ? col.type : col.toString());
+        return [_key, _value].join(' && ');
       } else {
-        _value = "(" + value.map(this.escape.bind(this)).join(',') + ")"
-        return [_key, _value].join(" " + logicResult + " ")
+        _value = '(' + value.map(this.escape.bind(this)).join(',') + ')';
+        return [_key, _value].join(' ' + logicResult + ' ');
       }
     },
 
     removeColumnQuery: function(tableName, attributeName) {
-      var query = "ALTER TABLE <%= tableName %> DROP COLUMN <%= attributeName %>;"
+      var query = 'ALTER TABLE <%= tableName %> DROP COLUMN <%= attributeName %>;';
       return Utils._.template(query)({
-        tableName:     this.quoteIdentifiers(tableName),
+        tableName: this.quoteIdentifiers(tableName),
         attributeName: this.quoteIdentifier(attributeName)
-      })
+      });
     },
 
     changeColumnQuery: function(tableName, attributes) {
-      var query = "ALTER TABLE <%= tableName %> ALTER COLUMN <%= query %>;"
-        , sql   = []
+      var query = 'ALTER TABLE <%= tableName %> ALTER COLUMN <%= query %>;'
+        , sql = [];
 
       for (var attributeName in attributes) {
-        var definition = attributes[attributeName]
-        var attrSql = ''
+        var definition = attributes[attributeName];
+        var attrSql = '';
 
         if (definition.indexOf('NOT NULL') > 0) {
           attrSql += Utils._.template(query)({
             tableName: this.quoteIdentifiers(tableName),
-            query:     this.quoteIdentifier(attributeName) + ' SET NOT NULL'
-          })
+            query: this.quoteIdentifier(attributeName) + ' SET NOT NULL'
+          });
 
-          definition = definition.replace('NOT NULL', '').trim()
+          definition = definition.replace('NOT NULL', '').trim();
         } else {
           attrSql += Utils._.template(query)({
             tableName: this.quoteIdentifiers(tableName),
-            query:     this.quoteIdentifier(attributeName) + ' DROP NOT NULL'
-          })
+            query: this.quoteIdentifier(attributeName) + ' DROP NOT NULL'
+          });
         }
 
         if (definition.indexOf('DEFAULT') > 0) {
           attrSql += Utils._.template(query)({
             tableName: this.quoteIdentifiers(tableName),
-            query:     this.quoteIdentifier(attributeName) + ' SET DEFAULT ' + definition.match(/DEFAULT ([^;]+)/)[1]
-          })
+            query: this.quoteIdentifier(attributeName) + ' SET DEFAULT ' + definition.match(/DEFAULT ([^;]+)/)[1]
+          });
 
-          definition = definition.replace(/(DEFAULT[^;]+)/, '').trim()
+          definition = definition.replace(/(DEFAULT[^;]+)/, '').trim();
         } else {
           attrSql += Utils._.template(query)({
             tableName: this.quoteIdentifiers(tableName),
-            query:     this.quoteIdentifier(attributeName) + ' DROP DEFAULT'
-          })
+            query: this.quoteIdentifier(attributeName) + ' DROP DEFAULT'
+          });
         }
 
         if (definition.match(/^ENUM\(/)) {
-          query      = this.pgEnum(tableName, attributeName, definition) + query
-          definition = definition.replace(/^ENUM\(.+\)/, this.quoteIdentifier("enum_" + tableName + "_" + attributeName))
+          query = this.pgEnum(tableName, attributeName, definition) + query;
+          definition = definition.replace(/^ENUM\(.+\)/, this.quoteIdentifier('enum_' + tableName + '_' + attributeName));
         }
 
         if (definition.match(/UNIQUE;*$/)) {
-          definition = definition.replace(/UNIQUE;*$/, '')
+          definition = definition.replace(/UNIQUE;*$/, '');
 
           attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
             tableName: this.quoteIdentifiers(tableName),
-            query:     'ADD CONSTRAINT ' + this.quoteIdentifier(attributeName + '_unique_idx') + ' UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
-          })
+            query: 'ADD CONSTRAINT ' + this.quoteIdentifier(attributeName + '_unique_idx') + ' UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
+          });
         }
 
         attrSql += Utils._.template(query)({
           tableName: this.quoteIdentifiers(tableName),
-          query:     this.quoteIdentifier(attributeName) + ' TYPE ' + definition
-        })
+          query: this.quoteIdentifier(attributeName) + ' TYPE ' + definition
+        });
 
-        sql.push(attrSql)
+        sql.push(attrSql);
       }
 
-      return sql.join('')
+      return sql.join('');
     },
 
     renameColumnQuery: function(tableName, attrBefore, attributes) {
-      var query      = "ALTER TABLE <%= tableName %> RENAME COLUMN <%= attributes %>;"
-      var attrString = []
+      var query = 'ALTER TABLE <%= tableName %> RENAME COLUMN <%= attributes %>;';
+      var attrString = [];
 
       for (var attributeName in attributes) {
         attrString.push(Utils._.template('<%= before %> TO <%= after %>')({
           before: this.quoteIdentifier(attrBefore),
-          after:  this.quoteIdentifier(attributeName)
-        }))
+          after: this.quoteIdentifier(attributeName)
+        }));
       }
 
       return Utils._.template(query)({
-        tableName:  this.quoteIdentifiers(tableName),
+        tableName: this.quoteIdentifiers(tableName),
         attributes: attrString.join(', ')
-      })
+      });
     },
 
     bulkInsertQuery: function(tableName, attrValueHashes, options, modelAttributes) {
-      var query        = "INSERT INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %> RETURNING *;"
-        , tuples       = []
-        , serials      = []
-        , allAttributes = []
+      var query = 'INSERT INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %> RETURNING *;'
+        , tuples = []
+        , serials = []
+        , allAttributes = [];
 
       Utils._.forEach(attrValueHashes, function(attrValueHash) {
         Utils._.forOwn(attrValueHash, function(value, key) {
           if (allAttributes.indexOf(key) === -1) {
-            allAttributes.push(key)
+            allAttributes.push(key);
           }
 
           if (modelAttributes && modelAttributes[key] && modelAttributes[key].autoIncrement === true) {
-            serials.push(key)
+            serials.push(key);
           }
-        })
-      })
+        });
+      });
 
       Utils._.forEach(attrValueHashes, function(attrValueHash) {
-        tuples.push("(" +
-          allAttributes.map(function (key) {
+        tuples.push('(' +
+          allAttributes.map(function(key) {
             if (serials.indexOf(key) !== -1) {
               return attrValueHash[key] || 'DEFAULT';
             }
-            return this.escape(attrValueHash[key], modelAttributes && modelAttributes[key])
-          }.bind(this)).join(",") +
-        ")")
-      }.bind(this))
+            return this.escape(attrValueHash[key], modelAttributes && modelAttributes[key]);
+          }.bind(this)).join(',') +
+        ')');
+      }.bind(this));
 
-      var replacements  = {
-        table:      this.quoteTable(tableName)
-      , attributes: allAttributes.map(function(attr){
-                      return this.quoteIdentifier(attr)
-                    }.bind(this)).join(",")
-      , tuples:     tuples.join(",")
-      }
+      var replacements = {
+        table: this.quoteTable(tableName)
+      , attributes: allAttributes.map(function(attr) {
+                      return this.quoteIdentifier(attr);
+                    }.bind(this)).join(',')
+      , tuples: tuples.join(',')
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     deleteQuery: function(tableName, where, options, model) {
-      options = options || {}
+      options = options ||  {};
 
-      tableName = Utils.removeTicks(this.quoteTable(tableName), '"')
+      tableName = Utils.removeTicks(this.quoteTable(tableName), '"');
 
       if (options.truncate === true) {
-        return "TRUNCATE " + QueryGenerator.quoteIdentifier(tableName)
+        return 'TRUNCATE ' + QueryGenerator.quoteIdentifier(tableName);
       }
 
-      if(Utils._.isUndefined(options.limit)) {
+      if (Utils._.isUndefined(options.limit)) {
         options.limit = 1;
       }
 
       primaryKeys[tableName] = primaryKeys[tableName] || [];
 
       if (!!model && primaryKeys[tableName].length < 1) {
-        primaryKeys[tableName] = Object.keys(model.primaryKeys)
+        primaryKeys[tableName] = Object.keys(model.primaryKeys);
       }
 
-      var query = "DELETE FROM <%= table %> WHERE <%= primaryKeys %> IN (SELECT <%= primaryKeysSelection %> FROM <%= table %> WHERE <%= where %><%= limit %>)"
+      var query = 'DELETE FROM <%= table %> WHERE <%= primaryKeys %> IN (SELECT <%= primaryKeysSelection %> FROM <%= table %> WHERE <%= where %><%= limit %>)';
 
       var pks;
       if (primaryKeys[tableName] && primaryKeys[tableName].length > 0) {
         pks = primaryKeys[tableName].map(function(pk) {
-          return this.quoteIdentifier(pk)
-        }.bind(this)).join(',')
+          return this.quoteIdentifier(pk);
+        }.bind(this)).join(',');
       } else {
-        pks = this.quoteIdentifier('id')
+        pks = this.quoteIdentifier('id');
       }
 
       var replacements = {
         table: this.quoteIdentifiers(tableName),
         where: this.getWhereConditions(where),
-        limit: !!options.limit? " LIMIT " + this.escape(options.limit) : "",
+        limit: !!options.limit ? ' LIMIT ' + this.escape(options.limit) : '',
         primaryKeys: primaryKeys[tableName].length > 1 ? '(' + pks + ')' : pks,
         primaryKeysSelection: pks
-      }
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     addIndexQuery: function(tableName, attributes, options) {
       var transformedAttributes = attributes.map(function(attribute) {
         if (typeof attribute === 'string') {
-          return this.quoteIdentifier(attribute)
+          return this.quoteIdentifier(attribute);
         } else {
-          var result = ""
+          var result = '';
 
           if (!attribute.attribute) {
-            throw new Error('The following index attribute has no attribute: ' + util.inspect(attribute))
+            throw new Error('The following index attribute has no attribute: ' + util.inspect(attribute));
           }
 
-          result += this.quoteIdentifier(attribute.attribute)
+          result += this.quoteIdentifier(attribute.attribute);
 
           if (attribute.length) {
-            result += '(' + attribute.length + ')'
+            result += '(' + attribute.length + ')';
           }
 
           if (attribute.order) {
-            result += ' ' + attribute.order
+            result += ' ' + attribute.order;
           }
 
-          return result
+          return result;
         }
-      }.bind(this))
+      }.bind(this));
 
       var onlyAttributeNames = attributes.map(function(attribute) {
-        return (typeof attribute === "string") ? attribute : attribute.attribute
-      }.bind(this))
+        return (typeof attribute === 'string') ? attribute : attribute.attribute;
+      }.bind(this));
 
-      var indexTable = tableName.split('.')
+      var indexTable = tableName.split('.');
       options = Utils._.extend({
         indicesType: null,
-        indexName:   Utils._.underscored(indexTable[indexTable.length-1] + '_' + onlyAttributeNames.join('_')),
-        parser:      null
-      }, options || {})
+        indexName: Utils._.underscored(indexTable[indexTable.length - 1] + '_' + onlyAttributeNames.join('_')),
+        parser: null
+      }, options || {});
 
       return Utils._.compact([
-        "CREATE", options.indicesType, "INDEX", this.quoteIdentifiers(options.indexName),
-        "ON", this.quoteIdentifiers(tableName), (options.indexType ? ('USING ' + options.indexType) : undefined),
+        'CREATE', options.indicesType, 'INDEX', this.quoteIdentifiers(options.indexName),
+        'ON', this.quoteIdentifiers(tableName), (options.indexType ? ('USING ' + options.indexType) : undefined),
         '(' + transformedAttributes.join(', ') + ')'
-      ]).join(' ')
+      ]).join(' ');
     },
 
     showIndexQuery: function(tableName, options) {
-      var query = "SELECT relname FROM pg_class WHERE oid IN ( SELECT indexrelid FROM pg_index, pg_class WHERE pg_class.relname='<%= tableName %>' AND pg_class.oid=pg_index.indrelid);"
+      var query = "SELECT relname FROM pg_class WHERE oid IN ( SELECT indexrelid FROM pg_index, pg_class WHERE pg_class.relname='<%= tableName %>' AND pg_class.oid=pg_index.indrelid);";
       return Utils._.template(query)({ tableName: tableName });
     },
 
     removeIndexQuery: function(tableName, indexNameOrAttributes) {
-      var sql       = "DROP INDEX IF EXISTS <%= indexName %>"
-        , indexName = indexNameOrAttributes
+      var sql = 'DROP INDEX IF EXISTS <%= indexName %>'
+        , indexName = indexNameOrAttributes;
 
-      if (typeof indexName !== "string") {
-        indexName = Utils._.underscored(tableName + '_' + indexNameOrAttributes.join('_'))
+      if (typeof indexName !== 'string') {
+        indexName = Utils._.underscored(tableName + '_' + indexNameOrAttributes.join('_'));
       }
 
       return Utils._.template(sql)({
         tableName: this.quoteIdentifiers(tableName),
         indexName: this.quoteIdentifiers(indexName)
-      })
+      });
     },
 
-    addLimitAndOffset: function(options, query){
-      query = query || ""
+    addLimitAndOffset: function(options, query) {
+      query = query || '';
       if (options.limit) {
-        query += " LIMIT " + options.limit
+        query += ' LIMIT ' + options.limit;
       }
 
       if (options.offset) {
-        query += " OFFSET " + options.offset
+        query += ' OFFSET ' + options.offset;
       }
 
       return query;
     },
 
     attributesToSQL: function(attributes) {
-      var result = {}
+      var result = {};
 
       for (var name in attributes) {
-        var dataType = attributes[name]
+        var dataType = attributes[name];
 
-        if(Utils.isHash(dataType)) {
-          var template     = "<%= type %>"
-            , replacements = { type: dataType.type }
+        if (Utils.isHash(dataType)) {
+          var template = '<%= type %>'
+            , replacements = { type: dataType.type };
 
           if (dataType.type.toString() === DataTypes.ENUM.toString()) {
             if (Array.isArray(dataType.values) && (dataType.values.length > 0)) {
-              replacements.type = "ENUM(" + Utils._.map(dataType.values, function(value) {
-                return this.escape(value)
-              }.bind(this)).join(", ") + ")"
+              replacements.type = 'ENUM(' + Utils._.map(dataType.values, function(value) {
+                return this.escape(value);
+              }.bind(this)).join(', ') + ')';
             } else {
-              throw new Error('Values for ENUM haven\'t been defined.')
+              throw new Error('Values for ENUM haven\'t been defined.');
             }
           }
 
-          if (dataType.type === "TINYINT(1)") {
-            dataType.type = 'BOOLEAN'
+          if (dataType.type === 'TINYINT(1)') {
+            dataType.type = 'BOOLEAN';
           }
 
-          if (dataType.type === "DATETIME") {
-            dataType.originalType = "DATETIME"
-            dataType.type = 'TIMESTAMP WITH TIME ZONE'
+          if (dataType.type === 'DATETIME') {
+            dataType.originalType = 'DATETIME';
+            dataType.type = 'TIMESTAMP WITH TIME ZONE';
           }
 
           if (dataType.hasOwnProperty('allowNull') && (!dataType.allowNull)) {
-            template += " NOT NULL"
+            template += ' NOT NULL';
           }
 
           if (dataType.autoIncrement) {
-            template += " SERIAL"
+            template += ' SERIAL';
           }
 
           if (Utils.defaultValueSchemable(dataType.defaultValue)) {
             // TODO thoroughly check that DataTypes.NOW will properly
             // get populated on all databases as DEFAULT value
             // i.e. mysql requires: DEFAULT CURRENT_TIMESTAMP
-            template += " DEFAULT <%= defaultValue %>"
-            replacements.defaultValue = this.escape(dataType.defaultValue, dataType)
+            template += ' DEFAULT <%= defaultValue %>';
+            replacements.defaultValue = this.escape(dataType.defaultValue, dataType);
           }
 
           if (dataType.unique === true) {
-            template += " UNIQUE"
+            template += ' UNIQUE';
           }
 
           if (dataType.primaryKey) {
-            template += " PRIMARY KEY"
+            template += ' PRIMARY KEY';
           }
 
-          if(dataType.references) {
-            template += " REFERENCES <%= referencesTable %> (<%= referencesKey %>)"
-            replacements.referencesTable = this.quoteTable(dataType.references)
+          if (dataType.references) {
+            template += ' REFERENCES <%= referencesTable %> (<%= referencesKey %>)';
+            replacements.referencesTable = this.quoteTable(dataType.references);
 
-            if(dataType.referencesKey) {
-              replacements.referencesKey = this.quoteIdentifiers(dataType.referencesKey)
+            if (dataType.referencesKey) {
+              replacements.referencesKey = this.quoteIdentifiers(dataType.referencesKey);
             } else {
-              replacements.referencesKey = this.quoteIdentifier('id')
+              replacements.referencesKey = this.quoteIdentifier('id');
             }
 
-            if(dataType.onDelete) {
-              template += " ON DELETE <%= onDeleteAction %>"
-              replacements.onDeleteAction = dataType.onDelete.toUpperCase()
+            if (dataType.onDelete) {
+              template += ' ON DELETE <%= onDeleteAction %>';
+              replacements.onDeleteAction = dataType.onDelete.toUpperCase();
             }
 
-            if(dataType.onUpdate) {
-              template += " ON UPDATE <%= onUpdateAction %>"
-              replacements.onUpdateAction = dataType.onUpdate.toUpperCase()
+            if (dataType.onUpdate) {
+              template += ' ON UPDATE <%= onUpdateAction %>';
+              replacements.onUpdateAction = dataType.onUpdate.toUpperCase();
             }
           }
 
           if (dataType.comment && Utils._.isString(dataType.comment)) {
-            template += " COMMENT ON COLUMN <%= tableName %>.<%= columnName %> IS <%= comment %>"
-            replacements.columnName = this.quoteIdentifier(name)
-            replacements.tableName = '<%= table %>' // Hacky, table name will be inserted by create table
-            replacements.comment = this.escape(dataType.comment)
+            template += ' COMMENT ON COLUMN <%= tableName %>.<%= columnName %> IS <%= comment %>';
+            replacements.columnName = this.quoteIdentifier(name);
+            replacements.tableName = '<%= table %>'; // Hacky, table name will be inserted by create table
+            replacements.comment = this.escape(dataType.comment);
           }
 
-          result[name] = Utils._.template(template)(replacements)
+          result[name] = Utils._.template(template)(replacements);
         } else {
-          result[name] = dataType
+          result[name] = dataType;
         }
       }
 
-      return result
+      return result;
     },
 
     findAutoIncrementField: function(factory) {
-      var fields = []
+      var fields = [];
 
       for (var name in factory.attributes) {
-        var definition = factory.attributes[name]
+        var definition = factory.attributes[name];
 
         if (definition && definition.autoIncrement) {
-          fields.push(name)
+          fields.push(name);
         }
       }
 
-      return fields
+      return fields;
     },
 
     createTrigger: function(tableName, triggerName, eventType, fireOnSpec, functionName, functionParams, optionsArray) {
@@ -519,7 +519,7 @@ module.exports = (function() {
           , 'ON <%= tableName %>'
           , '<%= optionsSpec %>'
           , 'EXECUTE PROCEDURE <%= functionName %>(<%= paramList %>);'
-        ].join('\n\t')
+        ].join('\n\t');
 
       return Utils._.template(sql)({
         constraintVal: this.triggerEventTypeIsConstraint(eventType),
@@ -530,34 +530,34 @@ module.exports = (function() {
         optionsSpec: this.expandOptions(optionsArray),
         functionName: functionName,
         paramList: this.expandFunctionParamList(functionParams)
-      })
+      });
     },
 
     dropTrigger: function(tableName, triggerName) {
-      var sql = 'DROP TRIGGER <%= triggerName %> ON <%= tableName %> RESTRICT;'
+      var sql = 'DROP TRIGGER <%= triggerName %> ON <%= tableName %> RESTRICT;';
       return Utils._.template(sql)({
         triggerName: triggerName,
         tableName: tableName
-      })
+      });
     },
 
     renameTrigger: function(tableName, oldTriggerName, newTriggerName) {
-      var sql = 'ALTER TRIGGER <%= oldTriggerName %> ON <%= tableName %> RENAME TO <%= newTriggerName%>;'
+      var sql = 'ALTER TRIGGER <%= oldTriggerName %> ON <%= tableName %> RENAME TO <%= newTriggerName%>;';
       return Utils._.template(sql)({
         tableName: tableName,
         oldTriggerName: oldTriggerName,
         newTriggerName: newTriggerName
-      })
+      });
     },
 
     createFunction: function(functionName, params, returnType, language, body, options) {
-      var sql = [ "CREATE FUNCTION <%= functionName %>(<%= paramList %>)"
-          , "RETURNS <%= returnType %> AS $$"
-          , "BEGIN"
-          , "\t<%= body %>"
-          , "END;"
+      var sql = ['CREATE FUNCTION <%= functionName %>(<%= paramList %>)'
+          , 'RETURNS <%= returnType %> AS $$'
+          , 'BEGIN'
+          , '\t<%= body %>'
+          , 'END;'
           , "$$ language '<%= language %>'<%= options %>;"
-      ].join('\n')
+      ].join('\n');
 
       return Utils._.template(sql)({
         functionName: functionName,
@@ -566,66 +566,66 @@ module.exports = (function() {
         body: body.replace('\n', '\n\t'),
         language: language,
         options: this.expandOptions(options)
-      })
+      });
     },
 
     dropFunction: function(functionName, params) {
       // RESTRICT is (currently, as of 9.2) default but we'll be explicit
-      var sql = 'DROP FUNCTION <%= functionName %>(<%= paramList %>) RESTRICT;'
+      var sql = 'DROP FUNCTION <%= functionName %>(<%= paramList %>) RESTRICT;';
       return Utils._.template(sql)({
         functionName: functionName,
         paramList: this.expandFunctionParamList(params)
-      })
+      });
     },
 
     renameFunction: function(oldFunctionName, params, newFunctionName) {
-      var sql = 'ALTER FUNCTION <%= oldFunctionName %>(<%= paramList %>) RENAME TO <%= newFunctionName %>;'
+      var sql = 'ALTER FUNCTION <%= oldFunctionName %>(<%= paramList %>) RENAME TO <%= newFunctionName %>;';
       return Utils._.template(sql)({
         oldFunctionName: oldFunctionName,
         paramList: this.expandFunctionParamList(params),
         newFunctionName: newFunctionName
-      })
+      });
     },
 
     databaseConnectionUri: function(config) {
-      var template = '<%= protocol %>://<%= user %>:<%= password %>@<%= host %><% if(port) { %>:<%= port %><% } %>/<%= database %>'
+      var template = '<%= protocol %>://<%= user %>:<%= password %>@<%= host %><% if(port) { %>:<%= port %><% } %>/<%= database %>';
 
       return Utils._.template(template)({
-        user:     config.username,
+        user: config.username,
         password: config.password,
         database: config.database,
-        host:     config.host,
-        port:     config.port,
+        host: config.host,
+        port: config.port,
         protocol: config.protocol
-      })
+      });
     },
 
-    pgEscapeAndQuote: function (val) {
-      return this.quoteIdentifier(Utils.removeTicks(this.escape(val), "'"))
+    pgEscapeAndQuote: function(val) {
+      return this.quoteIdentifier(Utils.removeTicks(this.escape(val), "'"));
     },
 
     expandFunctionParamList: function expandFunctionParamList(params) {
       if (Utils._.isUndefined(params) || !Utils._.isArray(params)) {
-        throw new Error("expandFunctionParamList: function parameters array required, including an empty one for no arguments")
+        throw new Error('expandFunctionParamList: function parameters array required, including an empty one for no arguments');
       }
 
-      var paramList = Utils._.each(params, function expandParam(curParam){
-        paramDef = []
+      var paramList = Utils._.each(params, function expandParam(curParam) {
+        var paramDef = [];
         if (Utils._.has(curParam, 'type')) {
-          if (Utils._.has(curParam, 'direction')) { paramDef.push(curParam.direction) }
-          if (Utils._.has(curParam, 'name')) { paramDef.push(curParam.name) }
-          paramDef.push(curParam.type)
+          if (Utils._.has(curParam, 'direction')) { paramDef.push(curParam.direction); }
+          if (Utils._.has(curParam, 'name')) { paramDef.push(curParam.name); }
+          paramDef.push(curParam.type);
         } else {
-          throw new Error('createFunction called with a parameter with no type')
+          throw new Error('createFunction called with a parameter with no type');
         }
-        return paramDef.join(' ')
-      })
-      return paramList.join(', ')
+        return paramDef.join(' ');
+      });
+      return paramList.join(', ');
     },
 
     expandOptions: function expandOptions(options) {
-      return  Utils._.isUndefined(options) || Utils._.isEmpty(options) ?
-          '' : '\n\t' + options.join('\n\t')
+      return Utils._.isUndefined(options) || Utils._.isEmpty(options) ?
+          '' : '\n\t' + options.join('\n\t');
     },
 
     decodeTriggerEventType: function decodeTriggerEventType(eventSpecifier) {
@@ -634,174 +634,174 @@ module.exports = (function() {
         'before': 'BEFORE',
         'instead_of': 'INSTEAD OF',
         'after_constraint': 'AFTER'
-      }
+      };
 
       if (!Utils._.has(EVENT_DECODER, eventSpecifier)) {
-        throw new Error('Invalid trigger event specified: ' + eventSpecifier)
+        throw new Error('Invalid trigger event specified: ' + eventSpecifier);
       }
 
-      return EVENT_DECODER[eventSpecifier]
+      return EVENT_DECODER[eventSpecifier];
     },
 
     triggerEventTypeIsConstraint: function triggerEventTypeIsConstraint(eventSpecifier) {
-      return eventSpecifier === 'after_constrain' ? 'CONSTRAINT ' : ''
+      return eventSpecifier === 'after_constrain' ? 'CONSTRAINT ' : '';
     },
 
     expandTriggerEventSpec: function expandTriggerEventSpec(fireOnSpec) {
       if (Utils._.isEmpty(fireOnSpec)) {
-        throw new Error('no table change events specified to trigger on')
+        throw new Error('no table change events specified to trigger on');
       }
 
-      return Utils._.map(fireOnSpec, function parseTriggerEventSpec(fireValue, fireKey){
+      return Utils._.map(fireOnSpec, function parseTriggerEventSpec(fireValue, fireKey) {
         var EVENT_MAP = {
           'insert': 'INSERT',
           'update': 'UPDATE',
           'delete': 'DELETE',
           'truncate': 'TRUNCATE'
-        }
+        };
 
         if (!Utils._.has(EVENT_MAP, fireKey)) {
-          throw new Error('parseTriggerEventSpec: undefined trigger event ' + fireKey)
+          throw new Error('parseTriggerEventSpec: undefined trigger event ' + fireKey);
         }
 
-        var eventSpec = EVENT_MAP[fireKey]
+        var eventSpec = EVENT_MAP[fireKey];
         if (eventSpec === 'UPDATE') {
           if (Utils._.isArray(fireValue) && fireValue.length > 0) {
-            eventSpec += ' OF ' + fireValue.join(', ')
+            eventSpec += ' OF ' + fireValue.join(', ');
           }
         }
 
-        return eventSpec
-      }).join(' OR ')
+        return eventSpec;
+      }).join(' OR ');
     },
 
     pgListEnums: function(tableName, attrName, options) {
       if (arguments.length === 1) {
-        options = tableName
-        tableName = null
+        options = tableName;
+        tableName = null;
       }
 
-      var enumName = ''
+      var enumName = '';
 
       if (!!tableName && !!attrName) {
-        enumName = ' AND t.typname=' + this.escape("enum_" + tableName + "_" + attrName) + ' '
+        enumName = ' AND t.typname=' + this.escape('enum_' + tableName + '_' + attrName) + ' ';
       }
 
       var query = 'SELECT t.typname enum_name, array_agg(e.enumlabel) enum_value FROM pg_type t ' +
         'JOIN pg_enum e ON t.oid = e.enumtypid ' +
         'JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace ' +
-        'WHERE n.nspname = \'public\' ' + enumName + ' GROUP BY 1'
+        'WHERE n.nspname = \'public\' ' + enumName + ' GROUP BY 1';
 
-      return query
+      return query;
     },
 
-    pgEnum: function (tableName, attr, dataType, options) {
-      var enumName = this.pgEscapeAndQuote("enum_" + tableName + "_" + attr)
-        , values
+    pgEnum: function(tableName, attr, dataType, options) {
+      var enumName = this.pgEscapeAndQuote('enum_' + tableName + '_' + attr)
+        , values;
 
       if (dataType.values) {
-        values = "ENUM('"+dataType.values.join("', '")+"')";
+        values = "ENUM('" + dataType.values.join("', '") + "')";
       } else {
-        values = dataType.toString().match(/^ENUM\(.+\)/)[0]
+        values = dataType.toString().match(/^ENUM\(.+\)/)[0];
       }
 
-      var sql = "CREATE TYPE " + enumName + " AS " + values + "; "
+      var sql = 'CREATE TYPE ' + enumName + ' AS ' + values + '; ';
       if (!!options && options.force === true) {
-        sql = this.pgEnumDrop(tableName, attr) + sql
+        sql = this.pgEnumDrop(tableName, attr) + sql;
       }
-      return sql
+      return sql;
     },
 
     pgEnumAdd: function(tableName, attr, value, options) {
-      var enumName = this.pgEscapeAndQuote("enum_" + tableName + "_" + attr)
-      var sql = 'ALTER TYPE ' + enumName + ' ADD VALUE ' + this.escape(value)
+      var enumName = this.pgEscapeAndQuote('enum_' + tableName + '_' + attr);
+      var sql = 'ALTER TYPE ' + enumName + ' ADD VALUE ' + this.escape(value);
 
       if (!!options.before) {
-        sql += ' BEFORE ' + this.escape(options.before)
+        sql += ' BEFORE ' + this.escape(options.before);
       }
       else if (!!options.after) {
-        sql += ' AFTER ' + this.escape(options.after)
+        sql += ' AFTER ' + this.escape(options.after);
       }
 
-      return sql
+      return sql;
     },
 
     pgEnumDrop: function(tableName, attr, enumName) {
-      enumName = enumName || this.pgEscapeAndQuote("enum_" + tableName + "_" + attr)
-      return 'DROP TYPE IF EXISTS ' + enumName + '; '
+      enumName = enumName || this.pgEscapeAndQuote('enum_' + tableName + '_' + attr);
+      return 'DROP TYPE IF EXISTS ' + enumName + '; ';
     },
 
     fromArray: function(text) {
-      text = text.replace(/^{/, '').replace(/}$/, '')
-      var matches = text.match(/("(?:\\.|[^"\\\\])*"|[^,]*)(?:\s*,\s*|\s*$)/ig)
+      text = text.replace(/^{/, '').replace(/}$/, '');
+      var matches = text.match(/("(?:\\.|[^"\\\\])*"|[^,]*)(?:\s*,\s*|\s*$)/ig);
 
       if (matches.length < 1) {
-        return []
+        return [];
       }
 
-      matches = matches.map(function(m){
-        return m.replace(/",$/, '').replace(/,$/, '').replace(/(^"|"$)/, '')
-      })
+      matches = matches.map(function(m) {
+        return m.replace(/",$/, '').replace(/,$/, '').replace(/(^"|"$)/, '');
+      });
 
-      return matches.slice(0, -1)
+      return matches.slice(0, -1);
     },
 
-    padInt: function (i) {
-      return (i < 10) ? '0' + i.toString() : i.toString()
+    padInt: function(i) {
+      return (i < 10) ? '0' + i.toString() : i.toString();
     },
 
-    pgDataTypeMapping: function (tableName, attr, dataType) {
+    pgDataTypeMapping: function(tableName, attr, dataType) {
       if (Utils._.includes(dataType, 'PRIMARY KEY')) {
-        primaryKeys[tableName].push(attr)
-        dataType = dataType.replace(/PRIMARY KEY/, '')
+        primaryKeys[tableName].push(attr);
+        dataType = dataType.replace(/PRIMARY KEY/, '');
       }
 
       if (Utils._.includes(dataType, 'TINYINT(1)')) {
-        dataType = dataType.replace(/TINYINT\(1\)/, 'BOOLEAN')
+        dataType = dataType.replace(/TINYINT\(1\)/, 'BOOLEAN');
       }
 
       if (Utils._.includes(dataType, 'DATETIME')) {
-        dataType = dataType.replace(/DATETIME/, 'TIMESTAMP WITH TIME ZONE')
+        dataType = dataType.replace(/DATETIME/, 'TIMESTAMP WITH TIME ZONE');
       }
 
       if (Utils._.includes(dataType, 'SERIAL')) {
         if (Utils._.includes(dataType, 'BIGINT')) {
-          dataType = dataType.replace(/SERIAL/, 'BIGSERIAL')
-          dataType = dataType.replace(/BIGINT/, '')
-          tables[tableName][attr] = 'bigserial'
+          dataType = dataType.replace(/SERIAL/, 'BIGSERIAL');
+          dataType = dataType.replace(/BIGINT/, '');
+          tables[tableName][attr] = 'bigserial';
         } else {
-          dataType = dataType.replace(/INTEGER/, '')
-          tables[tableName][attr] = 'serial'
+          dataType = dataType.replace(/INTEGER/, '');
+          tables[tableName][attr] = 'serial';
         }
-        dataType = dataType.replace(/NOT NULL/, '')
+        dataType = dataType.replace(/NOT NULL/, '');
       }
 
       if (Utils._.includes(dataType, 'INTEGER') || Utils._.includes(dataType, 'BIGINT')) {
-        dataType = dataType.replace(/(INTEGER|BIGINT)\s*\(\d+\)/, '$1') // Postgres does not allow length on INTEGER and BIGINT
+        dataType = dataType.replace(/(INTEGER|BIGINT)\s*\(\d+\)/, '$1'); // Postgres does not allow length on INTEGER and BIGINT
       }
 
       if (dataType.lastIndexOf('BLOB') !== -1 || dataType.lastIndexOf('BINARY') !== -1) {
-        dataType = 'bytea'
+        dataType = 'bytea';
       }
 
       if (dataType.match(/^ENUM\(/)) {
-        dataType = dataType.replace(/^ENUM\(.+\)/, this.pgEscapeAndQuote("enum_" + tableName + "_" + attr))
+        dataType = dataType.replace(/^ENUM\(.+\)/, this.pgEscapeAndQuote('enum_' + tableName + '_' + attr));
       }
 
-      return dataType
+      return dataType;
     },
 
     quoteIdentifier: function(identifier, force) {
-      if (identifier === '*') return identifier
-      if(!force && this.options && this.options.quoteIdentifiers === false) { // default is `true`
+      if (identifier === '*') return identifier;
+      if (!force && this.options && this.options.quoteIdentifiers === false) { // default is `true`
         // In Postgres, if tables or attributes are created double-quoted,
         // they are also case sensitive. If they contain any uppercase
         // characters, they must always be double-quoted. This makes it
         // impossible to write queries in portable SQL if tables are created in
         // this way. Hence, we strip quotes if we don't want case sensitivity.
-        return Utils.removeTicks(identifier, '"')
+        return Utils.removeTicks(identifier, '"');
       } else {
-        return Utils.addTicks(identifier, '"')
+        return Utils.addTicks(identifier, '"');
       }
     },
 
@@ -810,13 +810,13 @@ module.exports = (function() {
     */
     escape: function(value, field) {
       if (value && value._isSequelizeMethod) {
-        return value.toString(this)
+        return value.toString(this);
       } else {
         if (field && field.type && field.type.toString() === DataTypes.HSTORE.type && Utils._.isObject(value)) {
           value = hstore.stringify(value);
         }
 
-        return  SqlString.escape(value, false, null, this.dialect, field)
+        return SqlString.escape(value, false, null, this.dialect, field);
       }
     },
 
@@ -828,7 +828,7 @@ module.exports = (function() {
      * @return {String}            The generated sql query.
      */
     getForeignKeysQuery: function(tableName, schemaName) {
-      return "SELECT conname as constraint_name, pg_catalog.pg_get_constraintdef(r.oid, true) as condef FROM pg_catalog.pg_constraint r WHERE r.conrelid = (SELECT oid FROM pg_class WHERE relname = '" + tableName + "' LIMIT 1) AND r.contype = 'f' ORDER BY 1;"
+      return "SELECT conname as constraint_name, pg_catalog.pg_get_constraintdef(r.oid, true) as condef FROM pg_catalog.pg_constraint r WHERE r.conrelid = (SELECT oid FROM pg_class WHERE relname = '" + tableName + "' LIMIT 1) AND r.contype = 'f' ORDER BY 1;";
     },
 
     /**
@@ -839,9 +839,9 @@ module.exports = (function() {
      * @return {String}            The generated sql query.
      */
     dropForeignKeyQuery: function(tableName, foreignKey) {
-      return 'ALTER TABLE ' + this.quoteTable(tableName) + ' DROP CONSTRAINT ' + this.quoteIdentifier(foreignKey) + ';'
+      return 'ALTER TABLE ' + this.quoteTable(tableName) + ' DROP CONSTRAINT ' + this.quoteIdentifier(foreignKey) + ';';
     }
-  }
+  };
 
-  return Utils._.extend(Utils._.clone(require("../abstract/query-generator")), QueryGenerator)
-})()
+  return Utils._.extend(Utils._.clone(require('../abstract/query-generator')), QueryGenerator);
+})();

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -1,127 +1,128 @@
-"use strict";
+'use strict';
 
-var Utils         = require("../../utils")
+var Utils = require('../../utils')
   , AbstractQuery = require('../abstract/query')
-  , DataTypes     = require('../../data-types')
-  , hstore        = require('./hstore')
-  , QueryTypes    = require('../../query-types')
-  , Promise       = require('../../promise')
+  , DataTypes = require('../../data-types')
+  , hstore = require('./hstore')
+  , QueryTypes = require('../../query-types')
+  , Promise = require('../../promise');
 
 module.exports = (function() {
   var Query = function(client, sequelize, callee, options) {
-    this.client = client
-    this.sequelize = sequelize
-    this.callee = callee
+    this.client = client;
+    this.sequelize = sequelize;
+    this.callee = callee;
     this.options = Utils._.extend({
       logging: console.log,
       plain: false,
       raw: false
-    }, options || {})
+    }, options || {});
 
-    this.checkLoggingOption()
-  }
-  Utils.inherit(Query, AbstractQuery)
+    this.checkLoggingOption();
+  };
+  Utils.inherit(Query, AbstractQuery);
 
   Query.prototype.run = function(sql) {
-    this.sql = sql
+    /* jshint -W027 */
+    this.sql = sql;
 
-    var self          = this
+    var self = this
       , receivedError = false
-      , query         = this.client.query(sql)
-      , rows          = []
+      , query = this.client.query(sql)
+      , rows = [];
 
     if (this.options.logging !== false) {
-      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql)
+      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql);
     }
 
-    return new Promise(function (resolve, reject) {
+    return new Promise(function(resolve, reject) {
       var promise = this;
 
       query.on('row', function(row) {
-        rows.push(row)
-      })
+        rows.push(row);
+      });
 
       query.on('error', function(err) {
-        receivedError = true
-        err.sql = sql
-        promise.emit('sql', sql, self.options.uuid)
+        receivedError = true;
+        err.sql = sql;
+        promise.emit('sql', sql, self.options.uuid);
         reject(err);
-      })
+      });
 
       query.on('end', function(result) {
         if (receivedError) {
           return;
         }
 
-        promise.emit('sql', self.sql, self.options.uuid)
+        promise.emit('sql', self.sql, self.options.uuid);
         resolve([rows, sql, result]);
-      })
-    }).spread(function (rows, sql, result) {
-      var results          = rows
+      });
+    }).spread(function(rows, sql, result) {
+      var results = rows
         , isTableNameQuery = (sql.indexOf('SELECT table_name FROM information_schema.tables') === 0)
-        , isRelNameQuery   = (sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0)
+        , isRelNameQuery = (sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0);
 
       if (isTableNameQuery || isRelNameQuery) {
         if (isRelNameQuery) {
           results = rows.map(function(row) {
             return {
-              name:       row.relname,
-              tableName:  row.relname.split('_')[0]
-            }
-          })
+              name: row.relname,
+              tableName: row.relname.split('_')[0]
+            };
+          });
         } else {
-          results = rows.map(function(row) { return Utils._.values(row) })
+          results = rows.map(function(row) { return Utils._.values(row); });
         }
-        return results
+        return results;
       }
 
       if (self.send('isSelectQuery')) {
         if (self.sql.toLowerCase().indexOf('select c.column_name') === 0) {
-          result = {}
+          result = {};
 
           rows.forEach(function(_result) {
             result[_result.Field] = {
-              type:         _result.Type.toUpperCase(),
-              allowNull:    (_result.Null === 'YES'),
+              type: _result.Type.toUpperCase(),
+              allowNull: (_result.Null === 'YES'),
               defaultValue: _result.Default,
               special: (!!_result.special ? self.sequelize.queryInterface.QueryGenerator.fromArray(_result.special) : [])
-            }
+            };
 
             if (result[_result.Field].type === 'BOOLEAN') {
-              result[_result.Field].defaultValue = { 'false': false, 'true': true }[result[_result.Field].defaultValue]
+              result[_result.Field].defaultValue = { 'false': false, 'true': true }[result[_result.Field].defaultValue];
 
               if (result[_result.Field].defaultValue === undefined) {
-                result[_result.Field].defaultValue = null
+                result[_result.Field].defaultValue = null;
               }
             }
 
             if (typeof result[_result.Field].defaultValue === 'string') {
-              result[_result.Field].defaultValue = result[_result.Field].defaultValue.replace(/'/g, "")
+              result[_result.Field].defaultValue = result[_result.Field].defaultValue.replace(/'/g, '');
 
               if (result[_result.Field].defaultValue.indexOf('::') > -1) {
-                var split = result[_result.Field].defaultValue.split('::')
-                if (split[1].toLowerCase() !== "regclass)") {
-                  result[_result.Field].defaultValue = split[0]
+                var split = result[_result.Field].defaultValue.split('::');
+                if (split[1].toLowerCase() !== 'regclass)') {
+                  result[_result.Field].defaultValue = split[0];
                 }
               }
             }
-          })
+          });
 
-          return result
+          return result;
         } else {
           // Postgres will treat tables as case-insensitive, so fix the case
           // of the returned values to match attributes
           if (self.options.raw === false && self.sequelize.options.quoteIdentifiers === false) {
-            var attrsMap = Utils._.reduce(self.callee.attributes, function(m, v, k) { m[k.toLowerCase()] = k; return m}, {})
+            var attrsMap = Utils._.reduce(self.callee.attributes, function(m, v, k) { m[k.toLowerCase()] = k; return m; }, {});
             rows.forEach(function(row) {
               Utils._.keys(row).forEach(function(key) {
-                var targetAttr = attrsMap[key]
-                if (targetAttr != key) {
-                  row[targetAttr] = row[key]
-                  delete row[key]
+                var targetAttr = attrsMap[key];
+                if (targetAttr !== key) {
+                  row[targetAttr] = row[key];
+                  delete row[key];
                 }
-              })
-            })
+              });
+            });
           }
 
           // Parse hstore fields if the model has any hstore fields.
@@ -130,43 +131,43 @@ module.exports = (function() {
             rows.forEach(function(row) {
               Utils._.keys(row).forEach(function(key) {
                 if (self.callee._isHstoreAttribute(key)) {
-                  row[key] = hstore.parse(row[key])
+                  row[key] = hstore.parse(row[key]);
                 }
-              })
-            })
+              });
+            });
           }
 
-          return  self.send('handleSelectQuery', rows)
+          return self.send('handleSelectQuery', rows);
         }
       } else if (self.send('isShowOrDescribeQuery')) {
-        return results
+        return results;
       } else if ([QueryTypes.BULKUPDATE, QueryTypes.BULKDELETE].indexOf(self.options.type) !== -1) {
-        return result.rowCount
+        return result.rowCount;
       } else if (self.send('isInsertQuery') || self.send('isUpdateQuery')) {
         if (self.callee !== null) { // may happen for bulk inserts or bulk updates
           for (var key in rows[0]) {
             if (rows[0].hasOwnProperty(key)) {
-              var record = rows[0][key]
+              var record = rows[0][key];
               if (!!self.callee.Model && !!self.callee.Model.rawAttributes && !!self.callee.Model.rawAttributes[key] && !!self.callee.Model.rawAttributes[key].type && self.callee.Model.rawAttributes[key].type.toString() === DataTypes.HSTORE.toString()) {
-                record = hstore.parse(record)
+                record = hstore.parse(record);
               }
-              self.callee.dataValues[key] = record
+              self.callee.dataValues[key] = record;
             }
           }
         }
 
-        return self.callee
+        return self.callee;
       } else {
-        return results
+        return results;
       }
-    })
+    });
 
-    return this
-  }
+    return this;
+  };
 
   Query.prototype.getInsertIdField = function() {
-    return 'id'
-  }
+    return 'id';
+  };
 
-  return Query
-})()
+  return Query;
+})();

--- a/lib/dialects/sqlite/connector-manager.js
+++ b/lib/dialects/sqlite/connector-manager.js
@@ -1,50 +1,50 @@
-"use strict";
+'use strict';
 
 var sqlite3
-  , Utils   = require("../../utils")
-  , Query   = require("./query")
+  , Utils = require('../../utils')
+  , Query = require('./query');
 
 module.exports = (function() {
   var ConnectorManager = function(sequelize, config) {
-    this.sequelize = sequelize
-    this.config    = config
+    this.sequelize = sequelize;
+    this.config = config;
 
     if (config.dialectModulePath) {
-      sqlite3 = require(config.dialectModulePath).verbose()
+      sqlite3 = require(config.dialectModulePath).verbose();
     } else {
-      sqlite3 = require('sqlite3').verbose()
+      sqlite3 = require('sqlite3').verbose();
     }
-  }
+  };
 
-  Utils._.extend(ConnectorManager.prototype, require("../abstract/connector-manager").prototype)
+  Utils._.extend(ConnectorManager.prototype, require('../abstract/connector-manager').prototype);
 
   ConnectorManager.prototype.connect = function() {
     var emitter = new (require('events').EventEmitter)()
       , self = this
-      , db
+      , db;
 
     this.database = db = new sqlite3.Database(self.sequelize.options.storage || ':memory:', function(err) {
       if (err) {
-        if (err.code === "SQLITE_CANTOPEN") {
-          emitter.emit('error', 'Failed to find SQL server. Please double check your settings.')
+        if (err.code === 'SQLITE_CANTOPEN') {
+          emitter.emit('error', 'Failed to find SQL server. Please double check your settings.');
         }
       }
 
-      if(!err && self.sequelize.options.foreignKeys !== false) {
+      if (!err && self.sequelize.options.foreignKeys !== false) {
         // Make it possible to define and use foreign key constraints unless
         // explicitly disallowed. It's still opt-in per relation
-        db.run('PRAGMA FOREIGN_KEYS=ON')
+        db.run('PRAGMA FOREIGN_KEYS=ON');
       }
-    })
-  }
+    });
+  };
 
   ConnectorManager.prototype.query = function(sql, callee, options) {
     if (!this.database) {
-      this.connect()
+      this.connect();
     }
 
-    return new Query(this.database, this.sequelize, callee, options).run(sql)
-  }
+    return new Query(this.database, this.sequelize, callee, options).run(sql);
+  };
 
-  return ConnectorManager
-})()
+  return ConnectorManager;
+})();

--- a/lib/dialects/sqlite/index.js
+++ b/lib/dialects/sqlite/index.js
@@ -1,15 +1,15 @@
-"use strict";
+'use strict';
 
 var _ = require('lodash')
-  , Abstract = require('../abstract')
+  , Abstract = require('../abstract');
 
 var SqliteDialect = function(sequelize) {
-  this.sequelize = sequelize
-}
+  this.sequelize = sequelize;
+};
 
 SqliteDialect.prototype.supports = _.defaults({
   'DEFAULT': false,
   'DEFAULT VALUES': true
-}, Abstract.prototype.supports)
+}, Abstract.prototype.supports);
 
-module.exports = SqliteDialect
+module.exports = SqliteDialect;

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -1,16 +1,16 @@
-"use strict";
+'use strict';
 
-var Utils       = require("../../utils")
-  , DataTypes   = require("../../data-types")
-  , SqlString   = require("../../sql-string")
-  , Transaction = require("../../transaction")
+var Utils = require('../../utils')
+  , DataTypes = require('../../data-types')
+  , SqlString = require('../../sql-string')
+  , Transaction = require('../../transaction');
 
 var MySqlQueryGenerator = Utils._.extend(
-  Utils._.clone(require("../abstract/query-generator")),
-  Utils._.clone(require("../mysql/query-generator"))
-)
+  Utils._.clone(require('../abstract/query-generator')),
+  Utils._.clone(require('../mysql/query-generator'))
+);
 
-var hashToWhereConditions = MySqlQueryGenerator.hashToWhereConditions
+var hashToWhereConditions = MySqlQueryGenerator.hashToWhereConditions;
 
 module.exports = (function() {
   var QueryGenerator = {
@@ -18,35 +18,35 @@ module.exports = (function() {
     dialect: 'sqlite',
 
     createSchema: function() {
-      var query = "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';"
-      return Utils._.template(query)({})
+      var query = "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';";
+      return Utils._.template(query)({});
     },
 
     dropSchema: function(tableName, options) {
-      return this.dropTableQuery(tableName, options)
+      return this.dropTableQuery(tableName, options);
     },
 
     showSchemasQuery: function() {
-      return "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';"
+      return "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';";
     },
 
     createTableQuery: function(tableName, attributes, options) {
-      options = options || {}
+      options = options || {};
 
-      var query       = "CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>)"
+      var query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>)'
         , primaryKeys = []
         , needsMultiplePrimaryKeys = (Utils._.values(attributes).filter(function(definition) {
-                    return Utils._.includes(definition, 'PRIMARY KEY')
+                    return Utils._.includes(definition, 'PRIMARY KEY');
                   }).length > 1)
-        , attrStr     = []
-        , modifierLastIndex = -1
+        , attrStr = []
+        , modifierLastIndex = -1;
 
       for (var attr in attributes) {
         if (attributes.hasOwnProperty(attr)) {
-          var dataType = attributes[attr]
+          var dataType = attributes[attr];
 
           if (Utils._.includes(dataType, 'AUTOINCREMENT')) {
-            dataType = dataType.replace(/BIGINT/, 'INTEGER')
+            dataType = dataType.replace(/BIGINT/, 'INTEGER');
           }
 
           // SQLite thinks that certain modifiers should come before the length declaration,
@@ -54,40 +54,41 @@ module.exports = (function() {
 
           // Start by finding the index of the last of the modifiers
           ['UNSIGNED', 'BINARY', 'ZEROFILL'].forEach(function (modifier) {
-            var tmpIndex = dataType.indexOf(modifier)
+            var tmpIndex = dataType.indexOf(modifier);
 
             if (tmpIndex > modifierLastIndex) {
-              modifierLastIndex = tmpIndex + modifier.length
+              modifierLastIndex = tmpIndex + modifier.length;
             }
-          })
+          });
+
           if (modifierLastIndex) {
             // If a modifier was found, and a lenght declaration is given before the modifier, move the length
-            var length = dataType.match(/\(\s*\d+(\s*,\s*\d)?\s*\)/)
+            var length = dataType.match(/\(\s*\d+(\s*,\s*\d)?\s*\)/);
             if (length && length.index < modifierLastIndex) {
-              dataType = dataType.replace(length[0], '')
+              dataType = dataType.replace(length[0], '');
 
               // Since the legnth was placed before the modifier, removing the legnth has changed the index
               if (length.index < modifierLastIndex) {
-                modifierLastIndex -= length[0].length
+                modifierLastIndex -= length[0].length;
               }
-              dataType = Utils._.insert(dataType, modifierLastIndex, length[0]).trim()
+              dataType = Utils._.insert(dataType, modifierLastIndex, length[0]).trim();
             }
 
-            modifierLastIndex = -1
+            modifierLastIndex = -1;
           }
 
-          var dataTypeString = dataType
+          var dataTypeString = dataType;
           if (Utils._.includes(dataType, 'PRIMARY KEY')) {
             if (Utils._.includes(dataType, 'INTEGER')) {
-              dataTypeString = 'INTEGER PRIMARY KEY' // Only INTEGER is allowed for primary key, see https://github.com/sequelize/sequelize/issues/969 (no lenght, unsigned etc)
+              dataTypeString = 'INTEGER PRIMARY KEY'; // Only INTEGER is allowed for primary key, see https://github.com/sequelize/sequelize/issues/969 (no lenght, unsigned etc)
             }
 
             if (needsMultiplePrimaryKeys) {
-              primaryKeys.push(attr)
-              dataTypeString = dataType.replace(/PRIMARY KEY/, 'NOT NULL')
+              primaryKeys.push(attr);
+              dataTypeString = dataType.replace(/PRIMARY KEY/, 'NOT NULL');
             }
           }
-          attrStr.push(this.quoteIdentifier(attr) + " " + dataTypeString)
+          attrStr.push(this.quoteIdentifier(attr) + " " + dataTypeString);
         }
       }
 
@@ -96,20 +97,20 @@ module.exports = (function() {
         attributes: attrStr.join(", "),
         charset: (options.charset ? "DEFAULT CHARSET=" + options.charset : "")
       }
-      , pkString = primaryKeys.map(function(pk) { return this.quoteIdentifier(pk) }.bind(this)).join(", ")
+      , pkString = primaryKeys.map(function(pk) { return this.quoteIdentifier(pk); }.bind(this)).join(", ");
 
       if (!!options.uniqueKeys) {
         Utils._.each(options.uniqueKeys, function(columns) {
-          values.attributes += ", UNIQUE (" + columns.fields.join(', ') + ")"
-        })
+          values.attributes += ", UNIQUE (" + columns.fields.join(', ') + ")";
+        });
       }
 
       if (pkString.length > 0) {
-        values.attributes += ", PRIMARY KEY (" + pkString + ")"
+        values.attributes += ", PRIMARY KEY (" + pkString + ")";
       }
 
-      var sql = Utils._.template(query, values).trim() + ";"
-      return this.replaceBooleanDefaults(sql)
+      var sql = Utils._.template(query, values).trim() + ";";
+      return this.replaceBooleanDefaults(sql);
     },
 
     booleanValue: function(value){
@@ -119,219 +120,219 @@ module.exports = (function() {
     uniqueConstraintMapping: {
       code: 'SQLITE_CONSTRAINT',
       map: function(str) {
-        var match = str.match(/columns (.*?) are/)
+        var match = str.match(/columns (.*?) are/);
         if (match === null || match.length < 2) {
-          return false
+          return false;
         }
 
-        return match[1].split(', ')
+        return match[1].split(', ');
       }
     },
 
     addLimitAndOffset: function(options, query){
-      query = query || ""
+      query = query || "";
       if (options.offset && !options.limit) {
         query += " LIMIT " + options.offset + ", " + 10000000000000;
       } else if (options.limit) {
         if (options.offset) {
-          query += " LIMIT " + options.offset + ", " + options.limit
+          query += " LIMIT " + options.offset + ", " + options.limit;
         } else {
-          query += " LIMIT " + options.limit
+          query += " LIMIT " + options.limit;
         }
       }
       return query;
     },
 
     addColumnQuery: function() {
-      var sql = MySqlQueryGenerator.addColumnQuery.apply(this, arguments)
-      return this.replaceBooleanDefaults(sql)
+      var sql = MySqlQueryGenerator.addColumnQuery.apply(this, arguments);
+      return this.replaceBooleanDefaults(sql);
     },
 
     showTablesQuery: function() {
-      return "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';"
+      return "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';";
     },
 
     bulkInsertQuery: function(tableName, attrValueHashes, options) {
       var query = "INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %>;"
         , tuples = []
-        , allAttributes = []
+        , allAttributes = [];
 
       Utils._.forEach(attrValueHashes, function(attrValueHash, i) {
         Utils._.forOwn(attrValueHash, function(value, key, hash) {
-          if (allAttributes.indexOf(key) === -1) allAttributes.push(key)
-        })
-      })
+          if (allAttributes.indexOf(key) === -1) allAttributes.push(key);
+        });
+      });
 
       Utils._.forEach(attrValueHashes, function(attrValueHash, i) {
         tuples.push("(" +
           allAttributes.map(function (key) {
-            return this.escape(attrValueHash[key])
+            return this.escape(attrValueHash[key]);
           }.bind(this)).join(",") +
-        ")")
-      }.bind(this))
+        ")");
+      }.bind(this));
 
       var replacements  = {
         ignoreDuplicates: options && options.ignoreDuplicates ? ' OR IGNORE' : '',
         table: this.quoteTable(tableName),
-        attributes: allAttributes.map(function(attr){
-                      return this.quoteIdentifier(attr)
+        attributes: allAttributes.map(function(attr) {
+                      return this.quoteIdentifier(attr);
                     }.bind(this)).join(","),
         tuples: tuples
-      }
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     updateQuery: function(tableName, attrValueHash, where, options) {
-      attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull, options)
+      attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull, options);
 
       var query  = "UPDATE <%= table %> SET <%= values %> WHERE <%= where %>"
-        , values = []
+        , values = [];
 
       for (var key in attrValueHash) {
-        var value = attrValueHash[key]
-        values.push(this.quoteIdentifier(key) + "=" + this.escape(value))
+        var value = attrValueHash[key];
+        values.push(this.quoteIdentifier(key) + "=" + this.escape(value));
       }
 
       var replacements = {
         table: this.quoteTable(tableName),
         values: values.join(","),
         where: this.getWhereConditions(where)
-      }
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     deleteQuery: function(tableName, where, options) {
-      options = options || {}
+      options = options || {};
 
-      var query = "DELETE FROM <%= table %> WHERE <%= where %>"
+      var query = "DELETE FROM <%= table %> WHERE <%= where %>";
       var replacements = {
         table: this.quoteTable(tableName),
         where: this.getWhereConditions(where)
-      }
+      };
 
-      return Utils._.template(query)(replacements)
+      return Utils._.template(query)(replacements);
     },
 
     attributesToSQL: function(attributes) {
-      var result = {}
+      var result = {};
 
       for (var name in attributes) {
-        var dataType = attributes[name]
+        var dataType = attributes[name];
 
         if (Utils.isHash(dataType)) {
           var template     = "<%= type %>"
-            , replacements = { type: dataType.type }
+            , replacements = { type: dataType.type };
 
           if (dataType.type.toString() === DataTypes.ENUM.toString()) {
-            replacements.type = "TEXT"
+            replacements.type = "TEXT";
 
             if (!(Array.isArray(dataType.values) && (dataType.values.length > 0))) {
-              throw new Error('Values for ENUM haven\'t been defined.')
+              throw new Error('Values for ENUM haven\'t been defined.');
             }
           }
 
           if (dataType.hasOwnProperty('allowNull') && !dataType.allowNull && !dataType.primaryKey) {
-            template += " NOT NULL"
+            template += " NOT NULL";
           }
 
           if (Utils.defaultValueSchemable(dataType.defaultValue)) {
             // TODO thoroughly check that DataTypes.NOW will properly
             // get populated on all databases as DEFAULT value
             // i.e. mysql requires: DEFAULT CURRENT_TIMESTAMP
-            template += " DEFAULT <%= defaultValue %>"
-            replacements.defaultValue = this.escape(dataType.defaultValue)
+            template += " DEFAULT <%= defaultValue %>";
+            replacements.defaultValue = this.escape(dataType.defaultValue);
           }
 
           if (dataType.unique === true) {
-            template += " UNIQUE"
+            template += " UNIQUE";
           }
 
           if (dataType.primaryKey) {
-            template += " PRIMARY KEY"
+            template += " PRIMARY KEY";
 
             if (dataType.autoIncrement) {
-              template += ' AUTOINCREMENT'
+              template += ' AUTOINCREMENT';
             }
           }
 
           if(dataType.references) {
-            template += " REFERENCES <%= referencesTable %> (<%= referencesKey %>)"
-            replacements.referencesTable = this.quoteTable(dataType.references)
+            template += " REFERENCES <%= referencesTable %> (<%= referencesKey %>)";
+            replacements.referencesTable = this.quoteTable(dataType.references);
 
             if(dataType.referencesKey) {
-              replacements.referencesKey = this.quoteIdentifier(dataType.referencesKey)
+              replacements.referencesKey = this.quoteIdentifier(dataType.referencesKey);
             } else {
-              replacements.referencesKey = this.quoteIdentifier('id')
+              replacements.referencesKey = this.quoteIdentifier('id');
             }
 
             if(dataType.onDelete) {
-              template += " ON DELETE <%= onDeleteAction %>"
-              replacements.onDeleteAction = dataType.onDelete.toUpperCase()
+              template += " ON DELETE <%= onDeleteAction %>";
+              replacements.onDeleteAction = dataType.onDelete.toUpperCase();
             }
 
             if(dataType.onUpdate) {
-              template += " ON UPDATE <%= onUpdateAction %>"
-              replacements.onUpdateAction = dataType.onUpdate.toUpperCase()
+              template += " ON UPDATE <%= onUpdateAction %>";
+              replacements.onUpdateAction = dataType.onUpdate.toUpperCase();
             }
 
           }
 
-          result[name] = Utils._.template(template)(replacements)
+          result[name] = Utils._.template(template)(replacements);
         } else {
-          result[name] = dataType
+          result[name] = dataType;
         }
       }
 
-      return result
+      return result;
     },
 
     findAutoIncrementField: function(factory) {
-      var fields = []
+      var fields = [];
 
       for (var name in factory.attributes) {
         if (factory.attributes.hasOwnProperty(name)) {
-          var definition = factory.attributes[name]
+          var definition = factory.attributes[name];
           if (definition && definition.autoIncrement) {
-            fields.push(name)
+            fields.push(name);
           }
         }
       }
 
-      return fields
+      return fields;
     },
 
     showIndexQuery: function(tableName) {
-      var sql = "PRAGMA INDEX_LIST(<%= tableName %>)"
-      return Utils._.template(sql, { tableName: tableName })
+      var sql = "PRAGMA INDEX_LIST(<%= tableName %>)";
+      return Utils._.template(sql, { tableName: tableName });
     },
 
     removeIndexQuery: function(tableName, indexNameOrAttributes) {
       var sql       = "DROP INDEX IF EXISTS <%= indexName %>"
-        , indexName = indexNameOrAttributes
+        , indexName = indexNameOrAttributes;
 
       if (typeof indexName !== 'string') {
-        indexName = Utils._.underscored(tableName + '_' + indexNameOrAttributes.join('_'))
+        indexName = Utils._.underscored(tableName + '_' + indexNameOrAttributes.join('_'));
       }
 
-      return Utils._.template(sql, { tableName: tableName, indexName: indexName })
+      return Utils._.template(sql, { tableName: tableName, indexName: indexName });
     },
 
     describeTableQuery: function(tableName, schema, schemaDelimiter) {
-      var options = {}
-      options.schema = schema
-      options.schemaDelimiter = schemaDelimiter
+      var options = {};
+      options.schema = schema;
+      options.schemaDelimiter = schemaDelimiter;
       options.quoted = false;
 
-      var sql = "PRAGMA TABLE_INFO(<%= tableName %>);"
-      return Utils._.template(sql, { tableName: this.addSchema({tableName: tableName, options: options})})
+      var sql = "PRAGMA TABLE_INFO(<%= tableName %>);";
+      return Utils._.template(sql, { tableName: this.addSchema({tableName: tableName, options: options})});
     },
 
     removeColumnQuery: function(tableName, attributes) {
-      attributes = this.attributesToSQL(attributes)
+      attributes = this.attributesToSQL(attributes);
 
-      var backupTableName = tableName + "_backup"
+      var backupTableName = tableName + "_backup";
       var query = [
         this.createTableQuery(backupTableName, attributes).replace('CREATE TABLE', 'CREATE TEMPORARY TABLE'),
         "INSERT INTO <%= tableName %>_backup SELECT <%= attributeNames %> FROM <%= tableName %>;",
@@ -339,18 +340,18 @@ module.exports = (function() {
         this.createTableQuery(tableName, attributes),
         "INSERT INTO <%= tableName %> SELECT <%= attributeNames %> FROM <%= tableName %>_backup;",
         "DROP TABLE <%= tableName %>_backup;"
-      ].join("")
+      ].join("");
 
       return Utils._.template(query, {
         tableName: tableName,
         attributeNames: Utils._.keys(attributes).join(', ')
-      })
+      });
     },
 
     renameColumnQuery: function(tableName, attrNameBefore, attrNameAfter, attributes) {
-      attributes = this.attributesToSQL(attributes)
+      attributes = this.attributesToSQL(attributes);
 
-      var backupTableName = tableName + "_backup"
+      var backupTableName = tableName + "_backup";
       var query = [
         this.createTableQuery(backupTableName, attributes).replace('CREATE TABLE', 'CREATE TEMPORARY TABLE'),
         "INSERT INTO <%= tableName %>_backup SELECT <%= attributeNamesImport %> FROM <%= tableName %>;",
@@ -358,49 +359,49 @@ module.exports = (function() {
         this.createTableQuery(tableName, attributes),
         "INSERT INTO <%= tableName %> SELECT <%= attributeNamesExport %> FROM <%= tableName %>_backup;",
         "DROP TABLE <%= tableName %>_backup;"
-      ].join("")
+      ].join("");
 
       return Utils._.template(query, {
         tableName: tableName,
         attributeNamesImport: Utils._.keys(attributes).map(function(attr) {
-          return (attrNameAfter === attr) ? attrNameBefore + ' AS ' + attr : attr
+          return (attrNameAfter === attr) ? attrNameBefore + ' AS ' + attr : attr;
         }.bind(this)).join(', '),
         attributeNamesExport: Utils._.keys(attributes).map(function(attr) {
-          return attr
+          return attr;
         }.bind(this)).join(', ')
-      })
+      });
     },
 
     startTransactionQuery: function() {
-      return "BEGIN TRANSACTION;"
+      return "BEGIN TRANSACTION;";
     },
 
     setAutocommitQuery: function() {
-      return "-- SQLite does not support SET autocommit."
+      return "-- SQLite does not support SET autocommit.";
     },
 
     setIsolationLevelQuery: function(value) {
       switch (value) {
         case Transaction.ISOLATION_LEVELS.REPEATABLE_READ:
-          return "-- SQLite is not able to choose the isolation level REPEATABLE READ."
+          return "-- SQLite is not able to choose the isolation level REPEATABLE READ.";
         case Transaction.ISOLATION_LEVELS.READ_UNCOMMITTED:
-          return "PRAGMA read_uncommitted = ON;"
+          return "PRAGMA read_uncommitted = ON;";
         case Transaction.ISOLATION_LEVELS.READ_COMMITTED:
-          return "PRAGMA read_uncommitted = OFF;"
+          return "PRAGMA read_uncommitted = OFF;";
         case Transaction.ISOLATION_LEVELS.SERIALIZABLE:
-          return "-- SQLite's default isolation level is SERIALIZABLE. Nothing to do."
+          return "-- SQLite's default isolation level is SERIALIZABLE. Nothing to do.";
         default:
-          throw new Error('Unknown isolation level: ' + value)
+          throw new Error('Unknown isolation level: ' + value);
       }
     },
 
     replaceBooleanDefaults: function(sql) {
-      return sql.replace(/DEFAULT '?false'?/g, "DEFAULT 0").replace(/DEFAULT '?true'?/g, "DEFAULT 1")
+      return sql.replace(/DEFAULT '?false'?/g, "DEFAULT 0").replace(/DEFAULT '?true'?/g, "DEFAULT 1");
     },
 
     quoteIdentifier: function(identifier, force) {
-      if (identifier === '*') return identifier
-      return Utils.addTicks(identifier, "`")
+      if (identifier === '*') return identifier;
+      return Utils.addTicks(identifier, "`");
     },
 
         /**
@@ -411,10 +412,10 @@ module.exports = (function() {
      * @return {String}            The generated sql query.
      */
     getForeignKeysQuery: function(tableName, schemaName) {
-      var sql = "PRAGMA foreign_key_list(<%= tableName %>)"
-      return Utils._.template(sql, { tableName: tableName })
+      var sql = "PRAGMA foreign_key_list(<%= tableName %>)";
+      return Utils._.template(sql, { tableName: tableName });
     }
-  }
+  };
 
-  return Utils._.extend({}, MySqlQueryGenerator, QueryGenerator)
-})()
+  return Utils._.extend({}, MySqlQueryGenerator, QueryGenerator);
+})();

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-var Utils = require("../../utils")
+var Utils = require('../../utils');
 
 /**
  Returns an object that treats SQLite's inabilities to do certain queries.
@@ -25,18 +25,18 @@ var QueryInterface = module.exports = {
     @since 1.6.0
    */
   removeColumn: function(tableName, attributeName) {
-    var self = this
+    var self = this;
     return this.describeTable(tableName).then(function(fields) {
-      delete fields[attributeName]
+      delete fields[attributeName];
 
-      var sql        = self.QueryGenerator.removeColumnQuery(tableName, fields)
-        , subQueries = sql.split(';').filter(function(q) { return q !== '' })
+      var sql = self.QueryGenerator.removeColumnQuery(tableName, fields)
+        , subQueries = sql.split(';').filter(function(q) { return q !== ''; });
 
-      subQueries.unshift(null)
-      return Utils.Promise.reduce(subQueries, function (total, subQuery) {
-        return self.sequelize.query(subQuery + ';', null, { raw: true})
-      })
-    })
+      subQueries.unshift(null);
+      return Utils.Promise.reduce(subQueries, function(total, subQuery) {
+        return self.sequelize.query(subQuery + ';', null, { raw: true});
+      });
+    });
   },
 
   /**
@@ -56,19 +56,19 @@ var QueryInterface = module.exports = {
    */
   changeColumn: function(tableName, attributes) {
     var attributeName = Utils._.keys(attributes)[0]
-      , self = this
+      , self = this;
 
     return this.describeTable(tableName).then(function(fields) {
-      fields[attributeName] = attributes[attributeName]
+      fields[attributeName] = attributes[attributeName];
 
-      var sql        = self.QueryGenerator.removeColumnQuery(tableName, fields)
-        , subQueries = sql.split(';').filter(function(q) { return q !== '' })
+      var sql = self.QueryGenerator.removeColumnQuery(tableName, fields)
+        , subQueries = sql.split(';').filter(function(q) { return q !== ''; });
 
-      subQueries.unshift(null)
-      return Utils.Promise.reduce(subQueries, function (total, subQuery) {
-        return self.sequelize.query(subQuery + ';', null, { raw: true})
-      })
-    })
+      subQueries.unshift(null);
+      return Utils.Promise.reduce(subQueries, function(total, subQuery) {
+        return self.sequelize.query(subQuery + ';', null, { raw: true});
+      });
+    });
   },
 
   /**
@@ -88,18 +88,18 @@ var QueryInterface = module.exports = {
     @since 1.6.0
    */
   renameColumn: function(tableName, attrNameBefore, attrNameAfter) {
-    var self = this
+    var self = this;
     return this.describeTable(tableName).then(function(fields) {
-      fields[attrNameAfter] = Utils._.clone(fields[attrNameBefore])
-      delete fields[attrNameBefore]
+      fields[attrNameAfter] = Utils._.clone(fields[attrNameBefore]);
+      delete fields[attrNameBefore];
 
-      var sql        = self.QueryGenerator.renameColumnQuery(tableName, attrNameBefore, attrNameAfter, fields)
-        , subQueries = sql.split(';').filter(function(q) { return q !== '' })
+      var sql = self.QueryGenerator.renameColumnQuery(tableName, attrNameBefore, attrNameAfter, fields)
+        , subQueries = sql.split(';').filter(function(q) { return q !== ''; });
 
-      subQueries.unshift(null)
-      return Utils.Promise.reduce(subQueries, function (total, subQuery) {
-        return self.sequelize.query(subQuery + ';', null, { raw: true})
-      })
-    })
-  },
-}
+      subQueries.unshift(null);
+      return Utils.Promise.reduce(subQueries, function(total, subQuery) {
+        return self.sequelize.query(subQuery + ';', null, { raw: true});
+      });
+    });
+  }
+};

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -1,184 +1,184 @@
-"use strict";
+'use strict';
 
-var Utils         = require("../../utils")
+var Utils = require('../../utils')
   , AbstractQuery = require('../abstract/query')
-  , QueryTypes    = require('../../query-types')
+  , QueryTypes = require('../../query-types');
 
 module.exports = (function() {
   var Query = function(database, sequelize, callee, options) {
-    this.database = database
-    this.sequelize = sequelize
-    this.callee = callee
+    this.database = database;
+    this.sequelize = sequelize;
+    this.callee = callee;
     this.options = Utils._.extend({
       logging: console.log,
       plain: false,
       raw: false
-    }, options || {})
+    }, options || {});
 
-    this.checkLoggingOption()
-  }
-  Utils.inherit(Query, AbstractQuery)
+    this.checkLoggingOption();
+  };
+  Utils.inherit(Query, AbstractQuery);
 
   Query.prototype.getInsertIdField = function() {
-    return 'lastID'
-  }
+    return 'lastID';
+  };
 
   Query.prototype.run = function(sql) {
     var self = this
-      , promise
+      , promise;
 
-    this.sql = sql
+    this.sql = sql;
 
     if (this.options.logging !== false) {
-      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql)
+      this.sequelize.log('Executing (' + this.options.uuid + '): ' + this.sql);
     }
 
-    return new Utils.Promise(function (resolve) {
-      var columnTypes = {}
-      promise = this
+    return new Utils.Promise(function(resolve) {
+      var columnTypes = {};
+      promise = this;
 
       self.database.serialize(function() {
         var executeSql = function() {
           if (self.sql.indexOf('-- ') === 0) {
             // the sql query starts with a comment. don't bother the server with that ...
-            promise.emit('sql', self.sql, self.options.uuid)
-            return resolve()
+            promise.emit('sql', self.sql, self.options.uuid);
+            return resolve();
           } else {
-            resolve(new Utils.Promise(function (resolve, reject) {
+            resolve(new Utils.Promise(function(resolve, reject) {
               self.database[getDatabaseMethod.call(self)](self.sql, function(err, results) {
                 // allow clients to listen to sql to do their own logging or whatnot
-                promise.emit('sql', self.sql, self.options.uuid)
+                promise.emit('sql', self.sql, self.options.uuid);
 
                 if (err) {
-                  err.sql = self.sql
-                  reject(err)
+                  err.sql = self.sql;
+                  reject(err);
                 } else {
-                  var metaData = this
-                  metaData.columnTypes = columnTypes
-                  
-                  var result = self.callee
+                  var metaData = this;
+                  metaData.columnTypes = columnTypes;
+
+                  var result = self.callee;
 
                   // add the inserted row id to the instance
                   if (self.send('isInsertQuery', results, metaData)) {
-                    self.send('handleInsertQuery', results, metaData)
+                    self.send('handleInsertQuery', results, metaData);
                   }
 
                   if (self.sql.indexOf('sqlite_master') !== -1) {
-                    result = results.map(function(resultSet) { return resultSet.name })
+                    result = results.map(function(resultSet) { return resultSet.name; });
                   } else if (self.send('isSelectQuery')) {
-                    if(!self.options.raw) {
+                    if (!self.options.raw) {
                       results = results.map(function(result) {
                         for (var name in result) {
                           if (result.hasOwnProperty(name) && metaData.columnTypes[name]) {
                             if (metaData.columnTypes[name] === 'DATETIME') {
                               // we need to convert the timestamps into actual date objects
-                              var val = result[name]
+                              var val = result[name];
                               if (val !== null) {
-                                result[name] = new Date(val+'Z') // Z means UTC
+                                result[name] = new Date(val + 'Z'); // Z means UTC
                               }
                             } else if (metaData.columnTypes[name].lastIndexOf('BLOB') !== -1) {
                               if (result[name]) {
-                                result[name] = new Buffer(result[name])
+                                result[name] = new Buffer(result[name]);
                               }
                             }
                           }
                         }
-                        return result
-                      })
+                        return result;
+                      });
                     }
 
-                    result = self.send('handleSelectQuery', results)
+                    result = self.send('handleSelectQuery', results);
                   } else if (self.send('isShowOrDescribeQuery')) {
-                    result = results
+                    result = results;
                   } else if (self.sql.indexOf('PRAGMA INDEX_LIST') !== -1) {
                     // this is the sqlite way of getting the indexes of a table
                     result = results.map(function(result) {
                       return {
-                        name:       result.name,
-                        tableName:  result.name.split('_')[0],
-                        unique:     (result.unique === 0)
-                      }
-                    })
+                        name: result.name,
+                        tableName: result.name.split('_')[0],
+                        unique: (result.unique === 0)
+                      };
+                    });
                   } else if (self.sql.indexOf('PRAGMA TABLE_INFO') !== -1) {
                     // this is the sqlite way of getting the metadata of a table
-                    result = {}
+                    result = {};
 
                     results.forEach(function(_result) {
                       result[_result.name] = {
-                        type:         _result.type,
-                        allowNull:    (_result.notnull === 0),
+                        type: _result.type,
+                        allowNull: (_result.notnull === 0),
                         defaultValue: _result.dflt_value
-                      }
+                      };
 
                       if (result[_result.name].type === 'TINYINT(1)') {
-                        result[_result.name].defaultValue = { '0': false, '1': true }[result[_result.name].defaultValue]
+                        result[_result.name].defaultValue = { '0': false, '1': true }[result[_result.name].defaultValue];
                       }
 
                       if (result[_result.name].defaultValue === undefined) {
-                        result[_result.name].defaultValue = null
+                        result[_result.name].defaultValue = null;
                       }
 
                       if (typeof result[_result.name].defaultValue === 'string') {
-                        result[_result.name].defaultValue = result[_result.name].defaultValue.replace(/'/g, "")
+                        result[_result.name].defaultValue = result[_result.name].defaultValue.replace(/'/g, '');
                       }
-                    })
+                    });
                   } else if (self.sql.indexOf('PRAGMA foreign_keys;') !== -1) {
-                    result = results[0]
+                    result = results[0];
                   } else if (self.sql.indexOf('PRAGMA foreign_keys') !== -1) {
-                    result = results
+                    result = results;
                   } else if ([QueryTypes.BULKUPDATE, QueryTypes.BULKDELETE].indexOf(self.options.type) !== -1) {
-                    result = metaData.changes
+                    result = metaData.changes;
                   }
 
-                  resolve(result)
+                  resolve(result);
                 }
-              })
-            }))
+              });
+            }));
           }
-        }
+        };
 
         if ((getDatabaseMethod.call(self) === 'all')) {
-          var tableNames = []
+          var tableNames = [];
           if (self.options && self.options.tableNames) {
-            tableNames = self.options.tableNames
+            tableNames = self.options.tableNames;
           } else if (/FROM `(.*?)`/i.exec(self.sql)) {
-            tableNames.push(/FROM `(.*?)`/i.exec(self.sql)[1])
+            tableNames.push(/FROM `(.*?)`/i.exec(self.sql)[1]);
           }
 
           if (!tableNames.length) {
-            return executeSql()
+            return executeSql();
           } else {
-            return Utils.Promise.map(tableNames, function (tableName) {
+            return Utils.Promise.map(tableNames, function(tableName) {
               if (tableName !== 'sqlite_master') {
-                return new Utils.Promise(function (resolve) {
+                return new Utils.Promise(function(resolve) {
                   // get the column types
-                  self.database.all("PRAGMA table_info(" + tableName + ")", function(err, results) {
+                  self.database.all('PRAGMA table_info(' + tableName + ')', function(err, results) {
                     if (!err) {
-                      for (var i=0, l=results.length; i<l; i++) {
-                        columnTypes[tableName + '.' + results[i].name] = columnTypes[results[i].name] = results[i].type
+                      for (var i = 0, l = results.length; i < l; i++) {
+                        columnTypes[tableName + '.' + results[i].name] = columnTypes[results[i].name] = results[i].type;
                       }
                     }
-                    resolve()
-                  });                  
-                })
+                    resolve();
+                  });
+                });
               }
-            }).then(executeSql)
+            }).then(executeSql);
           }
         } else {
-          return executeSql()
+          return executeSql();
         }
-      })  
-    })
-  }
+      });
+    });
+  };
 
   //private
   var getDatabaseMethod = function() {
     if (this.send('isInsertQuery') || this.send('isUpdateQuery') || (this.sql.toLowerCase().indexOf('CREATE TEMPORARY TABLE'.toLowerCase()) !== -1) || this.options.type === QueryTypes.BULKDELETE) {
-      return 'run'
+      return 'run';
     } else {
-      return 'all'
+      return 'all';
     }
-  }
+  };
 
-  return Query
-})()
+  return Query;
+})();

--- a/lib/emitters/custom-event-emitter.js
+++ b/lib/emitters/custom-event-emitter.js
@@ -1,18 +1,18 @@
-"use strict";
+'use strict';
 
-var util           = require("util")
-  , EventEmitter   = require("events").EventEmitter
-  , Promise        = require("../promise")
+var util = require('util')
+  , EventEmitter = require('events').EventEmitter
+  , Promise = require('../promise')
   , proxyEventKeys = ['success', 'error', 'sql']
-  , Utils          = require('../utils')
+  , Utils = require('../utils');
 
 var bindToProcess = function(fct) {
   if (fct && process.domain) {
-    return process.domain.bind(fct)
+    return process.domain.bind(fct);
   }
 
-  return fct
-}
+  return fct;
+};
 
 /**
    * The EventEmitter is returned from all asynchronous Sequelize calls - So almost all of them.
@@ -30,15 +30,15 @@ var bindToProcess = function(fct) {
    * })
    *
    * Model.find(...).done(function (err, dao) {
-   *   // Using the done method, which is called both if the operation succeeds, 
+   *   // Using the done method, which is called both if the operation succeeds,
    *   // and if it fails. On success, the err argument will be null
    * })
    *
    * Model.find(...).then(function (dao) {
-   *   // Using the emitter as a promise. The first function is the success handler, 
-   *   // and the second is the error handler. 
+   *   // Using the emitter as a promise. The first function is the success handler,
+   *   // and the second is the error handler.
    * }, function (err) {
-   * 
+   *
    * })
    * ```
    *
@@ -48,14 +48,14 @@ var bindToProcess = function(fct) {
 module.exports = (function() {
   /**
    * Create a new emitter instance.
-   * 
+   *
    * @constructor CustomEventEmitter
    * @param {function} fct A function that this emitter should run. The function is called with the emitter as first argument and as context
    */
   var CustomEventEmitter = function(fct) {
-    this.fct = bindToProcess(fct)
-  }
-  util.inherits(CustomEventEmitter, EventEmitter)
+    this.fct = bindToProcess(fct);
+  };
+  util.inherits(CustomEventEmitter, EventEmitter);
 
   /**
    * Run the function that was passed when the emitter was instantiated.
@@ -64,12 +64,12 @@ module.exports = (function() {
   CustomEventEmitter.prototype.run = function() {
     Utils.tick(function() {
       if (this.fct) {
-        this.fct.call(this, this)
+        this.fct.call(this, this);
       }
-    }.bind(this))
+    }.bind(this));
 
-    return this
-  }
+    return this;
+  };
 
   /**
    * Emit an event from the emitter
@@ -88,22 +88,22 @@ module.exports = (function() {
       // boil it down to the value of the first key
       // (probably an Array in most cases)
       if (Utils._.isObject(er) && !(er instanceof Error)) {
-        er = er[Object.keys(er)[0]]
+        er = er[Object.keys(er)[0]];
       }
 
       // If error argument is an array, make sure we
       // pass only the first error to the original
       // .emit() function of EventEmitter
       if (er instanceof Array) {
-        er = Utils._.flatten(er)[0]
+        er = Utils._.flatten(er)[0];
       }
 
       // We don't want to throw strings. Make them Errors!
-      if (typeof er === "string") {
-        er = new Error(er)
+      if (typeof er === 'string') {
+        er = new Error(er);
       }
 
-      arguments[1] = er
+      arguments[1] = er;
     }
 
     EventEmitter.prototype.emit.apply(this, arguments);
@@ -111,7 +111,7 @@ module.exports = (function() {
 
   /**
    * Listen for success events.
-   * 
+   *
    * ```js
    * emitter.success(function (result) {
    *  //...
@@ -126,13 +126,13 @@ module.exports = (function() {
   CustomEventEmitter.prototype.success =
   CustomEventEmitter.prototype.ok =
   function(fct) {
-    this.on('success', bindToProcess(fct))
-    return this
-  }
+    this.on('success', bindToProcess(fct));
+    return this;
+  };
 
   /**
    * Listen for error events
-   * 
+   *
    * ```js
    * emitter.error(function (err) {
    *  //...
@@ -149,19 +149,19 @@ module.exports = (function() {
   CustomEventEmitter.prototype.fail =
   CustomEventEmitter.prototype.error =
   function(fct) {
-    this.on('error', bindToProcess(fct))
+    this.on('error', bindToProcess(fct));
     return this;
-  }
+  };
 
   /**
    * Listen for both success and error events.
-   * 
+   *
    * ```js
    * emitter.done(function (err, result) {
    *  //...
    * });
    * ```
-   * 
+   *
    * @param {function} onDone
    * @method done
    * @alias complete
@@ -171,14 +171,14 @@ module.exports = (function() {
   CustomEventEmitter.prototype.complete =
   function(fct) {
     fct = bindToProcess(fct);
-    this.on('error', function(err) { fct(err, null) })
+    this.on('error', function(err) { fct(err, null); })
         .on('success', function() {
           var args = Array.prototype.slice.call(arguments);
           args.unshift(null);
           fct.apply(fct, args);
-        })
-    return this
-  }
+        });
+    return this;
+  };
 
   /*
    * Attach a function that is called every time the function that created this emitter executes a query.
@@ -186,9 +186,9 @@ module.exports = (function() {
    * @return this
    */
   CustomEventEmitter.prototype.sql = function(fct) {
-    this.on('sql', bindToProcess(fct))
+    this.on('sql', bindToProcess(fct));
     return this;
-  }
+  };
 
   /**
    * Proxy every event of this event emitter to another one.
@@ -200,49 +200,49 @@ module.exports = (function() {
    */
   CustomEventEmitter.prototype.proxy = function(emitter, options) {
     options = Utils._.extend({
-      events:     proxyEventKeys,
+      events: proxyEventKeys,
       skipEvents: []
-    }, options || {})
+    }, options ||  {});
 
-    options.events = Utils._.difference(options.events, options.skipEvents)
+    options.events = Utils._.difference(options.events, options.skipEvents);
 
-    options.events.forEach(function (eventKey) {
-      this.on(eventKey, function () {
-        var args = [ eventKey ].concat([].slice.apply(arguments))
-        emitter.emit.apply(emitter, args)
-      })
-    }.bind(this))
+    options.events.forEach(function(eventKey) {
+      this.on(eventKey, function() {
+        var args = [eventKey].concat([].slice.apply(arguments));
+        emitter.emit.apply(emitter, args);
+      });
+    }.bind(this));
 
-    return this
-  }
+    return this;
+  };
 
   CustomEventEmitter.prototype.proxySql = function(promise) {
     return this.proxy(promise, {
       events: ['sql']
-    })
-  }
+    });
+  };
 
   /**
    * Attach listeners to the emitter, promise style.
-   * 
+   *
    * @param  {Function} onFulfilled The function to call if the promise is fulfilled (if the emitter emits success). Note that this function will always only be called with one argument, as per the promises/A spec. For functions that emit multiple arguments (e.g. findOrCreate) see `spread`
    * @param  {Function} onRejected
    * @return {Bluebird.Promise}
    */
   CustomEventEmitter.prototype.then = function(onFulfilled, onRejected) {
-    var self = this
+    var self = this;
 
-    onFulfilled = bindToProcess(onFulfilled)
-    onRejected = bindToProcess(onRejected)
+    onFulfilled = bindToProcess(onFulfilled);
+    onRejected = bindToProcess(onRejected);
 
-    var promise = (new Promise(function (resolve, reject) {
+    var promise = (new Promise(function(resolve, reject) {
       self.on('error', reject)
-          .on('success', resolve)
-    })).then(onFulfilled, onRejected)
+          .on('success', resolve);
+    })).then(onFulfilled, onRejected);
 
     this.proxySql(promise);
     return promise;
-  }
+  };
 
   /**
    * Attach listeners to the emitter, promise style. This listener will recieve all arguments emitted by the emitter, as opposed to `then` which will only recieve the first argument.
@@ -252,31 +252,31 @@ module.exports = (function() {
    * @return {Bluebird.Promise}
    */
   CustomEventEmitter.prototype.spread = function(onFulfilled, onRejected) {
-    var self = this
+    var self = this;
 
-    onFulfilled = bindToProcess(onFulfilled)
-    onRejected = bindToProcess(onRejected)
+    onFulfilled = bindToProcess(onFulfilled);
+    onRejected = bindToProcess(onRejected);
 
-    var promise = (new Promise(function (resolve, reject) {
+    var promise = (new Promise(function(resolve, reject) {
       self.on('error', reject)
-          .on('success', function () {
-            resolve(Array.prototype.slice.apply(arguments)) // Transform args to an array
-          })
-    })).spread(onFulfilled, onRejected)
+          .on('success', function() {
+            resolve(Array.prototype.slice.apply(arguments)); // Transform args to an array
+          });
+    })).spread(onFulfilled, onRejected);
 
     this.proxySql(promise);
     return promise;
-  }
+  };
 
   /**
    * Shorthand for `then(null, onRejected)`
    *
    * @param  {Function} onRejected
    * @return {Bluebird.Promise}
-   */ 
+   */
   CustomEventEmitter.prototype.catch = function(onRejected) {
-    return this.then(null, onRejected)
-  }
+    return this.then(null, onRejected);
+  };
 
-  return CustomEventEmitter
-})()
+  return CustomEventEmitter;
+})();

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
 /**
  * @fileOverview The Error Objects produced by Sequelize.
  */
 
-var util = require('util')
-var error = module.exports = {}
+var util = require('util');
+var error = module.exports = {};
 
 /**
  * The Base Error all Sequelize Errors inherit from.
@@ -13,9 +13,9 @@ var error = module.exports = {}
  * @constructor
  */
 error.BaseError = function() {
-  Error.apply(this, arguments)
+  Error.apply(this, arguments);
 };
-util.inherits(error.BaseError, Error)
+util.inherits(error.BaseError, Error);
 
 
 /**
@@ -24,6 +24,6 @@ util.inherits(error.BaseError, Error)
  * @constructor
  */
 error.ValidationError = function() {
-  error.BaseError.apply(this, arguments)
+  error.BaseError.apply(this, arguments);
 };
-util.inherits(error.ValidationError, error.BaseError)
+util.inherits(error.ValidationError, error.BaseError);

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
-var Utils = require("./utils")
-  , Promise = require("./promise")
+var Utils = require('./utils')
+  , Promise = require('./promise');
 
 /**
  * Hooks are function that are called before and after  (bulk-) creation/updating/deletion and validation. Hooks can be added to you models in three ways:
@@ -12,7 +12,7 @@ var Utils = require("./utils")
 
  * ```js
  * // Method 1
- * sequelize.define(name, { attributes }, { 
+ * sequelize.define(name, { attributes }, {
  *   hooks: {
  *     beforeBulkCreate: function () {
  *       // can be a single function
@@ -34,173 +34,173 @@ var Utils = require("./utils")
  * @see {Sequelize#define}
  * @mixin Hooks
  */
-var Hooks = module.exports = function(){}
+var Hooks = module.exports = function() {};
 var hookAliases = {
-  beforeDelete: "beforeDestroy",
-  afterDelete: "afterDestroy"
-}
+  beforeDelete: 'beforeDestroy',
+  afterDelete: 'afterDestroy'
+};
 
 Hooks.replaceHookAliases = function(hooks) {
-  var realHookName
+  var realHookName;
 
   Utils._.each(hooks, function(hooksArray, name) {
     // Does an alias for this hook name exist?
-    if(realHookName = hookAliases[name]) {
+    if (realHookName = hookAliases[name]) {
       // Add the hooks to the actual hook
-      hooks[realHookName] = (hooks[realHookName] || []).concat(hooksArray)
+      hooks[realHookName] = (hooks[realHookName] || []).concat(hooksArray);
 
       // Delete the alias
-      delete hooks[name]
+      delete hooks[name];
     }
-  })
+  });
 
-  return hooks
-}
+  return hooks;
+};
 
 Hooks.runHooks = function() {
-  var self      = this
-    , tick      = 0
-    , hooks     = arguments[0]
-    , lastIndex = arguments.length-1
-    , fn        = typeof arguments[lastIndex] === "function" ? arguments[lastIndex] : null
-    , fnArgs      = Array.prototype.slice.call(arguments, 1, fn ? lastIndex : arguments.length)
-    , resolveArgs = fnArgs
+  var self = this
+    , tick = 0
+    , hooks = arguments[0]
+    , lastIndex = arguments.length - 1
+    , fn = typeof arguments[lastIndex] === 'function' ? arguments[lastIndex] : null
+    , fnArgs = Array.prototype.slice.call(arguments, 1, fn ? lastIndex : arguments.length)
+    , resolveArgs = fnArgs;
 
-  if (typeof hooks === "string") {
-    hooks = this.options.hooks[hooks] || []
+  if (typeof hooks === 'string') {
+    hooks = this.options.hooks[hooks] || [];
   }
 
   if (!Array.isArray(hooks)) {
-    hooks = hooks === undefined ? [] : [hooks]
+    hooks = hooks === undefined ? [] : [hooks];
   }
 
-  var promise = new Promise(function (resolve, reject) {
+  var promise = new Promise(function(resolve, reject) {
     if (hooks.length < 1) {
-      return resolve(fnArgs)
+      return resolve(fnArgs);
     }
 
     var run = function(hook) {
       if (!hook) {
-        return resolve(resolveArgs)
+        return resolve(resolveArgs);
       }
 
-      if (typeof hook === "object") {
-        hook = hook.fn
+      if (typeof hook === 'object') {
+        hook = hook.fn;
       }
 
       var maybePromise = hook.apply(self, fnArgs.concat(function() {
-        tick++
+        tick++;
 
         if (!!arguments[0]) {
-          return reject(arguments[0])
-        } 
+          return reject(arguments[0]);
+        }
         if (arguments.length) {
-          resolveArgs = Array.prototype.slice.call(arguments, 1)
+          resolveArgs = Array.prototype.slice.call(arguments, 1);
         }
 
-        return run(hooks[tick])
-      }))
+        return run(hooks[tick]);
+      }));
 
       if (Utils.Promise.is(maybePromise)) {
-        maybePromise.spread(function () {
-          tick++
+        maybePromise.spread(function() {
+          tick++;
 
           if (arguments.length) {
-            resolveArgs = Array.prototype.slice.call(arguments)
+            resolveArgs = Array.prototype.slice.call(arguments);
           }
 
-          return run(hooks[tick])
-        }, reject)
+          return run(hooks[tick]);
+        }, reject);
       }
-    }
+    };
 
-    run(hooks[tick])
-  })
+    run(hooks[tick]);
+  });
 
   if (fn) {
-    promise = promise.spread(function () {
+    promise = promise.spread(function() {
       fn.apply(self, [null].concat(Array.prototype.slice.apply(arguments)));
-    }, fn);  
+    }, fn);
   }
-  
-  return promise
-}
+
+  return promise;
+};
 
 Hooks.hook = function() {
-  Hooks.addHook.apply(this, arguments)
-}
+  Hooks.addHook.apply(this, arguments);
+};
 
 /**
  * Add a hook to the model
- * 
+ *
  * @param {String}    hooktype
  * @param {String}    [name]    Provide a name for the hook function. This serves no purpose, other than the ability to be able to order hooks based on some sort of priority system in the future.
  * @param {Function}  fn        The hook function
  * @alias hook
  */
 Hooks.addHook = function(hookType, name, fn) {
-  if (typeof name === "function") {
-    fn = name
-    name = null
+  if (typeof name === 'function') {
+    fn = name;
+    name = null;
   }
 
   var method = function() {
-    return fn.apply(this, Array.prototype.slice.call(arguments, 0, arguments.length-1).concat(arguments[arguments.length-1]))
-  }
+    return fn.apply(this, Array.prototype.slice.call(arguments, 0, arguments.length - 1).concat(arguments[arguments.length - 1]));
+  };
 
   // Aliases
-  hookType = hookAliases[hookType] || hookType
+  hookType = hookAliases[hookType] || hookType;
 
   // Just in case if we override the default DAOFactory.options
-  this.options.hooks[hookType] = this.options.hooks[hookType] || []
-  this.options.hooks[hookType][this.options.hooks[hookType].length] = !!name ? {name: name, fn: method} : method
-}
+  this.options.hooks[hookType] = this.options.hooks[hookType] || [];
+  this.options.hooks[hookType][this.options.hooks[hookType].length] = !!name ? {name: name, fn: method} : method;
+};
 
 /**
- * A hook that is run before validation 
+ * A hook that is run before validation
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.beforeValidate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeValidate', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeValidate', name, fn);
+};
 
 /**
- * A hook that is run after validation 
+ * A hook that is run after validation
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.afterValidate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterValidate', name, fn)
-}
+  Hooks.addHook.call(this, 'afterValidate', name, fn);
+};
 
 /**
- * A hook that is run before creating a single instance 
+ * A hook that is run before creating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, callback(err)
  */
 Hooks.beforeCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeCreate', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeCreate', name, fn);
+};
 
 /**
- * A hook that is run after creating a single instance 
+ * A hook that is run after creating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, callback(err)
  */
 Hooks.afterCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterCreate', name, fn)
-}
+  Hooks.addHook.call(this, 'afterCreate', name, fn);
+};
 
 /**
- * A hook that is run before destroying a single instance  
+ * A hook that is run before destroying a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  * alias beforeDelete
  */
 Hooks.beforeDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeDestroy', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeDestroy', name, fn);
+};
 
 /**
  * A hook that is run after destroying a single instance
@@ -209,25 +209,25 @@ Hooks.beforeDestroy = function(name, fn) {
  * @alias afterDelete
  */
 Hooks.afterDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'afterDestroy', name, fn)
-}
+  Hooks.addHook.call(this, 'afterDestroy', name, fn);
+};
 
 Hooks.beforeDelete = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeDelete', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeDelete', name, fn);
+};
 
 Hooks.afterDelete = function(name, fn) {
-  Hooks.addHook.call(this, 'afterDelete', name, fn)
-}
+  Hooks.addHook.call(this, 'afterDelete', name, fn);
+};
 
 /**
- * A hook that is run before updating a single instance 
+ * A hook that is run before updating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.beforeUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeUpdate', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeUpdate', name, fn);
+};
 
 /**
  * A hook that is run after updating a single instance
@@ -235,8 +235,8 @@ Hooks.beforeUpdate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.afterUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterUpdate', name, fn)
-}
+  Hooks.addHook.call(this, 'afterUpdate', name, fn);
+};
 
 /**
  * A hook that is run before creating instances in bulk
@@ -244,50 +244,50 @@ Hooks.afterUpdate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with instances, fields, callback(err)
  */
 Hooks.beforeBulkCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeBulkCreate', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeBulkCreate', name, fn);
+};
 
 /**
- * A hook that is run after creating instances in bulk 
+ * A hook that is run after creating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instances, fields, callback(err)
  */
 Hooks.afterBulkCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterBulkCreate', name, fn)
-}
+  Hooks.addHook.call(this, 'afterBulkCreate', name, fn);
+};
 
 /**
- * A hook that is run before destroing instances in bulk 
+ * A hook that is run before destroing instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with where, callback(err)
  */
 Hooks.beforeBulkDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeBulkDestroy', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeBulkDestroy', name, fn);
+};
 
 /**
- * A hook that is run after destroying instances in bulk 
+ * A hook that is run after destroying instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with where, callback(err)
  */
 Hooks.afterBulkDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'afterBulkDestroy', name, fn)
-}
+  Hooks.addHook.call(this, 'afterBulkDestroy', name, fn);
+};
 
 /**
- * A hook that is run after updating instances in bulk 
+ * A hook that is run after updating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attribute, where, callback(err)
  */
 Hooks.beforeBulkUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeBulkUpdate', name, fn)
-}
+  Hooks.addHook.call(this, 'beforeBulkUpdate', name, fn);
+};
 
 /**
- * A hook that is run after updating instances in bulk 
+ * A hook that is run after updating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attribute, where, callback(err)
  */
 Hooks.afterBulkUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterBulkUpdate', name, fn)
-}
+  Hooks.addHook.call(this, 'afterBulkUpdate', name, fn);
+};

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -1,44 +1,44 @@
-"use strict";
+'use strict';
 
-var Validator = require("validator")
-  , Utils     = require("./utils")
-  , sequelizeError = require("./errors")
-  , Promise = require("./promise")
-  , DataTypes = require("./data-types")
-  , _ = require('lodash')
+var Validator = require('validator')
+  , Utils = require('./utils')
+  , sequelizeError = require('./errors')
+  , Promise = require('./promise')
+  , DataTypes = require('./data-types')
+  , _ = require('lodash');
 
 function noop() {}
 
 // Deprecate this.
-Validator.notNull = function () {
+Validator.notNull = function() {
   throw new Error('Warning "notNull" validation has been deprecated in favor of Schema based "allowNull"');
-}
+};
 
 // https://github.com/chriso/validator.js/blob/1.5.0/lib/validators.js
 
 Validator.extend('notEmpty', function(str) {
   return !str.match(/^[\s\t\r\n]*$/);
-})
+});
 
 Validator.extend('len', function(str, min, max) {
-  return this.isLength(str, min, max)
-})
+  return this.isLength(str, min, max);
+});
 
 Validator.extend('isUrl', function(str) {
-  return this.isURL(str)
-})
+  return this.isURL(str);
+});
 
 Validator.extend('isIPv6', function(str) {
-  return this.isIP(str, 6)
-})
+  return this.isIP(str, 6);
+});
 
 Validator.extend('isIPv4', function(str) {
-  return this.isIP(str, 4)
-})
+  return this.isIP(str, 4);
+});
 
 Validator.extend('notIn', function(str, values) {
-  return !this.isIn(str, values)
-})
+  return !this.isIn(str, values);
+});
 
 Validator.extend('regex', function(str, pattern, modifiers) {
   str += '';
@@ -46,46 +46,46 @@ Validator.extend('regex', function(str, pattern, modifiers) {
     pattern = new RegExp(pattern, modifiers);
   }
   return str.match(pattern);
-})
+});
 
 Validator.extend('notRegex', function(str, pattern, modifiers) {
   return !this.regex(str, pattern, modifiers);
-})
+});
 
 Validator.extend('isDecimal', function(str) {
   return str !== '' && str.match(/^(?:-?(?:[0-9]+))?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/);
-})
+});
 
 Validator.extend('min', function(str, val) {
   var number = parseFloat(str);
   return isNaN(number) || number >= val;
-})
+});
 
 Validator.extend('max', function(str, val) {
   var number = parseFloat(str);
   return isNaN(number) || number <= val;
-})
+});
 
 Validator.extend('not', function(str, pattern, modifiers) {
   return this.notRegex(str, pattern, modifiers);
-})
+});
 
 Validator.extend('contains', function(str, elem) {
   return str.indexOf(elem) >= 0 && !!elem;
-})
+});
 
 Validator.extend('notContains', function(str, elem) {
   return !this.contains(str, elem);
-})
+});
 
 Validator.extend('is', function(str, pattern, modifiers) {
   return this.regex(str, pattern, modifiers);
-})
+});
 
-function extendModelValidations(modelInstance){
+function extendModelValidations(modelInstance) {
   Validator.extend('isImmutable', function(str, param, field) {
     return (modelInstance.isNewRecord || modelInstance.dataValues[field] === modelInstance._previousDataValues[field]);
-  })
+  });
 }
 
 
@@ -97,20 +97,20 @@ function extendModelValidations(modelInstance){
  * @constructor
  */
 var InstanceValidator = module.exports = function(modelInstance, options) {
-  options = options || {}
+  options = options || {};
 
   // assign defined and default options
   this.options = Utils._.defaults(options, {
-    skip: [],
+    skip: []
   });
 
-  this.modelInstance   = modelInstance
-  
+  this.modelInstance = modelInstance;
+
   /**
    * Exposes a reference to validator.js. This allows you to add custom validations using `Validator.extend`
    * @name Validator
-   */ 
-  this.Validator = Validator
+   */
+  this.Validator = Validator;
 
   /**
    *  All errors will be stored here from the validations.
@@ -118,16 +118,16 @@ var InstanceValidator = module.exports = function(modelInstance, options) {
    * @type {Sequelize.error} Will contain keys that correspond to attributes which will
    *   be Arrays of Errors.
    */
-  this.errors = new sequelizeError.ValidationError('Validation error')
+  this.errors = new sequelizeError.ValidationError('Validation error');
 
   /** @type {boolean} Indicates if validations are in progress */
   this.inProgress = false;
 
   extendModelValidations(modelInstance);
-}
+};
 
 /** @define {string} The error key for arguments as passed by custom validators */
-InstanceValidator.RAW_KEY_NAME = '__raw'
+InstanceValidator.RAW_KEY_NAME = '__raw';
 
 /**
  * The main entry point for the Validation module, invoke to start the dance.
@@ -139,22 +139,22 @@ InstanceValidator.prototype.validate = function() {
     throw new Error('Validations already in progress.');
   }
   this.inProgress = true;
-  this.errors = new sequelizeError.ValidationError('Validation error')
+  this.errors = new sequelizeError.ValidationError('Validation error');
 
-  var self = this
+  var self = this;
   return Promise.settle([
     self._builtinValidators(),
-    self._customValidators(),
-  ]).then(function () {
+    self._customValidators()
+  ]).then(function() {
     if (Object.keys(self.errors).length) {
-      return self.errors
+      return self.errors;
     }
 
-    return new Promise(function (resolve) {
-      resolve()
-    })
-  })
-}
+    return new Promise(function(resolve) {
+      resolve();
+    });
+  });
+};
 
 /**
  * Invoke the Validation sequence:
@@ -165,17 +165,17 @@ InstanceValidator.prototype.validate = function() {
  * @return {Promise}
  */
 InstanceValidator.prototype.hookValidate = function() {
-  var self   = this
-  return self.modelInstance.Model.runHooks('beforeValidate', self.modelInstance).then(function () {
-    return self.validate().then(function (error) {
+  var self = this;
+  return self.modelInstance.Model.runHooks('beforeValidate', self.modelInstance).then(function() {
+    return self.validate().then(function(error) {
       if (error) {
-        throw error
+        throw error;
       }
     });
-  }).then(function () {
-    return self.modelInstance.Model.runHooks('afterValidate', self.modelInstance)
-  }).return(self.modelInstance);
-}
+  }).then(function() {
+    return self.modelInstance.Model.runHooks('afterValidate', self.modelInstance);
+  }).return (self.modelInstance);
+};
 
 /**
  * Will run all the built-in validators.
@@ -184,29 +184,29 @@ InstanceValidator.prototype.hookValidate = function() {
  * @private
  */
 InstanceValidator.prototype._builtinValidators = function() {
-  var self = this
+  var self = this;
 
   // promisify all attribute invocations
   var validators = [];
   Utils._.forIn(this.modelInstance.rawAttributes, function(rawAttribute, field) {
     if (self.options.skip.indexOf(field) >= 0) {
-      return
+      return;
     }
 
-    var value = self.modelInstance.dataValues[field]
+    var value = self.modelInstance.dataValues[field];
 
     if (!rawAttribute._autoGenerated && !rawAttribute.autoIncrement) {
       // perform validations based on schema
-      self._validateSchema(rawAttribute, field, value)
+      self._validateSchema(rawAttribute, field, value);
     }
 
     if (self.modelInstance.validators.hasOwnProperty(field)) {
-      validators.push(self._builtinAttrValidate.call(self, value, field))
+      validators.push(self._builtinAttrValidate.call(self, value, field));
     }
-  })
+  });
 
-  return Promise.settle(validators)
-}
+  return Promise.settle(validators);
+};
 
 /**
  * Will run all the custom validators.
@@ -223,13 +223,13 @@ InstanceValidator.prototype._customValidators = function() {
 
     var valprom = self._invokeCustomValidator(validator, validatorType)
       // errors are handled in settling, stub this
-      .catch(noop)
+      .catch (noop);
 
-    validators.push(valprom)
-  })
+    validators.push(valprom);
+  });
 
-  return Promise.settle(validators)
-}
+  return Promise.settle(validators);
+};
 
 /**
  * Validate a single attribute with all the defined built-in validators.
@@ -254,17 +254,17 @@ InstanceValidator.prototype._builtinAttrValidate = function(value, field) {
 
     // Check for custom validator.
     if (typeof test === 'function') {
-      return validators.push(self._invokeCustomValidator(test, validatorType, true, value, field))
+      return validators.push(self._invokeCustomValidator(test, validatorType, true, value, field));
     }
 
-    var validatorPromise = self._invokeBuiltinValidator(value, test, validatorType, field)
+    var validatorPromise = self._invokeBuiltinValidator(value, test, validatorType, field);
     // errors are handled in settling, stub this
-    validatorPromise.catch(noop)
-    validators.push(validatorPromise)
+    validatorPromise.catch(noop);
+    validators.push(validatorPromise);
   });
 
   return Promise.settle(validators)
-    .then(this._handleSettledResult.bind(this, field))
+    .then(this._handleSettledResult.bind(this, field));
 };
 
 /**
@@ -278,8 +278,8 @@ InstanceValidator.prototype._builtinAttrValidate = function(value, field) {
  * @private
  */
 InstanceValidator.prototype._invokeCustomValidator = Promise.method(function(validator, validatorType, optAttrDefined, optValue, optField) {
-  var validatorFunction = null  // the validation function to call
-  var isAsync = false
+  var validatorFunction = null;  // the validation function to call
+  var isAsync = false;
 
   var validatorArity = validator.length;
   // check if validator is async and requires a callback
@@ -297,17 +297,17 @@ InstanceValidator.prototype._invokeCustomValidator = Promise.method(function(val
 
   if (isAsync) {
     if (optAttrDefined) {
-      validatorFunction = Promise.promisify(validator.bind(this.modelInstance, invokeArgs))
+      validatorFunction = Promise.promisify(validator.bind(this.modelInstance, invokeArgs));
     } else {
-      validatorFunction = Promise.promisify(validator.bind(this.modelInstance))
+      validatorFunction = Promise.promisify(validator.bind(this.modelInstance));
     }
     return validatorFunction()
-      .catch(this._pushError.bind(this, false, errorKey))
+      .catch (this._pushError.bind(this, false, errorKey));
   } else {
     return Promise.try(validator.bind(this.modelInstance, invokeArgs))
-      .catch(this._pushError.bind(this, false, errorKey))
+      .catch (this._pushError.bind(this, false, errorKey));
   }
-})
+});
 
 /**
  * Prepare and invoke a build-in validator.
@@ -323,24 +323,24 @@ InstanceValidator.prototype._invokeBuiltinValidator = Promise.method(function(va
 
   // check if Validator knows that kind of validation test
   if (typeof Validator[validatorType] !== 'function') {
-    throw new Error('Invalid validator function: ' + validatorType)
+    throw new Error('Invalid validator function: ' + validatorType);
   }
 
   // extract extra arguments for the validator
   var validatorArgs = test.hasOwnProperty('args') ? test.args : test;
   // extract the error msg
   var errorMessage = test.hasOwnProperty('msg') ? test.msg :
-    'Validation ' + validatorType + ' failed'
+    'Validation ' + validatorType + ' failed';
 
 
   if (!Array.isArray(validatorArgs)) {
-    validatorArgs = [validatorArgs]
+    validatorArgs = [validatorArgs];
   } else {
     validatorArgs = validatorArgs.slice(0);
   }
-  validatorArgs.push(field)
+  validatorArgs.push(field);
   if (!Validator[validatorType].apply(Validator, [value].concat(validatorArgs))) {
-    throw errorMessage
+    throw errorMessage;
   }
 });
 
@@ -353,13 +353,13 @@ InstanceValidator.prototype._invokeBuiltinValidator = Promise.method(function(va
  * @private
  */
 InstanceValidator.prototype._validateSchema = function(rawAttribute, field, value) {
-  var error
+  var error;
 
   if (rawAttribute.allowNull === false && ((value === null) || (value === undefined))) {
-    error = new sequelizeError.ValidationError(field + ' cannot be null')
-    error.path = field
-    error.value = value
-    error.type = error.message = 'notNull Violation'
+    error = new sequelizeError.ValidationError(field + ' cannot be null');
+    error.path = field;
+    error.value = value;
+    error.type = error.message = 'notNull Violation';
     if (!this.errors.hasOwnProperty(field)) {
       this.errors[field] = [];
     }
@@ -368,10 +368,10 @@ InstanceValidator.prototype._validateSchema = function(rawAttribute, field, valu
 
   if (rawAttribute.type === DataTypes.STRING) {
     if (Array.isArray(value) || (_.isObject(value) && !value._isSequelizeMethod)) {
-      error = new sequelizeError.ValidationError(field + ' cannot be an array or an object')
-      error.path = field
-      error.value = value
-      error.type = error.message = 'string violation'
+      error = new sequelizeError.ValidationError(field + ' cannot be an array or an object');
+      error.path = field;
+      error.value = value;
+      error.type = error.message = 'string violation';
       if (!this.errors.hasOwnProperty(field)) {
         this.errors[field] = [];
       }
@@ -413,10 +413,10 @@ InstanceValidator.prototype._pushError = function(isBuiltin, errorKey, rawError)
     this.errors[errorKey] = [];
   }
 
-  var error = new sequelizeError.ValidationError()
+  var error = new sequelizeError.ValidationError();
 
-  error[InstanceValidator.RAW_KEY_NAME] = rawError
-  error.message = rawError.message || rawError || 'Validation error'
+  error[InstanceValidator.RAW_KEY_NAME] = rawError;
+  error.message = rawError.message || rawError || 'Validation error';
 
   this.errors[errorKey].push(error);
 };

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict';
 
-var Utils             = require("./utils")
-  , Mixin             = require("./associations/mixin")
-  , InstanceValidator = require("./instance-validator")
-  , DataTypes         = require("./data-types")
-  , _                 = require('lodash')
-  , defaultsOptions   = { raw: true }
-        
+var Utils = require('./utils')
+  , Mixin = require('./associations/mixin')
+  , InstanceValidator = require('./instance-validator')
+  , DataTypes = require('./data-types')
+  , _ = require('lodash')
+  , defaultsOptions = { raw: true };
+
 
 module.exports = (function() {
-  /** 
+  /**
    * This class represents an single instance, a database row. You might see it referred to as both Instance and instance. You should not
    * instantiate the Instance class directly, instead you access it using the finder and creation methods on the model.
-   * 
-   * Instance instances operate with the concept of a `dataValues` property, which stores the actual values represented by the instance. 
+   *
+   * Instance instances operate with the concept of a `dataValues` property, which stores the actual values represented by the instance.
    * By default, the values from dataValues can also be accessed directly from the Instance, that is:
    * ```js
    * instance.field
@@ -22,25 +22,25 @@ module.exports = (function() {
    * // is the same as
    * instance.getDataValue('field')
    * ```
-   * However, if getters and/or setters are defined for `field` they will be invoked, instead of returning the value from `dataValues`.  
+   * However, if getters and/or setters are defined for `field` they will be invoked, instead of returning the value from `dataValues`.
    * Accessing properties directly or using `get` is preferred for regular use, `getDataValue` should only be used for custom getters.
    *
    * @see {Sequelize#define} for more information about getters and setters
    * @class Instance
    */
   var Instance = function(values, options) {
-    this.dataValues                  = {}
-    this._previousDataValues         = {}
-    this.__options                   = this.Model.options
-    this.options                     = options
-    this.hasPrimaryKeys              = this.Model.options.hasPrimaryKeys
-    this.__eagerlyLoadedAssociations = []
+    this.dataValues = {};
+    this._previousDataValues = {};
+    this.__options = this.Model.options;
+    this.options = options;
+    this.hasPrimaryKeys = this.Model.options.hasPrimaryKeys;
+    this.__eagerlyLoadedAssociations = [];
     /**
      * Returns true if this instance has not yet been persisted to the database
      * @property isNewRecord
      * @return {Boolean}
      */
-    this.isNewRecord                 = options.isNewRecord
+    this.isNewRecord = options.isNewRecord;
 
     /**
      * Returns the Model the instance was created from.
@@ -50,7 +50,7 @@ module.exports = (function() {
      */
 
     initValues.call(this, values, options);
-  }
+  };
 
   /**
    * A reference to the sequelize instance
@@ -59,12 +59,12 @@ module.exports = (function() {
    * @return {Sequelize}
    */
   Object.defineProperty(Instance.prototype, 'sequelize', {
-    get: function(){ return this.Model.modelManager.sequelize }
-  })
+    get: function() { return this.Model.modelManager.sequelize; }
+  });
 
   Object.defineProperty(Instance.prototype, 'QueryInterface', {
-    get: function(){ return this.sequelize.getQueryInterface() }
-  })
+    get: function() { return this.sequelize.getQueryInterface(); }
+  });
 
   /**
    * If timestamps and paranoid are enabled, returns whether the deletedAt timestamp of this instance is set. Otherwise, always returns false.
@@ -73,76 +73,76 @@ module.exports = (function() {
    */
   Object.defineProperty(Instance.prototype, 'isDeleted', {
     get: function() {
-      return this.Model._timestampAttributes.deletedAt && this.dataValues[this.Model._timestampAttributes.deletedAt] !== null
+      return this.Model._timestampAttributes.deletedAt && this.dataValues[this.Model._timestampAttributes.deletedAt] !== null;
     }
-  })
+  });
 
-  /** 
+  /**
    * Get the values of this Instance. Proxies to `this.get`
    * @see {Instance#get}
    * @property values
-   * @return {Object} 
+   * @return {Object}
    */
   Object.defineProperty(Instance.prototype, 'values', {
     get: function() {
-      return this.get()
+      return this.get();
     }
-  })
+  });
 
-  /** 
+  /**
    * A getter for `this.changed()`. Returns true if any keys have changed.
    *
    * @see {Instance#changed}
    * @property isDirty
-   * @return {Boolean} 
+   * @return {Boolean}
    */
   Object.defineProperty(Instance.prototype, 'isDirty', {
     get: function() {
-      return !!this.changed()
+      return !!this.changed();
     }
-  })
+  });
 
   /**
-   * Get the values of the primary keys of this instance. 
-   * 
+   * Get the values of the primary keys of this instance.
+   *
    * @property primaryKeyValues
    * @return {Object}
    */
   Object.defineProperty(Instance.prototype, 'primaryKeyValues', {
     get: function() {
       var result = {}
-        , self   = this
+        , self = this;
 
       Utils._.each(this.Model.primaryKeys, function(_, attr) {
-        result[attr] = self.dataValues[attr]
-      })
+        result[attr] = self.dataValues[attr];
+      });
 
-      return result
+      return result;
     }
-  })
+  });
 
-  Object.defineProperty(Instance.prototype, "identifiers", {
+  Object.defineProperty(Instance.prototype, 'identifiers', {
     get: function() {
       var primaryKeys = Object.keys(this.Model.primaryKeys)
-        , result      = {}
-        , self        = this
+        , result = {}
+        , self = this;
       primaryKeys.forEach(function(identifier) {
-        result[identifier] = self.dataValues[identifier]
-      })
+        result[identifier] = self.dataValues[identifier];
+      });
 
-      return result
+      return result;
     }
-  })
+  });
 
   /**
    * Get the value of the underlying data value
-   * 
+   *
    * @param {String} key
    * @return {any}
    */
   Instance.prototype.getDataValue = function(key) {
-    return this.dataValues[key]
-  }
+    return this.dataValues[key];
+  };
 
   /**
    * Update the underlying data value
@@ -151,49 +151,49 @@ module.exports = (function() {
    * @param {any} value
    */
   Instance.prototype.setDataValue = function(key, value) {
-    this.dataValues[key] = value
-  }
+    this.dataValues[key] = value;
+  };
 
-  /** 
+  /**
    * If no key is given, returns all values of the instance, also invoking virtual getters.
    *
    * If key is given and a field or virtual getter is present for the key it will call that getter - else it will return the value for key.
-   * 
+   *
    * @param {String} [key]
    * @return {Object|any}
    */
-  Instance.prototype.get = function (key) {
+  Instance.prototype.get = function(key) {
     if (key) {
       if (this._customGetters[key]) {
-        return this._customGetters[key].call(this, key)
+        return this._customGetters[key].call(this, key);
       }
-      return this.dataValues[key]
+      return this.dataValues[key];
     }
 
     if (this._hasCustomGetters) {
       var values = {}
-        , key
+        , key;
 
       for (key in this._customGetters) {
         if (this._customGetters.hasOwnProperty(key)) {
-          values[key] = this.get(key)
+          values[key] = this.get(key);
         }
       }
 
       for (key in this.dataValues) {
         if (!values.hasOwnProperty(key) && this.dataValues.hasOwnProperty(key)) {
-          values[key] = this.dataValues[key]
+          values[key] = this.dataValues[key];
         }
       }
-      return values
+      return values;
     }
-    return this.dataValues
-  }
+    return this.dataValues;
+  };
 
   /**
    * Set is used to update values on the instance (the sequelize representation of the instance that is, remember that nothing will be persisted before you actually call `save`).
    * In its most basic form `set` will update a value stored in the underlying `dataValues` object. However, if a custom setter function is defined for the key, that function
-   * will be called instead. To bypass the setter, you can pass `raw: true` in the options object. 
+   * will be called instead. To bypass the setter, you can pass `raw: true` in the options object.
    *
    * If set is called with an object, it will loop over the object, and call set recursively for each key, value pair. If you set raw to true, the underlying dataValues will either be
    * set directly to the object passed, or used to extend dataValues, if dataValues already contain values.
@@ -211,73 +211,73 @@ module.exports = (function() {
    * @param {Object}  [options.include]
    * @alias setAttributes
    */
-  Instance.prototype.set = function (key, value, options) {
+  Instance.prototype.set = function(key, value, options) {
     var values
       , originalValue
       , keys
       , i
-      , length
+      , length;
 
-    if (typeof key === "object") {
-      values = key
-      options = value
-      options || (options = {})
+    if (typeof key === 'object') {
+      values = key;
+      options = value;
+      options || (options = {});
 
       if (options.reset) {
-        this.dataValues = {}
+        this.dataValues = {};
       }
 
       // If raw, and we're not dealing with includes or special attributes, just set it straight on the dataValues object
       if (options.raw && !(this.options && this.options.include) && !(this.options && this.options.attributes) && !this.Model._hasBooleanAttributes && !this.Model._hasDateAttributes) {
         if (Object.keys(this.dataValues).length) {
-          this.dataValues = _.extend(this.dataValues, values)
+          this.dataValues = _.extend(this.dataValues, values);
         } else {
-          this.dataValues = values
+          this.dataValues = values;
         }
         // If raw, .changed() shouldn't be true
-        this._previousDataValues = _.clone(this.dataValues)
+        this._previousDataValues = _.clone(this.dataValues);
       } else {
         // Loop and call set
 
         if (this.options.attributes) {
-          keys = this.options.attributes
+          keys = this.options.attributes;
 
           if (this.options && this.options.includeNames) {
-            keys = keys.concat(this.options.includeNames)
+            keys = keys.concat(this.options.includeNames);
           }
 
           for (i = 0, length = keys.length; i < length; i++) {
             if (values[keys[i]] !== undefined) {
-              this.set(keys[i], values[keys[i]], options)
+              this.set(keys[i], values[keys[i]], options);
             }
           }
         } else {
           for (key in values) {
-            this.set(key, values[key], options)
+            this.set(key, values[key], options);
           }
         }
 
         if (options.raw) {
           // If raw, .changed() shouldn't be true
-          this._previousDataValues = _.clone(this.dataValues)
+          this._previousDataValues = _.clone(this.dataValues);
         }
       }
     } else {
-      options || (options = {})
+      options || (options = {});
       if (!options.raw) {
-        originalValue = this.dataValues[key]
+        originalValue = this.dataValues[key];
       }
-      
+
       // If not raw, and there's a customer setter
       if (!options.raw && this._customSetters[key]) {
-        this._customSetters[key].call(this, value, key)
+        this._customSetters[key].call(this, value, key);
       } else {
         // Check if we have included models, and if this key matches the include model names/aliases
 
         if (this.options && this.options.include && this.options.includeNames.indexOf(key) !== -1 && value) {
           // Pass it on to the include handler
-          this._setInclude(key, value, options)
-          return
+          this._setInclude(key, value, options);
+          return;
         } else {
           // Bunch of stuff we won't do when its raw
           if (!options.raw) {
@@ -288,35 +288,35 @@ module.exports = (function() {
 
             // If attempting to set primary key and primary key is already defined, return
             if (this.Model._hasPrimaryKeys && originalValue && this.Model._isPrimaryKey(key)) {
-              return
+              return;
             }
 
             // If attempting to set read only attributes, return
             if (this.Model._hasReadOnlyAttributes && this.Model._isReadOnlyAttribute(key)) {
-              return
+              return;
             }
 
             // Convert date fields to real date objects
             if (this.Model._hasDateAttributes && this.Model._isDateAttribute(key) && value !== null && !(value instanceof Date) && !value._isSequelizeMethod) {
-              value = new Date(value)
+              value = new Date(value);
             }
           }
 
           // Convert boolean-ish values to booleans
           if (this.Model._hasBooleanAttributes && this.Model._isBooleanAttribute(key) && value !== null && value !== undefined && !value._isSequelizeMethod) {
-            value = !!value
+            value = !!value;
           }
 
           if (!options.raw && originalValue !== value) {
-            this._previousDataValues[key] = originalValue
+            this._previousDataValues[key] = originalValue;
           }
-          this.dataValues[key] = value
+          this.dataValues[key] = value;
         }
       }
     }
 
     return this;
-  }
+  };
 
   /**
    * If changed is called with a string it will return a boolean indicating whether the value of that key in `dataValues` is different from the value in `_previousDataValues`.
@@ -329,16 +329,16 @@ module.exports = (function() {
   Instance.prototype.changed = function(key) {
     if (key) {
       if (this.Model._isDateAttribute(key) && this._previousDataValues[key] && this.dataValues[key]) {
-        return this._previousDataValues[key].valueOf() !== this.dataValues[key].valueOf()
+        return this._previousDataValues[key].valueOf() !== this.dataValues[key].valueOf();
       }
-      return this._previousDataValues[key] !== this.dataValues[key]
+      return this._previousDataValues[key] !== this.dataValues[key];
     }
-    var changed = Object.keys(this.dataValues).filter(function (key) {
-      return this.changed(key)
-    }.bind(this))
+    var changed = Object.keys(this.dataValues).filter(function(key) {
+      return this.changed(key);
+    }.bind(this));
 
-    return changed.length ? changed : false
-  }
+    return changed.length ? changed : false;
+  };
 
   /**
    * Returns the previous value for key from `_previousDataValues`.
@@ -346,24 +346,24 @@ module.exports = (function() {
    * @return {Boolean}
    */
   Instance.prototype.previous = function(key) {
-    return this._previousDataValues[key]
-  }
+    return this._previousDataValues[key];
+  };
 
   Instance.prototype._setInclude = function(key, value, options) {
-    if (!Array.isArray(value)) value = [value]
+    if (!Array.isArray(value)) value = [value];
     if (value[0] instanceof Instance) {
-      value = value.map(function (instance) {
-        return instance.dataValues
-      })
+      value = value.map(function(instance) {
+        return instance.dataValues;
+      });
     }
 
-    var include              = this.options.includeMap[key]
-      , association          = include.association
-      , self                 = this
-      , accessor             = Utils._.camelize(key)
+    var include = this.options.includeMap[key]
+      , association = include.association
+      , self = this
+      , accessor = Utils._.camelize(key)
       , childOptions
-      , primaryKeyAttribute  = include.model.primaryKeyAttribute
-      , isEmpty              = value[0] && value[0][primaryKeyAttribute] === null
+      , primaryKeyAttribute = include.model.primaryKeyAttribute
+      , isEmpty = value[0] && value[0][primaryKeyAttribute] === null;
 
     if (!isEmpty) {
       childOptions = {
@@ -375,17 +375,17 @@ module.exports = (function() {
         includeValidated: true,
         raw: options.raw,
         attributes: include.originalAttributes
-      }
+      };
     }
     if (include.originalAttributes === undefined || include.originalAttributes.length) {
       // downcase the first char
-      accessor = accessor.slice(0,1).toLowerCase() + accessor.slice(1)
+      accessor = accessor.slice(0, 1).toLowerCase() + accessor.slice(1);
 
       if (association.isSingleAssociation) {
-        accessor = Utils.singularize(accessor, self.Model.options.language)
-        self[accessor] = self.dataValues[accessor] = isEmpty ? null : include.model.build(value[0], childOptions)
+        accessor = Utils.singularize(accessor, self.Model.options.language);
+        self[accessor] = self.dataValues[accessor] = isEmpty ? null : include.model.build(value[0], childOptions);
       } else {
-        self[accessor] = self.dataValues[accessor] = isEmpty ? [] : include.model.bulkBuild(value, childOptions)
+        self[accessor] = self.dataValues[accessor] = isEmpty ? [] : include.model.bulkBuild(value, childOptions);
       }
     }
   };
@@ -393,82 +393,82 @@ module.exports = (function() {
   /**
    * Validate this instance, and if the validation passes, persist it to the database.
    *
-   * On success, the callback will be called with this instance. On validation error, the callback will be called with an instance of `Sequelize.ValidationError`. 
+   * On success, the callback will be called with this instance. On validation error, the callback will be called with an instance of `Sequelize.ValidationError`.
    * This error will have a property for each of the fields for which validation failed, with the error message for that field.
-   * 
+   *
    * @param {Array} [fields] An optional array of strings, representing database columns. If fields is provided, only those columns will be validation and saved.
    * @param {Object} [options]
    * @param {Object} [options.fields] An alternative way of setting which fields should be persisted
-   * @param {Boolean} [options.silent=false] If true, the updatedAt timestamp will not be updated. 
+   * @param {Boolean} [options.silent=false] If true, the updatedAt timestamp will not be updated.
    * @param {Transaction} [options.transaction]
    *
    * @return {Promise<this>}
    */
   Instance.prototype.save = function(fieldsOrOptions, options) {
     if (fieldsOrOptions instanceof Array) {
-      fieldsOrOptions = { fields: fieldsOrOptions }
+      fieldsOrOptions = { fields: fieldsOrOptions };
     }
 
-    options = Utils._.extend({}, options, fieldsOrOptions)
+    options = Utils._.extend({}, options, fieldsOrOptions);
 
     if (!options.fields) {
-      options.fields = Object.keys(this.Model.attributes)
+      options.fields = Object.keys(this.Model.attributes);
     }
 
     if (options.returning === undefined) {
       if (options.association) {
-        options.returning = false
+        options.returning = false;
       } else {
-        options.returning = true
+        options.returning = true;
       }
     }
 
-    var self           = this
-      , values         = {}
-      , updatedAtAttr  = this.Model._timestampAttributes.updatedAt
-      , createdAtAttr  = this.Model._timestampAttributes.createdAt
+    var self = this
+      , values = {}
+      , updatedAtAttr = this.Model._timestampAttributes.updatedAt
+      , createdAtAttr = this.Model._timestampAttributes.createdAt;
 
     if (updatedAtAttr && options.fields.indexOf(updatedAtAttr) === -1) {
-      options.fields.push(updatedAtAttr)
+      options.fields.push(updatedAtAttr);
     }
 
     if (options.silent === true) {
       // UpdateAtAttr might have been added as a result of Object.keys(Model.attributes). In that case we have to remove it again
-      Utils._.remove(options.fields, function (val) {
-        return val === updatedAtAttr
-      })
-      updatedAtAttr = false
+      Utils._.remove(options.fields, function(val) {
+        return val === updatedAtAttr;
+      });
+      updatedAtAttr = false;
     }
 
     if (this.isNewRecord === true && createdAtAttr && options.fields.indexOf(createdAtAttr) === -1) {
-      options.fields.push(createdAtAttr)
+      options.fields.push(createdAtAttr);
     }
 
     return self.hookValidate({
       skip: _.difference(Object.keys(self.rawAttributes), options.fields)
-    }).then(function () {
+    }).then(function() {
       options.fields.forEach(function(field) {
         if (self.dataValues[field] !== undefined) {
-          values[field] = self.dataValues[field]
+          values[field] = self.dataValues[field];
         }
-      })
+      });
 
       for (var attrName in self.Model.rawAttributes) {
         if (self.Model.rawAttributes.hasOwnProperty(attrName)) {
           var definition = self.Model.rawAttributes[attrName]
-            , isEnum          = !!definition.type && (definition.type.toString() === DataTypes.ENUM.toString())
-            , isMySQL         = ['mysql', 'mariadb'].indexOf(self.Model.modelManager.sequelize.options.dialect) !== -1
-            , ciCollation     = !!self.Model.options.collate && self.Model.options.collate.match(/_ci$/i)
-            , valueOutOfScope
+            , isEnum = !!definition.type && (definition.type.toString() === DataTypes.ENUM.toString())
+            , isMySQL = ['mysql', 'mariadb'].indexOf(self.Model.modelManager.sequelize.options.dialect) !== -1
+            , ciCollation = !!self.Model.options.collate && self.Model.options.collate.match(/_ci$/i)
+            , valueOutOfScope;
 
           // Unfortunately for MySQL CI collation we need to map/lowercase values again
           if (isEnum && isMySQL && ciCollation && (attrName in values) && values[attrName]) {
-            var scopeIndex = (definition.values || []).map(function(d) { return d.toLowerCase() }).indexOf(values[attrName].toLowerCase())
-            valueOutOfScope = scopeIndex === -1
+            var scopeIndex = (definition.values || []).map(function(d) { return d.toLowerCase(); }).indexOf(values[attrName].toLowerCase());
+            valueOutOfScope = scopeIndex === -1;
 
             // We'll return what the actual case will be, since a simple SELECT query would do the same...
             if (!valueOutOfScope) {
-              values[attrName] = definition.values[scopeIndex]
+              values[attrName] = definition.values[scopeIndex];
             }
           }
         }
@@ -482,9 +482,9 @@ module.exports = (function() {
             && !!self.Model.rawAttributes[updatedAtAttr].defaultValue
           )
           ? self.Model.rawAttributes[updatedAtAttr].defaultValue
-          : Utils.now(self.sequelize.options.dialect))    
+          : Utils.now(self.sequelize.options.dialect));
       }
-      
+
       if (self.isNewRecord && createdAtAttr && !values[createdAtAttr]) {
         values[createdAtAttr] = (
           (
@@ -492,40 +492,40 @@ module.exports = (function() {
             && !!self.Model.rawAttributes[createdAtAttr].defaultValue
           )
           ? self.Model.rawAttributes[createdAtAttr].defaultValue
-          : Utils.now(self.sequelize.options.dialect))
+          : Utils.now(self.sequelize.options.dialect));
         }
 
       var query = null
-        , args  = []
-        , hook  = ''
+        , args = []
+        , hook = '';
 
       if (self.isNewRecord) {
-        query         = 'insert'
-        args          = [self, self.QueryInterface.QueryGenerator.addSchema(self.Model), values, options]
-        hook          = 'Create'
+        query = 'insert';
+        args = [self, self.QueryInterface.QueryGenerator.addSchema(self.Model), values, options];
+        hook = 'Create';
       } else {
-        var identifier = self.primaryKeyValues
+        var identifier = self.primaryKeyValues;
 
         if (identifier === null && self.__options.whereCollection !== null) {
           identifier = self.__options.whereCollection;
         }
 
-        query         = 'update'
-        args          = [self, self.QueryInterface.QueryGenerator.addSchema(self.Model), values, identifier, options]
-        hook          = 'Update'
+        query = 'update';
+        args = [self, self.QueryInterface.QueryGenerator.addSchema(self.Model), values, identifier, options];
+        hook = 'Update';
       }
 
       // Add the values to the Instance
-      self.dataValues = _.extend(self.dataValues, values)
+      self.dataValues = _.extend(self.dataValues, values);
 
-      return self.Model.runHooks('before' + hook, self).then(function () {
+      return self.Model.runHooks('before' + hook, self).then(function() {
         // dataValues might have changed inside the hook, rebuild
         // the values hash
-        values = {}
+        values = {};
 
         options.fields.forEach(function(attr) {
           if (self.dataValues[attr] !== undefined) {
-            values[attr] = self.dataValues[attr]
+            values[attr] = self.dataValues[attr];
           }
 
           // Field name mapping
@@ -533,38 +533,38 @@ module.exports = (function() {
             values[self.Model.rawAttributes[attr].field] = values[attr];
             delete values[attr];
           }
-        })
+        });
 
-        args[2] = values
+        args[2] = values;
 
-        return self.QueryInterface[query].apply(self.QueryInterface, args).catch(function(err) {
+        return self.QueryInterface[query].apply(self.QueryInterface, args).catch (function(err) {
           if (!!self.__options.uniqueKeys && err.code && self.QueryInterface.QueryGenerator.uniqueConstraintMapping.code === err.code) {
-            var fields = self.QueryInterface.QueryGenerator.uniqueConstraintMapping.map(err.toString())
+            var fields = self.QueryInterface.QueryGenerator.uniqueConstraintMapping.map(err.toString());
 
             if (fields !== false) {
-              fields = fields.filter(function(f) { return f !== self.Model.tableName; })
+              fields = fields.filter(function(f) { return f !== self.Model.tableName; });
               Utils._.each(self.__options.uniqueKeys, function(value) {
                 if (Utils._.isEqual(value.fields, fields) && !!value.msg) {
-                  err = new Error(value.msg)
+                  err = new Error(value.msg);
                 }
-              })
+              });
             }
           }
 
-          throw err
+          throw err;
         }).then(function(result) {
           // Transfer database generated values (defaults, autoincrement, etc)
-          values = _.extend(values, result.dataValues)
+          values = _.extend(values, result.dataValues);
 
           // Ensure new values are on Instance, and reset previousDataValues
-          result.dataValues = _.extend(result.dataValues, values)
-          result._previousDataValues = _.clone(result.dataValues)
+          result.dataValues = _.extend(result.dataValues, values);
+          result._previousDataValues = _.clone(result.dataValues);
 
-          return self.Model.runHooks('after' + hook, result).return(result)
-        })
-      })
-    })
-  }
+          return self.Model.runHooks('after' + hook, result).return (result);
+        });
+      });
+    });
+  };
 
  /*
   * Refresh the current instance in-place, i.e. update the object with current data from the DB and return the same object.
@@ -578,43 +578,43 @@ module.exports = (function() {
   Instance.prototype.reload = function(options) {
     var self = this
       , where = [
-        this.QueryInterface.quoteTable(this.Model.name) + '.' + this.QueryInterface.quoteIdentifier(this.Model.primaryKeyAttribute)+'=?',
+        this.QueryInterface.quoteTable(this.Model.name) + '.' + this.QueryInterface.quoteIdentifier(this.Model.primaryKeyAttribute) + '=?',
         this.get(this.Model.primaryKeyAttribute, {raw: true})
-      ]
+      ];
 
     return this.Model.find({
-      where:   where,
-      limit:   1,
+      where: where,
+      limit: 1,
       include: this.options.include || null
-    }, options).then(function (reload) {
+    }, options).then(function(reload) {
       self.set(reload.dataValues, {raw: true, reset: true});
-    }).return(self);
-  }
+    }).return (self);
+  };
 
   /*
    * Validate the attribute of this instance according to validation rules set in the model definition.
-   * 
+   *
    * Emits null if and only if validation successful; otherwise an Error instance containing { field name : [error msgs] } entries.
    *
    * @param {Object} [options] Options that are passed to the validator
    * @param {Array} [options.skip] An array of strings. All properties that are in this array will not be validated
    * @see {InstanceValidator}
-   * 
+   *
    * @return {Promise<undefined|Error}
    */
   Instance.prototype.validate = function(options) {
-    return new InstanceValidator(this, options).validate()
-  }
+    return new InstanceValidator(this, options).validate();
+  };
 
   Instance.prototype.hookValidate = function(object) {
-    var validator = new InstanceValidator(this, object)
+    var validator = new InstanceValidator(this, object);
 
-    return validator.hookValidate()
-  }
+    return validator.hookValidate();
+  };
 
   /**
    * This is the same as calling `setAttributes`, then calling `save`.
-   * 
+   *
    * @see {Instance#setAttributes}
    * @see {Instance#save}
    * @param {Object} updates See `setAttributes`
@@ -624,50 +624,50 @@ module.exports = (function() {
    */
   Instance.prototype.updateAttributes = function(updates, options) {
     if (options instanceof Array) {
-      options = { fields: options }
+      options = { fields: options };
     }
 
-    this.set(updates)
-    return this.save(options)
-  }
+    this.set(updates);
+    return this.save(options);
+  };
 
   Instance.prototype.setAttributes = function(updates) {
-    return this.set(updates)
-  }
+    return this.set(updates);
+  };
 
   /**
-   * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will either be completely deleted, or have its deletedAt timestamp set to the current time. 
+   * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will either be completely deleted, or have its deletedAt timestamp set to the current time.
    *
-   * @param {Object}  [options={}]
+   * @param {Object}  [options= {}]
    * @param {Boolean} [options.force=false] If set to true, paranoid models will actually be deleted
    *
    * @return {Promise<undefined>}
    */
   Instance.prototype.destroy = function(options) {
-    options = options || {}
-    options.force = options.force === undefined ? false : Boolean(options.force)
+    options = options || {};
+    options.force = options.force === undefined ? false : Boolean(options.force);
 
-    var self = this
+    var self = this;
 
     // This semi awkward syntax where we can't return the chain directly but have to return the last .then() call is to allow sql proxying
-    return self.Model.runHooks(self.Model.options.hooks.beforeDestroy, self).then(function () {
-      var identifier
+    return self.Model.runHooks(self.Model.options.hooks.beforeDestroy, self).then(function() {
+      var identifier;
 
       if (self.Model._timestampAttributes.deletedAt && options.force === false) {
-        self.dataValues[self.Model._timestampAttributes.deletedAt] = new Date()
-        return self.save(options)
+        self.dataValues[self.Model._timestampAttributes.deletedAt] = new Date();
+        return self.save(options);
       } else {
         identifier = self.__options.hasPrimaryKeys ? self.primaryKeyValues : { id: self.id };
-        return self.QueryInterface.delete(self, self.QueryInterface.QueryGenerator.addSchema(self.Model), identifier, options)
+        return self.QueryInterface.delete(self, self.QueryInterface.QueryGenerator.addSchema(self.Model), identifier, options);
       }
-    }).then(function (results) {
-      return self.Model.runHooks(self.Model.options.hooks.afterDestroy, self).return(results);
+    }).then(function(results) {
+      return self.Model.runHooks(self.Model.options.hooks.afterDestroy, self).return (results);
     });
-  }
+  };
 
   /**
-   * Increment the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The increment is done using a 
-   * ```sql 
+   * Increment the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The increment is done using a
+   * ```sql
    * SET column = column + X
    * ```
    * query. To get the correct value after an increment into the Instance you should do a reload.
@@ -675,13 +675,13 @@ module.exports = (function() {
    *```js
    * instance.increment('number') // increment number by 1
    * instance.increment(['number', 'count'], { by: 2 }) // increment number and count by 2
-   * instance.increment({ answer: 42, tries: 1}, { by: 2 }) // increment answer by 42, and tries by 1. 
+   * instance.increment({ answer: 42, tries: 1}, { by: 2 }) // increment answer by 42, and tries by 1.
    *                                                        // `by` is ignored, since each column has its own value
-   * ``` 
+   * ```
    *
    * @see {Instance#reload}
    * @param {String|Array|Object} fields If a string is provided, that column is incremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is incremented by the value given
-   * @param {Object} [options] 
+   * @param {Object} [options]
    * @param {Integer} [options.by=1] The number to increment by
    * @param {Transaction} [options.transaction=null]
    *
@@ -689,50 +689,50 @@ module.exports = (function() {
    */
   Instance.prototype.increment = function(fields, countOrOptions) {
     Utils.validateParameter(countOrOptions, Object, {
-      optional:           true,
-      deprecated:         'number',
-      deprecationWarning: "Increment expects an object as second parameter. Please pass the incrementor as option! ~> instance.increment(" + JSON.stringify(fields) + ", { by: " + countOrOptions + " })"
-    })
+      optional: true,
+      deprecated: 'number',
+      deprecationWarning: 'Increment expects an object as second parameter. Please pass the incrementor as option! ~> instance.increment(' + JSON.stringify(fields) + ', { by: ' + countOrOptions + ' })'
+    });
 
-    var identifier    = this.__options.hasPrimaryKeys ? this.primaryKeyValues : { id: this.id }
+    var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : { id: this.id }
       , updatedAtAttr = this.Model._timestampAttributes.updatedAt
-      , values        = {}
-      , where
+      , values = {}
+      , where;
 
     if (countOrOptions === undefined) {
-      countOrOptions = { by: 1, transaction: null }
+      countOrOptions = { by: 1, transaction: null };
     } else if (typeof countOrOptions === 'number') {
-      countOrOptions = { by: countOrOptions, transaction: null }
+      countOrOptions = { by: countOrOptions, transaction: null };
     }
 
     countOrOptions = Utils._.extend({
-      by:         1,
+      by: 1,
       attributes: {},
-      where:      {}
-    }, countOrOptions)
+      where: {}
+    }, countOrOptions);
 
     where = _.extend(countOrOptions.where, identifier);
 
     if (Utils._.isString(fields)) {
-      values[fields] = countOrOptions.by
+      values[fields] = countOrOptions.by;
     } else if (Utils._.isArray(fields)) {
-      Utils._.each(fields, function (field) {
-        values[field] = countOrOptions.by
-      })
+      Utils._.each(fields, function(field) {
+        values[field] = countOrOptions.by;
+      });
     } else { // Assume fields is key-value pairs
-      values = fields
+      values = fields;
     }
 
     if (updatedAtAttr && !values[updatedAtAttr]) {
-      countOrOptions.attributes[updatedAtAttr] = Utils.now(this.Model.modelManager.sequelize.options.dialect)
+      countOrOptions.attributes[updatedAtAttr] = Utils.now(this.Model.modelManager.sequelize.options.dialect);
     }
 
-    return this.QueryInterface.increment(this, this.QueryInterface.QueryGenerator.addSchema(this.Model.tableName, this.Model.options.schema), values, where, countOrOptions)
-  }
+    return this.QueryInterface.increment(this, this.QueryInterface.QueryGenerator.addSchema(this.Model.tableName, this.Model.options.schema), values, where, countOrOptions);
+  };
 
   /**
-   * Decrement the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The decrement is done using a 
-   * ```sql 
+   * Decrement the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The decrement is done using a
+   * ```sql
    * SET column = column - X
    * ```
    * query. To get the correct value after an decrement into the Instance you should do a reload.
@@ -740,110 +740,110 @@ module.exports = (function() {
    * ```js
    * instance.decrement('number') // decrement number by 1
    * instance.decrement(['number', 'count'], { by: 2 }) // decrement number and count by 2
-   * instance.decrement({ answer: 42, tries: 1}, { by: 2 }) // decrement answer by 42, and tries by 1. 
+   * instance.decrement({ answer: 42, tries: 1}, { by: 2 }) // decrement answer by 42, and tries by 1.
    *                                                        // `by` is ignored, since each column has its own value
-   * ``` 
+   * ```
    *
    * @see {Instance#reload}
    * @param {String|Array|Object} fields If a string is provided, that column is decremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is decremented by the value given
-   * @param {Object} [options] 
+   * @param {Object} [options]
    * @param {Integer} [options.by=1] The number to decrement by
    * @param {Transaction} [options.transaction=null]
-   * 
+   *
    * @return {Promise}
    */
-  Instance.prototype.decrement = function (fields, countOrOptions) {
+  Instance.prototype.decrement = function(fields, countOrOptions) {
     Utils.validateParameter(countOrOptions, Object, {
-      optional:           true,
-      deprecated:         'number',
-      deprecationWarning: "Decrement expects an object as second parameter. Please pass the decrementor as option! ~> instance.decrement(" + JSON.stringify(fields) + ", { by: " + countOrOptions + " })"
-    })
+      optional: true,
+      deprecated: 'number',
+      deprecationWarning: 'Decrement expects an object as second parameter. Please pass the decrementor as option! ~> instance.decrement(' + JSON.stringify(fields) + ', { by: ' + countOrOptions + ' })'
+    });
 
     if (countOrOptions === undefined) {
-      countOrOptions = { by: 1, transaction: null }
+      countOrOptions = { by: 1, transaction: null };
     } else if (typeof countOrOptions === 'number') {
-      countOrOptions = { by: countOrOptions, transaction: null }
+      countOrOptions = { by: countOrOptions, transaction: null };
     }
 
     if (countOrOptions.by === undefined) {
-      countOrOptions.by = 1
+      countOrOptions.by = 1;
     }
 
     if (!Utils._.isString(fields) && !Utils._.isArray(fields)) { // Assume fields is key-value pairs
-      Utils._.each(fields, function (value, field) {
-        fields[field] = -value
-      })
+      Utils._.each(fields, function(value, field) {
+        fields[field] = -value;
+      });
     }
 
-    countOrOptions.by = 0 - countOrOptions.by
+    countOrOptions.by = 0 - countOrOptions.by;
 
-    return this.increment(fields, countOrOptions)
-  }
+    return this.increment(fields, countOrOptions);
+  };
 
   /**
    * Check whether all values of this and `other` Instance are the same
    *
-   * @param {Instance} other 
+   * @param {Instance} other
    * @return {Boolean}
    */
   Instance.prototype.equals = function(other) {
-    var result = true
+    var result = true;
 
     Utils._.each(this.dataValues, function(value, key) {
-      if(Utils._.isDate(value) && Utils._.isDate(other[key])) {
-        result = result && (value.getTime() == other[key].getTime())
+      if (Utils._.isDate(value) && Utils._.isDate(other[key])) {
+        result = result && (value.getTime() === other[key].getTime());
       } else {
-        result = result && (value == other[key])
+        result = result && (value === other[key]);
       }
-    })
+    });
 
-    return result
-  }
+    return result;
+  };
 
   /**
    * Check if this is eqaul to one of `others` by calling equals
-   * 
+   *
    * @param {Array} others
    * @return {Boolean}
    */
   Instance.prototype.equalsOneOf = function(others) {
-    var self = this
+    var self = this;
 
-    return _.any(others, function (other) {
-      return self.equals(other)
-    })
-  }
+    return _.any(others, function(other) {
+      return self.equals(other);
+    });
+  };
 
   Instance.prototype.setValidators = function(attribute, validators) {
-    this.validators[attribute] = validators
-  }
+    this.validators[attribute] = validators;
+  };
 
   /**
    * Convert the instance to a JSON representation. Proxies to calling `get` with no keys. This means get all values gotten from the DB, and apply all custom getters.
-   * 
+   *
    * @see {Instance#get}
    * @return {object}
    */
   Instance.prototype.toJSON = function() {
     return this.get();
-  }
+  };
 
   // private
   var initValues = function(values, options) {
     var defaults
       , key;
 
-    values = values && _.clone(values) || {}
+    values = values && _.clone(values) || {};
 
     if (options.isNewRecord) {
-      defaults = {}
+      defaults = {};
 
       if (this.Model._hasDefaultValues) {
         Utils._.each(this.Model._defaultValues, function(valueFn, key) {
           if (!defaults.hasOwnProperty(key)) {
-            defaults[key] = valueFn()
+            defaults[key] = valueFn();
           }
-        })
+        });
       }
 
       // set id to null if not passed as value, a newly created dao has no id
@@ -871,14 +871,14 @@ module.exports = (function() {
       if (Object.keys(defaults).length) {
         for (key in defaults) {
           if (!values.hasOwnProperty(key)) {
-            this.set(key, Utils.toDefaultValue(defaults[key]), defaultsOptions)
+            this.set(key, Utils.toDefaultValue(defaults[key]), defaultsOptions);
           }
         }
       }
     }
 
-    this.set(values, options)
-  }
+    this.set(values, options);
+  };
 
-  return Instance
-})()
+  return Instance;
+})();

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -1,31 +1,31 @@
-"use strict";
+'use strict';
 
-var moment         = require("moment")
-  , path           = require("path")
-  , Utils          = require("./utils")
-  , DataTypes      = require("./data-types")
-  , QueryInterface = require("./query-interface")
+var moment = require('moment')
+  , path = require('path')
+  , Utils = require('./utils')
+  , DataTypes = require('./data-types')
+  , QueryInterface = require('./query-interface');
 
 module.exports = (function() {
   var Migration = function(migrator, p) {
-    this.migrator       = migrator
-    this.path           = path.resolve(p)
-    this.filename       = Utils._.last(this.path.split(path.sep))
+    this.migrator = migrator;
+    this.path = path.resolve(p);
+    this.filename = Utils._.last(this.path.split(path.sep));
 
-    var parsed          = Migration.parseFilename(this.filename)
+    var parsed = Migration.parseFilename(this.filename);
 
-    this.migrationId    = parsed.id
-    this.date           = parsed.date;
-    this.queryInterface = this.migrator.queryInterface
-  }
+    this.migrationId = parsed.id;
+    this.date = parsed.date;
+    this.queryInterface = this.migrator.queryInterface;
+  };
 
   for (var methodName in QueryInterface.prototype) {
     if (QueryInterface.prototype.hasOwnProperty(methodName) && (typeof QueryInterface.prototype[methodName]) === 'function') {
       (function(methodName) {
         Migration.prototype[methodName] = function() {
-          return this.queryInterface[methodName].apply(this.queryInterface, arguments)
-        }
-      })(methodName)
+          return this.queryInterface[methodName].apply(this.queryInterface, arguments);
+        };
+      })(methodName);
     }
   }
 
@@ -34,17 +34,17 @@ module.exports = (function() {
   ///////////////
 
   Migration.parseFilename = function(s) {
-    var matches = s.match(/^((\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2}))[-_].+/)
+    var matches = s.match(/^((\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2}))[-_].+/);
 
     if (matches === null) {
-      throw new Error(s + ' is not a valid migration name! Use YYYYMMDDHHmmss-migration-name format.')
+      throw new Error(s + ' is not a valid migration name! Use YYYYMMDDHHmmss-migration-name format.');
     }
 
     return {
       id: parseInt(matches[1], 10),
       date: moment(matches.slice(2, 8).join('-'), 'YYYYMMDDHHmmss')
-    }
-  }
+    };
+  };
 
   ///////////////
   // member /////
@@ -55,57 +55,57 @@ module.exports = (function() {
       if (this.path.match(/\.coffee$/)) {
         try {
           // 1.7.x compiler registration
-          require('coffee-script/register')
-        } catch(e) {
+          require('coffee-script/register');
+        } catch (e) {
           try {
             // Prior to 1.7.x compiler registration
-            require('coffee-script')
-          } catch(e) {
-            console.log("You have to add \"coffee-script\" to your package.json.")
-            process.exit(1)
+            require('coffee-script');
+          } catch (e) {
+            console.log('You have to add \"coffee-script\" to your package.json.');
+            process.exit(1);
           }
         }
       }
 
-      return require(this.path)
+      return require(this.path);
     }
-  })
+  });
 
   Migration.prototype.execute = function(options) {
     return new Utils.CustomEventEmitter(function(emitter) {
       options = Utils._.extend({
         method: 'up'
-      }, options || {})
+      }, options || {});
 
       this.migration[options.method].call(null, this, DataTypes, function(err) {
         if (err) {
-          emitter.emit('error', err)
+          emitter.emit('error', err);
         } else {
-          emitter.emit('success', null)
+          emitter.emit('success', null);
         }
-      })
-    }.bind(this)).run()
-  }
+      });
+    }.bind(this)).run();
+  };
 
   Migration.prototype.isBefore = function(dateString, options) {
     options = Utils._.extend({
       withoutEquals: false
-    }, options || {})
+    }, options || {});
 
-    var date = Migration.parseFilename(dateString.toString() + '-foo.js').date
+    var date = Migration.parseFilename(dateString.toString() + '-foo.js').date;
 
-    return options.withoutEqual ? (date > this.date) : (date >= this.date)
-  }
+    return options.withoutEqual ? (date > this.date) : (date >= this.date);
+  };
 
   Migration.prototype.isAfter = function(dateString, options) {
     options = Utils._.extend({
       withoutEquals: false
-    }, options || {})
+    }, options || {});
 
-    var date = Migration.parseFilename(dateString.toString() + '-foo.js').date
+    var date = Migration.parseFilename(dateString.toString() + '-foo.js').date;
 
-    return options.withoutEqual ? (date < this.date) : (date <= this.date)
-  }
+    return options.withoutEqual ? (date < this.date) : (date <= this.date);
+  };
 
-  return Migration
-})()
+  return Migration;
+})();

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -1,172 +1,172 @@
-"use strict";
+'use strict';
 
-var fs     = require("fs")
-  , moment = require("moment")
+var fs = require('fs')
+  , moment = require('moment');
 
-var Utils          = require(__dirname + "/utils")
-  , Migration      = require(__dirname + "/migration")
-  , DataTypes      = require(__dirname + "/data-types")
+var Utils = require(__dirname + '/utils')
+  , Migration = require(__dirname + '/migration')
+  , DataTypes = require(__dirname + '/data-types');
 
 module.exports = (function() {
   var Migrator = function(sequelize, options) {
-    this.sequelize = sequelize
-    this.options   = Utils._.extend({
-      path:        __dirname + '/../migrations',
-      from:        null,
-      to:          null,
-      logging:     console.log,
+    this.sequelize = sequelize;
+    this.options = Utils._.extend({
+      path: __dirname + '/../migrations',
+      from: null,
+      to: null,
+      logging: console.log,
       filesFilter: /\.js$/
-    }, options || {})
-  }
+    }, options || {});
+  };
 
-  Object.defineProperty(Migrator.prototype, "queryInterface", {
+  Object.defineProperty(Migrator.prototype, 'queryInterface', {
     get: function() {
-      return this.sequelize.getQueryInterface()
+      return this.sequelize.getQueryInterface();
     }
-  })
+  });
 
   Migrator.prototype.migrate = function(options) {
-    var self = this
+    var self = this;
 
     options = Utils._.extend({
       method: 'up'
-    }, options || {})
+    }, options || {});
 
     return new Utils.CustomEventEmitter(function(emitter) {
       self.getUndoneMigrations(function(err, migrations) {
         if (err) {
-          emitter.emit('error', err)
+          emitter.emit('error', err);
         } else {
           var chainer = new Utils.QueryChainer()
-            , from    = migrations[0]
+            , from = migrations[0];
 
           if (options.method === 'down') {
-            migrations.reverse()
+            migrations.reverse();
           }
 
           if (migrations.length === 0) {
-            self.sequelize.log("There are no pending migrations.")
+            self.sequelize.log('There are no pending migrations.');
           } else {
-            self.sequelize.log("Running migrations...")
+            self.sequelize.log('Running migrations...');
           }
 
           migrations.forEach(function(migration) {
-            var migrationTime
+            var migrationTime;
 
             chainer.add(migration, 'execute', [options], {
               before: function(migration) {
-                self.sequelize.log(migration.filename)
-                migrationTime = process.hrtime()
+                self.sequelize.log(migration.filename);
+                migrationTime = process.hrtime();
               },
 
               after: function(migration) {
-                migrationTime = process.hrtime(migrationTime)
-                migrationTime = Math.round( (migrationTime[0] * 1000) + (migrationTime[1] / 1000000));
+                migrationTime = process.hrtime(migrationTime);
+                migrationTime = Math.round((migrationTime[0] * 1000) + (migrationTime[1] / 1000000));
 
-                self.sequelize.log('Completed in ' + migrationTime + 'ms')
+                self.sequelize.log('Completed in ' + migrationTime + 'ms');
               },
 
               success: function(migration, callback) {
                 if (options.method === 'down') {
-                  deleteUndoneMigration.call(self, from, migration, callback)
+                  deleteUndoneMigration.call(self, from, migration, callback);
                 } else {
-                  saveSuccessfulMigration.call(self, from, migration, callback)
+                  saveSuccessfulMigration.call(self, from, migration, callback);
                 }
               }
-            })
-          })
+            });
+          });
 
           chainer
             .runSerially({ skipOnError: true })
-            .success(function() { emitter.emit('success', null) })
-            .error(function(err) { emitter.emit('error', err) })
+            .success(function() { emitter.emit('success', null); })
+            .error(function(err) { emitter.emit('error', err); });
         }
-      })
-    }).run()
-  }
+      });
+    }).run();
+  };
 
   Migrator.prototype.getUndoneMigrations = function(callback)  {
-    var self = this
+    var self = this;
 
     var filterFrom = function(migrations, from, callback, options) {
-      var result = migrations.filter(function(migration) { return migration.isAfter(from, options) })
-      callback && callback(null, result)
-    }
+      var result = migrations.filter(function(migration) { return migration.isAfter(from, options); });
+      callback && callback(null, result);
+    };
     var filterTo = function(migrations, to, callback, options) {
-      var result = migrations.filter(function(migration) { return migration.isBefore(to, options) })
-      callback && callback(null, result)
-    }
+      var result = migrations.filter(function(migration) { return migration.isBefore(to, options); });
+      callback && callback(null, result);
+    };
 
     var migrationFiles = fs.readdirSync(this.options.path).filter(function(file) {
-      return self.options.filesFilter.test(file)
-    })
+      return self.options.filesFilter.test(file);
+    });
 
     var migrations = migrationFiles.map(function(file) {
-      return new Migration(self, self.options.path + '/' + file)
-    })
+      return new Migration(self, self.options.path + '/' + file);
+    });
 
-    migrations = migrations.sort(function(a,b){
-      return parseInt(a.filename.split('-')[0]) - parseInt(b.filename.split('-')[0])
-    })
+    migrations = migrations.sort(function(a, b) {
+      return parseInt(a.filename.split('-')[0]) - parseInt(b.filename.split('-')[0]);
+    });
 
     if (this.options.from) {
       filterFrom(migrations, this.options.from, function(err, migrations) {
         if (self.options.to) {
-          filterTo(migrations, self.options.to, callback)
+          filterTo(migrations, self.options.to, callback);
         } else {
-          callback && callback(null, migrations)
+          callback && callback(null, migrations);
         }
-      })
+      });
     } else {
       getLastMigrationIdFromDatabase.call(this).success(function(lastMigrationId) {
         if (lastMigrationId) {
           filterFrom(migrations, lastMigrationId, function(err, migrations) {
             if (self.options.to) {
-              filterTo(migrations, self.options.to, callback)
+              filterTo(migrations, self.options.to, callback);
             } else {
-              callback && callback(null, migrations)
+              callback && callback(null, migrations);
             }
-          }, { withoutEqual: true })
+          }, { withoutEqual: true });
         } else {
           if (self.options.to) {
-            filterTo(migrations, self.options.to, callback)
+            filterTo(migrations, self.options.to, callback);
           } else {
-            callback && callback(null, migrations)
+            callback && callback(null, migrations);
           }
         }
       }).error(function(err) {
-        callback && callback(err, null)
-      })
+        callback && callback(err, null);
+      });
     }
-  }
+  };
 
   Migrator.prototype.findOrCreateSequelizeMetaDAO = function(syncOptions) {
-    var self = this
+    var self = this;
 
     return new Utils.CustomEventEmitter(function(emitter) {
-      var storedDAO   = self.sequelize.daoFactoryManager.getDAO('SequelizeMeta')
-        , SequelizeMeta = storedDAO
+      var storedDAO = self.sequelize.daoFactoryManager.getDAO('SequelizeMeta')
+        , SequelizeMeta = storedDAO;
 
       if (!storedDAO) {
         SequelizeMeta = self.sequelize.define('SequelizeMeta', {
           from: DataTypes.STRING,
-          to:   DataTypes.STRING
+          to: DataTypes.STRING
         }, {
           timestamps: false
-        })
+        });
       }
 
       // force sync when model has newly created or if syncOptions are passed
       if (!storedDAO || syncOptions) {
         SequelizeMeta
           .sync(syncOptions || {})
-          .success(function() { emitter.emit('success', SequelizeMeta) })
-          .error(function(err) { emitter.emit('error', err) })
+          .success(function() { emitter.emit('success', SequelizeMeta); })
+          .error(function(err) { emitter.emit('error', err); });
       } else {
-        emitter.emit('success', SequelizeMeta)
+        emitter.emit('success', SequelizeMeta);
       }
-    }).run()
-  }
+    }).run();
+  };
 
   /**
    * Explicitly executes one or multiple migrations.
@@ -179,11 +179,11 @@ module.exports = (function() {
 
     var self = this;
     return new Utils.CustomEventEmitter(function(emitter) {
-      var chainer = new Utils.QueryChainer()
+      var chainer = new Utils.QueryChainer();
       var addMigration = function(filename) {
-        var migration = new Migration(self, filename)
+        var migration = new Migration(self, filename);
 
-        self.sequelize.log('Adding migration script at ' + filename)
+        self.sequelize.log('Adding migration script at ' + filename);
 
         chainer.add(migration, 'execute', [{ method: 'up' }], {
           before: function(migration) {
@@ -202,28 +202,28 @@ module.exports = (function() {
             }
             callback();
           }
-        })
-      }
+        });
+      };
 
       if (Utils._.isArray(filename)) {
         Utils._.each(filename, function(f) {
           addMigration(f);
-        })
+        });
       } else {
         addMigration(filename);
       }
 
       chainer
         .runSerially({ skipOnError: true })
-        .success(function() { emitter.emit('success', null) })
-        .error(function(err) { emitter.emit('error', err) })
-    }).run()
-  }
+        .success(function() { emitter.emit('success', null); })
+        .error(function(err) { emitter.emit('error', err); });
+    }).run();
+  };
 
   // private
 
   var getLastMigrationFromDatabase = Migrator.prototype.getLastMigrationFromDatabase = function() {
-    var self = this
+    var self = this;
 
     return new Utils.CustomEventEmitter(function(emitter) {
       self
@@ -232,70 +232,70 @@ module.exports = (function() {
           SequelizeMeta
             .find({ order: 'id DESC' })
             .success(function(meta) {
-              emitter.emit('success', meta ? meta : null)
+              emitter.emit('success', meta ? meta : null);
             })
             .error(function(err) {
-              emitter.emit('error', err)
-            })
+              emitter.emit('error', err);
+            });
         })
         .error(function(err) {
-          emitter.emit('error', err)
-        })
-    }).run()
-  }
+          emitter.emit('error', err);
+        });
+    }).run();
+  };
 
   var getLastMigrationIdFromDatabase = Migrator.prototype.getLastMigrationIdFromDatabase = function() {
-    var self = this
+    var self = this;
 
     return new Utils.CustomEventEmitter(function(emitter) {
       getLastMigrationFromDatabase
         .call(self)
         .success(function(meta) {
-          emitter.emit('success', meta ? meta.to : null)
+          emitter.emit('success', meta ? meta.to : null);
         })
         .error(function(err) {
-          emitter.emit('error', err)
-        })
-    }).run()
-  }
+          emitter.emit('error', err);
+        });
+    }).run();
+  };
 
   var getFormattedDateString = Migrator.prototype.getFormattedDateString = function(s) {
-    var result = null
+    var result = null;
 
     try {
-      result = s.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/).slice(1, 6).join('-')
-    } catch(e) {
-      throw new Error(s + ' is no valid migration timestamp format! Use YYYYMMDDHHmmss!')
+      result = s.match(/(\d{4})(\d{2})(\d{2})(\d{2})(\d{2})(\d{2})/).slice(1, 6).join('-');
+    } catch (e) {
+      throw new Error(s + ' is no valid migration timestamp format! Use YYYYMMDDHHmmss!');
     }
 
-    return result
-  }
+    return result;
+  };
 
   var stringToDate = Migrator.prototype.stringToDate = function(s) {
-    return moment(getFormattedDateString(s), "YYYYMMDDHHmmss")
-  }
+    return moment(getFormattedDateString(s), 'YYYYMMDDHHmmss');
+  };
 
   var saveSuccessfulMigration = Migrator.prototype.saveSuccessfulMigration = function(from, to, callback) {
-    var self = this
+    var self = this;
 
     self.findOrCreateSequelizeMetaDAO().success(function(SequelizeMeta) {
       SequelizeMeta
         .create({ from: from.migrationId, to: to.migrationId })
-        .success(callback)
-    })
-  }
+        .success(callback);
+    });
+  };
 
   var deleteUndoneMigration = Migrator.prototype.deleteUndoneMigration = function(from, to, callback) {
-    var self = this
+    var self = this;
 
     self.findOrCreateSequelizeMetaDAO().success(function(SequelizeMeta) {
       SequelizeMeta
         .find({ where: { from: from.migrationId.toString(), to: to.migrationId.toString() } })
         .success(function(meta) {
-          meta.destroy().success(callback)
-        })
-    })
-  }
+          meta.destroy().success(callback);
+        });
+    });
+  };
 
-  return Migrator
-})()
+  return Migrator;
+})();

--- a/lib/model-manager.js
+++ b/lib/model-manager.js
@@ -1,42 +1,43 @@
-"use strict";
+'use strict';
 
-var Toposort   = require('toposort-class')
-  , _          = require('lodash')
+var Toposort = require('toposort-class')
+  , _ = require('lodash');
 
 module.exports = (function() {
   var ModelManager = function(sequelize) {
-    this.daos = []
-    this.sequelize = sequelize
-  }
+    this.daos = [];
+    this.sequelize = sequelize;
+  };
 
   ModelManager.prototype.addDAO = function(dao) {
-    this.daos.push(dao)
-    this.sequelize.models[dao.name] = dao
+    this.daos.push(dao);
+    this.sequelize.models[dao.name] = dao;
 
-    return dao
-  }
+    return dao;
+  };
 
   ModelManager.prototype.removeDAO = function(dao) {
     this.daos = this.daos.filter(function(_dao) {
-      return _dao.name != dao.name
-    })
-    delete this.sequelize.models[dao.name]
-  }
+      return _dao.name !== dao.name;
+    });
+    
+    delete this.sequelize.models[dao.name];
+  };
 
   ModelManager.prototype.getDAO = function(daoName, options) {
-    options = options || {}
-    options.attribute = options.attribute || 'name'
+    options = options || {};
+    options.attribute = options.attribute || 'name';
 
     var dao = this.daos.filter(function(dao) {
-      return dao[options.attribute] === daoName
-    })
+      return dao[options.attribute] === daoName;
+    });
 
-    return !!dao ? dao[0] : null
-  }
+    return !!dao ? dao[0] : null;
+  };
 
   ModelManager.prototype.__defineGetter__('all', function() {
-    return this.daos
-  })
+    return this.daos;
+  });
 
   /**
    * Iterate over DAOs in an order suitable for e.g. creating tables. Will
@@ -44,53 +45,53 @@ module.exports = (function() {
    * before dependents.
    */
   ModelManager.prototype.forEachDAO = function(iterator, options) {
-    var daos   = {}
+    var daos = {}
       , sorter = new Toposort()
       , sorted
-      , dep
-    
+      , dep;
+
     options = _.defaults(options || {}, {
       reverse: true
-    })
+    });
 
     this.daos.forEach(function(dao) {
       var deps = []
-        , tableName = dao.getTableName()
+        , tableName = dao.getTableName();
 
       if (_.isObject(tableName)) {
-        tableName = tableName.schema + '.' + tableName.tableName
+        tableName = tableName.schema + '.' + tableName.tableName;
       }
 
-      daos[tableName] = dao
+      daos[tableName] = dao;
 
       for (var attrName in dao.rawAttributes) {
         if (dao.rawAttributes.hasOwnProperty(attrName)) {
           if (dao.rawAttributes[attrName].references) {
-            dep = dao.rawAttributes[attrName].references
+            dep = dao.rawAttributes[attrName].references;
 
             if (_.isObject(dep)) {
-              dep = dep.schema + '.' + dep.tableName
+              dep = dep.schema + '.' + dep.tableName;
             }
-            deps.push(dep)
+            deps.push(dep);
           }
         }
       }
 
-      deps = deps.filter(function (dep) {
-        return tableName !== dep
-      })
+      deps = deps.filter(function(dep) {
+        return tableName !== dep;
+      });
 
-      sorter.add(tableName, deps)
-    })
+      sorter.add(tableName, deps);
+    });
 
-    sorted = sorter.sort()
+    sorted = sorter.sort();
     if (options.reverse) {
-      sorted = sorted.reverse()
+      sorted = sorted.reverse();
     }
     sorted.forEach(function(name) {
-      iterator(daos[name], name)
-    })
-  }
+      iterator(daos[name], name);
+    });
+  };
 
-  return ModelManager
-})()
+  return ModelManager;
+})();

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,17 +1,19 @@
-var Utils       = require("./utils")
-  , Instance    = require("./instance")
-  , Attribute   = require("./model/attribute")
-  , DataTypes   = require("./data-types")
-  , Util        = require('util')
-  , sql         = require('sql')
-  , SqlString   = require('./sql-string')
+"use strict";
+
+var Utils = require('./utils')
+  , Instance = require('./instance')
+  , Attribute = require('./model/attribute')
+  , DataTypes = require('./data-types')
+  , Util = require('util')
+  , sql = require('sql')
+  , SqlString = require('./sql-string')
   , Transaction = require('./transaction')
-  , QueryTypes  = require('./query-types')
+  , QueryTypes = require('./query-types');
 
 module.exports = (function() {
   /**
    * A Model represents a table in the database. Sometimes you might also see it refererred to as model, or simply as factory. This class should _not_ be instantiated directly, it is created using `sequelize.define`, and already created models can be loaded using `sequelize.import`
-   * 
+   *
    * @class Model
    * @mixes Hooks
    * @mixes Associations
@@ -39,28 +41,28 @@ module.exports = (function() {
         beforeCreate: [],
         afterCreate: []
       }
-    }, options || {})
+    }, options || {});
 
-    this.sequelize = options.sequelize
-    this.underscored = this.underscored || this.underscoredAll
+    this.sequelize = options.sequelize;
+    this.underscored = this.underscored || this.underscoredAll;
 
     // error check options
     Utils._.each(options.validate, function(validator, validatorType) {
       if (Utils._.contains(Utils._.keys(attributes), validatorType)) {
-        throw new Error("A model validator function must not have the same name as a field. Model: " + name + ", field/validation name: " + validatorType)
+        throw new Error('A model validator function must not have the same name as a field. Model: ' + name + ', field/validation name: ' + validatorType);
       }
 
       if (!Utils._.isFunction(validator)) {
-        throw new Error("Members of the validate option must be functions. Model: " + name + ", error with validate member " + validatorType)
+        throw new Error('Members of the validate option must be functions. Model: ' + name + ', error with validate member ' + validatorType);
       }
-    })
+    });
 
-    this.name = name
+    this.name = name;
 
     if (!this.options.tableName) {
-      this.tableName = this.options.freezeTableName ? name : Utils._.underscoredIf(Utils.pluralize(name, this.options.language), this.options.underscoredAll)
+      this.tableName = this.options.freezeTableName ? name : Utils._.underscoredIf(Utils.pluralize(name, this.options.language), this.options.underscoredAll);
     } else {
-      this.tableName = this.options.tableName
+      this.tableName = this.options.tableName;
     }
 
     // If you don't specify a valid data type lets help you debug it
@@ -74,189 +76,189 @@ module.exports = (function() {
         attribute.values = (attribute.type && attribute.type.values) || attribute.values;
 
         // We keep on working with the actual type object
-        dataType = attribute.type
+        dataType = attribute.type;
       } else {
         dataType = attribute;
       }
 
       if (dataType === undefined) {
-        throw new Error('Unrecognized data type for field '+ name)
+        throw new Error('Unrecognized data type for field ' + name);
       }
 
-      if (dataType.toString() === "ENUM") {
+      if (dataType.toString() === 'ENUM') {
         if (!(Array.isArray(attribute.values) && (attribute.values.length > 0))) {
-          throw new Error('Values for ENUM haven\'t been defined.')
+          throw new Error('Values for ENUM haven\'t been defined.');
         }
         attributes[name].validate = attributes[name].validate || {
           _checkEnum: function(value, next) {
-            var hasValue        = value !== undefined
-              , isMySQL         = ['mysql', 'mariadb'].indexOf(options.sequelize.options.dialect) !== -1
-              , ciCollation     = !!options.collate && options.collate.match(/_ci$/i) !== null
-              , valueOutOfScope
+            var hasValue = value !== undefined
+              , isMySQL = ['mysql', 'mariadb'].indexOf(options.sequelize.options.dialect) !== -1
+              , ciCollation = !!options.collate && options.collate.match(/_ci$/i) !== null
+              , valueOutOfScope;
 
 
             if (isMySQL && ciCollation && hasValue) {
-              var scopeIndex = (attributes[name].values || []).map(function(d) { return d.toLowerCase() }).indexOf(value.toLowerCase())
-              valueOutOfScope = scopeIndex === -1
+              var scopeIndex = (attributes[name].values || []).map(function(d) { return d.toLowerCase(); }).indexOf(value.toLowerCase());
+              valueOutOfScope = scopeIndex === -1;
             } else {
-              valueOutOfScope = ((attributes[name].values || []).indexOf(value) === -1)
+              valueOutOfScope = ((attributes[name].values || []).indexOf(value) === -1);
             }
 
-            if (hasValue && valueOutOfScope && !(attributes[name].allowNull === true && values[attrName] === null)) {
-              return next('Value "' + value + '" for ENUM ' + name + ' is out of allowed scope. Allowed values: ' + attributes[name].values.join(', '))
+            if (hasValue && valueOutOfScope && attributes[name].allowNull !== true) {
+              return next('Value "' + value + '" for ENUM ' + name + ' is out of allowed scope. Allowed values: ' + attributes[name].values.join(', '));
             }
-            next()
+            next();
           }
-        }
+        };
       }
-    })
+    });
 
     Object.keys(attributes).forEach(function(attrName) {
       if (attributes[attrName].references instanceof Model) {
-        attributes[attrName].references = attributes[attrName].references.tableName
+        attributes[attrName].references = attributes[attrName].references.tableName;
       }
-    })
-    
-    this.options.hooks = this.replaceHookAliases(this.options.hooks)
+    });
 
-    this.attributes        =
-    this.rawAttributes     = attributes
-    this.modelManager      = 
-    this.daoFactoryManager = null // defined in init function
-    this.associations      = {}
-    this.scopeObj          = {}
-  }
+    this.options.hooks = this.replaceHookAliases(this.options.hooks);
+
+    this.attributes =
+    this.rawAttributes = attributes;
+    this.modelManager =
+    this.daoFactoryManager = null; // defined in init function
+    this.associations = {};
+    this.scopeObj = {};
+  };
 
   Object.defineProperty(Model.prototype, 'QueryInterface', {
-    get: function() { return this.modelManager.sequelize.getQueryInterface() }
-  })
+    get: function() { return this.modelManager.sequelize.getQueryInterface(); }
+  });
 
   Object.defineProperty(Model.prototype, 'QueryGenerator', {
-    get: function() { return this.QueryInterface.QueryGenerator }
-  })
+    get: function() { return this.QueryInterface.QueryGenerator; }
+  });
 
   // inject the node-sql methods to the dao factory in order to
   // receive the syntax sugar ...
 
- ;(function() {
-    var instance = sql.define({ name: "dummy", columns: [] })
+(function() {
+    var instance = sql.define({ name: 'dummy', columns: [] });
 
     for (var methodName in instance) {
-     ;(function(methodName) {
+      ;(function(methodName) {
         Model.prototype[methodName] = function() {
           var dataset = this.dataset()
-            , result  = dataset[methodName].apply(dataset, arguments)
+            , result = dataset[methodName].apply(dataset, arguments)
             , dialect = this.modelManager.sequelize.options.dialect
-            , self    = this
+            , self = this;
 
           result.toSql = function() {
-            var query = result.toQuery()
-            return SqlString.format(query.text.replace(/(\$\d)/g, '?'), query.values, null, dialect) + ';'
-          }
+            var query = result.toQuery();
+            return SqlString.format(query.text.replace(/(\$\d)/g, '?'), query.values, null, dialect) + ';';
+          };
 
           result.exec = function(options) {
             options = Utils._.extend({
               transaction: null,
-              type:        QueryTypes.SELECT
-            }, options || {})
+              type: QueryTypes.SELECT
+            }, options || {});
 
-            return self.sequelize.query(result.toSql(), self, options)
-          }
+            return self.sequelize.query(result.toSql(), self, options);
+          };
 
-          return result
-        }
-      })(methodName)
+          return result;
+        };
+      })(methodName);
     }
-  })()
+  })();
 
   Model.prototype.init = function(modelManager) {
-    var self = this
+    var self = this;
 
-    this.modelManager       = 
-    this.daoFactoryManager  = modelManager
-    this.primaryKeys        = {}
-    self.options.uniqueKeys = {}
+    this.modelManager =
+    this.daoFactoryManager = modelManager;
+    this.primaryKeys = {};
+    self.options.uniqueKeys = {};
 
     // Setup names of timestamp attributes
-    this._timestampAttributes = {}
+    this._timestampAttributes = {};
     if (this.options.timestamps) {
       if (this.options.createdAt) {
-        this._timestampAttributes.createdAt = Utils._.underscoredIf(this.options.createdAt, this.options.underscored)
+        this._timestampAttributes.createdAt = Utils._.underscoredIf(this.options.createdAt, this.options.underscored);
       }
       if (this.options.updatedAt) {
-        this._timestampAttributes.updatedAt = Utils._.underscoredIf(this.options.updatedAt, this.options.underscored)
+        this._timestampAttributes.updatedAt = Utils._.underscoredIf(this.options.updatedAt, this.options.underscored);
       }
       if (this.options.paranoid && this.options.deletedAt) {
-        this._timestampAttributes.deletedAt = Utils._.underscoredIf(this.options.deletedAt, this.options.underscored)
+        this._timestampAttributes.deletedAt = Utils._.underscoredIf(this.options.deletedAt, this.options.underscored);
       }
     }
 
     // Identify primary and unique attributes
     Utils._.each(this.rawAttributes, function(options, attribute) {
       if (options.hasOwnProperty('unique') && options.unique !== true && options.unique !== false) {
-        var idxName = options.unique
-        if (typeof options.unique === "object") {
-          idxName = options.unique.name
+        var idxName = options.unique;
+        if (typeof options.unique === 'object') {
+          idxName = options.unique.name;
         }
 
-        self.options.uniqueKeys[idxName] = self.options.uniqueKeys[idxName] || {fields: [], msg: null}
-        self.options.uniqueKeys[idxName].fields.push(attribute)
-        self.options.uniqueKeys[idxName].msg = self.options.uniqueKeys[idxName].msg || options.unique.msg || null
+        self.options.uniqueKeys[idxName] = self.options.uniqueKeys[idxName] || {fields: [], msg: null};
+        self.options.uniqueKeys[idxName].fields.push(attribute);
+        self.options.uniqueKeys[idxName].msg = self.options.uniqueKeys[idxName].msg || options.unique.msg || null;
       }
 
       if (options.primaryKey === true) {
-        self.primaryKeys[attribute] = self.attributes[attribute]
+        self.primaryKeys[attribute] = self.attributes[attribute];
       }
-    })
+    });
 
     // Add head and tail default attributes (id, timestamps)
-    addDefaultAttributes.call(this)
-    addOptionalClassMethods.call(this)
+    addDefaultAttributes.call(this);
+    addOptionalClassMethods.call(this);
 
     // Primary key convenience variables
-    this.primaryKeyAttributes = Object.keys(this.primaryKeys)
-    this.primaryKeyAttribute = this.primaryKeyAttributes[0]
-    this.primaryKeyCount = this.primaryKeyAttributes.length
-    this._hasPrimaryKeys = this.options.hasPrimaryKeys = this.hasPrimaryKeys = this.primaryKeyCount > 0
+    this.primaryKeyAttributes = Object.keys(this.primaryKeys);
+    this.primaryKeyAttribute = this.primaryKeyAttributes[0];
+    this.primaryKeyCount = this.primaryKeyAttributes.length;
+    this._hasPrimaryKeys = this.options.hasPrimaryKeys = this.hasPrimaryKeys = this.primaryKeyCount > 0;
 
-    this._isPrimaryKey = Utils._.memoize(function (key) {
-      return self.primaryKeyAttributes.indexOf(key) !== -1
-    })
+    this._isPrimaryKey = Utils._.memoize(function(key) {
+      return self.primaryKeyAttributes.indexOf(key) !== -1;
+    });
 
 
-    if (typeof this.options.defaultScope === "object") {
-      Utils.injectScope.call(this, this.options.defaultScope)
+    if (typeof this.options.defaultScope === 'object') {
+      Utils.injectScope.call(this, this.options.defaultScope);
     }
 
     // Instance prototype
     this.Instance = this.DAO = function() {
       Instance.apply(this, arguments);
-    }
+    };
 
     Util.inherits(this.Instance, Instance);
 
-    this._readOnlyAttributes = Utils._.values(this._timestampAttributes)
-    this._hasReadOnlyAttributes = this._readOnlyAttributes && this._readOnlyAttributes.length
-    this._isReadOnlyAttribute = Utils._.memoize(function (key) {
-      return self._hasReadOnlyAttributes && self._readOnlyAttributes.indexOf(key) !== -1
-    })
+    this._readOnlyAttributes = Utils._.values(this._timestampAttributes);
+    this._hasReadOnlyAttributes = this._readOnlyAttributes && this._readOnlyAttributes.length;
+    this._isReadOnlyAttribute = Utils._.memoize(function(key) {
+      return self._hasReadOnlyAttributes && self._readOnlyAttributes.indexOf(key) !== -1;
+    });
 
     if (this.options.instanceMethods) {
       Utils._.each(this.options.instanceMethods, function(fct, name) {
-        self.Instance.prototype[name] = fct
-      })
+        self.Instance.prototype[name] = fct;
+      });
     }
 
     this.refreshAttributes();
     findAutoIncrementField.call(this);
 
-    this._booleanAttributes = []
-    this._dateAttributes = []
-    this._hstoreAttributes = []
-    this._defaultValues = {}
-    this.Instance.prototype.validators    = {}
+    this._booleanAttributes = [];
+    this._dateAttributes = [];
+    this._hstoreAttributes = [];
+    this._defaultValues = {};
+    this.Instance.prototype.validators = {};
 
-    Utils._.each(this.rawAttributes, function (definition, name) {
+    Utils._.each(this.rawAttributes, function(definition, name) {
       if (((definition === DataTypes.BOOLEAN) || (definition.type === DataTypes.BOOLEAN))) {
         self._booleanAttributes.push(name);
       }
@@ -268,129 +270,129 @@ module.exports = (function() {
       }
       if (definition.hasOwnProperty('defaultValue')) {
         self._defaultValues[name] = Utils._.partial(
-          Utils.toDefaultValue, definition.defaultValue)
+          Utils.toDefaultValue, definition.defaultValue);
       }
 
       if (definition.hasOwnProperty('validate')) {
         self.Instance.prototype.validators[name] = definition.validate;
       }
-    })
+    });
 
-    this._hasBooleanAttributes = !!this._booleanAttributes.length
-    this._isBooleanAttribute = Utils._.memoize(function (key) {
-      return self._booleanAttributes.indexOf(key) !== -1
-    })
+    this._hasBooleanAttributes = !!this._booleanAttributes.length;
+    this._isBooleanAttribute = Utils._.memoize(function(key) {
+      return self._booleanAttributes.indexOf(key) !== -1;
+    });
 
-    this._hasDateAttributes = !!this._dateAttributes.length
-    this._isDateAttribute = Utils._.memoize(function (key) {
-      return self._dateAttributes.indexOf(key) !== -1
-    })
+    this._hasDateAttributes = !!this._dateAttributes.length;
+    this._isDateAttribute = Utils._.memoize(function(key) {
+      return self._dateAttributes.indexOf(key) !== -1;
+    });
 
-    this._hasHstoreAttributes = !!this._hstoreAttributes.length
-    this._isHstoreAttribute = Utils._.memoize(function (key) {
-      return self._hstoreAttributes.indexOf(key) !== -1
-    })
+    this._hasHstoreAttributes = !!this._hstoreAttributes.length;
+    this._isHstoreAttribute = Utils._.memoize(function(key) {
+      return self._hstoreAttributes.indexOf(key) !== -1;
+    });
 
-    this.Instance.prototype.Model = this
+    this.Instance.prototype.Model = this;
 
-    this._hasDefaultValues = !Utils._.isEmpty(this._defaultValues)
+    this._hasDefaultValues = !Utils._.isEmpty(this._defaultValues);
 
-    return this
-  }
+    return this;
+  };
 
   Model.prototype.refreshAttributes = function() {
     var self = this
       , attributeManipulation = {};
 
-    this.Instance.prototype._customGetters = {}
-    this.Instance.prototype._customSetters = {}
+    this.Instance.prototype._customGetters = {};
+    this.Instance.prototype._customSetters = {};
 
     Utils._.each(['get', 'set'], function(type) {
-      var opt   = type + 'terMethods'
+      var opt = type + 'terMethods'
         , funcs = Utils._.clone(Utils._.isObject(self.options[opt]) ? self.options[opt] : {})
-        , _custom = type === 'get' ? self.Instance.prototype._customGetters : self.Instance.prototype._customSetters
+        , _custom = type === 'get' ? self.Instance.prototype._customGetters : self.Instance.prototype._customSetters;
 
-      Utils._.each(funcs, function (method, attribute) {
-        _custom[attribute] = method
+      Utils._.each(funcs, function(method, attribute) {
+        _custom[attribute] = method;
 
         if (type === 'get') {
           funcs[attribute] = function() {
-            return this.get(attribute)
-          }
+            return this.get(attribute);
+          };
         }
         if (type === 'set') {
           funcs[attribute] = function(value) {
-            return this.set(attribute, value)
-          }
+            return this.set(attribute, value);
+          };
         }
-      })
+      });
 
       Utils._.each(self.rawAttributes, function(options, attribute) {
-        options.Model = self
-        options.fieldName = attribute
-        options._modelAttribute = true
+        options.Model = self;
+        options.fieldName = attribute;
+        options._modelAttribute = true;
 
         if (options.hasOwnProperty(type)) {
-          _custom[attribute] = options[type]
+          _custom[attribute] = options[type];
         }
 
         if (type === 'get') {
           funcs[attribute] = function() {
-            return this.get(attribute)
-          }
+            return this.get(attribute);
+          };
         }
         if (type === 'set') {
           funcs[attribute] = function(value) {
-            return this.set(attribute, value)
-          }
+            return this.set(attribute, value);
+          };
         }
-      })
+      });
 
       Utils._.each(funcs, function(fct, name) {
         if (!attributeManipulation[name]) {
           attributeManipulation[name] = {
             configurable: true
-          }
+          };
         }
-        attributeManipulation[name][type] = fct
-      })
-    })
-  
+        attributeManipulation[name][type] = fct;
+      });
+    });
+
     this.attributes = this.rawAttributes;
 
-    this.Instance.prototype._hasCustomGetters = Object.keys(this.Instance.prototype._customGetters).length
-    this.Instance.prototype._hasCustomSetters = Object.keys(this.Instance.prototype._customSetters).length
+    this.Instance.prototype._hasCustomGetters = Object.keys(this.Instance.prototype._customGetters).length;
+    this.Instance.prototype._hasCustomSetters = Object.keys(this.Instance.prototype._customSetters).length;
 
-    Object.defineProperties(this.Instance.prototype, attributeManipulation)
+    Object.defineProperties(this.Instance.prototype, attributeManipulation);
 
     this.Instance.prototype.rawAttributes = this.rawAttributes;
-    this.Instance.prototype.attributes = Object.keys(this.Instance.prototype.rawAttributes)
-    this.Instance.prototype._isAttribute = Utils._.memoize(function (key) {
-      return self.Instance.prototype.attributes.indexOf(key) !== -1
-    })
-  }
+    this.Instance.prototype.attributes = Object.keys(this.Instance.prototype.rawAttributes);
+    this.Instance.prototype._isAttribute = Utils._.memoize(function(key) {
+      return self.Instance.prototype.attributes.indexOf(key) !== -1;
+    });
+  };
 
   /**
    * Sync this Model to the DB, that is create the table. Upon success, the callback will be called with the model instance (this)
    * @see {Sequelize#sync} for options
-   * @return {Promise<this>} 
+   * @return {Promise<this>}
    */
   Model.prototype.sync = function(options) {
-    options = Utils._.extend({}, this.options, options || {})
+    options = Utils._.extend({}, this.options, options || {});
 
     var self = this
       , doQuery = function() {
         return self.QueryInterface.createTable(self.getTableName(), self.attributes, options);
-      }
+      };
 
     if (options.force) {
-      return self.drop(options).then(function () {
-        return doQuery().return(self)
+      return self.drop(options).then(function() {
+        return doQuery().return (self);
       });
     } else {
-      return doQuery().return(this)
+      return doQuery().return (this);
     }
-  }
+  };
 
   /**
    * Drop the table represented by this Model
@@ -399,15 +401,15 @@ module.exports = (function() {
    * @return {Promise}
    */
   Model.prototype.drop = function(options) {
-    return this.QueryInterface.dropTable(this.getTableName(), options)
-  }
+    return this.QueryInterface.dropTable(this.getTableName(), options);
+  };
 
   Model.prototype.dropSchema = function(schema) {
-    return this.QueryInterface.dropSchema(schema)
-  }
+    return this.QueryInterface.dropSchema(schema);
+  };
 
   /**
-   * Apply a schema to this model. For postgres, this will actually place the schema in front of the table name - `"schema"."tableName"`, 
+   * Apply a schema to this model. For postgres, this will actually place the schema in front of the table name - `"schema"."tableName"`,
    * while the schema will be prepended to the table name for mysql and sqlite - `'schema.tablename'`.
    *
    * @param {String} schema The name of the schema
@@ -416,30 +418,30 @@ module.exports = (function() {
    * @return this
    */
   Model.prototype.schema = function(schema, options) {
-    this.options.schema = schema
+    this.options.schema = schema;
 
     if (!!options) {
-      if (typeof options === "string") {
-        this.options.schemaDelimiter = options
+      if (typeof options === 'string') {
+        this.options.schemaDelimiter = options;
       } else {
         if (!!options.schemaDelimiter) {
-          this.options.schemaDelimiter = options.schemaDelimiter
+          this.options.schemaDelimiter = options.schemaDelimiter;
         }
       }
     }
 
-    return this
-  }
+    return this;
+  };
 
   /**
-   * Get the tablename of the model, taking schema into account. The method will return The name as a string if the model has no schema, 
+   * Get the tablename of the model, taking schema into account. The method will return The name as a string if the model has no schema,
    * or an object with `tableName`, `schema` and `delimiter` properties.
    *
-   * @return {String|Object} 
+   * @return {String|Object}
    */
   Model.prototype.getTableName = function() {
-    return this.QueryGenerator.addSchema(this)
-  }
+    return this.QueryGenerator.addSchema(this);
+  };
 
   /**
    * Apply a scope created in `define` to the model. First let's look at how to create scopes:
@@ -469,15 +471,15 @@ module.exports = (function() {
    * ```js
    * Model.findAll() // WHERE username = 'dan'
    * Model.findAll({ where: { age: { gt: 12 } } }) // WHERE age > 12 AND username = 'dan'
-   * ``` 
+   * ```
    *
    * To invoke scope functions you can do:
    * ```js
-   * Model.scope({ method: ['complexFunction' 'dan@sequelize.com', 42]}).findAll() 
+   * Model.scope({ method: ['complexFunction' 'dan@sequelize.com', 42]}).findAll()
    * // WHERE email like 'dan@sequelize.com%' AND access_level >= 42
    * ```
    *
-   * @param {Array|Object|String|null}    options* The scope(s) to apply. Scopes can either be passed as consecutive arguments, or as an array of arguments. To apply simple scopes, pass them as strings. For scope function, pass an object, with a `method` property. The value can either be a string, if the method does not take any arguments, or an array, where the first element is the name of the method, and consecutive elements are arguments to that method. Pass null to remove all scopes, including the default.  
+   * @param {Array|Object|String|null}    options* The scope(s) to apply. Scopes can either be passed as consecutive arguments, or as an array of arguments. To apply simple scopes, pass them as strings. For scope function, pass an object, with a `method` property. The value can either be a string, if the method does not take any arguments, or an array, where the first element is the name of the method, and consecutive elements are arguments to that method. Pass null to remove all scopes, including the default.
    * @return {Model}                      A reference to the model, with the scope(s) applied. Calling scope again on the returned model will clear the previous scope.
    */
   Model.prototype.scope = function(option) {
@@ -490,14 +492,14 @@ module.exports = (function() {
       , scopeName
       , scopeOptions
       , argLength = arguments.length
-      , lastArg = arguments[argLength-1]
+      , lastArg = arguments[argLength - 1];
 
     // Set defaults
-    scopeOptions = (typeof lastArg === "object" && !Array.isArray(lastArg) ? lastArg : {}) || {} // <-- for no arguments
-    scopeOptions.silent = (scopeOptions !== null && scopeOptions.hasOwnProperty('silent') ? scopeOptions.silent : true)
+    scopeOptions = (typeof lastArg === 'object' && !Array.isArray(lastArg) ? lastArg : {}) || {}; // <-- for no arguments
+    scopeOptions.silent = (scopeOptions !== null && scopeOptions.hasOwnProperty('silent') ? scopeOptions.silent : true);
 
     // Clear out any predefined scopes...
-    self.scopeObj = {}
+    self.scopeObj = {};
 
     // Possible formats for option:
     // String of arguments: 'hello', 'world', 'etc'
@@ -505,66 +507,66 @@ module.exports = (function() {
     // Object: {merge: 'hello'}, {method: ['scopeName' [, args1, args2..]]}, {merge: true, method: ...}
 
     if (argLength < 1 || !option) {
-      return self
+      return self;
     }
 
     for (i = 0; i < argLength; i++) {
-      options = Array.isArray(arguments[i]) ? arguments[i] : [arguments[i]]
+      options = Array.isArray(arguments[i]) ? arguments[i] : [arguments[i]];
 
-      options.forEach(function(o){
-        type = typeof o
-        scope = null
-        merge = false
-        scopeName = null
+      options.forEach(function(o) {
+        type = typeof o;
+        scope = null;
+        merge = false;
+        scopeName = null;
 
-        if (type === "object") {
+        if (type === 'object') {
           // Right now we only support a merge functionality for objects
           if (!!o.merge) {
-            merge = true
-            scopeName = o.merge[0]
+            merge = true;
+            scopeName = o.merge[0];
             if (Array.isArray(o.merge) && !!self.options.scopes[scopeName]) {
-              scope = self.options.scopes[scopeName].apply(self, o.merge.splice(1))
+              scope = self.options.scopes[scopeName].apply(self, o.merge.splice(1));
             }
-            else if (typeof o.merge === "string") {
-              scopeName = o.merge
-              scope = self.options.scopes[scopeName]
+            else if (typeof o.merge === 'string') {
+              scopeName = o.merge;
+              scope = self.options.scopes[scopeName];
             }
           }
 
           if (!!o.method) {
             if (Array.isArray(o.method) && !!self.options.scopes[o.method[0]]) {
-              scopeName = o.method[0]
-              scope = self.options.scopes[scopeName].apply(self, o.method.splice(1))
-              merge = !!o.merge
+              scopeName = o.method[0];
+              scope = self.options.scopes[scopeName].apply(self, o.method.splice(1));
+              merge = !!o.merge;
             }
             else if (!!self.options.scopes[o.method]) {
-              scopeName = o.method
-              scope = self.options.scopes[scopeName].apply(self)
+              scopeName = o.method;
+              scope = self.options.scopes[scopeName].apply(self);
             }
           } else {
-            scopeName = o
-            scope = self.options.scopes[scopeName]
+            scopeName = o;
+            scope = self.options.scopes[scopeName];
           }
         } else {
-          scopeName = o
-          scope = self.options.scopes[scopeName]
+          scopeName = o;
+          scope = self.options.scopes[scopeName];
         }
 
         if (!!scope) {
-          Utils.injectScope.call(self, scope, merge)
+          Utils.injectScope.call(self, scope, merge);
         }
         else if (scopeOptions.silent !== true && !!scopeName) {
-          throw new Error("Invalid scope " + scopeName + " called.")
+          throw new Error('Invalid scope ' + scopeName + ' called.');
         }
-      })
+      });
     }
 
-    return self
-  }
+    return self;
+  };
 
   Model.prototype.all = function(options, queryOptions) {
-    return this.findAll(options, queryOptions)
-  }
+    return this.findAll(options, queryOptions);
+  };
 
   /**
    * Search for multiple instances.
@@ -581,7 +583,7 @@ module.exports = (function() {
    * ```sql
    * WHERE attr1 = 42 AND attr2 = 'cake'
    *```
-   * 
+   *
    * __Using greater than, less than etc.__
    * ```js
    *
@@ -600,12 +602,12 @@ module.exports = (function() {
    *       ne: 5
    *     }
    *   }
-   * }) 
+   * })
    * ```
    * ```sql
    * WHERE attr1 > 50 AND attr2 <= 45 AND attr3 IN (1,2,3) AND attr4 != 5
    * ```
-   * Possible options are: `gt, gte, lt, lte, ne, between/.., nbetween/notbetween/!.., in, not, like, nlike/notlike` 
+   * Possible options are: `gt, gte, lt, lte, ne, between/.., nbetween/notbetween/!.., in, not, like, nlike/notlike`
    *
    * __Queries using OR__
    * ```js
@@ -618,13 +620,13 @@ module.exports = (function() {
    *     )
    *   )
    * })
-   * ``` 
+   * ```
    * ```sql
    * WHERE name = 'a project' AND (id` IN (1,2,3) OR id > 10)
    * ```
-   * 
+   *
    * The success listener is called with an array of instances if the query succeeds.
-   * 
+   *
    * @param  {Object}                    [options] A hash of options to describe the scope of the search
    * @param  {Object}                    [options.where] A hash of attributes to describe your search. See above for examples.
    * @param  {Array<String>}             [options.attributes] A list of the attributes that you want to select
@@ -642,140 +644,140 @@ module.exports = (function() {
    */
   Model.prototype.findAll = function(options, queryOptions) {
     var hasJoin = false
-      , tableNames  = { }
+      , tableNames = { };
 
-    tableNames[this.tableName] = true
+    tableNames[this.tableName] = true;
 
-    options = optClone(options || {})
+    options = optClone(options || {});
     if (typeof options === 'object') {
       if (options.hasOwnProperty('include') && options.include) {
-        hasJoin = true
+        hasJoin = true;
 
-        validateIncludedElements.call(this, options, tableNames)
+        validateIncludedElements.call(this, options, tableNames);
 
         if (options.attributes) {
           if (options.attributes.indexOf(this.primaryKeyAttribute) === -1) {
             options.originalAttributes = options.attributes;
-            options.attributes =  [this.primaryKeyAttribute].concat(options.attributes);
+            options.attributes = [this.primaryKeyAttribute].concat(options.attributes);
           }
         }
       }
 
       // whereCollection is used for non-primary key updates
-      this.options.whereCollection = options.where || null
+      this.options.whereCollection = options.where || null;
     }
 
     if (options.attributes === undefined) {
       options.attributes = Object.keys(this.rawAttributes);
     }
-    mapFieldNames.call(this, options, this)
+    mapFieldNames.call(this, options, this);
 
-    options = paranoidClause.call(this, options)
+    options = paranoidClause.call(this, options);
 
     return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
-      type:    QueryTypes.SELECT,
+      type: QueryTypes.SELECT,
       hasJoin: hasJoin,
       tableNames: Object.keys(tableNames)
-    }, queryOptions, { transaction: (options || {}).transaction }))
-  }
+    }, queryOptions, { transaction: (options || {}).transaction }));
+  };
 
   //right now, the caller (has-many-double-linked) is in charge of the where clause
   Model.prototype.findAllJoin = function(joinTableName, options, queryOptions) {
-    var optcpy = Utils._.clone(options)
-    optcpy.attributes = optcpy.attributes || [this.QueryInterface.quoteTable(this.name)+".*"]
+    var optcpy = Utils._.clone(options);
+    optcpy.attributes = optcpy.attributes || [this.QueryInterface.quoteTable(this.name) + '.*'];
     // whereCollection is used for non-primary key updates
     this.options.whereCollection = optcpy.where || null;
 
     return this.QueryInterface.select(this, [[this.getTableName(), this.name], joinTableName], optcpy, Utils._.defaults({
       type: QueryTypes.SELECT
-    }, queryOptions, { transaction: (options || {}).transaction }))
-  }
+    }, queryOptions, { transaction: (options || {}).transaction }));
+  };
 
  /**
   * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single instance.
   *
   * @param  {Object|Number}             [options] A hash of options to describe the scope of the search, or a number to search by id.
   * @param  {Object}                    [queryOptions]
-  * 
+  *
   * @see {Model#findAll}           for an explanation of options and queryOptions
   * @return {Promise<Instance>}
   */
   Model.prototype.find = function(options, queryOptions) {
-    var hasJoin = false
+    var hasJoin = false;
 
     // no options defined?
     // return an emitter which emits null
     if ([null, undefined].indexOf(options) !== -1) {
-      return Utils.Promise.resolve(null)
+      return Utils.Promise.resolve(null);
     }
 
     var primaryKeys = this.primaryKeys
-      , keys        = Object.keys(primaryKeys)
-      , keysLength  = keys.length
-      , tableNames  = { }
+      , keys = Object.keys(primaryKeys)
+      , keysLength = keys.length
+      , tableNames = { };
 
-    tableNames[this.tableName] = true
+    tableNames[this.tableName] = true;
 
     // options is not a hash but an id
     if (typeof options === 'number') {
-      var oldOption = options
-      options = { where: {} }
+      var oldOption = options;
+      options = { where: {} };
       if (keysLength === 1) {
-        options.where[keys[0]] = oldOption
+        options.where[keys[0]] = oldOption;
       } else {
-        options.where.id = oldOption
+        options.where.id = oldOption;
       }
     } else if (Utils._.size(primaryKeys) && Utils.argsArePrimaryKeys(arguments, primaryKeys)) {
-      var where = {}
+      var where = {};
 
       Utils._.each(arguments, function(arg, i) {
-        var key = keys[i]
-        where[key] = arg
-      })
+        var key = keys[i];
+        where[key] = arg;
+      });
 
-      options = { where: where }
+      options = { where: where };
     } else if (typeof options === 'string' && parseInt(options, 10).toString() === options) {
-      var parsedId = parseInt(options, 10)
+      var parsedId = parseInt(options, 10);
 
       if (!Utils._.isFinite(parsedId)) {
-        throw new Error('Invalid argument to find(). Must be an id or an options object.')
+        throw new Error('Invalid argument to find(). Must be an id or an options object.');
       }
 
-      options = { where: parsedId }
+      options = { where: parsedId };
     } else if (typeof options === 'object') {
       options = Utils._.clone(options, function(thing) {
-        if (Buffer.isBuffer(thing)) { return thing }
+        if (Buffer.isBuffer(thing)) { return thing; }
         return undefined;
-      })
+      });
 
       if (options.hasOwnProperty('include') && options.include) {
-        hasJoin = true
+        hasJoin = true;
 
-        validateIncludedElements.call(this, options, tableNames)
+        validateIncludedElements.call(this, options, tableNames);
       }
 
       // whereCollection is used for non-primary key updates
-      this.options.whereCollection = options.where || null
-    } else if (typeof options === "string") {
-      var where = {}
+      this.options.whereCollection = options.where || null;
+    } else if (typeof options === 'string') {
+      var where = {};
 
       if (this.primaryKeyCount === 1) {
         where[primaryKeys[keys[0]]] = options;
         options = where;
       } else if (this.primaryKeyCount < 1) {
         // Revert to default behavior which is {where: [int]}
-        options = {where: parseInt(Number(options) || 0, 0)}
+        options = {where: parseInt(Number(options) || 0, 0)};
       }
     }
 
     if (options.attributes === undefined) {
       options.attributes = Object.keys(this.rawAttributes);
     }
-    mapFieldNames.call(this, options, this)
+    mapFieldNames.call(this, options, this);
 
-    options = paranoidClause.call(this, options)
+    options = paranoidClause.call(this, options);
     if (options.limit === undefined) {
-      options.limit = 1
+      options.limit = 1;
     }
 
     return this.QueryInterface.select(this, this.getTableName(), options, Utils._.defaults({
@@ -783,12 +785,12 @@ module.exports = (function() {
       type: QueryTypes.SELECT,
       hasJoin: hasJoin,
       tableNames: Object.keys(tableNames)
-    }, queryOptions, { transaction: (options || {}).transaction }))
-  }
+    }, queryOptions, { transaction: (options || {}).transaction }));
+  };
 
   /**
    * Run an aggregation method on the specified field
-   * 
+   *
    * @param {String}          field The field to aggregate over. Can be a field name or *
    * @param {String}          aggregateFunction The function to use for aggregation, e.g. sum, max etc.
    * @param {Object}          [options] Query options. See sequelize.query for full options
@@ -797,23 +799,23 @@ module.exports = (function() {
    * @return {Promise<options.dataType>}
    */
   Model.prototype.aggregate = function(field, aggregateFunction, options) {
-    options = Utils._.extend({ attributes: [] }, options || {})
+    options = Utils._.extend({ attributes: [] }, options || {});
 
-    options.attributes.push([this.sequelize.fn(aggregateFunction, this.sequelize.col(field)), aggregateFunction])
-    
+    options.attributes.push([this.sequelize.fn(aggregateFunction, this.sequelize.col(field)), aggregateFunction]);
+
     if (!options.dataType) {
       if (this.rawAttributes[field]) {
-        options.dataType = this.rawAttributes[field]
+        options.dataType = this.rawAttributes[field];
       } else {
         // Use FLOAT as fallback
-        options.dataType = DataTypes.FLOAT
+        options.dataType = DataTypes.FLOAT;
       }
     }
 
-    options = paranoidClause.call(this, options)
+    options = paranoidClause.call(this, options);
 
-    return this.QueryInterface.rawSelect(this.getTableName(), options, aggregateFunction, this)
-  }
+    return this.QueryInterface.rawSelect(this.getTableName(), options, aggregateFunction, this);
+  };
 
   /**
    * Count the number of records matching the provided where clause.
@@ -826,24 +828,24 @@ module.exports = (function() {
    * @return {Promise<Integer>}
    */
   Model.prototype.count = function(options) {
-    options = Utils._.clone(options || {})
+    options = Utils._.clone(options || {});
 
-    var col = '*'
+    var col = '*';
     if (options.include) {
-      col = this.name+'.'+this.primaryKeyAttribute
-      validateIncludedElements.call(this, options)
+      col = this.name + '.' + this.primaryKeyAttribute;
+      validateIncludedElements.call(this, options);
     }
 
-    options.dataType = DataTypes.INTEGER
-    options.includeIgnoreAttributes = false
-    options.limit = null
+    options.dataType = DataTypes.INTEGER;
+    options.includeIgnoreAttributes = false;
+    options.limit = null;
 
-    return this.aggregate(col, 'COUNT', options)
-  }
+    return this.aggregate(col, 'COUNT', options);
+  };
 
   /**
    * Find all the rows matching your query, within a specified offset / limit, and get the total number of rows matching your query. This is very usefull for paging
-   * 
+   *
    * ```js
    * Model.findAndCountAll({
    *   where: ...,
@@ -857,29 +859,29 @@ module.exports = (function() {
    * @param {Object} [findOptions] See findAll
    * @param {Object} [queryOptions] See Sequelize.query
    *
-   * @see {Model#findAll} for a specification of find and query options 
+   * @see {Model#findAll} for a specification of find and query options
    * @return {Promise<Object>}
    */
   Model.prototype.findAndCountAll = function(findOptions, queryOptions) {
-    var self  = this
+    var self = this
       // no limit, offset, order, attributes for the options given to count()
-      , countOptions = Utils._.omit(findOptions ? Utils._.merge({}, findOptions) : {}, ['offset', 'limit', 'order', 'attributes'])
+      , countOptions = Utils._.omit(findOptions ? Utils._.merge({}, findOptions) : {}, ['offset', 'limit', 'order', 'attributes']);
 
-    return self.count(countOptions).then(function (count) {
+    return self.count(countOptions).then(function(count) {
       if (count === 0) {
         return {
           count: count || 0,
           rows: []
-        }
+        };
       }
-      return self.findAll(findOptions, queryOptions).then(function (results) {
+      return self.findAll(findOptions, queryOptions).then(function(results) {
         return {
           count: count || 0,
           rows: (results && Array.isArray(results) ? results : [])
-        }
-      })
-    })
-  }
+        };
+      });
+    });
+  };
 
   /**
    * Find the maximum value of field
@@ -891,8 +893,8 @@ module.exports = (function() {
    * @return {Promise<Any>}
    */
   Model.prototype.max = function(field, options) {
-    return this.aggregate(field, 'max', options)
-  }
+    return this.aggregate(field, 'max', options);
+  };
 
   /**
    * Find the minimum value of field
@@ -904,8 +906,8 @@ module.exports = (function() {
    * @return {Promise<Any>}
    */
   Model.prototype.min = function(field, options) {
-    return this.aggregate(field, 'min', options)
-  }
+    return this.aggregate(field, 'min', options);
+  };
 
   /**
    * Find the sum of field
@@ -917,12 +919,12 @@ module.exports = (function() {
    * @return {Promise<Number>}
    */
   Model.prototype.sum = function(field, options) {
-    return this.aggregate(field, 'sum', options)
-  }
+    return this.aggregate(field, 'sum', options);
+  };
 
   /**
    * Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
-    
+
    * @param {Object}  values
    * @param {Object}  [options]
    * @param {Boolean} [options.raw=false] If set to true, values will ignore field and virtual setters.
@@ -930,52 +932,52 @@ module.exports = (function() {
    * @param {Boolean} [options.isDirty=true]
    * @param {Array}   [options.include] an array of include options - Used to build prefetched/included model instances. See `set`
    *
-   * @return {Instance}    
+   * @return {Instance}
    */
   Model.prototype.build = function(values, options) {
     if (Array.isArray(values)) {
-      return this.bulkBuild(values, options)
+      return this.bulkBuild(values, options);
     }
-    options = options || { isNewRecord: true, isDirty: true }
+    options = options || { isNewRecord: true, isDirty: true };
 
     if (options.attributes) {
-      options.attributes = options.attributes.map(function (attribute) {
-        return Array.isArray(attribute) ? attribute[1] : attribute
-      })
+      options.attributes = options.attributes.map(function(attribute) {
+        return Array.isArray(attribute) ? attribute[1] : attribute;
+      });
     }
 
     if (options.hasOwnProperty('include') && options.include && !options.includeValidated) {
-      validateIncludedElements.call(this, options)
+      validateIncludedElements.call(this, options);
     }
 
-    return new this.Instance(values, options)
-  }
+    return new this.Instance(values, options);
+  };
 
 
   Model.prototype.bulkBuild = function(valueSets, options) {
-    options = options || { isNewRecord: true, isDirty: true }
-    
+    options = options || { isNewRecord: true, isDirty: true };
+
     if (options.hasOwnProperty('include') && options.include && !options.includeValidated) {
-      validateIncludedElements.call(this, options)
+      validateIncludedElements.call(this, options);
     }
 
     if (options.attributes) {
-      options.attributes = options.attributes.map(function (attribute) {
-        return Array.isArray(attribute) ? attribute[1] : attribute
-      })
+      options.attributes = options.attributes.map(function(attribute) {
+        return Array.isArray(attribute) ? attribute[1] : attribute;
+      });
     }
 
-    return valueSets.map(function (values) {
-      return this.build(values, options)
-    }.bind(this))
-  }
+    return valueSets.map(function(values) {
+      return this.build(values, options);
+    }.bind(this));
+  };
 
   /**
    * Builds a new model instance and calls save on it.
-    
+
    * @see {Instance#build}
    * @see {Instance#save}
-   * 
+   *
    * @param {Object}        values
    * @param {Object}        [options]
    * @param {Boolean}       [options.raw=false] If set to true, values will ignore field and virtual setters.
@@ -986,23 +988,23 @@ module.exports = (function() {
    * @param {Transaction}   [options.transaction]
    *
    * @return {Promise<Instance>}
-   */  
+   */
   Model.prototype.create = function(values, options) {
-    Utils.validateParameter(values, Object, { optional: true })
-    Utils.validateParameter(options, Object, { deprecated: Array, optional: true, index: 2, method: 'Model#create' })
+    Utils.validateParameter(values, Object, { optional: true });
+    Utils.validateParameter(options, Object, { deprecated: Array, optional: true, index: 2, method: 'Model#create' });
     if (options instanceof Array) {
-      options = { fields: options }
+      options = { fields: options };
     }
 
     options = Utils._.extend({
       transaction: null
-    }, options || {})
+    }, options || {});
 
     return this.build(values, {
       isNewRecord: true,
       attributes: options.fields
-    }).save(options)
-  }
+    }).save(options);
+  };
 
   /**
    * Find a row that matches the query, or build (but don't save) the row if none is found.
@@ -1017,39 +1019,39 @@ module.exports = (function() {
    * @method
    * @alias findOrBuild
    */
-  Model.prototype.findOrInitialize = Model.prototype.findOrBuild = function (params, defaults, options) {
-    defaults = defaults || {}
-    options  = options  || {}
+  Model.prototype.findOrInitialize = Model.prototype.findOrBuild = function(params, defaults, options) {
+    defaults = defaults || {};
+    options = options || {};
 
-    var self          = this
-      , defaultKeys   = Object.keys(defaults)
-      , defaultLength = defaultKeys.length
+    var self = this
+      , defaultKeys = Object.keys(defaults)
+      , defaultLength = defaultKeys.length;
 
     if (!options.transaction && defaults.transaction && (defaults.transaction instanceof Transaction)) {
-      options.transaction = defaults.transaction
-      delete defaults.transaction
+      options.transaction = defaults.transaction;
+      delete defaults.transaction;
     }
 
     return self.find({
       where: params
-    }, options).then(function (instance) {
+    }, options).then(function(instance) {
       if (instance === null) {
-        var i = 0
+        var i = 0;
 
         for (i = 0; i < defaultLength; i++) {
-          params[defaultKeys[i]] = defaults[defaultKeys[i]]
+          params[defaultKeys[i]] = defaults[defaultKeys[i]];
         }
 
-        var build = self.build(params)
+        var build = self.build(params);
 
-        return build.hookValidate({skip: Object.keys(params)}).then(function () {
-          return Utils.Promise.resolve([build, true])
-        })
+        return build.hookValidate({skip: Object.keys(params)}).then(function() {
+          return Utils.Promise.resolve([build, true]);
+        });
       }
 
-      return Utils.Promise.resolve([instance, false])
-    })
-  }
+      return Utils.Promise.resolve([instance, false]);
+    });
+  };
 
   /**
    * Find a row that matches the query, or build and save the row if none is found
@@ -1062,17 +1064,17 @@ module.exports = (function() {
    *
    * @return {Promise<Instance>}
    */
-  Model.prototype.findOrCreate = function (where, defaults, options) {
-    var self   = this
-      , values = {}
+  Model.prototype.findOrCreate = function(where, defaults, options) {
+    var self = this
+      , values = {};
 
     options = Utils._.extend({
       transaction: null
-    }, options || {})
+    }, options ||  {});
 
     if (!(where instanceof Utils.or) && !(where instanceof Utils.and) && !Array.isArray(where)) {
       for (var attrname in where) {
-        values[attrname] = where[attrname]
+        values[attrname] = where[attrname];
       }
     }
 
@@ -1080,27 +1082,27 @@ module.exports = (function() {
       where: where
     }, {
       transaction: options.transaction
-    }).then(function (instance) {
+    }).then(function(instance) {
       if (instance === null) {
         for (var attrname in defaults) {
-          values[attrname] = defaults[attrname]
+          values[attrname] = defaults[attrname];
         }
 
-        return self.create(values, options).then(function (instance) {
-          return Utils.Promise.resolve([instance, true])
+        return self.create(values, options).then(function(instance) {
+          return Utils.Promise.resolve([instance, true]);
         });
       }
 
-      return Utils.Promise.resolve([instance, false])
-    })
-  }
+      return Utils.Promise.resolve([instance, false]);
+    });
+  };
 
   /**
    * Create and insert multiple instances in bulk.
    *
    * The success handler is passed an array of instances, but please notice that these may not completely represent the state of the rows in the DB. This is because MySQL
    * and SQLite do not make it easy to obtain back automatically generated IDs and other default values in a way that can be mapped to multiple records.
-   * To obtain Instances for the newly created values, you will need to query for them again. 
+   * To obtain Instances for the newly created values, you will need to query for them again.
    *
    * @param  {Array}        records List of objects (key/value pairs) to create instances from
    * @param  {Object}       [options]
@@ -1108,46 +1110,46 @@ module.exports = (function() {
    * @param  {Boolean}      [options.validate=false] Should each row be subject to validation before it is inserted. The whole insert will fail if one row fails validation
    * @param  {Boolean}      [options.hooks=false] Run before / after create hooks for each individual Instance? BulkCreate hooks will still be run.
    * @param  {Boolean}      [options.ignoreDuplicates=false] Ignore duplicate values for primary keys? (not supported by postgres)
-   * 
+   *
    * @return {Promise<Array<Instance>>}
    */
   Model.prototype.bulkCreate = function(records, fieldsOrOptions, options) {
-    Utils.validateParameter(fieldsOrOptions, Object, { deprecated: Array, optional: true, index: 2, method: 'Model#bulkCreate' })
-    Utils.validateParameter(options, 'undefined', { deprecated: Object, optional: true, index: 3, method: 'Model#bulkCreate' })
+    Utils.validateParameter(fieldsOrOptions, Object, { deprecated: Array, optional: true, index: 2, method: 'Model#bulkCreate' });
+    Utils.validateParameter(options, 'undefined', { deprecated: Object, optional: true, index: 3, method: 'Model#bulkCreate' });
 
     if (!records.length) {
       return new Utils.Promise(function(resolve) {
-        resolve([])
-      })
+        resolve([]);
+      });
     }
 
     options = Utils._.extend({
       validate: false,
       hooks: false,
       ignoreDuplicates: false
-    }, options || {})
+    }, options ||  {});
 
     if (fieldsOrOptions instanceof Array) {
-      options.fields = fieldsOrOptions
+      options.fields = fieldsOrOptions;
     } else {
-      options.fields = options.fields || Object.keys(this.attributes)
-      options = Utils._.extend(options, fieldsOrOptions)
+      options.fields = options.fields || Object.keys(this.attributes);
+      options = Utils._.extend(options, fieldsOrOptions);
     }
 
-    if(this.sequelize.options.dialect === 'postgres' && options.ignoreDuplicates) {
-      return Utils.Promise.reject(new Error('Postgres does not support the \'ignoreDuplicates\' option.'))
+    if (this.sequelize.options.dialect === 'postgres' && options.ignoreDuplicates) {
+      return Utils.Promise.reject(new Error('Postgres does not support the \'ignoreDuplicates\' option.'));
     }
 
-    var self          = this
+    var self = this
       , updatedAtAttr = this._timestampAttributes.updatedAt
       , createdAtAttr = this._timestampAttributes.createdAt
-      , errors        = []
-      , daoPromises   = []
-      , daos          = records.map(function(values) {
+      , errors = []
+      , daoPromises = []
+      , daos = records.map(function(values) {
         return self.build(values, {
           isNewRecord: true
-        })
-      })
+        });
+      });
 
     if (options.validate && options.fields.length) {
       var skippedFields = Utils._.difference(Object.keys(self.attributes), options.fields);
@@ -1155,69 +1157,69 @@ module.exports = (function() {
 
     var runAfterCreate = function() {
       return self.runHooks('afterBulkCreate', daos, options.fields).spread(function(newRecords) {
-        return new self.sequelize.Promise.resolve(newRecords || daos)
-      })
-    }
+        return new self.sequelize.Promise.resolve(newRecords || daos);
+      });
+    };
 
     return self.runHooks('beforeBulkCreate', daos, options.fields).spread(function(newRecords, newFields) {
-      daos           = newRecords || daos
-      options.fields = newFields  || options.fields
+      daos = newRecords || daos;
+      options.fields = newFields || options.fields;
 
-      var runHook = function (dao) {
+      var runHook = function(dao) {
         if (options.hooks === false) {
-          var values = options.fields.length > 0 ? {} : dao.dataValues
+          var values = options.fields.length > 0 ? {} : dao.dataValues;
 
           options.fields.forEach(function(field) {
-            values[field] = dao.dataValues[field]
-          })
+            values[field] = dao.dataValues[field];
+          });
 
           if (createdAtAttr && !values[createdAtAttr]) {
-            values[createdAtAttr] = Utils.now(self.modelManager.sequelize.options.dialect)
+            values[createdAtAttr] = Utils.now(self.modelManager.sequelize.options.dialect);
           }
 
           if (updatedAtAttr && !values[updatedAtAttr]) {
-            values[updatedAtAttr] = Utils.now(self.modelManager.sequelize.options.dialect)
+            values[updatedAtAttr] = Utils.now(self.modelManager.sequelize.options.dialect);
           }
 
-          records.push(values)
+          records.push(values);
 
-          return values
+          return values;
         }
-        
+
         return self.runHooks('beforeCreate', dao).spread(function(newValues) {
-          dao = newValues || dao
-          return dao.save({ transaction: options.transaction  }).then(function() {
-            return self.runHooks('afterCreate', dao)
-          })
-        })
-      }
+          dao = newValues || dao;
+          return dao.save({ transaction: options.transaction }).then(function() {
+            return self.runHooks('afterCreate', dao);
+          });
+        });
+      };
 
-      var runValidation = function (dao) {
+      var runValidation = function(dao) {
         if (options.validate === false) {
-          return dao
+          return dao;
         }
 
-        var fn = options.hooks === true ? 'hookValidate' : 'validate'
-        return dao[fn]({skip: skippedFields}).then(function (err) {
+        var fn = options.hooks === true ? 'hookValidate' : 'validate';
+        return dao[fn]({skip: skippedFields}).then(function(err) {
           if (!!err) {
-            errors.push({record: dao, errors: err})
+            errors.push({record: dao, errors: err});
           }
-        })
-      }
+        });
+      };
 
-      records = []
-      daos.forEach(function (dao) {
-        daoPromises.push(runValidation(dao))
-        daoPromises.push(runHook(dao))
-      })
+      records = [];
+      daos.forEach(function(dao) {
+        daoPromises.push(runValidation(dao));
+        daoPromises.push(runHook(dao));
+      });
 
       return self.sequelize.Promise.all(daoPromises).then(function() {
         if (errors.length) {
           // Validation or hooks failed
-          return self.sequelize.Promise.reject(errors)
+          return self.sequelize.Promise.reject(errors);
         } else if (records.length) {
           // Map field names
-          records.forEach(function (values) {
+          records.forEach(function(values) {
             for (var attr in values) {
               if (values.hasOwnProperty(attr)) {
                 if (self.rawAttributes[attr].field) {
@@ -1229,14 +1231,14 @@ module.exports = (function() {
           });
 
           // Insert all records at once
-          return self.QueryInterface.bulkInsert(self.getTableName(), records, options, self).then(runAfterCreate)
+          return self.QueryInterface.bulkInsert(self.getTableName(), records, options, self).then(runAfterCreate);
         } else {
           // Records were already saved while running create / update hooks
-          return runAfterCreate()
+          return runAfterCreate();
         }
-      })
-    })
-  }
+      });
+    });
+  };
 
   /**
    * Delete multiple instances
@@ -1250,81 +1252,81 @@ module.exports = (function() {
    * @return {Promise<undefined>}
    */
   Model.prototype.destroy = function(where, options) {
-    options = options || {}
-    options.force = options.force === undefined ? false : Boolean(options.force)
-    options.type = QueryTypes.BULKDELETE
+    options = options || {};
+    options.force = options.force === undefined ? false : Boolean(options.force);
+    options.type = QueryTypes.BULKDELETE;
 
-    var self  = this
+    var self = this
       , query = null
-      , args  = []
+      , args = [];
 
     return self.runHooks(self.options.hooks.beforeBulkDestroy, where).then(function(newWhere) {
-      where = newWhere || where
+      where = newWhere || where;
 
       if (self._timestampAttributes.deletedAt && options.force === false) {
-        var attrValueHash = {}
-        attrValueHash[self._timestampAttributes.deletedAt] = Utils.now()
-        query = 'bulkUpdate'
-        args  = [self.getTableName(), attrValueHash, where, self]
+        var attrValueHash = {};
+        attrValueHash[self._timestampAttributes.deletedAt] = Utils.now();
+        query = 'bulkUpdate';
+        args = [self.getTableName(), attrValueHash, where, self];
       } else {
-        query = 'bulkDelete'
-        args  = [self.getTableName(), where, options, self]
+        query = 'bulkDelete';
+        args = [self.getTableName(), where, options, self];
       }
 
       var runQuery = function(records) {
         return self.QueryInterface[query].apply(self.QueryInterface, args).then(function(results) {
           if (options && options.hooks === true) {
-            var tick = 0
+            var tick = 0;
             var next = function(i) {
               return self.runHooks(self.options.hooks.afterDestroy, records[i]).then(function(newValues) {
-                records[i].dataValues = !!newValues ? newValues.dataValues : records[i].dataValues
-                tick++
+                records[i].dataValues = !!newValues ? newValues.dataValues : records[i].dataValues;
+                tick++;
 
                 if (tick >= records.length) {
-                  return self.runHooks(self.options.hooks.afterBulkDestroy, where).return(results)
+                  return self.runHooks(self.options.hooks.afterBulkDestroy, where).return (results);
                 }
 
-                return next(tick)
-              })
-            }
+                return next(tick);
+              });
+            };
 
-            return next(tick)
+            return next(tick);
           } else {
-            return self.runHooks(self.options.hooks.afterBulkDestroy, where).return(results)
+            return self.runHooks(self.options.hooks.afterBulkDestroy, where).return (results);
           }
-        })
-      }
+        });
+      };
 
       if (options && options.hooks === true) {
-        var tick = 0
+        var tick = 0;
         return self.all({where: where}).then(function(records) {
           var next = function(i) {
             return self.runHooks(self.options.hooks.beforeDestroy, records[i]).then(function(newValues) {
-              records[i].dataValues = !!newValues ? newValues.dataValues : records[i].dataValues
-              tick++
+              records[i].dataValues = !!newValues ? newValues.dataValues : records[i].dataValues;
+              tick++;
 
               if (tick >= records.length) {
-                return runQuery(records)
+                return runQuery(records);
               }
 
-              return next(tick)
-            })
-          }
+              return next(tick);
+            });
+          };
 
-          return next(tick)
-        })
+          return next(tick);
+        });
       } else {
-        return runQuery()
+        return runQuery();
       }
-    })
-  }
+    });
+  };
 
   /**
    * Update multiple instances that match the where options.
    *
    * @param  {Object}   attrValueHash           A hash of fields to change and their new values
    * @param  {Object    where                   Options to describe the scope of the search. Note that these options are not wrapped in a { where: ... } is in find / findAll calls etc. This is probably due to change in 2.0
-   * @param  {Object}   [options]       
+   * @param  {Object}   [options]
    * @param  {Boolean}  [options.validate=true] Should each row be subject to validation before it is inserted. The whole insert will fail if one row fails validation
    * @param  {Boolean}  [options.hooks=false]   Run before / after bulkUpdate hooks?
    * @param  {Number}   [options.limit]         How many rows to update (only for mysql and mariadb)
@@ -1333,132 +1335,132 @@ module.exports = (function() {
    * @return {Promise}
    */
   Model.prototype.update = function(attrValueHash, where, options) {
-    var self  = this
-      , tick  = 0
+    var self = this
+      , tick = 0;
 
-    options = options || {}
-    options.validate  = options.validate === undefined ? true : Boolean(options.validate)
-    options.hooks     = options.hooks === undefined ? false : Boolean(options.hooks)
-    options.type      = QueryTypes.BULKUPDATE
+    options = options || {};
+    options.validate = options.validate === undefined ? true : Boolean(options.validate);
+    options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
+    options.type = QueryTypes.BULKUPDATE;
 
     if (self._timestampAttributes.updatedAt) {
-      attrValueHash[self._timestampAttributes.updatedAt] = Utils.now()
+      attrValueHash[self._timestampAttributes.updatedAt] = Utils.now();
     }
 
     var runSave = function() {
       return self.runHooks(self.options.hooks.beforeBulkUpdate, attrValueHash, where).spread(function(attributes, _where) {
-        where         = _where || where
-        attrValueHash = attributes || attrValueHash
+        where = _where || where;
+        attrValueHash = attributes || attrValueHash;
 
         var runQuery = function(records) {
           return self.QueryInterface.bulkUpdate(self.getTableName(), attrValueHash, where, options, self.rawAttributes).then(function(results) {
             if (options && options.hooks === true && !!records && records.length > 0) {
-              var tick = 0
+              var tick = 0;
               var next = function(i) {
                 return self.runHooks(self.options.hooks.afterUpdate, records[i]).then(function(newValues) {
-                  records[i].dataValues = (!!newValues && newValues.dataValues) ? newValues.dataValues : records[i].dataValues
-                  tick++
+                  records[i].dataValues = (!!newValues && newValues.dataValues) ? newValues.dataValues : records[i].dataValues;
+                  tick++;
 
                   if (tick >= records.length) {
-                    return self.runHooks(self.options.hooks.afterBulkUpdate, attrValueHash, where).return(records)
+                    return self.runHooks(self.options.hooks.afterBulkUpdate, attrValueHash, where).return (records);
                   }
 
-                  return next(tick)
-                })
-              }
+                  return next(tick);
+                });
+              };
 
-              return next(tick)
+              return next(tick);
             } else {
-              return self.runHooks(self.options.hooks.afterBulkUpdate, attrValueHash, where).return(results)
+              return self.runHooks(self.options.hooks.afterBulkUpdate, attrValueHash, where).return (results);
             }
-          })
-        }
+          });
+        };
 
         if (options.hooks === true) {
           return self.all({where: where}).then(function(records) {
             if (records === null || records.length < 1) {
-              return runQuery()
+              return runQuery();
             }
 
             var next = function(i) {
               return self.runHooks(self.options.hooks.beforeUpdate, records[i]).then(function(newValues) {
-                records[i].dataValues = (!!newValues && newValues.dataValues) ? newValues.dataValues : records[i].dataValues
-                tick++
+                records[i].dataValues = (!!newValues && newValues.dataValues) ? newValues.dataValues : records[i].dataValues;
+                tick++;
 
                 if (tick >= records.length) {
-                  return runQuery(records)
+                  return runQuery(records);
                 }
 
-                return next(tick)
-              })
-            }
+                return next(tick);
+              });
+            };
 
-            return next(tick)
-          })
+            return next(tick);
+          });
         } else {
-          return runQuery()
+          return runQuery();
         }
-      })
-    }
+      });
+    };
 
     if (options.validate === true) {
-      var build = self.build(attrValueHash)
+      var build = self.build(attrValueHash);
 
       // We want to skip validations for all other fields
-      var updatedFields = Object.keys(attrValueHash)
-      var skippedFields = Utils._.difference(Object.keys(self.attributes), updatedFields)
+      var updatedFields = Object.keys(attrValueHash);
+      var skippedFields = Utils._.difference(Object.keys(self.attributes), updatedFields);
 
       return build.hookValidate({skip: skippedFields}).then(function(attributes) {
         if (!!attributes && !!attributes.dataValues) {
-          attrValueHash = Utils._.pick.apply(Utils._, [].concat(attributes.dataValues).concat(Object.keys(attrValueHash)))
+          attrValueHash = Utils._.pick.apply(Utils._, [].concat(attributes.dataValues).concat(Object.keys(attrValueHash)));
         }
 
-        return runSave()
-      })
+        return runSave();
+      });
     } else {
-      return runSave()
+      return runSave();
     }
-  }
+  };
 
   /**
    * Run a describe query on the table. The result will be return to the listener as a hash of attributes and their types.
-   * 
+   *
    * @return {Promise}
    */
   Model.prototype.describe = function(schema) {
-    return this.QueryInterface.describeTable(this.tableName, schema || this.options.schema || undefined)
-  }
+    return this.QueryInterface.describeTable(this.tableName, schema || this.options.schema || undefined);
+  };
 
   /**
-   * A proxy to the node-sql query builder, which allows you to build your query through a chain of method calls. 
+   * A proxy to the node-sql query builder, which allows you to build your query through a chain of method calls.
    * The returned instance already has all the fields property populated with the field of the model.
-   * 
+   *
    * @see https://github.com/brianc/node-sql
    * @return {node-sql} A node-sql instance
    */
   Model.prototype.dataset = function() {
     if (!this.__sql) {
-      this.__setSqlDialect()
+      this.__setSqlDialect();
     }
 
-    var instance   = this.__sql.define({ name: this.tableName, columns: [] })
-      , attributes = this.attributes
+    var instance = this.__sql.define({ name: this.tableName, columns: [] })
+      , attributes = this.attributes;
 
     Object.keys(attributes).forEach(function(key) {
-      instance.addColumn(key, attributes[key])
-    })
+      instance.addColumn(key, attributes[key]);
+    });
 
-    return instance
-  }
+    return instance;
+  };
 
   Model.prototype.__setSqlDialect = function() {
-    var dialect = this.modelManager.sequelize.options.dialect
-    this.__sql = sql.setDialect(dialect === 'mariadb' ? 'mysql' : dialect)
-  }
+    var dialect = this.modelManager.sequelize.options.dialect;
+    this.__sql = sql.setDialect(dialect === 'mariadb' ? 'mysql' : dialect);
+  };
 
   var mapFieldNames = function(options, Model) {
     if (options.attributes) {
-      options.attributes = options.attributes.map(function (attr) {
+      options.attributes = options.attributes.map(function(attr) {
         if (Model.rawAttributes[attr] && Model.rawAttributes[attr].field) {
           return [Model.rawAttributes[attr].field, attr];
         }
@@ -1474,66 +1476,66 @@ module.exports = (function() {
         }
       }
     }
-    return options
-  }
+    return options;
+  };
 
   // private
 
-  var paranoidClause = function ( options ) {
-    if ( ! this.options.paranoid ) return options || {};
+  var paranoidClause = function(options ) {
+    if (! this.options.paranoid) return options || {};
 
-    options = options || {}
-    options.where = options.where || {}
+    options = options || {};
+    options.where = options.where || {};
 
     // Apply on each include
     // This should be handled before handling where conditions because of logic with returns
     // otherwise this code will never run on includes of a already conditionable where
-    if ( options.include && options.include.length ) {
+    if (options.include && options.include.length) {
       options.include.forEach(function(include) {
-        if( typeof include == 'object' && include.model ){
-          paranoidClause.call( include.model, include )
+        if (typeof include === 'object' && include.model) {
+          paranoidClause.call(include.model, include);
         }
-      })
+      });
     }
 
     var deletedAtCol = this._timestampAttributes.deletedAt
-      , quoteIdentifiedDeletedAtCol = this.QueryInterface.quoteIdentifier(deletedAtCol)
+      , quoteIdentifiedDeletedAtCol = this.QueryInterface.quoteIdentifier(deletedAtCol);
 
     // Don't overwrite our explicit deletedAt search value if we provide one
     if (!!options.where[deletedAtCol]) {
-      return options
+      return options;
     }
 
-    if(this.name || this.tableName) {
-      quoteIdentifiedDeletedAtCol = this.QueryInterface.quoteIdentifier(this.name || this.tableName) + '.' + quoteIdentifiedDeletedAtCol
+    if (this.name || this.tableName) {
+      quoteIdentifiedDeletedAtCol = this.QueryInterface.quoteIdentifier(this.name || this.tableName) + '.' + quoteIdentifiedDeletedAtCol;
     }
 
-    if (typeof options.where === "string") {
-      options.where += ' AND ' + quoteIdentifiedDeletedAtCol + ' IS NULL '
+    if (typeof options.where === 'string') {
+      options.where += ' AND ' + quoteIdentifiedDeletedAtCol + ' IS NULL ';
     }
     else if (Array.isArray(options.where)) {
 
       // Don't overwrite our explicit deletedAt search value if we provide one
-      if(options.where[0].indexOf(deletedAtCol) !== -1) {
-        return options
+      if (options.where[0].indexOf(deletedAtCol) !== -1) {
+        return options;
       }
-      options.where[0] += ' AND ' + quoteIdentifiedDeletedAtCol + ' IS NULL '
+      options.where[0] += ' AND ' + quoteIdentifiedDeletedAtCol + ' IS NULL ';
     } else {
-      options.where[deletedAtCol] = null
+      options.where[deletedAtCol] = null;
     }
 
     return options;
-  }
+  };
 
   var addOptionalClassMethods = function() {
-    var self = this
-    Utils._.each(this.options.classMethods || {}, function(fct, name) { self[name] = fct })
-  }
+    var self = this;
+    Utils._.each(this.options.classMethods || {}, function(fct, name) { self[name] = fct; });
+  };
 
   var addDefaultAttributes = function() {
-    var self              = this
+    var self = this
       , tail = {}
-      , head = {}
+      , head = {};
 
     // Add id if no primary key was manually added to definition
     if (!Object.keys(this.primaryKeys).length) {
@@ -1545,7 +1547,7 @@ module.exports = (function() {
           autoIncrement: true,
           _autoGenerated: true
         }
-      }
+      };
     }
 
     if (this._timestampAttributes.createdAt) {
@@ -1553,156 +1555,156 @@ module.exports = (function() {
         type: DataTypes.DATE,
         allowNull: false,
         _autoGenerated: true
-      }
+      };
     }
     if (this._timestampAttributes.updatedAt) {
       tail[this._timestampAttributes.updatedAt] = {
         type: DataTypes.DATE,
         allowNull: false,
         _autoGenerated: true
-      }
+      };
     }
     if (this._timestampAttributes.deletedAt) {
       tail[this._timestampAttributes.deletedAt] = {
         type: DataTypes.DATE,
         autoGenerated: true
-      }
+      };
     }
 
-    var existingAttributes = Utils._.clone(self.rawAttributes)
-    self.rawAttributes = {}
+    var existingAttributes = Utils._.clone(self.rawAttributes);
+    self.rawAttributes = {};
 
     Utils._.each(head, function(value, attr) {
-      self.rawAttributes[attr] = value
-    })
+      self.rawAttributes[attr] = value;
+    });
 
     Utils._.each(existingAttributes, function(value, attr) {
-      self.rawAttributes[attr] = value
-    })
+      self.rawAttributes[attr] = value;
+    });
 
     Utils._.each(tail, function(value, attr) {
       if (Utils._.isUndefined(self.rawAttributes[attr])) {
-        self.rawAttributes[attr] = value
+        self.rawAttributes[attr] = value;
       }
-    })
+    });
 
     if (!Object.keys(this.primaryKeys).length) {
-      self.primaryKeys.id = self.rawAttributes.id
+      self.primaryKeys.id = self.rawAttributes.id;
     }
-  }
+  };
 
   var findAutoIncrementField = function() {
-    var fields = this.QueryGenerator.findAutoIncrementField(this)
+    var fields = this.QueryGenerator.findAutoIncrementField(this);
 
-    this.autoIncrementField = null
+    this.autoIncrementField = null;
 
     fields.forEach(function(field) {
       if (this.autoIncrementField) {
-        throw new Error('Invalid Instance definition. Only one autoincrement field allowed.')
+        throw new Error('Invalid Instance definition. Only one autoincrement field allowed.');
       } else {
-        this.autoIncrementField = field
+        this.autoIncrementField = field;
       }
-    }.bind(this))
-  }
+    }.bind(this));
+  };
 
   var validateIncludedElements = function(options, tableNames) {
-    tableNames = tableNames || {}
-    options.includeNames = []
-    options.includeMap = {}
-    options.hasSingleAssociation = false
-    options.hasMultiAssociation = false
+    tableNames = tableNames || {};
+    options.includeNames = [];
+    options.includeMap = {};
+    options.hasSingleAssociation = false;
+    options.hasMultiAssociation = false;
 
     // if include is not an array, wrap in an array
     if (!Array.isArray(options.include)) {
-      options.include = [options.include]
+      options.include = [options.include];
     }
 
     // convert all included elements to { Model: Model } form
     var includes = options.include = options.include.map(function(include) {
       if (include instanceof Model) {
-        include = { model: include }
+        include = { model: include };
       } else if (typeof include !== 'object') {
-        throw new Error('Include unexpected. Element has to be either an instance of Model or an object.')
+        throw new Error('Include unexpected. Element has to be either an instance of Model or an object.');
       } else if (include.hasOwnProperty('daoFactory')) {
-        include.model = include.daoFactory
+        include.model = include.daoFactory;
       }
-      
-      return include
-    })
+
+      return include;
+    });
 
     // validate all included elements
     for (var index = 0; index < includes.length; index++) {
-      var include = includes[index]
+      var include = includes[index];
 
       if (include.all) {
-        includes.splice(index, 1)
-        index--
+        includes.splice(index, 1);
+        index--;
 
-        validateIncludedAllElement.call(this, includes, include)
-        continue
+        validateIncludedAllElement.call(this, includes, include);
+        continue;
       }
 
-      include = includes[index] = validateIncludedElement.call(this, include, tableNames)
+      include = includes[index] = validateIncludedElement.call(this, include, tableNames);
 
-      include.parent = options
+      include.parent = options;
       // associations that are required or have a required child as is not a ?:M association are candidates for the subquery
-      include.subQuery = !include.association.isMultiAssociation && (include.hasIncludeRequired || include.required)
-      include.hasParentWhere = options.hasParentWhere || !!options.where
-      include.hasParentRequired = options.hasParentRequired || !!options.required
+      include.subQuery = !include.association.isMultiAssociation && (include.hasIncludeRequired || include.required);
+      include.hasParentWhere = options.hasParentWhere || !!options.where;
+      include.hasParentRequired = options.hasParentRequired || !!options.required;
 
-      options.includeMap[include.as] = include
-      options.includeMap[include.as.substr(0,1).toLowerCase() + include.as.substr(1)] = include
-      options.includeNames.push(include.as)
-      options.includeNames.push(include.as.substr(0,1).toLowerCase() + include.as.substr(1))
+      options.includeMap[include.as] = include;
+      options.includeMap[include.as.substr(0, 1).toLowerCase() + include.as.substr(1)] = include;
+      options.includeNames.push(include.as);
+      options.includeNames.push(include.as.substr(0, 1).toLowerCase() + include.as.substr(1));
 
       if (include.association.isMultiAssociation || include.hasMultiAssociation) {
-        options.hasMultiAssociation = true
+        options.hasMultiAssociation = true;
       }
       if (include.association.isSingleAssociation || include.hasSingleAssociation) {
-        options.hasSingleAssociation = true
+        options.hasSingleAssociation = true;
       }
 
-      options.hasIncludeWhere = options.hasIncludeWhere || include.hasIncludeWhere || !!include.where
-      options.hasIncludeRequired = options.hasIncludeRequired || include.hasIncludeRequired || !!include.required
+      options.hasIncludeWhere = options.hasIncludeWhere || include.hasIncludeWhere || !!include.where;
+      options.hasIncludeRequired = options.hasIncludeRequired || include.hasIncludeRequired || !!include.required;
     }
-  }
+  };
   Model.$validateIncludedElements = validateIncludedElements;
 
   var validateIncludedElement = function(include, tableNames) {
     if (!include.hasOwnProperty('model')) {
-      throw new Error('Include malformed. Expected attributes: model')
+      throw new Error('Include malformed. Expected attributes: model');
     }
 
-    tableNames[include.model.tableName] = true
+    tableNames[include.model.tableName] = true;
 
     if (include.hasOwnProperty('attributes')) {
       include.originalAttributes = include.attributes.slice(0);
-      include.model.primaryKeyAttributes.forEach(function (attr) {
+      include.model.primaryKeyAttributes.forEach(function(attr) {
         if (include.attributes.indexOf(attr) === -1) {
           include.attributes.unshift(attr);
         }
       });
     } else {
-      include.attributes = Object.keys(include.model.attributes)
+      include.attributes = Object.keys(include.model.attributes);
     }
 
     include = mapFieldNames(include, include.model);
 
     // pseudo include just needed the attribute logic, return
     if (include._pseudo) {
-      return include
+      return include;
     }
 
     // check if the current Model is actually associated with the passed Model - or it's a pseudo include
-    var association = this.getAssociation(include.model, include.as)
+    var association = this.getAssociation(include.model, include.as);
     if (association) {
-      include.association = association
-      include.as = association.as
+      include.association = association;
+      include.as = association.as;
 
       // If through, we create a pseudo child include, to ease our parsing later on
       if (Object(include.association.through) === include.association.through) {
-        if (!include.include) include.include = []
-        var through = include.association.through
+        if (!include.include) include.include = [];
+        var through = include.association.through;
 
         include.through = Utils._.defaults(include.through || {}, {
           model: through,
@@ -1711,43 +1713,43 @@ module.exports = (function() {
             isSingleAssociation: true
           },
           _pseudo: true
-        })
+        });
 
-        include.include.push(include.through)
-        tableNames[through.tableName] = true
+        include.include.push(include.through);
+        tableNames[through.tableName] = true;
       }
 
       if (include.required === undefined) {
-        include.required = !!include.where
+        include.required = !!include.where;
       }
 
       // Validate child includes
       if (include.hasOwnProperty('include')) {
-        validateIncludedElements.call(include.model, include, tableNames)
+        validateIncludedElements.call(include.model, include, tableNames);
       }
 
-      return include
+      return include;
     } else {
-      var msg = include.model.name
+      var msg = include.model.name;
 
       if (include.as) {
-        msg += " (" + include.as + ")"
+        msg += ' (' + include.as + ')';
       }
 
-      msg += " is not associated to " + this.name + "!"
+      msg += ' is not associated to ' + this.name + '!';
 
-      throw new Error(msg)
+      throw new Error(msg);
     }
-  }
+  };
 
   var validateIncludedAllElement = function(includes, include) {
     // check 'all' attribute provided is valid
-    var all = include.all
-    delete include.all
+    var all = include.all;
+    delete include.all;
 
     if (all !== true) {
       if (!Array.isArray(all)) {
-        all = [all]
+        all = [all];
       }
 
       var validTypes = {
@@ -1757,28 +1759,28 @@ module.exports = (function() {
         One: ['BelongsTo', 'HasOne'],
         Has: ['HasOne', 'HasMany'],
         Many: ['HasMany']
-      }
+      };
 
       for (var i = 0; i < all.length; i++) {
-        var type = all[i]
-        if (type == 'All') {
-          all = true
-          break
+        var type = all[i];
+        if (type === 'All') {
+          all = true;
+          break;
         }
 
-        var types = validTypes[type]
+        var types = validTypes[type];
         if (!types) {
-          throw new Error('include all \'' + type + '\' is not valid - must be BelongsTo, HasOne, HasMany, One, Has, Many or All')
+          throw new Error('include all \'' + type + '\' is not valid - must be BelongsTo, HasOne, HasMany, One, Has, Many or All');
         }
 
         if (types !== true) {
           // replace type placeholder e.g. 'One' with it's constituent types e.g. 'HasOne', 'BelongsTo'
-          all.splice(i, 1)
-          i--
+          all.splice(i, 1);
+          i--;
           for (var j = 0; j < types.length; j++) {
-            if (all.indexOf(types[j]) == -1) {
-              all.unshift(types[j])
-              i++
+            if (all.indexOf(types[j]) === -1) {
+              all.unshift(types[j]);
+              i++;
             }
           }
         }
@@ -1786,77 +1788,77 @@ module.exports = (function() {
     }
 
     // add all associations of types specified to includes
-    var nested = include.nested
+    var nested = include.nested;
     if (nested) {
-      delete include.nested
+      delete include.nested;
 
       if (!include.include) {
-        include.include = []
+        include.include = [];
       } else if (!Array.isArray(include.include)) {
-        include.include = [include.include]
+        include.include = [include.include];
       }
     }
 
-    var used = []
-    ;(function addAllIncludes(parent, includes) {
-      used.push(parent)
+    var used = [];
+    (function addAllIncludes(parent, includes) {
+      used.push(parent);
       Utils._.forEach(parent.associations, function(association) {
-        if (all !== true && all.indexOf(association.associationType) == -1) {
-          return
+        if (all !== true && all.indexOf(association.associationType) === -1) {
+          return;
         }
 
         // check if model already included, and skip if so
-        var model = association.target
-        var as = association.options.as
+        var model = association.target;
+        var as = association.options.as;
         if (Utils._.find(includes, {model: model, as: as})) {
-          return
+          return;
         }
 
         // skip if recursing over a model already nested
-        if (nested && used.indexOf(model) != -1) {
-          return
+        if (nested && used.indexOf(model) !== -1) {
+          return;
         }
 
         // include this model
-        var thisInclude = optClone(include)
-        thisInclude.model = model
+        var thisInclude = optClone(include);
+        thisInclude.model = model;
         if (as) {
-          thisInclude.as = as
+          thisInclude.as = as;
         }
-        includes.push(thisInclude)
+        includes.push(thisInclude);
 
         // run recursively if nested
         if (nested) {
-          addAllIncludes(model, thisInclude.include)
-          if (thisInclude.include.length == 0) delete thisInclude.include
+          addAllIncludes(model, thisInclude.include);
+          if (thisInclude.include.length === 0) delete thisInclude.include;
         }
-      })
-      used.pop()
-    })(this, includes)
-  }
+      });
+      used.pop();
+    })(this, includes);
+  };
 
-  var optClone = function (options) {
-    return Utils._.cloneDeep(options, function (elem) {
+  var optClone = function(options) {
+    return Utils._.cloneDeep(options, function(elem) {
       // The InstanceFactories used for include are pass by ref, so don't clone them.
-      if (elem && 
+      if (elem &&
         (
           elem._isSequelizeMethod ||
-          elem instanceof Model || 
+          elem instanceof Model ||
           elem instanceof Transaction
         )
       ) {
-        return elem
+        return elem;
       }
       // Unfortunately, lodash.cloneDeep doesn't preserve Buffer.isBuffer, which we have to rely on for binary data
       if (Buffer.isBuffer(elem)) { return elem; }
 
       // Otherwise return undefined, meaning, 'handle this lodash'
-      return undefined
-    })
-  }
+      return undefined;
+    });
+  };
 
-  Utils._.extend(Model.prototype, require("./associations/mixin"))
-  Utils._.extend(Model.prototype, require(__dirname + '/hooks'))
+  Utils._.extend(Model.prototype, require('./associations/mixin'));
+  Utils._.extend(Model.prototype, require(__dirname + '/hooks'));
 
-  return Model
-})()
+  return Model;
+})();

--- a/lib/model/attribute.js
+++ b/lib/model/attribute.js
@@ -1,10 +1,10 @@
-"use strict";
+'use strict';
 
-module.exports = (function () {
-	var Attribute = function(options) {
-		if (options.type === undefined) options = {type: options};
-		this.type = options.type;
-	};
+module.exports = (function() {
+  var Attribute = function(options) {
+    if (options.type === undefined) options = {type: options};
+    this.type = options.type;
+  };
 
-	return Attribute;
+  return Attribute;
 })();

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict';
 
-var Promise
-  , EventEmitter    = require("events").EventEmitter
-  , proxyEventKeys  = ['success', 'error', 'sql']
-  , Utils           = require('./utils')
-  
+var Promise = require('sequelize-bluebird')
+  , EventEmitter = require('events').EventEmitter
+  , proxyEventKeys = ['success', 'error', 'sql']
+  , Utils = require('./utils');
+
 /**
  * A slightly modified version of bluebird promises. This means that, on top of the methods below, you can also call all the methods listed on the link below.
  *
  * The main difference is that sequelize promises allows you to attach a listener that will be called with the generated SQL, each time a query is run.
- * 
+ *
  * @mixes https://github.com/petkaantonov/bluebird/blob/master/API.md
  * @class Promise
  */
-var SequelizePromise = Promise = require('sequelize-bluebird')
+var SequelizePromise = Promise;
 
 /**
  * Listen for events, event emitter style. Mostly for backwards compat. with EventEmitter
- * 
+ *
  * @param {String} evt
  * @param {Function} fct
  */
@@ -33,7 +33,7 @@ SequelizePromise.prototype.on = function(evt, fct) {
   }
 
   return this;
-}
+};
 
 /**
  * Emit an event from the emitter
@@ -61,7 +61,7 @@ SequelizePromise.prototype.emit = function(evt) {
 
 /**
  * Listen for success events.
- * 
+ *
  * ```js
  * promise.success(function (result) {
  *  //...
@@ -80,11 +80,11 @@ SequelizePromise.prototype.ok = function(fct) {
   } else {
     return this.then(fct);
   }
-}
+};
 
 /**
  * Listen for error events
- * 
+ *
  * ```js
  * promise.error(function (err) {
  *  //...
@@ -101,17 +101,17 @@ SequelizePromise.prototype.failure =
 SequelizePromise.prototype.fail =
 SequelizePromise.prototype.error = function(fct) {
   return this.then(null, fct);
-}
+};
 
 /**
 * Listen for both success and error events.
-* 
+*
 * ```js
 * promise.done(function (err, result) {
 *  //...
 * });
 * ```
-* 
+*
 * @param {function} onDone
 * @method done
 * @alias complete
@@ -120,11 +120,11 @@ SequelizePromise.prototype.error = function(fct) {
 SequelizePromise.prototype.done =
 SequelizePromise.prototype.complete = function(fct) {
   if (fct.length > 2) {
-    return this.spread(function () {
+    return this.spread(function() {
       fct.apply(null, [null].concat(Array.prototype.slice.call(arguments)));
     }, fct);
   } else {
-    return this.then(function () {
+    return this.then(function() {
       fct.apply(null, [null].concat(Array.prototype.slice.call(arguments)));
     }, fct);
   }
@@ -136,9 +136,9 @@ SequelizePromise.prototype.complete = function(fct) {
  * @return this
  */
 SequelizePromise.prototype.sql = function(fct) {
-  this.on('sql', fct)
+  this.on('sql', fct);
   return this;
-}
+};
 
 /**
  * Proxy every event of this promise to another one.
@@ -150,21 +150,21 @@ SequelizePromise.prototype.sql = function(fct) {
  */
 SequelizePromise.prototype.proxy = function(promise, options) {
   options = Utils._.extend({
-    events:     proxyEventKeys,
+    events: proxyEventKeys,
     skipEvents: []
-  }, options || {})
+  }, options ||  {});
 
-  options.events = Utils._.difference(options.events, options.skipEvents)
+  options.events = Utils._.difference(options.events, options.skipEvents);
 
-  options.events.forEach(function (eventKey) {
-    this.on(eventKey, function () {
-      var args = [ eventKey ].concat([].slice.apply(arguments))
-      promise.emit.apply(promise, args)
-    })
-  }.bind(this))
+  options.events.forEach(function(eventKey) {
+    this.on(eventKey, function() {
+      var args = [eventKey].concat([].slice.apply(arguments));
+      promise.emit.apply(promise, args);
+    });
+  }.bind(this));
 
-  return this
-}
+  return this;
+};
 
 SequelizePromise.prototype.proxySql = function(promise) {
   return this.proxy(promise, {

--- a/lib/query-chainer.js
+++ b/lib/query-chainer.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-var Utils = require(__dirname + "/utils")
+var Utils = require(__dirname + '/utils');
 
 module.exports = (function() {
   /**
@@ -8,39 +8,39 @@ module.exports = (function() {
    * @class QueryChainer
    */
   var QueryChainer = function(emitters) {
-    var self = this
+    var self = this;
 
-    this.finishedEmits  = 0
-    this.emitters       = []
-    this.serials        = []
-    this.fails          = []
-    this.serialResults  = []
-    this.emitterResults = []
-    this.finished       = false
-    this.wasRunning     = false
-    this.eventEmitter   = null
+    this.finishedEmits = 0;
+    this.emitters = [];
+    this.serials = [];
+    this.fails = [];
+    this.serialResults = [];
+    this.emitterResults = [];
+    this.finished = false;
+    this.wasRunning = false;
+    this.eventEmitter = null;
 
-    emitters = emitters || []
+    emitters = emitters || [];
     emitters.forEach(function(emitter) {
       if (Array.isArray(emitter)) {
-        self.add.apply(self, emitter)
+        self.add.apply(self, emitter);
       } else {
-        self.add(emitter)
+        self.add(emitter);
       }
-    })
-  }
+    });
+  };
 
   /**
-   * Add an query to the chainer. This can be done in two ways - either by invoking the method like you would normally, and then adding the returned emitter to the chainer, or by passing the 
+   * Add an query to the chainer. This can be done in two ways - either by invoking the method like you would normally, and then adding the returned emitter to the chainer, or by passing the
    * class that you want to call a method on, the name of the method, and its parameters to the chainer. The second form might sound a bit cumbersome, but it is used when you want to run
-   * queries in serial. 
-   * 
-   * *Method 1:* 
+   * queries in serial.
+   *
+   * *Method 1:*
    * ```js
    * chainer.add(User.findAll({
    *   where: {
    *     admin: true
-   *   }, 
+   *   },
    *   limit: 3
    * }))
    * chainer.add(Project.findAll())
@@ -49,7 +49,7 @@ module.exports = (function() {
    * })
    * ```
    *
-   * *Method 2:* 
+   * *Method 2:*
    * ```js
    * chainer.add(User, 'findAll', {
    *   where: {
@@ -70,27 +70,27 @@ module.exports = (function() {
    */
   QueryChainer.prototype.add = function(emitterOrKlass, method, params, options) {
     if (!!method) {
-      this.serials.push({ klass: emitterOrKlass, method: method, params: params, options: options })
+      this.serials.push({ klass: emitterOrKlass, method: method, params: params, options: options });
     } else {
-      observeEmitter.call(this, emitterOrKlass)
-      this.emitters.push(emitterOrKlass)
+      observeEmitter.call(this, emitterOrKlass);
+      this.emitters.push(emitterOrKlass);
     }
 
-    return this
-  }
+    return this;
+  };
 
   /**
    * Run the query chainer. In reality, this means, wait for all the added emtiters to finish, since the queries began executing as soon as you invoked their methods.
    * @return {EventEmitter}
    */
   QueryChainer.prototype.run = function() {
-    var self = this
+    var self = this;
     this.eventEmitter = new Utils.CustomEventEmitter(function() {
-      self.wasRunning = true
-      finish.call(self, 'emitterResults')
-    })
-    return this.eventEmitter.run()
-  }
+      self.wasRunning = true;
+      finish.call(self, 'emitterResults');
+    });
+    return this.eventEmitter.run();
+  };
 
   /**
    * Run the chainer serially, so that each query waits for the previous one to finish before it starts.
@@ -99,101 +99,101 @@ module.exports = (function() {
    * @return {EventEmitter}
    */
   QueryChainer.prototype.runSerially = function(options) {
-    var self       = this
-      , serialCopy = Utils._.clone(this.serials)
+    var self = this
+      , serialCopy = Utils._.clone(this.serials);
 
     options = Utils._.extend({
       skipOnError: false
-    }, options)
+    }, options);
 
     var exec = function() {
-      var serial = self.serials.pop()
+      var serial = self.serials.pop();
 
       if (serial) {
-        serial.options = serial.options || {}
-        serial.options.before && serial.options.before(serial.klass)
+        serial.options = serial.options || {};
+        serial.options.before && serial.options.before(serial.klass);
 
         var onSuccess = function() {
-          serial.options.after && serial.options.after(serial.klass)
-          self.finishedEmits++
-          exec()
-        }
+          serial.options.after && serial.options.after(serial.klass);
+          self.finishedEmits++;
+          exec();
+        };
 
         var onError = function(err) {
-          serial.options.after && serial.options.after(serial.klass)
-          self.finishedEmits++
-          self.fails.push(err)
-          exec()
-        }
+          serial.options.after && serial.options.after(serial.klass);
+          self.finishedEmits++;
+          self.fails.push(err);
+          exec();
+        };
 
         if (options.skipOnError && (self.fails.length > 0)) {
-          onError('Skipped due to earlier error!')
+          onError('Skipped due to earlier error!');
         } else {
-          var emitter = serial.klass[serial.method].apply(serial.klass, serial.params)
-         
+          var emitter = serial.klass[serial.method].apply(serial.klass, serial.params);
+
           emitter.success(function(result) {
-            self.serialResults[serialCopy.indexOf(serial)] = result
+            self.serialResults[serialCopy.indexOf(serial)] = result;
 
             if (serial.options.success) {
-              serial.options.success(serial.klass, onSuccess)
+              serial.options.success(serial.klass, onSuccess);
             } else {
-              onSuccess()
+              onSuccess();
             }
-          }).error(onError).on('sql', function (sql) {
-            self.eventEmitter.emit('sql', sql)
-          })
+          }).error(onError).on('sql', function(sql) {
+            self.eventEmitter.emit('sql', sql);
+          });
         }
       } else {
-        self.wasRunning = true
-        finish.call(self, 'serialResults')
+        self.wasRunning = true;
+        finish.call(self, 'serialResults');
       }
-    }
+    };
 
-    this.serials.reverse()
-    this.eventEmitter = new Utils.CustomEventEmitter(exec)
-    return this.eventEmitter.run()
-  }
+    this.serials.reverse();
+    this.eventEmitter = new Utils.CustomEventEmitter(exec);
+    return this.eventEmitter.run();
+  };
 
   // private
 
   var observeEmitter = function(emitter) {
-    var self = this
+    var self = this;
 
     emitter
       .success(function(result) {
-        self.emitterResults[self.emitters.indexOf(emitter)] = result
-        self.finishedEmits++
-        finish.call(self, 'emitterResults')
+        self.emitterResults[self.emitters.indexOf(emitter)] = result;
+        self.finishedEmits++;
+        finish.call(self, 'emitterResults');
       })
       .error(function(err) {
-        self.finishedEmits++
-        self.fails.push(err)
-        finish.call(self, 'emitterResults')
+        self.finishedEmits++;
+        self.fails.push(err);
+        finish.call(self, 'emitterResults');
       })
       .on('sql', function(sql) {
         if (self.eventEmitter) {
-          self.eventEmitter.emit('sql', sql)
+          self.eventEmitter.emit('sql', sql);
         }
-      })
-  }
+      });
+  };
 
   var finish = function(resultsName) {
-    this.finished = true
+    this.finished = true;
 
     if (this.emitters.length > 0) {
-      this.finished = (this.finishedEmits === this.emitters.length)
+      this.finished = (this.finishedEmits === this.emitters.length);
     }
     else if (this.serials.length > 0) {
-      this.finished = (this.finishedEmits === this.serials.length)
+      this.finished = (this.finishedEmits === this.serials.length);
     }
 
     if (this.finished && this.wasRunning) {
       var status = (this.fails.length === 0 ? 'success' : 'error')
-        , result = (this.fails.length === 0 ? this[resultsName] : this.fails)
+        , result = (this.fails.length === 0 ? this[resultsName] : this.fails);
 
-      this.eventEmitter.emit.apply(this.eventEmitter, [status, result].concat(result))
+      this.eventEmitter.emit.apply(this.eventEmitter, [status, result].concat(result));
     }
-  }
+  };
 
-  return QueryChainer
-})()
+  return QueryChainer;
+})();

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1,11 +1,11 @@
-"use strict";
+'use strict';
 
-var Utils                = require(__dirname + '/utils')
-  , DataTypes            = require(__dirname + '/data-types')
+var Utils = require(__dirname + '/utils')
+  , DataTypes = require(__dirname + '/data-types')
   , SQLiteQueryInterface = require(__dirname + '/dialects/sqlite/query-interface')
-  , Transaction          = require(__dirname + '/transaction')
-  , Promise              = require(__dirname + '/promise')
-  , QueryTypes           = require('./query-types')
+  , Transaction = require(__dirname + '/transaction')
+  , Promise = require(__dirname + '/promise')
+  , QueryTypes = require('./query-types');
 
 module.exports = (function() {
   /*
@@ -13,350 +13,350 @@ module.exports = (function() {
    * @class QueryInterface
   **/
   var QueryInterface = function(sequelize) {
-    this.sequelize                = sequelize
-    this.QueryGenerator           = require('./dialects/' + this.sequelize.options.dialect + '/query-generator')
-    this.QueryGenerator.options   = this.sequelize.options
-    this.QueryGenerator._dialect  = this.sequelize.dialect
-    this.QueryGenerator.sequelize = this.sequelize
-  }
+    this.sequelize = sequelize;
+    this.QueryGenerator = require('./dialects/' + this.sequelize.options.dialect + '/query-generator');
+    this.QueryGenerator.options = this.sequelize.options;
+    this.QueryGenerator._dialect = this.sequelize.dialect;
+    this.QueryGenerator.sequelize = this.sequelize;
+  };
 
   QueryInterface.prototype.createSchema = function(schema) {
-    var sql = this.QueryGenerator.createSchema(schema)
-    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
-  }
+    var sql = this.QueryGenerator.createSchema(schema);
+    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
+  };
 
   QueryInterface.prototype.dropSchema = function(schema) {
-    var sql = this.QueryGenerator.dropSchema(schema)
-    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
-  }
+    var sql = this.QueryGenerator.dropSchema(schema);
+    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
+  };
 
   QueryInterface.prototype.dropAllSchemas = function() {
-    var self = this
+    var self = this;
 
     if (!this.QueryGenerator._dialect.supports.schemas) {
-      return this.sequelize.drop()
+      return this.sequelize.drop();
     } else {
-      return this.showAllSchemas().map(function (schemaName, index, length) {
-        return self.dropSchema(schemaName)
-      })
+      return this.showAllSchemas().map(function(schemaName, index, length) {
+        return self.dropSchema(schemaName);
+      });
     }
-  }
+  };
 
   QueryInterface.prototype.showAllSchemas = function(options) {
-    var self = this
+    var self = this;
 
     options = Utils._.extend({
       transaction: null,
-      raw:         true
-    }, options || {})
+      raw: true
+    }, options || {});
 
-    var showSchemasSql = self.QueryGenerator.showSchemasQuery()
+    var showSchemasSql = self.QueryGenerator.showSchemasQuery();
 
-    return this.sequelize.query(showSchemasSql, null, options).then(function (schemaNames) {
+    return this.sequelize.query(showSchemasSql, null, options).then(function(schemaNames) {
       return Utils._.flatten(
-        Utils._.map(schemaNames, function(value){ 
-          return (!!value.schema_name ? value.schema_name : value) 
+        Utils._.map(schemaNames, function(value) {
+          return (!!value.schema_name ? value.schema_name : value);
         })
-      )
-    })
-  }
+      );
+    });
+  };
 
   QueryInterface.prototype.createTable = function(tableName, attributes, options) {
-    var attributeHashes   = {}
-      , dataTypeValues    = Utils._.values(DataTypes)
-      , keys              = Object.keys(attributes)
-      , keyLen            = keys.length
-      , self              = this
-      , sql               = ''
-      , i                 = 0
+    var attributeHashes = {}
+      , dataTypeValues = Utils._.values(DataTypes)
+      , keys = Object.keys(attributes)
+      , keyLen = keys.length
+      , self = this
+      , sql = ''
+      , i = 0;
 
     for (i = 0; i < keyLen; i++) {
       if (dataTypeValues.indexOf(attributes[keys[i]]) > -1) {
-        attributeHashes[keys[i]] = { type: attributes[keys[i]], allowNull: true }
+        attributeHashes[keys[i]] = { type: attributes[keys[i]], allowNull: true };
       } else {
-        attributeHashes[keys[i]] = attributes[keys[i]]
+        attributeHashes[keys[i]] = attributes[keys[i]];
       }
     }
 
     options = Utils._.extend({
       logging: this.sequelize.options.logging
-    }, options || {})
+    }, options || {});
 
     // Postgres requires a special SQL command for enums
-    if (self.sequelize.options.dialect === "postgres") {
+    if (self.sequelize.options.dialect === 'postgres') {
       var promises = []
         // For backwards-compatibility, public schemas don't need to
         // explicitly state their schema when creating a new enum type
-        , getTableName = (!options || !options.schema || options.schema === "public" ? '' : options.schema + '_') + tableName
+        , getTableName = (!options || !options.schema || options.schema === 'public' ? '' : options.schema + '_') + tableName;
 
       for (i = 0; i < keyLen; i++) {
-        if (attributes[keys[i]].toString().match(/^ENUM\(/) || attributes[keys[i]].toString() === "ENUM" || (attributes[keys[i]].type && attributes[keys[i]].type.toString() === "ENUM")) {
-          sql = self.QueryGenerator.pgListEnums(getTableName, keys[i], options)
-          promises.push(self.sequelize.query(sql, null, { plain: true, raw: true, type: QueryTypes.SELECT, logging: options.logging }))
+        if (attributes[keys[i]].toString().match(/^ENUM\(/) || attributes[keys[i]].toString() === 'ENUM' || (attributes[keys[i]].type && attributes[keys[i]].type.toString() === 'ENUM')) {
+          sql = self.QueryGenerator.pgListEnums(getTableName, keys[i], options);
+          promises.push(self.sequelize.query(sql, null, { plain: true, raw: true, type: QueryTypes.SELECT, logging: options.logging }));
         }
       }
 
       return Promise.all(promises).then(function(results) {
         var promises = []
           // Find the table that we're trying to create throgh DAOFactoryManager
-          , daoTable = self.sequelize.daoFactoryManager.daos.filter(function(dao) { return dao.tableName === tableName })
-          , enumIdx  = 0
+          , daoTable = self.sequelize.daoFactoryManager.daos.filter(function(dao) { return dao.tableName === tableName; })
+          , enumIdx = 0;
 
-        daoTable = daoTable.length > 0 ? daoTable[0] : null
+        daoTable = daoTable.length > 0 ? daoTable[0] : null;
 
         for (i = 0; i < keyLen; i++) {
-          if (attributes[keys[i]].toString().match(/^ENUM\(/) || attributes[keys[i]].toString() === "ENUM" || (attributes[keys[i]].type && attributes[keys[i]].type.toString() === "ENUM")) {
+          if (attributes[keys[i]].toString().match(/^ENUM\(/) || attributes[keys[i]].toString() === 'ENUM' || (attributes[keys[i]].type && attributes[keys[i]].type.toString() === 'ENUM')) {
             // If the enum type doesn't exist then create it
             if (!results[enumIdx]) {
-              sql = self.QueryGenerator.pgEnum(getTableName, keys[i], attributes[keys[i]], options)
-              promises.push(self.sequelize.query(sql, null, { raw: true, logging: options.logging }))
+              sql = self.QueryGenerator.pgEnum(getTableName, keys[i], attributes[keys[i]], options);
+              promises.push(self.sequelize.query(sql, null, { raw: true, logging: options.logging }));
             } else if (!!results[enumIdx] && !!daoTable) {
               var enumVals = self.QueryGenerator.fromArray(results[enumIdx].enum_value)
-                , vals = daoTable.rawAttributes[keys[i]].values
+                , vals = daoTable.rawAttributes[keys[i]].values;
 
               vals.forEach(function(value, idx) {
                 // reset out after/before options since it's for every enum value
-                options.before = null
-                options.after = null
+                options.before = null;
+                options.after = null;
 
                 if (enumVals.indexOf(value) === -1) {
-                  if (!!vals[idx+1]) {
-                    options.before = vals[idx+1]
+                  if (!!vals[idx + 1]) {
+                    options.before = vals[idx + 1];
                   }
-                  else if (!!vals[idx-1]) {
-                    options.after = vals[idx-1]
+                  else if (!!vals[idx - 1]) {
+                    options.after = vals[idx - 1];
                   }
 
-                  promises.push(self.sequelize.query(self.QueryGenerator.pgEnumAdd(getTableName, keys[i], value, options)))
+                  promises.push(self.sequelize.query(self.QueryGenerator.pgEnumAdd(getTableName, keys[i], value, options)));
                 }
-              })
-              enumIdx++
+              });
+              enumIdx++;
             }
           }
         }
 
-        attributes = self.QueryGenerator.attributesToSQL(attributeHashes)
-        sql = self.QueryGenerator.createTableQuery(tableName, attributes, options)
+        attributes = self.QueryGenerator.attributesToSQL(attributeHashes);
+        sql = self.QueryGenerator.createTableQuery(tableName, attributes, options);
 
         return Promise.all(promises).then(function() {
-          return self.sequelize.query(sql, null, options)
-        })
-      })
+          return self.sequelize.query(sql, null, options);
+        });
+      });
     } else {
-      attributes = self.QueryGenerator.attributesToSQL(attributeHashes)
-      sql = self.QueryGenerator.createTableQuery(tableName, attributes, options)
+      attributes = self.QueryGenerator.attributesToSQL(attributeHashes);
+      sql = self.QueryGenerator.createTableQuery(tableName, attributes, options);
 
-      return self.sequelize.query(sql, null, options)
+      return self.sequelize.query(sql, null, options);
     }
-  }
+  };
 
   QueryInterface.prototype.dropTable = function(tableName, options) {
     // if we're forcing we should be cascading unless explicitly stated otherwise
-    options = options || {}
-    options.cascade = options.cascade || options.force || false
+    options = options || {};
+    options.cascade = options.cascade || options.force || false;
 
-    var sql  = this.QueryGenerator.dropTableQuery(tableName, options)
-      , self = this
+    var sql = this.QueryGenerator.dropTableQuery(tableName, options)
+      , self = this;
 
-    return this.sequelize.query(sql, null, options).then(function () {
-      var promises = []
+    return this.sequelize.query(sql, null, options).then(function() {
+      var promises = [];
 
       // Since postgres has a special case for enums, we should drop the related
       // enum type within the table and attribute
-      if (self.sequelize.options.dialect === "postgres") {
-        // Find the table that we're trying to drop        
-        var daoTable = self.sequelize.daoFactoryManager.getDAO(tableName, 'tableName')
+      if (self.sequelize.options.dialect === 'postgres') {
+        // Find the table that we're trying to drop
+        var daoTable = self.sequelize.daoFactoryManager.getDAO(tableName, 'tableName');
 
         if (!!daoTable) {
-          var getTableName = (!options || !options.schema || options.schema === "public" ? '' : options.schema + '_') + tableName
+          var getTableName = (!options || !options.schema || options.schema === 'public' ? '' : options.schema + '_') + tableName;
 
           var keys = Object.keys(daoTable.rawAttributes)
             , keyLen = keys.length
-            , i = 0
+            , i = 0;
 
           for (i = 0; i < keyLen; i++) {
-            if (daoTable.rawAttributes[keys[i]].type && daoTable.rawAttributes[keys[i]].type.toString() === "ENUM") {
-              promises.push(self.sequelize.query(self.QueryGenerator.pgEnumDrop(getTableName, keys[i]), null, {logging: options.logging, raw: true}))
+            if (daoTable.rawAttributes[keys[i]].type && daoTable.rawAttributes[keys[i]].type.toString() === 'ENUM') {
+              promises.push(self.sequelize.query(self.QueryGenerator.pgEnumDrop(getTableName, keys[i]), null, {logging: options.logging, raw: true}));
             }
           }
         }
       }
 
       return Promise.all(promises).get(0);
-    })
-  }
+    });
+  };
 
   QueryInterface.prototype.dropAllTables = function(options) {
-    var self = this
+    var self = this;
 
-    options = options || {}
+    options = options || {};
 
     var dropAllTables = function(tableNames) {
-      tableNames.unshift(null)
-      return Utils.Promise.reduce(tableNames, function (total, tableName) {
+      tableNames.unshift(null);
+      return Utils.Promise.reduce(tableNames, function(total, tableName) {
         // if tableName is not in the Array of tables names then dont drop it
         if (skip.indexOf(tableName) === -1) {
-          return self.dropTable(tableName, { cascade: true })
+          return self.dropTable(tableName, { cascade: true });
         }
-      })
-    }
+      });
+    };
 
     var skip = options.skip || [];
 
     return self.showAllTables().then(function(tableNames) {
       if (self.sequelize.options.dialect === 'sqlite') {
-        return self.sequelize.query('PRAGMA foreign_keys;').then(function (result) {
-          var foreignKeysAreEnabled = result.foreign_keys === 1
+        return self.sequelize.query('PRAGMA foreign_keys;').then(function(result) {
+          var foreignKeysAreEnabled = result.foreign_keys === 1;
 
           if (foreignKeysAreEnabled) {
-            return self.sequelize.query('PRAGMA foreign_keys = OFF').then(function () {
-              return dropAllTables(tableNames).then(function (){
-                return self.sequelize.query('PRAGMA foreign_keys = ON')
-              })
-            })
+            return self.sequelize.query('PRAGMA foreign_keys = OFF').then(function() {
+              return dropAllTables(tableNames).then(function() {
+                return self.sequelize.query('PRAGMA foreign_keys = ON');
+              });
+            });
           } else {
-            return dropAllTables(tableNames)
+            return dropAllTables(tableNames);
           }
-        })
+        });
       } else {
         return self.getForeignKeysForTables(tableNames).then(function(foreignKeys) {
-          var promises = []
+          var promises = [];
 
-          tableNames.forEach(function (tableName) {
-            foreignKeys[tableName].forEach(function (foreignKey) {
-              var sql = self.QueryGenerator.dropForeignKeyQuery(tableName, foreignKey)
-              promises.push(self.sequelize.query(sql))
-            })
-          })
+          tableNames.forEach(function(tableName) {
+            foreignKeys[tableName].forEach(function(foreignKey) {
+              var sql = self.QueryGenerator.dropForeignKeyQuery(tableName, foreignKey);
+              promises.push(self.sequelize.query(sql));
+            });
+          });
 
-          return Utils.Promise.all(promises).then(function () {
-           return dropAllTables(tableNames)
-          })
-        })          
+          return Utils.Promise.all(promises).then(function() {
+           return dropAllTables(tableNames);
+          });
+        });
       }
-    })
-  }
+    });
+  };
 
   QueryInterface.prototype.dropAllEnums = function(options) {
     if (this.sequelize.getDialect() !== 'postgres') {
-      return Utils.Promise.resolve()
+      return Utils.Promise.resolve();
     }
 
-    options = options || {}
+    options = options || {};
 
     var self = this
-      , sql = this.QueryGenerator.pgListEnums()
+      , sql = this.QueryGenerator.pgListEnums();
 
-    return this.sequelize.query(sql, null, { plain: false, raw: true, type: QueryTypes.SELECT, logging: options.logging }).map(function (result) {
+    return this.sequelize.query(sql, null, { plain: false, raw: true, type: QueryTypes.SELECT, logging: options.logging }).map(function(result) {
       return self.sequelize.query(
         self.QueryGenerator.pgEnumDrop(null, null, self.QueryGenerator.pgEscapeAndQuote(result.enum_name)),
         null,
         {logging: options.logging, raw: true}
-      )
-    })
-  }
+      );
+    });
+  };
 
   QueryInterface.prototype.renameTable = function(before, after) {
-    var sql = this.QueryGenerator.renameTableQuery(before, after)
-    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
-  }
+    var sql = this.QueryGenerator.renameTableQuery(before, after);
+    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
+  };
 
   QueryInterface.prototype.showAllTables = function(options) {
-    var self = this
+    var self = this;
     options = Utils._.extend({
       transaction: null,
-      raw:         true
-    }, options || {})
+      raw: true
+    }, options || {});
 
-    var showTablesSql = self.QueryGenerator.showTablesQuery()
+    var showTablesSql = self.QueryGenerator.showTablesQuery();
 
     return self.sequelize.query(showTablesSql, null, options).then(function(tableNames) {
-      return Utils._.flatten(tableNames)
-    })
-  }
+      return Utils._.flatten(tableNames);
+    });
+  };
 
   QueryInterface.prototype.describeTable = function(tableName, options) {
     var schema = null
-      , schemaDelimiter = null
+      , schemaDelimiter = null;
 
-    if (typeof options === "string") {
-      schema = options
-    } else if (typeof options === "object") {
-      schema = options.schema || null
-      schemaDelimiter = options.schemaDelimiter || null
+    if (typeof options === 'string') {
+      schema = options;
+    } else if (typeof options === 'object') {
+      schema = options.schema || null;
+      schemaDelimiter = options.schemaDelimiter || null;
     }
 
-    var sql = this.QueryGenerator.describeTableQuery(tableName, schema, schemaDelimiter)
+    var sql = this.QueryGenerator.describeTableQuery(tableName, schema, schemaDelimiter);
 
     return this.sequelize.query(sql, null, { raw: true }).then(function(data) {
       // If no data is returned from the query, then the table name may be wrong.
       // Query generators that use information_schema for retrieving table info will just return an empty result set,
       // it will not throw an error like built-ins do (e.g. DESCRIBE on MySql).
-      if(Utils._.isEmpty(data)) {
-        return Promise.reject('No description found for "' + tableName + '" table. Check the table name and schema; remember, they _are_ case sensitive.')
+      if (Utils._.isEmpty(data)) {
+        return Promise.reject('No description found for "' + tableName + '" table. Check the table name and schema; remember, they _are_ case sensitive.');
       } else {
-        return Promise.resolve(data)
+        return Promise.resolve(data);
       }
-    })
-  }
+    });
+  };
 
   QueryInterface.prototype.addColumn = function(tableName, attributeName, dataTypeOrOptions) {
-    var attributes = {}
+    var attributes = {};
 
     if (Utils._.values(DataTypes).indexOf(dataTypeOrOptions) > -1) {
-      attributes[attributeName] = { type: dataTypeOrOptions, allowNull: true }
+      attributes[attributeName] = { type: dataTypeOrOptions, allowNull: true };
     } else {
-      attributes[attributeName] = dataTypeOrOptions
+      attributes[attributeName] = dataTypeOrOptions;
     }
 
     var options = this.QueryGenerator.attributesToSQL(attributes)
-      , sql     = this.QueryGenerator.addColumnQuery(tableName, options)
+      , sql = this.QueryGenerator.addColumnQuery(tableName, options);
 
-    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
-  }
+    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
+  };
 
   QueryInterface.prototype.removeColumn = function(tableName, attributeName) {
     if (this.sequelize.options.dialect === 'sqlite') {
       // sqlite needs some special treatment as it cannot drop a column
-      return SQLiteQueryInterface.removeColumn.call(this, tableName, attributeName)
+      return SQLiteQueryInterface.removeColumn.call(this, tableName, attributeName);
     } else {
-      var sql = this.QueryGenerator.removeColumnQuery(tableName, attributeName)
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+      var sql = this.QueryGenerator.removeColumnQuery(tableName, attributeName);
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     }
-  }
+  };
 
   QueryInterface.prototype.changeColumn = function(tableName, attributeName, dataTypeOrOptions) {
-    var attributes = {}
+    var attributes = {};
 
     if (Utils._.values(DataTypes).indexOf(dataTypeOrOptions) > -1) {
-      attributes[attributeName] = { type: dataTypeOrOptions, allowNull: true }
+      attributes[attributeName] = { type: dataTypeOrOptions, allowNull: true };
     } else {
-      attributes[attributeName] = dataTypeOrOptions
+      attributes[attributeName] = dataTypeOrOptions;
     }
 
     if (this.sequelize.options.dialect === 'sqlite') {
       // sqlite needs some special treatment as it cannot change a column
-      return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes)
+      return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes);
     } else {
       var options = this.QueryGenerator.attributesToSQL(attributes)
-        , sql     = this.QueryGenerator.changeColumnQuery(tableName, options)
+        , sql = this.QueryGenerator.changeColumnQuery(tableName, options);
 
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     }
-  }
+  };
 
   QueryInterface.prototype.renameColumn = function(tableName, attrNameBefore, attrNameAfter) {
     return this.describeTable(tableName).then(function(data) {
-      data = data[attrNameBefore] || {}
+      data = data[attrNameBefore] || {};
 
-      var options =  {}
+      var options = {};
 
       options[attrNameAfter] = {
-        attribute:    attrNameAfter,
-        type:         data.type,
-        allowNull:    data.allowNull,
+        attribute: attrNameAfter,
+        type: data.type,
+        allowNull: data.allowNull,
         defaultValue: data.defaultValue
-      }
+      };
 
       // fix: a not-null column cannot have null as default value
       if (data.defaultValue === null && !data.allowNull) {
@@ -365,123 +365,123 @@ module.exports = (function() {
 
       if (this.sequelize.options.dialect === 'sqlite') {
         // sqlite needs some special treatment as it cannot rename a column
-        return SQLiteQueryInterface.renameColumn.call(this, tableName, attrNameBefore, attrNameAfter)
+        return SQLiteQueryInterface.renameColumn.call(this, tableName, attrNameBefore, attrNameAfter);
       } else {
         var sql = this.QueryGenerator.renameColumnQuery(
           tableName,
           attrNameBefore,
           this.QueryGenerator.attributesToSQL(options)
-        )
-        return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+        );
+        return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
       }
     }.bind(this));
-  }
+  };
 
   QueryInterface.prototype.addIndex = function(tableName, attributes, options) {
-    var sql = this.QueryGenerator.addIndexQuery(tableName, attributes, options)
-    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
-  }
+    var sql = this.QueryGenerator.addIndexQuery(tableName, attributes, options);
+    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
+  };
 
   QueryInterface.prototype.showIndex = function(tableName, options) {
-    var sql = this.QueryGenerator.showIndexQuery(tableName, options)
-    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
-  }
+    var sql = this.QueryGenerator.showIndexQuery(tableName, options);
+    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
+  };
 
   QueryInterface.prototype.getForeignKeysForTables = function(tableNames) {
-    var self = this
+    var self = this;
 
     if (tableNames.length === 0) {
-      return Utils.Promise.resolve({})
+      return Utils.Promise.resolve({});
     }
 
-    return Utils.Promise.map(tableNames, function (tableName) {
-      return self.sequelize.query(self.QueryGenerator.getForeignKeysQuery(tableName, self.sequelize.config.database))
-    }).then(function (results) {
-      var result = {}
+    return Utils.Promise.map(tableNames, function(tableName) {
+      return self.sequelize.query(self.QueryGenerator.getForeignKeysQuery(tableName, self.sequelize.config.database));
+    }).then(function(results) {
+      var result = {};
 
       tableNames.forEach(function(tableName, i) {
-        result[tableName] = Utils._.compact(results[i]).map(function(r) { 
-          return r.constraint_name 
-        })
-      })
+        result[tableName] = Utils._.compact(results[i]).map(function(r) {
+          return r.constraint_name;
+        });
+      });
 
-      return result
-    })
-  }
+      return result;
+    });
+  };
 
   QueryInterface.prototype.removeIndex = function(tableName, indexNameOrAttributes) {
-    var sql = this.QueryGenerator.removeIndexQuery(tableName, indexNameOrAttributes)
-    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
-  }
+    var sql = this.QueryGenerator.removeIndexQuery(tableName, indexNameOrAttributes);
+    return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
+  };
 
   QueryInterface.prototype.insert = function(dao, tableName, values, options) {
     var sql = this.QueryGenerator.insertQuery(tableName, values, dao.Model.rawAttributes);
 
-    return this.sequelize.query(sql, dao, options).then(function (result) {
+    return this.sequelize.query(sql, dao, options).then(function(result) {
       result.isNewRecord = false;
       return result;
     });
-  }
+  };
 
   QueryInterface.prototype.bulkInsert = function(tableName, records, options, Model) {
-    var sql = this.QueryGenerator.bulkInsertQuery(tableName, records, options, Model.rawAttributes)
-    return this.sequelize.query(sql, null, options)
-  }
+    var sql = this.QueryGenerator.bulkInsertQuery(tableName, records, options, Model.rawAttributes);
+    return this.sequelize.query(sql, null, options);
+  };
 
   QueryInterface.prototype.update = function(dao, tableName, values, identifier, options) {
     var self = this
       , restrict = false
-      , sql = self.QueryGenerator.updateQuery(tableName, values, identifier, options, dao.Model.rawAttributes)
+      , sql = self.QueryGenerator.updateQuery(tableName, values, identifier, options, dao.Model.rawAttributes);
 
     // Check for a restrict field
     if (!!dao.Model && !!dao.Model.associations) {
       var keys = Object.keys(dao.Model.associations)
-        , length = keys.length
+        , length = keys.length;
 
       for (var i = 0; i < length; i++) {
-        if (dao.Model.associations[keys[i]].options && dao.Model.associations[keys[i]].options.onUpdate && dao.Model.associations[keys[i]].options.onUpdate === "restrict") {
-          restrict = true
+        if (dao.Model.associations[keys[i]].options && dao.Model.associations[keys[i]].options.onUpdate && dao.Model.associations[keys[i]].options.onUpdate === 'restrict') {
+          restrict = true;
         }
       }
     }
 
-    return this.sequelize.query(sql, dao, options)
-  }
+    return this.sequelize.query(sql, dao, options);
+  };
 
   QueryInterface.prototype.bulkUpdate = function(tableName, values, identifier, options, attributes) {
-    var sql = this.QueryGenerator.updateQuery(tableName, values, identifier, options, attributes)
+    var sql = this.QueryGenerator.updateQuery(tableName, values, identifier, options, attributes);
 
-    return this.sequelize.query(sql, null, options)
-  }
+    return this.sequelize.query(sql, null, options);
+  };
 
   QueryInterface.prototype.delete = function(dao, tableName, identifier, options) {
-    var self      = this
-      , restrict  = false
-      , cascades  = []
-      , sql       = self.QueryGenerator.deleteQuery(tableName, identifier, null, dao.Model)
+    var self = this
+      , restrict = false
+      , cascades = []
+      , sql = self.QueryGenerator.deleteQuery(tableName, identifier, null, dao.Model);
 
     // Check for a restrict field
     if (!!dao.Model && !!dao.Model.associations) {
       var keys = Object.keys(dao.Model.associations)
-        , length = keys.length
+        , length = keys.length;
 
       for (var i = 0; i < length; i++) {
         if (dao.Model.associations[keys[i]].options && dao.Model.associations[keys[i]].options.onDelete) {
-          if (dao.Model.associations[keys[i]].options.onDelete === "restrict") {
-            restrict = true
+          if (dao.Model.associations[keys[i]].options.onDelete === 'restrict') {
+            restrict = true;
           }
-          else if (dao.Model.associations[keys[i]].options.onDelete === "cascade" && dao.Model.associations[keys[i]].options.useHooks === true) {
-            cascades[cascades.length] = dao.Model.associations[keys[i]].accessors.get
+          else if (dao.Model.associations[keys[i]].options.onDelete === 'cascade' && dao.Model.associations[keys[i]].options.useHooks === true) {
+            cascades[cascades.length] = dao.Model.associations[keys[i]].accessors.get;
           }
         }
       }
-    }    
+    }
 
-    return new Utils.Promise(function (resolve, reject) {
-      var tick = 0
+    return new Utils.Promise(function(resolve, reject) {
+      var tick = 0;
       var iterate = function(err, i) {
         if (err) {
-          return reject(err)
+          return reject(err);
         }
 
         if (i >= cascades.length) {
@@ -490,73 +490,73 @@ module.exports = (function() {
 
         dao[cascades[i]]().success(function(tasks) {
           if (tasks === null || tasks.length < 1) {
-            return resolve()
+            return resolve();
           }
 
-          tasks = Array.isArray(tasks) ? tasks : [tasks]
+          tasks = Array.isArray(tasks) ? tasks : [tasks];
 
-          var ii = 0
+          var ii = 0;
           var next = function(err, ii) {
             if (!!err || ii >= tasks.length) {
-              return iterate(err)
+              return iterate(err);
             }
 
             tasks[ii].destroy().error(function(err) {
-              return iterate(err)
+              return iterate(err);
             })
             .success(function() {
-              ii++
+              ii++;
 
               if (ii >= tasks.length) {
-                tick++
-                return iterate(null, tick)
+                tick++;
+                return iterate(null, tick);
               }
 
-              next(null, ii)
-            })
-          }
+              next(null, ii);
+            });
+          };
 
-          next(null, ii)
-        })
-      }
+          next(null, ii);
+        });
+      };
 
       if (cascades.length > 0) {
-        iterate(null, tick)
+        iterate(null, tick);
       } else {
         resolve();
       }
-    }).then(function () {
-      return self.sequelize.query(sql, dao, options)
+    }).then(function() {
+      return self.sequelize.query(sql, dao, options);
     });
-  }
+  };
 
   QueryInterface.prototype.bulkDelete = function(tableName, identifier, options, model) {
-    var sql = this.QueryGenerator.deleteQuery(tableName, identifier, Utils._.defaults(options || {}, {limit: null}), model)
-    return this.sequelize.query(sql, null, options)  
-  }
+    var sql = this.QueryGenerator.deleteQuery(tableName, identifier, Utils._.defaults(options || {}, {limit: null}), model);
+    return this.sequelize.query(sql, null, options);
+  };
 
   QueryInterface.prototype.select = function(factory, tableName, options, queryOptions) {
-    options = options || {}
+    options = options || {};
 
     // See if we need to merge options and factory.scopeObj
     // we're doing this on the QueryInterface level because it's a bridge between
     // sequelize and the databases
     if (Object.keys(factory.scopeObj).length > 0) {
       if (!!options) {
-        Utils.injectScope.call(factory, options, true)
+        Utils.injectScope.call(factory, options, true);
       }
 
-      var scopeObj = buildScope.call(factory)
+      var scopeObj = buildScope.call(factory);
       Object.keys(scopeObj).forEach(function(method) {
-        if (typeof scopeObj[method] === "number" || !Utils._.isEmpty(scopeObj[method])) {
-          options[method] = scopeObj[method]
+        if (typeof scopeObj[method] === 'number' || !Utils._.isEmpty(scopeObj[method])) {
+          options[method] = scopeObj[method];
         }
-      })
+      });
     }
 
-    options.lock = queryOptions.lock
+    options.lock = queryOptions.lock;
 
-    var sql = this.QueryGenerator.selectQuery(tableName, options, factory)
+    var sql = this.QueryGenerator.selectQuery(tableName, options, factory);
     queryOptions = Utils._.extend({}, queryOptions, {
       include: options.include,
       includeNames: options.includeNames,
@@ -565,26 +565,26 @@ module.exports = (function() {
       hasMultiAssociation: options.hasMultiAssociation,
       attributes: options.attributes,
       originalAttributes: options.originalAttributes
-    })
+    });
 
-    return this.sequelize.query(sql, factory, queryOptions)
-  }
+    return this.sequelize.query(sql, factory, queryOptions);
+  };
 
   QueryInterface.prototype.increment = function(dao, tableName, values, identifier, options) {
-    var sql = this.QueryGenerator.incrementQuery(tableName, values, identifier, options.attributes)
-    return this.sequelize.query(sql, dao, options)
-  }
+    var sql = this.QueryGenerator.incrementQuery(tableName, values, identifier, options.attributes);
+    return this.sequelize.query(sql, dao, options);
+  };
 
   QueryInterface.prototype.rawSelect = function(tableName, options, attributeSelector, Model) {
-    var sql          = this.QueryGenerator.selectQuery(tableName, options, Model)
-      , queryOptions = Utils._.extend({ transaction: options.transaction }, { plain: true, raw: true, type: QueryTypes.SELECT })
+    var sql = this.QueryGenerator.selectQuery(tableName, options, Model)
+      , queryOptions = Utils._.extend({ transaction: options.transaction }, { plain: true, raw: true, type: QueryTypes.SELECT });
 
     if (attributeSelector === undefined) {
-      throw new Error('Please pass an attribute selector!')
+      throw new Error('Please pass an attribute selector!');
     }
 
-    return this.sequelize.query(sql, null, queryOptions).then(function (data) {
-      var result = data ? data[attributeSelector] : null
+    return this.sequelize.query(sql, null, queryOptions).then(function(data) {
+      var result = data ? data[attributeSelector] : null;
 
       if (options && options.dataType) {
         var dataType = options.dataType;
@@ -600,65 +600,65 @@ module.exports = (function() {
         }
       }
 
-      return result
-    })
-  }
+      return result;
+    });
+  };
 
   QueryInterface.prototype.createTrigger = function(tableName, triggerName, timingType, fireOnArray,
       functionName, functionParams, optionsArray) {
     var sql = this.QueryGenerator.createTrigger(tableName, triggerName, timingType, fireOnArray, functionName
-      , functionParams, optionsArray)
-    if (sql){
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+      , functionParams, optionsArray);
+    if (sql) {
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     } else {
-      return Utils.Promise.resolve()
+      return Utils.Promise.resolve();
     }
-  }
+  };
 
   QueryInterface.prototype.dropTrigger = function(tableName, triggerName) {
-    var sql = this.QueryGenerator.dropTrigger(tableName, triggerName)
-    if (sql){
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+    var sql = this.QueryGenerator.dropTrigger(tableName, triggerName);
+    if (sql) {
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     } else {
-      return Utils.Promise.resolve()
+      return Utils.Promise.resolve();
     }
-  }
+  };
 
   QueryInterface.prototype.renameTrigger = function(tableName, oldTriggerName, newTriggerName) {
-    var sql = this.QueryGenerator.renameTrigger(tableName, oldTriggerName, newTriggerName)
-    if (sql){
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+    var sql = this.QueryGenerator.renameTrigger(tableName, oldTriggerName, newTriggerName);
+    if (sql) {
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     } else {
-      return Utils.Promise.resolve()
+      return Utils.Promise.resolve();
     }
-  }
+  };
 
   QueryInterface.prototype.createFunction = function(functionName, params, returnType, language, body, options) {
-    var sql = this.QueryGenerator.createFunction(functionName, params, returnType, language, body, options)
-    if (sql){
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+    var sql = this.QueryGenerator.createFunction(functionName, params, returnType, language, body, options);
+    if (sql) {
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     } else {
-      return Utils.Promise.resolve()
+      return Utils.Promise.resolve();
     }
-  }
+  };
 
   QueryInterface.prototype.dropFunction = function(functionName, params) {
-    var sql = this.QueryGenerator.dropFunction(functionName, params)
-    if (sql){
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+    var sql = this.QueryGenerator.dropFunction(functionName, params);
+    if (sql) {
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     } else {
-      return Utils.Promise.resolve()
+      return Utils.Promise.resolve();
     }
-  }
+  };
 
   QueryInterface.prototype.renameFunction = function(oldFunctionName, params, newFunctionName) {
-    var sql = this.QueryGenerator.renameFunction(oldFunctionName, params, newFunctionName)
-    if (sql){
-      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging})
+    var sql = this.QueryGenerator.renameFunction(oldFunctionName, params, newFunctionName);
+    if (sql) {
+      return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});
     } else {
-      return Utils.Promise.resolve()
+      return Utils.Promise.resolve();
     }
-  }
+  };
 
   // Helper methods useful for querying
 
@@ -668,12 +668,12 @@ module.exports = (function() {
    * false.
    */
   QueryInterface.prototype.quoteIdentifier = function(identifier, force) {
-    return this.QueryGenerator.quoteIdentifier(identifier, force)
-  }
+    return this.QueryGenerator.quoteIdentifier(identifier, force);
+  };
 
   QueryInterface.prototype.quoteTable = function(identifier) {
-    return this.QueryGenerator.quoteTable(identifier)
-  }
+    return this.QueryGenerator.quoteTable(identifier);
+  };
 
   /**
    * Split an identifier into .-separated tokens and quote each part.
@@ -681,83 +681,83 @@ module.exports = (function() {
    * `quoteIdentifiers` option is false.
    */
   QueryInterface.prototype.quoteIdentifiers = function(identifiers, force) {
-    return this.QueryGenerator.quoteIdentifiers(identifiers, force)
-  }
+    return this.QueryGenerator.quoteIdentifiers(identifiers, force);
+  };
 
   /**
    * Escape a value (e.g. a string, number or date)
    */
   QueryInterface.prototype.escape = function(value) {
-    return this.QueryGenerator.escape(value)
-  }
+    return this.QueryGenerator.escape(value);
+  };
 
   QueryInterface.prototype.setAutocommit = function(transaction, value) {
     if (!transaction || !(transaction instanceof Transaction)) {
-      throw new Error('Unable to set autocommit for a transaction without transaction object!')
+      throw new Error('Unable to set autocommit for a transaction without transaction object!');
     }
 
-    var sql = this.QueryGenerator.setAutocommitQuery(value)
-    return this.sequelize.query(sql, null, { transaction: transaction})
-  }
+    var sql = this.QueryGenerator.setAutocommitQuery(value);
+    return this.sequelize.query(sql, null, { transaction: transaction});
+  };
 
   QueryInterface.prototype.setIsolationLevel = function(transaction, value) {
     if (!transaction || !(transaction instanceof Transaction)) {
-      throw new Error('Unable to set isolation level for a transaction without transaction object!')
+      throw new Error('Unable to set isolation level for a transaction without transaction object!');
     }
 
-    var sql = this.QueryGenerator.setIsolationLevelQuery(value)
-    return this.sequelize.query(sql, null, { transaction: transaction })
-  }
+    var sql = this.QueryGenerator.setIsolationLevelQuery(value);
+    return this.sequelize.query(sql, null, { transaction: transaction });
+  };
 
   QueryInterface.prototype.startTransaction = function(transaction, options) {
     if (!transaction || !(transaction instanceof Transaction)) {
-      throw new Error('Unable to start a transaction without transaction object!')
+      throw new Error('Unable to start a transaction without transaction object!');
     }
 
     options = Utils._.extend({
       transaction: transaction
-    }, options || {})
+    }, options || {});
 
-    var sql = this.QueryGenerator.startTransactionQuery(options)
-    return this.sequelize.query(sql, null, options)
-  }
+    var sql = this.QueryGenerator.startTransactionQuery(options);
+    return this.sequelize.query(sql, null, options);
+  };
 
   QueryInterface.prototype.commitTransaction = function(transaction, options) {
     if (!transaction || !(transaction instanceof Transaction)) {
-      throw new Error('Unable to commit a transaction without transaction object!')
+      throw new Error('Unable to commit a transaction without transaction object!');
     }
 
     options = Utils._.extend({
       transaction: transaction
-    }, options || {})
+    }, options || {});
 
-    var sql = this.QueryGenerator.commitTransactionQuery(options)
-    return this.sequelize.query(sql, null, options)
-  }
+    var sql = this.QueryGenerator.commitTransactionQuery(options);
+    return this.sequelize.query(sql, null, options);
+  };
 
   QueryInterface.prototype.rollbackTransaction = function(transaction, options) {
     if (!transaction || !(transaction instanceof Transaction)) {
-      throw new Error('Unable to rollback a transaction without transaction object!')
+      throw new Error('Unable to rollback a transaction without transaction object!');
     }
 
     options = Utils._.extend({
       transaction: transaction
-    }, options || {})
+    }, options || {});
 
-    var sql = this.QueryGenerator.rollbackTransactionQuery(options)
-    return this.sequelize.query(sql, null, options)
-  }
+    var sql = this.QueryGenerator.rollbackTransactionQuery(options);
+    return this.sequelize.query(sql, null, options);
+  };
 
   // private
 
   var buildScope = function() {
-    var smart
+    var smart;
 
     // Use smartWhere to convert several {where} objects into a single where object
-    smart = Utils.smartWhere(this.scopeObj.where || [], this.daoFactoryManager.sequelize.options.dialect)
-    smart = Utils.compileSmartWhere.call(this, smart, this.daoFactoryManager.sequelize.options.dialect)
-    return {limit: this.scopeObj.limit || null, offset: this.scopeObj.offset || null, where: smart, order: (this.scopeObj.order || []).join(', ')}
-  }
+    smart = Utils.smartWhere(this.scopeObj.where || [], this.daoFactoryManager.sequelize.options.dialect);
+    smart = Utils.compileSmartWhere.call(this, smart, this.daoFactoryManager.sequelize.options.dialect);
+    return {limit: this.scopeObj.limit || null, offset: this.scopeObj.offset || null, where: smart, order: (this.scopeObj.order || []).join(', ')};
+  };
 
-  return QueryInterface
-})()
+  return QueryInterface;
+})();

--- a/lib/query-types.js
+++ b/lib/query-types.js
@@ -1,7 +1,7 @@
-"use strict";
+'use strict';
 
 module.exports = {
   SELECT: 'SELECT',
   BULKUPDATE: 'BULKUPDATE',
   BULKDELETE: 'BULKDELETE'
-}
+};

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1,17 +1,17 @@
-"use strict";
+'use strict';
 
-var url                = require("url")
-  , Path               = require("path")
-  , Utils              = require("./utils")
-  , Model              = require("./model")
-  , DataTypes          = require('./data-types')
-  , ModelManager       = require("./model-manager")
-  , QueryInterface     = require("./query-interface")
-  , Transaction        = require("./transaction")
+var url = require('url')
+  , Path = require('path')
+  , Utils = require('./utils')
+  , Model = require('./model')
+  , DataTypes = require('./data-types')
+  , ModelManager = require('./model-manager')
+  , QueryInterface = require('./query-interface')
+  , Transaction = require('./transaction')
   , TransactionManager = require('./transaction-manager')
-  , QueryTypes         = require('./query-types')
-  , sequelizeErrors    = require('./errors')
-  , Promise            = require('./promise')
+  , QueryTypes = require('./query-types')
+  , sequelizeErrors = require('./errors')
+  , Promise = require('./promise');
 
 /**
  * This is the main class, the entry point to sequelize. To use it, you just need to import sequelize:
@@ -19,16 +19,16 @@ var url                = require("url")
  * ```js
  * var Sequelize = require('sequelize');
  * ```
- * 
+ *
  * In addition to sequelize, the connection library for the dialect you want to use should also be installed in your project. You don't need to import it however, as sequelize will take care of that.
- * 
+ *
  * @class Sequelize
  */
 module.exports = (function() {
 
    /**
    * Instantiate sequelize with name of database, username and password
-   * 
+   *
    * #### Example usage
    *
    * ```javascript
@@ -54,27 +54,27 @@ module.exports = (function() {
    * @param {String}   database The name of the database
    * @param {String}   [username=null] The username which is used to authenticate against the database.
    * @param {String}   [password=null] The password which is used to authenticate against the database.
-   * @param {Object}   [options={}] An object with options.
+   * @param {Object}   [options= {}] An object with options.
    * @param {String}   [options.dialect='mysql'] The dialect you of the database you are connecting to. One of mysql, postgres, sqlite and mariadb
    * @param {String}   [options.dialectModulePath=null] If specified, load the dialect library from this path. For example, if you want to use pg.js instead of pg when connecting to a pg database, you should specify 'pg.js' here
    * @param {String}   [options.host='localhost'] The host of the relational database.
    * @param {Integer}  [options.port=] The port of the relational database.
    * @param {String}   [options.protocol='tcp'] The protocol of the relational database.
-   * @param {Object}   [options.define={}] Default options for model definitions. See sequelize.define for options
-   * @param {Object}   [options.query={}] Default options for sequelize.query
-   * @param {Object}   [options.sync={}] Default options for sequelize.sync
+   * @param {Object}   [options.define= {}] Default options for model definitions. See sequelize.define for options
+   * @param {Object}   [options.query= {}] Default options for sequelize.query
+   * @param {Object}   [options.sync= {}] Default options for sequelize.sync
    * @param {Function} [options.logging=console.log] A function that gets executed everytime Sequelize would log something.
    * @param {Boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
    * @param {Boolean}  [options.queue=true] Queue queries, so that only maxConcurrentQueries number of queries are executing at once. If false, all queries will be executed immediately.
    * @param {int}      [options.maxConcurrentQueries=50] The maximum number of queries that should be executed at once if queue is true.
    * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
    * @param {Boolean}  [options.replication=false] Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database`
-   * @param {Object}   [options.pool={}] Should sequelize use a connection pool. Default is true
+   * @param {Object}   [options.pool= {}] Should sequelize use a connection pool. Default is true
    * @param {int}      [options.pool.maxConnections]
    * @param {int}      [options.pool.minConnections]
    * @param {int}      [options.pool.maxIdleTime] The maximum time, in milliseconds, that a connection can be idle before being released
    * @param {function} [options.pool.validateConnection] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
-   
+
    * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.
   */
 
@@ -83,32 +83,32 @@ module.exports = (function() {
    * @name Sequelize
    * @constructor
    *
-   * @param {String} uri A full database URI 
-   * @param {object} [options={}] See above for possible options
+   * @param {String} uri A full database URI
+   * @param {object} [options= {}] See above for possible options
   */
   var Sequelize = function(database, username, password, options) {
-    var urlParts
-    options = options || {}
+    var urlParts;
+    options = options || {};
 
     if (arguments.length === 1 || (arguments.length === 2 && typeof username === 'object')) {
-      options = username || {}
-      urlParts = url.parse(arguments[0])
+      options = username || {};
+      urlParts = url.parse(arguments[0]);
 
       // SQLite don't have DB in connection url
       if (urlParts.pathname) {
-        database = urlParts.pathname.replace(/^\//,  '')
+        database = urlParts.pathname.replace(/^\//, '');
       }
 
-      options.dialect = urlParts.protocol.replace(/:$/, '')
-      options.host = urlParts.hostname
+      options.dialect = urlParts.protocol.replace(/:$/, '');
+      options.host = urlParts.hostname;
 
       if (urlParts.port) {
-        options.port = urlParts.port
+        options.port = urlParts.port;
       }
 
       if (urlParts.auth) {
-        username = urlParts.auth.split(':')[0]
-        password = urlParts.auth.split(':')[1]
+        username = urlParts.auth.split(':')[0];
+        password = urlParts.auth.split(':')[1];
       }
     }
 
@@ -129,86 +129,86 @@ module.exports = (function() {
       pool: {},
       quoteIdentifiers: true,
       language: 'en'
-    }, options || {})
+    }, options || {});
 
     if (this.options.dialect === 'postgresql') {
-      this.options.dialect = 'postgres'
+      this.options.dialect = 'postgres';
     }
 
     if (this.options.logging === true) {
-      console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log')
-      this.options.logging = console.log
+      console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
+      this.options.logging = console.log;
     }
 
     this.config = {
       database: database,
       username: username,
-      password: (( (["", null, false].indexOf(password) > -1) || (typeof password == 'undefined')) ? null : password),
-      host    : this.options.host,
-      port    : this.options.port,
-      pool    : this.options.pool,
+      password: (((['', null, false].indexOf(password) > -1) || (typeof password === 'undefined')) ? null : password),
+      host: this.options.host,
+      port: this.options.port,
+      pool: this.options.pool,
       protocol: this.options.protocol,
-      queue   : this.options.queue,
-      native  : this.options.native,
-      ssl     : this.options.ssl,
+      queue: this.options.queue,
+      native: this.options.native,
+      ssl: this.options.ssl,
       replication: this.options.replication,
       dialectModulePath: this.options.dialectModulePath,
       maxConcurrentQueries: this.options.maxConcurrentQueries,
-      dialectOptions: this.options.dialectOptions,
-    }
+      dialectOptions: this.options.dialectOptions
+    };
 
     try {
-      var Dialect = require("./dialects/" + this.getDialect())
-      this.dialect = new Dialect(this)
-    } catch(err) {
-      throw new Error("The dialect " + this.getDialect() + " is not supported.")
+      var Dialect = require('./dialects/' + this.getDialect());
+      this.dialect = new Dialect(this);
+    } catch (err) {
+      throw new Error('The dialect ' + this.getDialect() + ' is not supported.');
     }
 
     /**
      * Models are stored here under the name given to `sequelize.define`
      * @property models
      */
-    this.models = {}
-    this.modelManager = this.daoFactoryManager = new ModelManager(this)
-    this.transactionManager = new TransactionManager(this)
-   
-    this.importCache = {}
-  }
+    this.models = {};
+    this.modelManager = this.daoFactoryManager = new ModelManager(this);
+    this.transactionManager = new TransactionManager(this);
+
+    this.importCache = {};
+  };
 
   /**
    * A reference to sequelize utilities. Most users will not need to use these utils directly. However, you might want to use `Sequelize.Utils._`, which is a reference to the lodash library, if you don't already have it imported in your project.
    * @property Utils
    * @see {Utils}
    */
-  Sequelize.prototype.Utils = Sequelize.Utils = Utils
+  Sequelize.prototype.Utils = Sequelize.Utils = Utils;
 
   /**
    * A modified version of bluebird promises, that allows listening for sql events
    * @property Promise
    * @see {Promise}
    */
-  Sequelize.prototype.Promise = Sequelize.Promise = Promise
+  Sequelize.prototype.Promise = Sequelize.Promise = Promise;
 
-  Sequelize.QueryTypes = QueryTypes
+  Sequelize.QueryTypes = QueryTypes;
 
-  /** 
+  /**
    * Exposes the validator.js object, so you can extend it with custom validation functions. The validator is exposed both on the instance, and on the constructor.
    * @property Validator
    * @see https://github.com/chriso/validator.js
    */
-  Sequelize.prototype.Validator = Sequelize.Validator = require('validator')
+  Sequelize.prototype.Validator = Sequelize.Validator = require('validator');
 
-  Sequelize.Model = Sequelize.Model = Model
+  Sequelize.Model = Sequelize.Model = Model;
 
   for (var dataType in DataTypes) {
-    Sequelize[dataType] = DataTypes[dataType]
+    Sequelize[dataType] = DataTypes[dataType];
   }
 
   Object.defineProperty(Sequelize.prototype, 'connectorManager', {
     get: function() {
-      return this.transactionManager.getConnectorManager()
+      return this.transactionManager.getConnectorManager();
     }
-  })
+  });
 
   /**
    * A reference to the sequelize transaction class. Use this to access isolationLevels when creating a transaction
@@ -216,21 +216,21 @@ module.exports = (function() {
    * @see {Transaction}
    * @see {Sequelize#transaction}
    */
-  Sequelize.prototype.Transaction = Transaction
+  Sequelize.prototype.Transaction = Transaction;
 
   /**
    * A general error class
    * @property Error
    */
   Sequelize.prototype.Error = Sequelize.Error =
-    sequelizeErrors.BaseError
+    sequelizeErrors.BaseError;
 
   /**
    * Emitted when a validation fails
    * @property ValidationError
    */
   Sequelize.prototype.ValidationError = Sequelize.ValidationError =
-    sequelizeErrors.ValidationError
+    sequelizeErrors.ValidationError;
 
   /**
    * Returns the specified dialect.
@@ -238,8 +238,8 @@ module.exports = (function() {
    * @return {String} The specified dialect.
    */
   Sequelize.prototype.getDialect = function() {
-    return this.options.dialect
-  }
+    return this.options.dialect;
+  };
 
   /**
    * Returns an instance of QueryInterface.
@@ -250,30 +250,30 @@ module.exports = (function() {
    * @see {QueryInterface}
    */
   Sequelize.prototype.getQueryInterface = function() {
-    this.queryInterface = this.queryInterface || new QueryInterface(this)
-    return this.queryInterface
-  }
+    this.queryInterface = this.queryInterface || new QueryInterface(this);
+    return this.queryInterface;
+  };
 
   /**
    * Returns an instance (singleton) of Migrator.
    *
    * @see {Migrator}
    * @function getMigrator
-   * @param {Object} [options={}] See Migrator for options
+   * @param {Object} [options= {}] See Migrator for options
    * @param {Boolean} [force=false] A flag that defines if the migrator should get instantiated or not.
    * @return {Migrator} An instance of Migrator.
    */
   Sequelize.prototype.getMigrator = function(options, force) {
-    var Migrator = require("./migrator")
+    var Migrator = require('./migrator');
 
     if (force) {
-      this.migrator = new Migrator(this, options)
+      this.migrator = new Migrator(this, options);
     } else {
-      this.migrator = this.migrator || new Migrator(this, options)
+      this.migrator = this.migrator || new Migrator(this, options);
     }
 
-    return this.migrator
-  }
+    return this.migrator;
+  };
 
   /**
    * Define a new model, representing a table in the DB.
@@ -310,7 +310,7 @@ module.exports = (function() {
    * For more about getters and setters, see http://sequelizejs.com/docs/latest/models#getters---setters
    *
    * For more about instance and class methods, see http://sequelizejs.com/docs/latest/models#expansion-of-models
-   * 
+   *
    * For more about validation, see http://sequelizejs.com/docs/latest/models#validations
    *
    * @see {DataTypes}
@@ -351,7 +351,7 @@ module.exports = (function() {
    * @param {Object}                  [options.setterMethods] Provide setter functions that work like those defined per column. If you provide a setter method with the same name as a column, it will be used to update the value of that column. If you provide a name that does not match a column, this function will act as a virtual setter, that can act on and set other values, but will not be persisted
    * @param {Object}                  [options.instanceMethods] Provide functions that are added to each instance (DAO)
    * @param {Object}                  [options.classMethods] Provide functions that are added to the model (Model)
-   * @param {String}                  [options.schema='public'] 
+   * @param {String}                  [options.schema='public']
    * @param {String}                  [options.engine]
    * @param {String}                  [options.charset]
    * @param {String}                  [options.comment]
@@ -362,34 +362,34 @@ module.exports = (function() {
    * @return {Model}
    */
   Sequelize.prototype.define = function(daoName, attributes, options) {
-    options = options || {}
+    options = options || {};
     var self = this
-      , globalOptions = this.options
+      , globalOptions = this.options;
 
     if (globalOptions.define) {
-      options = Utils._.extend({}, globalOptions.define, options)
+      options = Utils._.extend({}, globalOptions.define, options);
       Utils._(['classMethods', 'instanceMethods']).each(function(key) {
         if (globalOptions.define[key]) {
-          options[key] = options[key] || {}
-          Utils._.defaults(options[key], globalOptions.define[key])
+          options[key] = options[key] || {};
+          Utils._.defaults(options[key], globalOptions.define[key]);
         }
-      })
+      });
     }
 
-    options.omitNull = globalOptions.omitNull
-    options.language = globalOptions.language
+    options.omitNull = globalOptions.omitNull;
+    options.language = globalOptions.language;
 
     // if you call "define" multiple times for the same daoName, do not clutter the factory
-    if(this.isDefined(daoName)) {
-      this.modelManager.removeDAO(this.modelManager.getDAO(daoName))
+    if (this.isDefined(daoName)) {
+      this.modelManager.removeDAO(this.modelManager.getDAO(daoName));
     }
 
-    options.sequelize = this
-    var factory = new Model(daoName, attributes, options)
-    this.modelManager.addDAO(factory.init(this.modelManager))
+    options.sequelize = this;
+    var factory = new Model(daoName, attributes, options);
+    this.modelManager.addDAO(factory.init(this.modelManager));
 
-    return factory
-  }
+    return factory;
+  };
 
   /**
    * Fetch a DAO factory which is already defined
@@ -399,12 +399,12 @@ module.exports = (function() {
    * @return {Model}
    */
   Sequelize.prototype.model = function(daoName) {
-    if(!this.isDefined(daoName)) {
-      throw new Error(daoName + ' has not been defined')
+    if (!this.isDefined(daoName)) {
+      throw new Error(daoName + ' has not been defined');
     }
 
-    return this.modelManager.getDAO(daoName)
-  }
+    return this.modelManager.getDAO(daoName);
+  };
 
   /**
    * Checks whether a model with the given name is defined
@@ -413,15 +413,15 @@ module.exports = (function() {
    * @return {Boolean}
    */
   Sequelize.prototype.isDefined = function(daoName) {
-    var daos = this.modelManager.daos
-    return (daos.filter(function(dao) { return dao.name === daoName }).length !== 0)
-  }
+    var daos = this.modelManager.daos;
+    return (daos.filter(function(dao) { return dao.name === daoName; }).length !== 0);
+  };
 
   /**
-   * Imports a model defined in another file 
-   * 
+   * Imports a model defined in another file
+   *
    * Imported models are cached, so multiple calls to import with the same path will not load the file multiple times
-   * 
+   *
    * See https://github.com/sequelize/sequelize/blob/master/examples/using-multiple-model-files/Task.js for a short example of how to define your models in separate files so that they can be imported by sequelize.import
    * @param {String} path The path to the file that holds the model you want to import. If the part is relative, it will be resolved relatively to the calling file
    * @return {Model}
@@ -431,32 +431,32 @@ module.exports = (function() {
     if (Path.normalize(path).indexOf(path.sep) !== 0) {
       // make path relative to the caller
       var callerFilename = Utils.stack()[1].getFileName()
-        , callerPath     = Path.dirname(callerFilename)
+        , callerPath = Path.dirname(callerFilename);
 
-      path = Path.resolve(callerPath, path)
+      path = Path.resolve(callerPath, path);
     }
 
     if (!this.importCache[path]) {
-      var defineCall = (arguments.length > 1 ? arguments[1] : require(path))
-      this.importCache[path] = defineCall(this, DataTypes)
+      var defineCall = (arguments.length > 1 ? arguments[1] : require(path));
+      this.importCache[path] = defineCall(this, DataTypes);
     }
 
-    return this.importCache[path]
-  }
+    return this.importCache[path];
+  };
 
   Sequelize.prototype.migrate = function(options) {
-    return this.getMigrator().migrate(options)
-  }
+    return this.getMigrator().migrate(options);
+  };
 
   /**
-   * Execute a query on the DB, with the posibility to bypass all the sequelize goodness. 
+   * Execute a query on the DB, with the posibility to bypass all the sequelize goodness.
    *
    * If you do not provide other arguments than the SQL, raw will be assumed to the true, and sequelize will not try to do any formatting to the results of the query.
    *
    * @method query
    * @param {String} sql
    * @param {Model}  [callee] If callee is provided, the selected data will be used to build an instance of the DAO represented by the factory. Equivalent to calling Model.build with the values provided by the query.
-   * @param {Object}      [options={}] Query options.
+   * @param {Object}      [options= {}] Query options.
    * @param {Boolean}     [options.raw] If true, sequelize will not try to format the results of the query, or build an instance of a model from the result
    * @param {Transaction} [options.transaction=null] The transaction that the query should be executed under
    * @param [String]      [options.type='SELECT'] The type of query you are executing. The query type affects how results are formatted before they are passed back. If no type is provided sequelize will try to guess the right type based on the sql, and fall back to SELECT. The type is a string, but `Sequelize.QueryTypes` is provided is convenience shortcuts. Current options are SELECT, BULKUPDATE and BULKDELETE
@@ -468,27 +468,27 @@ module.exports = (function() {
   Sequelize.prototype.query = function(sql, callee, options, replacements) {
     if (arguments.length === 4) {
       if (Array.isArray(replacements)) {
-        sql = Utils.format([sql].concat(replacements), this.options.dialect)
+        sql = Utils.format([sql].concat(replacements), this.options.dialect);
       }
       else {
-        sql = Utils.formatNamedParameters(sql, replacements, this.options.dialect)
+        sql = Utils.formatNamedParameters(sql, replacements, this.options.dialect);
       }
     } else if (arguments.length === 3) {
-      options = options
+      options = options;
     } else if (arguments.length === 2) {
-      options = {}
+      options = {};
     } else {
-      options = { raw: true }
+      options = { raw: true };
     }
 
-    options = Utils._.extend(Utils._.clone(this.options.query), options)
+    options = Utils._.extend(Utils._.clone(this.options.query), options);
     options = Utils._.defaults(options, {
       logging: this.options.hasOwnProperty('logging') ? this.options.logging : console.log,
       type: (sql.toLowerCase().indexOf('select') === 0) ? QueryTypes.SELECT : false
-    })
+    });
 
     return this.transactionManager.query(sql, callee, options);
-  }
+  };
 
   /**
    * Create a new database schema
@@ -496,16 +496,16 @@ module.exports = (function() {
    * @return {Promise}
    */
   Sequelize.prototype.createSchema = function(schema) {
-    return this.getQueryInterface().createSchema(schema)
-  }
+    return this.getQueryInterface().createSchema(schema);
+  };
 
   /**
    * Show all defined schemas
    * @return {Promise}
    */
   Sequelize.prototype.showAllSchemas = function() {
-    return this.getQueryInterface().showAllSchemas()
-  }
+    return this.getQueryInterface().showAllSchemas();
+  };
 
   /**
    * Drop a single schema
@@ -513,77 +513,77 @@ module.exports = (function() {
    * @return {Promise}
    */
   Sequelize.prototype.dropSchema = function(schema) {
-    return this.getQueryInterface().dropSchema(schema)
-  }
+    return this.getQueryInterface().dropSchema(schema);
+  };
 
   /**
    * Drop all schemas
    * @return {Promise}
    */
   Sequelize.prototype.dropAllSchemas = function() {
-    return this.getQueryInterface().dropAllSchemas()
-  }
+    return this.getQueryInterface().dropAllSchemas();
+  };
 
   /**
-   * Sync all defined DAOs to the DB. 
-   * 
-   * @param {Object} [options={}]
+   * Sync all defined DAOs to the DB.
+   *
+   * @param {Object} [options= {}]
    * @param {Boolean} [options.force=false] If force is true, each DAO will do DROP TABLE IF EXISTS ..., before it tries to create its own table
    * @param {Boolean|function} [options.logging=console.log] A function that logs sql queries, or false for no logging
    * @param {String} [options.schema='public'] The schema that the tables should be created in. This can be overriden for each table in sequelize.define
    * @return {Promise}
    */
   Sequelize.prototype.sync = function(options) {
-    var self = this
+    var self = this;
 
-    options = Utils._.defaults(options || {}, this.options.sync, this.options)
-    options.logging = options.logging === undefined ? false : options.logging
+    options = Utils._.defaults(options || {}, this.options.sync, this.options);
+    options.logging = options.logging === undefined ? false : options.logging;
 
-    var when
+    var when;
     if (options.force) {
-      when = this.drop(options)
+      when = this.drop(options);
     } else {
-      when = Promise.resolve()
+      when = Promise.resolve();
     }
 
-    return when.then(function () {
-      var daos = [null]
+    return when.then(function() {
+      var daos = [null];
 
       // Topologically sort by foreign key constraints to give us an appropriate
       // creation order
       self.modelManager.forEachDAO(function(dao) {
         if (dao) {
-          daos.push(dao)
+          daos.push(dao);
         } else {
           // DB should throw an SQL error if referencing inexistant table
         }
-      })
-      return Promise.reduce(daos, function (total, dao) {
-        return dao.sync(options)
-      })
-    })
-  }
+      });
+      return Promise.reduce(daos, function(total, dao) {
+        return dao.sync(options);
+      });
+    });
+  };
 
   /**
    * Drop all tables defined through this sequelize instance. This is done by calling Model.drop on each model
    * @see {Model#drop} for options
-   * 
+   *
    * @param {object} options  The options passed to each call to Model.drop
    * @return {Promise}
    */
   Sequelize.prototype.drop = function(options) {
-    var daos = [null]
+    var daos = [null];
 
     this.modelManager.forEachDAO(function(dao) {
       if (dao) {
-        daos.push(dao)
+        daos.push(dao);
       }
-    }, { reverse: false})
+    }, { reverse: false});
 
-    return Promise.reduce(daos, function (total, dao) {
-      return dao.drop(options)
-    })
-  }
+    return Promise.reduce(daos, function(total, dao) {
+      return dao.drop(options);
+    });
+  };
 
   /**
    * Test the connection by trying to authenticate
@@ -594,17 +594,17 @@ module.exports = (function() {
    * @return {Promise}
    */
   Sequelize.prototype.authenticate = function() {
-    return this.query('SELECT 1+1 AS result', null, { raw: true, plain: true }).return().catch(function (err) {
-      throw new Error(err)
-    })
-  }
+    return this.query('SELECT 1+1 AS result', null, { raw: true, plain: true }).return ().catch (function(err) {
+      throw new Error(err);
+    });
+  };
 
   Sequelize.prototype.validate = Sequelize.prototype.authenticate;
 
   /**
    * Creates a object representing a database function. This can be used in search queries, both in where and order parts, and as default values in column definitions.
    * If you want to refer to columns in your function, you should use `sequelize.col`, so that the columns are properly interpreted as columns and not a strings.
-   * 
+   *
    * Convert a user's username to upper case
    * ```js
    * instance.updateAttributes({
@@ -617,63 +617,63 @@ module.exports = (function() {
    * @see {Model#define}
    * @see {Sequelize#col}
    * @method fn
-   * 
+   *
    * @param {String} fn The function you want to call
    * @param {any} args All further arguments will be passed as arguments to the function
    *
    * @since v2.0.0-dev3
    * @return {Sequelize.fn}
    */
-  Sequelize.fn = Sequelize.prototype.fn = function (fn) {
-    return new Utils.fn(fn, Array.prototype.slice.call(arguments, 1))
-  }
+  Sequelize.fn = Sequelize.prototype.fn = function(fn) {
+    return new Utils.fn(fn, Array.prototype.slice.call(arguments, 1));
+  };
 
   /**
    * Creates a object representing a column in the DB. This is often useful in conjunction with `sequelize.fn`, since raw string arguments to fn will be escaped.
    * @see {Sequelize#fn}
-   * 
+   *
    * @method col
    * @param {String} col The name of the column
    * @since v2.0.0-dev3
    * @return {Sequelize.col}
    */
-  Sequelize.col = Sequelize.prototype.col = function (col) {
-    return new Utils.col(col)
-  }
+  Sequelize.col = Sequelize.prototype.col = function(col) {
+    return new Utils.col(col);
+  };
 
 
   /**
-   * Creates a object representing a call to the cast function. 
-   * 
+   * Creates a object representing a call to the cast function.
+   *
    * @method cast
    * @param {any} val The value to cast
    * @param {String} type The type to cast it to
    * @since v2.0.0-dev3
    * @return {Sequelize.cast}
    */
-  Sequelize.cast = Sequelize.prototype.cast = function (val, type) {
-    return new Utils.cast(val, type)
-  }
+  Sequelize.cast = Sequelize.prototype.cast = function(val, type) {
+    return new Utils.cast(val, type);
+  };
 
   /**
    * Creates a object representing a literal, i.e. something that will not be escaped.
-   * 
+   *
    * @method literal
    * @param {any} val
    * @alias asIs
    * @since v2.0.0-dev3
    * @return {Sequelize.literal}
    */
-  Sequelize.literal = Sequelize.prototype.literal = function (val) {
-    return new Utils.literal(val)
-  }
-  
-  Sequelize.asIs = Sequelize.prototype.asIs = function (val) {
-    return new Utils.asIs(val)
-  }
+  Sequelize.literal = Sequelize.prototype.literal = function(val) {
+    return new Utils.literal(val);
+  };
+
+  Sequelize.asIs = Sequelize.prototype.asIs = function(val) {
+    return new Utils.asIs(val);
+  };
 
   /**
-   * An AND query 
+   * An AND query
    * @see {Model#find}
    *
    * @method and
@@ -682,11 +682,11 @@ module.exports = (function() {
    * @return {Sequelize.and}
    */
   Sequelize.and = Sequelize.prototype.and = function() {
-    return new Utils.and(Array.prototype.slice.call(arguments))
-  }
+    return new Utils.and(Array.prototype.slice.call(arguments));
+  };
 
   /**
-   * An OR query 
+   * An OR query
    * @see {Model#find}
    *
    * @method or
@@ -695,8 +695,8 @@ module.exports = (function() {
    * @return {Sequelize.or}
    */
   Sequelize.or = Sequelize.prototype.or = function() {
-    return new Utils.or(Array.prototype.slice.call(arguments))
-  }
+    return new Utils.or(Array.prototype.slice.call(arguments));
+  };
 
   /*
    * A way of specifying attr = condition. Mostly used internally
@@ -710,12 +710,12 @@ module.exports = (function() {
    * @return {Sequelize.where}
    */
   Sequelize.where = Sequelize.prototype.where = function() {
-    return new Utils.where(Array.prototype.slice.call(arguments))
-  }
+    return new Utils.where(Array.prototype.slice.call(arguments));
+  };
 
   Sequelize.condition = Sequelize.prototype.condition = function() {
-    return new Utils.condition(Array.prototype.slice.call(arguments))
-  }
+    return new Utils.condition(Array.prototype.slice.call(arguments));
+  };
 
   /**
    * Start a transaction. When using transactions, you should pass the transaction in the options argument in order for the query to happen under that transaction
@@ -727,16 +727,16 @@ module.exports = (function() {
    *       t.commit()
    *     })
    *   })
-   *   
+   *
    *   // the commit / rollback will emit events which can be observed via:
-   *   t.done(function() { 
+   *   t.done(function() {
    *   })
    * })
    * ```
-   * 
-   * @see {Transaction} 
+   *
+   * @see {Transaction}
 
-   * @param {Object} [options={}]
+   * @param {Object} [options= {}]
    * @param {Boolean} [options.autocommit=true]
    * @param {String} [options.isolationLevel='REPEATABLE READ'] See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
    * @param {Function} callback Called when the transaction has been set up and is ready for use. If the callback takes two arguments it will be called with err, transaction, otherwise it will be called with transaction.
@@ -745,38 +745,38 @@ module.exports = (function() {
    * @fires success When the transaction has ended (either comitted or rolled back)
    */
   Sequelize.prototype.transaction = function(_options, _callback) {
-    var options     = (typeof _options === 'function') ? {} : _options
-      , callback    = (typeof _options === 'function') ? _options : _callback
-      , wantsError  = (callback.length === 2)
-      , transaction = new Transaction(this, options)
-      
+    var options = (typeof _options === 'function') ? {} : _options
+      , callback = (typeof _options === 'function') ? _options : _callback
+      , wantsError = (callback.length === 2)
+      , transaction = new Transaction(this, options);
+
     Utils.tick(function() {
       if (wantsError) {
         transaction.error(function(err) {
-          callback(err, transaction)
-        })
+          callback(err, transaction);
+        });
       }
 
       transaction.prepareEnvironment(function() {
-        wantsError ? callback(null, transaction) : callback(transaction)
-      })
-    })
+        wantsError ? callback(null, transaction) : callback(transaction);
+      });
+    });
 
-    return transaction
-  }
+    return transaction;
+  };
 
   Sequelize.prototype.log = function() {
-    var args = [].slice.call(arguments)
+    var args = [].slice.call(arguments);
 
     if (this.options.logging) {
       if (this.options.logging === true) {
-        console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log')
-        this.options.logging = console.log
+        console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
+        this.options.logging = console.log;
       }
 
-      this.options.logging.apply(null, args)
+      this.options.logging.apply(null, args);
     }
-  }
+  };
 
-  return Sequelize
-})()
+  return Sequelize;
+})();

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -1,46 +1,46 @@
-"use strict";
+'use strict';
 
-var moment = require("moment")
+var moment = require('moment')
   , isArrayBufferView
   , SqlString = exports;
 
 if (typeof ArrayBufferView === 'function') {
-  isArrayBufferView = function(object) { return object && (object instanceof ArrayBufferView) }
+  isArrayBufferView = function(object) { return object && (object instanceof ArrayBufferView); };
 } else {
   var arrayBufferViews = [
     Int8Array, Uint8Array, Int16Array, Uint16Array,
     Int32Array, Uint32Array, Float32Array, Float64Array
-  ]
+  ];
   isArrayBufferView = function(object) {
-    for (var i=0; i<8; i++) {
+    for (var i = 0; i < 8; i++) {
       if (object instanceof arrayBufferViews[i]) {
-        return true
+        return true;
       }
     }
-    return false
+    return false;
   };
 }
 
 
-SqlString.escapeId = function (val, forbidQualified) {
+SqlString.escapeId = function(val, forbidQualified) {
   if (forbidQualified) {
-    return '`' + val.replace(/`/g, '``') + '`'
+    return '`' + val.replace(/`/g, '``') + '`';
   }
-  return '`' + val.replace(/`/g, '``').replace(/\./g, '`.`') + '`'
-}
+  return '`' + val.replace(/`/g, '``').replace(/\./g, '`.`') + '`';
+};
 
 SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
-  if (arguments.length === 1 && typeof arguments[0] === "object") {
-    val = val.val || val.value || null
-    stringifyObjects = val.stringifyObjects || val.objects || undefined
-    timeZone = val.timeZone || val.zone || null
-    dialect = val.dialect || null
-    field = val.field || null
+  if (arguments.length === 1 && typeof arguments[0] === 'object') {
+    val = val.val || val.value || null;
+    stringifyObjects = val.stringifyObjects || val.objects || undefined;
+    timeZone = val.timeZone || val.zone || null;
+    dialect = val.dialect || null;
+    field = val.field || null;
   }
-  else if (arguments.length < 3 && typeof arguments[1] === "object") {
-    timeZone = stringifyObjects.timeZone || stringifyObjects.zone || null
-    dialect = stringifyObjects.dialect || null
-    field = stringifyObjects.field || null
+  else if (arguments.length < 3 && typeof arguments[1] === 'object') {
+    timeZone = stringifyObjects.timeZone || stringifyObjects.zone || null;
+    dialect = stringifyObjects.dialect || null;
+    field = stringifyObjects.field || null;
   }
 
   if (val === undefined || val === null) {
@@ -54,175 +54,175 @@ SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
     // but sequelize doesn't use it yet.
     return dialect === 'sqlite' ? +!!val : ('' + !!val);
   case 'number':
-    return val+'';
+    return val + '';
   }
 
   if (val instanceof Date) {
-    val = SqlString.dateToString(val, timeZone || "Z", dialect)
+    val = SqlString.dateToString(val, timeZone || 'Z', dialect);
   }
 
   if (Buffer.isBuffer(val)) {
-    return SqlString.bufferToString(val, dialect)
+    return SqlString.bufferToString(val, dialect);
   }
   if (Array.isArray(val) || isArrayBufferView(val)) {
-    return SqlString.arrayToList(val, timeZone, dialect, field)
+    return SqlString.arrayToList(val, timeZone, dialect, field);
   }
 
   if (typeof val === 'object') {
     if (stringifyObjects) {
-      val = val.toString()
+      val = val.toString();
     } else {
-      return SqlString.objectToValues(val, timeZone)
+      return SqlString.objectToValues(val, timeZone);
     }
   }
 
   if (dialect === 'postgres' || dialect === 'sqlite') {
     // http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
     // http://stackoverflow.com/q/603572/130598
-    val = val.replace(/'/g, "''")
+    val = val.replace(/'/g, "''");
   } else {
     val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, function(s) {
-      switch(s) {
-        case "\0": return "\\0";
-        case "\n": return "\\n";
-        case "\r": return "\\r";
-        case "\b": return "\\b";
-        case "\t": return "\\t";
-        case "\x1a": return "\\Z";
-        default: return "\\"+s;
+      switch (s) {
+        case '\0': return '\\0';
+        case '\n': return '\\n';
+        case '\r': return '\\r';
+        case '\b': return '\\b';
+        case '\t': return '\\t';
+        case '\x1a': return '\\Z';
+        default: return '\\' + s;
       }
-    })
+    });
   }
-  return "'"+val+"'"
-}
+  return "'" + val + "'";
+};
 
 SqlString.arrayToList = function(array, timeZone, dialect, field) {
   if (dialect === 'postgres') {
+    var valstr = '';
     if (array.map) {
-      var valstr = array.map(function(v) {
-        return SqlString.escape(v, true, timeZone, dialect, field)
-      }).join(',')
+      valstr = array.map(function(v) {
+        return SqlString.escape(v, true, timeZone, dialect, field);
+      }).join(',');
     } else {
-      var valstr = ""
       for (var i = 0; i < array.length; i++) {
-        valstr += SqlString.escape(array[i], true, timeZone, dialect, field) + ','
+        valstr += SqlString.escape(array[i], true, timeZone, dialect, field) + ',';
       }
-      valstr = valstr.slice(0,-1)
+      valstr = valstr.slice(0, -1);
     }
-    var ret = 'ARRAY[' + valstr + ']'
+    var ret = 'ARRAY[' + valstr + ']';
     if (!!field && !!field.type) {
-      ret += '::' + field.type.replace(/\(\d+\)/g, '')
+      ret += '::' + field.type.replace(/\(\d+\)/g, '');
     }
-    return ret
+    return ret;
   } else {
     if (array.map) {
       return array.map(function(v) {
         if (Array.isArray(v)) {
-          return '(' + SqlString.arrayToList(v, timeZone, dialect) + ')'
+          return '(' + SqlString.arrayToList(v, timeZone, dialect) + ')';
         }
-        return SqlString.escape(v, true, timeZone, dialect)
-      }).join(', ')
+        return SqlString.escape(v, true, timeZone, dialect);
+      }).join(', ');
     } else {
-      var valstr = ""
+      var valstr = '';
       for (var i = 0; i < array.length; i++) {
-        valstr += SqlString.escape(array[i], true, timeZone, dialect) + ', '
+        valstr += SqlString.escape(array[i], true, timeZone, dialect) + ', ';
       }
-      return valstr.slice(0, -2)
+      return valstr.slice(0, -2);
     }
   }
-}
+};
 
 SqlString.format = function(sql, values, timeZone, dialect) {
   values = [].concat(values);
 
   return sql.replace(/\?/g, function(match) {
     if (!values.length) {
-      return match
+      return match;
     }
 
-    return SqlString.escape(values.shift(), false, timeZone, dialect)
-  })
-}
+    return SqlString.escape(values.shift(), false, timeZone, dialect);
+  });
+};
 
 SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
-  return sql.replace(/\:+(?!\d)(\w+)/g, function (value, key) {
+  return sql.replace(/\:+(?!\d)(\w+)/g, function(value, key) {
     if ('postgres' === dialect && '::' === value.slice(0, 2)) {
-      return value
+      return value;
     }
 
     if (values.hasOwnProperty(key)) {
-      return SqlString.escape(values[key], false, timeZone, dialect)
+      return SqlString.escape(values[key], false, timeZone, dialect);
     } else {
-      throw new Error('Named parameter "' + value + '" has no value in the given object.')
+      throw new Error('Named parameter "' + value + '" has no value in the given object.');
     }
-  })
-}
+  });
+};
 
 SqlString.dateToString = function(date, timeZone, dialect) {
-  var dt = new Date(date)
+  var dt = new Date(date);
 
   // TODO: Ideally all dialects would work a bit more like this
-  if (dialect === "postgres") {
-    return moment(dt).zone('+00:00').format("YYYY-MM-DD HH:mm:ss.SSS Z")
+  if (dialect === 'postgres') {
+    return moment(dt).zone('+00:00').format('YYYY-MM-DD HH:mm:ss.SSS Z');
   }
 
   if (timeZone !== 'local') {
-    var tz = convertTimezone(timeZone)
+    var tz = convertTimezone(timeZone);
 
-    dt.setTime(dt.getTime() + (dt.getTimezoneOffset() * 60000))
+    dt.setTime(dt.getTime() + (dt.getTimezoneOffset() * 60000));
     if (tz !== false) {
-      dt.setTime(dt.getTime() + (tz * 60000))
+      dt.setTime(dt.getTime() + (tz * 60000));
     }
   }
 
-  return moment(dt).format("YYYY-MM-DD HH:mm:ss")
-}
+  return moment(dt).format('YYYY-MM-DD HH:mm:ss');
+};
 
 SqlString.bufferToString = function(buffer, dialect) {
-  var hex = ''
+  var hex = '';
   try {
-    hex = buffer.toString('hex')
+    hex = buffer.toString('hex');
   } catch (err) {
     // node v0.4.x does not support hex / throws unknown encoding error
     for (var i = 0; i < buffer.length; i++) {
-      var byte = buffer[i]
-      hex += zeroPad(byte.toString(16))
+      var byte = buffer[i];
+      hex += zeroPad(byte.toString(16));
     }
   }
 
   if (dialect === 'postgres') {
     // bytea hex format http://www.postgresql.org/docs/current/static/datatype-binary.html
-    return "E'\\\\x" + hex+ "'"
+    return "E'\\\\x" + hex + "'";
   }
-  return "X'" + hex+ "'"
-}
+  return "X'" + hex + "'";
+};
 
 SqlString.objectToValues = function(object, timeZone) {
-  var values = []
+  var values = [];
   for (var key in object) {
-    var value = object[key]
-    if(typeof value === 'function') {
+    var value = object[key];
+    if (typeof value === 'function') {
       continue;
     }
 
-    values.push(this.escapeId(key) + ' = ' + SqlString.escape(value, true, timeZone))
+    values.push(this.escapeId(key) + ' = ' + SqlString.escape(value, true, timeZone));
   }
 
-  return values.join(', ')
-}
+  return values.join(', ');
+};
 
 function zeroPad(number) {
-  return (number < 10) ? '0' + number : number
+  return (number < 10) ? '0' + number : number;
 }
 
 function convertTimezone(tz) {
-  if (tz == "Z") {
-    return 0
+  if (tz === 'Z') {
+    return 0;
   }
 
-  var m = tz.match(/([\+\-\s])(\d\d):?(\d\d)?/)
+  var m = tz.match(/([\+\-\s])(\d\d):?(\d\d)?/);
   if (m) {
-    return (m[1] == '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60
+    return (m[1] === '-' ? -1 : 1) * (parseInt(m[2], 10) + ((m[3] ? parseInt(m[3], 10) : 0) / 60)) * 60;
   }
-  return false
+  return false;
 }

--- a/lib/transaction-manager.js
+++ b/lib/transaction-manager.js
@@ -1,23 +1,23 @@
-"use strict";
+'use strict';
 
-var Utils = require('./utils')
+var Utils = require('./utils');
 
 var TransactionManager = module.exports = function(sequelize) {
-  this.sequelize         = sequelize
-  this.connectorManagers = {}
+  this.sequelize = sequelize;
+  this.connectorManagers = {};
 
   try {
-    this.ConnectorManager = require("./dialects/" + sequelize.getDialect() + "/connector-manager")
-  } catch(err) {
-    throw new Error("The dialect " + sequelize.getDialect() + " is not supported.")
+    this.ConnectorManager = require('./dialects/' + sequelize.getDialect() + '/connector-manager');
+  } catch (err) {
+    throw new Error('The dialect ' + sequelize.getDialect() + ' is not supported.');
   }
-}
+};
 
 TransactionManager.prototype.getConnectorManager = function(uuid) {
-  uuid = uuid || 'default'
+  uuid = uuid || 'default';
 
   if (!this.connectorManagers.hasOwnProperty(uuid)) {
-    var config = Utils._.extend({ uuid: uuid }, this.sequelize.config)
+    var config = Utils._.extend({ uuid: uuid }, this.sequelize.config);
 
     if (uuid !== 'default') {
       config.pool = Utils._.extend(
@@ -26,30 +26,30 @@ TransactionManager.prototype.getConnectorManager = function(uuid) {
         {
           minConnections: 1,
           maxConnections: 1,
-          useReplicaton:  false
+          useReplicaton: false
         }
-      )
-      config.keepDefaultTimezone = true
+      );
+      config.keepDefaultTimezone = true;
     }
 
-    this.connectorManagers[uuid] = new this.ConnectorManager(this.sequelize, config)
+    this.connectorManagers[uuid] = new this.ConnectorManager(this.sequelize, config);
   }
 
-  return this.connectorManagers[uuid]
-}
+  return this.connectorManagers[uuid];
+};
 
 TransactionManager.prototype.releaseConnectionManager = function(uuid) {
   this.connectorManagers[uuid].cleanup();
-  delete this.connectorManagers[uuid]
-}
+  delete this.connectorManagers[uuid];
+};
 
 TransactionManager.prototype.query = function(sql, callee, options) {
-  options      = options || {}
-  options.uuid = 'default'
+  options = options || {};
+  options.uuid = 'default';
 
   if (options.transaction) {
-    options.uuid = options.transaction.id
+    options.uuid = options.transaction.id;
   }
 
-  return this.getConnectorManager(options.uuid).query(sql, callee, options)
-}
+  return this.getConnectorManager(options.uuid).query(sql, callee, options);
+};

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -1,24 +1,24 @@
-"use strict";
+'use strict';
 
 var Utils = require('./utils')
-  , util  = require('util')
+  , util = require('util');
 
 /**
- * The transaction object is used to identify a running transaction. It is created by calling `Sequelize.transaction()`. 
+ * The transaction object is used to identify a running transaction. It is created by calling `Sequelize.transaction()`.
  *
  * To run a query under a transaction, you should pass the transaction in the options object.
  * @class Transaction
- */ 
+ */
 var Transaction = module.exports = function(sequelize, options) {
-  this.sequelize = sequelize
-  this.id        = Utils.generateUUID()
-  this.options   = Utils._.extend({
+  this.sequelize = sequelize;
+  this.id = Utils.generateUUID();
+  this.options = Utils._.extend({
     autocommit: true,
     isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ
-  }, options || {})
-}
+  }, options || {});
+};
 
-util.inherits(Transaction, Utils.CustomEventEmitter)
+util.inherits(Transaction, Utils.CustomEventEmitter);
 
 /**
  * The possible isolations levels to use when starting a transaction
@@ -35,11 +35,11 @@ util.inherits(Transaction, Utils.CustomEventEmitter)
  * @property ISOLATION_LEVELS
  */
 Transaction.ISOLATION_LEVELS = {
-  READ_UNCOMMITTED: "READ UNCOMMITTED",
-  READ_COMMITTED: "READ COMMITTED",
-  REPEATABLE_READ: "REPEATABLE READ",
-  SERIALIZABLE: "SERIALIZABLE"
-}
+  READ_UNCOMMITTED: 'READ UNCOMMITTED',
+  READ_COMMITTED: 'READ COMMITTED',
+  REPEATABLE_READ: 'REPEATABLE READ',
+  SERIALIZABLE: 'SERIALIZABLE'
+};
 
 /**
  * Possible options for row locking. Used in conjuction with `find` calls:
@@ -59,26 +59,26 @@ Transaction.ISOLATION_LEVELS = {
 Transaction.LOCK = Transaction.prototype.LOCK = {
   UPDATE: 'UPDATE',
   SHARE: 'SHARE'
-}
+};
 
 /**
  * Commit the transaction
- * 
+ *
  * @return {this}
- */ 
+ */
 Transaction.prototype.commit = function() {
   return this
     .sequelize
     .getQueryInterface()
     .commitTransaction(this, {})
     .proxy(this)
-    .done(this.cleanup.bind(this))
-}
+    .done(this.cleanup.bind(this));
+};
 
 
 /**
  * Rollback (abort) the transaction
- * 
+ *
  * @return {this}
  */
 Transaction.prototype.rollback = function() {
@@ -87,21 +87,26 @@ Transaction.prototype.rollback = function() {
     .getQueryInterface()
     .rollbackTransaction(this, {})
     .proxy(this)
-    .done(this.cleanup.bind(this))
-}
+    .done(this.cleanup.bind(this));
+};
 
 Transaction.prototype.prepareEnvironment = function(callback) {
-  var self             = this
-    , connectorManager = self.sequelize.transactionManager.getConnectorManager(this.id)
+  var self = this
+    , connectorManager = self.sequelize.transactionManager.getConnectorManager(this.id);
 
   this.begin(function() {
     self.setIsolationLevel(function() {
       self.setAutocommit(function() {
-        connectorManager.afterTransactionSetup(callback)
-      })
-    })
-  })
-}
+        connectorManager.afterTransactionSetup(callback);
+      });
+    });
+  });
+};
+
+// private
+var onError = function(err) {
+  this.emit('error', err);
+};
 
 Transaction.prototype.begin = function(callback) {
   this
@@ -109,8 +114,8 @@ Transaction.prototype.begin = function(callback) {
     .getQueryInterface()
     .startTransaction(this, {})
     .success(callback)
-    .error(onError.bind(this))
-}
+    .error(onError.bind(this));
+};
 
 Transaction.prototype.setAutocommit = function(callback) {
   this
@@ -118,8 +123,8 @@ Transaction.prototype.setAutocommit = function(callback) {
     .getQueryInterface()
     .setAutocommit(this, this.options.autocommit)
     .success(callback)
-    .error(onError.bind(this))
-}
+    .error(onError.bind(this));
+};
 
 Transaction.prototype.setIsolationLevel = function(callback) {
   this
@@ -127,15 +132,9 @@ Transaction.prototype.setIsolationLevel = function(callback) {
     .getQueryInterface()
     .setIsolationLevel(this, this.options.isolationLevel)
     .success(callback)
-    .error(onError.bind(this))
-}
+    .error(onError.bind(this));
+};
 
 Transaction.prototype.cleanup = function() {
-  this.sequelize.transactionManager.releaseConnectionManager(this.id)
-}
-
-// private
-
-var onError = function(err) {
-  this.emit('error', err)
-}
+  this.sequelize.transactionManager.releaseConnectionManager(this.id);
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,38 +1,38 @@
-"use strict";
+'use strict';
 
-var util               = require("util")
-  , DataTypes          = require("./data-types")
-  , SqlString          = require("./sql-string")
-  , lodash             = require("lodash")
-  , _string            = require('underscore.string')
+var util = require('util')
+  , DataTypes = require('./data-types')
+  , SqlString = require('./sql-string')
+  , lodash = require('lodash')
+  , _string = require('underscore.string')
   , ParameterValidator = require('./utils/parameter-validator')
-  , uuid               = require('node-uuid')
+  , uuid = require('node-uuid');
 
 var Utils = module.exports = {
   _: (function() {
-    var _  = lodash
-      , _s = _string
+    var _ = lodash
+      , _s = _string;
 
-    _.mixin(_s.exports())
+    _.mixin(_s.exports());
     _.mixin({
       includes: _s.include,
       camelizeIf: function(string, condition) {
-        var result = string
+        var result = string;
 
         if (condition) {
-          result = _.camelize(string)
+          result = _.camelize(string);
         }
 
-        return result
+        return result;
       },
       underscoredIf: function(string, condition) {
-        var result = string
+        var result = string;
 
         if (condition) {
-          result = _.underscored(string)
+          result = _.underscored(string);
         }
 
-        return result
+        return result;
       },
       /*
        * Returns an array with some falsy values removed. The values null, "", undefined and NaN are considered falsey.
@@ -44,85 +44,85 @@ var Utils = module.exports = {
 
         while (++index < length) {
           var value = array[index];
-          if (typeof value === "boolean" || value === 0 || value) {
+          if (typeof value === 'boolean' || value === 0 || value) {
             result.push(value);
           }
         }
         return result;
       }
-    })
+    });
 
-    return _
+    return _;
   })(),
   format: function(arr, dialect) {
     var timeZone = null;
     // Make a clone of the array beacuse format modifies the passed args
-    return SqlString.format(arr[0], arr.slice(1), timeZone, dialect)
+    return SqlString.format(arr[0], arr.slice(1), timeZone, dialect);
   },
   formatNamedParameters: function(sql, parameters, dialect) {
     var timeZone = null;
-    return SqlString.formatNamedParameters(sql, parameters, timeZone, dialect)
+    return SqlString.formatNamedParameters(sql, parameters, timeZone, dialect);
   },
   injectScope: function(scope, merge) {
-    var self = this
+    var self = this;
 
-    scope = scope || {}
-    self.scopeObj = self.scopeObj || {}
+    scope = scope || {};
+    self.scopeObj = self.scopeObj || {};
 
     if (Array.isArray(scope.where)) {
-      self.scopeObj.where = self.scopeObj.where || []
-      self.scopeObj.where.push(scope.where)
-      return true
+      self.scopeObj.where = self.scopeObj.where || [];
+      self.scopeObj.where.push(scope.where);
+      return true;
     }
 
-    if (typeof scope.order === "string") {
-      self.scopeObj.order = self.scopeObj.order || []
-      self.scopeObj.order[self.scopeObj.order.length] = scope.order
+    if (typeof scope.order === 'string') {
+      self.scopeObj.order = self.scopeObj.order || [];
+      self.scopeObj.order[self.scopeObj.order.length] = scope.order;
     }
 
     // Limit and offset are *always* merged.
     if (!!scope.limit) {
-      self.scopeObj.limit = scope.limit
+      self.scopeObj.limit = scope.limit;
     }
 
     if (!!scope.offset) {
-      self.scopeObj.offset = scope.offset
+      self.scopeObj.offset = scope.offset;
     }
 
     // Where objects are a mixed variable. Possible values are arrays, strings, and objects
     if (!!scope.where) {
       // Begin building our scopeObj
-      self.scopeObj.where = self.scopeObj.where || []
+      self.scopeObj.where = self.scopeObj.where || [];
 
       // Reset if we're merging!
       if (merge === true && !!scope.where && !!self.scopeObj.where) {
-        var scopeKeys = Object.keys(scope.where)
+        var scopeKeys = Object.keys(scope.where);
         self.scopeObj.where = self.scopeObj.where.map(function(scopeObj) {
-          if (!Array.isArray(scopeObj) && typeof scopeObj === "object") {
-            return lodash.omit.apply(undefined, [scopeObj].concat(scopeKeys))
+          if (!Array.isArray(scopeObj) && typeof scopeObj === 'object') {
+            return lodash.omit.apply(undefined, [scopeObj].concat(scopeKeys));
           } else {
-            return scopeObj
+            return scopeObj;
           }
         }).filter(function(scopeObj) {
-          return !lodash.isEmpty(scopeObj)
-        })
-        self.scopeObj.where = self.scopeObj.where.concat(scope.where)
+          return !lodash.isEmpty(scopeObj);
+        });
+        self.scopeObj.where = self.scopeObj.where.concat(scope.where);
       }
 
       if (Array.isArray(scope.where)) {
-        self.scopeObj.where.push(scope.where)
+        self.scopeObj.where.push(scope.where);
       }
-      else if (typeof scope.where === "object") {
-        Object.keys(scope.where).forEach(function(){
-          self.scopeObj.where.push(scope.where)
-        })
+      else if (typeof scope.where === 'object') {
+        Object.keys(scope.where).forEach(function() {
+          self.scopeObj.where.push(scope.where);
+        });
       } else { // Assume the value is a string
-        self.scopeObj.where.push([scope.where])
+        self.scopeObj.where.push([scope.where]);
       }
     }
 
     if (!!self.scopeObj.where) {
-      self.scopeObj.where = lodash.uniq(self.scopeObj.where)
+      self.scopeObj.where = lodash.uniq(self.scopeObj.where);
     }
   },
   // smartWhere can accept an array of {where} objects, or a single {where} object.
@@ -136,95 +136,95 @@ var Utils = module.exports = {
     var self = this
       , _where = {}
       , logic
-      , type
+      , type;
 
     (Array.isArray(whereArg) ? whereArg : [whereArg]).forEach(function(where) {
       // If it's an array we're already good... / it's in a format that can't be broken down further
       // e.g. Util.format['SELECT * FROM world WHERE status=?', 'hello']
       if (Array.isArray(where)) {
-        _where._ = where._ || {queries: [], bindings: []}
-        _where._.queries[_where._.queries.length] = where[0]
+        _where._ = where._ || {queries: [], bindings: []};
+        _where._.queries[_where._.queries.length] = where[0];
         if (where.length > 1) {
-          var values = where.splice(1)
-          if (dialect === "sqlite") {
+          var values = where.splice(1);
+          if (dialect === 'sqlite') {
             values.forEach(function(v, i) {
-              if (typeof v === "boolean") {
-                values[i] = (v === true ? 1 : 0)
+              if (typeof v === 'boolean') {
+                values[i] = (v === true ? 1 : 0);
               }
-            })
+            });
           }
-          _where._.bindings = _where._.bindings.concat(values)
+          _where._.bindings = _where._.bindings.concat(values);
         }
       }
-      else if (typeof where === "object") {
+      else if (typeof where === 'object') {
         // First iteration is trying to compress IN and NOT IN as much as possible...
         // .. reason being is that WHERE username IN (?) AND username IN (?) != WHERE username IN (?,?)
         Object.keys(where).forEach(function(i) {
           if (Array.isArray(where[i])) {
             where[i] = {
-              in: where[i]
-            }
+              in : where[i]
+            };
           }
-        })
+        });
 
         // Build our smart object
         Object.keys(where).forEach(function(i) {
-          type = typeof where[i]
-          _where[i] = _where[i] || {}
+          type = typeof where[i];
+          _where[i] = _where[i] || {};
 
           if (where[i] === null) {
             // skip nulls
           }
           else if (Array.isArray(where[i])) {
-            _where[i].in = _where[i].in || []
-            _where[i].in.concat(where[i])
+            _where[i].in = _where[i]. in || [];
+            _where[i]. in .concat(where[i]);
           }
           else if (Utils.isHash(where[i])) {
             Object.keys(where[i]).forEach(function(ii) {
               logic = self.getWhereLogic(ii, where[i][ii]);
 
-              switch(logic) {
+              switch (logic) {
               case 'IN':
-                _where[i].in = _where[i].in || []
-                _where[i].in = _where[i].in.concat(where[i][ii]);
-                break
+                _where[i].in = _where[i]. in || [];
+                _where[i].in = _where[i]. in .concat(where[i][ii]);
+                break;
               case 'NOT':
-                _where[i].not = _where[i].not || []
+                _where[i].not = _where[i].not || [];
                 _where[i].not = _where[i].not.concat(where[i][ii]);
-                break
+                break;
               case 'BETWEEN':
-                _where[i].between = _where[i].between || []
-                _where[i].between[_where[i].between.length] = [where[i][ii][0], where[i][ii][1]]
-                break
+                _where[i].between = _where[i].between || [];
+                _where[i].between[_where[i].between.length] = [where[i][ii][0], where[i][ii][1]];
+                break;
               case 'NOT BETWEEN':
-                _where[i].nbetween = _where[i].nbetween || []
-                _where[i].nbetween[_where[i].nbetween.length] = [where[i][ii][0], where[i][ii][1]]
-                break
+                _where[i].nbetween = _where[i].nbetween || [];
+                _where[i].nbetween[_where[i].nbetween.length] = [where[i][ii][0], where[i][ii][1]];
+                break;
               case 'JOIN':
-                _where[i].joined = _where[i].joined || []
-                _where[i].joined[_where[i].joined.length] = where[i][ii]
-                break
+                _where[i].joined = _where[i].joined || [];
+                _where[i].joined[_where[i].joined.length] = where[i][ii];
+                break;
               default:
-                _where[i].lazy = _where[i].lazy || {conditions: [], bindings: []}
-                _where[i].lazy.conditions[_where[i].lazy.conditions.length] = logic + ' ?'
-                _where[i].lazy.bindings = _where[i].lazy.bindings.concat(where[i][ii])
+                _where[i].lazy = _where[i].lazy || {conditions: [], bindings: []};
+                _where[i].lazy.conditions[_where[i].lazy.conditions.length] = logic + ' ?';
+                _where[i].lazy.bindings = _where[i].lazy.bindings.concat(where[i][ii]);
               }
-            })
+            });
           }
-          else if (type === "string" || type === "number" || type === "boolean" || Buffer.isBuffer(where[i])) {
-            _where[i].lazy = _where[i].lazy || {conditions: [], bindings: []}
-            if (type === "boolean") {
-              _where[i].lazy.conditions[_where[i].lazy.conditions.length] = '= ' + SqlString.escape(where[i], false, null, dialect) // sqlite is special
+          else if (type === 'string' || type === 'number' || type === 'boolean' || Buffer.isBuffer(where[i])) {
+            _where[i].lazy = _where[i].lazy || {conditions: [], bindings: []};
+            if (type === 'boolean') {
+              _where[i].lazy.conditions[_where[i].lazy.conditions.length] = '= ' + SqlString.escape(where[i], false, null, dialect); // sqlite is special
             } else {
-              _where[i].lazy.conditions[_where[i].lazy.conditions.length] = '= ?'
-              _where[i].lazy.bindings = _where[i].lazy.bindings.concat(where[i])
+              _where[i].lazy.conditions[_where[i].lazy.conditions.length] = '= ?';
+              _where[i].lazy.bindings = _where[i].lazy.bindings.concat(where[i]);
             }
           }
-        })
+        });
       }
-    })
+    });
 
-    return _where
+    return _where;
   },
   // Converts {smart where} object(s) into an array that's friendly for Utils.format()
   // NOTE: Must be applied/called from the QueryInterface
@@ -232,91 +232,91 @@ var Utils = module.exports = {
     var self = this
       , whereArgs = []
       , text = []
-      , columnName
+      , columnName;
 
-    if (typeof obj !== "object") {
-      return obj
+    if (typeof obj !== 'object') {
+      return obj;
     }
 
     for (var column in obj) {
-      if (column === "_") {
-        text[text.length] = obj[column].queries.join(' AND ')
+      if (column === '_') {
+        text[text.length] = obj[column].queries.join(' AND ');
         if (obj[column].bindings.length > 0) {
-          whereArgs = whereArgs.concat(obj[column].bindings)
+          whereArgs = whereArgs.concat(obj[column].bindings);
         }
       } else {
         Object.keys(obj[column]).forEach(function(condition) {
-          columnName = self.QueryInterface.quoteIdentifiers(column)
-          switch(condition) {
+          columnName = self.QueryInterface.quoteIdentifiers(column);
+          switch (condition) {
           case 'in':
-            text[text.length] = columnName + ' IN (' + obj[column][condition].map(function(){ return '?' }) + ')'
-            whereArgs = whereArgs.concat(obj[column][condition])
-            break
+            text[text.length] = columnName + ' IN (' + obj[column][condition].map(function() { return '?'; }) + ')';
+            whereArgs = whereArgs.concat(obj[column][condition]);
+            break;
           case 'not':
-            text[text.length] = columnName + ' NOT IN (' + obj[column][condition].map(function(){ return '?' }) + ')'
-            whereArgs = whereArgs.concat(obj[column][condition])
-            break
+            text[text.length] = columnName + ' NOT IN (' + obj[column][condition].map(function() { return '?'; }) + ')';
+            whereArgs = whereArgs.concat(obj[column][condition]);
+            break;
           case 'between':
             Object.keys(obj[column][condition]).forEach(function(row) {
-              text[text.length] = columnName + ' BETWEEN ? AND ?'
-              whereArgs = whereArgs.concat(obj[column][condition][row][0], obj[column][condition][row][1])
-            })
-            break
+              text[text.length] = columnName + ' BETWEEN ? AND ?';
+              whereArgs = whereArgs.concat(obj[column][condition][row][0], obj[column][condition][row][1]);
+            });
+            break;
           case 'nbetween':
             Object.keys(obj[column][condition]).forEach(function(row) {
-              text[text.length] = columnName + ' BETWEEN ? AND ?'
-              whereArgs = whereArgs.concat(obj[column][condition][row][0], obj[column][condition][row][1])
-            })
-            break
+              text[text.length] = columnName + ' BETWEEN ? AND ?';
+              whereArgs = whereArgs.concat(obj[column][condition][row][0], obj[column][condition][row][1]);
+            });
+            break;
           case 'joined':
             Object.keys(obj[column][condition]).forEach(function(row) {
-              text[text.length] = columnName + ' = ' + self.QueryInterface.quoteIdentifiers(obj[column][condition][row])
-            })
-            break
+              text[text.length] = columnName + ' = ' + self.QueryInterface.quoteIdentifiers(obj[column][condition][row]);
+            });
+            break;
           default: // lazy
-            text = text.concat(obj[column].lazy.conditions.map(function(val){ return columnName + ' ' + val }))
-            whereArgs = whereArgs.concat(obj[column].lazy.bindings)
+            text = text.concat(obj[column].lazy.conditions.map(function(val) { return columnName + ' ' + val; }));
+            whereArgs = whereArgs.concat(obj[column].lazy.bindings);
           }
-        })
+        });
       }
     }
 
-    return Utils._.compactLite([text.join(' AND ')].concat(whereArgs))
+    return Utils._.compactLite([text.join(' AND ')].concat(whereArgs));
   },
   getWhereLogic: function(logic, val) {
     switch (logic) {
     case 'join':
-      return 'JOIN'
+      return 'JOIN';
     case 'gte':
-      return '>='
+      return '>=';
     case 'gt':
-      return '>'
+      return '>';
     case 'lte':
-      return '<='
+      return '<=';
     case 'lt':
-      return '<'
+      return '<';
     case 'eq':
-      return '='
+      return '=';
     case 'ne':
-      return val === null ? 'IS NOT' : '!='
+      return val === null ? 'IS NOT' : '!=';
     case 'between':
     case '..':
-      return 'BETWEEN'
+      return 'BETWEEN';
     case 'nbetween':
     case 'notbetween':
     case '!..':
-      return 'NOT BETWEEN'
+      return 'NOT BETWEEN';
     case 'in':
-      return 'IN'
+      return 'IN';
     case 'not':
-      return 'NOT IN'
+      return 'NOT IN';
     case 'like':
-      return 'LIKE'
+      return 'LIKE';
     case 'nlike':
     case 'notlike':
-      return 'NOT LIKE'
+      return 'NOT LIKE';
     default:
-      return ''
+      return '';
     }
   },
   isHash: function(obj) {
@@ -325,65 +325,65 @@ var Utils = module.exports = {
   hasChanged: function(attrValue, value) {
     //If attribute value is Date, check value as a date
     if (Utils._.isDate(attrValue) && !Utils._.isDate(value)) {
-      value = new Date(value)
+      value = new Date(value);
     }
 
     if (Utils._.isDate(attrValue)) {
-      return attrValue.valueOf() !== value.valueOf()
+      return attrValue.valueOf() !== value.valueOf();
     }
 
     //If both of them are empty, don't set as changed
     if ((attrValue === undefined || attrValue === null || attrValue === '') && (value === undefined || value === null || value === '')) {
-      return false
+      return false;
     }
 
-    return attrValue !== value
+    return attrValue !== value;
   },
   argsArePrimaryKeys: function(args, primaryKeys) {
-    var result = (args.length == Object.keys(primaryKeys).length)
+    var result = (args.length === Object.keys(primaryKeys).length);
     if (result) {
       Utils._.each(args, function(arg) {
         if (result) {
           if (['number', 'string'].indexOf(typeof arg) !== -1) {
-            result = true
+            result = true;
           } else {
             result = (arg instanceof Date) || Buffer.isBuffer(arg);
           }
         }
-      })
+      });
     }
-    return result
+    return result;
   },
   combineTableNames: function(tableName1, tableName2) {
-    return (tableName1.toLowerCase() < tableName2.toLowerCase()) ? (tableName1 + tableName2) : (tableName2 + tableName1)
+    return (tableName1.toLowerCase() < tableName2.toLowerCase()) ? (tableName1 + tableName2) : (tableName2 + tableName1);
   },
 
   singularize: function(s, language) {
-    return Utils.Lingo[language || 'en'].isSingular(s) ? s : Utils.Lingo[language || 'en'].singularize(s)
+    return Utils.Lingo[language || 'en'].isSingular(s) ? s : Utils.Lingo[language || 'en'].singularize(s);
   },
 
   pluralize: function(s, language) {
-    return Utils.Lingo[language || 'en'].isPlural(s) ? s : Utils.Lingo[language || 'en'].pluralize(s)
+    return Utils.Lingo[language || 'en'].isPlural(s) ? s : Utils.Lingo[language || 'en'].pluralize(s);
   },
 
   removeCommentsFromFunctionString: function(s) {
-    s = s.replace(/\s*(\/\/.*)/g, '')
-    s = s.replace(/(\/\*[\n\r\s\S]*?\*\/)/mg, '')
+    s = s.replace(/\s*(\/\/.*)/g, '');
+    s = s.replace(/(\/\*[\n\r\s\S]*?\*\/)/mg, '');
 
-    return s
+    return s;
   },
 
   toDefaultValue: function(value) {
     if (lodash.isFunction(value)) {
-      return value()
+      return value();
     } else if (value === DataTypes.UUIDV1) {
-      return uuid.v1()
+      return uuid.v1();
     } else if (value === DataTypes.UUIDV4) {
-      return uuid.v4()
+      return uuid.v4();
     } else if (value === DataTypes.NOW) {
-      return Utils.now()
+      return Utils.now();
     } else {
-      return value
+      return value;
     }
   },
 
@@ -395,99 +395,99 @@ var Utils = module.exports = {
    * @return {boolean} yes / no.
    */
   defaultValueSchemable: function(value) {
-    if (typeof value === 'undefined') {return false}
+    if (typeof value === 'undefined') { return false; }
 
     // TODO this will be schemable when all supported db
     // have been normalized for this case
-    if (value === DataTypes.NOW) {return false}
+    if (value === DataTypes.NOW) { return false; }
 
-    if (value === DataTypes.UUIDV1 || value === DataTypes.UUIDV4) {return false}
+    if (value === DataTypes.UUIDV1 || value === DataTypes.UUIDV4) { return false; }
 
     if (lodash.isFunction(value)) {
-      return false
+      return false;
     }
 
-    return true
+    return true;
   },
 
   setAttributes: function(hash, identifier, instance, prefix) {
-    prefix = prefix || ''
+    prefix = prefix || '';
     if (this.isHash(identifier)) {
       this._.each(identifier, function(elem, key) {
-        hash[prefix + key] = Utils._.isString(instance) ? instance : Utils._.isObject(instance) ? instance[elem.key || elem] : null
-      })
+        hash[prefix + key] = Utils._.isString(instance) ? instance : Utils._.isObject(instance) ? instance[elem.key || elem] : null;
+      });
     } else {
-      hash[prefix + identifier] = Utils._.isString(instance) ? instance : Utils._.isObject(instance) ? instance.id : null
+      hash[prefix + identifier] = Utils._.isString(instance) ? instance : Utils._.isObject(instance) ? instance.id : null;
     }
 
-    return hash
+    return hash;
   },
 
   removeNullValuesFromHash: function(hash, omitNull, options) {
-    var result = hash
+    var result = hash;
 
-    options = options || {}
-    options.allowNull = options.allowNull || []
+    options = options || {};
+    options.allowNull = options.allowNull || [];
 
     if (omitNull) {
-      var _hash = {}
+      var _hash = {};
 
       Utils._.each(hash, function(val, key) {
         if (options.allowNull.indexOf(key) > -1 || key.match(/Id$/) || ((val !== null) && (val !== undefined))) {
-          _hash[key] = val
+          _hash[key] = val;
         }
-      })
+      });
 
-      result = _hash
+      result = _hash;
     }
 
-    return result
+    return result;
   },
 
   firstValueOfHash: function(obj) {
     for (var key in obj) {
       if (obj.hasOwnProperty(key))
-        return obj[key]
+        return obj[key];
     }
-    return null
+    return null;
   },
 
-  inherit: function(subClass, superClass) {
-    if (superClass.constructor == Function) {
+  inherit: function(SubClass, SuperClass) {
+    if (SuperClass.constructor === Function) {
       // Normal Inheritance
-      subClass.prototype = new superClass();
-      subClass.prototype.constructor = subClass;
-      subClass.prototype.parent = superClass.prototype;
+      SubClass.prototype = new SuperClass();
+      SubClass.prototype.constructor = SubClass;
+      SubClass.prototype.parent = SuperClass.prototype;
     } else {
       // Pure Virtual Inheritance
-      subClass.prototype = superClass;
-      subClass.prototype.constructor = subClass;
-      subClass.prototype.parent = superClass;
+      SubClass.prototype = SuperClass;
+      SubClass.prototype.constructor = SubClass;
+      SubClass.prototype.parent = SuperClass;
     }
 
-    return subClass;
+    return SubClass;
   },
 
 
   stack: function() {
     var orig = Error.prepareStackTrace;
-    Error.prepareStackTrace = function(_, stack){ return stack; };
+    Error.prepareStackTrace = function(_, stack) { return stack; };
     var err = new Error();
-    Error.captureStackTrace(err, stack);
-    var stack = err.stack;
+    Error.captureStackTrace(err, this);
+    var errStack = err.stack;
     Error.prepareStackTrace = orig;
-    return stack;
+    return errStack;
   },
 
   now: function(dialect) {
-    var now = new Date()
-    if(dialect != "postgres") now.setMilliseconds(0)
-    return now
+    var now = new Date();
+    if (dialect !== 'postgres') now.setMilliseconds(0);
+    return now;
   },
 
   tick: function(func) {
-    var tick = (global.hasOwnProperty('setImmediate') ? global.setImmediate : process.nextTick)
-    tick(func)
+    var tick = (global.hasOwnProperty('setImmediate') ? global.setImmediate : process.nextTick);
+    tick(func);
   },
 
   // Note: Use the `quoteIdentifier()` and `escape()` methods on the
@@ -495,118 +495,118 @@ var Utils = module.exports = {
 
   TICK_CHAR: '`',
   addTicks: function(s, tickChar) {
-    tickChar = tickChar || Utils.TICK_CHAR
-    return tickChar + Utils.removeTicks(s, tickChar) + tickChar
+    tickChar = tickChar || Utils.TICK_CHAR;
+    return tickChar + Utils.removeTicks(s, tickChar) + tickChar;
   },
   removeTicks: function(s, tickChar) {
-    tickChar = tickChar || Utils.TICK_CHAR
-    return s.replace(new RegExp(tickChar, 'g'), "")
+    tickChar = tickChar || Utils.TICK_CHAR;
+    return s.replace(new RegExp(tickChar, 'g'), '');
   },
 
   /*
    * Utility functions for representing SQL functions, and columns that should be escaped.
    * Please do not use these functions directly, use Sequelize.fn and Sequelize.col instead.
    */
-  fn: function (fn, args) {
-    this.fn = fn
-    this.args = args
+  fn: function(fn, args) {
+    this.fn = fn;
+    this.args = args;
   },
 
-  col: function (col) {
+  col: function(col) {
     if (arguments.length > 1) {
       col = Array.prototype.slice.call(arguments);
     }
-    this.col = col
+    this.col = col;
   },
 
-  cast: function (val, type) {
-    this.val  = val
-    this.type = (type || '').trim()
+  cast: function(val, type) {
+    this.val = val;
+    this.type = (type || '').trim();
   },
 
-  literal: function (val) {
-    this.val = val
+  literal: function(val) {
+    this.val = val;
   },
 
   asIs: function(val) {
-    this.val = val
+    this.val = val;
   },
 
   and: function(args) {
-    this.args = args
+    this.args = args;
   },
 
   or: function(args) {
-    this.args = args
+    this.args = args;
   },
 
   where: function(attribute, logic) {
-    this.attribute = attribute
-    this.logic = logic
+    this.attribute = attribute;
+    this.logic = logic;
   },
 
   generateUUID: function() {
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-      var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8)
-      return v.toString(16)
-    })
+      var r = Math.random() * 16 | 0, v = c === 'x' ? r : (r & 0x3 | 0x8);
+      return v.toString(16);
+    });
   },
 
   validateParameter: function(value, expectation, options) {
-    return ParameterValidator.check(value, expectation, options)
+    return ParameterValidator.check(value, expectation, options);
   }
-}
+};
 
-Utils.condition = Utils.where
+Utils.condition = Utils.where;
 
-Utils.and.prototype._isSequelizeMethod = 
-Utils.or.prototype._isSequelizeMethod = 
-Utils.where.prototype._isSequelizeMethod = 
-Utils.literal.prototype._isSequelizeMethod = 
-Utils.cast.prototype._isSequelizeMethod = 
-Utils.fn.prototype._isSequelizeMethod = 
-Utils.col.prototype._isSequelizeMethod = true
+Utils.and.prototype._isSequelizeMethod =
+Utils.or.prototype._isSequelizeMethod =
+Utils.where.prototype._isSequelizeMethod =
+Utils.literal.prototype._isSequelizeMethod =
+Utils.cast.prototype._isSequelizeMethod =
+Utils.fn.prototype._isSequelizeMethod =
+Utils.col.prototype._isSequelizeMethod = true;
 
 // I know this may seem silly, but this gives us the ability to recognize whether
 // or not we should be escaping or if we should trust the user. Basically, it
 // keeps things in perspective and organized.
 Utils.literal.prototype.toString = function() {
-  return this.val
-}
-Utils.asIs.prototype = Utils.literal.prototype
+  return this.val;
+};
+Utils.asIs.prototype = Utils.literal.prototype;
 
 Utils.cast.prototype.toString = function(queryGenerator) {
   if (!this.val instanceof Utils.fn && !this.val instanceof Utils.col && !this.val instanceof Utils.literal) {
-    this.val = queryGenerator.escape(this.val)
+    this.val = queryGenerator.escape(this.val);
   } else {
-    this.val = this.val.toString(queryGenerator)
-  } 
+    this.val = this.val.toString(queryGenerator);
+  }
 
-  return 'CAST(' + this.val + ' AS ' + this.type.toUpperCase() + ')'
-}
+  return 'CAST(' + this.val + ' AS ' + this.type.toUpperCase() + ')';
+};
 
 Utils.fn.prototype.toString = function(queryGenerator, parentModel) {
-  return this.fn + '(' + this.args.map(function (arg) {
+  return this.fn + '(' + this.args.map(function(arg) {
     if (arg instanceof Utils.fn || arg instanceof Utils.col) {
-      return arg.toString(queryGenerator, parentModel)
+      return arg.toString(queryGenerator, parentModel);
     } else {
-      return queryGenerator.escape(arg)
+      return queryGenerator.escape(arg);
     }
-  }).join(', ') + ')'
-}
+  }).join(', ') + ')';
+};
 
-Utils.col.prototype.toString = function (queryGenerator, parentModel) {
+Utils.col.prototype.toString = function(queryGenerator, parentModel) {
   if (Array.isArray(this.col)) {
     if (!parentModel) {
-      throw new Error('Cannot call Sequelize.col() with array outside of order / group clause')
+      throw new Error('Cannot call Sequelize.col() with array outside of order / group clause');
     }
   } else if (this.col.indexOf('*') === 0) {
-    return '*'
+    return '*';
   }
-  return queryGenerator.quote(this.col, parentModel)
-}
+  return queryGenerator.quote(this.col, parentModel);
+};
 
-Utils.CustomEventEmitter = require(__dirname + "/emitters/custom-event-emitter")
-Utils.Promise = require(__dirname + "/promise")
-Utils.QueryChainer = require(__dirname + "/query-chainer")
-Utils.Lingo = require("lingo")
+Utils.CustomEventEmitter = require(__dirname + '/emitters/custom-event-emitter');
+Utils.Promise = require(__dirname + '/promise');
+Utils.QueryChainer = require(__dirname + '/query-chainer');
+Utils.Lingo = require('lingo');

--- a/lib/utils/parameter-validator.js
+++ b/lib/utils/parameter-validator.js
@@ -1,93 +1,93 @@
-"use strict";
+'use strict';
 
 var cJSON = require('circular-json')
-  , _ = require('lodash') // Don't require Utils here, as it creates a circular dependency
+  , _ = require('lodash'); // Don't require Utils here, as it creates a circular dependency
 
-var ParameterValidator = module.exports = {
-  check: function(value, expectation, options) {
-    options = _.extend({
-      throwError:         true,
-      deprecated:         false,
-      deprecationWarning: generateDeprecationWarning(value, expectation, options),
-      onDeprecated:       function(s) { console.log('DEPRECATION WARNING:', s) },
-      index:              null,
-      method:             null,
-      optional:           false
-    }, options || {})
-
-    if (options.optional && ((value === undefined) || (value === null)) ) {
-      return true
-    }
-
-    if (value === undefined) {
-      throw new Error('No value has been passed.')
-    }
-
-    if (expectation === undefined) {
-      throw new Error('No expectation has been passed.')
-    }
-
-    return false
-      || validateDeprication(value, expectation, options)
-      || validate(value, expectation, options)
+var extractClassName = function(o) {
+  if (typeof o === 'string') {
+    return o;
+  } else if (!!o) {
+    return o.toString().match(/function ([^\(]+)/)[1];
+  } else {
+    return 'undefined';
   }
-}
+};
 
 var generateDeprecationWarning = function(value, expectation, options) {
-  options = options || {}
+  options = options || {};
 
   if (options.method && options.index) {
     return [
       'The',
-      {1:'first',2:'second',3:'third',4:'fourth',5:'fifth'}[options.index],
+      {1: 'first', 2: 'second', 3: 'third', 4: 'fourth', 5: 'fifth'}[options.index],
       'parameter of',
       options.method,
       'should be a',
       extractClassName(expectation) + '!'
-    ].join(" ")
+    ].join(' ');
   } else {
-    return ["Expected", cJSON.stringify(value), "to be", extractClassName(expectation) + '!'].join(" ")
+    return ['Expected', cJSON.stringify(value), 'to be', extractClassName(expectation) + '!'].join(' ');
   }
-}
+};
 
 var matchesExpectation = function(value, expectation) {
   if (typeof expectation === 'string') {
-    return (typeof value === expectation.toString())
+    return (typeof value === expectation.toString());
   } else {
-    return (value instanceof expectation)
+    return (value instanceof expectation);
   }
-}
+};
 
 var validateDeprication = function(value, expectation, options) {
   if (options.deprecated) {
     if (matchesExpectation(value, options.deprecated)) {
-      options.onDeprecated(options.deprecationWarning)
-      return true
+      options.onDeprecated(options.deprecationWarning);
+      return true;
     }
   }
-}
+};
 
 var validate = function(value, expectation, options) {
-  var result = matchesExpectation(value, expectation)
+  var result = matchesExpectation(value, expectation);
 
   if (result) {
-    return result
+    return result;
   } else if (!options.throwError) {
+    return false;
+  } else {
+    var _value = (value === null) ? 'null' : value.toString()
+      , _expectation = extractClassName(expectation);
+
+    throw new Error('The parameter (value: ' + _value + ') is no ' + _expectation + '.');
+  }
+};
+
+var ParameterValidator = module.exports = {
+  check: function(value, expectation, options) {
+    options = _.extend({
+      throwError: true,
+      deprecated: false,
+      deprecationWarning: generateDeprecationWarning(value, expectation, options),
+      onDeprecated: function(s) { console.log('DEPRECATION WARNING:', s); },
+      index: null,
+      method: null,
+      optional: false
+    }, options || {});
+
+    if (options.optional && ((value === undefined) || (value === null))) {
+      return true;
+    }
+
+    if (value === undefined) {
+      throw new Error('No value has been passed.');
+    }
+
+    if (expectation === undefined) {
+      throw new Error('No expectation has been passed.');
+    }
+
     return false
-  } else {
-    var _value       = (value === null) ? 'null' : value.toString()
-      , _expectation = extractClassName(expectation)
-
-    throw new Error('The parameter (value: ' + _value + ') is no ' + _expectation + '.')
+      || validateDeprication(value, expectation, options)
+      || validate(value, expectation, options);
   }
-}
-
-var extractClassName = function(o) {
-  if (typeof o === 'string') {
-    return o
-  } else if (!!o) {
-    return o.toString().match(/function ([^\(]+)/)[1]
-  } else {
-    return 'undefined'
-  }
-}
+};


### PR DESCRIPTION
A few passes of fixjsstyle, gjslint and jshint were used to clean up the codebase. Most obvious change is a forced consistent use of semicolons everywhere. There were a number of errors elicited in the process (unused variables mostly), as well as consistent coerced comparison issues (===, !==)
