### PR TITLE
Fix(queryGenerator#quote): `as` variable

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -556,7 +556,7 @@ module.exports = (function() {
           }
 
           // check if model provided is through table
-          if (!as && parentAssociation && parentAssociation.through.model === model) {
+          if (!as && parentAssociation && parentAssociation.through && parentAssociation.through.model === model) {
             association = {as: Utils.singularize(model.tableName, model.options.language)};
           } else {
             // find applicable association for linking parent to this model


### PR DESCRIPTION
Just discovered a bug in code that I (oh the shame of it!) put into Sequelize a while ago.

The `as` variable should be set to undefined each time it goes round the for loop, but it wasn't being reset. This could in circumstances cause the wrong behaviour.
