### PR TITLE
keep original error message when wrapping in DatabaseError

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -72,7 +72,7 @@ error.ValidationError.prototype.errors;
  * @constructor
  */
 error.DatabaseError = function (parent) {
-  error.BaseError.apply(this, arguments);
+  error.BaseError.apply(this, [parent.message]);
   this.name = 'SequelizeDatabaseError';
 
   this.parent = parent;

--- a/test/error.test.js
+++ b/test/error.test.js
@@ -55,6 +55,14 @@ describe(Support.getTestDialectTeaser("Sequelize Errors"), function () {
       expect(matches).to.have.lengthOf(1);
       expect(matches[0]).to.have.property('message', 'invalid');
     });
+    it('SequelizeDatabaseError should keep original message', function() {
+      var orig = new Error('original database error message');
+      var databaseError = new Sequelize.DatabaseError(orig);
+
+      expect(databaseError).to.have.property('parent');
+      expect(databaseError.name).to.equal('SequelizeDatabaseError');
+      expect(databaseError.message).to.equal('original database error message');
+    });
   });
 
   describe('Constraint error', function () {


### PR DESCRIPTION
See #2521 for more information

As an aside. I think `.parent` is a bad name for the original error. `.original` is a better name in my mind but maybe that has name conflicts?
