### PR TITLE
fix replication always use write host

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -603,7 +603,7 @@ module.exports = (function() {
     });
 
     return Promise.resolve(
-      options.transaction ? options.transaction.connection : self.connectionManager.getConnection()
+      options.transaction ? options.transaction.connection : self.connectionManager.getConnection(options)
     ).then(function (connection) {
       var query = new self.dialect.Query(connection, self, callee, options);
       return query.run(sql).finally(function() {


### PR DESCRIPTION
The options which has been prepared for the replication code to read was not passed to the getConnection() call.
