### PR TITLE
Downward migrations don't work properly

### DIFF
--- a/test/migrator.test.js
+++ b/test/migrator.test.js
@@ -156,16 +156,20 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
       it("executes migration #20111117063700 correctly up (createTable) and downwards (dropTable)", function(done) {
         var self = this
-
-        this.sequelize.getQueryInterface().showAllTables().success(function(tableNames) {
-          tableNames = tableNames.filter(function(e){ return e != 'SequelizeMeta' })
-          expect(tableNames).to.eql([ 'Person' ])
-
-          self.migrator.migrate({ method: 'down' }).success(function() {
-            self.sequelize.getQueryInterface().showAllTables().success(function(tableNames) {
-              tableNames = tableNames.filter(function(e){ return e != 'SequelizeMeta' })
-              expect(tableNames).to.eql([])
-              done()
+        this.init({
+        }, function(migrator) {
+          self.migrator = migrator
+          self.sequelize.getQueryInterface().showAllTables().success(function(tableNames) {
+            tableNames = tableNames.filter(function(e){ return e != 'SequelizeMeta' })
+            expect(tableNames).to.eql([ 'Person' ])
+            self.migrator.migrate({ method: 'up' }).success(function() {
+              self.migrator.migrate({ method: 'down' }).success(function() {
+                self.sequelize.getQueryInterface().showAllTables().success(function(tableNames) {
+                  tableNames = tableNames.filter(function(e){ return e != 'SequelizeMeta' })
+                  expect(tableNames).to.eql([])
+                  done()
+                })
+              })
             })
           })
         })


### PR DESCRIPTION
Migrator always fetches migrations that are not done yet, so when there's {method: 'down'} option cannot work because migrator cannot access any migration that could actually be reverted.
