### PR TITLE
Some fixes to docs generator

### DIFF
--- a/docs/api/associations.md
+++ b/docs/api/associations.md
@@ -1,6 +1,6 @@
 <a name="mixin"></a>
 # Mixin Mixin
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/associations/mixin.js#L95)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/associations/mixin.js#L95)
 Creating assocations in sequelize is done by calling one of the belongsTo / hasOne / hasMany functions
 on a model (the source), and prodiving another model as the first argument to the function (the target).
 
@@ -89,7 +89,7 @@ you should either disable some constraints, or rethink your associations complet
 
 <a name="hasone"></a>
 ## `hasOne(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/associations/mixin.js#L145)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/associations/mixin.js#L145)
 Creates an association between this (the source) and the provided target. The foreign key is added on the target.
 
 Example: `User.hasOne(Profile)`. This will add userId to the profile table.
@@ -121,7 +121,7 @@ All methods return a promise
 
 <a name="belongsto"></a>
 ## `belongsTo(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/associations/mixin.js#L170)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/associations/mixin.js#L170)
 Creates an association between this (the source) and the provided target. The foreign key is added on the source.
 
 Example: `Profile.belongsTo(User)`. This will add userId to the profile table.
@@ -153,7 +153,7 @@ All methods return a promise
 
 <a name="hasmany"></a>
 ## `hasMany(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/associations/mixin.js#L245)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/associations/mixin.js#L245)
 Create an association that is either 1:m or n:m.
 
 ```js
@@ -236,7 +236,7 @@ user.getProjects().success(function (projects) {
 
 <a name="belongstomany"></a>
 ## `belongsToMany(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/associations/mixin.js#L339)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/associations/mixin.js#L339)
 Create an N:M association with a join table
 
 ```js

--- a/docs/api/datatypes.md
+++ b/docs/api/datatypes.md
@@ -1,6 +1,6 @@
 <a name="datatypes"></a>
 # Class DataTypes
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L36)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L36)
 A convenience class holding commonly used data types. The datatypes are used when definining a new model using `Sequelize.define`, like this:
 ```js
 sequelize.define('model', {
@@ -32,7 +32,7 @@ sequelize.define('model', {
 
 <a name="string"></a>
 ## `STRING()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L54)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L54)
 A variable length string. Default length 255
 
 Available properties: `BINARY`
@@ -42,7 +42,7 @@ Available properties: `BINARY`
 
 <a name="char"></a>
 ## `CHAR()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L87)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L87)
 A fixed length string. Default length 255
 
 Available properties: `BINARY`
@@ -52,14 +52,14 @@ Available properties: `BINARY`
 
 <a name="text"></a>
 ## `TEXT()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L108)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L108)
 An unlimited length text column
 
 ***
 
 <a name="integer"></a>
 ## `INTEGER()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L168)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L168)
 A 32 bit integer.
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -69,7 +69,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="bigint"></a>
 ## `BIGINT()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L187)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L187)
 A 64 bit integer.
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -79,7 +79,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="float"></a>
 ## `FLOAT()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L206)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L206)
 Floating point number. Accepts one or two arguments for precision
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -89,7 +89,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="decimal"></a>
 ## `DECIMAL()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L225)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L225)
 Decimal number. Accepts one or two arguments for precision
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -99,63 +99,63 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="boolean"></a>
 ## `BOOLEAN()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L248)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L248)
 A boolean / tinyint column, depending on dialect
 
 ***
 
 <a name="time"></a>
 ## `TIME()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L264)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L264)
 A time column
 
 ***
 
 <a name="date"></a>
 ## `DATE()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L279)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L279)
 A datetime column
 
 ***
 
 <a name="dateonly"></a>
 ## `DATEONLY()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L295)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L295)
 A date only column
 
 ***
 
 <a name="hstore"></a>
 ## `HSTORE()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L311)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L311)
 A key / value column. Only available in postgres.
 
 ***
 
 <a name="json"></a>
 ## `JSON()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L323)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L323)
 A JSON string column. Only available in postgres.
 
 ***
 
 <a name="jsonb"></a>
 ## `JSONB()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L335)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L335)
 A pre-processed JSON data column. Only available in postgres.
 
 ***
 
 <a name="now"></a>
 ## `NOW()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L347)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L347)
 A default value of the current timestamp
 
 ***
 
 <a name="blob"></a>
 ## `BLOB()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L361)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L361)
 Binary storage. Available lengths: `tiny`, `medium`, `long`
 
 
@@ -163,7 +163,7 @@ Binary storage. Available lengths: `tiny`, `medium`, `long`
 
 <a name="range"></a>
 ## `RANGE()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L391)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L391)
 Range types are data types representing a range of values of some element type (called the range's subtype).
 Only available in postgres.
 See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres documentation} for more details
@@ -172,30 +172,29 @@ See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres do
 
 <a name="uuid"></a>
 ## `UUID()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L420)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L420)
 A column storing a unique univeral identifier. Use with `UUIDV1` or `UUIDV4` for default values.
 
 ***
 
 <a name="uuidv1"></a>
 ## `UUIDV1()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L433)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L433)
 A default unique universal identifier generated following the UUID v1 standard
 
 ***
 
 <a name="uuidv4"></a>
 ## `UUIDV4()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L446)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L446)
 A default unique universal identifier generated following the UUID v2 standard
 
 ***
 
 <a name="virtual"></a>
 ## `VIRTUAL()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L482)
-A virtual value that is not stored in the DB. This could for example be useful if you want to provide a default value in your model
-that is returned to the user but not stored in the DB.
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L481)
+A virtual value that is not stored in the DB. This could for example be useful if you want to provide a default value in your model that is returned to the user but not stored in the DB.
 
 You could also use it to validate a value before permuting and storing it. Checking password length before hashing it for example:
 ```js
@@ -204,7 +203,7 @@ sequelize.define('user', {
   password: {
     type: DataTypes.VIRTUAL,
     set: function (val) {
-       this.setDataValue('password', val);
+       this.setDataValue('password', val); // Remember to set the data value, otherwise it won't be validated
        this.setDataValue('password_hash', this.salt + val);
      },
      validate: {
@@ -224,7 +223,7 @@ __Aliases:__ NONE
 
 <a name="enum"></a>
 ## `ENUM()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L495)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L494)
 An enumeration. `DataTypes.ENUM('value', 'another value')`.
 
 
@@ -232,7 +231,7 @@ An enumeration. `DataTypes.ENUM('value', 'another value')`.
 
 <a name="array"></a>
 ## `ARRAY()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/data-types.js#L512)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/data-types.js#L511)
 An array of `type`, e.g. `DataTypes.ARRAY(DataTypes.DECIMAL)`. Only available in postgres.
 
 ***

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,6 +1,6 @@
 <a name="errors"></a>
 # Class Errors
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L11)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L11)
 Sequelize provides a host of custom error classes, to allow you to do easier debugging. All of these errors are exposed on the sequelize object and the sequelize constructor.
 All sequelize errors inherit from the base JS error object.
 
@@ -9,7 +9,7 @@ All sequelize errors inherit from the base JS error object.
 
 <a name="baseerror"></a>
 ## `new BaseError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L20)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L20)
 The Base Error all Sequelize Errors inherit from.
 
 __Aliases:__ Error
@@ -18,7 +18,7 @@ __Aliases:__ Error
 
 <a name="validationerror"></a>
 ## `new ValidationError(message, [errors])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L40)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L40)
 Validation Error. Thrown when the sequelize validation has failed. The error contains an `errors` property,
 which is an array with 1 or more ValidationErrorItems, one for each validation that failed.
 
