### PR TITLE
Without schemas flag override in mssql dialect, queries incorrectly serialized.

### DIFF
--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -21,6 +21,7 @@ MssqlDialect.prototype.supports = _.merge(_.cloneDeep(Abstract.prototype.support
   transactions: false,
   migrations: false,
   upserts: false,
+  schema: true,
   autoIncrement: {
     identityInsert: true,
     defaultValue: false,

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -21,7 +21,7 @@ MssqlDialect.prototype.supports = _.merge(_.cloneDeep(Abstract.prototype.support
   transactions: false,
   migrations: false,
   upserts: false,
-  schema: true,
+  schemas: true,
   autoIncrement: {
     identityInsert: true,
     defaultValue: false,


### PR DESCRIPTION
Example:
SELECT "id", "username" FROM "myschema.mytable" as "mytable"
is incorrect and produces invalid object name errors.
Should be ... "myschema"."mytable" ...