### PR TITLE
Add missing runtime dep: pg-hstore

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "moment": "~2.8.0",
     "node-uuid": "~1.4.1",
     "toposort-class": "~0.3.0",
-    "validator": "~3.22.1"
+    "validator": "~3.22.1",
+    "pg-hstore": "~2.3.1"
   },
   "devDependencies": {
     "continuation-local-storage": "3.1.2",


### PR DESCRIPTION
Hey

I found a little bug, after I upgraded from sequelize 2.0.0-rc3 to 2.0.0-rc7. The postgres hstore.js file require the pg-hstore module - which is not defined in the package.json file, here's a sample error:
```
>> Mocha exploded!
>> Error: The dialect postgres is not supported. (Error: Cannot find module 'pg-hstore')
>>     at new module.exports.Sequelize (/var/lib/jenkins/XXX/node_modules/sequelize/lib/sequelize.js:191:13)
```