### PR TITLE
Fix bug: the fields with undefined value should not be null when updatin...

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -231,7 +231,7 @@ var Utils = module.exports = {
       }
 
       // Field name mapping
-      if (Model.rawAttributes[attr] && Model.rawAttributes[attr].field && Model.rawAttributes[attr].field !== attr) {
+      if (Model.rawAttributes[attr] && Model.rawAttributes[attr].field && Model.rawAttributes[attr].field !== attr && values[attr] !== undefined) {
         values[Model.rawAttributes[attr].field] = values[attr];
         delete values[attr];
       }


### PR DESCRIPTION
Fix bug: the fields with undefined value should not be null when updating data

For example:

    var model = sequelize.define('account', {
      id: {
        type: Sequelize.INTEGER.UNSIGNED,
        autoIncrement: true,
        primaryKey: true
      },
      username: {
        type: Sequelize.STRING(40),
      },
      password: {
        type: Sequelize.STRING(32),
        field: 'passwd'
      }
    );
    model.update({username: 'amoa400'}, {where: {id: 1}}).done();

The sql generated by sequelize is `UPDATE account SET username="amoa400", passwd=NULL WHERE uid = 1;`, it's wrong.