### PR TITLE
[PostgreSQL] Parsing included fields of HSTORE and RANGE datatype

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -209,21 +209,6 @@ module.exports = (function() {
         attributes: this.options.originalAttributes || this.options.attributes,
         raw: true
       });
-    } else if (this.options.hasJoinTableModel === true) {
-      result = results.map(function(result) {
-        result = Dot.transform(result);
-
-        var joinTableData = result[this.options.joinTableModel.name]
-          , joinTableDAO = this.options.joinTableModel.build(joinTableData, { isNewRecord: false, isDirty: false, raw: true })
-          , mainDao;
-
-        delete result[this.options.joinTableModel.name];
-        mainDao = this.callee.build(result, { isNewRecord: false, isDirty: false, raw: true });
-        mainDao[this.options.joinTableModel.name] = joinTableDAO;
-
-        return mainDao;
-      }.bind(this));
-
     // Regular queries
     } else {
       result = this.callee.bulkBuild(results, {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -9,37 +9,64 @@ var Utils = require('../../utils')
   , Promise = require('../../promise')
   , sequelizeErrors = require('../../errors.js');
 
-// Parses hstore fields if the model has any hstore fields.
-// This cannot be done in the 'pg' lib because hstore is a UDT.
-var parseHstoreFields = function(model, row) {
-  Utils._.forEach(row, function(value, key) {
-    if(value === null) return row[key] = null;
+var parseDialectSpecificFields = {
+      // Parses hstore fields if the model has any hstore fields.
+      // This cannot be done in the 'pg' lib because hstore is a UDT.
+      hstore: function (value, options) {
+        if (value === null) return null;
 
-    if (model._isHstoreAttribute(key)) {
-      row[key] = hstore.parse(value);
-    }else if (model.attributes[key] && DataTypes.ARRAY.is(model.attributes[key].type, DataTypes.HSTORE)) {
-      var array = JSON.parse('[' + value.slice(1).slice(0,-1) + ']');
-      row[key] = Utils._.map(array, function(v){return hstore.parse(v);});
-    }else{
-      row[key] = value;
-    }
+        return DataTypes.ARRAY.is(options.dataType, DataTypes.HSTORE) ?
+          Utils._.map(
+            JSON.parse('[' + value.substring(1, value.length - 1) + ']'), function (v) {
+              return hstore.parse(v);
+            }) : hstore.parse(value);
+      },
+      range:  function (value, options) {
+        if (value === null) return null;
+
+        return DataTypes.ARRAY.is(options.dataType, DataTypes.RANGE) ?
+          Utils._.map(
+            JSON.parse('[' + value.substring(1, value.length - 1) + ']'),
+            function (v) {
+              return range.parse(v, options.dataType.type);
+            }) :
+          range.parse(value, options.dataType);
+      }
+    },
+    dialectSpecificTypes  = Utils._.keys(parseDialectSpecificFields);
+
+function dialectSpecificFieldDatatypeMap (options, prefix) {
+  if (!Utils._.isArray(options.types))
+    return [];
+
+  prefix = prefix || '';
+
+  var fields = {};
+  if (options.callee) {
+    if (options.as)
+      prefix += options.as + '.';
+
+    Utils._.each(options.types, function (type) {
+      Utils._.each(options.callee['_' + type + 'Attributes'], function (attrName) {
+        fields[prefix + attrName] = {
+          dataType: options.callee.attributes[attrName].type || null,
+          type:     type
+        };
+      });
+    });
+  }
+
+  Utils._.each(options.include, function (include) {
+    fields = Utils._.merge(fields, dialectSpecificFieldDatatypeMap({
+      callee:  include.model,
+      as:      include.as,
+      include: include.include,
+      types:   options.types
+    }, prefix));
   });
-};
 
-var parseRangeFields = function (model, row) {
-  Utils._.forEach(row, function (value, key) {
-    if (value === null) return row[key] = null;
-
-    if (model._isRangeAttribute(key)) {
-      row[key] = range.parse(value, model.attributes[key].type);
-    } else if (model.attributes[key] && DataTypes.ARRAY.is(model.attributes[key].type, DataTypes.RANGE)) {
-      var array = JSON.parse('[' + value.slice(1).slice(0, -1) + ']');
-      row[key] = Utils._.map(array, function (v) { return range.parse(v, model.attributes[key].type.type); });
-    } else {
-      row[key] = value;
-    }
-  });
-};
+  return fields;
+}
 
 module.exports = (function() {
   var Query = function(client, sequelize, callee, options) {
@@ -90,7 +117,9 @@ module.exports = (function() {
     }).spread(function(rows, sql, result) {
       var results = rows
         , isTableNameQuery = (sql.indexOf('SELECT table_name FROM information_schema.tables') === 0)
-        , isRelNameQuery = (sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0);
+        , isRelNameQuery = (sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0)
+        , dialectSpecificFields
+        , isDialectSpecificField = Utils._.memoize(function (key) { return dialectSpecificFields.hasOwnProperty(key); });
 
       if (isTableNameQuery || isRelNameQuery) {
         if (isRelNameQuery) {
@@ -177,16 +206,23 @@ module.exports = (function() {
           });
         }
 
-        if (!!self.callee && !!self.callee._hasHstoreAttributes) {
-          rows.forEach(function(row) {
-            parseHstoreFields(self.callee, row);
+        if (!!self.callee && rows.length > 0) {
+          dialectSpecificFields = dialectSpecificFieldDatatypeMap({
+            callee:  self.callee,
+            include: self.options.include,
+            types:   dialectSpecificTypes
           });
-        }
 
-        if (!!self.callee && !!self.callee._hasRangeAttributes) {
-          rows.forEach(function (row) {
-            parseRangeFields(self.callee, row);
-          });
+          // check whether custom fields exist in responses model
+          if (!Utils._.isEmpty(dialectSpecificFields)) {
+            rows.forEach(function (row, rowId, rows) {
+              Utils._.each(row, function (value, key) {
+                if (isDialectSpecificField(key))
+                  rows[rowId][key] =
+                  parseDialectSpecificFields[dialectSpecificFields[key].type](value, { dataType: dialectSpecificFields[key].dataType });
+              });
+            });
+          }
         }
 
         return self.handleSelectQuery(rows);
@@ -229,16 +265,22 @@ module.exports = (function() {
           return parseInt(result.rowCount, 10);
         }
 
-        if (!!self.callee && !!self.callee._hasHstoreAttributes) {
-          rows.forEach(function(row) {
-            parseHstoreFields(self.callee, row);
+        if (!!self.callee && rows.length > 0) {
+          dialectSpecificFields = dialectSpecificFieldDatatypeMap({
+            callee:  self.callee,
+            types:   dialectSpecificTypes
           });
-        }
 
-        if (!!self.callee && !!self.callee._hasRangeAttributes) {
-          rows.forEach(function (row) {
-            parseRangeFields(self.callee, row);
-          });
+          // check whether custom fields exist in responses model
+          if (!Utils._.isEmpty(dialectSpecificFields)) {
+            rows.forEach(function (row, rowId, rows) {
+              Utils._.each(row, function (value, key) {
+                if (isDialectSpecificField(key))
+                  rows[rowId][key] =
+                  parseDialectSpecificFields[dialectSpecificFields[key].type](value, { dataType: dialectSpecificFields[key].dataType });
+              });
+            });
+          }
         }
 
         return self.handleSelectQuery(rows);
@@ -248,12 +290,20 @@ module.exports = (function() {
         return rows[0].sequelize_upsert;
       } else if (self.isInsertQuery() || self.isUpdateQuery()) {
         if (!!self.callee && self.callee.dataValues) {
-          if (!!self.callee.Model && !!self.callee.Model._hasHstoreAttributes) {
-            parseHstoreFields(self.callee.Model, rows[0]);
-          }
+          if (!!self.callee.Model) {
+            dialectSpecificFields = dialectSpecificFieldDatatypeMap({
+              callee:  self.callee.Model,
+              types:   dialectSpecificTypes
+            });
 
-          if (!!self.callee.Model && !!self.callee.Model._hasRangeAttributes) {
-            parseRangeFields(self.callee.Model, rows[0]);
+            // check whether custom fields exist in responses model
+            if (!Utils._.isEmpty(dialectSpecificFields)) {
+              Utils._.each(rows[0], function (value, key) {
+                if (isDialectSpecificField(key))
+                  rows[0][key] =
+                  parseDialectSpecificFields[dialectSpecificFields[key].type](value, { dataType: dialectSpecificFields[key].dataType });
+              });
+            }
           }
 
           for (var key in rows[0]) {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -9,31 +9,35 @@ var Utils = require('../../utils')
   , Promise = require('../../promise')
   , sequelizeErrors = require('../../errors.js');
 
-var parseDialectSpecificFields = {
-      // Parses hstore fields if the model has any hstore fields.
-      // This cannot be done in the 'pg' lib because hstore is a UDT.
-      hstore: function (value, options) {
-        if (value === null) return null;
+var parseDialectSpecificFields,
+    dialectSpecificTypes;
 
-        return DataTypes.ARRAY.is(options.dataType, DataTypes.HSTORE) ?
-          Utils._.map(
-            JSON.parse('[' + value.substring(1, value.length - 1) + ']'), function (v) {
-              return hstore.parse(v);
-            }) : hstore.parse(value);
-      },
-      range:  function (value, options) {
-        if (value === null) return null;
+parseDialectSpecificFields = {
+  // Parses hstore fields if the model has any hstore fields.
+  // This cannot be done in the 'pg' lib because hstore is a UDT.
+  hstore: function (value, options) {
+    if (value === null) return null;
 
-        return DataTypes.ARRAY.is(options.dataType, DataTypes.RANGE) ?
-          Utils._.map(
-            JSON.parse('[' + value.substring(1, value.length - 1) + ']'),
-            function (v) {
-              return range.parse(v, options.dataType.type);
-            }) :
-          range.parse(value, options.dataType);
-      }
-    },
-    dialectSpecificTypes  = Utils._.keys(parseDialectSpecificFields);
+    return DataTypes.ARRAY.is(options.dataType, DataTypes.HSTORE) ?
+      Utils._.map(
+        JSON.parse('[' + value.substring(1, value.length - 1) + ']'), function (v) {
+          return hstore.parse(v);
+        }) : hstore.parse(value);
+  },
+  range:  function (value, options) {
+    if (value === null) return null;
+
+    return DataTypes.ARRAY.is(options.dataType, DataTypes.RANGE) ?
+      Utils._.map(
+        JSON.parse('[' + value.substring(1, value.length - 1) + ']'),
+        function (v) {
+          return range.parse(v, options.dataType.type);
+        }) :
+      range.parse(value, options.dataType);
+  }
+};
+
+dialectSpecificTypes = Utils._.keys(parseDialectSpecificFields);
 
 function dialectSpecificFieldDatatypeMap (options, prefix) {
   if (!Utils._.isArray(options.types))

--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -34,7 +34,7 @@ module.exports = {
     AttributeType = AttributeType || ''; // if attribute is not defined, assign empty string in order to prevent
                                          // AttributeType.toString() to fail with uncaught exception later in the code
     var result = value
-      .slice(1, -1)
+      .substring(1, value.length - 1)
       .split(',', 2);
 
     if (result.length !== 2) return value;

--- a/lib/model.js
+++ b/lib/model.js
@@ -302,9 +302,9 @@ module.exports = (function() {
         self._booleanAttributes.push(name);
       } else if (definition.type instanceof DataTypes.DATE) {
         self._dateAttributes.push(name);
-      } else if (definition.type instanceof DataTypes.HSTORE) {
+      } else if (definition.type instanceof DataTypes.HSTORE || DataTypes.ARRAY.is(definition.type, DataTypes.HSTORE)) {
         self._hstoreAttributes.push(name);
-      } else if (definition.type instanceof DataTypes.RANGE) {
+      } else if (definition.type instanceof DataTypes.RANGE || DataTypes.ARRAY.is(definition.type, DataTypes.RANGE)) {
         self._rangeAttributes.push(name);
       } else if (definition.type instanceof DataTypes.JSON) {
         self._jsonAttributes.push(name);

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -744,8 +744,8 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should update range correctly', function() {
-        var User = this.User,
-            period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
+        var User = this.User
+          , period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
 
         return User.create({ username: 'user', email: ['foo@bar.com'], course_period: period}).then(function(newUser) {
           // Check to see if the default value for a range field works
@@ -775,8 +775,8 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should update range correctly and return the affected rows', function () {
-        var User = this.User,
-            period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
+        var User = this.User
+          , period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
 
         return User.create({
           username:      'user',
@@ -863,9 +863,9 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should read range correctly from included models as well', function () {
-        var self = this,
-            period = [new Date(2016, 0, 1), new Date(2016, 11, 31)],
-            HolidayDate = this.sequelize.define('holidayDate', {
+        var self = this
+          , period = [new Date(2016, 0, 1), new Date(2016, 11, 31)]
+          , HolidayDate = this.sequelize.define('holidayDate', {
               period: DataTypes.RANGE(DataTypes.DATE)
             });
 

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -670,8 +670,7 @@ if (dialect.match(/^postgres/)) {
             expect(user.hasOwnProperty('hstoreSubmodels')).to.be.ok;
             expect(user.hstoreSubmodels.length).to.equal(1);
             expect(user.hstoreSubmodels[0].someValue).to.deep.equal(submodelValue);
-          })
-          .error(console.log);
+          });
       });
 
       it('should save range correctly', function() {
@@ -893,10 +892,6 @@ if (dialect.match(/^postgres/)) {
             expect(user.holidayDates[0].period.length).to.equal(2);
             expect(user.holidayDates[0].period[0]).to.equalTime(period[0]);
             expect(user.holidayDates[0].period[1]).to.equalTime(period[1]);
-          })
-          .error(function (err) {
-            console.log.apply(console, arguments);
-            throw err;
           });
       });
     });

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -643,6 +643,37 @@ if (dialect.match(/^postgres/)) {
           .error(console.log);
       });
 
+      it('should read hstore correctly from included models as well', function() {
+        var self = this,
+          HstoreSubmodel = self.sequelize.define('hstoreSubmodel', {
+            someValue: DataTypes.HSTORE
+          }),
+          submodelValue = { testing: '"hstore"' };
+
+        self.User.hasMany(HstoreSubmodel);
+
+        return self.sequelize
+          .sync({ force: true })
+          .then(function() {
+            return self.User.create({ username: 'user1' })
+              .then(function (user) {
+                return HstoreSubmodel.create({ someValue: submodelValue})
+                  .then(function (submodel) {
+                    return user.setHstoreSubmodels([submodel]);
+                  });
+              });
+          })
+          .then(function() {
+            return self.User.find({ where: { username: 'user1' }, include: [HstoreSubmodel]});
+          })
+          .then(function(user) {
+            expect(user.hasOwnProperty('hstoreSubmodels')).to.be.ok;
+            expect(user.hstoreSubmodels.length).to.equal(1);
+            expect(user.hstoreSubmodels[0].someValue).to.deep.equal(submodelValue);
+          })
+          .error(console.log);
+      });
+
       it('should save range correctly', function() {
         var period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
         return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: period}).then(function(newUser) {
@@ -673,7 +704,7 @@ if (dialect.match(/^postgres/)) {
             [new Date(2015, 8, 1), new Date(2015, 9, 15)]
           ];
 
-        return this.User.create({
+        return User.create({
           username: 'bob',
           email: ['myemail@email.com'],
           holidays: holidays
@@ -698,7 +729,7 @@ if (dialect.match(/^postgres/)) {
         var User = this.User,
             period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
 
-        return this.User.bulkCreate([{
+        return User.bulkCreate([{
           username: 'bob',
           email: ['myemail@email.com'],
           course_period: period
@@ -714,10 +745,10 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should update range correctly', function() {
-        var self = this,
+        var User = this.User,
             period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
 
-        return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: period}).then(function(newUser) {
+        return User.create({ username: 'user', email: ['foo@bar.com'], course_period: period}).then(function(newUser) {
           // Check to see if the default value for a range field works
           expect(newUser.acceptable_marks.length).to.equal(2);
           expect(newUser.acceptable_marks[0]).to.equal(0.65); // lower bound
@@ -732,7 +763,7 @@ if (dialect.match(/^postgres/)) {
           period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
 
           // Check to see if updating a range field works
-          return self.User.update({course_period: period}, {where: newUser.identifiers}).then(function() {
+          return User.update({course_period: period}, {where: newUser.identifiers}).then(function() {
             return newUser.reload().success(function() {
               expect(newUser.course_period[0] instanceof Date).to.be.ok;
               expect(newUser.course_period[1] instanceof Date).to.be.ok;
@@ -744,32 +775,39 @@ if (dialect.match(/^postgres/)) {
         });
       });
 
-      it('should update range correctly and return the affected rows', function() {
-        var self = this,
+      it('should update range correctly and return the affected rows', function () {
+        var User = this.User,
             period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
 
-        return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]}).then(function(oldUser) {
-          // Update the user and check that the returned object's fields have been parsed by the range parser
-          return self.User.update({course_period: period}, {where: oldUser.identifiers, returning: true }).spread(function(count, users) {
-            expect(count).to.equal(1);
-            expect(users[0].course_period[0] instanceof Date).to.be.ok;
-            expect(users[0].course_period[1] instanceof Date).to.be.ok;
-            expect(users[0].course_period[0]).to.equalTime(period[0]); // lower bound
-            expect(users[0].course_period[1]).to.equalTime(period[1]); // upper bound
-            expect(users[0].course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+        return User.create({
+          username:      'user',
+          email:         ['foo@bar.com'],
+          course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]
+        }).then(function (oldUser) {
+            // Update the user and check that the returned object's fields have been parsed by the range parser
+            return User.update({ course_period: period }, { where: oldUser.identifiers, returning: true })
+              .spread(function (count, users) {
+                expect(count).to.equal(1);
+                expect(users[0].course_period[0] instanceof Date).to.be.ok;
+                expect(users[0].course_period[1] instanceof Date).to.be.ok;
+                expect(users[0].course_period[0]).to.equalTime(period[0]); // lower bound
+                expect(users[0].course_period[1]).to.equalTime(period[1]); // upper bound
+                expect(users[0].course_period.inclusive).to.deep.equal([false, false]); // not inclusive
+              });
           });
-        });
       });
 
       it('should read range correctly', function() {
-        var self = this;
+        var User = this.User;
+
         var course_period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
         course_period.inclusive = [false, false];
+
         var data = { username: 'user', email: ['foo@bar.com'], course_period: course_period};
 
-        return this.User.create(data)
+        return User.create(data)
           .then(function() {
-            return self.User.find({ where: { username: 'user' }});
+            return User.find({ where: { username: 'user' }});
           })
           .then(function(user) {
             // Check that the range fields are the same when retrieving the user
@@ -778,7 +816,7 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should read range array correctly', function() {
-        var self = this,
+        var User = this.User,
             holidays = [
               [new Date(2015, 3, 1, 10), new Date(2015, 3, 15)],
               [new Date(2015, 8, 1), new Date(2015, 9, 15)]
@@ -789,30 +827,30 @@ if (dialect.match(/^postgres/)) {
 
         var data = { username: 'user', email: ['foo@bar.com'], holidays: holidays };
 
-        return this.User.create(data)
+        return User.create(data)
           .then(function() {
             // Check that the range fields are the same when retrieving the user
-            return self.User.find({ where: { username: 'user' }});
+            return User.find({ where: { username: 'user' }});
           }).then(function(user) {
             expect(user.holidays).to.deep.equal(data.holidays);
           });
       });
 
       it('should read range correctly from multiple rows', function() {
-        var self = this,
+        var User = this.User,
             periods = [
               [new Date(2015, 0, 1), new Date(2015, 11, 31)],
               [new Date(2016, 0, 1), new Date(2016, 11, 31)]
             ];
 
-        return self.User
+        return User
           .create({ username: 'user1', email: ['foo@bar.com'], course_period: periods[0]})
           .then(function() {
-            return self.User.create({ username: 'user2', email: ['foo2@bar.com'], course_period: periods[1]});
+            return User.create({ username: 'user2', email: ['foo2@bar.com'], course_period: periods[1]});
           })
           .then(function() {
             // Check that the range fields are the same when retrieving the user
-            return self.User.findAll({ order: 'username' });
+            return User.findAll({ order: 'username' });
           })
           .then(function(users) {
             expect(users[0].course_period[0]).to.equalTime(periods[0][0]); // lower bound
@@ -823,6 +861,43 @@ if (dialect.match(/^postgres/)) {
             expect(users[1].course_period.inclusive).to.deep.equal([false, false]); // not inclusive
           })
           .error(console.log);
+      });
+
+      it('should read range correctly from included models as well', function () {
+        var self = this,
+            period = [new Date(2016, 0, 1), new Date(2016, 11, 31)],
+            HolidayDate = this.sequelize.define('holidayDate', {
+              period: DataTypes.RANGE(DataTypes.DATE)
+            });
+
+        self.User.hasMany(HolidayDate);
+
+        return self.sequelize
+          .sync({ force: true })
+          .then(function () {
+            return self.User
+              .create({ username: 'user', email: ['foo@bar.com'] })
+              .then(function (user) {
+                return HolidayDate.create({ period: period })
+                  .then(function (holidayDate) {
+                    return user.setHolidayDates([holidayDate]);
+                  });
+              });
+          })
+          .then(function () {
+            return self.User.find({ where: { username: 'user' }, include: [HolidayDate] });
+          })
+          .then(function (user) {
+            expect(user.hasOwnProperty('holidayDates')).to.be.ok;
+            expect(user.holidayDates.length).to.equal(1);
+            expect(user.holidayDates[0].period.length).to.equal(2);
+            expect(user.holidayDates[0].period[0]).to.equalTime(period[0]);
+            expect(user.holidayDates[0].period[1]).to.equalTime(period[1]);
+          })
+          .error(function (err) {
+            console.log.apply(console, arguments);
+            throw err;
+          });
       });
     });
 


### PR DESCRIPTION
Well, this pull request includes some refactored code for processing "custom" fields (i.e., `RANGE` and `HSTORE`) as well as fix for such fields to be parsed in child models (which were apparently not being processed, only those in parent model were).

In terms of performance, spy-js was used to check it and results show that there is no performance degradation while parsing child model attributes in a way, proposed by this pull request.

Also, tests for such cases were added as well. :wink: 