### PR TITLE
prevent tedious errors from taking down app

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -47,6 +47,11 @@ ConnectionManager.prototype.connect = function(config) {
     var connection = new self.lib.Connection(connectionConfig);
     connection.lib = self.lib;
 
+    // don't let tedious errors take down the entire application
+    connection.on('error', function(err) {
+      connection._invalid = true;
+    });
+
     connection.on('connect', function(err) {
       if (!err) {
         resolve(connection);


### PR DESCRIPTION
Tedious error events must be handled in the connection manager in
order to prevent said errors from crashing an app using sequelize
to connect to a mssql database.