@@ -37,7 +37,7 @@ __Extends:__ BaseError
 
 <a name="get"></a>
 ## `get(path)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L53)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L59)
 Gets all validation error items for the path / field specified.
 
 
@@ -52,14 +52,14 @@ Gets all validation error items for the path / field specified.
 
 <a name="errors"></a>
 ## `errors()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L67)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L73)
 An array of ValidationErrorItems
 
 ***
 
 <a name="databaseerror"></a>
 ## `new DatabaseError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L74)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L80)
 A base class for all database related errors.
 
 __Extends:__ BaseError
@@ -68,21 +68,21 @@ __Extends:__ BaseError
 
 <a name="parent"></a>
 ## `parent()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L89)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L95)
 The database specific error which triggered this one
 
 ***
 
 <a name="sql"></a>
 ## `sql()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L95)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L101)
 The SQL that triggered the error
 
 ***
 
 <a name="timeouterror"></a>
 ## `new TimeoutError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L102)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L108)
 Thrown when a database query times out because of a deadlock
 
 __Extends:__ DatabaseError
@@ -91,7 +91,7 @@ __Extends:__ DatabaseError
 
 <a name="uniqueconstrainterror"></a>
 ## `new UniqueConstraintError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L113)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L119)
 Thrown when a unique constraint is violated in the database
 
 __Extends:__ DatabaseError
@@ -100,7 +100,7 @@ __Extends:__ DatabaseError
 
 <a name="foreignkeyconstrainterror"></a>
 ## `new ForeignKeyConstraintError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L132)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L138)
 Thrown when a foreign key constraint is violated in the database
 
 __Extends:__ DatabaseError
@@ -109,7 +109,7 @@ __Extends:__ DatabaseError
 
 <a name="exclusionconstrainterror"></a>
 ## `new ExclusionConstraintError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L152)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L158)
 Thrown when an exclusion constraint is violated in the database
 
 __Extends:__ DatabaseError
@@ -118,35 +118,35 @@ __Extends:__ DatabaseError
 
 <a name="message"></a>
 ## `message()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L171)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L177)
 The message from the DB.
 
 ***
 
 <a name="fields"></a>
 ## `fields()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L177)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L183)
 The fields of the unique constraint
 
 ***
 
 <a name="value"></a>
 ## `value()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L183)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L189)
 The value(s) which triggered the error
 
 ***
 
 <a name="index"></a>
 ## `index()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L189)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L195)
 The name of the index that triggered the error
 
 ***
 
 <a name="validationerroritem"></a>
 ## `new ValidationErrorItem(message, type, path, value)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L201)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L207)
 Validation Error Item
 Instances of this class are included in the `ValidationError.errors` property.
 
@@ -165,7 +165,7 @@ Instances of this class are included in the `ValidationError.errors` property.
 
 <a name="connectionerror"></a>
 ## `new ConnectionError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L213)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L219)
 A base class for all connection related errors.
 
 __Extends:__ BaseError
@@ -174,14 +174,14 @@ __Extends:__ BaseError
 
 <a name="parent"></a>
 ## `parent()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L227)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L233)
 The connection specific error which triggered this one
 
 ***
 
 <a name="connectionrefusederror"></a>
 ## `new ConnectionRefusedError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L234)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L240)
 Thrown when a connection to a database is refused
 
 __Extends:__ ConnectionError
@@ -190,7 +190,7 @@ __Extends:__ ConnectionError
 
 <a name="accessdeniederror"></a>
 ## `new AccessDeniedError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L245)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L251)
 Thrown when a connection to a database is refused due to insufficient privileges
 
 __Extends:__ ConnectionError
@@ -199,7 +199,7 @@ __Extends:__ ConnectionError
 
 <a name="hostnotfounderror"></a>
 ## `new HostNotFoundError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L256)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L262)
 Thrown when a connection to a database has a hostname that was not found
 
 __Extends:__ ConnectionError
@@ -208,7 +208,7 @@ __Extends:__ ConnectionError
 
 <a name="hostnotreachableerror"></a>
 ## `new HostNotReachableError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L267)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L273)
 Thrown when a connection to a database has a hostname that was not reachable
 
 __Extends:__ ConnectionError
@@ -217,7 +217,7 @@ __Extends:__ ConnectionError
 
 <a name="invalidconnectionerror"></a>
 ## `new InvalidConnectionError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L278)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L284)
 Thrown when a connection to a database has invalid values for any of the connection parameters
 
 __Extends:__ ConnectionError
@@ -226,7 +226,7 @@ __Extends:__ ConnectionError
 
 <a name="connectiontimedouterror"></a>
 ## `new ConnectionTimedOutError()`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/errors.js#L289)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/errors.js#L295)
 Thrown when a connection to a database times out
 
 __Extends:__ ConnectionError

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -1,6 +1,6 @@
-<a name="hooks"></a>
-# Mixin Hooks
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L37)
+<a name="hooktypes"></a>
+# Mixin hookTypes
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L38)
 Hooks are function that are called before and after  (bulk-) creation/updating/deletion and validation. Hooks can be added to you models in three ways:
 
 1. By specifying them as options in `sequelize.define`
@@ -38,7 +38,7 @@ Model.afterBulkUpdate(function () {})
 
 <a name="addhook"></a>
 ## `addHook(hooktype, [name], fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L149)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L151)
 Add a hook to the model
 
 
@@ -56,7 +56,7 @@ __Aliases:__ hook
 
 <a name="hashook"></a>
 ## `hasHook(hookType)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L171)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L171)
 Check whether the mode has any hooks of this type
 
 
@@ -72,7 +72,7 @@ __Aliases:__ hasHooks
 
 <a name="beforevalidate"></a>
 ## `beforeValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L181)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L184)
 A hook that is run before validation
 
 **Params:**
@@ -87,7 +87,7 @@ A hook that is run before validation
 
 <a name="aftervalidate"></a>
 ## `afterValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L190)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L191)
 A hook that is run after validation
 
 **Params:**
@@ -102,7 +102,7 @@ A hook that is run after validation
 
 <a name="beforecreate"></a>
 ## `beforeCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L199)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L198)
 A hook that is run before creating a single instance
 
 **Params:**
@@ -117,7 +117,7 @@ A hook that is run before creating a single instance
 
 <a name="aftercreate"></a>
 ## `afterCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L208)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L205)
 A hook that is run after creating a single instance
 
 **Params:**
@@ -132,7 +132,7 @@ A hook that is run after creating a single instance
 
 <a name="beforedestroy"></a>
 ## `beforeDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L219)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L214)
 A hook that is run before destroying a single instance
 
 **Params:**
@@ -148,7 +148,7 @@ __Aliases:__ beforeDelete
 
 <a name="afterdestroy"></a>
 ## `afterDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L234)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L223)
 A hook that is run after destroying a single instance
 
 **Params:**
@@ -164,7 +164,7 @@ __Aliases:__ afterDelete
 
 <a name="beforeupdate"></a>
 ## `beforeUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L247)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L230)
 A hook that is run before updating a single instance
 
 **Params:**
@@ -179,7 +179,7 @@ A hook that is run before updating a single instance
 
 <a name="afterupdate"></a>
 ## `afterUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L256)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L237)
 A hook that is run after updating a single instance
 
 **Params:**
@@ -194,7 +194,7 @@ A hook that is run after updating a single instance
 
 <a name="beforebulkcreate"></a>
 ## `beforeBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L265)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L244)
 A hook that is run before creating instances in bulk
 
 **Params:**
