### PR TITLE
Correctly escaping NULL; that is: do NOT add quotation marks if running SQLite

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -43,7 +43,7 @@ SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
     field = stringifyObjects.field || null;
   }
 
-  if (val === undefined || val === null) {
+  if (val === undefined || val === null || (dialect === 'sqlite' && val === 'NULL')) {
     return 'NULL';
   }
 


### PR DESCRIPTION
Alternative to Pull Request #2075; simply don't add quotation marks around NULL when running SQLite.