### PR TITLE
Use postgresql 9.4 on .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - DB=mysql DIALECT=mssql
 
 addons:
-  postgresql: "9.3"
+  postgresql: "9.4"
 
 before_script:
   - "mysql -e 'create database sequelize_test;'"


### PR DESCRIPTION
In 2 days, Travis-CI will start officially supporting postgresql 9.4. All tests pass on this version.