### PR TITLE
Pass up the underlying results object from insertion queries

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -66,7 +66,7 @@ module.exports = (function() {
     var result = this.callee;
 
     if (this.isInsertQuery(data)) {
-      this.handleInsertQuery(data);
+      result = this.handleInsertQuery(data);
     }
 
     if (this.isSelectQuery()) {
@@ -160,6 +160,8 @@ module.exports = (function() {
       id = id || (metaData && metaData[this.getInsertIdField()]);
 
       this.callee[autoIncrementField] = id;
+    } else {
+      return results;
     }
   };
 

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -66,7 +66,11 @@ module.exports = (function() {
     var result = this.callee;
 
     if (this.isInsertQuery(data)) {
-      result = this.handleInsertQuery(data);
+      if (this.callee === null) {
+        result = this.handleInsertQuery(data);
+      } else {
+        this.handleInsertQuery(data);
+      }
     }
 
     if (this.isSelectQuery()) {
@@ -161,7 +165,9 @@ module.exports = (function() {
 
       this.callee[autoIncrementField] = id;
     } else {
-      return results;
+      if (this.callee === null) {
+        return results;
+      }
     }
   };
 

--- a/test/sequelize.test.js
+++ b/test/sequelize.test.js
@@ -225,7 +225,7 @@ describe(Support.getTestDialectTeaser("Sequelize"), function () {
       this.sequelize.query(this.insertQuery, null, { raw: true })
       .complete(function(err, result) {
         expect(err).to.be.null
-        expect(result).to.be.null
+        expect(result).to.be.instanceOf(Object)
         done()
       })
     })


### PR DESCRIPTION
Pass up the underlying results object from insertion queries in ``formatResults()``.

Closes Issue #2172