@@ -209,7 +209,7 @@ A hook that is run before creating instances in bulk
 
 <a name="afterbulkcreate"></a>
 ## `afterBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L274)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L251)
 A hook that is run after creating instances in bulk
 
 **Params:**
@@ -224,7 +224,7 @@ A hook that is run after creating instances in bulk
 
 <a name="beforebulkdestroy"></a>
 ## `beforeBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L285)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L260)
 A hook that is run before destroying instances in bulk
 
 **Params:**
@@ -240,7 +240,7 @@ __Aliases:__ beforeBulkDelete
 
 <a name="afterbulkdestroy"></a>
 ## `afterBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L300)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L269)
 A hook that is run after destroying instances in bulk
 
 **Params:**
@@ -256,7 +256,7 @@ __Aliases:__ afterBulkDelete
 
 <a name="beforebulkupdate"></a>
 ## `beforeBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L313)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L276)
 A hook that is run after updating instances in bulk
 
 **Params:**
@@ -271,7 +271,7 @@ A hook that is run after updating instances in bulk
 
 <a name="afterbulkupdate"></a>
 ## `afterBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L322)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L283)
 A hook that is run after updating instances in bulk
 
 **Params:**
@@ -286,7 +286,7 @@ A hook that is run after updating instances in bulk
 
 <a name="beforefind"></a>
 ## `beforeFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L331)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L290)
 A hook that is run before a find (select) query
 
 **Params:**
@@ -301,7 +301,7 @@ A hook that is run before a find (select) query
 
 <a name="beforefindafterexpandincludeall"></a>
 ## `beforeFindAfterExpandIncludeAll(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L340)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L297)
 A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
 
 **Params:**
@@ -316,7 +316,7 @@ A hook that is run before a find (select) query, after any { include: {all: ...}
 
 <a name="beforefindafteroptions"></a>
 ## `beforeFindAfterOptions(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L349)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L304)
 A hook that is run before a find (select) query, after all option parsing is complete
 
 **Params:**
@@ -331,7 +331,7 @@ A hook that is run before a find (select) query, after all option parsing is com
 
 <a name="afterfind"></a>
 ## `afterFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L358)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L311)
 A hook that is run after a find (select) query
 
 **Params:**
@@ -346,7 +346,7 @@ A hook that is run after a find (select) query
 
 <a name="beforedefine"></a>
 ## `beforeDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L367)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L318)
 A hook that is run before a define call
 
 **Params:**
@@ -361,7 +361,7 @@ A hook that is run before a define call
 
 <a name="afterdefine"></a>
 ## `afterDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L376)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L325)
 A hook that is run after a define call
 
 **Params:**
@@ -376,7 +376,7 @@ A hook that is run after a define call
 
 <a name="beforeinit"></a>
 ## `beforeInit(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L385)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L332)
 A hook that is run before Sequelize() call
 
 **Params:**
@@ -390,8 +390,8 @@ A hook that is run before Sequelize() call
 ***
 
 <a name="afterinit"></a>
-## `afterInit(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/hooks.js#L394)
+## `afterInit`
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/hooks.js#L340)
 A hook that is run after Sequelize() call
 
 **Params:**

--- a/docs/api/instance.md
+++ b/docs/api/instance.md
@@ -1,6 +1,6 @@
 <a name="instance"></a>
 # Class Instance
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L32)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L42)
 This class represents an single instance, a database row. You might see it referred to as both Instance and instance. You should not
 instantiate the Instance class directly, instead you access it using the finder and creation methods on the model.
 
@@ -26,14 +26,14 @@ Accessing properties directly or using `get` is preferred for regular use, `getD
 
 <a name="isnewrecord"></a>
 ## `isNewRecord` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L44)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L54)
 Returns true if this instance has not yet been persisted to the database
 
 ***
 
 <a name="model"></a>
 ## `Model()` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L53)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L63)
 Returns the Model the instance was created from.
 
 **See:**
@@ -45,7 +45,7 @@ Returns the Model the instance was created from.
 
 <a name="sequelize"></a>
 ## `sequelize()` -> `Sequelize`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L62)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L72)
 A reference to the sequelize instance
 
 **See:**
@@ -57,15 +57,16 @@ A reference to the sequelize instance
 
 <a name="isdeleted"></a>
 ## `isDeleted()` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L75)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L85)
 If timestamps and paranoid are enabled, returns whether the deletedAt timestamp of this instance is set. Otherwise, always returns false.
 
 ***
 
 <a name="values"></a>
 ## `values()` -> `Object`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L87)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L98)
 Get the values of this Instance. Proxies to `this.get`
+**Deprecated** .values is deprecated. Please use .get() instead.
 
 **See:**
 
@@ -76,7 +77,7 @@ Get the values of this Instance. Proxies to `this.get`
 
 <a name="isdirty"></a>
 ## `isDirty()` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L100)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L112)
 A getter for `this.changed()`. Returns true if any keys have changed.
 
 
@@ -89,7 +90,7 @@ A getter for `this.changed()`. Returns true if any keys have changed.
 
 <a name="primarykeyvalues"></a>
 ## `primaryKeyValues()` -> `Object`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L112)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L124)
 Get the values of the primary keys of this instance.
 
 
@@ -97,7 +98,7 @@ Get the values of the primary keys of this instance.
 
 <a name="getdatavalue"></a>
 ## `getDataValue(key)` -> `any`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L148)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L160)
 Get the value of the underlying data value
 
 
@@ -112,7 +113,7 @@ Get the value of the underlying data value
 
 <a name="setdatavalue"></a>
 ## `setDataValue(key, value)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L158)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L170)
 Update the underlying data value
 
 
@@ -128,7 +129,7 @@ Update the underlying data value
 
 <a name="get"></a>
 ## `get([key], [options])` -> `Object|any`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L172)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L184)
 If no key is given, returns all values of the instance, also invoking virtual getters.
 
 If key is given and a field or virtual getter is present for the key it will call that getter - else it will return the value for key.
@@ -147,7 +148,7 @@ If key is given and a field or virtual getter is present for the key it will cal
 
 <a name="set"></a>
 ## `set(key, value, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L251)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L263)
 Set is used to update values on the instance (the sequelize representation of the instance that is, remember that nothing will be persisted before you actually call `save`).
 In its most basic form `set` will update a value stored in the underlying `dataValues` object. However, if a custom setter function is defined for the key, that function
 will be called instead. To bypass the setter, you can pass `raw: true` in the options object.
@@ -182,7 +183,7 @@ __Aliases:__ setAttributes
 
 <a name="changed"></a>
 ## `changed([key])` -> `Boolean|Array`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L385)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L397)
 If changed is called with a string it will return a boolean indicating whether the value of that key in `dataValues` is different from the value in `_previousDataValues`.
 
 If changed is called without an argument, it will return an array of keys that have changed.
@@ -199,7 +200,7 @@ If changed is called without an argument, it will return an array of keys that h
 
 <a name="previous"></a>
 ## `previous(key)` -> `any`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L404)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L416)
 Returns the previous value for key from `_previousDataValues`.
 
 **Params:**
@@ -213,7 +214,7 @@ Returns the previous value for key from `_previousDataValues`.
 
 <a name="save"></a>
 ## `save([options])` -> `Promise<this|Errors.ValidationError>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L465)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L477)
 Validate this instance, and if the validation passes, persist it to the database.
 
 On success, the callback will be called with this instance. On validation error, the callback will be called with an instance of `Sequelize.ValidationError`.
