### PR TITLE
[PostgreSQL] Support for range datatype

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -410,7 +410,7 @@ var pgRangeSubtypes = {
 
 RANGE.prototype.key = RANGE.key = 'RANGE';
 RANGE.prototype.toSql = function() {
-  return pgRangeSubtypes[this._subtype.toLowerCase()] || pgRangeSubtypes['integer'];
+  return pgRangeSubtypes[this._subtype.toLowerCase()];
 };
 
 /**
@@ -510,7 +510,7 @@ ENUM.prototype.key = ENUM.key = 'ENUM';
  * @property ARRAY
  */
 var ARRAY = function(type) {
-  var options = _.isPlainObject(type) && !(type instanceof ABSTRACT) && type || {
+  var options = _.isPlainObject(type) ? type : {
     type: type
   };
   if (!(this instanceof ARRAY)) return new ARRAY(options);

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -382,24 +382,21 @@ BLOB.prototype.toSql = function() {
 };
 
 /**
- * Range types are data types representing a range of values of some element type (called the range's subtype). Only available in postgres.
+ * Range types are data types representing a range of values of some element type (called the range's subtype).
+ * Only available in postgres.
  * See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres documentation} for more details
  * @property RANGE
  */
 
-var RANGE = function (Subtype) {
-  var options = {};
-  if(typeof Subtype === 'function') { // if subtype passed - instantiate object of this subtype and return new function
-    options.subtype = new Subtype();
-    return RANGE.bind({}, options);
-  }
-  else if(typeof Subtype === 'object' && Subtype.hasOwnProperty('subtype'))
-    options = Subtype;
+var RANGE = function (subtype) {
+  var options = _.isPlainObject(subtype) ? subtype : { subtype: subtype };
+
+  if (!options.subtype) options.subtype = INTEGER;
 
   if (!(this instanceof RANGE)) return new RANGE(options);
   ABSTRACT.apply(this, arguments);
 
-  this._subtype = options.subtype ? (options.subtype.key || 'INTEGER') : 'INTEGER';
+  this._subtype = options.subtype.key;
 };
 util.inherits(RANGE, ABSTRACT);
 
@@ -513,7 +510,7 @@ ENUM.prototype.key = ENUM.key = 'ENUM';
  * @property ARRAY
  */
 var ARRAY = function(type) {
-  var options = typeof type === "object" && !(type instanceof ABSTRACT) && type || {
+  var options = _.isPlainObject(type) && !(type instanceof ABSTRACT) && type || {
     type: type
   };
   if (!(this instanceof ARRAY)) return new ARRAY(options);

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -328,7 +328,7 @@ util.inherits(JSONTYPE, ABSTRACT);
 
 JSONTYPE.prototype.key = JSONTYPE.key = 'JSON';
 
-/*
+/**
  * A pre-processed JSON data column. Only available in postgres.
  * @property JSONB
  */
@@ -379,6 +379,41 @@ BLOB.prototype.toSql = function() {
   default:
     return this.key;
   }
+};
+
+/**
+ * Range types are data types representing a range of values of some element type (called the range's subtype). Only available in postgres.
+ * See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres documentation} for more details
+ * @property RANGE
+ */
+
+var RANGE = function (subtype) {
+  var options = {};
+  if(typeof subtype === 'function') { // if subtype passed - instantiate object of this subtype and return new function
+    options.subtype = new subtype();
+    return RANGE.bind({}, options);
+  }
+  else if(typeof subtype === 'object' && subtype.hasOwnProperty('subtype'))
+    options = subtype;
+
+  if (!(this instanceof RANGE)) return new RANGE(options);
+  ABSTRACT.apply(this, arguments);
+
+  this._subtype = options.subtype ? (options.subtype.key || 'INTEGER') : 'INTEGER';
+};
+util.inherits(RANGE, ABSTRACT);
+
+var pgRangeSubtypes = {
+  integer: 'int4range',
+  bigint: 'int8range',
+  decimal: 'numrange',
+  dateonly: 'daterange',
+  date: 'tstzrange'
+};
+
+RANGE.prototype.key = RANGE.key = 'RANGE';
+RANGE.prototype.toSql = function() {
+  return pgRangeSubtypes[this._subtype.toLowerCase()] || pgRangeSubtypes['integer'];
 };
 
 /**
@@ -544,5 +579,6 @@ module.exports = {
   VIRTUAL: VIRTUAL,
   ARRAY: ARRAY,
   NONE: VIRTUAL,
-  ENUM: ENUM
+  ENUM: ENUM,
+  RANGE: RANGE
 };

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -387,14 +387,14 @@ BLOB.prototype.toSql = function() {
  * @property RANGE
  */
 
-var RANGE = function (subtype) {
+var RANGE = function (Subtype) {
   var options = {};
-  if(typeof subtype === 'function') { // if subtype passed - instantiate object of this subtype and return new function
-    options.subtype = new subtype();
+  if(typeof Subtype === 'function') { // if subtype passed - instantiate object of this subtype and return new function
+    options.subtype = new Subtype();
     return RANGE.bind({}, options);
   }
-  else if(typeof subtype === 'object' && subtype.hasOwnProperty('subtype'))
-    options = subtype;
+  else if(typeof Subtype === 'object' && Subtype.hasOwnProperty('subtype'))
+    options = Subtype;
 
   if (!(this instanceof RANGE)) return new RANGE(options);
   ABSTRACT.apply(this, arguments);

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -2,6 +2,7 @@
 
 var Utils = require('../../utils')
   , hstore = require('./hstore')
+  , range = require('./range')
   , util = require('util')
   , DataTypes = require('../../data-types')
   , SqlString = require('../../sql-string')
@@ -870,6 +871,13 @@ module.exports = (function() {
           return "'"  + hstore.stringify(value) + "'";
         } else if (DataTypes.ARRAY.is(field.type, DataTypes.HSTORE)) {
           return "ARRAY[" + Utils._.map(value, function(v){return "'" + hstore.stringify(v) + "'::hstore";}).join(",") + "]::HSTORE[]";
+        }
+      } else if(Utils._.isArray(value) && field && (field.type instanceof DataTypes.RANGE || DataTypes.ARRAY.is(field.type, DataTypes.RANGE))) {
+        if(field.type instanceof DataTypes.RANGE) { // escape single value
+          return "'"  + range.stringify(value) + "'";
+        }
+        else if (DataTypes.ARRAY.is(field.type, DataTypes.RANGE)) { // escape array of ranges
+          return "ARRAY[" + Utils._.map(value, function(v){return "'" + range.stringify(v) + "'";}).join(",") + "]::" + field.type.toString();
         }
       } else if (field && (field.type instanceof DataTypes.JSON || field.type instanceof DataTypes.JSONB)) {
         value = JSON.stringify(value);

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -344,43 +344,19 @@ module.exports = (function() {
 
         break;
       case '23P01':
-        // there are multiple different formats of error messages for this error code
-        // this regex should check at least two
         match = errDetail.match(/Key \((.*?)\)=\((.*?)\)/);
 
-        if (match) {
-          fields = Utils._.zipObject(match[1].split(', '), match[2].split(', '));
-          errors = [];
-          message = 'Validation error';
+        fields = Utils._.zipObject(match[1].split(', '), match[2].split(', '));
+        message = 'Exclusion constraint error';
 
-          Utils._.forOwn(fields, function(value, field) {
-            errors.push(new sequelizeErrors.ValidationErrorItem(
-              field + ' must be unique', 'unique violation', field, value));
-          });
+        return new sequelizeErrors.ExclusionConstraintError({
+          message: message,
+          constraint: err.constraint,
+          fields: fields,
+          table: err.table,
+          parent: err
+        });
 
-          if (this.callee && this.callee.__options && this.callee.__options.uniqueKeys) {
-            Utils._.forOwn(this.callee.__options.uniqueKeys, function(constraint) {
-              if (Utils._.isEqual(constraint.fields, Object.keys(fields)) && !!constraint.msg) {
-                message = constraint.msg;
-                return false;
-              }
-            });
-          }
-
-          return new sequelizeErrors.ExclusionConstraintError({
-            message: message,
-            errors: errors,
-            parent: err,
-            fields: fields
-          });
-        } else {
-          return new sequelizeErrors.ExclusionConstraintError({
-            message: errMessage,
-            parent: err
-          });
-        }
-
-        break;
       default:
         return new sequelizeErrors.DatabaseError(err);
     }

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -121,7 +121,7 @@ module.exports = (function() {
               attribute: field,
               collate: attribute.match(/COLLATE "(.*?)"/) ? /COLLATE "(.*?)"/.exec(attribute)[1] : undefined,
               order: attribute.indexOf('DESC') !== -1 ? 'DESC' : attribute.indexOf('ASC') !== -1 ? 'ASC': undefined,
-              length: undefined,
+              length: undefined
             };
           });
           delete result.columns;
@@ -254,7 +254,10 @@ module.exports = (function() {
   Query.prototype.formatError = function (err) {
     var match
       , table
-      , index;
+      , index
+      , fields
+      , errors
+      , message;
 
     var code = err.code || err.sqlState
       , errMessage = err.message || err.messagePrimary
@@ -277,9 +280,9 @@ module.exports = (function() {
         match = errDetail.match(/Key \((.*?)\)=\((.*?)\)/);
 
         if (match) {
-          var fields = Utils._.zipObject(match[1].split(', '), match[2].split(', '))
-            , errors = []
-            , message = 'Validation error';
+          fields = Utils._.zipObject(match[1].split(', '), match[2].split(', '));
+          errors = [];
+          message = 'Validation error';
 
           Utils._.forOwn(fields, function(value, field) {
             errors.push(new sequelizeErrors.ValidationErrorItem(
@@ -303,6 +306,44 @@ module.exports = (function() {
           });
         } else {
           return new sequelizeErrors.UniqueConstraintError({
+            message: errMessage,
+            parent: err
+          });
+        }
+
+        break;
+      case '23P01':
+        // there are multiple different formats of error messages for this error code
+        // this regex should check at least two
+        match = errDetail.match(/Key \((.*?)\)=\((.*?)\)/);
+
+        if (match) {
+          fields = Utils._.zipObject(match[1].split(', '), match[2].split(', '));
+          errors = [];
+          message = 'Validation error';
+
+          Utils._.forOwn(fields, function(value, field) {
+            errors.push(new sequelizeErrors.ValidationErrorItem(
+              field + ' must be unique', 'unique violation', field, value));
+          });
+
+          if (this.callee && this.callee.__options && this.callee.__options.uniqueKeys) {
+            Utils._.forOwn(this.callee.__options.uniqueKeys, function(constraint) {
+              if (Utils._.isEqual(constraint.fields, Object.keys(fields)) && !!constraint.msg) {
+                message = constraint.msg;
+                return false;
+              }
+            });
+          }
+
+          return new sequelizeErrors.ExclusionConstraintError({
+            message: message,
+            errors: errors,
+            parent: err,
+            fields: fields
+          });
+        } else {
+          return new sequelizeErrors.ExclusionConstraintError({
             message: errMessage,
             parent: err
           });

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -4,6 +4,7 @@ var Utils = require('../../utils')
   , AbstractQuery = require('../abstract/query')
   , DataTypes = require('../../data-types')
   , hstore = require('./hstore')
+  , range = require('./range')
   , QueryTypes = require('../../query-types')
   , Promise = require('../../promise')
   , sequelizeErrors = require('../../errors.js');
@@ -25,6 +26,20 @@ var parseHstoreFields = function(model, row) {
   });
 };
 
+var parseRangeFields = function (model, row) {
+  Utils._.forEach(row, function (value, key) {
+    if (value === null) return row[key] = null;
+
+    if (model._isRangeAttribute(key)) {
+      row[key] = range.parse(value, model.attributes[key].type);
+    } else if (model.attributes[key] && DataTypes.ARRAY.is(model.attributes[key].type, DataTypes.RANGE)) {
+      var array = JSON.parse('[' + value.slice(1).slice(0, -1) + ']');
+      row[key] = Utils._.map(array, function (v) { return range.parse(v, model.attributes[key].type.type); });
+    } else {
+      row[key] = value;
+    }
+  });
+};
 
 module.exports = (function() {
   var Query = function(client, sequelize, callee, options) {
@@ -168,6 +183,12 @@ module.exports = (function() {
           });
         }
 
+        if (!!self.callee && !!self.callee._hasRangeAttributes) {
+          rows.forEach(function (row) {
+            parseRangeFields(self.callee, row);
+          });
+        }
+
         return self.handleSelectQuery(rows);
       } else if (QueryTypes.DESCRIBE === self.options.type) {
         result = {};
@@ -214,6 +235,12 @@ module.exports = (function() {
           });
         }
 
+        if (!!self.callee && !!self.callee._hasRangeAttributes) {
+          rows.forEach(function (row) {
+            parseRangeFields(self.callee, row);
+          });
+        }
+
         return self.handleSelectQuery(rows);
       } else if (QueryTypes.BULKDELETE === self.options.type) {
         return parseInt(result.rowCount, 10);
@@ -223,6 +250,10 @@ module.exports = (function() {
         if (!!self.callee && self.callee.dataValues) {
           if (!!self.callee.Model && !!self.callee.Model._hasHstoreAttributes) {
             parseHstoreFields(self.callee.Model, rows[0]);
+          }
+
+          if (!!self.callee.Model && !!self.callee.Model._hasRangeAttributes) {
+            parseRangeFields(self.callee.Model, rows[0]);
           }
 
           for (var key in rows[0]) {

--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -33,11 +33,11 @@ module.exports = {
     return (data.inclusive[0] ? '[' : '(') + JSON.stringify(data[0]) + ',' + JSON.stringify(data[1]) +
            (data.inclusive[1] ? ']' : ')');
   },
-  parse:     function (value, attrType) {
+  parse:     function (value, AttributeType) {
     if (value === null) return null;
 
-    if(typeof attrType === 'function') attrType = new attrType();
-    attrType = attrType || '';
+    if(typeof AttributeType === 'function') AttributeType = new AttributeType();
+    AttributeType = AttributeType || '';
 
     var result = value
       .slice(1, -1)
@@ -48,7 +48,7 @@ module.exports = {
 
     result = result
       .map(function (value) {
-        switch (attrType.toString()) {
+        switch (AttributeType.toString()) {
           case 'int4range':
             return parseInt(value, 10);
           case 'numrange':

--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -7,44 +7,37 @@ module.exports = {
   stringify: function (data) {
     if (data === null) return null;
 
-    if (!Utils._.isArray(data) || data.length !== 2)
-      return '';
+    if (!Utils._.isArray(data) || data.length !== 2) return '';
 
-    if (Utils._.any(data, Utils._.isNull))
-      return '';
+    if (Utils._.any(data, Utils._.isNull)) return '';
 
     if (data.hasOwnProperty('inclusive')) {
-      if (!data.inclusive)
-        data.inclusive = [false, false];
-      else if (data.inclusive === true)
-        data.inclusive = [true, true];
-    } else
+      if (!data.inclusive) data.inclusive = [false, false];
+      else if (data.inclusive === true) data.inclusive = [true, true];
+    } else {
       data.inclusive = [false, false];
+    }
+
     Utils._.each(data, function (value, index) {
       if (Utils._.isObject(value)) {
-        if (value.hasOwnProperty('inclusive'))
-          data.inclusive[index] = !!value.inclusive;
-
-        if (value.hasOwnProperty('value'))
-          data[index] = value.value;
+        if (value.hasOwnProperty('inclusive')) data.inclusive[index] = !!value.inclusive;
+        if (value.hasOwnProperty('value')) data[index] = value.value;
       }
     });
 
-    return (data.inclusive[0] ? '[' : '(') + JSON.stringify(data[0]) + ',' + JSON.stringify(data[1]) +
-           (data.inclusive[1] ? ']' : ')');
+    return (data.inclusive[0] ? '[' : '(') + JSON.stringify(data[0]) + ',' + JSON.stringify(data[1]) + (data.inclusive[1] ? ']' : ')');
   },
-  parse:     function (value, AttributeType) {
+  parse: function (value, AttributeType) {
     if (value === null) return null;
 
     if(typeof AttributeType === 'function') AttributeType = new AttributeType();
-    AttributeType = AttributeType || '';
-
+    AttributeType = AttributeType || ''; // if attribute is not defined, assign empty string in order to prevent
+                                         // AttributeType.toString() to fail with uncaught exception later in the code
     var result = value
       .slice(1, -1)
       .split(',', 2);
 
-    if (result.length !== 2)
-      return value;
+    if (result.length !== 2) return value;
 
     result = result
       .map(function (value) {

--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -1,0 +1,69 @@
+'use strict';
+
+var Utils = require('../../utils'),
+  moment = require('moment');
+
+module.exports = {
+  stringify: function (data) {
+    if (data === null) return null;
+
+    if (!Utils._.isArray(data) || data.length !== 2)
+      return '';
+
+    if (Utils._.any(data, Utils._.isNull))
+      return '';
+
+    if (data.hasOwnProperty('inclusive')) {
+      if (!data.inclusive)
+        data.inclusive = [false, false];
+      else if (data.inclusive === true)
+        data.inclusive = [true, true];
+    } else
+      data.inclusive = [false, false];
+    Utils._.each(data, function (value, index) {
+      if (Utils._.isObject(value)) {
+        if (value.hasOwnProperty('inclusive'))
+          data.inclusive[index] = !!value.inclusive;
+
+        if (value.hasOwnProperty('value'))
+          data[index] = value.value;
+      }
+    });
+
+    return (data.inclusive[0] ? '[' : '(') + JSON.stringify(data[0]) + ',' + JSON.stringify(data[1]) +
+           (data.inclusive[1] ? ']' : ')');
+  },
+  parse:     function (value, attrType) {
+    if (value === null) return null;
+
+    if(typeof attrType === 'function') attrType = new attrType();
+    attrType = attrType || '';
+
+    var result = value
+      .slice(1, -1)
+      .split(',', 2);
+
+    if (result.length !== 2)
+      return value;
+
+    result = result
+      .map(function (value) {
+        switch (attrType.toString()) {
+          case 'int4range':
+            return parseInt(value, 10);
+          case 'numrange':
+            return parseFloat(value);
+          case 'daterange':
+          case 'tsrange':
+          case 'tstzrange':
+            return moment(value).toDate();
+        }
+
+        return value;
+      });
+
+    result.inclusive = [(value[0] === '['), (value[value.length - 1] === ']')];
+
+    return result;
+  }
+};

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -145,6 +145,26 @@ error.ForeignKeyConstraintError = function (options) {
 util.inherits(error.ForeignKeyConstraintError, error.DatabaseError);
 
 /**
+ * Thrown when an exclusion constraint is violated in the database
+ * @extends DatabaseError
+ * @constructor
+ */
+error.ExclusionConstraintError = function (options) {
+  options = options || {};
+  options.parent = options.parent || { sql: '' };
+
+  error.DatabaseError.call(this, options.parent);
+  this.name = 'SequelizeExclusionConstraintError';
+
+  this.message = options.message;
+  this.fields = options.fields;
+  this.table = options.table;
+  this.value = options.value;
+  this.index = options.index;
+};
+util.inherits(error.ExclusionConstraintError, error.DatabaseError);
+
+/**
  * The message from the DB.
  * @property message
  * @name message

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -157,10 +157,9 @@ error.ExclusionConstraintError = function (options) {
   this.name = 'SequelizeExclusionConstraintError';
 
   this.message = options.message;
+  this.constraint = options.constraint;
   this.fields = options.fields;
   this.table = options.table;
-  this.value = options.value;
-  this.index = options.index;
 };
 util.inherits(error.ExclusionConstraintError, error.DatabaseError);
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -80,7 +80,7 @@ module.exports = (function() {
 
       if (attribute.type === undefined) {
         throw new Error('Unrecognized data type for field ' + name);
-      }      
+      }
 
       if (attribute.type instanceof DataTypes.ENUM) {
         if (!attribute.values.length) {
@@ -156,7 +156,7 @@ module.exports = (function() {
           self.options.uniqueKeys[idxName] = {
             name: idxName,
             fields: [attribute],
-            singleField: true,
+            singleField: true
           };
         } else if (options.unique !== false) {
           idxName = options.unique;
@@ -281,6 +281,7 @@ module.exports = (function() {
     this._booleanAttributes = [];
     this._dateAttributes = [];
     this._hstoreAttributes = [];
+    this._rangeAttributes = [];
     this._jsonAttributes = [];
     this._virtualAttributes = [];
     this._defaultValues = {};
@@ -303,6 +304,8 @@ module.exports = (function() {
         self._dateAttributes.push(name);
       } else if (definition.type instanceof DataTypes.HSTORE) {
         self._hstoreAttributes.push(name);
+      } else if (definition.type instanceof DataTypes.RANGE) {
+        self._rangeAttributes.push(name);
       } else if (definition.type instanceof DataTypes.JSON) {
         self._jsonAttributes.push(name);
       } else if (definition.type instanceof DataTypes.VIRTUAL) {
@@ -313,7 +316,7 @@ module.exports = (function() {
         if (typeof definition.defaultValue === "function" && (
             definition.defaultValue === DataTypes.NOW ||
             definition.defaultValue === DataTypes.UUIDV4 ||
-            definition.defaultValue === DataTypes.UUIDV4 
+            definition.defaultValue === DataTypes.UUIDV4
         )) {
           definition.defaultValue = new definition.defaultValue();
         }
@@ -339,6 +342,11 @@ module.exports = (function() {
     this._hasHstoreAttributes = !!this._hstoreAttributes.length;
     this._isHstoreAttribute = Utils._.memoize(function(key) {
       return self._hstoreAttributes.indexOf(key) !== -1;
+    });
+
+    this._hasRangeAttributes = !!this._rangeAttributes.length;
+    this._isRangeAttribute = Utils._.memoize(function(key) {
+      return self._rangeAttributes.indexOf(key) !== -1;
     });
 
     this._hasJsonAttributes = !!this._jsonAttributes.length;
@@ -819,7 +827,7 @@ module.exports = (function() {
     }
 
     options = paranoidClause(this, options);
-    
+
     return this.QueryInterface.rawSelect(this.getTableName(options), options, aggregateFunction, this);
   };
 
@@ -1141,7 +1149,7 @@ module.exports = (function() {
       queryOptions.transaction = transaction;
 
       return self.find(options, {
-        transaction: transaction,
+        transaction: transaction
       });
     }).then(function(instance) {
       if (instance !== null) {
@@ -1171,7 +1179,7 @@ module.exports = (function() {
 
         // Someone must have created a matching instance inside the same transaction since we last did a find. Let's find it!
         return self.find(options, {
-          transaction: internalTransaction ? null : this.transaction,
+          transaction: internalTransaction ? null : this.transaction
         }).then(function(instance) {
           // Sanity check, ideally we caught this at the defaultFeilds/err.fields check
           // But if we didn't and instance is null, we will throw

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -321,6 +321,13 @@ module.exports = (function() {
     sequelizeErrors.UniqueConstraintError;
 
   /**
+   * Thrown when an exclusion constraint is violated in the database
+   * @see {Errors#ExclusionConstraintError}
+   */
+  Sequelize.prototype.ExclusionConstraintError = Sequelize.ExclusionConstraintError =
+    sequelizeErrors.ExclusionConstraintError;
+
+  /**
    * Thrown when a foreign key constraint is violated in the database
    * @see {Errors#ForeignKeyConstraintError}
    */

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -696,13 +696,13 @@ if (dialect.match(/^postgres/)) {
 
       it('should bulkCreate with range property', function() {
         var User = this.User,
-          period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
+            period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
 
         return this.User.bulkCreate([{
-                                       username: 'bob',
-                                       email: ['myemail@email.com'],
-                                       course_period: period
-                                     }]).then(function() {
+          username: 'bob',
+          email: ['myemail@email.com'],
+          course_period: period
+        }]).then(function() {
           return User.find(1).then(function(user) {
             expect(user.course_period[0] instanceof Date).to.be.ok;
             expect(user.course_period[1] instanceof Date).to.be.ok;
@@ -715,7 +715,7 @@ if (dialect.match(/^postgres/)) {
 
       it('should update range correctly', function() {
         var self = this,
-          period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
+            period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
 
         return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: period}).then(function(newUser) {
           // Check to see if the default value for a range field works
@@ -746,7 +746,7 @@ if (dialect.match(/^postgres/)) {
 
       it('should update range correctly and return the affected rows', function() {
         var self = this,
-          period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
+            period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
 
         return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]}).then(function(oldUser) {
           // Update the user and check that the returned object's fields have been parsed by the range parser

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -24,7 +24,11 @@ if (dialect.match(/^postgres/)) {
         friends: {
           type: DataTypes.ARRAY(DataTypes.JSON),
           defaultValue: []
-        }
+        },
+        course_period: DataTypes.RANGE(DataTypes.DATE),
+        acceptable_marks: { type: DataTypes.RANGE(DataTypes.DECIMAL), defaultValue: [0.65, 1] },
+        available_amount: DataTypes.RANGE,
+        holidays: DataTypes.ARRAY(DataTypes.RANGE(DataTypes.DATE))
       });
       this.User.sync({ force: true }).success(function() {
         done();
@@ -37,8 +41,8 @@ if (dialect.match(/^postgres/)) {
     });
 
     it('should be able to search within an array', function(done) {
-      this.User.all({where: {email: ['hello', 'world']}}).on('sql', function(sql) {
-        expect(sql).to.equal('SELECT "id", "username", "email", "settings", "document", "phones", "emergency_contact", "friends", "createdAt", "updatedAt" FROM "Users" AS "User" WHERE "User"."email" = ARRAY[\'hello\',\'world\']::TEXT[];');
+      this.User.all({where: {email: ['hello', 'world']}, attributes: ['id','username','email','settings','document','phones','emergency_contact','friends']}).on('sql', function(sql) {
+        expect(sql).to.equal('SELECT "id", "username", "email", "settings", "document", "phones", "emergency_contact", "friends" FROM "Users" AS "User" WHERE "User"."email" = ARRAY[\'hello\',\'world\']::TEXT[];');
         done();
       });
     });
@@ -295,6 +299,27 @@ if (dialect.match(/^postgres/)) {
           settings: {mailing: false, push: 'facebook', frequency: 3}
         }).on('sql', function(sql) {
           var expected = '\'"mailing"=>"false","push"=>"facebook","frequency"=>"3"\',\'"default"=>"\'\'value\'\'"\'';
+          expect(sql.indexOf(expected)).not.to.equal(-1);
+        });
+      });
+
+    });
+
+    describe('range', function() {
+      it('should tell me that a column is range and not USER-DEFINED', function() {
+        return this.sequelize.queryInterface.describeTable('Users').then(function(table) {
+          expect(table.course_period.type).to.equal('TSTZRANGE');
+          expect(table.available_amount.type).to.equal('INT4RANGE');
+        });
+      });
+
+      it('should stringify range with insert', function() {
+        return this.User.create({
+          username: 'bob',
+          email: ['myemail@email.com'],
+          course_period: [{value: new Date(2015,0,1), inclusive: true}, {value: new Date(2015,11,31), inclusive: true}]
+        }).on('sql', function(sql) {
+          var expected = '["2015-01-01T00:00:00.000Z","2015-12-31T00:00:00.000Z"]';
           expect(sql.indexOf(expected)).not.to.equal(-1);
         });
       });
@@ -621,6 +646,172 @@ if (dialect.match(/^postgres/)) {
           .then(function(users) {
             expect(users[0].settings).to.deep.equal({ test: '"value"' });
             expect(users[1].settings).to.deep.equal({ another: '"example"' });
+
+            done();
+          })
+          .error(console.log);
+      });
+
+      it('should save range correctly', function() {
+        return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]}).then(function(newUser) {
+          // Check to see if the default value for a range field works
+          expect(newUser.acceptable_marks.length).to.equal(2);
+          expect(newUser.acceptable_marks[0]).to.equal(0.65); // lower bound
+          expect(newUser.acceptable_marks[1]).to.equal(1); // upper bound
+          expect(newUser.acceptable_marks.inclusive).to.deep.equal([false, false]); // not inclusive
+          expect(newUser.course_period[0] instanceof Date).to.be.ok; // lower bound
+          expect(newUser.course_period[1] instanceof Date).to.be.ok; // upper bound
+          expect(newUser.course_period[0].toISOString()).to.equal('2015-01-01T00:00:00.000Z'); // lower bound
+          expect(newUser.course_period[1].toISOString()).to.equal('2015-12-31T00:00:00.000Z'); // upper bound
+          expect(newUser.course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+
+          // Check to see if updating a range field works
+          return newUser.updateAttributes({acceptable_marks: [0.8, 0.9]}).then(function(oldUser) {
+            expect(newUser.acceptable_marks.length).to.equal(2);
+            expect(newUser.acceptable_marks[0]).to.equal(0.8); // lower bound
+            expect(newUser.acceptable_marks[1]).to.equal(0.9); // upper bound
+          });
+        });
+      });
+
+      it('should save range array correctly', function() {
+        var User = this.User;
+
+        return this.User.create({
+          username: 'bob',
+          email: ['myemail@email.com'],
+          holidays: [[new Date(2015, 3, 1), new Date(2015, 3, 15)], [new Date(2015, 8, 1), new Date(2015, 9, 15)]]
+        }).then(function() {
+          return User.find(1).then(function(user) {
+            expect(user.holidays.length).to.equal(2);
+            expect(user.holidays[0].length).to.equal(2);
+            expect(user.holidays[0][0] instanceof Date).to.be.ok;
+            expect(user.holidays[0][1] instanceof Date).to.be.ok;
+            expect(user.holidays[0][0].toISOString()).to.equal("2015-03-31T23:00:00.000Z");
+            expect(user.holidays[0][1].toISOString()).to.equal("2015-04-14T23:00:00.000Z");
+            expect(user.holidays[1].length).to.equal(2);
+            expect(user.holidays[1][0] instanceof Date).to.be.ok;
+            expect(user.holidays[1][1] instanceof Date).to.be.ok;
+            expect(user.holidays[1][0].toISOString()).to.equal("2015-08-31T23:00:00.000Z");
+            expect(user.holidays[1][1].toISOString()).to.equal("2015-10-14T23:00:00.000Z");
+          });
+        });
+      });
+
+      it('should bulkCreate with range property', function() {
+        var User = this.User;
+
+        return this.User.bulkCreate([{
+                                       username: 'bob',
+                                       email: ['myemail@email.com'],
+                                       course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]
+                                     }]).then(function() {
+          return User.find(1).then(function(user) {
+            expect(user.course_period[0] instanceof Date).to.be.ok;
+            expect(user.course_period[1] instanceof Date).to.be.ok;
+            expect(user.course_period[0].toISOString()).to.equal('2015-01-01T00:00:00.000Z'); // lower bound
+            expect(user.course_period[1].toISOString()).to.equal('2015-12-31T00:00:00.000Z'); // upper bound
+            expect(user.course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+          });
+        });
+      });
+
+      it('should update range correctly', function() {
+        var self = this;
+
+        return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]}).then(function(newUser) {
+          // Check to see if the default value for a range field works
+          expect(newUser.acceptable_marks.length).to.equal(2);
+          expect(newUser.acceptable_marks[0]).to.equal(0.65); // lower bound
+          expect(newUser.acceptable_marks[1]).to.equal(1); // upper bound
+          expect(newUser.acceptable_marks.inclusive).to.deep.equal([false, false]); // not inclusive
+          expect(newUser.course_period[0] instanceof Date).to.be.ok;
+          expect(newUser.course_period[1] instanceof Date).to.be.ok;
+          expect(newUser.course_period[0].toISOString()).to.equal('2015-01-01T00:00:00.000Z'); // lower bound
+          expect(newUser.course_period[1].toISOString()).to.equal('2015-12-31T00:00:00.000Z'); // upper bound
+          expect(newUser.course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+
+          // Check to see if updating a range field works
+          return self.User.update({course_period: [new Date(2015, 1, 1), new Date(2015, 10, 30)]}, {where: newUser.identifiers}).then(function() {
+            return newUser.reload().success(function() {
+              expect(newUser.course_period[0] instanceof Date).to.be.ok;
+              expect(newUser.course_period[1] instanceof Date).to.be.ok;
+              expect(newUser.course_period[0].toISOString()).to.equal('2015-02-01T00:00:00.000Z'); // lower bound
+              expect(newUser.course_period[1].toISOString()).to.equal('2015-11-30T00:00:00.000Z'); // upper bound
+              expect(newUser.course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+            });
+          });
+        });
+      });
+
+      it('should update range correctly and return the affected rows', function() {
+        var self = this;
+
+        return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]}).then(function(oldUser) {
+          // Update the user and check that the returned object's fields have been parsed by the range parser
+          return self.User.update({course_period: [new Date(2015, 1, 1), new Date(2015, 10, 30)]}, {where: oldUser.identifiers, returning: true }).spread(function(count, users) {
+            expect(count).to.equal(1);
+            expect(users[0].course_period[0] instanceof Date).to.be.ok;
+            expect(users[0].course_period[1] instanceof Date).to.be.ok;
+            expect(users[0].course_period[0].toISOString()).to.equal('2015-02-01T00:00:00.000Z'); // lower bound
+            expect(users[0].course_period[1].toISOString()).to.equal('2015-11-30T00:00:00.000Z'); // upper bound
+            expect(users[0].course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+          });
+        });
+      });
+
+      it('should read range correctly', function() {
+        var self = this;
+        var course_period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
+        course_period.inclusive = [false, false];
+        var data = { username: 'user', email: ['foo@bar.com'], course_period: course_period};
+
+        return this.User.create(data)
+          .then(function() {
+            return self.User.find({ where: { username: 'user' }});
+          })
+          .then(function(user) {
+            // Check that the range fields are the same when retrieving the user
+            expect(user.course_period).to.deep.equal(data.course_period);
+          });
+      });
+
+      it('should read range array correctly', function() {
+        var self = this;
+        var holidays = [[new Date(2015, 3, 1, 10), new Date(2015, 3, 15)],[new Date(2015, 8, 1), new Date(2015, 9, 15)]];
+        holidays[0].inclusive = [true, true];
+        holidays[1].inclusive = [true, true];
+
+        var data = { username: 'user', email: ['foo@bar.com'], holidays: holidays };
+
+        return this.User.create(data)
+          .then(function() {
+            // Check that the range fields are the same when retrieving the user
+            return self.User.find({ where: { username: 'user' }});
+          }).then(function(user) {
+            expect(user.holidays).to.deep.equal(data.holidays);
+          });
+      });
+
+      it('should read range correctly from multiple rows', function(done) {
+        var self = this;
+
+        self.User
+          .create({ username: 'user1', email: ['foo@bar.com'], course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]})
+          .then(function() {
+            return self.User.create({ username: 'user2', email: ['foo2@bar.com'], course_period: [new Date(2016, 0, 1), new Date(2016, 11, 31)]});
+          })
+          .then(function() {
+            // Check that the range fields are the same when retrieving the user
+            return self.User.findAll({ order: 'username' });
+          })
+          .then(function(users) {
+            expect(users[0].course_period[0].toISOString()).to.equal('2015-01-01T00:00:00.000Z'); // lower bound
+            expect(users[0].course_period[1].toISOString()).to.equal('2015-12-31T00:00:00.000Z'); // upper bound
+            expect(users[0].course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+            expect(users[1].course_period[0].toISOString()).to.equal('2016-01-01T00:00:00.000Z'); // lower bound
+            expect(users[1].course_period[1].toISOString()).to.equal('2016-12-31T00:00:00.000Z'); // upper bound
+            expect(users[1].course_period.inclusive).to.deep.equal([false, false]); // not inclusive
 
             done();
           })

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -793,10 +793,10 @@ if (dialect.match(/^postgres/)) {
           });
       });
 
-      it('should read range correctly from multiple rows', function(done) {
+      it('should read range correctly from multiple rows', function() {
         var self = this;
 
-        self.User
+        return self.User
           .create({ username: 'user1', email: ['foo@bar.com'], course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]})
           .then(function() {
             return self.User.create({ username: 'user2', email: ['foo2@bar.com'], course_period: [new Date(2016, 0, 1), new Date(2016, 11, 31)]});
@@ -812,8 +812,6 @@ if (dialect.match(/^postgres/)) {
             expect(users[1].course_period[0].toISOString()).to.equal('2016-01-01T00:00:00.000Z'); // lower bound
             expect(users[1].course_period[1].toISOString()).to.equal('2016-12-31T00:00:00.000Z'); // upper bound
             expect(users[1].course_period.inclusive).to.deep.equal([false, false]); // not inclusive
-
-            done();
           })
           .error(console.log);
       });

--- a/test/integration/dialects/postgres/error.test.js
+++ b/test/integration/dialects/postgres/error.test.js
@@ -1,0 +1,72 @@
+'use strict';
+
+var chai      = require('chai')
+  , sinon     = require('sinon')
+  , expect    = chai.expect
+  , DataTypes = require(__dirname + '/../../../../lib/data-types')
+  , Support   = require(__dirname + '/../../support')
+  , Sequelize = Support.Sequelize
+  , dialect   = Support.getTestDialect()
+  , Promise   = Sequelize.Promise
+  , _ = require('lodash');
+
+chai.config.includeStack = true;
+
+if (dialect.match(/^postgres/)) {
+  var constraintName = 'overlap_period';
+  beforeEach(function () {
+    var self = this;
+    this.Booking = self.sequelize.define('Booking', {
+      roomNo: DataTypes.INTEGER,
+      period: DataTypes.RANGE(DataTypes.DATE)
+    });
+    return self.Booking
+      .sync({ force: true })
+      .then(function () {
+        return self.sequelize.query('ALTER TABLE "' + self.Booking.tableName + '" ADD CONSTRAINT ' + constraintName +
+                                    ' EXCLUDE USING gist ("roomNo" WITH =, period WITH &&)');
+      });
+  });
+
+  describe('[POSTGRES Specific] ExclusionConstraintError', function () {
+
+    it('should contain error specific properties', function () {
+      var errDetails = {
+        message:    'Exclusion constraint error',
+        constraint: 'constraint_name',
+        fields:     { 'field1': 1, 'field2': [123, 321] },
+        table:      'table_name',
+        parent:     new Error('Test error')
+      };
+      var err = new Sequelize.ExclusionConstraintError(errDetails);
+
+      _.each(errDetails, function (value, key) {
+        expect(value).to.be.deep.equal(err[key]);
+      });
+    });
+
+    it('should throw ExclusionConstraintError when "period" value overlaps existing', function () {
+      var Booking = this.Booking;
+
+      return Booking
+        .create({
+          roomNo:    1,
+          guestName: 'Incognito Visitor',
+          period:    [new Date(2015, 0, 1), new Date(2015, 0, 3)]
+        })
+        .then(function () {
+          return Booking
+            .create({
+              roomNo:    1,
+              guestName: 'Frequent Visitor',
+              period:    [new Date(2015, 0, 2), new Date(2015, 0, 5)]
+            })
+            .done(function (err) {
+              expect(!!err).to.be.ok;
+              expect(err instanceof Sequelize.ExclusionConstraintError).to.be.ok;
+            });
+        });
+    });
+
+  });
+}

--- a/test/integration/dialects/postgres/error.test.js
+++ b/test/integration/dialects/postgres/error.test.js
@@ -55,16 +55,12 @@ if (dialect.match(/^postgres/)) {
           period:    [new Date(2015, 0, 1), new Date(2015, 0, 3)]
         })
         .then(function () {
-          return Booking
+          return expect(Booking
             .create({
               roomNo:    1,
               guestName: 'Frequent Visitor',
               period:    [new Date(2015, 0, 2), new Date(2015, 0, 5)]
-            })
-            .done(function (err) {
-              expect(!!err).to.be.ok;
-              expect(err instanceof Sequelize.ExclusionConstraintError).to.be.ok;
-            });
+            })).to.eventually.be.rejectedWith(Sequelize.ExclusionConstraintError);
         });
     });
 

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+var chai    = require('chai')
+  , expect  = chai.expect
+  , Support = require(__dirname + '/../../support')
+  , DataTypes = require(__dirname + '/../../../../lib/data-types')
+  , dialect = Support.getTestDialect()
+  , range   = require('../../../../lib/dialects/postgres/range');
+
+chai.config.includeStack = true;
+
+if (dialect.match(/^postgres/)) {
+  describe('[POSTGRES Specific] range datatype', function () {
+    describe('stringify', function () {
+      it('should handle empty objects correctly', function () {
+        expect(range.stringify([])).to.equal('');
+      });
+
+      it('should return empty string when either of boundaries is null', function () {
+        expect(range.stringify([null, "test"])).to.equal('');
+        expect(range.stringify([123, null])).to.equal('');
+      });
+
+      it('should return empty string when boundaries array of invalid size', function () {
+        expect(range.stringify([1])).to.equal('');
+        expect(range.stringify([1, 2, 3])).to.equal('');
+      });
+
+      it('should return empty string when non-array parameter is passed', function (done) {
+        expect(range.stringify({})).to.equal('');
+        expect(range.stringify('test')).to.equal('');
+        expect(range.stringify(undefined)).to.equal('');
+        done();
+      });
+
+      it('should handle array of objects with `inclusive` and `value` properties', function () {
+        expect(range.stringify([{ inclusive: true, value: 0 }, { value: 1 }])).to.equal('[0,1)');
+        expect(range.stringify([{ inclusive: true, value: 0 }, { inclusive: true, value: 1 }])).to.equal('[0,1]');
+        expect(range.stringify([{ inclusive: false, value: 0 }, 1])).to.equal('(0,1)');
+        expect(range.stringify([0, { inclusive: true, value: 1 }])).to.equal('(0,1]');
+      });
+
+      it('should handle inclusive property of input array properly', function () {
+        var testRange = [1, 2];
+
+        testRange.inclusive = [true, false];
+        expect(range.stringify(testRange)).to.equal('[1,2)');
+
+        testRange.inclusive = [false, true];
+        expect(range.stringify(testRange)).to.equal('(1,2]');
+
+        testRange.inclusive = [true, true];
+        expect(range.stringify(testRange)).to.equal('[1,2]');
+
+        testRange.inclusive = true;
+        expect(range.stringify(testRange)).to.equal('[1,2]');
+
+        testRange.inclusive = false;
+        expect(range.stringify(testRange)).to.equal('(1,2)');
+      });
+
+      it('should handle date values', function () {
+        expect(range.stringify([new Date(2000, 1, 1),
+                                new Date(2000, 1, 2)])).to.equal('("2000-02-01T00:00:00.000Z","2000-02-02T00:00:00.000Z")');
+      });
+    });
+
+    describe('parse', function () {
+      it('should handle a null object correctly', function () {
+        expect(range.parse(null)).to.equal(null);
+      });
+
+      it('should handle empty string correctly', function () {
+        expect(range.parse('')).to.deep.equal('');
+      });
+
+      it('should return raw value if not range is returned', function () {
+        expect(range.parse('some_non_array')).to.deep.equal('some_non_array');
+      });
+    });
+    describe('stringify and parse', function () {
+      it('should stringify then parse back the same structure', function () {
+        var testRange = [5,10];
+        testRange.inclusive = [true, true];
+
+        expect(range.parse(range.stringify(testRange), DataTypes.RANGE(DataTypes.INTEGER))).to.deep.equal(testRange);
+        expect(range.parse(range.stringify(range.parse(range.stringify(testRange), DataTypes.RANGE(DataTypes.INTEGER))), DataTypes.RANGE(DataTypes.INTEGER))).to.deep.equal(testRange);
+      });
+    });
+  });
+}

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -453,9 +453,9 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
   describe('define', function() {
     it('adds a new dao to the dao manager', function(done) {
-      expect(this.sequelize.daoFactoryManager.all.length).to.equal(0);
+      var count = this.sequelize.daoFactoryManager.all.length;
       this.sequelize.define('foo', { title: DataTypes.STRING });
-      expect(this.sequelize.daoFactoryManager.all.length).to.equal(1);
+      expect(this.sequelize.daoFactoryManager.all.length).to.equal(count+1);
       done();
     });
 

--- a/test/integration/support.js
+++ b/test/integration/support.js
@@ -10,6 +10,15 @@ before(function() {
   return Support.sequelize.query('CREATE EXTENSION IF NOT EXISTS hstore', null, {raw: true});
 });
 
+before(function() {
+  var dialect = Support.getTestDialect();
+
+  if (dialect !== 'postgres' && dialect !== 'postgres-native') {
+    return;
+  }
+  return Support.sequelize.query('CREATE EXTENSION IF NOT EXISTS btree_gist', null, {raw: true});
+});
+
 beforeEach(function() {
   return Support.clearDatabase(this.sequelize);
 });


### PR DESCRIPTION
This pull request contains basic support for built-in range datatypes (can be extended to support custom user-defined types though but I don't know any use cases for it yet, moreover it will be still returning them but as a strings).

You can read more about range types in official documentation ([here](http://www.postgresql.org/docs/9.4/static/rangetypes.html)).

Why is usage of range datatype interesting? Mostly because of flexibility for constraints it allows to create. While UNIQUE is a natural constraint for scalar values, it is usually unsuitable for range types. Instead, an exclusion constraint is often more appropriate. Exclusion constraints allow the specification of constraints such as "non-overlapping" on a range type.

By default, column type can be simply specified as `Sequelize.RANGE`, which will translate it to `int4range` datatype. However, there are 6 built-in range types (as of Postgres version 9.4):
- **int4range** — Range of `INTEGER`
- **int8range** — Range of `BIGINT`
- **numrange** — Range of `NUMERIC`
- **tsrange** - Range of `TIMESTAMP WITHOUT TIME ZONE` - please note: this one is not used because there is no default datatype in Sequelize that allows to specify whether to use time zone or not (or I haven't found one :smile:)
- **tstzrange** - Range of `TIMESTAMP WITH TIME ZONE`
- **daterange** - Range of `DATE`

So, to make use of them, you can explicitly define them, passing range *subtype* as a parameter to datatype. For instance, to use datetime range, we define our column type as `Sequelize.RANGE(Sequelize.DATE)`. Because Sequelize is aware that this range contains timestamp, they are automatically converted to native JavaScript's Date objects. Furthermore, you can use Date objects when defining your query condition.

Because range bounds can be either inclusive or exclusive, it requires to pass this property both ways - when querying database and when retrieving example as well. The most easy and sane way is to represent range as simple array with two values: first and second values are lower and upper bounds respectively, while array property `inclusive` is either a boolean that applies for both boundaries or an array with two boolean values (array in array, "we need to go deeper" :smirk:), which specify whether each boundary is inclusive or exclusive. By default (if no inclusive parameter is specified, it assumes that boundaries are exclusive). See example below.
```javascript
var range = [0,1]; // in query: (0,1)
range.inclusive = true; // in query: [0,1]
range.inclusive = [ false, true ]; // in query: (0,1]
range.inclusive = [ true, false ]; // in query: [0,1)
```
Also, it is not the only way to pass boundary type to the database via Sequelize, because it also supports passing object in array. Each boundary can be represented in form of an object with following properties: `value` (required), `inclusive` (optional). While setting `inclusive` property of an array we pass might be painful because it requires creation of variable, we can avoid this using objects as a values. Following example demonstrates it:
```javascript
YourModel.find({
    where: {
        range: {
            overlap: [ { value: 0, inclusive: true }, { value: 1, inclusive: true } ]
            // will equal '[0,1]' in query
        },
        range2: {
            contains: [ 5, { value: 7, inclusive: true } ]
            // mixed way of declaration, will equal to '(5,7]' in query
        }
    });
```
However, in response all range fields will be returned as an array with values and `inclusive` property with two booleans. Something like `[ value1, value2, inclusive: [ true/false, true/false ]`

One thing, that I'm concerned about, is defining this datatype as Postgres dialect specific. However, I haven't had a chance to thoroughly go through @mickhansen's recent changes to the way datatypes defined.

Feel free to comment, I'm open for discussion of the ~~shit~~ code I wrote :wink: