### PR TITLE
Field Name mapping was not being run on increment/decrement functions

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -549,7 +549,7 @@ module.exports = (function() {
             if (hookChanged) {
               if (options.validate) {
                 // Validate again
-                
+
                 options.skip = _.difference(Object.keys(this.Model.rawAttributes), hookChanged);
                 return Promise.bind(this).then(function () {
                   // hookValidate rejects with errors, validate returns with errors
@@ -840,10 +840,24 @@ module.exports = (function() {
       deprecationWarning: 'Increment expects an object as second parameter. Please pass the incrementor as option! ~> instance.increment(' + JSON.stringify(fields) + ', { by: ' + countOrOptions + ' })'
     });
 
-    var identifier = this.__options.hasPrimaryKeys ? this.primaryKeyValues : { id: this.id }
+    var identifier = this.primaryKeyValues
       , updatedAtAttr = this.Model._timestampAttributes.updatedAt
       , values = {}
       , where;
+
+    if (identifier) {
+      for (var attrName in identifier) {
+        // Field name mapping
+        var rawAttribute = this.Model.rawAttributes[attrName];
+        if (rawAttribute.field && rawAttribute.field !== rawAttribute.fieldName) {
+          identifier[this.Model.rawAttributes[attrName].field] = identifier[attrName];
+          delete identifier[attrName];
+        }
+      }
+    }
+    if (identifier === null && this.__options.whereCollection !== null) {
+      identifier = this.__options.whereCollection;
+    }
 
     if (countOrOptions === undefined) {
       countOrOptions = { by: 1 };
@@ -872,6 +886,14 @@ module.exports = (function() {
     if (updatedAtAttr && !values[updatedAtAttr]) {
       countOrOptions.attributes[updatedAtAttr] = this.Model.__getTimestamp(updatedAtAttr);
     }
+
+    Object.keys(values).forEach(function(attr) {
+      // Field name mapping
+      if (this.Model.rawAttributes[attr] && this.Model.rawAttributes[attr].field && this.Model.rawAttributes[attr].field !== attr) {
+        values[this.Model.rawAttributes[attr].field] = values[attr];
+        delete values[attr];
+      }
+    }, this);
 
     return this.QueryInterface.increment(this, this.Model.getTableName(countOrOptions), values, where, countOrOptions);
   };


### PR DESCRIPTION
The `instance.increment` (and also, by extension, the `instance.decrement`) function was not mapping field names for passed fields, or the primary key. This fixes that using conventions found elsewhere in the instance.js file.