### PR TITLE
Run afterDestroy hook on paranoid model

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -739,7 +739,6 @@ module.exports = (function() {
 
       if (self.Model._timestampAttributes.deletedAt && options.force === false) {
         self.dataValues[self.Model._timestampAttributes.deletedAt] = new Date();
-        options.hooks = false;
         return self.save(options);
       } else {
         identifier = self.__options.hasPrimaryKeys ? self.primaryKeyValues : { id: self.id };


### PR DESCRIPTION
This tripped me up until I went and saw that there was no way to run an afterDestroy hook on a paranoid model. Can't think of any good reason for this to be how it is; open to hearing a reason to keep it. At the very least it should honor an explicit `{hooks : true}` option passed into the `destroy` call.
