### PR TITLE
fix tedious error handling

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -47,11 +47,6 @@ ConnectionManager.prototype.connect = function(config) {
     var connection = new self.lib.Connection(connectionConfig);
     connection.lib = self.lib;
 
-    // don't let tedious errors take down the entire application
-    connection.on('error', function(err) {
-      connection._invalid = true;
-    });
-
     connection.on('connect', function(err) {
       if (!err) {
         resolve(connection);
@@ -93,12 +88,23 @@ ConnectionManager.prototype.connect = function(config) {
         break;
       }
     });
+
+    if (config.pool.handleDisconnects) {
+      connection.on('error', function (err) {
+        switch (err.code) {
+        case 'ESOCKET':
+        case 'ECONNRESET':
+          self.pool.destroy(connection);
+        }
+      });
+    }
+
   });
 };
 
 ConnectionManager.prototype.disconnect = function(connection) {
   // Dont disconnect a connection that is already disconnected
-  if (!connection.connected) {
+  if (!!connection.closed) {
     return Promise.resolve();
   }
 


### PR DESCRIPTION
The previous commit incorrectly invalidated the connection, when we
should really be removing the connection from the pool completely.
This also fixes an error in the disconnect logic, which was erroneously
checking connection.connected to identify an already disconnected
connection.