### PR TITLE
Allow overriding `plain` in rawSelect functions

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -803,8 +803,9 @@ module.exports = (function() {
    * @param {DataType|String} [options.dataType] The type of the result. If `field` is a field in this Model, the default will be the type of that field, otherwise defaults to float.
    * @param {boolean}         [options.distinct] Applies DISTINCT to the field being aggregated over
    * @param {Transaction}     [options.transaction]
+   * @param {boolean}         [options.plain] When `true`, the first returned value of `aggregateFunction` is cast to `dataType` and returned. If additional attributes are specified, along with `group` clauses, set `plain` to `false` to return all values of all returned rows.  Defaults to `true`
    *
-   * @return {Promise<options.dataType>}
+   * @return {Promise<options.dataType|object>}                Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in which case the complete data result is returned.
    */
   Model.prototype.aggregate = function(field, aggregateFunction, options) {
     options = Utils._.extend({ attributes: [] }, options || {});
@@ -839,7 +840,9 @@ module.exports = (function() {
    * @param {Object}  [options]
    * @param {Object}  [options.where] A hash of search attributes.
    * @param {Object}  [options.include] Include options. See `find` for details
-   * @param {boolean} [options.distinct] Appliy COUNT(DISTINCT(col))
+   * @param {boolean} [options.distinct] Apply COUNT(DISTINCT(col))
+   * @param {Object}  [options.attributes] Used in conjustion with `group`
+   * @param {Object}  [options.group] For creating complex counts. Will return multiple rows as needed.
    *
    * @return {Promise<Integer>}
    */
@@ -856,6 +859,7 @@ module.exports = (function() {
 
     Utils.mapOptionFieldNames(options, this);
 
+    options.plain = options.group ? false : true;
     options.dataType = new DataTypes.INTEGER();
     options.includeIgnoreAttributes = false;
     options.limit = null;

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -746,8 +746,10 @@ module.exports = (function() {
       });
     }
 
+    options.plain = options.plain === undefined ? true : options.plain;
+
     var sql = this.QueryGenerator.selectQuery(tableName, options, Model)
-      , queryOptions = Utils._.extend({ transaction: options.transaction }, { plain: true, raw: true, type: QueryTypes.SELECT })
+      , queryOptions = Utils._.extend({ transaction: options.transaction, plain: options.plain }, { raw: true, type: QueryTypes.SELECT })
       , self = this;
 
     if (attributeSelector === undefined) {
@@ -755,6 +757,10 @@ module.exports = (function() {
     }
 
     return this.sequelize.query(sql, null, queryOptions).then(function(data) {
+      if (!queryOptions.plain) {
+        return data;
+      }
+
       var result = data ? data[attributeSelector] : null;
 
       if (options && options.dataType) {
@@ -765,7 +771,7 @@ module.exports = (function() {
         } else if (dataType instanceof DataTypes.INTEGER || dataType instanceof DataTypes.BIGINT) {
           result = parseInt(result, 10);
         } else if (dataType instanceof DataTypes.DATE) {
-          if (!Utils._.isDate(result)) {
+          if (!Utils._.isNull(result) && !Utils._.isDate(result)) {
             result = new Date(result);
           }
         } else if (dataType instanceof DataTypes.STRING) {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1583,6 +1583,21 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
     });
+    it('returns multiple rows when using group', function() {
+      var self = this;
+      return this.User.bulkCreate([
+        {username: 'user1', data: 'A'},
+        {username: 'user2', data: 'A'},
+        {username: 'user3', data: 'B'}
+      ]).then(function() {
+        return self.User.count({
+          attributes: ['data'],
+          group: ['data']
+        }).then(function(count) {
+          expect(count.length).to.equal(2);
+        });
+      });
+    });
 
     it('does not modify the passed arguments', function(done) {
       var options = { where: ['username = ?', 'user1']};


### PR DESCRIPTION
I was trying to run a complex count query that utilized multiple attributes and group by columns. The query was built fine, but I was only getting back the first row of results. I determined that this was due to the `rawSelect` function defaulting `plain` to true.

I added a couple lines to allow `plain` to be set to false in the passed options and if that is done, the data is returned as is.

