### PR TITLE
Cannot read property 'uniqueKeys' of undefined

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -116,7 +116,7 @@ module.exports = (function() {
         var values = match[1].split('-')
           , fields = {}
           , message = 'Validation error'
-          , uniqueKey = this.callee && this.callee.__options.uniqueKeys[match[2]];
+          , uniqueKey = this.callee && this.callee.options.uniqueKeys[match[2]];
 
         if (!!uniqueKey) {
           if (!!uniqueKey.msg) message = uniqueKey.msg;


### PR DESCRIPTION
Error given in MySQL dialect when object has a unique key. __options is being referenced instead of options.