### PR TITLE
Option to not pluralize associated table names (master)

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -132,7 +132,7 @@ module.exports = (function() {
     if (this.as) {
       this.isAliased = true;
     } else {
-      this.as = (this.options.freezeTableNameAssociations?this.target.tableName:Utils.pluralize(this.target.tableName, this.target.options.language));      
+      this.as = (this.options.freezeAssociations ? this.target.tableName : Utils.pluralize(this.target.tableName, this.target.options.language));
     }
 
     this.accessors = {

--- a/lib/model.js
+++ b/lib/model.js
@@ -29,7 +29,7 @@ module.exports = (function() {
       classMethods: {},
       validate: {},
       freezeTableName: false,
-      freezeTableNameAssociations: false,
+      freezeAssociations: false,
       underscored: false,
       underscoredAll: false,
       paranoid: false,

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -342,7 +342,7 @@ module.exports = (function() {
    * @param {Boolean}                 [options.underscored=false] Converts all camelCased columns to underscored if true
    * @param {Boolean}                 [options.underscoredAll=false] Converts camelCased model names to underscored tablenames if true
    * @param {Boolean}                 [options.freezeTableName=false] If freezeTableName is true, sequelize will not try to alter the DAO name to get the table name. Otherwise, the dao name will be pluralized
-   * @param {Boolean}                 [options.freezeTableNameAssociations=false] If freezeTableNameAssociations is true, sequelize will not try to alter the DAO name to get the table name of the associated tables. Otherwise, the dao name will be pluralized
+   * @param {Boolean}                 [options.freezeAssociations=false] If freezeAssociations is true, sequelize will not try to alter the DAO name to get the table name of the associated tables. Otherwise, the dao name will be pluralized
    * @param {String|Boolean}          [options.createdAt] Override the name of the createdAt column if a string is provided, or disable it if false. Timestamps must be true
    * @param {String|Boolean}          [options.updatedAt] Override the name of the updatedAt column if a string is provided, or disable it if false. Timestamps must be true
    * @param {String|Boolean}          [options.deletedAt] Override the name of the deletedAt column if a string is provided, or disable it if false. Timestamps must be true


### PR DESCRIPTION
In v1.7.0rc6 the pluralization of associated table names was introduced.

This pull request introduces a new option to return to how it behaved pre v1.7.0rc6.

This pull request is for latest master. There is another pull request for latest branch v1.7.9.
