### PR TITLE
Bug fix - corrected detection of relative paths in import function.

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -280,7 +280,7 @@ module.exports = (function() {
 
   Sequelize.prototype.import = function(path) {
     // is it a relative path?
-    if (Path.normalize(path).indexOf(path.sep) !== 0) {
+    if(Path.normalize(path) !== Path.resolve(path)){
       // make path relative to the caller
       var callerFilename = Utils.stack()[1].getFileName()
         , callerPath     = Path.dirname(callerFilename)


### PR DESCRIPTION
Original check was using "path.sep" (which is undefined) instead of "Path.sep".  Also, the check failed to catch absolute paths in Windows when the path starts with a drive letter (ex. "C:\folder\file.js").
