### PR TITLE
Fix assignment to read only property on `getDAO()`

### DIFF
--- a/lib/model-manager.js
+++ b/lib/model-manager.js
@@ -25,8 +25,9 @@ module.exports = (function() {
   };
 
   ModelManager.prototype.getDAO = function(daoName, options) {
-    options = options || {};
-    options.attribute = options.attribute || 'name';
+    options = _.defaults(options || {}, {
+      attribute: 'name'
+    });
 
     var dao = this.daos.filter(function(dao) {
       return dao[options.attribute] === daoName;


### PR DESCRIPTION
Fixes support on node@0.11.15+ and io.js.