### PR TITLE
Include options when calling destroy on a paranoid table

### DIFF
--- a/lib/dao-factory.js
+++ b/lib/dao-factory.js
@@ -994,7 +994,7 @@ module.exports = (function() {
           var attrValueHash = {}
           attrValueHash[self._timestampAttributes.deletedAt] = Utils.now()
           query = 'bulkUpdate'
-          args  = [self.tableName, attrValueHash, where]
+          args  = [self.tableName, attrValueHash, where, options]
         } else {
           query = 'bulkDelete'
           args  = [self.tableName, where, options]


### PR DESCRIPTION
In order to use transactions with paranoid tables in 1.7.0, the `options` variable needs to be passed into the `bulkUpdate` call with the transaction. 

Fixes https://github.com/sequelize/sequelize/issues/2387.
