### PR TITLE
Create literal-in-included-model-attributes.js

### DIFF
--- a/test/include.test.js
+++ b/test/include.test.js
@@ -801,25 +801,19 @@ describe(Support.getTestDialectTeaser("Include"), function () {
       var PostComment = this.sequelize.define('PostComment',{})
       Post.hasMany(PostComment)
       this.sequelize.sync({ force: true }).done(function(){
-        try {
-	  Post.findAll({
-            include: [
-              { model: PostComment } 
-            ],
-            attributes: [Sequelize.literal('EXISTS(SELECT 1) AS "PostComment.someProperty"')]
-          }).done(function(err,posts){
-            expect(err).to.be.null
-            expect(posts).to.be.an(Array)
-            expect(posts.length).to.be.equal(0)
-            done()
-          })
-        } catch(err) {
-          // if any errors occured it should not be related to literal attribute
-          if(err){
-            expect(err.message).not.to.be.equal("Object EXISTS(SELECT 1) AS \"PostComment.someProperty\" has no method 'replace'")
-          }
+        
+	Post.findAll({
+          include: [
+            { model: PostComment } 
+          ],
+          attributes: [Sequelize.literal('EXISTS(SELECT 1) AS "PostComment.someProperty"')]
+        }).done(function(err,posts){
+          expect(err).to.be.null
+          expect(posts).to.be.an(Array)
+          expect(posts.length).to.be.equal(0)
           done()
-        }
+        })
+        
       })
     })
   })


### PR DESCRIPTION
This is failing test for using `Sequelize.literal(...)` as one of attributes in model that is included in another model (via `include`). It seems that sequelize does not checks if any attribute of included model is instance of `Sequelize.literal()`.

There are actually 2 test in this file:
1. First one passes because `Sequelize.literal` is in root query model attributes
2. Second one fails because `Sequelize.literal` is in query included model attributes