@@ -235,7 +236,7 @@ This error will have a property for each of the fields for which validation fail
 
 <a name="reload"></a>
 ## `reload([options])` -> `Promise<this>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L647)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L710)
 Refresh the current instance in-place, i.e. update the object with current data from the DB and return the same object.
 This is different from doing a `find(Instance.id)`, because that would create and return a new instance. With this method,
 all references to the Instance are updated with the new data and no new objects are created.
@@ -257,7 +258,7 @@ all references to the Instance are updated with the new data and no new objects 
 
 <a name="validate"></a>
 ## `validate([options])` -> `Promise<undefined|Errors.ValidationError>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L674)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L737)
 Validate the attribute of this instance according to validation rules set in the model definition.
 
 Emits null if and only if validation successful; otherwise an Error instance containing { field name : [error msgs] } entries.
@@ -280,7 +281,7 @@ Emits null if and only if validation successful; otherwise an Error instance con
 
 <a name="update"></a>
 ## `update(updates, options)` -> `Promise<this>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L693)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L756)
 This is the same as calling `set` and then calling `save`.
 
 
@@ -303,7 +304,7 @@ __Aliases:__ updateAttributes
 
 <a name="destroy"></a>
 ## `destroy([options={}])` -> `Promise<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L717)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L788)
 Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will either be completely deleted, or have its deletedAt timestamp set to the current time.
 
 
@@ -320,7 +321,7 @@ Destroy the row corresponding to this instance. Depending on your setting for pa
 
 <a name="restore"></a>
 ## `restore([options={}])` -> `Promise<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L760)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L831)
 Restore the row corresponding to this instance. Only available for paranoid models.
 
 
@@ -336,7 +337,7 @@ Restore the row corresponding to this instance. Only available for paranoid mode
 
 <a name="increment"></a>
 ## `increment(fields, [options])` -> `Promise<this>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L808)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L879)
 Increment the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The increment is done using a
 ```sql
 SET column = column + X
@@ -370,7 +371,7 @@ instance.increment({ answer: 42, tries: 1}, { by: 2 }) // increment answer by 42
 
 <a name="decrement"></a>
 ## `decrement(fields, [options])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L895)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L966)
 Decrement the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The decrement is done using a
 ```sql
 SET column = column - X
@@ -404,7 +405,7 @@ instance.decrement({ answer: 42, tries: 1}, { by: 2 }) // decrement answer by 42
 
 <a name="equals"></a>
 ## `equals(other)` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L929)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L1000)
 Check whether all values of this and `other` Instance are the same
 
 
@@ -419,7 +420,7 @@ Check whether all values of this and `other` Instance are the same
 
 <a name="equalsoneof"></a>
 ## `equalsOneOf(others)` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L949)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L1020)
 Check if this is eqaul to one of `others` by calling equals
 
 
@@ -434,7 +435,7 @@ Check if this is eqaul to one of `others` by calling equals
 
 <a name="tojson"></a>
 ## `toJSON()` -> `object`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/instance.js#L967)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/instance.js#L1038)
 Convert the instance to a JSON representation. Proxies to calling `get` with no keys. This means get all values gotten from the DB, and apply all custom getters.
 
 

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -1,6 +1,6 @@
 <a name="model"></a>
 # Class Model
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L25)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L25)
 A Model represents a table in the database. Sometimes you might also see it refererred to as model, or simply as factory. This class should _not_ be instantiated directly, it is created using `sequelize.define`, and already created models can be loaded using `sequelize.import`
 
 ### Mixes:
@@ -11,7 +11,7 @@ A Model represents a table in the database. Sometimes you might also see it refe
 
 <a name="removeattribute"></a>
 ## `removeAttribute([attribute])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L383)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L387)
 Remove attribute from model definition
 
 **Params:**
@@ -25,7 +25,7 @@ Remove attribute from model definition
 
 <a name="sync"></a>
 ## `sync()` -> `Promise<this>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L393)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L397)
 Sync this Model to the DB, that is create the table. Upon success, the callback will be called with the model instance (this)
 
 **See:**
@@ -37,7 +37,7 @@ Sync this Model to the DB, that is create the table. Upon success, the callback 
 
 <a name="drop"></a>
 ## `drop([options])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L429)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L433)
 Drop the table represented by this Model
 
 **Params:**
@@ -52,7 +52,7 @@ Drop the table represented by this Model
 
 <a name="schema"></a>
 ## `schema(schema, [options])` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L446)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L450)
 Apply a schema to this model. For postgres, this will actually place the schema in front of the table name - `"schema"."tableName"`,
 while the schema will be prepended to the table name for mysql and sqlite - `'schema.tablename'`.
 
@@ -70,7 +70,7 @@ while the schema will be prepended to the table name for mysql and sqlite - `'sc
 
 <a name="gettablename"></a>
 ## `getTableName(options)` -> `String|Object`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L469)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L473)
 Get the tablename of the model, taking schema into account. The method will return The name as a string if the model has no schema,
 or an object with `tableName`, `schema` and `delimiter` properties.
 
@@ -86,7 +86,7 @@ or an object with `tableName`, `schema` and `delimiter` properties.
 
 <a name="scope"></a>
 ## `scope(options*)` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L512)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L516)
 Apply a scope created in `define` to the model. First let's look at how to create scopes:
 ```js
 var Model = sequelize.define('model', attributes, {
@@ -135,7 +135,7 @@ __Returns:__ A reference to the model, with the scope(s) applied. Calling scope 
 
 <a name="findall"></a>
 ## `findAll([options], [queryOptions])` -> `Promise<Array<Instance>>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L687)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L691)
 Search for multiple instances.
 
 __Simple search using AND and =__
@@ -207,7 +207,7 @@ The success listener is called with an array of instances if the query succeeds.
 | [options] | Object | A hash of options to describe the scope of the search |
 | [options.where] | Object | A hash of attributes to describe your search. See above for examples. |
 | [options.attributes] | Array&lt;String&gt; | A list of the attributes that you want to select. To rename an attribute, you can pass an array, with two elements - the first is the name of the attribute in the DB (or some kind of expression such as `Sequelize.literal`, `Sequelize.fn` and so on), and the second is the name you want the attribute to have in the returned instance |
-| [options.paranoid=true] | Boolean | If false, will include columns which have a non-null deletedAt column. |
+| [options.paranoid=true] | Boolean | If true, only non-deleted records will be returned. If false, both deleted and non-deleted records will be returned. Only applies if `options.paranoid` is true for the model. |
 | [options.include] | Array&lt;Object &#124; Model&gt; | A list of associations to eagerly load using a left join. Supported is either `{ include: [ Model1, Model2, ...]}` or `{ include: [{ model: Model1, as: 'Alias' }]}`. If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in the as attribute when eager loading Y). |
 | [options.include[].model] | Model | The model you want to eagerly load |
 | [options.include[].as] | String | The alias of the relation, in case the model you want to eagerly load is aliassed. For `hasOne` / `belongsTo`, this should be the singular name, and for `hasMany`, it should be the plural |
@@ -229,7 +229,7 @@ __Aliases:__ all
 
 <a name="findone"></a>
 ## `findOne([options], [queryOptions])` -> `Promise<Instance>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L771)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L775)
 Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single instance.
 
 
@@ -252,7 +252,7 @@ __Aliases:__ find
 
 <a name="aggregate"></a>
 ## `aggregate(field, aggregateFunction, [options])` -> `Promise<options.dataType|object>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L810)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L814)
 Run an aggregation method on the specified field
 
 
@@ -275,7 +275,7 @@ __Returns:__ Returns the aggregate result cast to `options.dataType`, unless `op
 
 <a name="count"></a>
 ## `count([options])` -> `Promise<Integer>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L849)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L853)
 Count the number of records matching the provided where clause.
 
 If you provide an `include` option, the number of matching associations will be counted instead.
