### PR TITLE
Fix invalid column name in many-to-many JOIN query

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -971,7 +971,7 @@ module.exports = (function() {
               , primaryKeysSource = association.source.primaryKeyAttributes
               , tableSource = parentTable
               , identSource = association.identifierField
-              , attrSource = association.source.rawAttributes[primaryKeysSource[0]].field || primaryKeysSource[0]
+              , attrSource = primaryKeysSource[0]
               , where
 
               , primaryKeysTarget = association.target.primaryKeyAttributes

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -246,7 +246,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
       });
 
       var User_has_Group = this.sequelize.define('User_has_Group', {
-      
+
       }, {
         tableName: 'tbl_user_has_group'
       });
@@ -265,6 +265,57 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
             where: {}
           }).then(function (user) {
             return user.getGroups();
+          });
+        });
+      });
+    });
+
+    it('supports primary key attributes with different field names', function () {
+      var User = this.sequelize.define('User', {
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+          defaultValue: DataTypes.UUIDV4,
+          field: 'user_id'
+        }
+      }, {
+        tableName: 'tbl_user'
+      });
+
+      var Group = this.sequelize.define('Group', {
+        id: {
+          type: DataTypes.UUID,
+          allowNull: false,
+          primaryKey: true,
+          defaultValue: DataTypes.UUIDV4,
+          field: 'group_id'
+        }
+      }, {
+        tableName: 'tbl_group'
+      });
+
+      var User_has_Group = this.sequelize.define('User_has_Group', {
+
+      }, {
+        tableName: 'tbl_user_has_group'
+      });
+
+      User.belongsToMany(Group, {through: User_has_Group});
+      Group.belongsToMany(User, {through: User_has_Group});
+
+      return this.sequelize.sync({force: true}).then(function () {
+        return Promise.join(
+          User.create(),
+          Group.create()
+        ).spread(function (user, group) {
+          return user.addGroup(group);
+        }).then(function () {
+          return User.findOne({
+            where: {},
+            include: Group
+          }).then(function (user) {
+            return user;
           });
         });
       });


### PR DESCRIPTION
Adds a failing unit test and proposed fix for #3279 

The fix might be a bit naive, so if you just want the failing unit test I can pluck that commit out instead.