### PR TITLE
Prevent `log` options from being dumped to log

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1047,6 +1047,9 @@ module.exports = (function() {
 
     if (last && Utils._.isPlainObject(last) && last.hasOwnProperty('logging')) {
       options = last;
+      
+      // remove options from set of logged arguments
+      args.splice(args.length-1, 1);
     } else {
       options = this.options;
     }


### PR DESCRIPTION
This commit (https://github.com/sequelize/sequelize/commit/6147c8e814494dcaf33adf614d07276f4ecc605b) made logging more customizable, but introduced a bug: All options passed to `sequelize.log` where also dumped to log file. This revision removes the options from the set of logged arguments.
