### PR TITLE
Sqlite: AUTOINCREMENT wasn't present in the create statement when field is primary key.

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -46,15 +46,16 @@ module.exports = (function() {
       for (var attr in attributes) {
         if (attributes.hasOwnProperty(attr)) {
           var dataType = attributes[attr];
+          var containsAutoIncrement = Utils._.includes(dataType, 'AUTOINCREMENT');
 
-          if (Utils._.includes(dataType, 'AUTOINCREMENT')) {
+          if (containsAutoIncrement) {
             dataType = dataType.replace(/BIGINT/, 'INTEGER');
           }
 
           var dataTypeString = dataType;
           if (Utils._.includes(dataType, 'PRIMARY KEY')) {
-            if (Utils._.includes(dataType, 'INTEGER')) {
-              dataTypeString = 'INTEGER PRIMARY KEY'; // Only INTEGER is allowed for primary key, see https://github.com/sequelize/sequelize/issues/969 (no lenght, unsigned etc)
+            if (Utils._.includes(dataType, 'INTEGER')) { // Only INTEGER is allowed for primary key, see https://github.com/sequelize/sequelize/issues/969 (no lenght, unsigned etc)
+              dataTypeString = containsAutoIncrement ? 'INTEGER PRIMARY KEY AUTOINCREMENT' : 'INTEGER PRIMARY KEY';
             }
 
             if (needsMultiplePrimaryKeys) {

--- a/test/integration/dialects/sqlite/query-generator.test.js
+++ b/test/integration/dialects/sqlite/query-generator.test.js
@@ -105,6 +105,10 @@ if (dialect === 'sqlite') {
         {
           arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)', otherId: 'INTEGER REFERENCES `otherTable` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION'}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255), `otherId` INTEGER REFERENCES `otherTable` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION);'
+        },
+        {
+          arguments: ['myTable', {id: 'INTEGER PRIMARY KEY AUTOINCREMENT', name: 'VARCHAR(255)'}],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255));'
         }
       ],
 


### PR DESCRIPTION
Given the following Employee:

     var Employee = sequelize.define("Employee", {
         id: {
             type: dataTypes.INTEGER,
             autoIncrement: true,
             primaryKey: true
         },
         name: dataTypes.STRING
     });

When the Sync() is called

Then I expect the following create statement:

     CREATE TABLE IF NOT EXISTS `Employees` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255));

But got:

     CREATE TABLE IF NOT EXISTS `Employees` (`id` INTEGER PRIMARY KEY, `name` VARCHAR(255));