### PR TITLE
Remove callback from transaction API in favor of promises

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -759,23 +759,19 @@ module.exports = (function() {
    * @param {Object} [options= {}]
    * @param {Boolean} [options.autocommit=true]
    * @param {String} [options.isolationLevel='REPEATABLE READ'] See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
-   * @param {Function} callback Called when the transaction has been set up and is ready for use. If the callback takes two arguments it will be called with err, transaction, otherwise it will be called with transaction.
-   * @return {Transaction}
+   * @return {Promise}
    * @fires error If there is an uncaught error during the transaction
    * @fires success When the transaction has ended (either comitted or rolled back)
    */
-  Sequelize.prototype.transaction = function(_options, _callback) {
-    var options = (typeof _options === 'function') ? {} : _options
-      , callback = (typeof _options === 'function') ? _options : _callback
-      , wantsError = callback && callback.length === 2
-      , transaction = new Transaction(this, options);
-   
-    return transaction.prepareEnvironment().then(function () {
-      wantsError ? callback(null, transaction) : callback && callback(transaction);
+  Sequelize.prototype.transaction = function(options) {
+    if (Utils._.any(arguments, Utils._.isFunction)) {
+      throw new Error('DEPRECATION WARNING: This function no longer accepts callbacks. Use sequelize.transaction().then(function (t) {}) instead.');
+    }
+
+    var transaction = new Transaction(this, options);
+
+    return transaction.prepareEnvironment().then(function() {
       return transaction;
-    }).catch(function (err) {
-      if (wantsError) callback(err);
-      else throw err;
     });
   };
 

--- a/test/associations/belongs-to.test.js
+++ b/test/associations/belongs-to.test.js
@@ -34,7 +34,7 @@ describe(Support.getTestDialectTeaser("BelongsTo"), function() {
         sequelize.sync({ force: true }).success(function() {
           User.create({ username: 'foo' }).success(function(user) {
             Group.create({ name: 'bar' }).success(function(group) {
-              sequelize.transaction(function(t) {
+              sequelize.transaction().then(function(t) {
                 group.setUser(user, { transaction: t }).success(function() {
                   Group.all().success(function(groups) {
                     groups[0].getUser().success(function(associatedUser) {
@@ -118,7 +118,7 @@ describe(Support.getTestDialectTeaser("BelongsTo"), function() {
         sequelize.sync({ force: true }).success(function() {
           User.create({ username: 'foo' }).success(function(user) {
             Group.create({ name: 'bar' }).success(function(group) {
-              sequelize.transaction(function(t) {
+              sequelize.transaction().then(function(t) {
                 group.setUser(user, { transaction: t }).success(function() {
                   Group.all().success(function(groups) {
                     groups[0].getUser().success(function(associatedUser) {
@@ -268,7 +268,7 @@ describe(Support.getTestDialectTeaser("BelongsTo"), function() {
 
         sequelize.sync({ force: true }).success(function() {
           Group.create({ name: 'bar' }).success(function(group) {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               group.createUser({ username: 'foo' }, { transaction: t }).success(function() {
                 group.getUser().success(function(user) {
                   expect(user).to.be.null

--- a/test/associations/has-many.test.js
+++ b/test/associations/has-many.test.js
@@ -58,7 +58,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
             expect(err).not.to.be.ok
             Article.create({ title: 'foo' }).success(function(article) {
               Label.create({ text: 'bar' }).success(function(label) {
-                sequelize.transaction(function(t) {
+                sequelize.transaction().then(function(t) {
                   article.setLabels([ label ], { transaction: t }).success(function() {
                     Article.all({ transaction: t }).success(function(articles) {
                       articles[0].hasLabel(label).success(function(hasLabel) {
@@ -172,7 +172,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
             expect(err).not.to.be.ok
             Article.create({ title: 'foo' }).success(function(article) {
               Label.create({ text: 'bar' }).success(function(label) {
-                sequelize.transaction(function(t) {
+                sequelize.transaction().then(function(t) {
                   article.setLabels([ label ], { transaction: t }).success(function() {
                     Article.all({ transaction: t }).success(function(articles) {
                       articles[0].hasLabels([ label ]).success(function(hasLabel) {
@@ -267,7 +267,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           sequelize.sync({ force: true }).success(function() {
             Article.create({ title: 'foo' }).success(function(article) {
               Label.create({ text: 'bar' }).success(function(label) {
-                sequelize.transaction(function(t) {
+                sequelize.transaction().then(function(t) {
                   article.setLabels([ label ], { transaction: t }).success(function() {
                     Label
                       .findAll({ where: { ArticleId: article.id }, transaction: undefined })
@@ -380,7 +380,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           sequelize.sync({ force: true }).success(function() {
             Article.create({ title: 'foo' }).success(function(article) {
               Label.create({ text: 'bar' }).success(function(label) {
-                sequelize.transaction(function(t) {
+                sequelize.transaction().then(function(t) {
                   article.addLabel(label, { transaction: t }).success(function() {
                     Label
                       .findAll({ where: { ArticleId: article.id }, transaction: undefined })
@@ -543,7 +543,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           Article.sync({ force: true }).success(function() {
             Label.sync({ force: true }).success(function() {
               Article.create({ title: 'foo' }).success(function(article) {
-                sequelize.transaction(function (t) {
+                sequelize.transaction().then(function (t) {
                   article.createLabel({ text: 'bar' }, { transaction: t }).success(function() {
                     Label.findAll().success(function (labels) {
                       expect(labels.length).to.equal(0);
@@ -758,7 +758,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           sequelize.sync({ force: true }).success(function() {
             Article.create({ title: 'foo' }).success(function(article) {
               Label.create({ text: 'bar' }).success(function(label) {
-                sequelize.transaction(function(t) {
+                sequelize.transaction().then(function(t) {
                   article.setLabels([ label ], { transaction: t }).success(function() {
                     Article.all({ transaction: t }).success(function(articles) {
                       articles[0].getLabels().success(function(labels) {
@@ -1071,7 +1071,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
 
           sequelize.sync({ force: true }).success(function() {
             Task.create({ title: 'task' }).success(function(task) {
-              sequelize.transaction(function (t) {
+              sequelize.transaction().then(function (t) {
                 task.createUser({ username: 'foo' }, { transaction: t }).success(function() {
                   task.getUsers().success(function(users) {
                     expect(users).to.have.length(0)
@@ -1101,7 +1101,7 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           sequelize.sync({ force: true }).success(function() {
             User.create({ username: 'foo' }).success(function(user) {
               Task.create({ title: 'task' }).success(function(task) {
-                sequelize.transaction(function(t){
+                sequelize.transaction().then(function(t){
                   task.addUser(user, { transaction: t }).success(function() {
                     task.hasUser(user).success(function(hasUser) {
                       expect(hasUser).to.be.false

--- a/test/associations/has-one.test.js
+++ b/test/associations/has-one.test.js
@@ -32,7 +32,7 @@ describe(Support.getTestDialectTeaser("HasOne"), function() {
           User.create({ username: 'foo' }).success(function(fakeUser) {
             User.create({ username: 'foo' }).success(function(user) {
               Group.create({ name: 'bar' }).success(function(group) {
-                sequelize.transaction(function(t) {
+                sequelize.transaction().then(function(t) {
                   group.setUser(user, { transaction: t }).success(function() {
                     Group.all().success(function(groups) {
                       groups[0].getUser().success(function(associatedUser) {
@@ -89,7 +89,7 @@ describe(Support.getTestDialectTeaser("HasOne"), function() {
         sequelize.sync({ force: true }).success(function() {
           User.create({ username: 'foo' }).success(function(user) {
             Group.create({ name: 'bar' }).success(function(group) {
-              sequelize.transaction(function(t) {
+              sequelize.transaction().then(function(t) {
                 group
                   .setUser(user, { transaction: t })
                   .success(function() {
@@ -217,7 +217,7 @@ describe(Support.getTestDialectTeaser("HasOne"), function() {
 
         sequelize.sync({ force: true }).success(function() {
           User.create({ username: 'bob' }).success(function(user) {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               user.createGroup({ name: 'testgroup' }, { transaction: t }).success(function() {
                 User.all().success(function (users) {
                   users[0].getGroup().success(function (group) {

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -548,7 +548,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING, foo: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'foo' }, { transaction: t }).success(function() {
               User.find({ where: { username: 'foo' }, transaction: t }).success(function(user) {
                 expect(user).to.not.be.null
@@ -567,7 +567,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING, foo: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'foo' }, { transaction: t }).success(function() {
               User.findOrInitialize({ username: 'foo' }).spread(function(user1) {
                 User.findOrInitialize({ username: 'foo' }, { transaction: t }).spread(function(user2) {
@@ -646,7 +646,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
 
         User.sync({ force: true }).done(function() {
           User.create({ username: 'foo' }).done(function() {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               User.update({ username: 'bar' }, {}, { transaction: t }).done(function(err) {
                 User.all().done(function(err, users1) {
                   User.all({ transaction: t }).done(function(err, users2) {
@@ -856,7 +856,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
 
         User.sync({ force: true }).success(function() {
           User.create({ username: 'foo' }).success(function() {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               User.destroy({}, { transaction: t }).success(function() {
                 User.count().success(function(count1) {
                   User.count({ transaction: t }).success(function(count2) {
@@ -1121,7 +1121,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'foo' }, { transaction: t }).success(function() {
               User.count().success(function(count1) {
                 User.count({ transaction: t }).success(function(count2) {
@@ -1199,7 +1199,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { age: Sequelize.INTEGER })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.bulkCreate([{ age: 2 }, { age: 5 }, { age: 3 }], { transaction: t }).success(function() {
               User.min('age').success(function(min1) {
                 User.min('age', { transaction: t }).success(function(min2) {
@@ -1288,7 +1288,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { age: Sequelize.INTEGER })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.bulkCreate([{ age: 2 }, { age: 5 }, { age: 3 }], { transaction: t }).success(function() {
               User.max('age').success(function(min1) {
                 User.max('age', { transaction: t }).success(function(min2) {
@@ -1829,7 +1829,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
           var User = sequelize.define('User', { username: Sequelize.STRING })
 
           User.sync({ force: true }).success(function() {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               User.create({ username: 'foo' }, { transaction: t }).success(function() {
                 User.where({ username: "foo" }).exec().success(function(users1) {
                   User.where({ username: "foo" }).exec({ transaction: t }).success(function(users2) {

--- a/test/dao-factory/create.test.js
+++ b/test/dao-factory/create.test.js
@@ -39,7 +39,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         User
           .sync({ force: true })
           .success(function() {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               User.findOrCreate({ username: 'Username' }, { data: 'some data' }, { transaction: t }).complete(function(err) {
                 expect(err).to.be.null
 
@@ -183,7 +183,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('user_with_transaction', { username: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'user' }, { transaction: t }).success(function() {
               User.count().success(function(count) {
                 expect(count).to.equal(0)
@@ -880,7 +880,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User
               .bulkCreate([{ username: 'foo' }, { username: 'bar' }], { transaction: t })
               .success(function() {

--- a/test/dao-factory/find.test.js
+++ b/test/dao-factory/find.test.js
@@ -35,7 +35,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'foo' }, { transaction: t }).success(function() {
               User.find({ username: 'foo' }).success(function(user1) {
                 User.find({ username: 'foo' }, { transaction: t }).success(function(user2) {

--- a/test/dao-factory/findAll.test.js
+++ b/test/dao-factory/findAll.test.js
@@ -38,7 +38,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'foo' }, { transaction: t }).success(function() {
               User.findAll({ username: 'foo' }).success(function(users1) {
                 User.findAll({ transaction: t }).success(function(users2) {
@@ -1337,7 +1337,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'foo' }, { transaction: t }).success(function() {
 
               User.findAndCountAll().success(function(info1) {
@@ -1476,7 +1476,7 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         var User = sequelize.define('User', { username: Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.create({ username: 'foo' }, { transaction: t }).success(function() {
               User.all().success(function(users1) {
                 User.all({ transaction: t }).success(function(users2) {

--- a/test/dao.test.js
+++ b/test/dao.test.js
@@ -278,7 +278,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
 
         User.sync({ force: true }).success(function() {
           User.create({ number: 1 }).success(function(user) {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               user.increment('number', { by: 2, transaction: t }).success(function() {
                 User.all().success(function(users1) {
                   User.all({ transaction: t }).success(function(users2) {
@@ -422,7 +422,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
 
         User.sync({ force: true }).success(function() {
           User.create({ number: 3 }).success(function(user) {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               user.decrement('number', { by: 2, transaction: t }).success(function() {
                 User.all().success(function(users1) {
                   User.all({ transaction: t }).success(function(users2) {
@@ -550,7 +550,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
 
         User.sync({ force: true }).success(function() {
           User.create({ username: 'foo' }).success(function(user) {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               User.update({ username: 'bar' }, {}, { transaction: t }).success(function() {
                 user.reload().success(function(user) {
                   expect(user.username).to.equal('foo')
@@ -753,7 +753,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
         var User = sequelize.define('User', { username: Support.Sequelize.STRING })
 
         User.sync({ force: true }).success(function() {
-          sequelize.transaction(function(t) {
+          sequelize.transaction().then(function(t) {
             User.build({ username: 'foo' }).save({ transaction: t }).success(function() {
               User.count().success(function(count1) {
                 User.count({ transaction: t }).success(function(count2) {
@@ -1473,7 +1473,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
 
         User.sync({ force: true }).success(function() {
           User.create({ username: 'foo' }).success(function(user) {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               user.updateAttributes({ username: 'bar' }, { transaction: t }).success(function() {
                 User.all().success(function(users1) {
                   User.all({ transaction: t }).success(function(users2) {
@@ -1607,7 +1607,7 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
 
         User.sync({ force: true }).success(function() {
           User.create({ username: 'foo' }).success(function(user) {
-            sequelize.transaction(function(t) {
+            sequelize.transaction().then(function(t) {
               user.destroy({ transaction: t }).success(function() {
                 User.count().success(function(count1) {
                   User.count({ transaction: t }).success(function(count2) {

--- a/test/sequelize.test.js
+++ b/test/sequelize.test.js
@@ -789,16 +789,32 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
       })
 
       it('passes a transaction object to the callback', function(done) {
-        this.sequelizeWithTransaction.transaction(function(t) {
+        this.sequelizeWithTransaction.transaction().then(function(t) {
           expect(t).to.be.instanceOf(Transaction)
           done()
         })
       })
 
+      it('throws an error if a function was passed as the first argument', function() {
+        var self = this
+
+        expect(function() {
+          self.sequelizeWithTransaction.transaction(function() {})
+        }).to.throw('DEPRECATION WARNING: This function no longer accepts callbacks. Use sequelize.transaction().then(function (t) {}) instead.')
+      });
+
+      it('throws an error if a function was passed as the second argument', function() {
+        var self = this
+
+        expect(function() {
+          self.sequelizeWithTransaction.transaction(null, function() {})
+        }).to.throw('DEPRECATION WARNING: This function no longer accepts callbacks. Use sequelize.transaction().then(function (t) {}) instead.')
+      });
+
       it('allows me to define a callback on the result', function(done) {
         this
           .sequelizeWithTransaction
-          .transaction(function(t) { t.commit() })
+          .transaction().then(function(t) { t.commit() })
           .done(done)
       })
 
@@ -817,7 +833,7 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
           }
 
           TransactionTest.sync({ force: true }).success(function() {
-            self.sequelizeWithTransaction.transaction(function(t1) {
+            self.sequelizeWithTransaction.transaction().then(function(t1) {
               self.sequelizeWithTransaction.query('INSERT INTO ' + qq('TransactionTests') + ' (' + qq('name') + ') VALUES (\'foo\');', null, { plain: true, raw: true, transaction: t1 }).success(function() {
                 count(null, function(cnt) {
                   expect(cnt).to.equal(0)
@@ -852,9 +868,9 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
           }
 
           TransactionTest.sync({ force: true }).success(function() {
-            self.sequelizeWithTransaction.transaction(function(t1) {
+            self.sequelizeWithTransaction.transaction().then(function(t1) {
               self.sequelizeWithTransaction.query('INSERT INTO ' + qq('TransactionTests') + ' (' + qq('name') + ') VALUES (\'foo\');', null, { plain: true, raw: true, transaction: t1 }).success(function() {
-                self.sequelizeWithTransaction.transaction(function(t2) {
+                self.sequelizeWithTransaction.transaction().then(function(t2) {
                   self.sequelizeWithTransaction.query('INSERT INTO ' + qq('TransactionTests') + ' (' + qq('name') + ') VALUES (\'bar\');', null, { plain: true, raw: true, transaction: t2 }).success(function() {
                     count(null, function(cnt) {
                       expect(cnt).to.equal(0)
@@ -893,9 +909,9 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
         var User = this.sequelize.define('Users', { username: DataTypes.STRING })
 
         User.sync({ force: true }).success(function() {
-          self.sequelizeWithTransaction.transaction(function(t1) {
+          self.sequelizeWithTransaction.transaction().then(function(t1) {
             User.create({ username: 'foo' }, { transaction: t1 }).success(function(user) {
-              self.sequelizeWithTransaction.transaction({ transaction: t1 }, function(t2) {
+              self.sequelizeWithTransaction.transaction({ transaction: t1 }).then(function(t2) {
                 user.updateAttributes({ username: 'bar' }, { transaction: t2 }).success(function() {
                   t2.commit().then(function() {
                     user.reload({ transaction: t1 }).success(function(newUser) {
@@ -918,9 +934,9 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
         var User = this.sequelize.define('Users', { username: DataTypes.STRING })
 
         User.sync({ force: true }).success(function() {
-          self.sequelizeWithTransaction.transaction(function(t1) {
+          self.sequelizeWithTransaction.transaction().then(function(t1) {
             User.create({ username: 'foo' }, { transaction: t1 }).success(function(user) {
-              self.sequelizeWithTransaction.transaction({ transaction: t1 }, function(t2) {
+              self.sequelizeWithTransaction.transaction({ transaction: t1 }).then(function(t2) {
                 user.updateAttributes({ username: 'bar' }, { transaction: t2 }).success(function() {
                   t2.rollback().then(function() {
                     user.reload({ transaction: t2 }).success(function(newUser) {
@@ -943,9 +959,9 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
         var User = this.sequelize.define('Users', { username: DataTypes.STRING })
 
         User.sync({ force: true }).success(function() {
-          self.sequelizeWithTransaction.transaction(function(t1) {
+          self.sequelizeWithTransaction.transaction().then(function(t1) {
             User.create({ username: 'foo' }, { transaction: t1 }).success(function(user) {
-              self.sequelizeWithTransaction.transaction({ transaction: t1 }, function(t2) {
+              self.sequelizeWithTransaction.transaction({ transaction: t1 }).then(function(t2) {
                 user.updateAttributes({ username: 'bar' }, { transaction: t2 }).success(function() {
                   t1.rollback().then(function() {
                     User.findAll().success(function(users) {

--- a/test/sequelize.transaction.test.js
+++ b/test/sequelize.transaction.test.js
@@ -11,14 +11,14 @@ describe(Support.getTestDialectTeaser("Sequelize#transaction"), function () {
     it("gets triggered once a transaction has been successfully committed", function(done) {
       this
         .sequelize
-        .transaction(function(t) { t.commit(); })
+        .transaction().then(function(t) { t.commit(); })
         .success(function() { done(); });
     });
 
     it("gets triggered once a transaction has been successfully rollbacked", function(done) {
       this
         .sequelize
-        .transaction(function(t) { t.rollback(); })
+        .transaction().then(function(t) { t.rollback(); })
         .success(function() { done(); });
     });
 
@@ -93,30 +93,13 @@ describe(Support.getTestDialectTeaser("Sequelize#transaction"), function () {
         sequelize.config.username = 'foobarbaz';
 
         sequelize
-          .transaction(function() {})
+          .transaction().then(function() {})
           .catch(function(err) {
             expect(err).to.not.be.undefined;
             done();
           });
       });
     }
-  });
-
-  describe('callback', function() {
-    it("receives the transaction if only one argument is passed", function(done) {
-      this.sequelize.transaction(function(t) {
-        expect(t).to.be.instanceOf(Transaction);
-        t.commit();
-      }).done(done);
-    });
-
-    it("receives an error and the transaction if two arguments are passed", function(done) {
-      this.sequelize.transaction(function(err, t) {
-        expect(err).to.not.be.instanceOf(Transaction);
-        expect(t).to.be.instanceOf(Transaction);
-        t.commit();
-      }).done(done);
-    });
   });
 
   describe('complex long running example', function() {
@@ -130,7 +113,9 @@ describe(Support.getTestDialectTeaser("Sequelize#transaction"), function () {
         sequelize
           .sync({ force: true })
           .then(function() {
-            sequelize.transaction(function(transaction) {
+            sequelize.transaction().then(function(transaction) {
+              expect(transaction).to.be.instanceOf(Transaction);
+
               Test
                 .create({ name: 'Peter' }, { transaction: transaction })
                 .then(function() {
@@ -173,8 +158,8 @@ describe(Support.getTestDialectTeaser("Sequelize#transaction"), function () {
       it("triggers the error event for the second transactions", function(done) {
         var self = this
 
-        this.sequelize.transaction(function(t1) {
-          self.sequelize.transaction(function(t2) {
+        this.sequelize.transaction().then(function(t1) {
+          self.sequelize.transaction().then(function(t2) {
             self
               .Model
               .create({ name: 'omnom' }, { transaction: t1 })

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -47,7 +47,7 @@ describe(Support.getTestDialectTeaser("Transaction"), function () {
         this.sequelize.sync({ force: true }).then(function () {
           return User.create({ username: 'jan'})
         }).then(function () {
-          self.sequelize.transaction(function (t1) {
+          self.sequelize.transaction().then(function (t1) {
             return User.find({
               where: {
                 username: 'jan'
@@ -58,7 +58,7 @@ describe(Support.getTestDialectTeaser("Transaction"), function () {
             }).then(function (t1Jan) {
               self.sequelize.transaction({
                 isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED
-              }, function (t2) {
+              }).then(function (t2) {
                 User.find({
                   where: {
                     username: 'jan'
@@ -99,7 +99,7 @@ describe(Support.getTestDialectTeaser("Transaction"), function () {
         this.sequelize.sync({ force: true }).then(function () {
           return User.create({ username: 'jan'})
         }).then(function () {
-          self.sequelize.transaction(function (t1) {
+          self.sequelize.transaction().then(function (t1) {
             return User.find({
               where: {
                 username: 'jan'
@@ -110,7 +110,7 @@ describe(Support.getTestDialectTeaser("Transaction"), function () {
             }).then(function (t1Jan) {
               self.sequelize.transaction({
                 isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED
-              }, function (t2) {
+              }).then(function (t2) {
                 User.find({
                   where: {
                     username: 'jan'


### PR DESCRIPTION
This PR standardises the transaction API by removing the old callback implementation and using the promise returned by the _transaction_ function.

This change fixes the [issue](https://github.com/sequelize/sequelize/issues/1218#issuecomment-42535985) where the callback was not following the standard Node pattern, as well as removes ambiguity as to what API to use. (Promises all the way :+1:)

This is a breaking change for anyone that was using the old callback API so I understand if you're reluctant to merge. Any thoughts?
