### PR TITLE
Update `inflection` dependency to v1.5.3

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [INTERNALS] Update `inflection` dependency to v1.5.3
+
 # 2.0.0-rc3
 - [FEATURE] Added the possibility of removing multiple associations in 1 call [#2338](https://github.com/sequelize/sequelize/issues/2338)
 - [FEATURE] Undestroy method for paranoid models [#2540](https://github.com/sequelize/sequelize/pull/2540)

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bluebird": "~2.3.11",
     "dottie": "0.2.4",
     "generic-pool": "2.1.1",
-    "inflection": "1.5.2",
+    "inflection": "1.5.3",
     "lodash": "~2.4.0",
     "moment": "~2.8.0",
     "node-uuid": "~1.4.1",


### PR DESCRIPTION
This PR updates inflection dependency to the newly-released v1.5.3 which corrects several errors in not pluralizing words which should be pluralizable. (see https://github.com/dreamerslab/node.inflection/pull/33)

The behaviour in 1.5.2 which I found most irritating was that it would not pluralize "permission" to "permissions" meaning that my Sequelize model `permission` had its table called `permission` too. Argh!
