### PR TITLE
$in and $notIn support literals.

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1743,7 +1743,9 @@ module.exports = (function() {
         comparator = 'IN';
         if (value.$notIn) comparator = 'NOT IN';
 
-        if ((value.$in || value.$notIn).length) {
+        if ((value.$in || value.$notIn) instanceof Utils.literal) {
+          value = (value.$in || value.$notIn).val;
+        } else if ((value.$in || value.$notIn).length) {
           value = '('+(value.$in || value.$notIn).map(function (item) {
             return self.escape(item);
           }).join(', ')+')';

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -106,6 +106,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       }, {
         default: '[muscles] IN (2, 4)'
       });
+
+      testsql('equipment', {
+        $in: current.literal('(1, 2)')
+      }, {
+        default: '[equipment] IN (1, 2)'
+      });
     });
 
     suite('Buffer', function () {
@@ -150,6 +156,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         $notIn: [4, 19]
       }, {
         default: '[equipment] NOT IN (4, 19)'
+      });
+
+      testsql('equipment', {
+        $notIn: current.literal('(1, 2)')
+      }, {
+        default: '[equipment] NOT IN (1, 2)'
       });
     });
 

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -108,9 +108,11 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
 
       testsql('equipment', {
-        $in: current.literal('(1, 2)')
+        $in: current.literal(
+          '(select order_id from product_orders where product_id = 3)'
+        )
       }, {
-        default: '[equipment] IN (1, 2)'
+        default: '[equipment] IN (select order_id from product_orders where product_id = 3)'
       });
     });
 
@@ -159,9 +161,11 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
 
       testsql('equipment', {
-        $notIn: current.literal('(1, 2)')
+        $notIn: current.literal(
+          '(select order_id from product_orders where product_id = 3)'
+        )
       }, {
-        default: '[equipment] NOT IN (1, 2)'
+        default: '[equipment] NOT IN (select order_id from product_orders where product_id = 3)'
       });
     });
 


### PR DESCRIPTION
```js
Model.findAll({
  where: {attr: {$in: sequelize.literal('…')}}
}).then(…);
```