### PR TITLE
Pass options to getTableName function

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -81,7 +81,7 @@ module.exports = (function() {
       } else {
         dataType = attribute;
       }
-      
+
       if (dataType === undefined) {
         throw new Error('Unrecognized data type for field ' + name);
       }
@@ -449,7 +449,7 @@ module.exports = (function() {
    * Get the tablename of the model, taking schema into account. The method will return The name as a string if the model has no schema,
    * or an object with `tableName`, `schema` and `delimiter` properties.
    *
-   * @param {Object} [options]
+   * @param {Object}  options  The hash of options from any query. You can use one model to access tables with matching schemas by overriding `getTableName` and using custom key/values to alter the name of the table. (eg. subscribers_1, subscribers_2)
    * @return {String|Object}
    */
   Model.prototype.getTableName = function(options) {
@@ -644,7 +644,7 @@ module.exports = (function() {
    * @param  {Object}                    [options.where] A hash of attributes to describe your search. See above for examples.
    * @param  {Array<String>}             [options.attributes] A list of the attributes that you want to select. To rename an attribute, you can pass an array, with two elements - the first is the name of the attribute in the DB (or some kind of expression such as `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to have in the returned instance
    * @param  {Array<Object|Model>}       [options.include] A list of associations to eagerly load using a left join. Supported is either `{ include: [ Model1, Model2, ...]}` or `{ include: [{ model: Model1, as: 'Alias' }]}`. If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in the as attribute when eager loading Y).
-   * @param  {Model}                     [optinos.include[].model] The model you want to eagerly load
+   * @param  {Model}                     [options.include[].model] The model you want to eagerly load
    * @param  {String}                    [options.include[].as] The alias of the relation, in case the model you want to eagerly load is aliassed.
    * @param  {Object}                    [options.include[].where] Where clauses to apply to the child models. Note that this converts the eager load to an inner join, unless you explicitly set `required: true`
    * @param  {Array<String>}             [options.include[].attributes] A list of attributes to select from the child model
@@ -1461,7 +1461,7 @@ module.exports = (function() {
       }
 
       // Run query to update all rows
-      return self.QueryInterface.bulkUpdate(self.getTableName(), attrValueHashUse, where, options, self.tableAttributes).then(function(affectedRows) {
+      return self.QueryInterface.bulkUpdate(self.getTableName(options), attrValueHashUse, where, options, self.tableAttributes).then(function(affectedRows) {
         if (options.returning) {
           return [affectedRows.length, affectedRows];
         }


### PR DESCRIPTION
I work with a few databases that use tables names based on their parent ID. I don't want to generate unique sequelize models for each one- it would be a waste of resources. Instead, I made this small change to the code, overrode the getTableName function in the classMethods, added the logic needed to generate the correct table names and passed the needed values in with the options.

A simplified database example:
# Table _account_

| id | name |
| --- | --- |
| 1 | Arthur's Towels |
| 2 | Ford's Library |
# Table _customers_1_

| id | email |
| --- | --- |
| 1 | fenchurch@yahoo.co.milkyway |
| 2 | zaphod@sirius.star |
# Table _customers_2_

| id | email |
| --- | --- |
| 1 | trillian@mcmillian.zz9 |
| 2 | zaphod@sirius.star |