@@ -297,7 +297,7 @@ If you provide an `include` option, the number of matching associations will be 
 
 <a name="findandcount"></a>
 ## `findAndCount([findOptions], [queryOptions])` -> `Promise<Object>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L890)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L894)
 Find all the rows matching your query, within a specified offset / limit, and get the total number of rows matching your query. This is very usefull for paging
 
 ```js
@@ -329,7 +329,7 @@ __Aliases:__ findAndCountAll
 
 <a name="max"></a>
 ## `max(field, [options])` -> `Promise<Any>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L946)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L950)
 Find the maximum value of field
 
 
@@ -350,7 +350,7 @@ Find the maximum value of field
 
 <a name="min"></a>
 ## `min(field, [options])` -> `Promise<Any>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L959)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L963)
 Find the minimum value of field
 
 
@@ -371,7 +371,7 @@ Find the minimum value of field
 
 <a name="sum"></a>
 ## `sum(field, [options])` -> `Promise<Number>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L972)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L976)
 Find the sum of field
 
 
@@ -392,7 +392,7 @@ Find the sum of field
 
 <a name="build"></a>
 ## `build(values, [options])` -> `Instance`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L988)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L992)
 Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
 
 
@@ -412,7 +412,7 @@ Builds a new model instance. Values is an object of key value pairs, must be def
 
 <a name="create"></a>
 ## `create(values, [options])` -> `Promise<Instance>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1058)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1062)
 Builds a new model instance and calls save on it.
 
 
@@ -441,7 +441,7 @@ Builds a new model instance and calls save on it.
 
 <a name="findorinitialize"></a>
 ## `findOrInitialize` -> `Promise<Instance>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1088)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1092)
 Find a row that matches the query, or build (but don't save) the row if none is found.
 The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
 
@@ -461,7 +461,7 @@ __Aliases:__ findOrBuild
 
 <a name="findorcreate"></a>
 ## `findOrCreate(options, [queryOptions])` -> `Promise<Instance|created>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1133)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1133)
 Find a row that matches the query, or build and save the row if none is found
 The successfull result of the promise will be (instance, created) - Make sure to use .spread()
 
@@ -484,7 +484,7 @@ If a transaction is created, a savepoint will be created instead, and any unique
 
 <a name="upsert"></a>
 ## `upsert(values, [options])` -> `Promise<created>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1221)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1221)
 Insert or update a single row. An update will be executed if a row which matches the supplied values on either the primary key or a unique key is found. Note that the unique index must be defined in your sequelize model and not just in the table. Otherwise you may experience a unique constraint violation, because sequelize fails to identify the row that should be updated.
 
 **Implementation details:**
@@ -512,7 +512,7 @@ __Aliases:__ insertOrUpdate
 
 <a name="bulkcreate"></a>
 ## `bulkCreate(records, [options])` -> `Promise<Array<Instance>>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1275)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1275)
 Create and insert multiple instances in bulk.
 
 The success handler is passed an array of instances, but please notice that these may not completely represent the state of the rows in the DB. This is because MySQL
@@ -539,7 +539,7 @@ To obtain Instances for the newly created values, you will need to query for the
 
 <a name="destroy"></a>
 ## `destroy(options)` -> `Promise<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1449)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1453)
 Delete multiple instances, or set their deletedAt timestamp to the current time if `paranoid` is enabled.
 
 
@@ -550,7 +550,7 @@ Delete multiple instances, or set their deletedAt timestamp to the current time 
 | options | Object |  |
 | [options.where] | Object | Filter the destroy |
 | [options.hooks=true] | Boolean | Run before / after bulk destroy hooks? |
-| [options.individualHooks=false] | Boolean | If set to true, destroy will find all records within the where parameter and will execute before / after bulkDestroy hooks on each row |
+| [options.individualHooks=false] | Boolean | If set to true, destroy will SELECT all records matching the where parameter and will execute before / after destroy hooks on each row |
 | [options.limit] | Number | How many rows to delete |
 | [options.force=false] | Boolean | Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled) |
 | [options.truncate=false] | Boolean | If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored |
@@ -562,7 +562,7 @@ Delete multiple instances, or set their deletedAt timestamp to the current time 
 
 <a name="restore"></a>
 ## `restore(options)` -> `Promise<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1524)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1528)
 Restore multiple instances if `paranoid` is enabled.
 
 
@@ -582,7 +582,7 @@ Restore multiple instances if `paranoid` is enabled.
 
 <a name="update"></a>
 ## `update(values, options)` -> `Promise<Array<affectedCount|affectedRows>>`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1594)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1598)
 Update multiple instances that match the where options. The promise returns an array with one or two elements. The first element is always the number
 of affected rows, while the second element is the actual affected rows (only supported in postgres with `options.returning` true.)
 
@@ -596,7 +596,7 @@ of affected rows, while the second element is the actual affected rows (only sup
 | options.where | Object | Options to describe the scope of the search. |
 | [options.validate=true] | Boolean | Should each row be subject to validation before it is inserted. The whole insert will fail if one row fails validation |
 | [options.hooks=true] | Boolean | Run before / after bulk update hooks? |
-| [options.individualHooks=false] | Boolean | Run before / after update hooks? |
+| [options.individualHooks=false] | Boolean | Run before / after update hooks?. If true, this will execute a SELECT followed by individual UPDATEs. A select is needed, because the row data needs to be passed to the hooks |
 | [options.returning=false] | Boolean | Return the affected rows (only for postgres) |
 | [options.limit] | Number | How many rows to update (only for mysql and mariadb) |
 | [options.transaction] | Transaction |  |
@@ -606,7 +606,7 @@ of affected rows, while the second element is the actual affected rows (only sup
 
 <a name="describe"></a>
 ## `describe()` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/model.js#L1759)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/model.js#L1763)
 Run a describe query on the table. The result will be return to the listener as a hash of attributes and their types.
 
 

--- a/docs/api/promise.md
+++ b/docs/api/promise.md
@@ -1,6 +1,6 @@
 <a name="promise"></a>
 # Class Promise
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L25)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L25)
 A slightly modified version of bluebird promises. This means that, on top of the methods below, you can also call all the methods listed on the link below.
 
 The main difference is that sequelize promises allows you to attach a listener that will be called with the generated SQL, each time a query is run.
@@ -15,7 +15,7 @@ If you want to propagate SQL events across `then`, `all` calls etc., you must us
 
 <a name="on"></a>
 ## `on(evt, fct)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L119)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L119)
 Listen for events, event emitter style. Mostly for backwards compat. with EventEmitter
 
 **Deprecated** 
@@ -32,7 +32,7 @@ Listen for events, event emitter style. Mostly for backwards compat. with EventE
 
 <a name="emit"></a>
 ## `emit(type, value(s)*)`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L140)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L140)
 Emit an event from the emitter
 **Deprecated** 
 
@@ -48,7 +48,7 @@ Emit an event from the emitter
 
 <a name="success"></a>
 ## `success(onSuccess)` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L178)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L178)
 Listen for success events.
 
 ```js
@@ -71,7 +71,7 @@ __Aliases:__ ok
 
 <a name="error"></a>
 ## `error(onError)` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L205)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L205)
 Listen for error events
 
 ```js
