### PR TITLE
reset fields on update attributes

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -668,6 +668,9 @@ module.exports = (function() {
       options = { fields: options };
     }
 
+    if (this.options.attributes) {
+        this.options.attributes = options && options.fields ? options.fields : null;
+    }
     this.set(updates);
     return this.save(options);
   };

--- a/test/dao.test.js
+++ b/test/dao.test.js
@@ -1598,6 +1598,27 @@ describe(Support.getTestDialectTeaser("DAO"), function () {
         })
       })
     })
+
+    it('should update fields that are not specified on create', function(done) {
+      var User = this.sequelize.define('User' + config.rand(), {
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
+        email: DataTypes.STRING
+      })
+
+      User.sync({force: true}).success(function() {
+        User.create({
+          name: 'snafu',
+          email: 'email'
+        }, {fields: ['name', 'email']}).success(function(user) {
+          var emitter = user.updateAttributes({bio: 'bio'});
+          emitter.on('sql', function(sql) {
+            expect(sql).to.match(/[`"]bio[`"]..bio./)
+            done();
+          })
+        })
+      })
+    })
   })
 
   describe('destroy', function() {


### PR DESCRIPTION
When you call `updateAttributes` after `create`, fields are kept from the create method.
btw I think that this pull also solve #1320 but didn't test it

Here is the bug code example that this pull solve

```
var Sequelize = require('sequelize');

var sequelize = new Sequelize(dbname, username, password, settings);

var Project = sequelize.define('Project', {
  title: Sequelize.STRING,
  description: Sequelize.TEXT,
  foo: Sequelize.STRING
});

sequelize.sync({force: true}).then(function() {
    Project.create({title: 'test', description: 'desc'}, {fields: ['title', 'description']}).then(function(project) {
        return project.updateAttributes({foo: 'bar'})
    }).then(function(project){
        // project.foo is undefined because this.options.attributes are ['title', 'description'] 
    });
});
```
