### PR TITLE
Adds support for instance name based MS SQL connections.

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -28,10 +28,14 @@ ConnectionManager.prototype.connect = function(config) {
       server: config.host,
       /* domain: 'DOMAIN' */
       options: {
-        port: config.port,
         database: config.database,
       }
     };
+
+    // only set port if no instance name was provided
+    if(!config.dialectOptions.instanceName){
+      connectionConfig.options.port = config.port;
+    }
 
     if (config.dialectOptions) {
       Object.keys(config.dialectOptions).forEach(function(key) {


### PR DESCRIPTION
This PR checks if in the passed dialect options for MS SQL an instanceName property was defined. It sets the instanceName property on the config and omits the port property, so that the tedious library will use the instance name instead of direct port connection.

Note: if a port and a instanceName would have been provided, tedious would throw an exception.

Tested with a local SQLExpress 2008 installation.

Signed-off-by: Luca Moser <l.moser@triumph-adler.ch>