@@ -94,7 +94,7 @@ __Aliases:__ fail, failure
 
 <a name="done"></a>
 ## `done(onDone)` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L228)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L228)
 Listen for both success and error events.
 
 ```js
@@ -117,7 +117,7 @@ __Aliases:__ complete
 
 <a name="sql"></a>
 ## `sql(onSQL)` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L253)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L253)
 Attach a function that is called every time the function that created this emitter executes a query.
 
 **Params:**
@@ -131,7 +131,7 @@ Attach a function that is called every time the function that created this emitt
 
 <a name="proxy"></a>
 ## `proxy(promise, [options])` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/promise.js#L268)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/promise.js#L268)
 Proxy every event of this promise to another one.
 
 **Deprecated** 

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -1,6 +1,6 @@
 <a name="sequelize"></a>
 # Class Sequelize
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L34)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L34)
 This is the main class, the entry point to sequelize. To use it, you just need to import sequelize:
 
 ```js
@@ -14,7 +14,7 @@ In addition to sequelize, the connection library for the dialect you want to use
 
 <a name="sequelize"></a>
 ## `new Sequelize(database, [username=null], [password=null], [options={}])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L91)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L89)
 Instantiate sequelize with name of database, username and password
 
 #### Example usage
@@ -73,7 +73,7 @@ var sequelize = new Sequelize('mysql://localhost:3306/database', {})
 
 <a name="sequelize"></a>
 ## `new Sequelize(uri, [options={}])`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L100)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L98)
 Instantiate sequlize with an URI
 
 **Params:**
@@ -88,14 +88,14 @@ Instantiate sequlize with an URI
 
 <a name="models"></a>
 ## `models`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L199)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L195)
 Models are stored here under the name given to `sequelize.define`
 
 ***
 
 <a name="sequelize"></a>
 ## `Sequelize`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L215)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L222)
 A reference to Sequelize constructor from sequelize. Useful for accessing DataTypes, Errors etc.
 
 **See:**
@@ -107,7 +107,7 @@ A reference to Sequelize constructor from sequelize. Useful for accessing DataTy
 
 <a name="utils"></a>
 ## `Utils`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L222)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L229)
 A reference to sequelize utilities. Most users will not need to use these utils directly. However, you might want to use `Sequelize.Utils._`, which is a reference to the lodash library, if you don't already have it imported in your project.
 
 **See:**
@@ -119,7 +119,7 @@ A reference to sequelize utilities. Most users will not need to use these utils 
 
 <a name="promise"></a>
 ## `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L229)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L236)
 A modified version of bluebird promises, that allows listening for sql events
 
 **See:**
@@ -131,14 +131,14 @@ A modified version of bluebird promises, that allows listening for sql events
 
 <a name="querytypes"></a>
 ## `QueryTypes`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L235)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L242)
 Available query types for use with `sequelize.query`
 
 ***
 
 <a name="validator"></a>
 ## `Validator`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L242)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L249)
 Exposes the validator.js object, so you can extend it with custom validation functions. The validator is exposed both on the instance, and on the constructor.
 
 **See:**
@@ -150,7 +150,7 @@ Exposes the validator.js object, so you can extend it with custom validation fun
 
 <a name="transaction"></a>
 ## `Transaction`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L262)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L269)
 A reference to the sequelize transaction class. Use this to access isolationLevels when creating a transaction
 
 **See:**
@@ -163,7 +163,7 @@ A reference to the sequelize transaction class. Use this to access isolationLeve
 
 <a name="instance"></a>
 ## `Instance`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L269)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L276)
 A reference to the sequelize instance class.
 
 **See:**
@@ -175,7 +175,7 @@ A reference to the sequelize instance class.
 
 <a name="error"></a>
 ## `Error`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L283)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L289)
 A general error class
 
 **See:**
@@ -187,7 +187,7 @@ A general error class
 
 <a name="validationerror"></a>
 ## `ValidationError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L291)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L297)
 Emitted when a validation fails
 
 **See:**
@@ -199,7 +199,7 @@ Emitted when a validation fails
 
 <a name="validationerroritem"></a>
 ## `ValidationErrorItem`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L299)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L305)
 Describes a validation error on an instance path
 
 **See:**
@@ -211,7 +211,7 @@ Describes a validation error on an instance path
 
 <a name="databaseerror"></a>
 ## `DatabaseError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L306)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L312)
 A base class for all database related errors.
 
 **See:**
@@ -223,7 +223,7 @@ A base class for all database related errors.
 
 <a name="timeouterror"></a>
 ## `TimeoutError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L313)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L319)
 Thrown when a database query times out because of a deadlock
 
 **See:**
@@ -235,7 +235,7 @@ Thrown when a database query times out because of a deadlock
 
 <a name="uniqueconstrainterror"></a>
 ## `UniqueConstraintError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L320)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L326)
 Thrown when a unique constraint is violated in the database
 
 **See:**
@@ -247,7 +247,7 @@ Thrown when a unique constraint is violated in the database
 
 <a name="exclusionconstrainterror"></a>
 ## `ExclusionConstraintError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L327)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L333)
 Thrown when an exclusion constraint is violated in the database
 
 **See:**
@@ -259,7 +259,7 @@ Thrown when an exclusion constraint is violated in the database
 
 <a name="foreignkeyconstrainterror"></a>
 ## `ForeignKeyConstraintError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L334)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L340)
 Thrown when a foreign key constraint is violated in the database
 
 **See:**
@@ -271,7 +271,7 @@ Thrown when a foreign key constraint is violated in the database
 
 <a name="connectionerror"></a>
 ## `ConnectionError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L341)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L347)
 A base class for all connection related errors.
 
 **See:**
@@ -283,7 +283,7 @@ A base class for all connection related errors.
 
 <a name="connectionrefusederror"></a>
 ## `ConnectionRefusedError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L348)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L354)
 Thrown when a connection to a database is refused
 
 **See:**
@@ -295,7 +295,7 @@ Thrown when a connection to a database is refused
 
 <a name="accessdeniederror"></a>
 ## `AccessDeniedError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L355)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L361)
 Thrown when a connection to a database is refused due to insufficient access
 
 **See:**
@@ -307,7 +307,7 @@ Thrown when a connection to a database is refused due to insufficient access
 
 <a name="hostnotfounderror"></a>
 ## `HostNotFoundError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L362)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L368)
 Thrown when a connection to a database has a hostname that was not found
 
 **See:**
@@ -319,7 +319,7 @@ Thrown when a connection to a database has a hostname that was not found
 
 <a name="hostnotreachableerror"></a>
 ## `HostNotReachableError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L369)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L375)
 Thrown when a connection to a database has a hostname that was not reachable
 
 **See:**
@@ -331,7 +331,7 @@ Thrown when a connection to a database has a hostname that was not reachable
 
 <a name="invalidconnectionerror"></a>
 ## `InvalidConnectionError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L376)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L382)
 Thrown when a connection to a database has invalid values for any of the connection parameters
 
 **See:**
@@ -343,7 +343,7 @@ Thrown when a connection to a database has invalid values for any of the connect
 
 <a name="connectiontimedouterror"></a>
 ## `ConnectionTimedOutError`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L383)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L389)
 Thrown when a connection to a database times out
 
 **See:**
@@ -355,7 +355,7 @@ Thrown when a connection to a database times out
 
 <a name="getdialect"></a>
 ## `getDialect()` -> `String`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L391)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L397)
 Returns the specified dialect.
 
 __Returns:__ The specified dialect.
@@ -364,7 +364,7 @@ __Returns:__ The specified dialect.
 
 <a name="getqueryinterface"></a>
 ## `getQueryInterface()` -> `QueryInterface`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L403)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L409)
 Returns an instance of QueryInterface.
 
 
