### PR TITLE
add ability to determine dialect migration support

### DIFF
--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -33,6 +33,7 @@ AbstractDialect.prototype.supports = {
   'IGNORE': '',
   schemas: false,
   transactions: true,
+  migrations: true,
   constraints: {
     restrict: true
   },

--- a/test/migrator.test.js
+++ b/test/migrator.test.js
@@ -4,8 +4,11 @@ var chai         = require('chai')
   , Migrator     = require("../lib/migrator")
   , DataTypes     = require("../lib/data-types")
   , dialect      = Support.getTestDialect()
+  , current   = Support.sequelize;
 
 chai.config.includeStack = true
+
+if (current.dialect.supports.migrations) {
 
 describe(Support.getTestDialectTeaser("Migrator"), function() {
   beforeEach(function() {
@@ -590,3 +593,5 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
 
   } // if dialect postgres
 })
+
+}


### PR DESCRIPTION
This provides the ability to determine whether a given dialect
is supported for migrations. This is mostly another switch that
allows incremental implementation of new dialects.
