### PR TITLE
Add reference to Instance to public API

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -12,6 +12,7 @@ var url = require('url')
   , sequelizeErrors = require('./errors')
   , Promise = require('./promise')
   , Hooks = require('./hooks')
+  , Instance = require('./instance')
   , deprecatedSeen = {}
   , deprecated = function(message) {
     if (deprecatedSeen[message]) return;
@@ -243,6 +244,13 @@ module.exports = (function() {
    * @see {Sequelize#transaction}
    */
   Sequelize.prototype.Transaction = Sequelize.Transaction = Transaction;
+
+  /**
+   * A reference to the sequelize instance class.
+   * @property Instance
+   * @see {Instance}
+   */
+  Sequelize.prototype.Instance = Sequelize.Instance = Instance;
 
   /**
    * Allow hooks to be defined on Sequelize + on sequelize instance as universal hooks to run on all models


### PR DESCRIPTION
Hello all.

This PR exposes `Instance` in the public API.

Use-case is so that plugins can add methods to `Instance.prototype`. This would certainly be helpful for me with some of the stuff I'm working on.

There may be a downside to this that I haven't thought of, but all tests pass.
