### PR TITLE
Set default transaction level to safest option

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - [FEATURE] Partial index support for Postgres with `index.where`
 - [DEPRECATED] The query-chainer is deprecated and will be removed in version 2.2. Please use promises instead.
 - [REMOVED] Events are no longer supported.
+- [FEATURE] The default transaction level has been changed from `REPEATABLE READ` to `SERIALIZABLE` as it is the safest possibility.
 
 #### Backwards compatibility changes
 - Events support have been removed so using `.on('succes')` or `.succes()` is no longer supported.

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1117,7 +1117,7 @@ module.exports = (function() {
 
    * @param {Object} [options={}]
    * @param {Boolean} [options.autocommit=true]
-   * @param {String} [options.isolationLevel='REPEATABLE READ'] See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
+   * @param {String} [options.isolationLevel='SERIALIZABLE'] See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options
    * @return {Promise}
    * @fires error If there is an uncaught error during the transaction
    * @fires success When the transaction has ended (either comitted or rolled back)

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -13,7 +13,7 @@ var Transaction = module.exports = function(sequelize, options) {
   this.savepoints = [];
   this.options = Utils._.extend({
     autocommit: true,
-    isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ
+    isolationLevel: Transaction.ISOLATION_LEVELS.SERIALIZABLE
   }, options || {});
   this.id = this.options.transaction ? this.options.transaction.id : Utils.generateUUID();
 


### PR DESCRIPTION
This commit changes the default transaction level to `SERIALIZABLE`
which is the safest option available and also the default of SQLite.

This change could be considered BC breaking.