@@ -378,7 +378,7 @@ __Returns:__ An instance (singleton) of QueryInterface.
 
 <a name="getmigrator"></a>
 ## `getMigrator([options={}], [force=false])` -> `Migrator`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L417)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L423)
 Returns an instance (singleton) of Migrator.
 
 
@@ -400,7 +400,7 @@ __Returns:__ An instance of Migrator.
 
 <a name="define"></a>
 ## `define(modelName, attributes, [options])` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L535)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L541)
 Define a new model, representing a table in the DB.
 
 The table columns are define by the hash that is given as the second argument. Each attribute of the hash represents a column. A short table definition might look like this:
@@ -485,7 +485,7 @@ For more about validation, see http://sequelizejs.com/docs/latest/models#validat
 | [options.indexes[].method] | String | The method to create the index by (`USING` statement in SQL). BTREE and HASH are supported by mysql and postgres, and postgres additionally supports GIST and GIN. |
 | [options.indexes[].unique=false] | Boolean | Should the index by unique? Can also be triggered by setting type to `UNIQUE` |
 | [options.indexes[].concurrently=false] | Boolean | PostgreSQL will build the index without taking any write locks. Postgres only |
-| [options.indexes[].fields] | Array&lt;String &#124; Object&gt; | An array of the fields to index. Each field can either be a string containing the name of the field, or an object with the following attributes: `attribute` (field name), `length` (create a prefix index of length chars), `order` (the direction the column should be sorted in), `collate` (the collation (sort order) for the column) |
+| [options.indexes[].fields] | Array&lt;String &#124; Object&gt; | An array of the fields to index. Each field can either be a string containing the name of the field, a sequelize object (e.g `sequelize.fn`), or an object with the following attributes: `attribute` (field name), `length` (create a prefix index of length chars), `order` (the direction the column should be sorted in), `collate` (the collation (sort order) for the column) |
 | [options.createdAt] | String &#124; Boolean | Override the name of the createdAt column if a string is provided, or disable it if false. Timestamps must be true |
 | [options.updatedAt] | String &#124; Boolean | Override the name of the updatedAt column if a string is provided, or disable it if false. Timestamps must be true |
 | [options.deletedAt] | String &#124; Boolean | Override the name of the deletedAt column if a string is provided, or disable it if false. Timestamps must be true |
@@ -508,7 +508,7 @@ For more about validation, see http://sequelizejs.com/docs/latest/models#validat
 
 <a name="model"></a>
 ## `model(modelName)` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L587)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L587)
 Fetch a DAO factory which is already defined
 
 
@@ -523,7 +523,7 @@ Fetch a DAO factory which is already defined
 
 <a name="isdefined"></a>
 ## `isDefined(modelName)` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L601)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L601)
 Checks whether a model with the given name is defined
 
 
@@ -538,7 +538,7 @@ Checks whether a model with the given name is defined
 
 <a name="import"></a>
 ## `import(path)` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L615)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L615)
 Imports a model defined in another file
 
 Imported models are cached, so multiple calls to import with the same path will not load the file multiple times
@@ -556,7 +556,7 @@ See https://github.com/sequelize/sequelize/blob/master/examples/using-multiple-m
 
 <a name="query"></a>
 ## `query(sql, [callee], [options={}])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L670)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L670)
 Execute a query on the DB, with the posibility to bypass all the sequelize goodness.
 
 By default, the function will return two arguments: an array of results, and a metadata object, containing number of affected rows etc. Use `.spread` to access the results.
