### PR TITLE
Use ec2 instance in us-west-1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,6 @@ matrix:
   allow_failures:
     - node_js: "0.10"
       env: COVERAGE=true
-    - node_js: "0.10"
-      env: DB=mysql DIALECT=mssql
 
 notifications:
   hipchat:

--- a/test/config/config.js
+++ b/test/config/config.js
@@ -16,7 +16,7 @@ module.exports = {
     database: process.env.SEQ_MSSQL_DB   || process.env.SEQ_DB   || ('sequelize_test_' + ~~(Math.random() * 100)),
     username: process.env.SEQ_MSSQL_USER || process.env.SEQ_USER || "sequelize",
     password: process.env.SEQ_MSSQL_PW   || process.env.SEQ_PW   || "test",
-    host:     process.env.SEQ_MSSQL_HOST || process.env.SEQ_HOST || "ec2-54-76-93-58.eu-west-1.compute.amazonaws.com",
+    host:     process.env.SEQ_MSSQL_HOST || process.env.SEQ_HOST || "ec2-54-85-24-15.compute-1.amazonaws.com",
     port:     process.env.SEQ_MSSQL_PORT || process.env.SEQ_PORT || 1433,
     pool:     {
       maxConnections: process.env.SEQ_MSSQL_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,


### PR DESCRIPTION
Using a aws machine in us-west-1 decreased the test run duration for mssql to ~2min
