### PR TITLE
Model.build() does not return a Promise

### DIFF
--- a/test/promise.test.js
+++ b/test/promise.test.js
@@ -284,6 +284,17 @@ describe(Support.getTestDialectTeaser("Promise"), function () {
           done()
         });
     })
+    
+    it('should also return a promise, when calling build', function(done) {
+      var spy = sinon.spy();
+
+      this.User.build({aNumber: 0})
+        .then(function(user) {
+          expect(spy.calledOnce).to.be.true
+          expect(user.aNumber).to.equal(0)
+          done()
+        });
+    })
 
     it('should fail a validation upon building', function(done) {
       this.User.build({aNumber: 0, validateCustom: 'aaaaaaaaaaaaaaaaaaaaaaaaaa'}).save()


### PR DESCRIPTION
Since we are able to use promises everywhere, it would be very nice to be able to call it also on build(), which seems not possible at the moment. I hope the test helps to tackle this.
