### PR TITLE
Fix bug where the options is undefined

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -114,6 +114,7 @@ TEXT.prototype.key = TEXT.key = 'TEXT';
 
 
 var NUMBER = function(options) {
+  options = options || {};
   this.options = options;
   this._length = options.length;
   this._zerofill = options.zerofill;


### PR DESCRIPTION
I've been having issues that look like this:
```
\node_modules\sequelize\lib\data-types.js:118
  this._length = options.length;
                        ^
TypeError: Cannot read property 'length' of undefined
```

and this fix fixes them.