### PR TITLE
Update moment@2.9.0

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -170,7 +170,7 @@ SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
 };
 
 SqlString.dateToString = function(date, timeZone, dialect) {
-  date = moment(date).zone(timeZone);
+  date = moment(date).utcOffset(timeZone);
 
   if (dialect === 'mysql' || dialect === 'mariadb') {
     return date.format('YYYY-MM-DD HH:mm:ss');

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "generic-pool": "2.1.1",
     "inflection": "1.5.3",
     "lodash": "~2.4.0",
-    "moment": "~2.8.0",
+    "moment": "^2.9.0",
     "node-uuid": "~1.4.1",
     "toposort-class": "~0.3.0",
     "validator": "~3.22.1"

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1300,7 +1300,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
 
       it('sorts the results via a date column', function(done) {
         var self = this;
-        self.User.create({username: 'user3', data: 'bar', theDate: moment().add('hours', 2).toDate()}).success(function() {
+        self.User.create({username: 'user3', data: 'bar', theDate: moment().add(2, 'hours').toDate()}).success(function() {
           self.User.findAll({ order: [['theDate', 'DESC']] }).success(function(users) {
             expect(users[0].id).to.be.above(users[2].id);
             done();


### PR DESCRIPTION
This should be triple checked. From the actual deprecation code, it seems that we should keep  `utcOffset()` as it is now, since `timeZone` is always a string.

* Fixed deprecation warning for moment().add().
* Fixed deprecation warning for moment().zone().