### PR TITLE
Recursive Extend Model Default Options for getterMethods and setterMethods

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -533,13 +533,7 @@ module.exports = (function() {
       , globalOptions = this.options;
 
     if (globalOptions.define) {
-      options = Utils._.extend({}, globalOptions.define, options);
-      Utils._(['classMethods', 'instanceMethods', 'getterMethods', 'setterMethods']).each(function(key) {
-        if (globalOptions.define[key]) {
-          options[key] = options[key] || {};
-          Utils._.defaults(options[key], globalOptions.define[key]);
-        }
-      });
+      options = Utils._.merge({}, globalOptions.define, options);
     }
 
     options = Utils._.merge({

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -534,7 +534,7 @@ module.exports = (function() {
 
     if (globalOptions.define) {
       options = Utils._.extend({}, globalOptions.define, options);
-      Utils._(['classMethods', 'instanceMethods']).each(function(key) {
+      Utils._(['classMethods', 'instanceMethods', 'getterMethods', 'setterMethods']).each(function(key) {
         if (globalOptions.define[key]) {
           options[key] = options[key] || {};
           Utils._.defaults(options[key], globalOptions.define[key]);

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -426,70 +426,110 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
   describe('set', function() {
     it("should be configurable with global functions", function() {
-      var overrideFunction = function() {
-        return 'override';
-      };
+      var defaultClassMethod = sinon.spy()
+        , overrideClassMethod = sinon.spy()
+        , defaultInstanceMethod = sinon.spy()
+        , overrideInstanceMethod = sinon.spy()
+        , defaultSetterMethod = sinon.spy()
+        , overrideSetterMethod = sinon.spy()
+        , defaultGetterMethod = sinon.spy()
+        , overrideGetterMethod = sinon.spy()
+        , customClassMethod = sinon.spy()
+        , customOverrideClassMethod = sinon.spy()
+        , customInstanceMethod = sinon.spy()
+        , customOverrideInstanceMethod = sinon.spy()
+        , customSetterMethod = sinon.spy()
+        , customOverrideSetterMethod = sinon.spy()
+        , customGetterMethod = sinon.spy()
+        , customOverrideGetterMethod = sinon.spy();
 
       this.sequelize.options.define = {
         'classMethods': {
-          'defaultClassMethod': function() {},
-          'overrideClassMethod': function() {}
+          'defaultClassMethod': defaultClassMethod,
+          'overrideClassMethod': overrideClassMethod
         },
         'instanceMethods': {
-          'defaultInstanceMethod': function() {},
-          'overrideInstanceMethod': function() {}
+          'defaultInstanceMethod': defaultInstanceMethod,
+          'overrideInstanceMethod': overrideInstanceMethod
         },
         'setterMethods': {
-          'default': function() {},
-          'override': function() {},
+          'default': defaultSetterMethod,
+          'override': overrideSetterMethod
         },
         'getterMethods': {
-          'default': function() {
-            return 'default';
-          },
-          'override': function() {
-            return 'default';
-          }
+          'default': defaultGetterMethod,
+          'override': overrideGetterMethod
         }
       };
       var testEntity = this.sequelize.define('TestEntity', {}, {
         'classMethods': {
-          'customClassMethod': function() {},
-          'overrideClassMethod': overrideFunction
+          'customClassMethod': customClassMethod,
+          'overrideClassMethod': customOverrideClassMethod
         },
         'instanceMethods': {
-          'customInstanceMethod': function() {},
-          'overrideInstanceMethod': overrideFunction
+          'customInstanceMethod': customInstanceMethod,
+          'overrideInstanceMethod': customOverrideInstanceMethod
         },
         'setterMethods': {
-          'custom': function() {},
-          'override': function() {}
+          'custom': customSetterMethod,
+          'override': customOverrideSetterMethod
         },
         'getterMethods': {
-          'custom': function() {
-            return 'custom';
-          },
-          'override': function() {
-            return 'custom';
-          }
+          'custom': customGetterMethod,
+          'override': customOverrideGetterMethod
         }
       });
 
+      // Call all Class Methods
+      testEntity.defaultClassMethod();
+      testEntity.customClassMethod();
+      testEntity.overrideClassMethod();
+
+      expect(typeof testEntity.defaultClassMethod).to.equal('function');
+      expect(typeof testEntity.customClassMethod).to.equal('function');
+      expect(typeof testEntity.overrideClassMethod).to.equal('function');
+
+      expect(defaultClassMethod).to.have.been.calledOnce;
+      expect(customClassMethod).to.have.been.calledOnce;
+      expect(overrideClassMethod.callCount).to.be.eql(0);
+      expect(customOverrideClassMethod).to.have.been.calledOnce;
+
+      // Create Instance to test
       var instance = testEntity.build();
 
-      expect(testEntity).to.have.property('defaultClassMethod');
-      expect(testEntity).to.have.property('customClassMethod');
-      expect(testEntity).to.have.property('overrideClassMethod');
-      expect(testEntity.overrideClassMethod()).to.be.eql('override');
-      expect(instance).to.have.property('defaultInstanceMethod');
-      expect(instance).to.have.property('customInstanceMethod');
-      expect(instance).to.have.property('overrideInstanceMethod');
-      expect(instance.overrideInstanceMethod()).to.be.eql('override');
-      expect(instance.default).to.be.eql('default');
-      expect(instance.custom).to.be.eql('custom');
-      expect(instance.override).to.be.eql('custom');
+      // Call all Instance Methods
+      instance.defaultInstanceMethod();
+      instance.customInstanceMethod();
+      instance.overrideInstanceMethod();
 
-      // @TODO: How to Test Setters?
+      expect(typeof instance.defaultInstanceMethod).to.equal('function');
+      expect(typeof instance.customInstanceMethod).to.equal('function');
+      expect(typeof instance.overrideInstanceMethod).to.equal('function');
+
+      expect(defaultInstanceMethod).to.have.been.calledOnce;
+      expect(customInstanceMethod).to.have.been.calledOnce;
+      expect(overrideInstanceMethod.callCount).to.be.eql(0);
+      expect(customOverrideInstanceMethod).to.have.been.calledOnce;
+
+      // Call Getters
+      var defaultVal = instance.default
+        , custom = instance.custom
+        , override = instance.override;
+
+      expect(defaultGetterMethod).to.have.been.calledOnce;
+      expect(customGetterMethod).to.have.been.calledOnce;
+      expect(overrideGetterMethod.callCount).to.be.eql(0);
+      expect(customOverrideGetterMethod).to.have.been.calledOnce;
+
+      // Call Setters
+      instance.default = 'test';
+      instance.custom = 'test';
+      instance.override = 'test';
+
+      expect(defaultSetterMethod).to.have.been.calledOnce;
+      expect(customSetterMethod).to.have.been.calledOnce;
+      expect(overrideSetterMethod.callCount).to.be.eql(0);
+      expect(customOverrideSetterMethod).to.have.been.calledOnce;
     });
   });
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -440,12 +440,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
           'overrideInstanceMethod': function() {}
         },
         'setterMethods': {
-          'default': function() {
-            this.defaultVal = 'default';
-          },
-          'override': function() {
-            this.overrideVal = 'default';
-          },
+          'default': function() {},
+          'override': function() {},
         },
         'getterMethods': {
           'default': function() {
@@ -456,11 +452,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
           }
         }
       };
-      var testEntity = this.sequelize.define('TestEntity', {
-        'defaultVal': Sequelize.STRING(50),
-        'customVal': Sequelize.STRING(50),
-        'overrideVal': Sequelize.STRING(50)
-      }, {
+      var testEntity = this.sequelize.define('TestEntity', {}, {
         'classMethods': {
           'customClassMethod': function() {},
           'overrideClassMethod': overrideFunction
@@ -470,12 +462,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
           'overrideInstanceMethod': overrideFunction
         },
         'setterMethods': {
-          'custom': function() {
-            this.customVal = 'custom';
-          },
-          'override': function() {
-            this.overrideVal = 'default';
-          },
+          'custom': function() {},
+          'override': function() {}
         },
         'getterMethods': {
           'custom': function() {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -424,6 +424,87 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
     }
   });
 
+  describe('set', function() {
+    it("should be configurable with global functions", function() {
+      var overrideFunction = function() {
+        return 'override';
+      };
+
+      this.sequelize.options.define = {
+        'classMethods': {
+          'defaultClassMethod': function() {},
+          'overrideClassMethod': function() {}
+        },
+        'instanceMethods': {
+          'defaultInstanceMethod': function() {},
+          'overrideInstanceMethod': function() {}
+        },
+        'setterMethods': {
+          'default': function() {
+            this.defaultVal = 'default';
+          },
+          'override': function() {
+            this.overrideVal = 'default';
+          },
+        },
+        'getterMethods': {
+          'default': function() {
+            return 'default';
+          },
+          'override': function() {
+            return 'default';
+          }
+        }
+      };
+      var testEntity = this.sequelize.define('TestEntity', {
+        'defaultVal': Sequelize.STRING(50),
+        'customVal': Sequelize.STRING(50),
+        'overrideVal': Sequelize.STRING(50)
+      }, {
+        'classMethods': {
+          'customClassMethod': function() {},
+          'overrideClassMethod': overrideFunction
+        },
+        'instanceMethods': {
+          'customInstanceMethod': function() {},
+          'overrideInstanceMethod': overrideFunction
+        },
+        'setterMethods': {
+          'custom': function() {
+            this.customVal = 'custom';
+          },
+          'override': function() {
+            this.overrideVal = 'default';
+          },
+        },
+        'getterMethods': {
+          'custom': function() {
+            return 'custom';
+          },
+          'override': function() {
+            return 'custom';
+          }
+        }
+      });
+
+      var instance = testEntity.build();
+
+      expect(testEntity).to.have.property('defaultClassMethod');
+      expect(testEntity).to.have.property('customClassMethod');
+      expect(testEntity).to.have.property('overrideClassMethod');
+      expect(testEntity.overrideClassMethod()).to.be.eql('override');
+      expect(instance).to.have.property('defaultInstanceMethod');
+      expect(instance).to.have.property('customInstanceMethod');
+      expect(instance).to.have.property('overrideInstanceMethod');
+      expect(instance.overrideInstanceMethod()).to.be.eql('override');
+      expect(instance.default).to.be.eql('default');
+      expect(instance.custom).to.be.eql('custom');
+      expect(instance.override).to.be.eql('custom');
+
+      // @TODO: How to Test Setters?
+    });
+  });
+
   if (Support.dialectIsMySQL()) {
     describe('set', function() {
       it("should return an promised error if transaction isn't defined", function() {


### PR DESCRIPTION
If I define default getters and setters and create a Modle with some getter / setters themselves, the default ones won't be added.

I think we should handle getters & setters the same way we handle classMethods & instanceMethods.