### PR TITLE
Fixing issues with rollback

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -25,6 +25,48 @@ module.exports = (function() {
     }
   });
 
+  function executeMigrations(migrations, self, chainer, options, from, emitter) {
+    if (migrations.length === 0) {
+      self.sequelize.log('There are no pending migrations.');
+    } else {
+      self.sequelize.log('Running migrations...');
+    }
+    migrations.forEach(function (migration) {
+      var migrationTime;
+
+      chainer.add(migration, 'execute', [options], {
+        before: function (migration) {
+          self.sequelize.log(migration.filename);
+          migrationTime = process.hrtime();
+        },
+
+        after: function (migration) {
+          migrationTime = process.hrtime(migrationTime);
+          migrationTime = Math.round((migrationTime[0] * 1000) + (migrationTime[1] / 1000000));
+
+          self.sequelize.log('Completed in ' + migrationTime + 'ms');
+        },
+
+        success: function (migration, callback) {
+          if (options.method === 'down') {
+            deleteUndoneMigration.call(self, from, migration, callback);
+          } else {
+            saveSuccessfulMigration.call(self, from, migration, callback);
+          }
+        }
+      });
+    });
+
+    chainer
+      .runSerially({ skipOnError: true })
+      .success(function () {
+        emitter.emit('success', null);
+      })
+      .error(function (err) {
+        emitter.emit('error', err);
+      });
+  }
+
   Migrator.prototype.migrate = function(options) {
     var self = this;
 
@@ -33,7 +75,7 @@ module.exports = (function() {
     }, options || {});
 
     return new Utils.CustomEventEmitter(function(emitter) {
-      self.getUndoneMigrations(function(err, migrations) {
+      self.getUndoneMigrations(options.method, function(err, migrations) {
         if (err) {
           emitter.emit('error', err);
         } else {
@@ -41,57 +83,33 @@ module.exports = (function() {
             , from = migrations[0];
 
           if (options.method === 'down') {
-            migrations.reverse();
-          }
-
-          if (migrations.length === 0) {
-            self.sequelize.log('There are no pending migrations.');
-          } else {
-            self.sequelize.log('Running migrations...');
-          }
-
-          migrations.forEach(function(migration) {
-            var migrationTime;
-
-            chainer.add(migration, 'execute', [options], {
-              before: function(migration) {
-                self.sequelize.log(migration.filename);
-                migrationTime = process.hrtime();
-              },
-
-              after: function(migration) {
-                migrationTime = process.hrtime(migrationTime);
-                migrationTime = Math.round((migrationTime[0] * 1000) + (migrationTime[1] / 1000000));
-
-                self.sequelize.log('Completed in ' + migrationTime + 'ms');
-              },
-
-              success: function(migration, callback) {
-                if (options.method === 'down') {
-                  deleteUndoneMigration.call(self, from, migration, callback);
-                } else {
-                  saveSuccessfulMigration.call(self, from, migration, callback);
-                }
+            self.options.to = self.options.to || migrations[migrations.length-1].migrationId;
+            filterFrom(migrations, self.options.to, function(err, migrations){
+              if(migrations.length) {
+                migrations.reverse();
               }
+              executeMigrations(migrations, self, chainer, options, from, emitter);
             });
-          });
+          } else {
+            executeMigrations(migrations, self, chainer, options, from, emitter);
+          }
 
-          chainer
-            .runSerially({ skipOnError: true })
-            .success(function() { emitter.emit('success', null); })
-            .error(function(err) { emitter.emit('error', err); });
         }
       });
     }).run();
   };
+  function filterFrom(migrations, from, callback, options) {
+    var result = migrations.filter(function(migration) { return migration.isAfter(from, options); });
+    callback && callback(null, result);
+  }
 
-  Migrator.prototype.getUndoneMigrations = function(callback)  {
+  Migrator.prototype.getUndoneMigrations = function(method, callback)  {
     var self = this;
 
-    var filterFrom = function(migrations, from, callback, options) {
-      var result = migrations.filter(function(migration) { return migration.isAfter(from, options); });
-      callback && callback(null, result);
-    };
+    if(["up","down"].indexOf(method)<0) {
+      throw "method should be either up/down, given "+method;
+    }
+
     var filterTo = function(migrations, to, callback, options) {
       var result = migrations.filter(function(migration) { return migration.isBefore(to, options); });
       callback && callback(null, result);
@@ -120,18 +138,29 @@ module.exports = (function() {
     } else {
       getLastMigrationIdFromDatabase.call(this).success(function(lastMigrationId) {
         if (lastMigrationId) {
-          filterFrom(migrations, lastMigrationId, function(err, migrations) {
+          if (method === "up") {
+            filterFrom(migrations, lastMigrationId, function(err, migrations) {
+              if (self.options.to) {
+                filterTo(migrations, self.options.to, callback);
+              } else {
+                callback && callback(null, migrations);
+              }
+            }, { withoutEqual: true });
+          } else {
+
+            filterTo(migrations, lastMigrationId, function(err, migrations){
+              callback && callback(null, migrations);
+            });
+          }
+        } else {
+          if (method === "up") {
             if (self.options.to) {
               filterTo(migrations, self.options.to, callback);
             } else {
               callback && callback(null, migrations);
             }
-          }, { withoutEqual: true });
-        } else {
-          if (self.options.to) {
-            filterTo(migrations, self.options.to, callback);
           } else {
-            callback && callback(null, migrations);
+            callback && callback(null, []);
           }
         }
       }).error(function(err) {
@@ -140,31 +169,31 @@ module.exports = (function() {
     }
   };
 
+  Migrator.prototype.sequelizeMeta = function() {
+    var storedDAO = this.sequelize.daoFactoryManager.getDAO('SequelizeMeta')
+      , SequelizeMeta = storedDAO;
+    if (storedDAO) {
+      return storedDAO;
+    } else {
+      return this.sequelize.define('SequelizeMeta', {
+        from: DataTypes.STRING,
+        to: DataTypes.STRING
+      }, {
+        timestamps: false
+      });
+    }
+  };
+
   Migrator.prototype.findOrCreateSequelizeMetaDAO = function(syncOptions) {
     var self = this;
 
     return new Utils.CustomEventEmitter(function(emitter) {
-      var storedDAO = self.sequelize.daoFactoryManager.getDAO('SequelizeMeta')
-        , SequelizeMeta = storedDAO;
-
-      if (!storedDAO) {
-        SequelizeMeta = self.sequelize.define('SequelizeMeta', {
-          from: DataTypes.STRING,
-          to: DataTypes.STRING
-        }, {
-          timestamps: false
-        });
-      }
-
       // force sync when model has newly created or if syncOptions are passed
-      if (!storedDAO || syncOptions) {
-        SequelizeMeta
-          .sync(syncOptions || {})
-          .success(function() { emitter.emit('success', SequelizeMeta); })
-          .error(function(err) { emitter.emit('error', err); });
-      } else {
-        emitter.emit('success', SequelizeMeta);
-      }
+      var SequelizeMeta = self.sequelizeMeta();
+      SequelizeMeta
+        .sync(syncOptions || {})
+        .success(function() { emitter.emit('success', SequelizeMeta); })
+        .error(function(err) { emitter.emit('error', err); });
     }).run();
   };
 

--- a/test/migrator.test.js
+++ b/test/migrator.test.js
@@ -33,7 +33,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
         filesFilter: /\.coffee$/,
         to: 20111130161100
       }, function(migrator) {
-        migrator.getUndoneMigrations(function(err, migrations) {
+        migrator.getUndoneMigrations("up", function(err, migrations) {
           expect(err).to.be.null
           expect(migrations).to.have.length(1)
           done()
@@ -43,7 +43,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
     it("returns no files if timestamps are after the files timestamp", function(done) {
       this.init({ from: 20140101010101 }, function(migrator) {
-        migrator.getUndoneMigrations(function(err, migrations) {
+        migrator.getUndoneMigrations("up", function(err, migrations) {
           expect(err).to.be.null
           expect(migrations.length).to.equal(0)
           done()
@@ -53,7 +53,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
     it("returns only files between from and to", function(done) {
       this.init({ from: 19700101000000, to: 20111117063700 }, function(migrator) {
-        migrator.getUndoneMigrations(function(err, migrations) {
+        migrator.getUndoneMigrations("up", function(err, migrations) {
           expect(err).to.be.null
           expect(migrations.length).to.equal(1)
           expect(migrations[migrations.length - 1].filename).to.equal('20111117063700-createPerson.js')
@@ -64,7 +64,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
     it("returns exactly the migration which is defined in from and to", function(done) {
       this.init({ from: 20111117063700, to: 20111117063700 }, function(migrator) {
-        migrator.getUndoneMigrations(function(err, migrations) {
+        migrator.getUndoneMigrations("up", function(err, migrations) {
           expect(err).to.be.null
           expect(migrations.length).to.equal(1)
           expect(migrations[migrations.length - 1].filename).to.equal('20111117063700-createPerson.js')
@@ -75,7 +75,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
     it("returns also the file which is exactly options.from or options.to", function(done) {
       this.init({ from: 20111117063700, to: 20111130161100 }, function(migrator) {
-        migrator.getUndoneMigrations(function(err, migrations) {
+        migrator.getUndoneMigrations("up", function(err, migrations) {
           expect(err).to.be.null
           expect(migrations).to.have.length(2)
           expect(migrations[0].filename).to.equal('20111117063700-createPerson.js')
@@ -87,7 +87,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
     it("returns all files to options.to if no options.from is defined", function(done) {
       this.init({ to: 20111130161100 }, function(migrator) {
-        migrator.getUndoneMigrations(function(err, migrations) {
+        migrator.getUndoneMigrations("up", function(err, migrations) {
           expect(err).to.be.null
           expect(migrations).to.have.length(2)
           done()
@@ -98,7 +98,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
     it("returns all files from last migration id stored in database", function(done) {
       this.init(undefined, function(migrator, SequelizeMeta) {
         SequelizeMeta.create({ from: null, to: 20111117063700 }).success(function() {
-          migrator.getUndoneMigrations(function(err, migrations) {
+          migrator.getUndoneMigrations("up", function(err, migrations) {
             expect(err).to.be.null
             expect(migrations).to.have.length(14)
             expect(migrations[0].filename).to.equal('20111130161100-emptyMigration.js')


### PR DESCRIPTION
Rollback was almost completely broken, there were basically two main issues:

1) The calculations of what migrations needs to be rolled-back was incorrect for rollback,
Since it was actually doing "what migrations need to be run"
2) The default behaviour of rollback was weird, it tried to rollback ALL migrations,
which, unlike forward migrations, is really really weird, since most of the time you
only want to rollback the last migration, and be very granular with it.

The code is still a mess IMHO, i've did my best to organize it.. but there are a few missing
helpers and objects..
