### PR TITLE
Fix create include parameter

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1027,7 +1027,8 @@ module.exports = (function() {
 
     return this.build(values, {
       isNewRecord: true,
-      attributes: options.fields
+      attributes: options.fields,
+      include: options.include
     }).save(options);
   };
 


### PR DESCRIPTION
The include parameter is described in the comments but has not effect. This fix adds the include parameter to the `build` methods, so when calling `reload` all includes will be fetched.
