### PR TITLE
Add hstore array support

### DIFF
--- a/lib/dialects/postgres/hstore.js
+++ b/lib/dialects/postgres/hstore.js
@@ -17,12 +17,22 @@ module.exports = {
           return '"' + JSON.stringify(part).replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
     }
   },
-  stringify: function(data) {
+  stringifyObject: function(data) {
     var self = this;
 
     return Object.keys(data).map(function(key) {
       return self.stringifyPart(key) + '=>' + self.stringifyPart(data[key]);
     }).join(',');
+  },
+  stringifyArray: function(data) {
+    return data.map(this.stringifyObject, this);
+  },
+  stringify: function(data) {
+    if (Array.isArray(data)) {
+      return this.stringifyArray(data);
+    }
+
+    return this.stringifyObject(data);
   },
   parsePart: function(part) {
     part = part.replace(/\\\\/g, '\\').replace(/\\"/g, '"');
@@ -35,11 +45,11 @@ module.exports = {
         return part;
     }
   },
-  parse: function(string) {
+  parseObject: function(string) {
     var self = this,
         object = { };
 
-    if (('string' !== typeof string) || (0 === string.length)) {
+    if (0 === string.length) {
       return object;
     }
 
@@ -65,5 +75,22 @@ module.exports = {
     });
 
     return object;
+  },
+  parseArray: function(string) {
+    var matches = string.match(/{(.*)}/);
+    var array = JSON.parse('['+ matches[1] +']');
+
+    return array.map(this.parseObject, this);
+  },
+  parse: function(value) {
+    if ('string' !== typeof value) {
+      return value;
+    }
+
+    if ('{' === value[0] && '}' === value[value.length - 1]) {
+      return this.parseArray(value);
+    }
+
+    return this.parseObject(value);
   }
 };

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -439,12 +439,12 @@ module.exports = (function() {
             }
           }
 
-          if (dataType.type === 'TINYINT(1)') {
+          if (dataType.type === DataTypes.BOOLEAN) {
             dataType.type = 'BOOLEAN';
           }
 
-          if (dataType.type === 'DATETIME') {
-            dataType.originalType = 'DATETIME';
+          if (dataType.type === DataTypes.DATE) {
+            dataType._typeName = 'DATETIME';
             dataType.type = 'TIMESTAMP WITH TIME ZONE';
           }
 
@@ -823,13 +823,13 @@ module.exports = (function() {
     escape: function(value, field) {
       if (value && value._isSequelizeMethod) {
         return value.toString(this);
-      } else {
-        if (Utils._.isObject(value) && field && (field === DataTypes.HSTORE || field.type === DataTypes.HSTORE)) {
-          value = hstore.stringify(value);
-        }
-
-        return SqlString.escape(value, false, null, this.dialect, field);
       }
+
+      if (Utils._.isObject(value) && field && (field.type === DataTypes.HSTORE || field.type === DataTypes.ARRAY(DataTypes.HSTORE))) {
+        value = hstore.stringify(value);
+      }
+
+      return SqlString.escape(value, false, null, this.dialect, field);
     },
 
     /**

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -10,10 +10,14 @@ var Utils = require('../../utils')
 // Parses hstore fields if the model has any hstore fields.
 // This cannot be done in the 'pg' lib because hstore is a UDT.
 var parseHstoreFields = function(model, row) {
-  Utils._.keys(row).forEach(function(key) {
-    if (model._isHstoreAttribute(key)) {
-      row[key] = hstore.parse(row[key]);
+  Utils._.forEach(row, function(value, key) {
+    if (model._isHstoreAttribute(key) || (model.attributes[key] && model.attributes[key].type === DataTypes.ARRAY(DataTypes.HSTORE))) {
+      row[key] = hstore.parse(value);
+
+      return;
     }
+
+    row[key] = value;
   });
 };
 

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -475,7 +475,7 @@ module.exports = (function() {
       for (var attrName in self.Model.rawAttributes) {
         if (self.Model.rawAttributes.hasOwnProperty(attrName)) {
           var definition = self.Model.rawAttributes[attrName]
-            , isEnum = !!definition.type && (definition.type.toString() === DataTypes.ENUM.toString())
+            , isEnum = definition.type.toString() === DataTypes.ENUM.toString()
             , isMySQL = ['mysql', 'mariadb'].indexOf(self.Model.modelManager.sequelize.options.dialect) !== -1
             , ciCollation = !!self.Model.options.collate && self.Model.options.collate.match(/_ci$/i)
             , valueOutOfScope;

--- a/lib/model.js
+++ b/lib/model.js
@@ -45,8 +45,19 @@ module.exports = (function() {
       }
     }, options || {});
 
+    this.associations = {};
+    this.modelManager = this.daoFactoryManager = null;
+    this.name = name;
+    this.options.hooks = this.replaceHookAliases(this.options.hooks);
+    this.scopeObj = {};
     this.sequelize = options.sequelize;
     this.underscored = this.underscored || this.underscoredAll;
+
+    if (!this.options.tableName) {
+      this.tableName = this.options.freezeTableName ? name : Utils._.underscoredIf(Utils.pluralize(name, this.options.language), this.options.underscoredAll);
+    } else {
+      this.tableName = this.options.tableName;
+    }
 
     // error check options
     Utils._.each(options.validate, function(validator, validatorType) {
@@ -59,38 +70,27 @@ module.exports = (function() {
       }
     });
 
-    this.name = name;
-
-    if (!this.options.tableName) {
-      this.tableName = this.options.freezeTableName ? name : Utils._.underscoredIf(Utils.pluralize(name, this.options.language), this.options.underscoredAll);
-    } else {
-      this.tableName = this.options.tableName;
-    }
-
-    // If you don't specify a valid data type lets help you debug it
-    Utils._.each(attributes, function(attribute, name) {
-      var dataType;
-      if (Utils._.isPlainObject(attribute)) {
-        // We have special cases where the type is an object containing
-        // the values (e.g. Sequelize.ENUM(value, value2) returns an object
-        // instead of a function)
-        // Copy these values to the dataType
-        attribute.values = (attribute.type && attribute.type.values) || attribute.values;
-
-        // We keep on working with the actual type object
-        dataType = attribute.type;
-      } else {
-        dataType = attribute;
+    this.attributes = this.rawAttributes = Utils._.mapValues(attributes, function(attribute, name) {
+      if (!Utils._.isPlainObject(attribute)) {
+        attribute = { type: attribute };
       }
 
-      if (dataType === undefined) {
+      if (attribute.references instanceof Model) {
+        attribute.references = attribute.references.tableName;
+      }
+
+      if (attribute.type === undefined) {
         throw new Error('Unrecognized data type for field ' + name);
       }
 
-      if (dataType.toString() === 'ENUM') {
-        if (!(Array.isArray(attribute.values) && (attribute.values.length > 0))) {
+      if (attribute.type.toString() === DataTypes.ENUM.toString()) {
+        // The ENUM is a special case where the type is an object containing the values
+        attribute.values = attribute.type.values || attribute.values || [];
+
+        if (!attribute.values.length) {
           throw new Error('Values for ENUM haven\'t been defined.');
         }
+
         attributes[name].validate = attributes[name].validate || {
           _checkEnum: function(value, next) {
             var hasValue = value !== undefined
@@ -113,22 +113,9 @@ module.exports = (function() {
           }
         };
       }
+
+      return attribute;
     });
-
-    Object.keys(attributes).forEach(function(attrName) {
-      if (attributes[attrName].references instanceof Model) {
-        attributes[attrName].references = attributes[attrName].references.tableName;
-      }
-    });
-
-    this.options.hooks = this.replaceHookAliases(this.options.hooks);
-
-    this.attributes =
-    this.rawAttributes = attributes;
-    this.modelManager =
-    this.daoFactoryManager = null; // defined in init function
-    this.associations = {};
-    this.scopeObj = {};
   };
 
   Object.defineProperty(Model.prototype, 'QueryInterface', {
@@ -263,7 +250,7 @@ module.exports = (function() {
     this.Instance.prototype.validators = {};
 
     Utils._.each(this.rawAttributes, function(definition, name) {
-      var type = definition.originalType || definition.type || definition;
+      var type = definition.type._typeName || definition.type;
 
       if (type === DataTypes.BOOLEAN) {
         self._booleanAttributes.push(name);
@@ -831,7 +818,7 @@ module.exports = (function() {
 
     if (!options.dataType) {
       if (this.rawAttributes[field]) {
-        options.dataType = this.rawAttributes[field];
+        options.dataType = this.rawAttributes[field].type;
       } else {
         // Use FLOAT as fallback
         options.dataType = DataTypes.FLOAT;

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -62,21 +62,19 @@ module.exports = (function() {
   };
 
   QueryInterface.prototype.createTable = function(tableName, attributes, options) {
-    var attributeHashes = {}
-      , dataTypeValues = Utils._.values(DataTypes)
-      , keys = Object.keys(attributes)
+    var keys = Object.keys(attributes)
       , keyLen = keys.length
       , self = this
       , sql = ''
       , i = 0;
 
-    for (i = 0; i < keyLen; i++) {
-      if (dataTypeValues.indexOf(attributes[keys[i]]) > -1) {
-        attributeHashes[keys[i]] = { type: attributes[keys[i]], allowNull: true };
-      } else {
-        attributeHashes[keys[i]] = attributes[keys[i]];
+    attributes = Utils._.mapValues(attributes, function(attribute, name) {
+      if (!Utils._.isPlainObject(attribute)) {
+        attribute = { type: attribute, allowNull: true };
       }
-    }
+
+      return attribute;
+    });
 
     options = Utils._.extend({
       logging: this.sequelize.options.logging
@@ -90,7 +88,7 @@ module.exports = (function() {
         , getTableName = (!options || !options.schema || options.schema === 'public' ? '' : options.schema + '_') + tableName;
 
       for (i = 0; i < keyLen; i++) {
-        if (attributes[keys[i]].toString().match(/^ENUM\(/) || attributes[keys[i]].toString() === 'ENUM' || (attributes[keys[i]].type && attributes[keys[i]].type.toString() === 'ENUM')) {
+        if (attributes[keys[i]].type.toString() === DataTypes.ENUM.toString()) {
           sql = self.QueryGenerator.pgListEnums(getTableName, keys[i], options);
           promises.push(self.sequelize.query(sql, null, { plain: true, raw: true, type: QueryTypes.SELECT, logging: options.logging }));
         }
@@ -105,7 +103,7 @@ module.exports = (function() {
         daoTable = daoTable.length > 0 ? daoTable[0] : null;
 
         for (i = 0; i < keyLen; i++) {
-          if (attributes[keys[i]].toString().match(/^ENUM\(/) || attributes[keys[i]].toString() === 'ENUM' || (attributes[keys[i]].type && attributes[keys[i]].type.toString() === 'ENUM')) {
+          if (attributes[keys[i]].type.toString() === DataTypes.ENUM.toString()) {
             // If the enum type doesn't exist then create it
             if (!results[enumIdx]) {
               sql = self.QueryGenerator.pgEnum(getTableName, keys[i], attributes[keys[i]], options);
@@ -135,7 +133,7 @@ module.exports = (function() {
           }
         }
 
-        attributes = self.QueryGenerator.attributesToSQL(attributeHashes);
+        attributes = self.QueryGenerator.attributesToSQL(attributes);
         sql = self.QueryGenerator.createTableQuery(tableName, attributes, options);
 
         return Promise.all(promises).then(function() {
@@ -143,7 +141,7 @@ module.exports = (function() {
         });
       });
     } else {
-      attributes = self.QueryGenerator.attributesToSQL(attributeHashes);
+      attributes = self.QueryGenerator.attributesToSQL(attributes);
       sql = self.QueryGenerator.createTableQuery(tableName, attributes, options);
 
       return self.sequelize.query(sql, null, options);
@@ -175,7 +173,7 @@ module.exports = (function() {
             , i = 0;
 
           for (i = 0; i < keyLen; i++) {
-            if (daoTable.rawAttributes[keys[i]].type && daoTable.rawAttributes[keys[i]].type.toString() === 'ENUM') {
+            if (daoTable.rawAttributes[keys[i]].type.toString() === DataTypes.ENUM.toString()) {
               promises.push(self.sequelize.query(self.QueryGenerator.pgEnumDrop(getTableName, keys[i]), null, {logging: options.logging, raw: true}));
             }
           }

--- a/test/postgres/dao.test.js
+++ b/test/postgres/dao.test.js
@@ -15,7 +15,8 @@ if (dialect.match(/^postgres/)) {
         username: DataTypes.STRING,
         email: { type: DataTypes.ARRAY(DataTypes.TEXT) },
         settings: DataTypes.HSTORE,
-        document: { type: DataTypes.HSTORE, defaultValue: { default: 'value' } }
+        document: { type: DataTypes.HSTORE, defaultValue: { default: 'value' } },
+        phones: DataTypes.ARRAY(DataTypes.HSTORE)
       })
       this.User.sync({ force: true }).success(function() {
         done()
@@ -30,7 +31,7 @@ if (dialect.match(/^postgres/)) {
 
     it('should be able to search within an array', function(done) {
       this.User.all({where: {email: ['hello', 'world']}}).on('sql', function(sql) {
-        expect(sql).to.equal('SELECT "id", "username", "email", "settings", "document", "createdAt", "updatedAt" FROM "Users" AS "User" WHERE "User"."email" && ARRAY[\'hello\',\'world\']::TEXT[];')
+        expect(sql).to.equal('SELECT "id", "username", "email", "settings", "document", "phones", "createdAt", "updatedAt" FROM "Users" AS "User" WHERE "User"."email" && ARRAY[\'hello\',\'world\']::TEXT[];')
         done()
       })
     })
@@ -273,6 +274,18 @@ if (dialect.match(/^postgres/)) {
           .error(console.log)
       })
 
+      it('should save hstore array correctly', function(done) {
+        this.User.create({
+          username: 'bob',
+          email: ['myemail@email.com'],
+          phones: [{ number: '123456789', type: 'mobile' }, { number: '987654321', type: 'landline' }]
+        }).on('sql', function(sql) {
+          var expected = 'INSERT INTO "Users" ("id","username","email","document","phones","createdAt","updatedAt") VALUES (DEFAULT,\'bob\',ARRAY[\'myemail@email.com\']::TEXT[],\'"default"=>"value"\',ARRAY[\'"number"=>"123456789","type"=>"mobile"\',\'"number"=>"987654321","type"=>"landline"\']::HSTORE[]'
+          expect(sql).to.contain(expected)
+          done()
+        })
+      })
+
       it("should update hstore correctly", function(done) {
         var self = this
 
@@ -327,6 +340,23 @@ if (dialect.match(/^postgres/)) {
               })
           })
           .error(console.log)
+      })
+
+      it('should read an hstore array correctly', function(done) {
+        var self = this
+        var data = { username: 'user', email: ['foo@bar.com'], phones: [{ number: '123456789', type: 'mobile' }, { number: '987654321', type: 'landline' }] }
+
+        this.User
+          .create(data)
+          .success(function() {
+            // Check that the hstore fields are the same when retrieving the user
+            self.User.find({ where: { username: 'user' }})
+              .success(function(user) {
+                expect(user.phones).to.deep.equal(data.phones)
+
+                done()
+              })
+          })
       })
 
       it("should read hstore correctly from multiple rows", function(done) {

--- a/test/postgres/hstore.test.js
+++ b/test/postgres/hstore.test.js
@@ -73,6 +73,11 @@ if (dialect.match(/^postgres/)) {
         done()
       })
 
+      it('should handle arrays correctly', function(done) {
+        expect(hstore.stringify([{ test: 'value' }, { another: 'val' }])).to.deep.equal(['\"test\"=>\"value\"','\"another\"=>\"val\"'])
+        done()
+      });
+
       it('should handle nested objects correctly', function(done) {
         expect(hstore.stringify({ test: { nested: 'value' } })).to.equal('"test"=>"{\\"nested\\":\\"value\\"}"')
         done()
@@ -91,7 +96,7 @@ if (dialect.match(/^postgres/)) {
 
     describe('parse', function() {
       it('should handle null objects correctly', function(done) {
-        expect(hstore.parse(null)).to.deep.equal({ })
+        expect(hstore.parse(null)).to.equal(null)
         done()
       })
 
@@ -102,6 +107,11 @@ if (dialect.match(/^postgres/)) {
 
       it('should handle simple objects correctly', function(done) {
         expect(hstore.parse('"test"=>"value"')).to.deep.equal({ test: 'value' })
+        done()
+      })
+
+      it('should handle arrays correctly', function(done) {
+        expect(hstore.parse('{"\\"test\\"=>\\"value\\"","\\"another\\"=>\\"val\\""}')).to.deep.equal([{ test: 'value' }, { another: 'val' }])
         done()
       })
 


### PR DESCRIPTION
This PR adds support for _hstore_ array fields in Postgres.

The model constructor was also refactored a bit to normalize the _DataTypes_ definition throughout the library. The separation of concerns between dialects still needs a bit of work but that can be fixed in the future. 
