### PR TITLE
Fix increment and decrement usage with schemata

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@
 - [BUG] Fixed a bug where plain objects like `{ in: [...] }` were not properly converted to SQL when combined with a sequelize method (`fn`, `where` etc.). Closes [#2077](https://github.com/sequelize/sequelize/issues/2077)
 - [BUG] Made the default for array search in postgres exact comparison instead of overlap
 - [BUG] Allow logging from individual functions even though the global logging setting is false. Closes [#2571](https://github.com/sequelize/sequelize/issues/2571)
+- [BUG] Allow increment/decrement operations when using schemata
 - [INTERNALS] Update `inflection` dependency to v1.5.2
 
 #### Backwards compatability changes

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -377,7 +377,7 @@ module.exports = (function() {
       }
 
       var replacements = {
-        table: this.quoteIdentifiers(tableName),
+        table: this.quoteTable(tableName),
         values: values.join(','),
         where: this.getWhereConditions(where)
       };

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -842,7 +842,7 @@ module.exports = (function() {
       countOrOptions.attributes[updatedAtAttr] = this.Model.__getTimestamp(updatedAtAttr);
     }
 
-    return this.QueryInterface.increment(this, this.QueryInterface.QueryGenerator.addSchema(this.Model.tableName, this.Model.options.schema), values, where, countOrOptions);
+    return this.QueryInterface.increment(this, this.QueryInterface.QueryGenerator.addSchema(this.Model), values, where, countOrOptions);
   };
 
   /**

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/support')
+  , DataTypes = require(__dirname + '/../lib/data-types');
+
+chai.config.includeStack = true;
+
+describe(Support.getTestDialectTeaser('Schema'), function () {
+  before(function() {
+    return this.sequelize.createSchema('testschema');
+  });
+
+  after(function() {
+    return this.sequelize.dropSchema('testschema');
+  });
+
+  beforeEach(function() {
+    this.User = this.sequelize.define('User', {
+      aNumber: { type: DataTypes.INTEGER }
+    }, {
+      schema: 'testschema'
+    });
+
+   return this.User.sync({ force: true });
+  });
+
+  it('supports increment', function () {
+    return this.User.create({ aNumber: 1 }).then(function(user) {
+      return user.increment('aNumber', { by: 3 });
+    }).then(function(result) {
+      return result.reload();
+    }).then(function(user) {
+      expect(user).to.be.ok;
+      expect(user.aNumber).to.be.equal(4);
+    });
+  });
+
+  it('supports decrement', function () {
+    return this.User.create({ aNumber: 10 }).then(function(user) {
+      return user.decrement('aNumber', { by: 3 });
+    }).then(function(result) {
+      return result.reload();
+    }).then(function(user) {
+      expect(user).to.be.ok;
+      expect(user.aNumber).to.be.equal(7);
+    });
+  });
+});


### PR DESCRIPTION
When working with Postgres and schemas lately, I noticed that increment/decrement operations did not work if I tried to specify a schema on my models. Other operations (select, delete, save, etc.) worked though, so we narrowed it down into 2 locations.

It looks like `.addSchema()` wasn't updated to only take in a single parameter (`this.Model`) and `.incrementQuery()` was incorrectly quoting the table name (which would work unless using a schema).

Code to duplicate (fails on current master, works with the PR):

``` javascript
var Sequelize = require('sequelize')
  , sequelize = new Sequelize('test', 'postgres', '', {
      logging: false,
      dialect: 'postgres'
    })
  , myModel;

sequelize.dropSchema('mySchema')
  .then(function createSchema() {
    return sequelize.createSchema('myschema');
  })
  .then(function createModel() {

    myModel = sequelize.define('myModel', {
      id: {
        type: Sequelize.INTEGER,
        primaryKey: true
      },
      incremental: {
        type: Sequelize.INTEGER,
        defaultValue: 0
      }
    }, {
      schema: 'myschema'
    });

    return sequelize.sync();
  })
  .then(function createInstance() {
    return myModel.create({ id: 1, incremental: 2 });
  })
  .then(function incrementResult(instance) {
    return instance.increment('incremental', { by: 1 });
  })
  .then(function nope(result) {
    console.log('Increment worked!', result);
  })
  .catch(function failure(err) {
    console.log('Increment failed', err);
  });
```
