### PR TITLE
updated bluebird to 2.6.2

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -63,8 +63,8 @@ Promise.prototype._then = function (didFulfill, didReject, didProgress, receiver
 
 var bluebirdSettle = Promise.prototype._settlePromiseAt;
 Promise.prototype._settlePromiseAt = function (index) {
-  bluebirdSettle.call(this, index);
   var receiver = this._receiverAt(index);
+  bluebirdSettle.call(this, index);
 
   if (this.$sql && receiver && receiver.emit) {
     this.$sql.forEach(function (sql) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/sequelize/sequelize/issues"
   },
   "dependencies": {
-    "bluebird": "~2.6.2",
+    "bluebird": "2.4.2",
     "dottie": "0.2.4",
     "generic-pool": "2.1.1",
     "inflection": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/sequelize/sequelize/issues"
   },
   "dependencies": {
-    "bluebird": "~2.3.11",
+    "bluebird": "~2.6.2",
     "dottie": "0.2.4",
     "generic-pool": "2.1.1",
     "inflection": "1.5.3",


### PR DESCRIPTION
"Significantly improve parallel promise performance and memory usage (+50% faster, -50% less memory)", https://github.com/petkaantonov/bluebird/blob/master/changelog.md#260-2015-01-06

Thought this should be added :)
It's backwards-compatible and the sequelize tests run green