### PR TITLE
Add support for keyword `after` in options of a field

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [FEATURE] Add support for keyword `after` in options of a field (useful for migrations), only for MySQL.
+
 # 2.0.3
 - [BUG] Support for plain strings, ints and bools on JSON insert
 - [BUG] Fixed regression where `{$in: []}` would result in `IN ()` rather than `IN (NULL)` [#3105](https://github.com/sequelize/sequelize/issues/3105) [#3132](https://github.com/sequelize/sequelize/issues/3132)

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -289,6 +289,10 @@ module.exports = (function() {
         template += ' PRIMARY KEY';
       }
 
+      if (attribute.after) {
+        template += ' AFTER ' + this.quoteIdentifier(attribute.after);
+      }
+
       if (attribute.references) {
         template += ' REFERENCES ' + this.quoteTable(attribute.references);
 

--- a/test/integration/dialects/mysql/query-generator.test.js
+++ b/test/integration/dialects/mysql/query-generator.test.js
@@ -45,6 +45,10 @@ if (Support.dialectIsMySQL()) {
           expectation: {id: 'INTEGER UNIQUE'}
         },
         {
+          arguments: [{id: {type: 'INTEGER', after: 'Bar'}}],
+          expectation: {id: 'INTEGER AFTER `Bar`'}
+        },
+        {
           arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`)'}
         },


### PR DESCRIPTION
Add support for keyword `after` in options of a field (useful for migrations), only for MySQL.
And add unit test.