### PR TITLE
Fix ENUM Type Name

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -83,7 +83,7 @@ module.exports = (function() {
         if (typeof attribute.defaultValue === "function" && (
             attribute.defaultValue === DataTypes.NOW ||
             attribute.defaultValue === DataTypes.UUIDV4 ||
-            attribute.defaultValue === DataTypes.UUIDV4 
+            attribute.defaultValue === DataTypes.UUIDV4
         )) {
           attribute.defaultValue = new attribute.defaultValue();
         }
@@ -114,7 +114,7 @@ module.exports = (function() {
 
       for (i = 0; i < keyLen; i++) {
         if (attributes[keys[i]].type instanceof DataTypes.ENUM) {
-          sql = self.QueryGenerator.pgListEnums(getTableName, keys[i], options);
+          sql = self.QueryGenerator.pgListEnums(getTableName, attributes[keys[i]].field || keys[i], options);
           promises.push(self.sequelize.query(sql, null, { plain: true, raw: true, type: QueryTypes.SELECT, logging: options.logging }));
         }
       }
@@ -131,7 +131,7 @@ module.exports = (function() {
           if (attributes[keys[i]].type instanceof DataTypes.ENUM) {
             // If the enum type doesn't exist then create it
             if (!results[enumIdx]) {
-              sql = self.QueryGenerator.pgEnum(getTableName, keys[i], attributes[keys[i]], options);
+              sql = self.QueryGenerator.pgEnum(getTableName, attributes[keys[i]].field || keys[i], attributes[keys[i]], options);
               promises.push(self.sequelize.query(sql, null, { raw: true, logging: options.logging }));
             } else if (!!results[enumIdx] && !!daoTable) {
               var enumVals = self.QueryGenerator.fromArray(results[enumIdx].enum_value)
@@ -632,7 +632,7 @@ module.exports = (function() {
     return Promise.reduce(cascades, function (memo, cascade) {
       return dao[cascade]().then(function (instances) {
         if (!Array.isArray(instances)) instances = [instances];
-        
+
         return Promise.reduce(instances, function (memo, instance) {
           return instance.destroy();
         }, []);

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -200,6 +200,17 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
       });
     });
 
+    it('should work with enums (3)', function() {
+      return this.queryInterface.createTable('SomeTable', {
+        someEnum: {
+          type: DataTypes.ENUM,
+          values: ['value1', 'value2', 'value3'],
+          field: "otherName"
+        }
+      });
+    });
+
+
     it('should work with schemas', function() {
       var self = this;
       return self.sequelize.dropAllSchemas().then(function() {


### PR DESCRIPTION
Sequelize was creating ENUM Types with only the attribute's key name.

This is not always a problem, but if we add a 'field' value to the attribute, the CREATE TABLE SQL will use that value to fetch the created ENUM, and fail.
```JS
this.queryInterface.createTable('SomeTable', {
        someEnum: {
          type: DataTypes.ENUM,
          values: ['value1', 'value2', 'value3'],
          field: "otherName"
        }
});
```
Would create ENUM Type enum_SomeTable_someEnum
And create table would look for a ENUM Type enum_SomeTable_otherName