### PR TITLE
Fixes has-many-dobule-linked join table attribute changes on injected setter

### DIFF
--- a/lib/associations/has-many-double-linked.js
+++ b/lib/associations/has-many-double-linked.js
@@ -128,8 +128,8 @@ module.exports = (function() {
           attributes: Utils._.defaults({}, throughAttributes, defaultAttributes)
         }
 
-        changedAssociation.where[self.association.identifier] = self.instance[self.association.identifier] || self.instance.id
-        changedAssociation.where[foreignIdentifier] = newObj[foreignIdentifier] || newObj.id
+        changedAssociation.where[self.association.identifier] = self.instance[self.association.identifier] || self.instance[self.association.source.primaryKeyAttributes[0]] || self.instance.id
+        changedAssociation.where[foreignIdentifier] = newObj[foreignIdentifier] || newObj[self.association.target.primaryKeyAttributes[0]] || newObj.id
 
         if (Object.keys(changedAssociation.attributes).length) {
           changedAssociations.push(changedAssociation)


### PR DESCRIPTION
I'm not quite sure how the first version should've worked since the foreign
keys are afaik always prefixed with the table name which results in
mytable.mytable_id.

This commit keeps the old behavior as first try to remain backwards compatible.

Would be nice to see this as well as my other commit in NPM version of sequelize.
