### PR TITLE
Prevent closing connections on transaction commit on sqlite in-memory databases

### DIFF
--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -23,16 +23,17 @@ ConnectionManager.prototype.getConnection = function(options) {
   var self = this;
   options = options || {};
   options.uuid = options.uuid || 'default';
+	options.inMemory = ((self.sequelize.options.storage || ':memory:') == ':memory:')?1:0;
 
-  if (self.connections[options.uuid]) return Promise.resolve(self.connections[options.uuid]);
+  if (self.connections[options.inMemory||options.uuid]) return Promise.resolve(self.connections[options.inMemory||options.uuid]);
 
   return new Promise(function (resolve, reject) {
-    self.connections[options.uuid] = new self.lib.Database(self.sequelize.options.storage || ':memory:', function(err) {
+    self.connections[options.inMemory||options.uuid] = new self.lib.Database(self.sequelize.options.storage || ':memory:', function(err) {
       if (err) {
         if (err.code === 'SQLITE_CANTOPEN') return reject('Failed to find SQL server. Please double check your settings.');
         return reject(err);
       }
-      resolve(self.connections[options.uuid]);
+      resolve(self.connections[options.inMemory||options.uuid]);
     });
   }).tap(function (connection) {
     if (self.sequelize.options.foreignKeys !== false) {

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -23,17 +23,17 @@ ConnectionManager.prototype.getConnection = function(options) {
   var self = this;
   options = options || {};
   options.uuid = options.uuid || 'default';
-	options.inMemory = ((self.sequelize.options.storage || ':memory:') == ':memory:')?1:0;
+  options.inMemory = ((self.sequelize.options.storage || ':memory:') === ':memory:')?1:0;
 
-  if (self.connections[options.inMemory||options.uuid]) return Promise.resolve(self.connections[options.inMemory||options.uuid]);
+  if (self.connections[options.inMemory || options.uuid]) return Promise.resolve(self.connections[options.inMemory || options.uuid]);
 
   return new Promise(function (resolve, reject) {
-    self.connections[options.inMemory||options.uuid] = new self.lib.Database(self.sequelize.options.storage || ':memory:', function(err) {
+    self.connections[options.inMemory || options.uuid] = new self.lib.Database(self.sequelize.options.storage || ':memory:', function(err) {
       if (err) {
         if (err.code === 'SQLITE_CANTOPEN') return reject('Failed to find SQL server. Please double check your settings.');
         return reject(err);
       }
-      resolve(self.connections[options.inMemory||options.uuid]);
+      resolve(self.connections[options.inMemory || options.uuid]);
     });
   }).tap(function (connection) {
     if (self.sequelize.options.foreignKeys !== false) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -591,7 +591,7 @@ module.exports = (function() {
     ).then(function (connection) {
       var query = new self.dialect.Query(connection, self, callee, options);
       return query.run(sql).finally(function() {
-        if (options.transaction || connection.filename == ":memory:") return;
+        if (options.transaction || (connection.filename === ":memory:")) return;
         return self.connectionManager.releaseConnection(connection);
       });
     });

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -591,7 +591,7 @@ module.exports = (function() {
     ).then(function (connection) {
       var query = new self.dialect.Query(connection, self, callee, options);
       return query.run(sql).finally(function() {
-        if (options.transaction) return;
+        if (options.transaction || connection.filename == ":memory:") return;
         return self.connectionManager.releaseConnection(connection);
       });
     });

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -55,41 +55,41 @@ describe(Support.getTestDialectTeaser("Transaction"), function () {
     });
   });
 
-	if (dialect == 'sqlite'){
-		it('provides persistent transactions', function (done) {
-			var sequelize = new Support.Sequelize('database', 'username', 'password', {dialect: 'sqlite'});
-			var User = sequelize.define('user', {
-				username: Support.Sequelize.STRING,
-				awesome: Support.Sequelize.BOOLEAN
-			});
-			return sequelize.transaction()
-				.then(function(t) {
-					return sequelize.sync({transaction:t})
-						.then(function( ) {
-							return t;							
-						});
-				})
-				.then(function(t) {
-					return User.create({}, {transaction:t})
-						.then(function( ) {
-							t.commit();
-						});
-				})
-				.then(function( ) {
-					return sequelize.transaction();
-				})
-				.then(function(t) {
-					return User.findAll({}, {transaction:t});
-				})
-				.then(function(users) {
-					return expect(users.length).to.equal(2);
-				})
-				.then(function(object) {
-					done();
-				});
-		});	
-	}
-			
+  if (dialect === 'sqlite'){
+    it('provides persistent transactions', function (done) {
+      var sequelize = new Support.Sequelize('database', 'username', 'password', {dialect: 'sqlite'}),
+          User = sequelize.define('user', {
+            username: Support.Sequelize.STRING,
+            awesome: Support.Sequelize.BOOLEAN
+          });
+      return sequelize.transaction()
+        .then(function(t) {
+          return sequelize.sync({transaction:t})
+            .then(function( ) {
+              return t;              
+            });
+        })
+        .then(function(t) {
+          return User.create({}, {transaction:t})
+            .then(function( ) {
+              t.commit();
+            });
+        })
+        .then(function( ) {
+          return sequelize.transaction();
+        })
+        .then(function(t) {
+          return User.findAll({}, {transaction:t});
+        })
+        .then(function(users) {
+          return expect(users.length).to.equal(2);
+        })
+        .then(function(object) {
+          done();
+        });
+    });  
+  }
+
   if (dialect !== 'sqlite') {
     describe('row locking', function () {
       this.timeout(10000);

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -82,7 +82,7 @@ describe(Support.getTestDialectTeaser("Transaction"), function () {
           return User.findAll({}, {transaction:t});
         })
         .then(function(users) {
-          return expect(users.length).to.equal(2);
+          return expect(users.length).to.equal(1);
         })
         .then(function(object) {
           done();

--- a/test/transaction.test.js
+++ b/test/transaction.test.js
@@ -55,6 +55,41 @@ describe(Support.getTestDialectTeaser("Transaction"), function () {
     });
   });
 
+	if (dialect == 'sqlite'){
+		it('provides persistent transactions', function (done) {
+			var sequelize = new Support.Sequelize('database', 'username', 'password', {dialect: 'sqlite'});
+			var User = sequelize.define('user', {
+				username: Support.Sequelize.STRING,
+				awesome: Support.Sequelize.BOOLEAN
+			});
+			return sequelize.transaction()
+				.then(function(t) {
+					return sequelize.sync({transaction:t})
+						.then(function( ) {
+							return t;							
+						});
+				})
+				.then(function(t) {
+					return User.create({}, {transaction:t})
+						.then(function( ) {
+							t.commit();
+						});
+				})
+				.then(function( ) {
+					return sequelize.transaction();
+				})
+				.then(function(t) {
+					return User.findAll({}, {transaction:t});
+				})
+				.then(function(users) {
+					return expect(users.length).to.equal(2);
+				})
+				.then(function(object) {
+					done();
+				});
+		});	
+	}
+			
   if (dialect !== 'sqlite') {
     describe('row locking', function () {
       this.timeout(10000);


### PR DESCRIPTION
When committing transactions on in-memory (:memory:) sqlite databases the connection should not be closed - closing the connection causes the database to be dropped/reset. This request contains a test as well as a (somewhat hacky) solution to this problem.