### PR TITLE
make abstract dialect more abstract

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -732,9 +732,12 @@ module.exports = (function() {
         , subJoinQueries = []
         , mainTableAs = null;
 
-      if (!Array.isArray(tableName) && model) {
+      if (options.tableAs) {
+        mainTableAs = this.quoteTable(options.tableAs);
+      } else if (!Array.isArray(tableName) && model) {
         options.tableAs = mainTableAs = this.quoteTable(model.name);
       }
+
       options.table = table = !Array.isArray(tableName) ? this.quoteTable(tableName) : tableName.map(function(t) {
         if (Array.isArray(t)) {
           return this.quoteTable(t[0], t[1]);
@@ -752,7 +755,6 @@ module.exports = (function() {
           }
         });
       }
-
 
       // Escape attributes
       mainAttributes = mainAttributes && mainAttributes.map(function(attr) {
@@ -792,7 +794,6 @@ module.exports = (function() {
         mainAttributes = [mainTableAs + '.*'];
       }
 
-
       if (options.include) {
         var generateJoinQueries = function(include, parentTable) {
           var table = include.model.getTableName()
@@ -821,7 +822,6 @@ module.exports = (function() {
             attributes = include.attributes.map(function(attr) {
               var attrAs = attr,
                   verbatim = false;
-
 
               if (Array.isArray(attr) && attr.length === 2) {
                 if (attr[0]._isSequelizeMethod) {
@@ -1035,23 +1035,26 @@ module.exports = (function() {
               // If its a multi association we need to add a where query to the main where (executed in the subquery)
               if (subQuery && association.isMultiAssociation && include.required) {
                 if (!options.where) options.where = {};
-
                 // Creating the as-is where for the subQuery, checks that the required association exists
-                options.where['__' + as] = self.sequelize.asIs(['(',
+                var $query = self.selectQuery(include.model.getTableName(), {
+                  tableAs: as,
+                  attributes: [attrRight],
+                  where: self.sequelize.asIs([joinOn]),
+                  limit: 1
+                }, include.model);
 
-                  'SELECT ' + self.quoteIdentifier(attrRight),
-                  'FROM ' + self.quoteTable(table, as),
-                  'WHERE ' + joinOn,
-                  'LIMIT 1',
-
-                ')', 'IS NOT NULL'].join(' '));
+                options.where['__' + as] = self.sequelize.asIs([
+                  '(',
+                    $query.replace(/\;$/, ""),
+                  ')',
+                  'IS NOT NULL'
+                ].join(' '));
               }
             }
             // Generate join SQL
             joinQueryItem += joinType + self.quoteTable(table, as) + ' ON ' + joinOn;
-
-
           }
+
           if (include.subQuery && subQuery) {
             joinQueries.subQuery.push(joinQueryItem);
           } else {
@@ -1158,9 +1161,8 @@ module.exports = (function() {
         }
       }
 
-      var limitOrder = this.addLimitAndOffset(options, query);
-
       // Add LIMIT, OFFSET to sub or main query
+      var limitOrder = this.addLimitAndOffset(options, model);
       if (limitOrder) {
         if (subQuery) {
           subQueryItems.push(limitOrder);
@@ -1267,19 +1269,26 @@ module.exports = (function() {
       return 'ROLLBACK;';
     },
 
-    addLimitAndOffset: function(options, query) {
-      query = query || '';
-
+    /**
+     * Returns an SQL fragment for adding result constraints
+     *
+     * @param  {Object} options An object with selectQuery options.
+     * @param  {Object} options The model passed to the selectQuery.
+     * @return {String}         The generated sql query.
+     */
+    addLimitAndOffset: function(options, model) {
+      var fragment = '';
       if (options.offset && !options.limit) {
-        query += ' LIMIT ' + options.offset + ', ' + 10000000000000;
+        fragment += ' LIMIT ' + options.offset + ', ' + 18440000000000000000;
       } else if (options.limit) {
         if (options.offset) {
-          query += ' LIMIT ' + options.offset + ', ' + options.limit;
+          fragment += ' LIMIT ' + options.offset + ', ' + options.limit;
         } else {
-          query += ' LIMIT ' + options.limit;
+          fragment += ' LIMIT ' + options.limit;
         }
       }
-      return query;
+
+      return fragment;
     },
 
     handleSequelizeMethod: function (smth, tableName, factory, options, prepend) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -327,20 +327,6 @@ module.exports = (function() {
       return fields;
     },
 
-    addLimitAndOffset: function(options, query) {
-      query = query || '';
-      if (options.offset && !options.limit) {
-        query += ' LIMIT ' + options.offset + ', ' + 18440000000000000000;
-      } else if (options.limit) {
-        if (options.offset) {
-          query += ' LIMIT ' + options.offset + ', ' + options.limit;
-        } else {
-          query += ' LIMIT ' + options.limit;
-        }
-      }
-      return query;
-    },
-
     quoteIdentifier: function(identifier, force) {
       if (identifier === '*') return identifier;
       return Utils.addTicks(identifier, '`');

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -433,17 +433,12 @@ module.exports = (function() {
       });
     },
 
-    addLimitAndOffset: function(options, query) {
-      query = query || '';
-      if (options.limit) {
-        query += ' LIMIT ' + options.limit;
-      }
+    addLimitAndOffset: function(options, model) {
+      var fragment = '';
+      if (options.limit) fragment += ' LIMIT ' + options.limit;
+      if (options.offset) fragment += ' OFFSET ' + options.offset;
 
-      if (options.offset) {
-        query += ' OFFSET ' + options.offset;
-      }
-
-      return query;
+      return fragment;
     },
 
     attributeToSQL: function(attribute, options) {

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -142,18 +142,19 @@ module.exports = (function() {
       }
     },
 
-    addLimitAndOffset: function(options, query){
-      query = query || "";
+    addLimitAndOffset: function(options, model){
+      var fragment = '';
       if (options.offset && !options.limit) {
-        query += " LIMIT " + options.offset + ", " + 10000000000000;
+        fragment += " LIMIT " + options.offset + ", " + 10000000000000;
       } else if (options.limit) {
         if (options.offset) {
-          query += " LIMIT " + options.offset + ", " + options.limit;
+          fragment += " LIMIT " + options.offset + ", " + options.limit;
         } else {
-          query += " LIMIT " + options.limit;
+          fragment += " LIMIT " + options.limit;
         }
       }
-      return query;
+
+      return fragment;
     },
 
     addColumnQuery: function(table, key, dataType) {


### PR DESCRIPTION
This fixes two problems in particular:
- there was no existing way to access information about the model
  you were generating a limit and offset for, so the model has been
  added to the options
- included where generation was done from raw SQL, making it impossible
  to support other dialects that don't support the same LIMIT syntax

**optionally** I would consider simply passing "model" into addLimitAndOffset, I just didn't know which way you all would prefer (I was trying to modify the mssql dialect with minimal changes to the existing abstract dialect).
