### PR TITLE
Docs: replace .values with .get({plain: true})

### DIFF
--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -277,7 +277,9 @@ sequelize.Promise.all([
   // Get the association
   return source.getTarget();
 }).then(function(_target) {
-  console.log(_target.values)
+  console.log(_target.get({
+    plain: true
+  }))
   /*
     {
       id: 1,

--- a/docs/docs/instances.md
+++ b/docs/docs/instances.md
@@ -68,7 +68,9 @@ It is also possible to define which attributes can be set via the create method&
 ```js
 User.create({ username: 'barfooz', isAdmin: true }, [ 'username' ]).then(function(user) {
   // let's assume the default of isAdmin is false:
-  console.log(user.values) // => { username: 'barfooz', isAdmin: false }
+  console.log(user.get({
+    plain: true
+  })) // => { username: 'barfooz', isAdmin: false }
 })
 ```
 
@@ -241,14 +243,16 @@ Tasks.bulkCreate([
 
 ## Values of an instance
 
-If you log an instance you will notice&comma; that there is a lot of additional stuff&period; In order to hide such stuff and reduce it to the very interesting information&comma; you can use the`values`-attribute&period; Calling it will return only the values of an instance&period;
+If you log an instance you will notice&comma; that there is a lot of additional stuff&period; In order to hide such stuff and reduce it to the very interesting information&comma; you can use the`get`-attribute&period; Calling it with the option `plain` = true will only return the values of an instance&period;
     
 ```js
 Person.create({
   name: 'Rambow',
   firstname: 'John'
 }).then(function(john) {
-  console.log(john.values)
+  console.log(john.get({
+    plain: true
+  }))
 })
  
 // result:

--- a/docs/docs/models.md
+++ b/docs/docs/models.md
@@ -579,7 +579,9 @@ Let's assume we have an empty database with a `User` model which has a `username
 User
   .findOrCreate({where: {username: 'sdepold'}, defaults: {job: 'Technical Lead JavaScript'}})
   .spread(function(user, created) {
-    console.log(user.values)
+    console.log(user.get({
+      plain: true
+    }))
     console.log(created)
 
     /*
@@ -603,7 +605,9 @@ User
     User
       .findOrCreate({where: {username: 'fnord'}, defaults: {job: 'something else'}})
       .spread(function(user, created) {
-        console.log(user.values)
+        console.log(user.get({
+          plain: true
+        }))
         console.log(created)
 
         /*

--- a/docs/index.md
+++ b/docs/index.md
@@ -26,6 +26,8 @@ return sequelize.sync().then(function() {
     birthday: new Date(1980, 06, 20)
   });
 }).then(function(jane) {
-  console.log(jane.values)
+  console.log(jane.get({
+    plain: true
+  }))
 });
 ```

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -6,7 +6,13 @@ var Utils = require('./utils')
   , DataTypes = require('./data-types')
   , Promise = require("./promise")
   , _ = require('lodash')
-  , defaultsOptions = { raw: true };
+  , defaultsOptions = { raw: true }
+  , deprecatedSeen = {}
+  , deprecated = function(message) {
+    if (deprecatedSeen[message]) return;
+    console.warn(message);
+    deprecatedSeen[message] = true;
+  };
 
 
 module.exports = (function() {
@@ -80,12 +86,14 @@ module.exports = (function() {
 
   /**
    * Get the values of this Instance. Proxies to `this.get`
+   * @deprecated .values is deprecated. Please use .get() instead.
    * @see {Instance#get}
    * @property values
    * @return {Object}
    */
   Object.defineProperty(Instance.prototype, 'values', {
     get: function() {
+      deprecated('Using .values has been deprecated. Please use .get() instead');
       return this.get();
     }
   });


### PR DESCRIPTION
Would you mind, if I'd insert a "Deprecated" area? I think it's useful to keep old information but to keep depcreated stuff separated from the rest of the docs.