### PR TITLE
fix: use new whereQuery in SQLlite updateQuery

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -177,7 +177,7 @@ module.exports = (function() {
 
       attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, options.omitNull, options);
 
-      var query  = "UPDATE <%= table %> SET <%= values %> WHERE <%= where %>"
+      var query  = "UPDATE <%= table %> SET <%= values %> <%= where %>"
         , values = [];
 
       for (var key in attrValueHash) {
@@ -188,10 +188,10 @@ module.exports = (function() {
       var replacements = {
         table: this.quoteTable(tableName),
         values: values.join(","),
-        where: this.getWhereConditions(where)
+        where: this.whereQuery(where)
       };
 
-      return Utils._.template(query)(replacements);
+      return Utils._.template(query)(replacements).trim();
     },
 
     deleteQuery: function(tableName, where, options) {


### PR DESCRIPTION
Looks like regression bug described in #3113 was still present in SQLite. This PR fixes that.