### PR TITLE
Fix error parsing for foreign key constraints

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -244,8 +244,8 @@ module.exports = (function() {
 
     switch (err.code) {
       case '23503':
-        tableMatch = err.message.match(/on table \"(.+?)\"/);
-        keyMatch = err.message.match(/violates foreign key constraint \"(.+?)\"/);
+        var tableMatch = err.message.match(/on table \"(.+?)\"/);
+        var keyMatch = err.message.match(/violates foreign key constraint \"(.+?)\"/);
         return new sequelizeErrors.ForeignKeyConstraintError({
           fields: null,
           table: tableMatch[1],


### PR DESCRIPTION
I checked the docs and looks like the error has been "on table <table> violates foreign key constraint <constraint>" since postgres 7.4
http://www.postgresql.org/docs/7.4/static/tutorial-fk.html
http://www.postgresql.org/docs/9.3/static/tutorial-fk.html

I tried to run the tests, but ran into problems getting things set up cleanly on OSX
