### PR TITLE
Show more appropriate error message for model validation error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -41,6 +41,12 @@ error.ValidationError = function(message, errors) {
   error.BaseError.apply(this, arguments);
   this.name = 'SequelizeValidationError';
   this.errors = errors || [];
+
+  if (this.errors.length > 0 && this.errors[0].message) {
+    this.message = this.errors.map(function (err) {
+      return err.type + ": " + err.message;
+    }).join(',\n');
+  }
 };
 util.inherits(error.ValidationError, error.BaseError);
 

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -3,6 +3,7 @@
 var chai      = require('chai')
   , sinon     = require('sinon')
   , expect    = chai.expect
+  , errors    = require('../../lib/errors')
   , Support   = require(__dirname + '/support')
   , Sequelize = Support.Sequelize
   , Promise   = Sequelize.Promise;
@@ -20,7 +21,10 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), function () {
     });
     it('Sequelize Errors instances should be instances of Error', function() {
       var error = new Sequelize.Error();
-      var validationError = new Sequelize.ValidationError();
+      var validationError = new Sequelize.ValidationError('Validation Error', [
+        new errors.ValidationErrorItem('<field name> cannot be null', 'notNull Violation', '<field name>', null)
+      , new errors.ValidationErrorItem('<field name> cannot be an array or an object', 'string violation', '<field name>', null)
+      ]);
 
 
       var sequelize = new Sequelize();
@@ -34,6 +38,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), function () {
       expect(validationError).to.be.instanceOf(Sequelize.ValidationError);
       expect(validationError).to.be.instanceOf(Error);
       expect(validationError).to.have.property('name', 'SequelizeValidationError');
+      expect(validationError.message).to.match(/notNull Violation: <field name> cannot be null,\nstring violation: <field name> cannot be an array or an object/);
 
       expect(instError).to.be.instanceOf(Sequelize.Error);
       expect(instError).to.be.instanceOf(Error);


### PR DESCRIPTION
Before:
```
Possibly unhandled SequelizeValidationError: Validation error
    at /home/phanect/dev/notel-api/node_modules/sequelize/lib/instance-validator.js:150:14
    ...
```

After:
```
Possibly unhandled SequelizeValidationError: field_name cannot be null
    at /home/phanect/dev/notel-api/node_modules/sequelize/lib/instance-validator.js:150:14
    ...
```