### PR TITLE
Test for includes with find using both hasMany and belongsTo

### DIFF
--- a/test/model/attributes.test.js
+++ b/test/model/attributes.test.js
@@ -201,7 +201,7 @@ describe(Support.getTestDialectTeaser("Model"), function () {
           users.forEach(function (user) {
             expect(user.get('name')).to.be.ok;
             expect(user.get('tasks')[0].get('title')).to.equal('DoDat');
-            expect(user.get('tasks')[0].get('comments')).to.be;
+            expect(user.get('tasks')[0].get('comments')).to.be.ok;
           });
         });
       });


### PR DESCRIPTION
Test for currently failing find with includes where primary attribute has renamed field property
