### PR TITLE
Update inflection dependency to v1.5.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - [BUG] Copy the options object in association getters. [#2311](https://github.com/sequelize/sequelize/issues/2311)
 - [BUG] `Model#destroy()` now supports `field`, this also fixes an issue with `N:M#removeAssociation` and `field`
 - [BUG] Customized error message can now be set for unique constraint that was created manually (not with sync, but e.g. with migrations) or that has fields with underscore naming. This was problem at least with postgres before.
+- [INTERNALS] Update `inflection` dependency to v1.5.2
 
 #### Backwards compatability changes
 - When eager-loading a many-to-many association, the attributes of the through table are now accessible through an attribute named after the through model rather than the through table name singularized. i.e. `Task.find({include: Worker})` where the table name for through model `TaskWorker` is `TableTaskWorkers` used to produce `{ Worker: { ..., TableTaskWorker: {...} } }`. It now produces `{ Worker: { ..., TaskWorker: {...} } }`. Does not affect models where table name is auto-defined by Sequelize, or where table name is model name pluralized.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "dependencies": {
     "dottie": "0.2.4",
     "generic-pool": "2.1.1",
-    "inflection": "1.5.1",
+    "inflection": "1.5.2",
     "lodash": "~2.4.0",
     "moment": "~2.8.0",
     "node-uuid": "~1.4.1",


### PR DESCRIPTION
`inflection` module was updated last night to address it failing to correctly pluralize the words "access" and "business". "Business" was correctly pluralized as "businesses" in inflection v.1.4.x but this was broken in v.1.5.0, and v1.5.2 repairs it.

That apart, the version bump to v1.5.2 makes no other changes.

This PR updates Sequelize's inflection dependency to v.1.5.2
