### PR TITLE
Add Missing Columns in Model.sync()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -414,6 +414,13 @@ module.exports = (function() {
     }).then(function () {
       return self.QueryInterface.createTable(self.getTableName(), attributes, options);
     }).then(function () {
+      return self.QueryInterface.describeTable(self.getTableName(), options);
+    }).then(function (columns) {
+      var columnsToAdd = Utils._.difference(Utils._.keys(attributes), Utils._.keys(columns));
+      return Promise.map(columnsToAdd, function(column) {
+        self.QueryInterface.addColumn(self.getTableName(), column, attributes[column]);
+      });
+    }).then(function () {
       return self.QueryInterface.showIndex(self.getTableName(), options);
     }).then(function (indexes) {
       // Assign an auto-generated name to indexes which are not named by the user


### PR DESCRIPTION
Extend Model.sync() to add columns that are missing.
