### PR TITLE
fix column comments

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -307,6 +307,10 @@ module.exports = (function() {
         }
       }
 
+      if (attribute.comment && Utils._.isString(attribute.comment) && attribute.comment.length) {
+        template += ' COMMENT ' + this.escape(attribute.comment);
+      }
+
       return template;
     },
 

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -289,6 +289,10 @@ module.exports = (function() {
         template += ' PRIMARY KEY';
       }
 
+      if (attribute.comment && Utils._.isString(attribute.comment) && attribute.comment.length) {
+        template += ' COMMENT ' + this.escape(attribute.comment);
+      }
+
       if (attribute.references) {
         template += ' REFERENCES ' + this.quoteTable(attribute.references);
 
@@ -305,10 +309,6 @@ module.exports = (function() {
         if (attribute.onUpdate) {
           template += ' ON UPDATE ' + attribute.onUpdate.toUpperCase();
         }
-      }
-
-      if (attribute.comment && Utils._.isString(attribute.comment) && attribute.comment.length) {
-        template += ' COMMENT ' + this.escape(attribute.comment);
       }
 
       return template;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -526,6 +526,10 @@ module.exports = (function() {
         template += ' PRIMARY KEY';
       }
 
+      if (attribute.comment && Utils._.isString(attribute.comment) && attribute.comment.length) {
+        template += ' COMMENT ' + this.escape(attribute.comment);
+      }
+
       if (attribute.references) {
         template += ' REFERENCES <%= referencesTable %> (<%= referencesKey %>)';
         replacements.referencesTable = this.quoteTable(attribute.references);
@@ -545,10 +549,6 @@ module.exports = (function() {
           template += ' ON UPDATE <%= onUpdateAction %>';
           replacements.onUpdateAction = attribute.onUpdate.toUpperCase();
         }
-      }
-
-      if (attribute.comment && Utils._.isString(attribute.comment) && attribute.comment.length) {
-        template += ' COMMENT ' + this.escape(attribute.comment);
       }
 
       return  Utils._.template(template)(replacements);

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -547,6 +547,10 @@ module.exports = (function() {
         }
       }
 
+      if (attribute.comment && Utils._.isString(attribute.comment) && attribute.comment.length) {
+        template += ' COMMENT ' + this.escape(attribute.comment);
+      }
+
       return  Utils._.template(template)(replacements);
     },
 

--- a/test/integration/dialects/mysql/query-generator.test.js
+++ b/test/integration/dialects/mysql/query-generator.test.js
@@ -63,6 +63,10 @@ if (Support.dialectIsMySQL()) {
         {
           arguments: [{id: {type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', comment: 'column comment'}}],
+          expectation: {id: "INTEGER COMMENT 'column comment'"}
         }
       ],
 

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -105,6 +105,10 @@ if (dialect.match(/^postgres/)) {
           arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES Bar (id) ON DELETE CASCADE ON UPDATE RESTRICT'},
           context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', comment: 'column comment'}}],
+          expectation: {id: "INTEGER COMMENT 'column comment'"}
         }
 
       ],


### PR DESCRIPTION
Column comments seem to have been remove by 0c1ec1cc0f38edb1d57d0a37d26f3664440c6f49. Not sure why?

Column comments are still mentioned in [the docs](http://docs.sequelizejs.com/en/latest/docs/models/) but are currently unable to be created.