### PR TITLE
Adding support for changing column default value

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -72,7 +72,7 @@ module.exports = (function() {
 
       var values = {
         table: this.quoteTable(tableName),
-        attributes: attrStr.join(', '),
+        attributes: attrStr.join(', ').replace(/%tableName%/g, tableName),
       }
       , pkString = primaryKeys.map(function(pk) { return this.quoteIdentifier(pk); }.bind(this)).join(', ');
 
@@ -150,7 +150,7 @@ module.exports = (function() {
           key: this.quoteIdentifier(key),
           definition: this.attributeToSQL(dataType, {
             context: 'addColumn'
-          })
+          }).replace(/%tableName%/g, table)
         });
 
       return Utils._.template(query)({
@@ -168,22 +168,50 @@ module.exports = (function() {
     },
 
     changeColumnQuery: function(tableName, attributes) {
-      var query = 'ALTER TABLE <%= tableName %> ALTER COLUMN <%= attributes %>;';
-      var attrString = [];
+      var query = 'ALTER TABLE <%= tableName %> ALTER COLUMN <%= attributes %>';
+      var attrString = []
+        , defaultValueKeys = {}
+        , queries = []
+        , match = []
+        , defaultValueMatcher = / CONSTRAINT <%(.+)%> DEFAULT <%(.+)%>/;
 
       for (var attrName in attributes) {
-        var definition = attributes[attrName];
-
-        attrString.push(Utils._.template('<%= attrName %> <%= definition %>')({
-          attrName: this.quoteIdentifier(attrName),
-          definition: definition
-        }));
+        if (attributes.hasOwnProperty(attrName)) {
+          var definition = attributes[attrName];
+          if (Utils._.includes(definition, 'DEFAULT')) {
+            match = definition.match(defaultValueMatcher);
+            defaultValueKeys[attrName] = {
+              constraint: match[1].replace(/%tableName%/g, tableName),
+              value: match[2]
+            };
+            definition = definition.replace(defaultValueMatcher, '');
+          }
+          attrString.push(Utils._.template('<%= attrName %> <%= definition %>')({
+            attrName: this.quoteIdentifier(attrName),
+            definition: definition
+          }));
+        }
       }
 
-      return Utils._.template(query)({
+      queries.push(Utils._.template(query)({
         tableName: this.quoteTable(tableName),
         attributes: attrString.join(', ')
-      });
+      }));
+
+      var dropConstraintQuery = "IF OBJECT_ID('<%= constraint %>', 'D') IS NOT NULL ALTER TABLE <%= tableName %> DROP CONSTRAINT <%= constraint %>"
+        , addConstraintQuery = 'ALTER TABLE <%= tableName %> ADD CONSTRAINT <%= constraint %> DEFAULT <%= value %> FOR <%= attrName %>';
+      for (var defaultValueKey in defaultValueKeys) {
+        if (defaultValueKeys.hasOwnProperty(defaultValueKey)) {
+          var data = Utils._.extend({
+            attrName: this.quoteIdentifier(defaultValueKey),
+            tableName: this.quoteTable(tableName)
+          }, defaultValueKeys[defaultValueKey]);
+          queries.push(Utils._.template(dropConstraintQuery)(data));
+          queries.push(Utils._.template(addConstraintQuery)(data));
+        }
+      }
+
+      return queries.join('; ');
     },
 
     renameColumnQuery: function(tableName, attrBefore, attributes) {
@@ -331,6 +359,8 @@ module.exports = (function() {
         };
       }
 
+      var context = Utils._.result(options, 'context');
+
       // handle self referential constraints
       if (attribute.Model && attribute.Model.tableName === attribute.references) {
         this.sequelize.log('MSSQL does not support self referencial constraints, '
@@ -343,7 +373,7 @@ module.exports = (function() {
 
       if (attribute.type instanceof DataTypes.ENUM) {
         if (attribute.type.values && !attribute.values) attribute.values = attribute.type.values;
-        
+
         // enums are a special case
         template = 'VARCHAR(10) NULL' /* + (attribute.allowNull ? 'NULL' : 'NOT NULL') */;
         template += ' CHECK (' + attribute.field + ' IN(' + Utils._.map(attribute.values, function(value) {
@@ -367,7 +397,15 @@ module.exports = (function() {
       // Blobs/texts cannot have a defaultValue
       if (attribute.type !== 'TEXT' && attribute.type._binary !== true &&
           Utils.defaultValueSchemable(attribute.defaultValue)) {
-        template += ' DEFAULT ' + this.escape(attribute.defaultValue);
+        var tableName = attribute.Model ? attribute.Model.tableName : '%tableName%';
+        if (context === 'addColumn' || context === 'createTable') {
+          template += ' CONSTRAINT df_' + tableName + '_' + attribute.field + ' DEFAULT ' + this.escape(attribute.defaultValue);
+        } else if (context === 'changeColumn') {
+          // to extract it changeColumnQuery
+          template += ' CONSTRAINT <%df_' + tableName + '_' + attribute.field + '%> DEFAULT <%' + this.escape(attribute.defaultValue) + '%>';
+        } else {
+          template += ' DEFAULT ' + this.escape(attribute.defaultValue);
+        }
       }
 
       if (attribute.unique === true) {

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -378,7 +378,7 @@ module.exports = (function() {
       // sqlite needs some special treatment as it cannot change a column
       return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes);
     } else {
-      var options = this.QueryGenerator.attributesToSQL(attributes)
+      var options = this.QueryGenerator.attributesToSQL(attributes, {context: 'changeColumn'})
         , sql = this.QueryGenerator.changeColumnQuery(tableName, options);
 
       return this.sequelize.query(sql, null, {logging: this.sequelize.options.logging});


### PR DESCRIPTION
Current version of mssql query-generator generate incorrect sql code for changing column default value.
E.g. migration.changeColumn('Users', 'flags', {type: DataTypes.INTEGER, defaultValue: 1}); generate next code:

```sql
ALTER TABLE [Users] ALTER COLUMN [flags] INTEGER DEFAULT 1;
```
but this code is generate next error:
```
Incorrect syntax near the keyword 'DEFAULT'
```
After some researching I found that in tsql default values implemented over constraints, so changing value should be s.th. like this:
```sql
ALTER TABLE [Users] ALTER COLUMN [flags] INTEGER; 
IF OBJECT_ID('df_users_flags', 'D') IS NOT NULL ALTER TABLE [Users] DROP CONSTRAINT df_users_flags; 
ALTER TABLE [Users] ADD CONSTRAINT df_users_flags DEFAULT 1 FOR [flags]
```

This patch implements described behavior by adding constraint with name df_tablename_fieldname for default values.

Useful links:
http://stackoverflow.com/questions/2095289/sql-server-alter-column-adding-default-constraint
http://stackoverflow.com/questions/1782714/declaring-a-default-constraint-when-creating-a-table
http://stackoverflow.com/questions/92082/add-a-column-with-a-default-value-to-an-existing-table-in-sql-server