### PR TITLE
breaking tests for assns w/ foreignKey fields

### DIFF
--- a/test/associations/has-many.test.js
+++ b/test/associations/has-many.test.js
@@ -1573,6 +1573,8 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
             self.Project.create({name: 'Good Will Hunting'})
           ]);
         }).spread(function (user, project) {
+          self.user = user;
+          self.project = project;
           return user.addProject(project).return(user);
         }).then(function(user) {
           return user.getProjects();
@@ -1580,6 +1582,9 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           var project = projects[0];
 
           expect(project).to.be.defined;
+          return self.user.removeProject(project);
+        }).then(function() {
+          return self.user.setProjects([project]);
         });
       });
 


### PR DESCRIPTION
when specifying an association that has a foreign key in which the attribute name and field name are different certain helper methods do not work because they fail to substitute the attribute name with the field name in the query, this includes `set[AS]` and `remove[AS]`
