### PR TITLE
Clone options for save and update

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -455,6 +455,8 @@ module.exports = (function() {
    * @return {Promise<this|Errors.ValidationError>}
    */
   Instance.prototype.save = function(options, deprecated) {
+    options = _.clone(options) || {};
+
     if (options instanceof Array) {
       options = { fields: options };
     }
@@ -719,7 +721,7 @@ module.exports = (function() {
    * @alias updateAttributes
    */
   Instance.prototype.update = function(values, options) {
-    options = options || {};
+    options = _.clone(options) || {};
     if (Array.isArray(options)) options = {fields: options};
 
     this.set(values, {attributes: options.fields});


### PR DESCRIPTION
I use the same options for multiple sequelize calls:

```javascript
var options = {
  transaction : ...
} 

model1.update({attr1 : 'value'},  options).then(function(){
  return model2.update({attr2: 'value2'}, options);
})
```

The current implementation (rc8) does not update model2 because `options` will be modified by `model1.update()`. After the call options will include a `options.fields` value. This prohibits the detection of changed values.

I think it is not necessary to do a deep clone at this moment. If this is the approach you want to go, we need to extend this behavior to more methods.