### PR TITLE
refactor Hooks mixin

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -34,7 +34,7 @@ var Utils = require('./utils')
  * @see {Sequelize#define}
  * @mixin Hooks
  */
-var Hooks = module.exports = function() {};
+
 var hookTypes = {
   beforeValidate: {params: 2},
   afterValidate: {params: 2},
@@ -59,6 +59,7 @@ var hookTypes = {
   beforeInit: {params: 2, sync: true},
   afterInit: {params: 1, sync: true}
 };
+
 var hookAliases = {
   beforeDelete: 'beforeDestroy',
   afterDelete: 'afterDestroy',
@@ -66,109 +67,112 @@ var hookAliases = {
   afterBulkDelete: 'afterBulkDestroy'
 };
 
-Hooks.replaceHookAliases = function(hooks) {
-  var realHookName;
+var Hooks = {
+  replaceHookAliases: function(hooks) {
+    var realHookName;
 
-  Utils._.each(hooks, function(hooksArray, name) {
-    // Does an alias for this hook name exist?
-    if (realHookName = hookAliases[name]) {
-      // Add the hooks to the actual hook
-      hooks[realHookName] = (hooks[realHookName] || []).concat(hooksArray);
+    Utils._.each(hooks, function(hooksArray, name) {
+      // Does an alias for this hook name exist?
+      if (realHookName = hookAliases[name]) {
+        // Add the hooks to the actual hook
+        hooks[realHookName] = (hooks[realHookName] || []).concat(hooksArray);
 
-      // Delete the alias
-      delete hooks[name];
-    }
-  });
-
-  return hooks;
-};
-
-Hooks.runHooks = function(hooks) {
-  var self = this
-    , fn
-    , fnArgs = Array.prototype.slice.call(arguments, 1)
-    , hookType;
-
-  if (typeof fnArgs[fnArgs.length - 1] === 'function') {
-    fn = fnArgs.pop();
-  }
-
-  if (typeof hooks === 'string') {
-    hookType = hooks;
-    hooks = this.options.hooks[hookType] || [];
-	if (!Array.isArray(hooks)) hooks = hooks === undefined ? [] : [hooks];
-	if (this.sequelize) hooks = hooks.concat(this.sequelize.options.hooks[hookType] || []);
-  }
-
-  if (!Array.isArray(hooks)) {
-    hooks = hooks === undefined ? [] : [hooks];
-  }
-
-  // run hooks as sync functions if flagged as sync
-  if (hookTypes[hookType] && hookTypes[hookType].sync) {
-    hooks.forEach(function(hook) {
-      if (typeof hook === 'object') hook = hook.fn;
-      return hook.apply(self, fnArgs);
+        // Delete the alias
+        delete hooks[name];
+      }
     });
-    return;
-  }
 
-  // run hooks async
-  var promise = Promise.each(hooks, function (hook) {
-    if (typeof hook === 'object') {
-      hook = hook.fn;
+    return hooks;
+  },
+
+  runHooks: function(hooks) {
+    var self = this
+      , fn
+      , fnArgs = Array.prototype.slice.call(arguments, 1)
+      , hookType;
+
+    if (typeof fnArgs[fnArgs.length - 1] === 'function') {
+      fn = fnArgs.pop();
     }
 
-    if (hookType && hook.length > hookTypes[hookType].params) {
-      hook = Promise.promisify(hook, self);
+    if (typeof hooks === 'string') {
+      hookType = hooks;
+      hooks = this.options.hooks[hookType] || [];
+      if (!Array.isArray(hooks)) hooks = hooks === undefined ? [] : [hooks];
+      if (this.sequelize) hooks = hooks.concat(this.sequelize.options.hooks[hookType] || []);
     }
 
-    return hook.apply(self, fnArgs);
-  }).return();
+    if (!Array.isArray(hooks)) {
+      hooks = hooks === undefined ? [] : [hooks];
+    }
 
-  if (fn) {
-    return promise.nodeify(fn);
-  }
+    // run hooks as sync functions if flagged as sync
+    if (hookTypes[hookType] && hookTypes[hookType].sync) {
+      hooks.forEach(function(hook) {
+        if (typeof hook === 'object') hook = hook.fn;
+        return hook.apply(self, fnArgs);
+      });
+      return;
+    }
 
-  return promise;
+    // run hooks async
+    var promise = Promise.each(hooks, function (hook) {
+      if (typeof hook === 'object') {
+        hook = hook.fn;
+      }
+
+      if (hookType && hook.length > hookTypes[hookType].params) {
+        hook = Promise.promisify(hook, self);
+      }
+
+      return hook.apply(self, fnArgs);
+    }).return();
+
+    if (fn) {
+      return promise.nodeify(fn);
+    }
+
+    return promise;
+  },
+
+  hook: function() {
+    return Hooks.addHook.apply(this, arguments);
+  },
+
+  /**
+   * Add a hook to the model
+   *
+   * @param {String}    hooktype
+   * @param {String}    [name]    Provide a name for the hook function. This serves no purpose, other than the ability to be able to order hooks based on some sort of priority system in the future.
+   * @param {Function}  fn        The hook function
+   *
+   * @alias hook
+   */
+  addHook: function(hookType, name, fn) {
+    if (typeof name === 'function') {
+      fn = name;
+      name = null;
+    }
+
+    hookType = hookAliases[hookType] || hookType;
+
+    this.options.hooks[hookType] = this.options.hooks[hookType] || [];
+    this.options.hooks[hookType].push(!!name ? {name: name, fn: fn} : fn);
+    return this;
+  },
+
+  /*
+   * Check whether the mode has any hooks of this type
+   *
+   * @param {String}  hookType
+   *
+   * @alias hasHooks
+   */
+  hasHook: function(hookType) {
+    return this.options.hooks[hookType] && !!this.options.hooks[hookType].length;
+  },
 };
 
-Hooks.hook = function() {
-  return Hooks.addHook.apply(this, arguments);
-};
-
-/**
- * Add a hook to the model
- *
- * @param {String}    hooktype
- * @param {String}    [name]    Provide a name for the hook function. This serves no purpose, other than the ability to be able to order hooks based on some sort of priority system in the future.
- * @param {Function}  fn        The hook function
- *
- * @alias hook
- */
-Hooks.addHook = function(hookType, name, fn) {
-  if (typeof name === 'function') {
-    fn = name;
-    name = null;
-  }
-
-  hookType = hookAliases[hookType] || hookType;
-
-  this.options.hooks[hookType] = this.options.hooks[hookType] || [];
-  this.options.hooks[hookType].push(!!name ? {name: name, fn: fn} : fn);
-  return this;
-};
-
-/*
- * Check whether the mode has any hooks of this type
- *
- * @param {String}  hookType
- *
- * @alias hasHooks
- */
-Hooks.hasHook = function(hookType) {
-  return this.options.hooks[hookType] && !!this.options.hooks[hookType].length;
-};
 Hooks.hasHooks = Hooks.hasHook;
 
 /**
@@ -176,36 +180,24 @@ Hooks.hasHooks = Hooks.hasHook;
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
  */
-Hooks.beforeValidate = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeValidate', name, fn);
-};
 
 /**
  * A hook that is run after validation
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
  */
-Hooks.afterValidate = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterValidate', name, fn);
-};
 
 /**
  * A hook that is run before creating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, options, callback(err)
  */
-Hooks.beforeCreate = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeCreate', name, fn);
-};
 
 /**
  * A hook that is run after creating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, options, callback(err)
  */
-Hooks.afterCreate = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterCreate', name, fn);
-};
 
 /**
  * A hook that is run before destroying a single instance
@@ -214,13 +206,6 @@ Hooks.afterCreate = function(name, fn) {
  *
  * @alias beforeDelete
  */
-Hooks.beforeDestroy = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeDestroy', name, fn);
-};
-
-Hooks.beforeDelete = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeDelete', name, fn);
-};
 
 /**
  * A hook that is run after destroying a single instance
@@ -229,49 +214,30 @@ Hooks.beforeDelete = function(name, fn) {
  *
  * @alias afterDelete
  */
-Hooks.afterDestroy = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterDestroy', name, fn);
-};
-
-Hooks.afterDelete = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterDelete', name, fn);
-};
 
 /**
  * A hook that is run before updating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
  */
