### PR TITLE
Fixing downward migration issue

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -107,6 +107,17 @@ module.exports = (function() {
       .value();
   };
 
+  Migrator.prototype._filterWithFromAndTo = function(migrations) {
+    if (this.options.from) {
+      migrations = Utils._.filter(migrations, function(m) { return m.isAfter(this.options.from); }, this);
+    }
+    if (this.options.to) {
+      migrations = Utils._.filter(migrations, function(m) { return m.isBefore(this.options.to); }, this);
+    }
+
+    return migrations;
+  };
+
   Migrator.prototype.getUndoneMigrations = function(callback)  {
     var self = this;
 
@@ -128,12 +139,17 @@ module.exports = (function() {
       });
     };
 
-    getPendingMigrations(function(err, pendingMigrations) {
-      if (self.options.to) {
-        pendingMigrations = pendingMigrations.filter(function(m) { return m.isBefore(self.options.to); });
-      }
-      callback && callback(err, pendingMigrations);
-    });
+    if (this.options.from) {
+      migrations = this._filterWithFromAndTo(migrations);
+      callback && callback(null, migrations);
+    } else {
+      getPendingMigrations(function(err, pendingMigrations) {
+        if (self.options.to) {
+          pendingMigrations = pendingMigrations.filter(function(m) { return m.isBefore(self.options.to); });
+        }
+        callback && callback(err, pendingMigrations);
+      });
+    }
   };
 
   Migrator.prototype.getCompletedMigrations = function(callback)  {
@@ -152,12 +168,7 @@ module.exports = (function() {
       });
 
       var migrations = filterByMigrationId(self.getMigrations(), allMigrationIds);
-      if (self.options.from) {
-        migrations = migrations.filter(function(m) { return m.isAfter(self.options.from); });
-      }
-      if (self.options.to) {
-        migrations = migrations.filter(function(m) { return m.isBefore(self.options.to); });
-      }
+      migrations = self._filterWithFromAndTo(migrations);
 
       callback(null, migrations || []);
     });

