### PR TITLE
stop sequelize from erroneously adding timezone to raw query dates

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -684,7 +684,9 @@ module.exports = (function() {
         } else if (dataType === DataTypes.INTEGER || dataType instanceof DataTypes.BIGINT) {
           result = parseInt(result, 10);
         } else if (dataType === DataTypes.DATE) {
-          result = new Date(result + self.sequelize.options.timezone);
+          if (!Utils._.isDate(result)) {
+            result = new Date(result);
+          }
         } else if (dataType === DataTypes.STRING) {
           // Nothing to do, result is already a string.
         }

--- a/test/dao-factory.test.js
+++ b/test/dao-factory.test.js
@@ -1727,14 +1727,17 @@ describe(Support.getTestDialectTeaser("DAOFactory"), function () {
 
     it("should allow dates in max", function(done) {
       var self = this
-      this.User.bulkCreate([{theDate: new Date(2013, 12, 31)}, {theDate: new Date(2000, 01, 01)}]).success(function(){
-        self.User.max('theDate').success(function(max){
+      this.User.bulkCreate([
+        {theDate: new Date(2013, 11, 31)},
+        {theDate: new Date(2000, 01, 01)}
+      ]).success(function() {
+        self.User.max('theDate').success(function(max) {
           expect(max).to.be.a('Date');
-          expect(max).to.equalDate(new Date(2013, 12, 31))
-          done()
-        })
-      })
-    })
+          expect(max).to.equalDate(new Date(2013, 11, 31));
+          done();
+        });
+      });
+    });
 
     it("should allow strings in max", function(done) {
       var self = this


### PR DESCRIPTION
Only for rawSelects it seems that Sequelize forcibly adds timezone
information to dates returned from the database. This breaks in
strange and magical ways
