### PR TITLE
count() returned NaN with Postgres and quoteIdentifiers=false

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -865,7 +865,7 @@ module.exports = (function() {
     options.includeIgnoreAttributes = false;
     options.limit = null;
 
-    return this.aggregate(col, 'COUNT', options);
+    return this.aggregate(col, 'count', options);
   };
 
   /**

--- a/test/postgres/dao.test.js
+++ b/test/postgres/dao.test.js
@@ -536,14 +536,24 @@ if (dialect.match(/^postgres/)) {
                 where: {fullName: "John Smith"}
               })
               .success(function(user2) {
-                self.sequelize.options.quoteIndentifiers = true
-                self.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = true
-                self.sequelize.options.logging = false
                 // We can map values back to non-quoted identifiers
                 expect(user2.id).to.equal(user.id)
                 expect(user2.username).to.equal('user')
                 expect(user2.fullName).to.equal('John Smith')
-                done()
+
+                // We can query and aggregate by non-quoted identifiers
+                self.User
+                  .count({
+                    where: {fullName: "John Smith"}
+                  })
+                  .success(function(count) {
+                    self.sequelize.options.quoteIndentifiers = true
+                    self.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = true
+                    self.sequelize.options.logging = false
+
+                    expect(count).to.equal(1)
+                    done()
+                  })
               })
             })
         })


### PR DESCRIPTION
Model.count() and findAndCountAll() returned NaN with Postgres and quoteIdentifiers==false. The Postgres returns "count" in lower case. 
