### PR TITLE
dialects.mysql.connection-manager: Use `connection._protocol._ended` state on $validate

### DIFF
--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -74,7 +74,7 @@ ConnectionManager.prototype.disconnect = function(connection) {
   });
 };
 ConnectionManager.prototype.validate = function(connection) {
-  return connection && [ 'disconnected', 'protocol_error' ].indexOf( connection.state ) !== -1;
+  return connection && ['disconnected', 'protocol_error'].indexOf(connection.state) !== -1;
 };
 
 module.exports = ConnectionManager;


### PR DESCRIPTION
Change validation method, as discussed on #2381
