### PR TITLE
SQLite: tables loose PrimaryKey constraint on renameColumn

### DIFF
--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -113,7 +113,8 @@ module.exports = (function() {
                       result[_result.name] = {
                         type: _result.type,
                         allowNull: (_result.notnull === 0),
-                        defaultValue: _result.dflt_value
+                        defaultValue: _result.dflt_value,
+                        primaryKey : (_result.pk === 1)
                       };
 
                       if (result[_result.name].type === 'TINYINT(1)') {


### PR DESCRIPTION
When using renameColumn with SQLite, the table is recreated with the changed column name. For recreating, the result of describeTable() is used.
As describeTable() doesn't return information on the primary key column(s), the recreated table does not have a primary.

Fixed by adding primaryKey to result of describeTable()
