### PR TITLE
[WIP] Add io.js support to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - "0.10"
+  - "iojs"
 
 sudo: false
 
@@ -37,8 +38,20 @@ matrix:
   include:
     - node_js: "0.10"
       env: COVERAGE=true
+    - node_js: iojs
+      env: COVERAGE=true
   allow_failures:
+    - node_js: "iojs"
+      env: DB=mysql DIALECT=mysql
+    - node_js: "iojs"
+      env: DB=mysql DIALECT=sqlite
+    - node_js: "iojs"
+      env: DB=mysql DIALECT=mariadb
+    - node_js: "iojs"
+      env: DB=mysql DIALECT=mssql
     - node_js: "0.10"
+      env: COVERAGE=true
+    - node_js: iojs
       env: COVERAGE=true
 
 notifications:

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "devDependencies": {
     "continuation-local-storage": "3.1.2",
     "chai-as-promised": "^4.1.1",
-    "sqlite3": "~3.0.0",
+    "sqlite3": "fengmk2/node-sqlite3#support-iojs-version",
     "mysql": "~2.5.0",
     "pg": "^4.2.0",
     "pg-native": "^1.8.0",


### PR DESCRIPTION
In 2 days, Travis-CI will start officially supporting io.js. `postgres` and `postgres-native` tests already pass. 