### PR TITLE
Fix typo in getting-started.md

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -15,7 +15,7 @@ $ npm install --save tedious // MSSQL
 
 ## Setting up a connection
 
-Sequelize will setup a connection pool on initialization so you should ideally only ever create on instance per application.
+Sequelize will setup a connection pool on initialization so you should ideally only ever create one instance per application.
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {


### PR DESCRIPTION
Found a typo in the getting-started doc. Believe this edit clarifies intention.

![image](https://cloud.githubusercontent.com/assets/5377436/5790977/f914c10c-9e68-11e4-9d1c-d2bbaec71477.png)

![image](https://cloud.githubusercontent.com/assets/5377436/5790979/07063a52-9e69-11e4-85b6-c581648fa0ac.png)
