### PR TITLE
Update migrator logging

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -14,7 +14,7 @@ module.exports = (function() {
       path: __dirname + '/../migrations',
       from: null,
       to: null,
-      logging: console.log,
+      logging: this.sequelize.log.bind(this.sequelize),
       filesFilter: /\.js$/
     }, options || {});
   };


### PR DESCRIPTION
This is the point of migrator.options.logging, right? It's helped me to filter out all of the debug info that migration was printing out to the console.
