### PR TITLE
add dialect checks for upsert support

### DIFF
--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -34,6 +34,7 @@ AbstractDialect.prototype.supports = {
   schemas: false,
   transactions: true,
   migrations: true,
+  upserts: true,
   constraints: {
     restrict: true
   },


### PR DESCRIPTION
Upserts in MSSQL are non-trivial to implement, adding the ability
to test for support is a valid stopgap for later implementation
