### PR TITLE
pg: remove the useless connection string

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -20,12 +20,16 @@ Utils._.extend(ConnectionManager.prototype, AbstractConnectionManager.prototype)
 
 ConnectionManager.prototype.connect = function(config) {
   var self = this
-    , clientConfig = {};
+    , connectionConfig = {};
 
   config.user = config.username;
+  connectionConfig = Utils._.pick(config, [
+    'user', 'password', 'host', 'database', 'port'
+  ]);
 
   if (config.dialectOptions) {
-    clientConfig = Utils._.pick(config.dialectOptions, [
+    Utils._.merge(connectionConfig,
+                  Utils._.pick(config.dialectOptions, [
       // see [http://www.postgresql.org/docs/9.3/static/runtime-config-logging.html#GUC-APPLICATION-NAME]
       'application_name',
       // choose the SSL mode with the PGSSLMODE environment variable
@@ -40,11 +44,11 @@ ConnectionManager.prototype.connect = function(config) {
       // (unless you know what you're doing)
       // see [http://www.postgresql.org/message-id/flat/bc9549a50706040852u27633f41ib1e6b09f8339d845@mail.gmail.com#bc9549a50706040852u27633f41ib1e6b09f8339d845@mail.gmail.com]
       'binary'
-    ]);
+    ]));
   }
 
   return new Promise(function (resolve, reject) {
-    var connection = new self.lib.Client(clientConfig)
+    var connection = new self.lib.Client(connectionConfig)
       , responded = false;
 
     connection.connect(function(err) {


### PR DESCRIPTION
Hi Sequelize !

When trying to connect to node-postgresql, we don't have to give a connection string, we can also give directly the connection object.

This has the following benefices : 
- no useless string generation then string parsing
- allow us to put smarter data in the configuration object. For example, this allow the connection to a pg database through a named socket via `{host: '/path/to/socket/directory'}`

I didn't see any test to change. It works on our machines with our configuration.
