### PR TITLE
support specifying the field of a foreign key for mssql

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -52,7 +52,7 @@ module.exports = (function() {
     createSchema: function(schema){
       return SqlGenerator.getCreateSchemaSql(schema);
     },
-    showSchemasQuery: function(){   
+    showSchemasQuery: function(){
       return 'SELECT name FROM sys.Tables;';
     },
     /*
@@ -138,13 +138,15 @@ module.exports = (function() {
       var modelAttributeMap = {};
       if (modelAttributes) {
         Utils._.each(modelAttributes, function(attribute, key) {
-          modelAttributeMap[key] = attribute;
           if (attribute.field) {
             modelAttributeMap[attribute.field] = attribute;
+          } else {
+            modelAttributeMap[key] = attribute;
           }
         });
       }
-      return SqlGenerator.insertSql(table,valueHash,modelAttributeMap);
+
+      return SqlGenerator.insertSql(table, valueHash, modelAttributeMap);
     },
 
     /*
@@ -185,7 +187,7 @@ module.exports = (function() {
           query += SqlGenerator.insertSql(tableName);
         }
       }
-      return query; 
+      return query;
     },
 
     /*
@@ -212,7 +214,7 @@ module.exports = (function() {
           delete attrValueHash[key];
         }
         if(attrValueHash[key] && attrValueHash[key].fn){
-          
+
         }
       }
       if(!Object.keys(attrValueHash).length){


### PR DESCRIPTION
The MSSQL dialect implements its own sql generator, and was accidentally adding an extra raw attribute for an aliased field. Apologies for the whitespace changes, the editor has a mind of it's own! I can resubmit without them if it's a pain.
