### PR TITLE
Rename the CLI to sequelize-legacy

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "docs": "node_modules/.bin/yuidoc . -o docs"
   },
   "bin": {
-    "sequelize": "bin/sequelize"
+    "sequelize-legacy": "bin/sequelize"
   },
   "engines": {
     "node": ">=0.6.21"


### PR DESCRIPTION
In order to use the new CLI with v1.7 it is necessary to rename or remove the old executable. This PR renames the old executable to `sequelize-legacy`.

Fixes https://github.com/sequelize/cli/issues/47 and https://github.com/sequelize/sequelize/issues/2376
