### PR TITLE
Show appropriate error message for model validation error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -38,9 +38,23 @@ util.inherits(error.BaseError, Error);
  * @constructor
  */
 error.ValidationError = function(message, errors) {
+  var self = this;
+
   error.BaseError.apply(this, arguments);
   this.name = 'SequelizeValidationError';
   this.errors = errors || [];
+
+  if (this.errors.length > 0 && this.errors[0].message) {
+    this.message = "";
+
+    this.errors.forEach(function(_err, i) {
+      if (i > 0) {
+        self.message = self.message + "; ";
+      }
+
+      self.message = self.message + _err.message;
+    });
+  }
 };
 util.inherits(error.ValidationError, error.BaseError);
 


### PR DESCRIPTION
Before:
Possibly unhandled SequelizeValidationError: Validation error
    at /home/phanect/dev/notel-api/node_modules/sequelize/lib/instance-validator.js:150:14
    ...

After:
Possibly unhandled SequelizeValidationError: field_name cannot be null
    at /home/phanect/dev/notel-api/node_modules/sequelize/lib/instance-validator.js:150:14
    ...