### PR TITLE
Foreign languages used in the db might crash the app

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -112,7 +112,7 @@ module.exports = (function() {
       case 1062:
         match = err.message.match(/Duplicate entry '(.*)' for key '?((.|\s)*?)'?$/);
 
-        var values = match[1].split('-')
+        var values = match ? match[1].split('-') : undefined
           , fields = {}
           , message = 'Validation error'
           , uniqueKey = this.callee && this.callee.__options.uniqueKeys[match[2]];
@@ -142,7 +142,7 @@ module.exports = (function() {
 
         return new sequelizeErrors.ForeignKeyConstraintError({
           fields: null,
-          index: match[3],
+          index: match ? match[3] : undefined,
           parent: err
         });
 
@@ -151,7 +151,7 @@ module.exports = (function() {
 
         return new sequelizeErrors.ForeignKeyConstraintError({
           fields: null,
-          index: match[1],
+          index: match ? match[1] : undefined,
           parent: err
         });
 

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -354,8 +354,10 @@ module.exports = (function() {
 
     switch (code) {
       case '23503':
-        index = errMessage.match(/violates foreign key constraint \"(.+?)\"/)[1];
-        table = errMessage.match(/on table \"(.+?)\"/)[1];
+        index = errMessage.match(/violates foreign key constraint \"(.+?)\"/);
+        index = index ? index[1] : undefined;
+        table = errMessage.match(/on table \"(.+?)\"/);
+        table = table ? table[1] : undefined;
 
         return new sequelizeErrors.ForeignKeyConstraintError({
           fields: null,
@@ -404,7 +406,9 @@ module.exports = (function() {
       case '23P01':
         match = errDetail.match(/Key \((.*?)\)=\((.*?)\)/);
 
-        fields = Utils._.zipObject(match[1].split(', '), match[2].split(', '));
+        if (match) {
+          fields = Utils._.zipObject(match[1].split(', '), match[2].split(', '));
+        }
         message = 'Exclusion constraint error';
 
         return new sequelizeErrors.ExclusionConstraintError({


### PR DESCRIPTION
The error messages are not parsed in a multi language friendly way. If the database in use is not english, error messages are checked with a match that might fail. This fixes the app crash.

This is definitly not a very good solution but more a kind of a hotfix. After all some time should be invested to check if there's a better solution. I couldn't come up with a good regression test for this either. Probably the best way to write a regression test for this is to fake each error with a foreign language. I do not have the time for that right now though.