### PR TITLE
Sequelize.close should close all connections once pool is being drained

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -48,9 +48,7 @@ ConnectionManager.prototype.onProcessExit = function() {
 
   if (this.pool) {
     this.pool.drain(function() {
-      if (self.pool.destroyAllNow) self.pool.destroyAllNow();
-      if (self.pool.read && self.pool.read.destroyAllNow) self.pool.read.destroyAllNow();
-      if (self.pool.write && self.pool.write.destroyAllNow) self.pool.write.destroyAllNow();
+      self.pool.destroyAllNow();
     });
   }
 };
@@ -121,6 +119,10 @@ ConnectionManager.prototype.initPools = function () {
       },
       destroy: function(connection) {
         return self.pool[connection.queryType].destroy(connection);
+      },
+      destroyAllNow: function() {
+        self.pool.read.destroyAllNow();
+        self.pool.write.destroyAllNow();
       },
       drain: function(cb) {
         self.pool.write.drain(function() {


### PR DESCRIPTION
I am currently running into the issue where tap test does not exit, because process is being held by sequelize database connections. 

From my understanding so far of sequelize, Sequelize.close doesn't really close connections rather just drain pool and do nothing, and once pool time outs connections are closed.

Here is a small patch for destroying all connections once pools are drained.
