### PR TITLE
Added handler for PRAGMA foreign_key_list query in sqlite dialect

### DIFF
--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -129,6 +129,8 @@ module.exports = (function() {
                     result = results[0];
                   } else if (self.sql.indexOf('PRAGMA foreign_keys') !== -1) {
                     result = results;
+                  } else if (self.sql.indexOf('PRAGMA foreign_key_list') !== -1) {
+                    result = results;
                   } else if ([QueryTypes.BULKUPDATE, QueryTypes.BULKDELETE].indexOf(self.options.type) !== -1) {
                     result = metaData.changes;
                   }


### PR DESCRIPTION
This addition should fix issues with getting foreign keys from a sqlite database

``` javascript
sequelize.query(self.queryInterface.QueryGenerator.getForeignKeysQuery(tableName, self.sequelize.config.database))
```

Maybe the preceding lines could be rewritten instead?

``` javascript
                   } else if (self.sql.indexOf('PRAGMA foreign_key') !== -1) {
                     result = results;
```
