### PR TITLE
Query.formatError fails when the line contains a newline.

### DIFF
--- a/test/dialects/mysql/query.test.js
+++ b/test/dialects/mysql/query.test.js
@@ -1,0 +1,27 @@
+"use strict";
+
+/* jshint camelcase: false */
+var chai      = require('chai')
+  , expect    = chai.expect
+  , Support   = require(__dirname + '/../../support')
+  , Query     = require("../../../lib/dialects/mysql/query")
+
+chai.config.includeStack = true
+
+if (Support.dialectIsMySQL()) {
+  describe("[MYSQL Specific] Query", function () {
+    describe('formatError', function() {
+      var origError = {
+        code: 1062,
+        message: 'Duplicate entry \'Error with\n:\n a newline\' for key \'compositeIndex\''
+      }
+
+      var query = new Query();
+      var parsedError = query.formatError(origError);
+
+      expect(parsedError.name).to.equal('SequelizeUniqueConstraintError');
+      expect(parsedError).to.have.property('parent');
+      expect(parsedError.message).to.equal(origError.message);
+    });
+  });
+};


### PR DESCRIPTION
I've run into this problem while trying to use a string with a newline for unique key. It tries to save to MySql and fails, but when Sequelize tries to parse the error and throw a UniqueConstraintError, it fails because the regex is not taking the newline into consideration.

I've attached a test which demonstrates this bug.
