### PR TITLE
With dialecets in postgres, removeColumn currently fails.  This fixes it

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -222,7 +222,7 @@ module.exports = (function() {
     removeColumnQuery: function(tableName, attributeName) {
       var query = 'ALTER TABLE <%= tableName %> DROP COLUMN <%= attributeName %>;';
       return Utils._.template(query)({
-        tableName: this.quoteIdentifiers(tableName),
+        tableName: this.quoteTable(tableName),
         attributeName: this.quoteIdentifier(attributeName)
       });
     },


### PR DESCRIPTION
If you were to run a migration like this:

```javascript
  down: function (queryInterface, Sequelize) {
    return queryInterface
      .removeColumn(
        {
          tableName: 'test_table',
          schema: 'awesome_schema'
        },
        'name'
      );
  }
```

A migration down gives an error:
```
Possibly unhandled TypeError: Object #<Object> has no method 'indexOf'
    at Object.module.exports.QueryGenerator.quoteIdentifiers (/Users/petemertz1/dev/lynx-core/node_modules/sequelize/lib/dialects/abstract/query-generator.js:752:23)
    at Object.module.exports.QueryGenerator.removeColumnQuery (/Users/petemertz1/dev/lynx-core/node_modules/sequelize/lib/dialects/postgres/query-generator.js:227:25)
    at module.exports.QueryInterface.removeColumn (/Users/petemertz1/dev/lynx-core/node_modules/sequelize/lib/query-interface.js:361:37)
    at Object.module.exports.down (/Users/petemertz1/dev/lynx-core/migrations/20150425150318-add-customer-id-to-customer-event.js:19:8)
    at module.exports.redefine.Class._exec (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/umzug/lib/migration.js:49:23)
    at module.exports.redefine.Class.down (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/umzug/lib/migration.js:37:17)
    at null.<anonymous> (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/umzug/index.js:78:28)
    at Object.tapHandler (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/finally.js:64:31)
    at Object.tryCatcher (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/util.js:24:31)
    at Promise._settlePromiseFromHandler (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/promise.js:454:31)
    at Promise._settlePromiseAt (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/promise.js:530:18)
    at Promise._settlePromises (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/promise.js:646:14)
    at Async._drainQueue (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/async.js:175:16)
    at Async._drainQueues (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/async.js:185:10)
    at Async.drainQueues (/Users/petemertz1/.nvm/v0.10.35/lib/node_modules/sequelize-cli/node_modules/bluebird/js/main/async.js:15:14)
    at process._tickCallback (node.js:442:13)
```

This puts it inline with the other migration functions and fixes the issue.