### PR TITLE
avoid cryptic errors by checking for transaction

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1162,7 +1162,7 @@ module.exports = (function() {
         });
       });
     }).finally(function () {
-      if (internalTransaction) {
+      if (internalTransaction && this.transaction) {
         // If we created a transaction internally, we should clean it up
         return this.transaction.commit();
       }


### PR DESCRIPTION
Without checking for this.transaction, a simple "access denied" error turns into the cryptic "cannot call commit on undefined" error.
