### PR TITLE
Allow removing has-many associations by id

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -474,6 +474,14 @@ module.exports = (function() {
       return instance[association.accessors.get]({}, options).then(function(currentAssociatedObjects) {
         var newAssociations = [];
 
+        if (!(oldAssociatedObject instanceof association.target.Instance)) {
+          var tmpInstance = {};
+          tmpInstance[primaryKeyAttribute] = oldAssociatedObject;
+          oldAssociatedObject = association.target.build(tmpInstance, {
+            isNewRecord: false
+          });
+        }
+
         currentAssociatedObjects.forEach(function(association) {
           if (!Utils._.isEqual(oldAssociatedObject.identifiers, association.identifiers)) {
             newAssociations.push(association);
@@ -488,6 +496,18 @@ module.exports = (function() {
       var instance = this;
       return instance[association.accessors.get]({}, options).then(function(currentAssociatedObjects) {
         var newAssociations = [];
+
+        // Ensure the oldAssociatedObjects array is an array of target instances
+        oldAssociatedObjects = oldAssociatedObjects.map(function(oldAssociatedObject) {
+          if (!(oldAssociatedObject instanceof association.target.Instance)) {
+            var tmpInstance = {};
+            tmpInstance[primaryKeyAttribute] = oldAssociatedObject;
+            oldAssociatedObject = association.target.build(tmpInstance, {
+              isNewRecord: false
+            });
+          }
+          return oldAssociatedObject;
+        });
 
         currentAssociatedObjects.forEach(function(association) {
 

--- a/test/associations/has-many.test.js
+++ b/test/associations/has-many.test.js
@@ -1971,14 +1971,16 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           return this.sequelize.sync().then(function() {
             return Sequelize.Promise.all([
               Worker.create({}),
-              Task.bulkCreate([{}, {}]).then(function () {
+              Task.bulkCreate([{}, {}, {}]).then(function () {
                 return Task.findAll();
               })
             ]);
           }).spread(function (worker, tasks) {
-            // Set all tasks, then remove one tasks, then return all tasks
+            // Set all tasks, then remove one task by instance, then remove one task by id, then return all tasks
             return worker.setTasks(tasks).then(function () {
               return worker.removeTask(tasks[0]);
+            }).then(function() {
+              return worker.removeTask(tasks[1].id);
             }).then(function () {
               return worker.getTasks();
             });
@@ -1999,14 +2001,16 @@ describe(Support.getTestDialectTeaser("HasMany"), function() {
           return this.sequelize.sync().then(function() {
             return Sequelize.Promise.all([
               Worker.create({}),
-              Task.bulkCreate([{}, {}, {}]).then(function () {
+              Task.bulkCreate([{}, {}, {}, {}, {}]).then(function () {
                 return Task.findAll();
               })
             ]);
           }).spread(function (worker, tasks) {
-            // Set all tasks, then remove two tasks, then return all tasks
+            // Set all tasks, then remove two tasks by instance, then remove two tasks by id, then return all tasks
             return worker.setTasks(tasks).then(function () {
               return worker.removeTasks([tasks[0], tasks[1]]);
+            }).then(function () {
+              return worker.removeTasks([tasks[2].id, tasks[3].id]);
             }).then(function () {
               return worker.getTasks();
             });


### PR DESCRIPTION
Allows you to do:
- `Project.removeTask(id)`
- `Project.removeTasks([id, id])`