-Hooks.beforeUpdate = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeUpdate', name, fn);
-};
 
 /**
  * A hook that is run after updating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
  */
-Hooks.afterUpdate = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterUpdate', name, fn);
-};
 
 /**
  * A hook that is run before creating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instances, options, callback(err)
  */
-Hooks.beforeBulkCreate = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeBulkCreate', name, fn);
-};
 
 /**
  * A hook that is run after creating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instances, options, callback(err)
  */
-Hooks.afterBulkCreate = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterBulkCreate', name, fn);
-};
 
 /**
  * A hook that is run before destroying instances in bulk
@@ -280,13 +246,6 @@ Hooks.afterBulkCreate = function(name, fn) {
  *
  * @alias beforeBulkDelete
  */
-Hooks.beforeBulkDestroy = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeBulkDestroy', name, fn);
-};
-
-Hooks.beforeBulkDelete = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeBulkDelete', name, fn);
-};
 
 /**
  * A hook that is run after destroying instances in bulk
@@ -295,100 +254,80 @@ Hooks.beforeBulkDelete = function(name, fn) {
  *
  * @alias afterBulkDelete
  */
-Hooks.afterBulkDestroy = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterBulkDestroy', name, fn);
-};
-
-Hooks.afterBulkDelete = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterBulkDelete', name, fn);
-};
 
 /**
  * A hook that is run after updating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
  */
