### PR TITLE
Revert "Workaround to deal with an issue in node-webkit where the valida...

### DIFF
--- a/lib/utils/parameter-validator.js
+++ b/lib/utils/parameter-validator.js
@@ -8,7 +8,7 @@ var validateDeprecation = function(value, expectation, options) {
     return;
   }
 
-  var valid = (value instanceof options.deprecated || typeof(value) === typeof(options.deprecated.call()));
+  var valid = value instanceof options.deprecated;
 
   if (valid) {
     var message = util.format('%s should not be of type "%s"', util.inspect(value), options.deprecated.name);
@@ -20,10 +20,7 @@ var validateDeprecation = function(value, expectation, options) {
 };
 
 var validate = function(value, expectation, options) {
-
-  // the second part of this check is a workaround to deal with an issue that occurs in node-webkit when
-  // using object literals.  https://github.com/sequelize/sequelize/issues/2685
-  if (value instanceof expectation || typeof(value) === typeof(expectation.call())) {
+  if (value instanceof expectation) {
     return true;
   }
 
@@ -56,4 +53,3 @@ var ParameterValidator = module.exports = {
       || validate(value, expectation, options);
   }
 };
-


### PR DESCRIPTION
Reverts sequelize/sequelize#2691

This fix resulted in a lot of deprecation warnings logging that object was deprecated when if fact it was array that was deprecated, because `typeof([]) === typeof({})` 
