### PR TITLE
Add order keywords whitelist

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1235,8 +1235,18 @@ module.exports = (function() {
         var mainQueryOrder = [];
         var subQueryOrder = [];
 
+        var validateOrder = function(order) {
+          if (!_.contains(['ASC', 'DESC'], order.toUpperCase())) {
+            throw new Error(util.format('Order must be \'ASC\' or \'DESC\', \'%s\' given', order));
+          }
+        };
+
         if (Array.isArray(options.order)) {
           options.order.forEach(function(t) {
+            if (Array.isArray(t) && _.size(t) > 1) {
+              validateOrder(_.last(t));
+            }
+
             if (subQuery && (Array.isArray(t) && !(t[0] instanceof Model) && !(t[0].model instanceof Model))) {
               subQueryOrder.push(this.quote(t, model));
             }

--- a/test/include.test.js
+++ b/test/include.test.js
@@ -525,7 +525,7 @@ describe(Support.getTestDialectTeaser('Include'), function() {
             ],
             order: [
               User.rawAttributes.id,
-              [Product, 'id']
+              [Product, 'id', 'ASC']
             ]
           }).done(function(err, user) {
             expect(err).not.to.be.ok;


### PR DESCRIPTION
Fixes #2906.
Breaking change: it is mandatory to provide the order when using the array notation.

@mickhansen I think we should create an abstract query-generator test file and add the missing tests there. I can also check if the number of arguments in the array is 1 and keep the BC in that case. Thoughts?