-Hooks.beforeBulkUpdate = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeBulkUpdate', name, fn);
-};
 
 /**
  * A hook that is run after updating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
  */
-Hooks.afterBulkUpdate = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterBulkUpdate', name, fn);
-};
 
 /**
  * A hook that is run before a find (select) query
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
  */
-Hooks.beforeFind = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeFind', name, fn);
-};
 
 /**
  * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
  */
-Hooks.beforeFindAfterExpandIncludeAll = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeFindAfterExpandIncludeAll', name, fn);
-};
 
 /**
  * A hook that is run before a find (select) query, after all option parsing is complete
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
  */
-Hooks.beforeFindAfterOptions = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeFindAfterOptions', name, fn);
-};
 
 /**
  * A hook that is run after a find (select) query
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance(s), options, callback(err)
  */
-Hooks.afterFind = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterFind', name, fn);
-};
 
 /**
  * A hook that is run before a define call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, options, callback(err)
  */
-Hooks.beforeDefine = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeDefine', name, fn);
-};
 
 /**
  * A hook that is run after a define call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with factory, callback(err)
  */
-Hooks.afterDefine = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterDefine', name, fn);
-};
 
 /**
  * A hook that is run before Sequelize() call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with config, options, callback(err)
  */
-Hooks.beforeInit = function(name, fn) {
-  return Hooks.addHook.call(this, 'beforeInit', name, fn);
-};
 
 /**
  * A hook that is run after Sequelize() call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with sequelize, callback(err)
  */
-Hooks.afterInit = function(name, fn) {
-  return Hooks.addHook.call(this, 'afterInit', name, fn);
+
+module.exports = {
+  hooks: hookTypes,
+  hookAliases: hookAliases,
+
+  applyTo: function(Model) {
+    Utils._.mixin(Model, Hooks);
+    Utils._.mixin(Model.prototype, Hooks);
+
+    var allHooks = Object.keys(hookTypes).concat(Object.keys(hookAliases));
+    allHooks.forEach(function(hook) {
+      Model.prototype[hook] = function(callback) {
+        return this.addHook(hook, callback);
+      };
+    });
+  }
 };

--- a/lib/model.js
+++ b/lib/model.js
@@ -2179,7 +2179,7 @@ module.exports = (function() {
   };
 
   Utils._.extend(Model.prototype, associationsMixin);
-  Utils._.extend(Model.prototype, Hooks);
+  Hooks.applyTo(Model);
 
   return Model;
 })();

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -268,8 +268,7 @@ module.exports = (function() {
    * Allow hooks to be defined on Sequelize + on sequelize instance as universal hooks to run on all models
    * and on Sequelize/sequelize methods e.g. Sequelize(), Sequelize#define()
    */
-  Utils._.extend(Sequelize, Hooks);
-  Utils._.extend(Sequelize.prototype, Hooks);
+  Hooks.applyTo(Sequelize);
 
   /**
    * A general error class


### PR DESCRIPTION
The existing Hooks mixin explicitly defines methods for all hooks on
the Sequelize instance or a given Model. This modifies the Hooks module
to provide a single method "applyTo", which mixes in the base Hook
functionality (addHook, runHooks, etc), as well as autogenerates
declarative hooks for the object its mixing in to (Model.beforeCreate,
Sequelize.beforeDefine, etc).

**NOTE:** the hooks and hookAliases are also exported in expectation of another PR I can get up soon (hopefully) that cleans up the hooks tests by generating them programmatically rather than 4k lines of explicit tests