### PR TITLE
Workaround to deal with an issue in node-webkit where the validate function fails on object literals

### DIFF
--- a/lib/utils/parameter-validator.js
+++ b/lib/utils/parameter-validator.js
@@ -20,6 +20,9 @@ var validateDeprecation = function(value, expectation, options) {
 };
 
 var validate = function(value, expectation, options) {
+
+  // the second part of this check is a workaround to deal with an issue that occurs in node-webkit when
+  // using object literals.  https://github.com/sequelize/sequelize/issues/2685
   if (value instanceof expectation || typeof(value) === typeof(expectation.call())) {
     return true;
   }


### PR DESCRIPTION
Detailed explanation of root problem in issue #2685.
