### PR TITLE
Allow to chain hook definitions on models

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -127,7 +127,7 @@ Hooks.runHooks = function() {
 };
 
 Hooks.hook = function() {
-  Hooks.addHook.apply(this, arguments);
+  return Hooks.addHook.apply(this, arguments);
 };
 
 /**
@@ -155,6 +155,7 @@ Hooks.addHook = function(hookType, name, fn) {
   // Just in case if we override the default DAOFactory.options
   this.options.hooks[hookType] = this.options.hooks[hookType] || [];
   this.options.hooks[hookType][this.options.hooks[hookType].length] = !!name ? {name: name, fn: method} : method;
+  return this;
 };
 
 /**
@@ -163,7 +164,7 @@ Hooks.addHook = function(hookType, name, fn) {
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.beforeValidate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeValidate', name, fn);
+  return Hooks.addHook.call(this, 'beforeValidate', name, fn);
 };
 
 /**
@@ -172,7 +173,7 @@ Hooks.beforeValidate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.afterValidate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterValidate', name, fn);
+  return Hooks.addHook.call(this, 'afterValidate', name, fn);
 };
 
 /**
@@ -181,7 +182,7 @@ Hooks.afterValidate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with attributes, callback(err)
  */
 Hooks.beforeCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeCreate', name, fn);
+  return Hooks.addHook.call(this, 'beforeCreate', name, fn);
 };
 
 /**
@@ -190,7 +191,7 @@ Hooks.beforeCreate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with attributes, callback(err)
  */
 Hooks.afterCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterCreate', name, fn);
+  return Hooks.addHook.call(this, 'afterCreate', name, fn);
 };
 
 /**
@@ -201,7 +202,7 @@ Hooks.afterCreate = function(name, fn) {
  * @alias beforeDelete
  */
 Hooks.beforeDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeDestroy', name, fn);
+  return Hooks.addHook.call(this, 'beforeDestroy', name, fn);
 };
 
 /**
@@ -212,15 +213,15 @@ Hooks.beforeDestroy = function(name, fn) {
  * @alias afterDelete
  */
 Hooks.afterDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'afterDestroy', name, fn);
+  return Hooks.addHook.call(this, 'afterDestroy', name, fn);
 };
 
 Hooks.beforeDelete = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeDelete', name, fn);
+  return Hooks.addHook.call(this, 'beforeDelete', name, fn);
 };
 
 Hooks.afterDelete = function(name, fn) {
-  Hooks.addHook.call(this, 'afterDelete', name, fn);
+  return Hooks.addHook.call(this, 'afterDelete', name, fn);
 };
 
 /**
@@ -229,7 +230,7 @@ Hooks.afterDelete = function(name, fn) {
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.beforeUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeUpdate', name, fn);
+  return Hooks.addHook.call(this, 'beforeUpdate', name, fn);
 };
 
 /**
@@ -238,7 +239,7 @@ Hooks.beforeUpdate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with instance, callback(err)
  */
 Hooks.afterUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterUpdate', name, fn);
+  return Hooks.addHook.call(this, 'afterUpdate', name, fn);
 };
 
 /**
@@ -247,7 +248,7 @@ Hooks.afterUpdate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with instances, fields, callback(err)
  */
 Hooks.beforeBulkCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeBulkCreate', name, fn);
+  return Hooks.addHook.call(this, 'beforeBulkCreate', name, fn);
 };
 
 /**
@@ -256,7 +257,7 @@ Hooks.beforeBulkCreate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with instances, fields, callback(err)
  */
 Hooks.afterBulkCreate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterBulkCreate', name, fn);
+  return Hooks.addHook.call(this, 'afterBulkCreate', name, fn);
 };
 
 /**
@@ -265,7 +266,7 @@ Hooks.afterBulkCreate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with where, callback(err)
  */
 Hooks.beforeBulkDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeBulkDestroy', name, fn);
+  return Hooks.addHook.call(this, 'beforeBulkDestroy', name, fn);
 };
 
 /**
@@ -274,7 +275,7 @@ Hooks.beforeBulkDestroy = function(name, fn) {
  * @param {Function} fn   A callback function that is called with where, callback(err)
  */
 Hooks.afterBulkDestroy = function(name, fn) {
-  Hooks.addHook.call(this, 'afterBulkDestroy', name, fn);
+  return Hooks.addHook.call(this, 'afterBulkDestroy', name, fn);
 };
 
 /**
@@ -283,7 +284,7 @@ Hooks.afterBulkDestroy = function(name, fn) {
  * @param {Function} fn   A callback function that is called with attribute, where, callback(err)
  */
 Hooks.beforeBulkUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'beforeBulkUpdate', name, fn);
+  return Hooks.addHook.call(this, 'beforeBulkUpdate', name, fn);
 };
 
 /**
@@ -292,5 +293,5 @@ Hooks.beforeBulkUpdate = function(name, fn) {
  * @param {Function} fn   A callback function that is called with attribute, where, callback(err)
  */
 Hooks.afterBulkUpdate = function(name, fn) {
-  Hooks.addHook.call(this, 'afterBulkUpdate', name, fn);
+  return Hooks.addHook.call(this, 'afterBulkUpdate', name, fn);
 };


### PR DESCRIPTION
This commit allows to chain hook definitions like

Project
    .afterCreate(function (proj, fn) {/\* HOOK _/})
    .beforeDestroy(function (proj, fn) {/_ HOOK */})
;
