### PR TITLE
[Ref #1824] Fix TypeError if got empty rows from findAndCountAll() with group

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -617,7 +617,8 @@ module.exports = (function() {
       options.limit = null
 
       this.find(options, {raw: true, transaction: options.transaction}).proxy(emitter, {events: ['sql', 'error']}).success(function (result) {
-        emitter.emit('success', parseInt(result.count, 10))
+        var count = (result && result.count) ? parseInt(result.count, 10) : 0
+        emitter.emit('success', count)
       })
     }.bind(this)).run()
   }


### PR DESCRIPTION
This error does not exist in version 2.0.0-dev11, so that I have not find out the origin of the bug, and make this fix for version 1.7.x.
