### PR TITLE
Changing query-chainer to promise-style

### DIFF
--- a/lib/query-chainer.js
+++ b/lib/query-chainer.js
@@ -162,12 +162,12 @@ module.exports = (function() {
     var self = this;
 
     emitter
-      .success(function(result) {
+      .then(function(result) {
         self.emitterResults[self.emitters.indexOf(emitter)] = result;
         self.finishedEmits++;
         finish.call(self, 'emitterResults');
       })
-      .error(function(err) {
+      .catch(function(err) {
         self.finishedEmits++;
         self.fails.push(err);
         finish.call(self, 'emitterResults');


### PR DESCRIPTION
Removing the warnings of:
success|ok() is deprecated and will be removed in 2.1, please use promise-style instead.
failure|fail|error() is deprecated  and will be removed in 2.1, please use promise-style instead

When using the QueryChainer().add()