### PR TITLE
Model.build default parameters are now set when an options object is given

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -955,7 +955,10 @@ module.exports = (function() {
     if (Array.isArray(values)) {
       return this.bulkBuild(values, options);
     }
-    options = options || { isNewRecord: true, isDirty: true };
+    options = Utils._.extend({
+      isNewRecord: true,
+      isDirty: true
+    }, options || {});
 
     if (options.attributes) {
       options.attributes = options.attributes.map(function(attribute) {
@@ -976,7 +979,10 @@ module.exports = (function() {
 
 
   Model.prototype.bulkBuild = function(valueSets, options) {
-    options = options || { isNewRecord: true, isDirty: true };
+    options = Utils._.extend({
+      isNewRecord: true,
+      isDirty: true
+    }, options || {});
 
     if (!options.includeValidated) {
       conformOptions(options);


### PR DESCRIPTION
This pull request fixes the default options extending behaviour like in all other functions.
