### PR TITLE
Fixing "error: syntax error at or near ")"" when using upsert with postgres dialect

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -355,7 +355,7 @@ module.exports = (function() {
 
     // http://www.maori.geek.nz/post/postgres_upsert_update_or_insert_in_ger_using_knex_js
     upsertQuery: function (tableName, insertValues, updateValues, where, rawAttributes, options) {
-      var insert = this.insertQuery(tableName, insertValues, rawAttributes, options).replace(/VALUES \((.*?)\)/, 'SELECT $1');
+      var insert = this.insertQuery(tableName, insertValues, rawAttributes, options);
       var update = this.updateQuery(tableName, updateValues, where, options, rawAttributes);
 
       // The numbers here are selected to match the number of affected rows returned by MySQL


### PR DESCRIPTION
When trying to upsert values containing the character `)` using `postgres`, the RegEx is not modifying the string properly, throwing this error message: `error: syntax error at or near ")"`.

Here's an example:

Initial value:
`VALUES ( \'Current Generator(s)\',\'CurrentGenerators__c\',NULL,NULL,\'Lead\',\'2014-12-10 22:31:24.076 +00:00\',\'2014-12-10 22:31:24.076 +00:00\');`

Expected result:
`SELECT \'Current Generator(s)\',\'CurrentGenerators__c\',NULL,NULL,\'Lead\',\'2014-12-10 22:31:24.076 +00:00\',\'2014-12-10 22:31:24.076 +00:00\';`

Current result:
`SELECT \'Current Generator(s\',\'CurrentGenerators__c\',NULL,NULL,\'Lead\',\'2014-12-10 22:31:24.076 +00:00\',\'2014-12-10 22:31:24.076 +00:00\');`

This commit is removing the `replace()` method called. After reading the blog post referred, there's no explanation of why this need to be replaced.

Reference: https://github.com/sequelize/sequelize/pull/2518#discussion_r21706569
