### PR TITLE
MaraiaDB dialect DATE parsing fix

### DIFF
--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -64,6 +64,8 @@ module.exports = (function() {
                   row[prop] = parseFloat(row[prop]);
                   break;
                 case 'DATE':
+                  row[prop] = new Date(row[prop]);
+                  break;
                 case 'TIMESTAMP':
                 case 'DATETIME':
                   row[prop] = new Date(row[prop] + self.sequelize.options.timezone);


### PR DESCRIPTION
Since date column do not have time adding timezone to them breaks them.

Shouldn't this entire parsing process be skipped if we set `raw` option to `true` ? 
