### PR TITLE
Update query.js

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -72,7 +72,7 @@ module.exports = (function() {
         });
 
       case 1452:
-        match = err.message.match(/FOREIGN KEY \(`(.*)`\) REFERENCES `(.*)` \(`(.*)`\)\)$/);
+        match = err.message.match(/FOREIGN KEY \(`(.*)`\) REFERENCES `(.*)` \(`(.*)`\)(.*)\)$/);
 
         return new sequelizeErrors.ForeignKeyConstraintError({
           fields: null,


### PR DESCRIPTION
Regex does not match the following error: ```Sql
Cannot add or update a child row: a foreign key constraint fails (`database`.`Table`, CONSTRAINT`Table_ibfk_1`FOREIGN KEY (`ForeignKey`) REFERENCES`OtherTable`(`id`) ON DELETE SET NULL ON UPDATE CASCADE)

```
Addionnal text like "ON DELETE SET NULL ON UPDATE CASCADE" was not handled by the regex.
```
