### PR TITLE
Added support for distinct option in Model.aggregate method

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -822,7 +822,11 @@ module.exports = (function() {
   Model.prototype.aggregate = function(field, aggregateFunction, options) {
     options = Utils._.extend({ attributes: [] }, options || {});
 
-    options.attributes.push([this.sequelize.fn(aggregateFunction, this.sequelize.col(field)), aggregateFunction]);
+    var aggregateColumn = this.sequelize.col(field);
+    if (options.distinct) {
+      aggregateColumn = this.sequelize.fn('DISTINCT', aggregateColumn);
+    }
+    options.attributes.push([this.sequelize.fn(aggregateFunction, aggregateColumn), aggregateFunction]);
 
     if (!options.dataType) {
       if (this.rawAttributes[field]) {

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -1174,6 +1174,28 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         })
       })
     })
+    
+    it('supports distinct option', function(done) {
+      var Post = this.sequelize.define('Post',{})
+      var PostComment = this.sequelize.define('PostComment',{})
+      Post.hasMany(PostComment) 
+      Post.sync({ force: true }).success(function() {
+        PostComment.sync({ force: true }).success(function() {
+          Post.create({}).success(function(post){
+            PostComment.bulkCreate([{ PostId: post.id },{ PostId: post.id }]).success(function(){
+              Post.count({ include: [{ model: PostComment, required: false }] }).success(function(count1){
+                Post.count({ distinct: true, include: [{ model: PostComment, required: false }] }).success(function(count2){
+                  expect(count1).to.equal(2)
+                  expect(count2).to.equal(1)
+                  done()
+                })
+              })
+            })
+          })
+        })
+      })
+    })
+    
   })
 
   describe('min', function() {


### PR DESCRIPTION
Modified aggregate method in `lib/model.js` to support `distinct` option and added test to `test/dao-factory.test.js`. Now it is possible to:

```
Model.count({ distinct: true, include: [{ model: OtherModel, required: false }] }).success(function(count){ ... })
```
