### PR TITLE
renameColumnQuery returns quoted column name (for branch 1.7.0)

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -382,13 +382,13 @@ module.exports = (function() {
       ].join("");
 
       return Utils._.template(query, {
-                tableName: tableName,
-                attributeNamesImport: Utils._.keys(attributes).map(function(attr) {
-                    return (attrNameAfter === attr) ? this.quoteIdentifier(attrNameBefore) + ' AS ' + this.quoteIdentifier(attr) : this.quoteIdentifier(attr);
-                }.bind(this)).join(', '),
-                attributeNamesExport: Utils._.keys(attributes).map(function(attr) {
-                    return this.quoteIdentifier(attr);
-                }.bind(this)).join(', ')
+        tableName: tableName,
+        attributeNamesImport: Utils._.keys(attributes).map(function(attr) {
+          return (attrNameAfter === attr) ? this.quoteIdentifier(attrNameBefore) + ' AS ' + this.quoteIdentifier(attr) : this.quoteIdentifier(attr);
+        }.bind(this)).join(', '),
+        attributeNamesExport: Utils._.keys(attributes).map(function(attr) {
+          return this.quoteIdentifier(attr);
+        }.bind(this)).join(', ')
       });
     },
 


### PR DESCRIPTION
I've quoted the column names as required by the SQL definition.
