### PR TITLE
Pass up the underlying fields and results objects from the dialect

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -37,7 +37,11 @@ module.exports = (function() {
           err.sql = sql;
           reject(err);
         } else {
-          resolve(self.formatResults(results));
+          resolve({
+            result: self.formatResults(results),
+            fields: fields,
+            results: results
+          });
         }
       }).setMaxListeners(100);
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -526,9 +526,14 @@ module.exports = (function() {
       options.transaction ? options.transaction.connection : self.connectionManager.getConnection()
     ).then(function (connection) {
       var query = new self.dialect.Query(connection, self, callee, options);
-      return query.run(sql).finally(function() {
-        if (options.transaction) return;
-        return self.connectionManager.releaseConnection(connection);
+      return query.run(sql)
+      .then(function(result) {
+        if (options.transaction) return result;
+        return self.connectionManager.releaseConnection(connection).then(
+          function (promise) {
+            return result;
+          }
+        );
       });
     });
   };


### PR DESCRIPTION
Pass up the underlying fields and results objects from the dialect up through to `Sequelize.prototype.query()`. Partially addresses Issue #2172 (at least for the mysql dialect).

TODO:
- support for postgresql, sqlite and maria dialects.
