### PR TITLE
Fix non-global string replace for docs

### DIFF
--- a/docs/docs-generator.js
+++ b/docs/docs-generator.js
@@ -144,9 +144,9 @@ Comment.concatTypes = function (types, convertEntities) {
   if (convertEntities) {
     // Convert a couple of things to their HTML-entities
     // The spacing around | is intentional, in order to introduce some linebreaks in the params table
-    type = type.replace('|', ' &#124; ')
-      .replace('>', '&gt;')
-      .replace('<', '&lt;');
+    type = type.replace(/\|/g, ' &#124; ')
+      .replace(/>/g, '&gt;')
+      .replace(/</g, '&lt;');
   }
 
   return type;


### PR DESCRIPTION
There is an issue with the docs generator that is causing param comments that offer more than 2 acceptable types to break formatting, pushing the third parameter into the Description box, and causing the description to be completely lost.

You can see this problem here, where the `options*` parameter has a description of `String`.
[Docs](http://sequelize.readthedocs.org/en/latest/api/model/#scopeoptions-model) | [Source comment](https://github.com/sequelize/sequelize/blob/6f46f9802f01461a069c6e3ea22c207153ced9e9/lib/model.js#L501)

This was caused by use of String.prototype.replace with a substring argument, which is not a global replace, so subsequent pipes after the first in a param list would not be HTML-entity-ized. This patch simply changes them into regex with global flags.

Disclaimer: I was in a hurry and couldn't figure out how to generate a doc to test that it actually works. Please do double check.