### PR TITLE
add different error format for 23505 error on postgres

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -266,7 +266,7 @@ module.exports = (function() {
         } else {
           return new sequelizeErrors.UniqueConstraintError({
             error: err,
-            message: 'Could not further parse error message.'
+            message: err.message
           });
         }
         break;


### PR DESCRIPTION
Would you guys like me to submit a failing test for this? Do you guys test this kind of thing?

Also, I tried to find somewhere on postgres where it mapped error codes into error messages but I didn't find it. Any idea on if this exists out there? There might be even more error formats for code 23505 or other codes...
