### PR TITLE
.docs-fixed typos in getting-started.md

### DIFF
--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -185,7 +185,7 @@ User
   });
 ```
 
-Please note that there won't be any error if no user with the name "john-doe" has been found. This is intended, as there is not internal or authentication error.
+Please note that, if no user with the name "john-doe" has been found, there won't be any errors. This is intended, as there are no internal or authentication errors.
 
 ## Defining associations
 


### PR DESCRIPTION
I thought these couple sentences were easier to understand with a quick re-wording.

![screen shot 2015-01-12 at 11 18 38 pm](https://cloud.githubusercontent.com/assets/2992862/5717206/651c5592-9ab1-11e4-8658-35de1fb20bbc.png)

![screen shot 2015-01-12 at 11 18 46 pm](https://cloud.githubusercontent.com/assets/2992862/5717207/69c1418e-9ab1-11e4-9ad1-6bf5b65cd214.png)

