### PR TITLE
Forcing result of self.getTableName() to string before passing into addIndex(), closes #3204

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -419,7 +419,7 @@ module.exports = (function() {
       });
 
       return Promise.map(indexes, function (index) {
-        return self.QueryInterface.addIndex(self.getTableName(options), index.fields, index, self.tableName);
+        return self.QueryInterface.addIndex(self.getTableName(options).toString(), index.fields, index, self.tableName);
       });
     }).return(this);
   };
@@ -1107,7 +1107,7 @@ module.exports = (function() {
         }
 
         instance = self.build(values);
-        
+
         return Promise.resolve([instance, true]);
       }
 


### PR DESCRIPTION
Error is produced when adding an index to a table using a schema because Model.getTableName() returns an object instead of a string under that context.
Chaining .toString() to enforce that a string is passed in to the addIndex() call.