### PR TITLE
Bug fix for hooks

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -98,7 +98,7 @@ Hooks.runHooks = function(hooks) {
     hooks = hooks === undefined ? [] : [hooks];
   }
 
-  var promise = Promise.each(hooks, function(hook) {
+  var promise = Promise.each(hooks, function (hook) {
     if (typeof hook === 'object') {
       hook = hook.fn;
     }


### PR DESCRIPTION
Turns out `Promise.map()` runs on the items in the array in an unpredictable order. Changed to `Promise.each()` instead for serial execution in order of array items.
