### PR TITLE
fix schema test and move dropSchema to AbstractDialect

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -28,6 +28,13 @@ module.exports = (function() {
     },
 
     /*
+      Returns a query for dropping a schema
+    */
+    dropSchema: function(tableName, options) {
+      return this.dropTableQuery(tableName, options);
+    },
+
+    /*
       Returns a query for creating a table.
       Parameters:
         - tableName: Name of the new table.

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -13,10 +13,6 @@ module.exports = (function() {
       return Utils._.template(query)({});
     },
 
-    dropSchema: function(tableName, options) {
-      return this.dropTableQuery(tableName, options);
-    },
-
     showSchemasQuery: function() {
       return 'SHOW TABLES';
     },

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -24,10 +24,6 @@ module.exports = (function() {
       return Utils._.template(query)({});
     },
 
-    dropSchema: function(tableName, options) {
-      return this.dropTableQuery(tableName, options);
-    },
-
     showSchemasQuery: function() {
       return "SELECT name FROM `sqlite_master` WHERE type='table' and name!='sqlite_sequence';";
     },

--- a/test/schema.test.js
+++ b/test/schema.test.js
@@ -8,11 +8,11 @@ var chai = require('chai')
 chai.config.includeStack = true;
 
 describe(Support.getTestDialectTeaser('Schema'), function () {
-  before(function() {
+  beforeEach(function() {
     return this.sequelize.createSchema('testschema');
   });
 
-  after(function() {
+  afterEach(function() {
     return this.sequelize.dropSchema('testschema');
   });
 


### PR DESCRIPTION
The schema.test.js added yesterday was using before/after in the
test cases when this.sequelize was not guaranteed to be present yet.
This also moves dropSchema to the AbstractDialect, currently the
code simply assumed you had this implemented in your dialect
