### PR TITLE
Fix regression in MSSQL ConnectionManager

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -28,16 +28,17 @@ ConnectionManager.prototype.connect = function(config) {
       server: config.host,
       /* domain: 'DOMAIN' */
       options: {
+        port: config.port,
         database: config.database,
       }
     };
 
-    // only set port if no instance name was provided
-    if(!config.dialectOptions.instanceName){
-      connectionConfig.options.port = config.port;
-    }
-
     if (config.dialectOptions) {
+      // only set port if no instance name was provided
+      if (config.dialectOptions.instanceName) {
+        delete connectionConfig.options.port;
+      }
+
       Object.keys(config.dialectOptions).forEach(function(key) {
         connectionConfig.options[key] = config.dialectOptions[key];
       });


### PR DESCRIPTION
https://github.com/sequelize/sequelize/pull/3098 introduced a regression in MSSQL ConnectionManager when `config.dialectOptions` was undefined, causing an exception:

```
Possibly unhandled TypeError: Cannot read property 'instanceName' of undefined
    at [...]/node_modules/sequelize/lib/dialects/mssql/connection-manager.js:36:30
```

This patch changes it so that the existence of `config.dialectOptions` is checked before trying to access it's properties. It might be a good idea to add a test case to connection-manager.test.js that tests that connections without certain options set.