### PR TITLE
Fix foreign key creation for mysql

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -54,15 +54,17 @@ module.exports = (function() {
 
           if (Utils._.includes(dataType, 'PRIMARY KEY')) {
             primaryKeys.push(attr)
-            attrStr.push(this.quoteIdentifier(attr) + " " + dataType.replace(/PRIMARY KEY/, ''))
-          } else if (Utils._.includes(dataType, 'REFERENCES')) {
+            dataType = dataType.replace(/PRIMARY KEY/, '');
+          }
+
+          if (Utils._.includes(dataType, 'REFERENCES')) {
             // MySQL doesn't support inline REFERENCES declarations: move to the end
             var m = dataType.match(/^(.+) (REFERENCES.*)$/)
-            attrStr.push(this.quoteIdentifier(attr) + " " + m[1])
+            dataType = m[1];
             foreignKeys[attr] = m[2]
-          } else {
-            attrStr.push(this.quoteIdentifier(attr) + " " + dataType)
           }
+
+          attrStr.push(this.quoteIdentifier(attr) + " " + dataType)
         }
       }
 

--- a/test/mysql/query-generator.test.js
+++ b/test/mysql/query-generator.test.js
@@ -115,6 +115,10 @@ if (Support.dialectIsMySQL()) {
         {
           arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)', otherId: 'INTEGER REFERENCES `otherTable` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION'}],
           expectation: "CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255), `otherId` INTEGER, FOREIGN KEY (`otherId`) REFERENCES `otherTable` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION) ENGINE=InnoDB;"
+        },
+        {
+          arguments: ['myTable', {id: 'INTEGER PRIMARY KEY REFERENCES `otherTable` (`id`)'}],
+          expectation: "CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER , PRIMARY KEY (`id`), FOREIGN KEY (`id`) REFERENCES `otherTable` (`id`)) ENGINE=InnoDB;"
         }
       ],
 


### PR DESCRIPTION
(Previously filed as issue #1817)

When creating a foreign key that is also a primary key, the mysql query
generator does not move the foreign key definition from the inline
attribute to the end of the table definition.
