### PR TITLE
Now you can use bare database URIs with sqlite also

### DIFF
--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -27,7 +27,7 @@ ConnectionManager.prototype.getConnection = function(options) {
   if (self.connections[options.uuid]) return Promise.resolve(self.connections[options.uuid]);
 
   return new Promise(function (resolve, reject) {
-    self.connections[options.uuid] = new self.lib.Database(self.sequelize.options.storage || ':memory:', function(err) {
+    self.connections[options.uuid] = new self.lib.Database(self.sequelize.options.storage || self.sequelize.options.host || ':memory:', function(err) {
       if (err) {
         if (err.code === 'SQLITE_CANTOPEN') return reject('Failed to find SQL server. Please double check your settings.');
         return reject(err);


### PR DESCRIPTION
Before db-uri like sqlite://database.db didn't work with sqlite. This little change fixes it.
