### PR TITLE
Fix an bug: Boolean always return true in mysql when column define has attributes of ZeroFill and Unsigned.

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -316,7 +316,7 @@ module.exports = (function() {
               // Bit fields are returned as buffers
               value = value[0];
             }
-            value = _.isString(value)?!!parseInt(value):!!value;
+            value = _.isString(value) ? !!parseInt(value) : !!value;
           }
 
           if (!options.raw && originalValue !== value) {


### PR DESCRIPTION
Find a bug about Query a boolean from database, when set column define to ZeroFill and Unsigned in database side.

If we use sequelizejs.define to create a boolean column, the define in Mysql database is not ZeroFill and not Unsigned, it will be OK.
And if you manually set the definition in Mysql to ZeroFill and Unsigned, and the Model.find/findAll will always return TRUE even the value in database is 0 or null!

So I change the code from direct using "!!value" into "!!parseInt(value)".
