### PR TITLE
Typo in findAll options.include[].where

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -678,7 +678,7 @@ module.exports = (function() {
    * @param  {Model}                     [options.include[].model] The model you want to eagerly load
    * @param  {String}                    [options.include[].as] The alias of the relation, in case the model you want to eagerly load is aliassed. For `hasOne` / `belongsTo`, this should be the singular name, and for `hasMany`, it should be the plural
    * @param  {Association}               [options.include[].association] The association you want to eagerly load. (This can be used instead of providing a model/as pair)
-   * @param  {Object}                    [options.include[].where] Where clauses to apply to the child models. Note that this converts the eager load to an inner join, unless you explicitly set `required: true`
+   * @param  {Object}                    [options.include[].where] Where clauses to apply to the child models. Note that this converts the eager load to an inner join, unless you explicitly set `required: false`
    * @param  {Array<String>}             [options.include[].attributes] A list of attributes to select from the child model
    * @param  {Boolean}                   [options.include[].required] If true, converts to an inner join, which means that the parent model will only be loaded if it has any matching children. True if `include.where` is set, false otherwise.
    * @param  {Array<Object|Model>}       [options.include[].include] Load further nested related models


### PR DESCRIPTION
Reference #2370 
