### PR TITLE
Fix change column migration for enums on Postgres

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -215,6 +215,7 @@ module.exports = (function() {
         if (definition.match(/^ENUM\(/)) {
           query = this.pgEnum(tableName, attributeName, definition) + query;
           definition = definition.replace(/^ENUM\(.+\)/, this.quoteIdentifier('enum_' + tableName + '_' + attributeName));
+          definition += ' USING (' + this.quoteIdentifier(attributeName) + '::' + this.quoteIdentifier(definition) + ')';
         }
 
         if (definition.match(/UNIQUE;*$/)) {

--- a/test/assets/migrations/20111205163000-addColumnLevelAndChangeToEnumToUser.js
+++ b/test/assets/migrations/20111205163000-addColumnLevelAndChangeToEnumToUser.js
@@ -1,0 +1,11 @@
+module.exports = {
+  up: function(migration, DataTypes, done) {
+    migration.addColumn('User', 'level', { type: DataTypes.STRING }).complete(function() {
+      migration.changeColumn('User', 'level', { type: DataTypes.ENUM, allowNull: false, values: ['basic', 'advanced'] }).complete(done);
+    });
+  },
+
+  down: function(migration, DataTypes, done) {
+    migration.removeColumn('User', 'level').complete(done);
+  }
+};

--- a/test/migrator.test.js
+++ b/test/migrator.test.js
@@ -100,7 +100,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
         SequelizeMeta.create({ from: null, to: 20111117063700 }).success(function() {
           migrator.getUndoneMigrations(function(err, migrations) {
             expect(err).to.be.null
-            expect(migrations).to.have.length(14)
+            expect(migrations).to.have.length(15)
             expect(migrations[0].filename).to.equal('20111130161100-emptyMigration.js')
             done()
           })
@@ -311,6 +311,28 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
               }
               expect(signature.allowNull).to.equal(false)
               expect(signature.defaultValue).to.equal('Signature')
+
+              done()
+            })
+          })
+        })
+      })
+
+      it('changes the level column from user and casts the data to the target enum type', function(done) {
+        var self = this
+
+        this.init({ to: 20111205163000 }, function(migrator) {
+          migrator.migrate().success(function() {
+            self.sequelize.getQueryInterface().describeTable('User').complete(function(err, data) {
+              var level = data.level;
+
+              if (dialect === 'postgres') {
+                expect(level.type).to.equal('USER-DEFINED');
+              } else if (dialect === 'sqlite') {
+                expect(level.type).to.equal('TEXT');
+              } else {
+                expect(level.type).to.equal('ENUM(\'BASIC\',\'ADVANCED\')');
+              }
 
               done()
             })


### PR DESCRIPTION
Fixes an issue in Postgres when altering a column from a _non-enum_ type into an _enum_ type.

For example, the following query:

``` SQL
ALTER TABLE "User" ALTER COLUMN "level" TYPE "enum_User_level";
```

would generate the error: `column "level" cannot be cast automatically to type "enum_User_level"`.

Postgres requires manually casting the column into the new type. This PR changes the query into:

``` SQL
ALTER TABLE "User" ALTER COLUMN "level" TYPE "enum_User_level" USING ("level"::"enum_User_level");
```
