### PR TITLE
Allow Model.update() to handle unique constraints - Fixes #3474

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Next
 - [BUG] Fix for newlines in hstore [#3383](https://github.com/sequelize/sequelize/issues/3383)
+- [BUG] Fix unique key handling in Model.update [#3474](https://github.com/sequelize/sequelize/issues/3474)
 - [INTERNALS] Updated dependencies. Most notably we are moving up one major version on lodash. If you are using `sequelize.Utils._`, notice that the semantics for many matching functions have changed to include a check for `hasOwnProperty`
     + dottie@0.3.1
     + inflection@1.6.0

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -607,6 +607,7 @@ module.exports = (function() {
       , table = Utils._.isObject(tableName) ? tableName : { tableName: tableName }
       , daoTable = Utils._.find(this.sequelize.daoFactoryManager.daos, { tableName: table.tableName });
 
+    daoTable.__options = daoTable.options;
     return this.sequelize.query(sql, daoTable, options);
   };
 

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -317,6 +317,31 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
           });
         });
       });
+
+      it('should enforce a unque constraint', function() {
+        var Model = this.sequelize.define('model', {
+          uniqueName: { type: Sequelize.STRING, unique: true }
+        });
+        var records = [
+          { uniqueName: 'unique name one' },
+          { uniqueName: 'unique name two' }
+        ];
+        return Model.sync({ force: true })
+          .then(function() {
+            return Model.create(records[0]);
+          }).then(function(instance) {
+            expect(instance).to.be.ok;
+            return Model.create(records[1]);
+          }).then(function(instance) {
+            expect(instance).to.be.ok;
+            return expect(Model.update(records[0], { where: { id: instance.id } })).to.be.rejected;
+          }).then(function(err) {
+            expect(err).to.be.an.instanceOf(Error);
+            expect(err.errors).to.have.length(1);
+            expect(err.errors[0].path).to.include('uniqueName');
+            expect(err.errors[0].message).to.include('must be unique');
+          });
+      });
     });
 
     describe('#create', function() {


### PR DESCRIPTION
This fixes an issue that has been mentioned a few times about unique constraints not working when using `Model.update()`. I simply set `dao.__options` = `dao.options` and it didn't seem to cause any issue, however I wouldn't be opposed to doing an `||` check in each of the dialect implementations as mention in a previous PR (it just seemed like excessive work)