### PR TITLE
Fix where dialectOptions are placed in the config object

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -35,7 +35,7 @@ ConnectionManager.prototype.connect = function(config) {
 
     if (config.dialectOptions) {
       Object.keys(config.dialectOptions).forEach(function(key) {
-        connectionConfig[key] = config.dialectOptions[key];
+        connectionConfig.options[key] = config.dialectOptions[key];
       });
     }
 


### PR DESCRIPTION
Per the [tedious api](http://pekim.github.io/tedious/api-connection.html#function_newConnection), dialectOptions should be placed in config.options.