### PR TITLE
Support searching included models from top-level where clause #3328

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 2.0.5
+- [FEATURE] Support searching included models from top-level where clause [#3328](https://github.com/sequelize/sequelize/issues/3328)
+
 # 2.0.4
 - [BUG] Fixed support for 2 x belongsToMany without foreignKey defined and association getter/adder [#3185](https://github.com/sequelize/sequelize/issues/3185)
 - [BUG] No longer throws on `Model.hasHook()` if no hooks are defiend [#3181](https://github.com/sequelize/sequelize/issues/3181)

--- a/docs/docs/models.md
+++ b/docs/docs/models.md
@@ -1057,6 +1057,178 @@ Include all also supports nested loading:
 User.findAll({ include: [{ all: true, nested: true }]});
 ```
 
+### Searching Eagerly Loaded Associations
+
+Finding records with a specific related entry can be accomplished with a where clause. This can be implemented in two ways. The first way is by adding the where clause as part of the include attribute:
+
+```js
+User.findAll({
+  include: [
+    {
+      model: Tool,
+      as: 'Instruments',
+      where: {
+        name: 'Toothpick'
+      }
+    }
+  ]
+}).then(function(users) {
+  console.log(JSON.stringify(users));
+
+  /*
+    [{
+      "name": "John Doe",
+      "id": 1,
+      "createdAt": "2013-03-20T20:31:45.000Z",
+      "updatedAt": "2013-03-20T20:31:45.000Z",
+      "Instruments": [{
+        "name": "Toothpick",
+        "id": 1,
+        "createdAt": null,
+        "updatedAt": null,
+        "UserId": 1
+      }]
+    }]
+  */
+});
+```
+
+The fields to search can also be specified in the where attribute for the model:
+
+```js
+User.findAll({
+  where: {
+    Instruments: {
+      name: 'Toothpick'
+    }
+  },
+  include: [{ model: Tool, as: 'Instruments' }]
+}).then(function(users) {
+  console.log(JSON.stringify(users));
+
+  /*
+    [{
+      "name": "John Doe",
+      "id": 1,
+      "createdAt": "2013-03-20T20:31:45.000Z",
+      "updatedAt": "2013-03-20T20:31:45.000Z",
+      "Instruments": [{
+        "name": "Toothpick",
+        "id": 1,
+        "createdAt": null,
+        "updatedAt": null,
+        "UserId": 1
+      }]
+    }]
+  */
+});
+```
+
+Notice that when constructing a where attribute in this fashion, the foreign key must be used (not the associated model name). If a where attribute is provided for both the model and the include, the two will be combined with the attributes in the include object taking precedence.
+
+Through tables can also be searched in the following ways:
+
+```js
+User.findAll({
+  include: [{
+    model: Tool,
+    as: 'Instruments',
+    through: {
+      where: {
+        ToolId: 1
+      }
+    }
+  }]
+}).then(function(users) {
+  console.log(JSON.stringify(users));
+});
+
+User.findAll({
+  where: {
+    UsersTools: {
+      ToolId: 1
+    }
+  },
+  include: [{ model: Tool, as: 'Instruments' }]
+}).then(function(users) {
+  console.log(JSON.stringify(users));
+});
+
+/*
+  Both functions will produce:
+  [{
+    "name": "John Doe",
+    "id": 1,
+    "createdAt": "2013-03-20T20:31:45.000Z",
+    "updatedAt": "2013-03-20T20:31:45.000Z",
+    "Instruments": [{
+      "name": "Toothpick",
+      "id": 1,
+      "createdAt": null,
+      "updatedAt": null,
+      "UserId": 1
+    }]
+  }]
+*/
+```
+
+Searching nested eagerly loaded associations is also possible:
+
+```js
+User.findAll({
+  include: [{
+    model: Tool,
+    as: 'Instruments',
+    include: {[
+      model: Teacher,
+      where: {
+        name: 'Jimi Hendrix'
+      }
+    ]}
+  }]
+}).then(function(users) {
+  console.log(JSON.stringify(users));
+});
+
+User.findAll({
+  where: {
+    Instruments: {
+      Teacher: {
+        name: 'Jimi Hendrix'
+      }
+    }
+  },
+  include: [{
+    model: Tool,
+    as: 'Instruments',
+    include: [{ model: Teacher }]
+  }]
+}).then(function(users) {
+  console.log(JSON.stringify(users));
+});
+
+
+/*
+  Both functions will produce:
+  [{
+    "name": "John Doe",
+    "id": 1,
+    "createdAt": "2013-03-20T20:31:45.000Z",
+    "updatedAt": "2013-03-20T20:31:45.000Z",
+    "Instruments": [{ // 1:M and N:M association
+      "name": "Toothpick",
+      "id": 1,
+      "createdAt": null,
+      "updatedAt": null,
+      "UserId": 1,
+      "Teacher": { // 1:1 association
+        "name": "Jimi Hendrix"
+      }
+    }]
+  }]
+*/
+```
+
 [0]: #configuration
 [3]: https://github.com/chriso/validator.js
 [4]: https://github.com/chriso/node-validator

--- a/lib/model.js
+++ b/lib/model.js
@@ -910,6 +910,8 @@ module.exports = (function() {
 
       validateIncludedElements.call(this, countOptions);
 
+      Utils._.extend(findOptions, countOptions);
+
       var keepNeeded = function(includes) {
         return includes.filter(function (include) {
           if (include.include) include.include = keepNeeded(include.include);
@@ -1929,7 +1931,7 @@ module.exports = (function() {
     // validate all included elements
     var includes = options.include;
     for (var index = 0; index < includes.length; index++) {
-      var include = includes[index] = validateIncludedElement.call(this, includes[index], tableNames);
+      var include = includes[index] = validateIncludedElement.call(this, includes[index], tableNames, options);
 
       include.parent = options;
       // associations that are required or have a required child and is not a ?:M association are candidates for the subquery
@@ -1953,7 +1955,7 @@ module.exports = (function() {
   };
   Model.$validateIncludedElements = validateIncludedElements;
 
-  var validateIncludedElement = function(include, tableNames) {
+  var validateIncludedElement = function(include, tableNames, parentOptions) {
     if (!include.hasOwnProperty('model') && !include.hasOwnProperty('association')) {
       throw new Error('Include malformed. Expected attributes: model or association');
     }
@@ -2006,6 +2008,10 @@ module.exports = (function() {
           _pseudo: true
         });
 
+        if (parentOptions.where && parentOptions.where[include.through.as]) {
+          include.through.where = Utils._.extend({}, parentOptions.where[include.through.as], include.through.where || {});
+          delete parentOptions.where[include.through.as];
+        }
 
         if (through.scope) {
           include.through.where = include.through.where ? new Utils.and([include.through.where, through.scope]) :  through.scope;
@@ -2013,6 +2019,12 @@ module.exports = (function() {
 
         include.include.push(include.through);
         tableNames[through.tableName] = true;
+      }
+
+      // check if the parent options contain a where clause for this include
+      if (parentOptions.where && parentOptions.where[include.as]) {
+        include.where = Utils._.extend({}, parentOptions.where[include.as], include.where || {});
+        delete parentOptions.where[include.as];
       }
 
       if (include.required === undefined) {

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -1555,6 +1555,28 @@ describe(Support.getTestDialectTeaser('Include'), function() {
       });
     });
 
+    it('should be possible to select on columns inside a through table with a top-level where', function() {
+      var self = this;
+      return this.fixtureA().then(function() {
+        return self.models.Product.findAll({
+          attributes: ['title'],
+          where: {
+            ProductsTags: {
+              ProductId: 3
+            }
+          },
+          include: [
+            {
+              model: self.models.Tag,
+              required: true
+            }
+          ]
+        }).then(function(products) {
+          expect(products).have.length(1);
+        });
+      });
+    });
+
     it('should be possible to select on columns inside a through table and a limit', function() {
       var self = this;
       return this.fixtureA().then(function () {
@@ -1907,6 +1929,29 @@ describe(Support.getTestDialectTeaser('Include'), function() {
           include: [
             {model: Group, where: {}},
             {model: Company, where: {}}
+          ]
+        });
+      });
+    });
+
+    it('should work with an empty top-level where for included models', function () {
+      var User = this.sequelize.define('User', {})
+        , Company = this.sequelize.define('Company', {})
+        , Group = this.sequelize.define('Group', {});
+
+      User.belongsTo(Company);
+      User.belongsToMany(Group);
+      Group.belongsToMany(User);
+
+      return this.sequelize.sync({force: true}).then(function () {
+        return User.findAll({
+          where: {
+            Groups: {},
+            Company: {}
+          },
+          include: [
+            { model: Group },
+            { model: Company }
           ]
         });
       });

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -108,6 +108,21 @@ describe(Support.getTestDialectTeaser('Include'), function() {
             }).then(function(result ) {
               expect(result.count).to.be.equal(2);
               expect(result.rows.length).to.be.equal(2);
+
+              // Make sure it still works when the where clause is not part of the include
+              return A.findAndCountAll({
+                where: {
+                  SomeConnections: {
+                    m: 'A',
+                    u: 1
+                  }
+                },
+                include: [{ model: SomeConnection, required: true }],
+                limit: 5
+              });
+            }).then(function(result) {
+                expect(result.count).to.be.equal(2);
+                expect(result.rows.length).to.be.equal(2);
             });
           });
         });


### PR DESCRIPTION
This is a pretty straightforward concept, but there are a few points I think we should discuss:

- When referencing an associated field in the main where clause, I've implemented it so that it looks for the `include.as` attribute instead of `include.model.name`. This is because, in my mind, these parameters are most likely coming in from another source (such as a web front-end) that wouldn't necessarily care about then name of the database model, but rather care about the name of the foreign key it wants to search on.

- This changes the main model's `options.where` so that it is not the same after the `beforeFind` hook. I could implement some kind of ignoreCertainPartsOfTheWhereClause parameter that is checked when building the query instead of deleting attributes, but that might be misleading in that any attempt to change `options.where` after `beforeFind` might not get you the result you're looking for.

- I've used the terms 'top-level' and 'include-level' to describe the placement of different where clauses. Maybe there's better terminology?