### PR TITLE
renameColumnQuery returns qouted column names (for branch master)

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -364,10 +364,10 @@ module.exports = (function() {
       return Utils._.template(query, {
         tableName: tableName,
         attributeNamesImport: Utils._.keys(attributes).map(function(attr) {
-          return (attrNameAfter === attr) ? '`' + attrNameBefore + '` AS `' + attr + '`' : '`' + attr + '`'
+            return (attrNameAfter === attr) ? this.quoteIdentifier(attrNameBefore) + ' AS ' + this.quoteIdentifier(attr) : this.quoteIdentifier(attr);
         }.bind(this)).join(', '),
         attributeNamesExport: Utils._.keys(attributes).map(function(attr) {
-          return '`' + attr + '`'
+            return this.quoteIdentifier(attr);
         }.bind(this)).join(', ')
       });
     },


### PR DESCRIPTION
I've quoted the column names as required by SQL.
