### PR TITLE
Throw an error if no where clause is given to Model.destroy()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Next
+- [FEATURE] Throw an error if no where clause is given to `Model.destroy()`.
 - [BUG] Fixed issue with `order: sequelize.literal('string')`
 - [FEATURE] add `clone: true` support to `.get()`. Is needed when using `delete` on values from a `.get()` (`toJSON()`, `this.values`). (.get() is just a reference to the values for performance reasons when there's no custom getters or includes)
 - [FEATURE] add `sequelize.escape(value)` convenience method

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -264,7 +264,7 @@ module.exports = (function() {
       var table = this.quoteTable(tableName);
       if (options.truncate === true) {
         // Truncate does not allow LIMIT and WHERE
-        return 'TRUNCATE ' + table;
+        return 'TRUNCATE TABLE ' + table;
       }
 
       where = this.getWhereConditions(where);

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -149,7 +149,7 @@ module.exports = (function() {
     } else if (this.isBulkUpdateQuery()) {
       result = data.length;
     } else if (this.isBulkDeleteQuery()){
-      result = data[0].AFFECTEDROWS;
+      result = data[0] && data[0].AFFECTEDROWS;
     } else if (this.isVersionQuery()) {
       result = data[0].version;
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1415,8 +1415,8 @@ module.exports = (function() {
     var self = this
       , instances;
 
-    if (!options || !options.where) {
-      throw new Error('Missing where attribute in the options parameter passed to destroy.');
+    if (!options || !(options.where || options.truncate)) {
+      throw new Error('Missing where or truncate attribute in the options parameter passed to destroy.');
     }
 
     options = Utils._.extend({

--- a/lib/model.js
+++ b/lib/model.js
@@ -1412,6 +1412,13 @@ module.exports = (function() {
    * @return {Promise<undefined>}
    */
   Model.prototype.destroy = function(options) {
+    var self = this
+      , instances;
+
+    if (!options || !options.where) {
+      throw new Error('Missing where attribute in the options parameter passed to destroy.');
+    }
+
     options = Utils._.extend({
       hooks: true,
       individualHooks: false,
@@ -1421,8 +1428,6 @@ module.exports = (function() {
 
     options.type = QueryTypes.BULKDELETE;
 
-    var self = this
-      , instances;
 
     mapFieldNames.call(this, options, this);
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1094,6 +1094,22 @@ describe(Support.getTestDialectTeaser('Model'), function() {
   });
 
   describe('destroy', function() {
+    it('truncate should clear the table', function() {
+      var User = this.sequelize.define('User', { username: DataTypes.STRING }),
+          data = [
+            { username: 'user1' },
+            { username: 'user2' }
+          ];
+
+      return this.sequelize.sync({ force: true }).then(function() {
+        return User.bulkCreate(data);
+      }).then(function() {
+        return User.destroy({ truncate: true });
+      }).then(function() {
+        return expect(User.findAll()).to.eventually.have.length(0);
+      });
+    });
+
     it('throws an error if no where clause is given', function() {
       var User = this.sequelize.define('User', { username: DataTypes.STRING });
 
@@ -1102,7 +1118,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       }).then(function() {
         throw new Error('Destroy should throw an error if no where clause is given.');
       }, function(err) {
-        expect(err.message).to.equal('Missing where attribute in the options parameter passed to destroy.');
+        expect(err).to.be.an.instanceof(Error);
+        expect(err.message).to.equal('Missing where or truncate attribute in the options parameter passed to destroy.');
       });
     });
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -857,6 +857,19 @@ describe(Support.getTestDialectTeaser('Model'), function() {
   });
 
   describe('update', function() {
+    it('throws an error if no where clause is given', function() {
+      var User = this.sequelize.define('User', { username: DataTypes.STRING });
+
+      return this.sequelize.sync({ force: true }).then(function() {
+        return User.update();
+      }).then(function() {
+        throw new Error('Update should throw an error if no where clause is given.');
+      }, function(err) {
+        expect(err).to.be.an.instanceof(Error);
+        expect(err.message).to.equal('Missing where attribute in the options parameter passed to update.');
+      });
+    });
+
     if (current.dialect.supports.transactions) {
       it('supports transactions', function(done) {
         Support.prepareTransactionTest(this.sequelize, function(sequelize) {


### PR DESCRIPTION
See #2847.

This throws an error similar to the one that's thrown if `Model.update()` is called with no where clause. I couldn't find a test that checks the same for `.update()` so I added one there too.