### PR TITLE
Add new lock modes and consolidate chai config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ cache:
     - node_modules
 
 env:
-  - DB=mysql DIALECT=mysql
-  - DB=mysql DIALECT=postgres
-  - DB=mysql DIALECT=postgres-native
-  - DB=mysql DIALECT=sqlite
-  - DB=mysql DIALECT=mariadb
-  - DB=mysql DIALECT=mssql
+  - DIALECT=mysql
+  - DIALECT=postgres
+  - DIALECT=postgres-native
+  - DIALECT=sqlite
+  - DIALECT=mariadb
+  - DIALECT=mssql
 
 addons:
   postgresql: "9.4"

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Next
+- [FEATURE] Lock modes in Postgres now support `OF table`
+- [FEATURE] New transaction lock modes `FOR KEY SHARE` and `NO KEY UPDATE` for Postgres 9.3+
+
 # 2.1.0
 - [BUG] Enable standards conforming strings on connection in postgres. Adresses [#3545](https://github.com/sequelize/sequelize/issues/3545)
 - [BUG] instance.removeAssociation(s) do not fire the select query twice anymore
@@ -8,6 +12,8 @@
 - [REFACTOR] `.changed()` now works proactively by setting a flag on `set` instead of matching reactively. Note that objects and arrays will not be checked for equality on set and will always result in a change if they are `set`.
 - [DEPRECATED] The query-chainer is deprecated and will be removed in version 2.2. Please use promises instead.
 - [REMOVED] Events are no longer supported.
+- [INTERNALS] Updated dependencies.
+    + bluebird@2.9.24
 
 #### Backwards compatibility changes
 - Events support have been removed so using `.on('succes')` or `.succes()` is no longer supported.

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -221,7 +221,7 @@ The success listener is called with an array of instances if the query succeeds.
 | [options.offset] | Number |  |
 | [options.transaction] | Transaction |  |
 | [queryOptions] | Object | Set the query options, e.g. raw, specifying that you want raw data instead of built Instances. See sequelize.query for options |
-| [queryOptions.lock] | String | Lock the selected rows in either share or update mode. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. See [transaction.LOCK for an example](https://github.com/sequelize/sequelize/wiki/API-Reference-Transaction#LOCK)  |
+| [queryOptions.lock] | String|Object | Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](api/transaction#lock)  |
 
 __Aliases:__ all
 

--- a/docs/api/transaction.md
+++ b/docs/api/transaction.md
@@ -36,9 +36,27 @@ Model.findAll({
 }, {
   transaction: t1,
   lock: t1.LOCK.UPDATE,
-  lock: t1.LOCK.SHARE
+  lock: t1.LOCK.SHARE,
+  lock: t1.LOCK.KEY_SHARE, // Postgres 9.3+ only
+  lock: t1.LOCK.NO_KEY_SHARE // Postgres 9.3+ only
 })
 ```
+
+Postgres also supports specific locks while eager loading by using `OF`.
+
+```js
+UserModel.findAll({
+  where: ...,
+  include: [TaskModel, ...]
+}, {
+  transaction: t1,
+  lock: {
+    level: t1.LOCK...,
+    of: UserModel
+  }
+})
+```
+UserModel will be locked but TaskModel won't!
 
 ***
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1387,10 +1387,19 @@ module.exports = (function() {
       }
 
       if (options.lock && this._dialect.supports.lock) {
-        if (options.lock === 'SHARE') {
+        var lock = options.lock;
+        if (typeof options.lock === 'object') {
+          lock = options.lock.level;
+        }
+        if (this._dialect.supports.lockKey && (lock === 'KEY SHARE' || lock === 'NO KEY UPDATE')) {
+          query += ' FOR ' + lock;
+        } else if (lock === 'SHARE') {
           query += ' ' + this._dialect.supports.forShare;
         } else {
           query += ' FOR UPDATE';
+        }
+        if (this._dialect.supports.lockOf && options.lock.of instanceof Model) {
+          query += ' OF ' + this.quoteTable(options.lock.of.name);
         }
       }
 

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -33,6 +33,9 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(Abstract.prototype.supp
   },
   schemas: true,
   lock: true,
+  lockOf: true,
+  lockKey: true,
+  lockOuterJoinFailure: true,
   forShare: 'FOR SHARE',
   index: {
     concurrently: true,

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -58,14 +58,18 @@ Transaction.ISOLATION_LEVELS = {
  * }, {
  *   transaction: t1,
  *   lock: t1.LOCK.UPDATE,
- *   lock: t1.LOCK.SHARE
+ *   lock: t1.LOCK.SHARE,
+ *   lock: t1.LOCK.KEY_SHARE, // Postgres 9.3+ only
+ *   lock: t1.LOCK.NO_KEY_UPDATE // Postgres 9.3+ only
  * })
  * ```
  * @property LOCK
  */
 Transaction.LOCK = Transaction.prototype.LOCK = {
   UPDATE: 'UPDATE',
-  SHARE: 'SHARE'
+  SHARE: 'SHARE',
+  KEY_SHARE: 'KEY SHARE',
+  NO_KEY_UPDATE: 'NO KEY UPDATE'
 };
 
 /**

--- a/test/integration/associations/alias.test.js
+++ b/test/integration/associations/alias.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , Sequelize = require('../../../index')
   , Promise = Sequelize.Promise;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Alias'), function() {
   it('should uppercase the first letter in alias getter, but not in eager loading', function() {
     var User = this.sequelize.define('user', {})

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -12,8 +12,6 @@ var chai = require('chai')
   , current = Support.sequelize
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
   describe('getAssociations', function() {
     beforeEach(function() {

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -10,8 +10,6 @@ var chai = require('chai')
   , Promise = Sequelize.Promise
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('BelongsTo'), function() {
   describe('Model.associations', function() {
     it('should store all assocations when associting to the same table multiple times', function() {

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -13,8 +13,6 @@ var chai = require('chai')
   , current = Support.sequelize
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('HasMany'), function() {
   describe('Model.associations', function() {
     it('should store all assocations when associting to the same table multiple times', function() {

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , Promise = Sequelize.Promise
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('HasOne'), function() {
   describe('Model.associations', function() {
     it('should store all assocations when associting to the same table multiple times', function() {

--- a/test/integration/associations/multiple-level-filters.test.js
+++ b/test/integration/associations/multiple-level-filters.test.js
@@ -5,8 +5,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/../support')
   , DataTypes = require(__dirname + '/../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Multiple Level Filters'), function() {
   it('can filter through belongsTo', function() {
     var User = this.sequelize.define('User', {username: DataTypes.STRING })

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , Sequelize = require('../../../index')
   , Promise = Sequelize.Promise;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('associations'), function() {
   describe('scope', function() {
     beforeEach(function() {

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -9,8 +9,6 @@ var chai = require('chai')
   , Promise = Sequelize.Promise
   , _ = require('lodash');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Self'), function() {
   it('supports freezeTableName', function() {
     var Group = this.sequelize.define('Group', {}, {

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -10,8 +10,6 @@ var chai      = require('chai')
   , cls       = require('continuation-local-storage')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 if (current.dialect.supports.transactions) {
   describe(Support.getTestDialectTeaser('Continuation local storage'), function () {
     before(function () {

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , dialect = Support.getTestDialect()
   , Sequelize = require(__dirname + '/../../index');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Configuration'), function() {
   describe('Connections problems should fail with a nice message', function() {
     it('when we don\'t have the correct server details', function() {

--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -11,8 +11,6 @@ var chai = require('chai')
   , _ = require('lodash')
   , Promise = require(__dirname + '/../../../../lib/promise');
 
-chai.config.includeStack = true;
-
 var baseConf = Config[Support.getTestDialect()];
 var poolEntry = {
   host: baseConf.host,

--- a/test/integration/dialects/mysql/associations.test.js
+++ b/test/integration/dialects/mysql/associations.test.js
@@ -6,8 +6,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/../../support')
   , DataTypes = require(__dirname + '/../../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 if (Support.dialectIsMySQL()) {
   describe('[MYSQL Specific] Associations', function() {
     describe('many-to-many', function() {
@@ -45,7 +43,6 @@ if (Support.dialectIsMySQL()) {
         });
       });
     });
-
 
     describe('HasMany', function() {
       beforeEach(function() {

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , sinon = require('sinon')
   , DataTypes = require(__dirname + '/../../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 if (Support.dialectIsMySQL()) {
   describe('[MYSQL Specific] Connector Manager', function() {
     it('works correctly after being idle', function() {

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
   , config = require(__dirname + '/../../../config/config');
 
-chai.config.includeStack = true;
-
 if (Support.dialectIsMySQL()) {
   describe('[MYSQL Specific] DAOFactory', function() {
     describe('constructor', function() {

--- a/test/integration/dialects/mysql/query-generator.test.js
+++ b/test/integration/dialects/mysql/query-generator.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , _ = require('lodash')
   , QueryGenerator = require('../../../../lib/dialects/mysql/query-generator');
 
-chai.config.includeStack = true;
-
 if (Support.dialectIsMySQL()) {
   describe('[MYSQL Specific] QueryGenerator', function() {
     var suites = {

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , config = require(__dirname + '/../../../config/config')
   , DataTypes = require(__dirname + '/../../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] associations', function() {
     describe('many-to-many', function() {

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -9,8 +9,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
   , sequelize = require(__dirname + '/../../../../lib/sequelize');
 
-chai.config.includeStack = true;
-
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] DAO', function() {
     beforeEach(function() {

--- a/test/integration/dialects/postgres/error.test.js
+++ b/test/integration/dialects/postgres/error.test.js
@@ -8,8 +8,6 @@ var chai      = require('chai')
   , dialect   = Support.getTestDialect()
   , _ = require('lodash');
 
-chai.config.includeStack = true;
-
 if (dialect.match(/^postgres/)) {
   var constraintName = 'overlap_period';
   beforeEach(function () {

--- a/test/integration/dialects/postgres/hstore.test.js
+++ b/test/integration/dialects/postgres/hstore.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , dialect = Support.getTestDialect()
   , hstore = require('../../../../lib/dialects/postgres/hstore');
 
-chai.config.includeStack = true;
-
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] hstore', function() {
     describe('stringify', function() {

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -11,8 +11,6 @@ var chai = require('chai')
   , current = Support.sequelize
   , _ = require('lodash');
 
-chai.config.includeStack = true;
-
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] QueryGenerator', function() {
     beforeEach(function() {

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -7,8 +7,6 @@ var chai    = require('chai')
   , dialect = Support.getTestDialect()
   , range   = require('../../../../lib/dialects/postgres/range');
 
-chai.config.includeStack = true;
-
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] range datatype', function () {
     describe('stringify', function () {

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -9,8 +9,6 @@ var chai = require('chai')
   , dbFile = __dirname + '/test.sqlite'
   , storages = [dbFile];
 
-chai.config.includeStack = true;
-
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAOFactory', function() {
     after(function() {

--- a/test/integration/dialects/sqlite/dao.test.js
+++ b/test/integration/dialects/sqlite/dao.test.js
@@ -6,8 +6,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAO', function() {
     beforeEach(function() {

--- a/test/integration/dialects/sqlite/query-generator.test.js
+++ b/test/integration/dialects/sqlite/query-generator.test.js
@@ -10,8 +10,6 @@ var chai = require('chai')
   , moment = require('moment')
   , QueryGenerator = require('../../../../lib/dialects/sqlite/query-generator');
 
-chai.config.includeStack = true;
-
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] QueryGenerator', function() {
     beforeEach(function() {

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -8,8 +8,6 @@ var chai      = require('chai')
   , Support   = require(__dirname + '/support')
   , Sequelize = Support.Sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Sequelize Errors'), function () {
   describe('API Surface', function() {
 

--- a/test/integration/hooks.test.js
+++ b/test/integration/hooks.test.js
@@ -9,8 +9,6 @@ var chai = require('chai')
   , sinon = require('sinon')
   , dialect   = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Hooks'), function() {
   describe('#validate', function() {
     describe('via define', function() {
@@ -3937,7 +3935,6 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           fn();
         });
 
-
         return this.User.bulkCreate([
           {aNumber: 1}, {aNumber: 1}, {aNumber: 1}
         ]).then(function() {
@@ -5120,7 +5117,6 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
                 , beforeMiniTask = false
                 , afterMiniTask = false;
 
-
               this.Projects.beforeCreate(function(project, options, fn) {
                 beforeProject = true;
                 fn();
@@ -5177,7 +5173,6 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
                 , beforeMiniTask = false
                 , afterMiniTask = false;
 
-
               this.Projects.beforeCreate(function(project, options, fn) {
                 beforeProject = true;
                 fn();
@@ -5228,7 +5223,6 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
         });
       });
 
-
       describe('multiple 1:M sequential hooks', function () {
         describe('cascade', function() {
           beforeEach(function() {
@@ -5265,7 +5259,6 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
                 , beforeMiniTask = false
                 , afterMiniTask = false;
 
-
               this.Projects.beforeCreate(function(project, options, fn) {
                 beforeProject = true;
                 fn();
@@ -5295,7 +5288,6 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
                 afterMiniTask = true;
                 fn();
               });
-
 
               return this.sequelize.Promise.all([
                 this.Projects.create({title: 'New Project'}),

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -10,8 +10,6 @@ var chai = require('chai')
   , _ = require('lodash')
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 var sortById = function(a, b) {
   return a.id < b.id ? -1 : 1;
 };
@@ -191,8 +189,8 @@ describe(Support.getTestDialectTeaser('Include'), function() {
         , Groups
         , Users;
 
-      Groups = User.belongsToMany(Group);
-      Users = Group.belongsToMany(User);
+      Groups = User.belongsToMany(Group, { through: 'UserGroup' });
+      Users = Group.belongsToMany(User), { through: 'UserGroup' };
 
       return this.sequelize.sync({force: true}).then(function () {
         return User.create().then(function (user) {

--- a/test/integration/include/find.test.js
+++ b/test/integration/include/find.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , Promise = Sequelize.Promise
   , DataTypes = require(__dirname + '/../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Include'), function() {
   describe('find', function() {
     it('should include a non required model, with conditions and two includes N:M 1:M', function( ) {

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -9,8 +9,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../lib/data-types')
   , Promise = Sequelize.Promise;
 
-chai.config.includeStack = true;
-
 var sortById = function(a, b) {
   return a.id < b.id ? -1 : 1;
 };
@@ -221,7 +219,6 @@ describe(Support.getTestDialectTeaser('Include'), function() {
 
       Category.hasMany(SubCategory, {foreignKey: 'boundCategory'});
       SubCategory.belongsTo(Category, {foreignKey: 'boundCategory'});
-
 
       return this.sequelize.sync({force: true}).then(function() {
         return User.find({
@@ -1455,7 +1452,6 @@ describe(Support.getTestDialectTeaser('Include'), function() {
         });
       });
     });
-
 
     it('should be possible to select on columns inside a through table', function() {
       var self = this;

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -6,8 +6,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../lib/data-types')
   , Promise = require('bluebird');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Include'), function() {
   describe('findAndCountAll', function() {
     it('should be able to include a required model. Result rows should match count', function() {

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -5,8 +5,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/../support')
   , DataTypes = require(__dirname + '/../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Paranoid'), function() {
 
   beforeEach(function( ) {

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -9,8 +9,6 @@ var chai = require('chai')
   , Promise = Sequelize.Promise
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 var sortById = function(a, b) {
   return a.id < b.id ? -1 : 1;
 };

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -13,9 +13,6 @@ var chai = require('chai')
   , uuid = require('node-uuid')
   , current = Support.sequelize;
 
-chai.should();
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Instance'), function() {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/support')
   , config = require(__dirname + '/../config/config');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
   describe('validations', function() {
     var checks = {

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -11,8 +11,6 @@ var chai = require('chai')
   , config = require(__dirname + '/../../config/config')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Instance'), function() {
   describe('update', function() {
     beforeEach(function () {

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , dialect = Support.getTestDialect()
   , DataTypes = require(__dirname + '/../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('DAO'), function() {
   describe('Values', function() {
     describe('set', function() {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -13,8 +13,6 @@ var chai = require('chai')
   , moment = require('moment')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {

--- a/test/integration/model/and-or-where.test.js
+++ b/test/integration/model/and-or-where.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../lib/data-types')
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -6,8 +6,6 @@ var chai = require('chai')
   , expect = chai.expect
   , Support = require(__dirname + '/../support');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('attributes', function() {
     describe('set', function() {

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -9,8 +9,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('attributes', function() {
     describe('field', function() {
@@ -495,7 +493,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           expect(comment.get('notes')).to.equal('Barfoo');
         });
       });
-
 
       it('should work with with an belongsTo association getter', function() {
         var userId = Math.floor(Math.random() * 100000);

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/../../support')
   , dialect = Support.getTestDialect();
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('attributes', function() {
     describe('types', function() {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -14,8 +14,6 @@ var chai = require('chai')
   , assert = require('assert')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   beforeEach(function() {
     return Support.prepareTransactionTest(this.sequelize).bind(this).then(function(sequelize) {
@@ -1575,7 +1573,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         schema: 'space1',
         tableName: 'Dummy'
       });
-
 
       return this.sequelize.dropAllSchemas().bind(this).then(function() {
         return this.sequelize.createSchema('space1');

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/../../support')
   , DataTypes = require(__dirname + '/../../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('create', function() {
     describe('include', function() {
@@ -182,7 +180,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
 
         var Job = User.hasOne(Task, {as: 'job'});
-
 
 
         return this.sequelize.sync({ force: true }).then(function() {

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -12,8 +12,6 @@ var chai = require('chai')
   , config = require(__dirname + '/../../config/config')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -14,8 +14,6 @@ var chai = require('chai')
   , moment = require('moment')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('findAll', function () {
     describe('order', function () {

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -10,8 +10,6 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../lib/data-types')
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   if (current.dialect.supports.JSONB) {
     describe('JSONB', function () {

--- a/test/integration/model/scopes.test.js
+++ b/test/integration/model/scopes.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/../support')
   , DataTypes = require(__dirname + '/../../../lib/data-types');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   beforeEach(function() {
     return Support.prepareTransactionTest(this.sequelize).bind(this).then(function(sequelize) {

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -10,8 +10,6 @@ var chai = require('chai')
   , dialect = Support.getTestDialect()
   , current = Support.sequelize;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Model'), function() {
   beforeEach(function() {
     this.User = this.sequelize.define('user', {

--- a/test/integration/plugins/counter-cache.test.js
+++ b/test/integration/plugins/counter-cache.test.js
@@ -8,8 +8,6 @@ var chai = require('chai')
   , Sequelize = require('../../../index')
   , Promise = Sequelize.Promise;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('CounterCache'), function() {
   it('adds an integer column', function() {
     var User = this.sequelize.define('User', {})

--- a/test/integration/query-chainer.test.js
+++ b/test/integration/query-chainer.test.js
@@ -7,8 +7,6 @@ var chai = require('chai')
   , QueryChainer = require('../../lib/query-chainer')
   , CustomEventEmitter;
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('QueryChainer'), function() {
 
   before(function() {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -15,8 +15,6 @@ var chai = require('chai')
     }
   };
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('QueryInterface'), function() {
   beforeEach(function() {
     this.sequelize.options.quoteIdenifiers = true;
@@ -206,7 +204,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
         }
       });
     });
-
 
     it('should work with schemas', function() {
       var self = this;

--- a/test/integration/schema.test.js
+++ b/test/integration/schema.test.js
@@ -6,8 +6,6 @@ var chai = require('chai')
   , Support = require(__dirname + '/support')
   , DataTypes = require(__dirname + '/../../lib/data-types');
 
-chai.config.includeStack = true;
-
 describe(Support.getTestDialectTeaser('Schema'), function() {
   beforeEach(function() {
     return this.sequelize.createSchema('testschema');

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -17,8 +17,6 @@ var chai = require('chai')
   , current = Support.sequelize;
 
 
-chai.config.includeStack = true;
-
 var qq = function(str) {
   if (dialect === 'postgres' || dialect === 'sqlite' || dialect === 'mssql') {
     return '"' + str + '"';
@@ -611,7 +609,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       // This DAO inherits the global methods
       DAO.overrideMe();
       DAO.build().overrideMe();
-
 
       DAO = sequelize.define('foo', {bar: DataTypes.STRING}, {
         classMethods: {

--- a/test/integration/sequelize/log.test.js
+++ b/test/integration/sequelize/log.test.js
@@ -2,13 +2,9 @@
 
 /* jshint -W030 */
 var chai = require('chai')
-  , sinonChai = require('sinon-chai')
   , sinon = require('sinon')
   , expect = chai.expect
   , Support = require(__dirname + '/../support');
-
-chai.use(sinonChai);
-chai.config.includeStack = true;
 
 describe(Support.getTestDialectTeaser('Sequelize'), function() {
   describe('log', function() {

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -3,13 +3,9 @@
 /* jshint -W030 */
 /* jshint -W110 */
 var chai = require('chai')
-  , spies = require('chai-spies')
   , expect = chai.expect
   , Utils = require(__dirname + '/../../lib/utils')
   , Support = require(__dirname + '/support');
-
-chai.use(spies);
-chai.config.includeStack = true;
 
 describe(Support.getTestDialectTeaser('Utils'), function() {
   describe('removeCommentsFromFunctionString', function() {

--- a/test/support.js
+++ b/test/support.js
@@ -9,8 +9,12 @@ var fs = require('fs')
   , chai = require('chai')
   , expect = chai.expect;
 
+chai.use(require('chai-spies'));
 chai.use(require('chai-datetime'));
 chai.use(require('chai-as-promised'));
+chai.use(require('sinon-chai'));
+chai.config.includeStack = true;
+chai.should();
 
 // Make sure errors get thrown when testing
 Sequelize.Promise.onPossiblyUnhandledRejection(function(e, promise) {

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -216,7 +216,6 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         sqlite: 'FLOAT UNSIGNED ZEROFILL(11)'
       });
 
-
       testsql('FLOAT(11, 12)', DataTypes.FLOAT(11, 12), {
         default: 'FLOAT(11,12)'
       });

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -37,7 +37,6 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
 
-
     test('function', function () {
       expectsql(sql.addIndexQuery('table', [current.fn('UPPER', current.col('test'))], { name: 'myindex'}), {
         default: 'CREATE INDEX [myindex] ON [table] (UPPER([test]))'


### PR DESCRIPTION
This inserts two new lock levels for postgres and adds specific table locks (SELECT ... FOR ... OF table). 

Besides that I also consolidated the chai config, so it's always available in every test file.