### PR TITLE
Simplify parameter validation and deprecation

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -744,7 +744,7 @@ module.exports = (function() {
   Instance.prototype.increment = function(fields, countOrOptions) {
     Utils.validateParameter(countOrOptions, Object, {
       optional: true,
-      deprecated: 'number',
+      deprecated: Number,
       deprecationWarning: 'Increment expects an object as second parameter. Please pass the incrementor as option! ~> instance.increment(' + JSON.stringify(fields) + ', { by: ' + countOrOptions + ' })'
     });
 
@@ -809,7 +809,7 @@ module.exports = (function() {
   Instance.prototype.decrement = function(fields, countOrOptions) {
     Utils.validateParameter(countOrOptions, Object, {
       optional: true,
-      deprecated: 'number',
+      deprecated: Number,
       deprecationWarning: 'Decrement expects an object as second parameter. Please pass the decrementor as option! ~> instance.decrement(' + JSON.stringify(fields) + ', { by: ' + countOrOptions + ' })'
     });
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1143,7 +1143,7 @@ module.exports = (function() {
    */
   Model.prototype.bulkCreate = function(records, fieldsOrOptions, options) {
     Utils.validateParameter(fieldsOrOptions, Object, { deprecated: Array, optional: true, index: 2, method: 'Model#bulkCreate' });
-    Utils.validateParameter(options, 'undefined', { deprecated: Object, optional: true, index: 3, method: 'Model#bulkCreate' });
+    Utils.validateParameter(options, undefined, { deprecated: Object, optional: true, index: 3, method: 'Model#bulkCreate' });
 
     if (!records.length) {
       return Promise.resolve([]);

--- a/lib/utils/parameter-validator.js
+++ b/lib/utils/parameter-validator.js
@@ -1,80 +1,42 @@
 'use strict';
 
-var cJSON = require('circular-json')
-  , _ = require('lodash'); // Don't require Utils here, as it creates a circular dependency
+var _ = require('lodash');
+var util = require('util');
 
-var extractClassName = function(o) {
-  if (typeof o === 'string') {
-    return o;
-  } else if (!!o) {
-    return o.toString().match(/function ([^\(]+)/)[1];
-  } else {
-    return 'undefined';
+var validateDeprecation = function(value, expectation, options) {
+  if (!options.deprecated) {
+    return;
   }
-};
 
-var generateDeprecationWarning = function(value, expectation, options) {
-  options = options || {};
+  var valid = value instanceof options.deprecated;
 
-  if (options.method && options.index) {
-    return [
-      'The',
-      {1: 'first', 2: 'second', 3: 'third', 4: 'fourth', 5: 'fifth'}[options.index],
-      'parameter of',
-      options.method,
-      'should be a',
-      extractClassName(expectation) + '!'
-    ].join(' ');
-  } else {
-    return ['Expected', cJSON.stringify(value), 'to be', extractClassName(expectation) + '!'].join(' ');
+  if (valid) {
+    var message = util.format('%s should not be of type "%s"', util.inspect(value), options.deprecated.name);
+
+    console.log('DEPRECATION WARNING:', options.deprecationWarning || message);
   }
-};
 
-var matchesExpectation = function(value, expectation) {
-  if (typeof expectation === 'string') {
-    return (typeof value === expectation.toString());
-  } else {
-    return (value instanceof expectation);
-  }
-};
-
-var validateDeprication = function(value, expectation, options) {
-  if (options.deprecated) {
-    if (matchesExpectation(value, options.deprecated)) {
-      options.onDeprecated(options.deprecationWarning);
-      return true;
-    }
-  }
+  return valid;
 };
 
 var validate = function(value, expectation, options) {
-  var result = matchesExpectation(value, expectation);
-
-  if (result) {
-    return result;
-  } else if (!options.throwError) {
-    return false;
-  } else {
-    var _value = (value === null) ? 'null' : value.toString()
-      , _expectation = extractClassName(expectation);
-
-    throw new Error('The parameter (value: ' + _value + ') is no ' + _expectation + '.');
+  if (value instanceof expectation) {
+    return true;
   }
+
+  throw new Error(util.format('The parameter (value: %s) is no %s.', value, expectation.name));
 };
 
 var ParameterValidator = module.exports = {
   check: function(value, expectation, options) {
     options = _.extend({
-      throwError: true,
       deprecated: false,
-      deprecationWarning: generateDeprecationWarning(value, expectation, options),
-      onDeprecated: function(s) { console.log('DEPRECATION WARNING:', s); },
       index: null,
       method: null,
       optional: false
     }, options || {});
 
-    if (options.optional && ((value === undefined) || (value === null))) {
+    if (!value && options.optional) {
       return true;
     }
 
@@ -87,7 +49,7 @@ var ParameterValidator = module.exports = {
     }
 
     return false
-      || validateDeprication(value, expectation, options)
+      || validateDeprecation(value, expectation, options)
       || validate(value, expectation, options);
   }
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "toposort-class": "~0.3.0",
     "generic-pool": "2.0.4",
     "sql": "~0.35.0",
-    "circular-json": "~0.1.5",
     "sequelize-bluebird": "git://github.com/sequelize/bluebird.git#9df139af53c5d346ffd38df30fc9dc60c62a9c98",
     "node-uuid": "~1.4.1"
   },

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -146,10 +146,6 @@ describe(Support.getTestDialectTeaser("Utils"), function() {
     })
 
     describe('expectation', function() {
-      it('uses the typeof method if the expectation is a string', function() {
-        expect(Utils.validateParameter(1, 'number')).to.be.true
-      })
-
       it('uses the instanceof method if the expectation is a class', function() {
         expect(Utils.validateParameter(new Number(1), Number)).to.be.true
       })
@@ -160,21 +156,6 @@ describe(Support.getTestDialectTeaser("Utils"), function() {
         expect(function() {
           Utils.validateParameter(1, String)
         }).to.throw(/The parameter.*is no.*/)
-      })
-
-      it('does not throw an error if throwError is false', function() {
-        expect(Utils.validateParameter(1, String, { throwError: false })).to.be.false
-      })
-    })
-
-    describe('deprecation warning', function() {
-      it('uses the passed function', function() {
-        var spy = chai.spy(function(s){})
-        Utils.validateParameter([], Object, {
-          deprecated: Array,
-          onDeprecated: spy
-        })
-        expect(spy).to.have.been.called()
       })
     })
   })


### PR DESCRIPTION
This PR simplifies the parameter validator class. This class was causing a few issues when generating the warning message for complex objects.

Me and @fixe have taken the opportunity to clean up the entire class and normalize the `deprecated` parameter.

One upside is that the `circular-json` dependency is no longer needed.
