### PR TITLE
Fix bug where setting same date twice would prevent persistence

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -351,8 +351,8 @@ module.exports = (function() {
             value = _.isString(value) ? !!parseInt(value, 10) : !!value;
           }
 
-          if (!options.raw && originalValue !== value) {
-            this._previousDataValues[key] = originalValue;
+          if (!options.raw && (options.isNewRecord || options.reset)) {
+            this._previousDataValues[key] = value;
           }
           this.dataValues[key] = value;
         }

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -449,6 +449,22 @@ describe(Support.getTestDialectTeaser('DAO'), function() {
         expect(user.previous('name')).to.equal('Jan Meier');
       });
 
+      it('setting the same value twice should not impact the result (Date)', function() {
+        var User = this.sequelize.define('User', {
+          birthday: {type: DataTypes.DATE}
+        });
+
+        var user = User.build({
+          birthday: null
+        });
+        user.set('birthday', new Date(1990, 0));
+        user.set('birthday', new Date(1990, 0));
+        expect(user.changed('birthday')).to.be.true;
+        expect(user.changed()).to.be.ok;
+        expect(user.isDirty).to.be.true;
+        expect(user.previous('birthday')).to.equal(null);
+      });
+
       it('should be available to a afterUpdate hook', function () {
         var User = this.sequelize.define('User', {
           name: {type: DataTypes.STRING}


### PR DESCRIPTION
This issue was caused by the difference in comparisons between
Instance.set and Instance.changed. Dates were being compared with !==
in #set, but with #valueOf in #changed. The _previousDataValue
would thus always get overwritten when setting a date field. This means
that performing a set on a Date field twice with two different Date
objects with the *same* #valueOf would trick Sequelize into thinking
that the field was clean.

This fix would change the behavior of Instance.previous in cases where the field has been set more than once. I believe this shouldn't be an issue given that the last value from the database is probably the most useful thing to return.