### PR TITLE
fixed write pooling release. This makes writes work for master/slave MySQL setups

### DIFF
--- a/lib/dialects/mysql/connector-manager.js
+++ b/lib/dialects/mysql/connector-manager.js
@@ -108,7 +108,7 @@ module.exports = (function() {
           create: function (done) {
             connect.call(self, function (err, connection) {
               if (connection) {
-                connection.queryType = 'read'
+                connection.queryType = 'write'
               }
 
               done(err, connection)
@@ -153,7 +153,7 @@ module.exports = (function() {
 
       return
     }.bind(this);
-    
+
     process.on('exit', this.onProcessExit)
   }
 
@@ -185,7 +185,7 @@ module.exports = (function() {
           setTimeout(function() {
             if (self.pendingQueries === 0){
               self.disconnect.call(self);
-            } 
+            }
           }, 100);
         }
       }


### PR DESCRIPTION
After 10 writes, the write connection pool would die because connections were not being released.
config:

``` js
sequelize = new Sequelize(
  MYSQL_SLAVE.DB
  null
  null
  replication:
    read: [
      host: MYSQL_SLAVE.HOST
      username: MYSQL_SLAVE.USER
      password: MYSQL_SLAVE.PASS
      pool: {} #https://github.com/sequelize/sequelize/pull/1251
    ]
    write:
      host: MYSQL_MASTER.HOST
      username: MYSQL_MASTER.USER
      password: MYSQL_MASTER.PASS
      pool: {} #https://github.com/sequelize/sequelize/pull/1251
)
```
