### PR TITLE
Fix attribute validation when allowNull is default.

### DIFF
--- a/lib/dao-validator.js
+++ b/lib/dao-validator.js
@@ -150,7 +150,7 @@ var validateAttributes = function() {
 
   Utils._.each(this.model.rawAttributes, function(rawAttribute, field) {
     var value          = self.model.dataValues[field]
-      , hasAllowedNull = ((rawAttribute === undefined || rawAttribute.allowNull === true) && ((value === null) || (value === undefined)))
+      , hasAllowedNull = ((rawAttribute === undefined || (rawAttribute.allowNull || rawAttribute.allowNull === undefined)) && ((value === null) || (value === undefined)) && rawAttribute.primaryKey !== true)
       , isSkipped      = self.options.skip.length > 0 && self.options.skip.indexOf(field) !== -1
 
     if (self.model.validators.hasOwnProperty(field) && !hasAllowedNull && !isSkipped) {


### PR DESCRIPTION
When allowNull is not set for a model's column, treat the default value as true. Also treat primaryKey attribute as allowNull = false.