### PR TITLE
Fix forIn rather than each for iterating on object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -447,7 +447,7 @@ var Utils = module.exports = {
     if (omitNull) {
       var _hash = {};
 
-      Utils._.each(hash, function(val, key) {
+      Utils._.forIn(hash, function(val, key) {
         if (options.allowNull.indexOf(key) > -1 || key.match(/Id$/) || ((val !== null) && (val !== undefined))) {
           _hash[key] = val;
         }


### PR DESCRIPTION
Tiny bug fix:
Should use `_.forIn(obj)` rather than `_.each(obj)` for iterating over an object. All works fine, until the object happens to have a attribute `length`! Then lodash thinks it's an array and starts looking for `obj[0]`.

I ran up against this as one of my tables has a column `length`.
