### PR TITLE
Fix findAndCountAll with include all

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -880,6 +880,8 @@ module.exports = (function() {
         return undefined;
       });
 
+      expandIncludeAll.call(this, countOptions);
+
       validateIncludedElements.call(this, countOptions);
 
       var keepNeeded = function(includes) {


### PR DESCRIPTION
A recent commit (https://github.com/sequelize/sequelize/commit/82403cfc1d165e2a01b6b0170efae6fc0355ba85) broke using `{ include: { all: ... } }` with `findAndCountAll()`

The "include all" parts of the options weren't parsed before the unnecessary includes are stripped out, so it throws an error when it encounters an include which has no `model` attribute.

This PR fixes it by parsing any "include all" options before the stripping of unnecessary includes happens.

I imagine I might well be the only person in the world using the "include all" functionality, so I doubt it affected anyone else!
