### PR TITLE
update postgresql error message parsing on foreign key

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -240,15 +240,19 @@ module.exports = (function() {
   };
 
   Query.prototype.formatError = function (err) {
-    var match;
+    var match
+      , table
+      , index;
 
     switch (err.code) {
       case '23503':
-        match = err.message.match(/violates foreign key constraint \"(.+?)\" on table \"(.+?)\"/);
+        index = err.message.match(/violates foreign key constraint \"(.+?)\"/)[1];
+        table = err.message.match(/on table \"(.+?)\"/)[1];
+
         return new sequelizeErrors.ForeignKeyConstraintError({
           fields: null,
-          index: match[1],
-          table: match[2],
+          index: index,
+          table: table,
           parent: err
         });
       case '23505':


### PR DESCRIPTION
Error code: 23503

On "recent" postgresql (> 8?), error message is:
`insert or update on table "$table" violates foreign key constraint
"$index"`

I updated the error match to get the right table and index in both
cases.

Before this patch, sequelize failed badly with: `TypeError: Cannot read
property '1' of null`
