### PR TITLE
fix {where: []} causing finds to crash if model is paranoid

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1598,12 +1598,14 @@ module.exports = (function() {
         var whereObj = {};
         whereObj[quoteIdentifiedDeletedAtCol] = null;
         options.where.push(whereObj);
-      } else {
-        // Don't overwrite our explicit deletedAt search value if we provide one
+      } else if (options.where.length) {
         if (options.where[0].indexOf(deletedAtCol) !== -1) {
           return options;
         }
+        // Don't overwrite our explicit deletedAt search value if we provide one
         options.where[0] += ' AND ' + quoteIdentifiedDeletedAtCol + ' IS NULL ';
+      } else {
+        options.where[0] = quoteIdentifiedDeletedAtCol + ' IS NULL ';
       }
     } else {
       options.where[deletedAtCol] = null;

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -642,6 +642,25 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
         })
       })
     })
+
+    it('should not fail if model is paranoid and where is an empty array', function(done) {
+      var User = this.sequelize.define('User', { username: Sequelize.STRING }, { paranoid: true })
+
+      User.sync({ force: true })
+        .then(function () {
+          return User.create({ username: 'A fancy name' })
+        })
+        .then(function(u) {
+          return User.find({ where: [] })
+        })
+        .then(function (u) {
+          expect(u.username).to.equal('A fancy name')
+          done();
+        })
+        .catch(function (err) {
+          done(err)
+        })
+    })
   })
 
   describe('findOrInitialize', function() {


### PR DESCRIPTION
In cases where the model is paranoid and the where is an empty array, the paranoid clause function would attempt to call .indexOf(...) on the first element of that empty array, causing a type error.
