### PR TITLE
Add MSSQL to documentation

### DIFF
--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -45,7 +45,7 @@ var sequelize = new Sequelize('mysql://localhost:3306/database', {})
 | [username=null] | String | The username which is used to authenticate against the database. |
 | [password=null] | String | The password which is used to authenticate against the database. |
 | [options={}] | Object | An object with options. |
-| [options.dialect='mysql'] | String | The dialect you of the database you are connecting to. One of mysql, postgres, sqlite and mariadb |
+| [options.dialect='mysql'] | String | The dialect you of the database you are connecting to. One of mysql, postgres, sqlite, mariadb, and mssql |
 | [options.dialectModulePath=null] | String | If specified, load the dialect library from this path. For example, if you want to use pg.js instead of pg when connecting to a pg database, you should specify 'pg.js' here |
 | [options.dialectOptions] | Object | An object of additional options, which are passed directly to the connection library |
 | [options.storage] | String | Only used by sqlite. Defaults to ':memory:' |

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -45,7 +45,7 @@ Open the created directory in your favorite text editor and add a new file calle
 ```js
 var Sequelize = require('sequelize')
   , sequelize = new Sequelize('database_name', 'username', 'password', {
-      dialect: "mysql", // or 'sqlite', 'postgres', 'mariadb'
+      dialect: "mysql", // or 'sqlite', 'postgres', 'mariadb', 'mssql'
       port:    3306, // or 5432 (for postgres)
     });
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -17,7 +17,7 @@ Sequelize will setup a connection pool on initialization so you should ideally o
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
   host: 'localhost',
-  dialect: 'mysql'|'mariadb'|'sqlite'|'postgres'
+  dialect: 'mysql'|'mariadb'|'sqlite'|'postgres'|'mssql'
 });
 
 // Or you can simply use a connection uri

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -56,12 +56,12 @@ var sequelize = new Sequelize('database', 'username', 'password', {
  
   // the sql dialect of the database
   // - default is 'mysql'
-  // - currently supported: 'mysql', 'sqlite', 'postgres', 'mariadb'
+  // - currently supported: 'mysql', 'sqlite', 'postgres', 'mariadb', 'mssql'
   dialect: 'mysql',
  
   // you can also pass any dialect options to the underlying dialect library
   // - default is empty
-  // - currently supported: 'mysql', 'mariadb'
+  // - currently supported: 'mysql', 'mariadb', 'postgres', 'mssql'
   dialectOptions: {
     socketPath: '/Applications/MAMP/tmp/mysql/mysql.sock',
     supportBigNumbers: true,

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-Sequelize is a promise-based Node.js ORM for Postgres, MySQL, SQLite and MariaDB. It features solid transaction support, relations, read replication and more. 
+Sequelize is a promise-based Node.js ORM for Postgres, MySQL, SQLite, MariaDB and MSSQL. It features solid transaction support, relations, read replication and more. 
 
 [Installation](http://sequelize.readthedocs.org/en/latest/docs/installation/)
 


### PR DESCRIPTION
Added MSSQL to the documentation to reflect its support. Also note, postgres was added to dialectOptions support. Probably, should have been another commit/pull request. ¯\\_(ツ)_/¯ 