### PR TITLE
.update include attributes changed by setter methods

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -754,13 +754,21 @@ module.exports = (function() {
    * @alias updateAttributes
    */
   Instance.prototype.update = function(values, options) {
+    var changedBefore = this.changed() || []
+      , sideEffects
+      , fields;
+
     options = options || {};
     if (Array.isArray(options)) options = {fields: options};
 
     this.set(values, {attributes: options.fields});
 
+    // Now we need to figure out which fields were actually affected by the setter.
+    sideEffects = _.without.apply(this, [this.changed() || []].concat(changedBefore));
+    fields = _.union(Object.keys(values), sideEffects);
+
     if (!options.fields) {
-      options.fields = _.intersection(Object.keys(values), this.changed());
+      options.fields = _.intersection(fields, this.changed());
       options.defaultFields = options.fields;
     }
 

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -36,6 +36,20 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           allowNull: true,
           validate: {len: {msg: 'Length failed.', args: [1, 20]}}
         },
+        validateSideEffect: {
+          type: DataTypes.VIRTUAL,
+          allowNull: true,
+          validate: {isInt: true},
+          set: function (val) {
+            this.setDataValue('validateSideEffect', val);
+            this.setDataValue('validateSideAffected', val*2);
+          }
+        },
+        validateSideAffected: {
+          type: DataTypes.INTEGER,
+          allowNull: true,
+          validate: {isInt: true}
+        },
 
         dateAllowNullTrue: {
           type: DataTypes.DATE,
@@ -138,6 +152,18 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         return user.reload();
       }).then(function () {
         expect(user.validateTest).to.not.be.equal(5);
+      });
+    });
+
+    it('should save attributes affected by setters', function () {
+      var user = this.User.build();
+      return user.update({validateSideEffect: 5}).then(function () {
+        expect(user.validateSideEffect).to.be.equal(5);
+      }).then(function () {
+        return user.reload();
+      }).then(function () {
+        expect(user.validateSideAffected).to.be.equal(10);
+        expect(user.validateSideEffect).not.to.be.ok;
       });
     });
 


### PR DESCRIPTION
The update method of an instance keeps track of possible side effect of setter methods and includes affected attributes in the save. Should fix #3221 