### PR TITLE
Only return migrations within the requested timespan

### DIFF
--- a/lib/migrator.js
+++ b/lib/migrator.js
@@ -280,13 +280,22 @@ module.exports = (function() {
     var self = this;
 
     return new Utils.CustomEventEmitter(function(emitter) {
+      var conditions = {};
+      if (self.options.from) {
+        conditions.from = {gte: self.options.from};
+      }
+      if (self.options.to) {
+        conditions.to = {lte: self.options.to};
+      }
+
       self
         .findOrCreateSequelizeMetaDAO()
         .success(function(SequelizeMeta) {
           SequelizeMeta
             .findAll({
               order: 'id DESC',
-              attributes: ['to']
+              attributes: ['to'],
+              where: conditions
             })
             .success(function(meta) {
               emitter.emit('success', meta ? meta : null);

--- a/test/migrator.test.js
+++ b/test/migrator.test.js
@@ -66,6 +66,21 @@ describe(Support.getTestDialectTeaser("Migrator"), function() {
         })
       })
     })
+
+    it("only returns migrations where timestamps in requested range", function(done) {
+      this.init({from: 20111130161100, to: 20111130161100}, function(migrator, SequelizeMeta) {
+        SequelizeMeta.bulkCreate([
+          { from: 20111117063700, to: 20111117063700 },
+          { from: 20111130161100, to: 20111130161100 }
+        ]).success(function() {
+          migrator.getCompletedMigrations(function(err, migrations) {
+            expect(err).to.be.null
+            expect(migrations).to.have.length(1)
+            done()
+          })
+        })
+      })
+    })
   })
 
   describe('getUndoneMigrations', function() {


### PR DESCRIPTION
Right now all migrate({method: 'down'}) runs all migrations down instead of the last (but only removes the last from the meta table).
