### PR TITLE
ILIKE support for postgres

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -315,6 +315,11 @@ var Utils = module.exports = {
     case 'nlike':
     case 'notlike':
       return 'NOT LIKE';
+    case 'ilike':
+      return 'ILIKE';
+    case 'nilike':
+    case 'notilike':
+      return 'NOT ILIKE';
     default:
       return '';
     }

--- a/test/dao-factory/findAll.test.js
+++ b/test/dao-factory/findAll.test.js
@@ -139,6 +139,40 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         })
       })
 
+      if (dialect === 'postgres') {
+        it('should be able to find a row using ilike', function(done) {
+          this.User.findAll({
+            where: {
+              username: {
+                ilike: '%2'
+              }
+            }
+          }).success(function(users) {
+            expect(users).to.be.an.instanceof(Array)
+            expect(users).to.have.length(1)
+            expect(users[0].username).to.equal('boo2')
+            expect(users[0].intVal).to.equal(10)
+            done()
+          })
+        })
+
+        it('should be able to find a row using not ilike', function(done) {
+          this.User.findAll({
+            where: {
+              username: {
+                notilike: '%2'
+              }
+            }
+          }).success(function(users) {
+            expect(users).to.be.an.instanceof(Array)
+            expect(users).to.have.length(1)
+            expect(users[0].username).to.equal('boo')
+            expect(users[0].intVal).to.equal(5)
+            done()
+          })
+        })
+      }
+
       it('should be able to find a row between a certain date using the between shortcut', function(done) {
         this.User.findAll({
           where: {


### PR DESCRIPTION
This PR would allow case insensitive like queries in Postgres via the ILIKE operator. Briefly discussed in https://github.com/sequelize/sequelize/issues/1853. 