--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -52,7 +52,7 @@ module.exports = (function() {
       emitter.emit('error', err);
     } else {
       var chainer = new Utils.QueryChainer()
-        , from = migrations[0];
+        , from = options.method === 'down' ? Utils._.last(migrations) : Utils._.first(migrations);
 
       if (migrations.length === 0) {
         self.options.logging('There are no pending migrations.');
@@ -93,17 +93,22 @@ module.exports = (function() {
     }
   };
 
+  Migrator.prototype.getMigrations = function(callback) {
+    return Utils._(fs.readdirSync(this.options.path))
+      .filter(function(file) {
+        return this.options.filesFilter.test(file);
+      }, this)
+      .map(function(file) {
+        return new Migration(this, this.options.path + '/' + file);
+      }, this)
+      .sortBy(function(file) {
+        return parseInt(file.filename.split('-')[0], 10);
+      })
+      .value();
+  };
+
   Migrator.prototype.getUndoneMigrations = function(callback)  {
     var self = this;
-
-    var filterFrom = function(migrations, from, callback, options) {
-      var result = migrations.filter(function(migration) { return migration.isAfter(from, options); });
-      callback && callback(null, result);
-    };
-    var filterTo = function(migrations, to, callback, options) {
-      var result = migrations.filter(function(migration) { return migration.isBefore(to, options); });
-      callback && callback(null, result);
-    };
 
     var filterByMigrationId = function(migrations, migrationIds, callback) {
       var result = migrations.filter(function(migration) { return migrationIds.indexOf(migration.migrationId) === -1;
@@ -111,86 +116,50 @@ module.exports = (function() {
       callback && callback(null, result);
     };
 
-    var migrationFiles = fs.readdirSync(this.options.path).filter(function(file) {
-      return self.options.filesFilter.test(file);
-    });
-
-    var migrations = migrationFiles.map(function(file) {
-      return new Migration(self, self.options.path + '/' + file);
-    });
-
-    migrations = migrations.sort(function(a, b) {
-      return parseInt(a.filename.split('-')[0]) - parseInt(b.filename.split('-')[0]);
-    });
-
-    var existingMigrationIds = migrations.map(function(migration) {
-      return migration.migrationId;
-    });
-
+    var migrations = this.getMigrations();
     var getPendingMigrations = function(callback) {
       getAllMigrationIdsFromDatabase.call(self).success(function(allMigrationIds) {
         allMigrationIds = allMigrationIds.map(function(migration) {
-          return parseInt(migration.to);
+          return parseInt(migration.to, 10);
         });
         if (allMigrationIds) {
           filterByMigrationId(migrations, allMigrationIds, callback);
         }
-
       });
     };
 
-    if (this.options.from) {
-      filterFrom(migrations, this.options.from, function(err, migrations) {
-        if (self.options.to) {
-          filterTo(migrations, self.options.to, callback);
-        } else {
-          callback && callback(null, migrations);
-        }
-      });
-    } else {
-      getPendingMigrations(function(err, pendingMigrations) {
-        if (self.options.to) {
-          filterTo(pendingMigrations, self.options.to, callback);
-        }
-        else {
-          callback && callback(err, pendingMigrations);
-        }
-      });
-    }
+    getPendingMigrations(function(err, pendingMigrations) {
+      if (self.options.to) {
+        pendingMigrations = pendingMigrations.filter(function(m) { return m.isBefore(self.options.to); });
+      }
+      callback && callback(err, pendingMigrations);
+    });
   };
 
   Migrator.prototype.getCompletedMigrations = function(callback)  {
     var self = this;
 
-    var filterByMigrationId = function(migrations, allMigrationIds, callback) {
+    var filterByMigrationId = function(migrations, allMigrationIds) {
       return migrations.filter(function(migration) {
         return allMigrationIds.indexOf(migration.migrationId) > -1;
       });
     };
 
-    var migrationFiles = fs.readdirSync(this.options.path).filter(function(file) {
-      return self.options.filesFilter.test(file);
-    });
-
-    var migrations = migrationFiles.map(function(file) {
-      return new Migration(self, self.options.path + '/' + file);
-    });
-
-    migrations = migrations.sort(function(a, b) {
-      return parseInt(a.filename.split('-')[0]) - parseInt(b.filename.split('-')[0]);
-    });
-
-    var existingMigrationIds = migrations.map(function(migration) {
-      return migration.migrationId;
-    });
-
     getAllMigrationIdsFromDatabase.call(self)
     .then(function(allMigrationIds) {
       allMigrationIds = allMigrationIds.map(function(migration) {
-        return parseInt(migration.to);
+        return parseInt(migration.to, 10);
       });
-      var completedMigrations = filterByMigrationId(migrations, allMigrationIds);
-      callback(null, completedMigrations || []);
+
+      var migrations = filterByMigrationId(self.getMigrations(), allMigrationIds);
+      if (self.options.from) {
+        migrations = migrations.filter(function(m) { return m.isAfter(self.options.from); });
+      }
+      if (self.options.to) {
+        migrations = migrations.filter(function(m) { return m.isBefore(self.options.to); });
+      }
+
+      callback(null, migrations || []);
     });
   };
 
@@ -380,3 +349,4 @@ module.exports = (function() {
 
   return Migrator;
 })();
+

--- a/test/migrator.test.js
+++ b/test/migrator.test.js
@@ -81,7 +81,7 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
     it("returns no files if timestamps are after the files timestamp", function(done) {
       this.init({ from: 20140101010101 }, function(migrator) {
-        migrator.getUndoneMigrations(function(err, migrations) {
+        migrator.getCompletedMigrations(function(err, migrations) {
           expect(err).to.be.null
           expect(migrations.length).to.equal(0)
           done()
@@ -204,6 +204,46 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
             })
           })
         })
+      })
+
+      it("executes migrations correctly up twice and downwards twice", function(done) {
+        var self = this
+
+        this.migrator.options.from = 20111205064000
+        this.migrator.options.to = 20111205064000
+
+        var getTables = function() {
+          return self.sequelize.getQueryInterface()
+            .showAllTables()
+            .then(function(tableNames) {
+              return tableNames.filter(function(e){ return e != 'SequelizeMeta' })
+            })
+        }
+
+        var migrateDown = function(ts) {
+          self.migrator.options.from = ts
+          self.migrator.options.to = ts
+          return self.migrator.migrate({method: 'down'})
+        }
+
+        this.migrator.migrate()
+          .then(getTables)
+          .then(function(tableNames) {
+            expect(tableNames).to.eql([ 'User' ])
+            return migrateDown(20111205064000)
+          })
+          .then(getTables)
+          .then(function(tableNames) {
+            expect(tableNames).to.eql([ 'Person' ])
+            return migrateDown(20111117063700)
+          })
+          .then(getTables)
+          .then(function(tableNames) {
+            expect(tableNames).to.eql([])
+          })
+          .done(function(err) {
+            done(err)
+          }, done)
       })
 
       it("supports coffee files", function(done) {


### PR DESCRIPTION
When running db:migrate:undo from sequelize-cli, it will not only undo the
last migration done, but undoes all migrations. This bug effectively
wipes out your entire database. Even worse, it only deletes the last
batch of migration metadata, so it leaves data in SequelizeMeta which will
likely cause future migrations to fail. The only workaround is to this
last issue is to clear out the SequelizeMeta table and start fresh.
Additional changes in this commit are:

- Refactors existing copied-pasted code into a common function
- Remove deprecated code path and change existing test to point to the correct version
- Add test case that would prevent the behavior in the future

@chrisatsc also noted this same behavior at https://github.com/sequelize/cli/issues/58#issuecomment-60618456


~~Side effect of this change is that anyone who's coded against
`getUndoneMigrations` to get the last batch of migrations will have
to call into `getCompletedMigrations` instead. The signature should
be identical.~~