### PR TITLE
Sequelize.prototype.Sequelize

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -203,6 +203,13 @@ module.exports = (function() {
   Sequelize.options = {hooks: {}};
 
   /**
+   * A reference to Sequelize constructor from sequelize. Useful for accessing DataTypes, Errors etc.
+   * @property Sequelize
+   * @see {Sequelize}
+   */
+  Sequelize.prototype.Sequelize = Sequelize;
+
+  /**
    * A reference to sequelize utilities. Most users will not need to use these utils directly. However, you might want to use `Sequelize.Utils._`, which is a reference to the lodash library, if you don't already have it imported in your project.
    * @property Utils
    * @see {Utils}


### PR DESCRIPTION
This PR adds `Sequelize` to `Sequelize.prototype`.

This may seem like a bit of a strange one. Why would you need access to `Sequelize` from `Sequelize.prototype` when you can just `require('sequelize')`?

I'm finding while writing plugins that I am listing Sequelize as a peerDependency rather than a straight dependency, so that you can chain multiple plugins like:

```
var Sequelize = require('sequelize');
require('sequelize-plugin1')(Sequelize);
require('sequelize-plugin2')(Sequelize);
```

In a hook function in a plugin, you may need to access `Sequelize` to get to for example `Sequelize.Error` or some of the data types. In this case you don't want to `require('sequelize')` as you want to make sure that you get the instance of `Sequelize` that was passed to the plugin, so better to be able to use `sequelize.Sequelize`.

I don't know if that makes sense!

I guess it does clutter the API a little, but doesn't affect the tests or BC, and I think it could be useful in some cases. What do you think?
