### PR TITLE
[BUG] 956: Connection failing using SSL with PostgresSql

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -588,7 +588,7 @@ module.exports = (function() {
     },
 
     databaseConnectionUri: function(config) {
-      var template = '<%= protocol %>://<%= user %>:<%= password %>@<%= host %><% if(port) { %>:<%= port %><% } %>/<%= database %><% if(ssl) { %>?ssl=<%= ssl %><% } %>'
+      var template = '<%= protocol %>://<%= user %>:<%= password %>@<%= host %><% if(port) { %>:<%= port %><% } %>/<%= database %><% if(ssl) { %>?ssl=<%= ssl %><% } %>';
 
       return Utils._.template(template)({
         user: config.username,


### PR DESCRIPTION
This adds ssl to the query string to connect using ssl with pg.  The value was not being pushed all the way through to the uri.  I wasn't sure how to write a test with this because of the setup it would take on the db side of it.  Any help doing that is appreciated.

@mickhansen this is the code that @nickarnold added for our company project.  Please help get this tested and into the code base.
