### PR TITLE
Option to not pluralize associated table names (branch 1.7.0)

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -116,7 +116,7 @@ module.exports = (function() {
     if (this.as) {
       this.isAliased = true
     } else {
-      this.as = (this.options.freezeTableNameAssociations?this.target.tableName:Utils.pluralize(this.target.tableName, this.target.options.language));      
+      this.as = (this.options.freezeAssociations ? this.target.tableName : Utils.pluralize(this.target.tableName, this.target.options.language));      
     }
     
     this.accessors = {

--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -18,7 +18,7 @@ module.exports = (function() {
       classMethods: {},
       validate: {},
       freezeTableName: false,
-      freezeTableNameAssociations: false,
+      freezeAssociations: false,
       underscored: false,
       syncOnAssociation: true,
       paranoid: false,


### PR DESCRIPTION
In v1.7.0rc6 the pluralization of associated table names was introduced.

This pull request introduces a new option to return to how it behaved pre v1.7.0rc6.

This pull request is for branch v1.7.0. There is another pull request for latest master
