### PR TITLE
Fix MySQL unique constraint error message parsing

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -53,7 +53,7 @@ module.exports = (function() {
 
     switch (err.errno || err.code) {
       case 1062:
-        match = err.message.match(/Duplicate entry '(.*)' for key '?(.*?)$/);
+        match = err.message.match(/Duplicate entry '(.*)' for key '?(.*?)'?$/);
 
         return new sequelizeErrors.UniqueConstraintError({
           fields: null,


### PR DESCRIPTION
Fix for incorrect parsing of unique constraint errors in MySQL.

There was a quote mark missing from the regular expression.
