### PR TITLE
Fixed misspelling of the word 'useful' in  associations.md

### DIFF
--- a/docs/api/associations.md
+++ b/docs/api/associations.md
@@ -10,7 +10,7 @@ on a model (the source), and prodiving another model as the first argument to th
 
 Creating an association will add a foreign key constraint to the attributes. All associations use `CASCADE` on update and `SET NULL` on delete, except for n:m, which also uses `CASCADE` on delete.
 
-When creating associations, you can provide an alias, via the `as` option. This is usefull if the same model
+When creating associations, you can provide an alias, via the `as` option. This is useful if the same model
 is associated twice, or you want your association to be called something other than the name of the target model.
 As an example, consider the case where users have many pictures, one of which is their profile picture. All pictures
 have a `userId`, but in addition the user model also has a `profilePictureId`, to be able to easily load the user's profile


### PR DESCRIPTION
Hi!

On line 13, 'useful' was misspelled as 'usefull'. It has now been changed to its proper spelling.

No other changes have been made to this document or the rest of the repo :)