### PR TITLE
Fix eager loading bug: associations with primary key of 0 were not inclu...

### DIFF
--- a/lib/dao.js
+++ b/lib/dao.js
@@ -249,7 +249,7 @@ module.exports = (function() {
           includeValidated: true,
           raw: options.raw
         })
-        , isEmpty = !Utils.firstValueOfHash(daoInstance.identifiers)
+        , isEmpty = Utils.firstValueOfHash(daoInstance.identifiers) === null
 
       if (association.isSingleAssociation) {
         accessor = Utils.singularize(accessor, self.sequelize.language)
@@ -350,9 +350,9 @@ module.exports = (function() {
               && !!self.daoFactory.rawAttributes[updatedAtAttr].defaultValue
             )
             ? self.daoFactory.rawAttributes[updatedAtAttr].defaultValue
-            : Utils.now(self.sequelize.options.dialect))    
+            : Utils.now(self.sequelize.options.dialect))
         }
-        
+
         if (self.isNewRecord && createdAtAttr && !values[createdAtAttr]) {
           values[createdAtAttr] = (
             (


### PR DESCRIPTION
...nded

isEmpty was set to true if identifier is 0 and the association was not loaded. Since Utils.firstValueOfHash returns null if the no value is present, we can do a === check to prevent 0 to be considered as false. (I know that 0  is a strange value for an integer primary key, but I do not have control on it in a particular project.)  