@@ -599,7 +599,7 @@ sequlize.query('SELECT...', { type: sequelize.QueryTypes.SELECT }).then(function
 
 <a name="set"></a>
 ## `set(variables, options)` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L746)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L769)
 Execute a query which would set an environment or user variable. The variables are set per connection, so this function needs a transaction.
 Only works for MySQL.
 
@@ -617,7 +617,7 @@ Only works for MySQL.
 
 <a name="escape"></a>
 ## `escape(value)` -> `String`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L780)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L803)
 Escape value.
 
 
@@ -632,7 +632,7 @@ Escape value.
 
 <a name="createschema"></a>
 ## `createSchema(schema)` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L794)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L817)
 Create a new database schema.
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -655,7 +655,7 @@ not a database table. In mysql and sqlite, this command will do nothing.
 
 <a name="showallschemas"></a>
 ## `showAllSchemas()` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L805)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L828)
 Show all defined schemas
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -665,7 +665,7 @@ not a database table. In mysql and sqlite, this will show all tables.
 
 <a name="dropschema"></a>
 ## `dropSchema(schema)` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L817)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L840)
 Drop a single schema
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -682,7 +682,7 @@ not a database table. In mysql and sqlite, this drop a table matching the schema
 
 <a name="dropallschemas"></a>
 ## `dropAllSchemas()` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L828)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L851)
 Drop all schemas
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -692,7 +692,7 @@ not a database table. In mysql and sqlite, this is the equivalent of drop all ta
 
 <a name="sync"></a>
 ## `sync([options={}])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L842)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L865)
 Sync all defined DAOs to the DB.
 
 
@@ -711,7 +711,7 @@ Sync all defined DAOs to the DB.
 
 <a name="drop"></a>
 ## `drop(options)` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L886)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L909)
 Drop all tables defined through this sequelize instance. This is done by calling Model.drop on each model
 
 **See:**
@@ -730,7 +730,7 @@ Drop all tables defined through this sequelize instance. This is done by calling
 
 <a name="authenticate"></a>
 ## `authenticate()` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L908)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L931)
 Test the connection by trying to authenticate
 
 __Aliases:__ validate
@@ -739,7 +739,7 @@ __Aliases:__ validate
 
 <a name="fn "></a>
 ## `fn (fn, args)` -> `Sequelize.fn`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L943)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L966)
 Creates a object representing a database function. This can be used in search queries, both in where and order parts, and as default values in column definitions.
 If you want to refer to columns in your function, you should use `sequelize.col`, so that the columns are properly interpreted as columns and not a strings.
 
@@ -771,7 +771,7 @@ instance.updateAttributes({
 
 <a name="col"></a>
 ## `col(col)` -> `Sequelize.col`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L956)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L979)
 Creates a object representing a column in the DB. This is often useful in conjunction with `sequelize.fn`, since raw string arguments to fn will be escaped.
 
 **See:**
@@ -790,7 +790,7 @@ Creates a object representing a column in the DB. This is often useful in conjun
 
 <a name="cast"></a>
 ## `cast(val, type)` -> `Sequelize.cast`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L970)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L993)
 Creates a object representing a call to the cast function.
 
 
@@ -806,7 +806,7 @@ Creates a object representing a call to the cast function.
 
 <a name="literal"></a>
 ## `literal(val)` -> `Sequelize.literal`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L983)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L1006)
 Creates a object representing a literal, i.e. something that will not be escaped.
 
 
@@ -822,7 +822,7 @@ __Aliases:__ asIs
 
 <a name="and"></a>
 ## `and(args)` -> `Sequelize.and`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L996)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L1019)
 An AND query
 
 **See:**
@@ -841,7 +841,7 @@ An AND query
 
 <a name="or"></a>
 ## `or(args)` -> `Sequelize.or`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L1009)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L1032)
 An OR query
 
 **See:**
@@ -860,7 +860,7 @@ An OR query
 
 <a name="json"></a>
 ## `json(conditions, [value])` -> `Sequelize.json`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L1022)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L1045)
 Creates an object representing nested where conditions for postgres's json data-type.
 
 **See:**
@@ -873,14 +873,14 @@ Creates an object representing nested where conditions for postgres's json data-
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | conditions | String &#124; Object | A hash containing strings/numbers or other nested hash, a string using dot notation or a string using postgres json syntax. |
-| [value] | String &#124; Number &#124; Boolean | An optional value to compare against. Produces a string of the form "<json path> = '<value>'". |
+| [value] | String &#124; Number &#124; Boolean | An optional value to compare against. Produces a string of the form "&lt;json path&gt; = '&lt;value&gt;'". |
 
 
 ***
 
 <a name="where"></a>
 ## `where(attr, [comparator='='], logic)` -> `Sequelize.where`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L1044)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L1067)
 A way of specifying attr = condition.
 
 The attr can either be an object taken from `Model.rawAttributes` (for example `Model.rawAttributes.id` or `Model.rawAttributes.name`). The
@@ -908,7 +908,7 @@ __Aliases:__ condition
 
 <a name="transaction"></a>
 ## `transaction([options={}])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/sequelize.js#L1096)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/sequelize.js#L1119)
 Start a transaction. When using transactions, you should pass the transaction in the options argument in order for the query to happen under that transaction
 
 ```js

--- a/docs/api/transaction.md
+++ b/docs/api/transaction.md
@@ -1,6 +1,6 @@
 <a name="transaction"></a>
 # Class Transaction
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/transaction.js#L12)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/transaction.js#L12)
 The transaction object is used to identify a running transaction. It is created by calling `Sequelize.transaction()`.
 
 To run a query under a transaction, you should pass the transaction in the options object.
@@ -9,7 +9,7 @@ To run a query under a transaction, you should pass the transaction in the optio
 
 <a name="isolation_levels"></a>
 ## `ISOLATION_LEVELS`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/transaction.js#L45)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/transaction.js#L45)
 The possible isolations levels to use when starting a transaction
 
 ```js
@@ -26,7 +26,7 @@ The possible isolations levels to use when starting a transaction
 
 <a name="lock"></a>
 ## `LOCK`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/transaction.js#L67)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/transaction.js#L67)
 Possible options for row locking. Used in conjuction with `find` calls:
 
 ```js
@@ -44,7 +44,7 @@ Model.findAll({
 
 <a name="commit"></a>
 ## `commit()` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/transaction.js#L77)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/transaction.js#L77)
 Commit the transaction
 
 
@@ -52,7 +52,7 @@ Commit the transaction
 
 <a name="rollback"></a>
 ## `rollback()` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/56b47a6bdd60a9a1c5e43a35409dffa9ed5a4d93/lib/transaction.js#L98)
+[View code](https://github.com/sequelize/sequelize/blob/768c4400949da3d727bfb733b87c26d36707ab4e/lib/transaction.js#L98)
 Rollback (abort) the transaction
 
 

--- a/docs/docs-generator.js
+++ b/docs/docs-generator.js
@@ -44,9 +44,7 @@ Comment.prototype.getTag = function(tagName) {
 };
 
 Comment.prototype.getTags = function(tagName) {
-  return _.where(this.data.tags, function (tag) {
-    return tag.type === tagName;
-  });
+  return _.where(this.data.tags, { type: tagName });
 };
 
 Comment.prototype.hasTag = function(tagName) {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -179,24 +179,28 @@ Hooks.hasHooks = Hooks.hasHook;
  * A hook that is run before validation
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
+ * @name beforeValidate
  */
 
 /**
  * A hook that is run after validation
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
+ * @name afterValidate
  */
 
 /**
  * A hook that is run before creating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, options, callback(err)
+ * @name beforeCreate
  */
 
 /**
  * A hook that is run after creating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, options, callback(err)
+ * @name afterCreate
  */
 
 /**
@@ -204,6 +208,7 @@ Hooks.hasHooks = Hooks.hasHook;
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
  *
+ * @name beforeDestroy
  * @alias beforeDelete
  */
 
@@ -212,6 +217,7 @@ Hooks.hasHooks = Hooks.hasHook;
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
  *
+ * @name afterDestroy
  * @alias afterDelete
  */
 
@@ -219,24 +225,28 @@ Hooks.hasHooks = Hooks.hasHook;
  * A hook that is run before updating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
+ * @name beforeUpdate
  */
 
 /**
  * A hook that is run after updating a single instance
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options, callback(err)
+ * @name afterUpdate
  */
 
 /**
  * A hook that is run before creating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instances, options, callback(err)
+ * @name beforeBulkCreate
  */
 
 /**
  * A hook that is run after creating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instances, options, callback(err)
+ * @name afterBulkCreate
  */
 
 /**
@@ -244,6 +254,7 @@ Hooks.hasHooks = Hooks.hasHook;
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
  *
+ * @name beforeBulkDestroy
  * @alias beforeBulkDelete
  */
 
@@ -252,6 +263,7 @@ Hooks.hasHooks = Hooks.hasHook;
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
  *
+ * @name afterBulkDestroy
  * @alias afterBulkDelete
  */
 
@@ -259,60 +271,70 @@ Hooks.hasHooks = Hooks.hasHook;
  * A hook that is run after updating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
+ * @name beforeBulkUpdate
  */
 
 /**
  * A hook that is run after updating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
+ * @name afterBulkUpdate
  */
 
 /**
  * A hook that is run before a find (select) query
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
+ * @name beforeFind
  */
 
 /**
  * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
+ * @name beforeFindAfterExpandIncludeAll
  */
 
 /**
  * A hook that is run before a find (select) query, after all option parsing is complete
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options, callback(err)
+ * @name beforeFindAfterOptions
  */
 
 /**
  * A hook that is run after a find (select) query
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance(s), options, callback(err)
+ * @name afterFind
  */
 
 /**
  * A hook that is run before a define call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with attributes, options, callback(err)
+ * @name beforeDefine
  */
 
 /**
  * A hook that is run after a define call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with factory, callback(err)
+ * @name afterDefine
  */
 
 /**
  * A hook that is run before Sequelize() call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with config, options, callback(err)
+ * @name beforeInit
  */
 
 /**
  * A hook that is run after Sequelize() call
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with sequelize, callback(err)
+ * @name afterInit
  */
 
 module.exports = {


### PR DESCRIPTION
When attempting to build the docs through `npm run docs`, I encountered some errors relating to some things being undefined. Exact error can be found below.

Some digging brought up two things.

* The usage of `_.where` inside `getTags()` - `docs/docs-generator.js`
* Some comment sections in `lib/hooks.js` that didn't have a code body directly below them (probably as a result of some refactoring).

Potential fixes for both are here, along with rebuilt docs. Let me know if there's something in here that needs another looking at. Thanks!

```
> sequelize@2.0.5 docs /Users/harimohanraj/Code/os/sequelize
> node docs/docs-generator.js

/Users/harimohanraj/Code/os/sequelize/docs/api/errors.md

/Users/harimohanraj/Code/os/sequelize/docs/docs-generator.js:91
    if (paramTag.name.indexOf('.') === -1) {
                      ^
TypeError: Cannot call method 'indexOf' of undefined
    at /Users/harimohanraj/Code/os/sequelize/docs/docs-generator.js:91:23
    at Array.forEach (native)
    at Comment.getParams (/Users/harimohanraj/Code/os/sequelize/docs/docs-generator.js:90:25)
    at /Users/harimohanraj/Code/os/sequelize/docs/docs-generator.js:182:53
    at Array.forEach (native)
    at parseComments (/Users/harimohanraj/Code/os/sequelize/docs/docs-generator.js:171:12)
    at /Users/harimohanraj/Code/os/sequelize/docs/docs-generator.js:287:22
    at fs.js:271:14
    at Object.oncomplete (fs.js:107:15)
```