### PR TITLE
Attempt to add Geometry datatype support for PostgreSQL (PostGis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ addons:
 
 before_script:
   - "mysql -e 'create database sequelize_test;'"
-  - "psql -c 'create database sequelize_test; create extension postgis;' -U postgres"
+  - "psql -c 'create database sequelize_test;' -U postgres"
+  - "psql -c 'create extension postgis;' -U postgres"
 
 script:
   - "make test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ addons:
 
 before_script:
   - "mysql -e 'create database sequelize_test;'"
-  - "psql -c 'create database sequelize_test;' -U postgres"
-  - psql -U postgres -c "create extension postgis"
+  - "psql -c 'create database sequelize_test; create extension postgis;' -U postgres"
 
 script:
   - "make test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ addons:
 before_script:
   - "mysql -e 'create database sequelize_test;'"
   - "psql -c 'create database sequelize_test;' -U postgres"
+  - psql -U postgres -c "create extension postgis"
 
 script:
   - "make test"

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -526,6 +526,30 @@ ARRAY.is = function(obj, type) {
   return obj instanceof ARRAY && obj.type instanceof type;
 };
 
+var GEOMETRY = function(type, srid) {
+  var options = typeof type === 'object' && type || {
+    type: type,
+    srid: srid
+  };
+
+  if (!(this instanceof GEOMETRY)) return new GEOMETRY(options);
+
+  this.options = options;
+  this._type = options.type;
+  this._srid = options.srid || 4326;
+};
+util.inherits(GEOMETRY, ABSTRACT);
+
+GEOMETRY.prototype.key = GEOMETRY.key = 'GEOMETRY';
+GEOMETRY.prototype.toSql = function() {
+  var result = this.key;
+  result += '(' + this._type;
+  if(this._srid){
+      result += ',' + this._srid;
+  }
+  result += ')';
+  return result;
+};
 
 var helpers = {
   BINARY: [STRING, CHAR],
@@ -576,5 +600,6 @@ module.exports = {
   ARRAY: ARRAY,
   NONE: VIRTUAL,
   ENUM: ENUM,
-  RANGE: RANGE
+  RANGE: RANGE,
+  GEOMETRY: GEOMETRY
 };

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -535,19 +535,25 @@ var GEOMETRY = function(type, srid) {
   if (!(this instanceof GEOMETRY)) return new GEOMETRY(options);
 
   this.options = options;
-  this._type = options.type;
-  this._srid = options.srid || 4326;
+  this.type = options.type;
+  this.srid = options.srid;
 };
 util.inherits(GEOMETRY, ABSTRACT);
 
 GEOMETRY.prototype.key = GEOMETRY.key = 'GEOMETRY';
 GEOMETRY.prototype.toSql = function() {
   var result = this.key;
-  result += '(' + this._type;
-  if(this._srid){
-      result += ',' + this._srid;
+
+  if (this.type){
+    result += '(' + this.type;
+
+    if (this.srid){
+      result += ',' + this.srid;
+    }
+
+    result += ')';
   }
-  result += ')';
+  
   return result;
 };
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -885,7 +885,6 @@ module.exports = (function() {
 
       // Escape attributes
       mainAttributes = mainAttributes && mainAttributes.map(function(attr) {
-	console.log(attr);
         var addTable = true;
 
         if (attr._isSequelizeMethod) {
@@ -902,7 +901,7 @@ module.exports = (function() {
             }
           }
           attr = [attr[0], self.quoteIdentifier(attr[1])].join(' AS ');
-        } else if (model._isGeometryAttribute(attr)){
+        } else if (mainModel && mainModel._isGeometryAttribute(attr)){
           attr = 'ST_AsGeoJSON('+self.quoteIdentifiers(attr)+') AS '+ self.quoteIdentifiers(attr);
         } else {
           attr = attr.indexOf(Utils.TICK_CHAR) < 0 && attr.indexOf('"') < 0 ? self.quoteIdentifiers(attr) : attr;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -885,6 +885,7 @@ module.exports = (function() {
 
       // Escape attributes
       mainAttributes = mainAttributes && mainAttributes.map(function(attr) {
+	console.log(attr);
         var addTable = true;
 
         if (attr._isSequelizeMethod) {
@@ -901,6 +902,8 @@ module.exports = (function() {
             }
           }
           attr = [attr[0], self.quoteIdentifier(attr[1])].join(' AS ');
+        } else if (model._isGeometryAttribute(attr)){
+          attr = 'ST_AsGeoJSON('+self.quoteIdentifiers(attr)+') AS '+ self.quoteIdentifiers(attr);
         } else {
           attr = attr.indexOf(Utils.TICK_CHAR) < 0 && attr.indexOf('"') < 0 ? self.quoteIdentifiers(attr) : attr;
         }

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -80,11 +80,6 @@ BLOB.prototype.toSql = function() {
   return 'BYTEA';
 };
 
-var GEOMETRY = function() {
-  BaseTypes.GEOMETRY.apply(this, arguments);
-};
-util.inherits(GEOMETRY, BaseTypes.GEOMETRY);
-
 module.exports = {
   STRING: STRING,
   CHAR: CHAR,

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -80,6 +80,11 @@ BLOB.prototype.toSql = function() {
   return 'BYTEA';
 };
 
+var GEOMETRY = function() {
+  BaseTypes.GEOMETRY.apply(this, arguments);
+};
+util.inherits(GEOMETRY, BaseTypes.GEOMETRY);
+
 module.exports = {
   STRING: STRING,
   CHAR: CHAR,

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -893,7 +893,7 @@ module.exports = (function() {
         return 'ARRAY[' + value.map(function (v) {
           return SqlString.escape(JSON.stringify(v), false, this.options.timezone, this.dialect, field);
         }, this).join(',') + ']::JSON[]';
-      } else if (field && (field.type instanceof DataTypes.GEOMETRY || field.type instanceof DataTypes.GEOMETRY)) {
+      } else if (field && field.type instanceof DataTypes.GEOMETRY) {
         return "ST_GeomFromGeoJSON('"+JSON.stringify(value)+"')";
       }
 

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -893,6 +893,8 @@ module.exports = (function() {
         return 'ARRAY[' + value.map(function (v) {
           return SqlString.escape(JSON.stringify(v), false, this.options.timezone, this.dialect, field);
         }, this).join(',') + ']::JSON[]';
+      } else if (field && (field.type instanceof DataTypes.GEOMETRY || field.type instanceof DataTypes.GEOMETRY)) {
+        return "ST_GeomFromText('"+field.type._type+"("+value.lon+" "+value.lat+")',"+field.type._srid+")";
       }
 
       return SqlString.escape(value, false, this.options.timezone, this.dialect, field);

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -880,7 +880,7 @@ module.exports = (function() {
         } else if (DataTypes.ARRAY.is(field.type, DataTypes.HSTORE)) {
           return 'ARRAY[' + Utils._.map(value, function(v){return "'" + hstore.stringify(v) + "'::hstore";}).join(',') + ']::HSTORE[]';
         }
-      } else if(Utils._.isArray(value) && field && (field.type instanceof DataTypes.RANGE || DataTypes.ARRAY.is(field.type, DataTypes.RANGE))) {
+      } else if (Utils._.isArray(value) && field && (field.type instanceof DataTypes.RANGE || DataTypes.ARRAY.is(field.type, DataTypes.RANGE))) {
         if(field.type instanceof DataTypes.RANGE) { // escape single value
           return "'"  + range.stringify(value) + "'";
         }
@@ -894,7 +894,7 @@ module.exports = (function() {
           return SqlString.escape(JSON.stringify(v), false, this.options.timezone, this.dialect, field);
         }, this).join(',') + ']::JSON[]';
       } else if (field && (field.type instanceof DataTypes.GEOMETRY || field.type instanceof DataTypes.GEOMETRY)) {
-        return "ST_GeomFromText('"+field.type._type+"("+value.lon+" "+value.lat+")',"+field.type._srid+")";
+        return "ST_GeomFromGeoJSON('"+JSON.stringify(value)+"')";
       }
 
       return SqlString.escape(value, false, this.options.timezone, this.dialect, field);

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -343,7 +343,7 @@ module.exports = (function() {
           if (!options.raw) {
             // If attribute is not in model definition, return
             if (!this._isAttribute(key)) {
-              if (key.indexOf('.') > -1 && (this.Model._isJsonAttribute(key.split('.')[0])))) {
+              if (key.indexOf('.') > -1 && this.Model._isJsonAttribute(key.split('.')[0])) {
                 Dottie.set(this.dataValues, key, value);
                 this.changed(key, true);
               }
@@ -380,6 +380,13 @@ module.exports = (function() {
             } else if (_.isNumber(value)) {
               // Only take action on valid boolean integers.
               value = (value === 1) ? true : (value === 0) ? false : value;
+            }
+          }
+
+          // Convert geojson string fields to real geojson fields
+          if (this.Model._hasGeometryAttributes && this.Model._isGeometryAttribute(key) && value !== null && value !== undefined && !value._isSequelizeMethod) {
+            if(_.isString(value)){
+              value = JSON.parse(value);
             }
           }
 

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -343,7 +343,7 @@ module.exports = (function() {
           if (!options.raw) {
             // If attribute is not in model definition, return
             if (!this._isAttribute(key)) {
-              if (key.indexOf('.') > -1 && this.Model._isJsonAttribute(key.split('.')[0])) {
+              if (key.indexOf('.') > -1 && (this.Model._isJsonAttribute(key.split('.')[0])))) {
                 Dottie.set(this.dataValues, key, value);
                 this.changed(key, true);
               }

--- a/lib/model.js
+++ b/lib/model.js
@@ -283,6 +283,7 @@ module.exports = (function() {
     this._hstoreAttributes = [];
     this._rangeAttributes = [];
     this._jsonAttributes = [];
+    this._geometryAttributes = [];
     this._virtualAttributes = [];
     this._defaultValues = {};
     this.Instance.prototype.validators = {};
@@ -314,7 +315,10 @@ module.exports = (function() {
         self._jsonAttributes.push(name);
       } else if (definition.type instanceof DataTypes.VIRTUAL) {
         self._virtualAttributes.push(name);
+      } else if (definition.type instanceof DataTypes.GEOMETRY) {
+        self._geometryAttributes.push(name);
       }
+
 
       if (definition.hasOwnProperty('defaultValue')) {
         if (typeof definition.defaultValue === 'function' && (
@@ -370,6 +374,11 @@ module.exports = (function() {
     this._hasVirtualAttributes = !!this._virtualAttributes.length;
     this._isVirtualAttribute = Utils._.memoize(function(key) {
       return self._virtualAttributes.indexOf(key) !== -1;
+    });
+
+    this._hasGeometryAttributes = !!this._geometryAttributes.length;
+    this._isGeometryAttribute = Utils._.memoize(function(key) {
+      return self._geometryAttributes.indexOf(key) !== -1;
     });
 
     this._hasDefaultValues = !Utils._.isEmpty(this._defaultValues);

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -282,6 +282,33 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
 
+    suite('GEOMETRY', function () {
+      testsql('GEOMETRY', DataTypes.GEOMETRY, {
+        default: 'GEOMETRY',
+        postgres: 'GEOMETRY'
+      });
+	
+      testsql('GEOMETRY(\'POINT\')', DataTypes.GEOMETRY('POINT'), {
+        default: 'GEOMETRY(POINT)',
+        postgres: 'GEOMETRY(POINT)'
+      });
+
+      testsql('GEOMETRY(\'LINESTRING\')', DataTypes.GEOMETRY('LINESTRING'), {
+        default: 'GEOMETRY(LINESTRING)',
+        postgres: 'GEOMETRY(LINESTRING)',
+      });
+
+      testsql('GEOMETRY(\'POLYGON\')', DataTypes.GEOMETRY('POLYGON'), {
+        default: 'GEOMETRY(POLYGON)',
+        postgres: 'GEOMETRY(POLYGON)'
+      });
+
+      testsql('GEOMETRY(\'POINT\',4326)', DataTypes.GEOMETRY('POINT', 4326), {
+        default: 'GEOMETRY(POINT,4326)',
+        postgres: 'GEOMETRY(POINT,4326)'
+      });
+    });
+
     if (current.dialect.supports.ARRAY) {
       suite('ARRAY', function () {
         testsql('ARRAY(VARCHAR)', DataTypes.ARRAY(DataTypes.STRING), {


### PR DESCRIPTION
As discussed on https://github.com/sequelize/sequelize/issues/2839, it would be nice to have this feature on sequelize. Particulary I'm working in a project using sequelize that needs to be able to insert and retrieve geographic data from PostgreSQL with <a href="http://postgis.net/">PostGIS</a>. So I made a fork of the sequelize and tried to insert some initial steps to achive this functionality.

Basicaly was created a new datatype GEOMETRY and some of the functions were adapted to store geometries using GeoJSON objects (<a href="http://www.postgis.org/docs/ST_AsGeoJSON.html">ST_GeomFromGeoJSON</a>) and retrieve them as GeoJSON (<a href="http://postgis.org/docs/ST_GeomFromGeoJSON.html">ST_AsGeoJSON</a>).

The new datatype created is based on <a href="http://postgis.net/docs/AddGeometryColumn.html">Geometry Type Definition</a> syntax added on PostGIS version 2.0.0:

<code>Sequelize.GEOMETRY(geometry_type::asString)</code>
Allows the method .sync() to create a new column of the type Geometry(geometry_type), which by default on PostGIS has srid equals -1.

<code>Sequelize.GEOMETRY(geometry_type::asString, srid::asNumber)</code>
Allows the method .sync() to create a column of type Geometry(geometry_type, srid).

<code>postgres.QueryGenerator.escape()</code>
Was modified to "escape" geometry data using PostGIS function ST_GeomFromGeoJSON.

<code>abstract.QueryGenerator.selectQuery()</code>
Was modified to retrieve data as GeoJSON using PostGIS function ST_AsGeoJSON.

<code>Instance.prototype.set()</code>
Was modified to parse GeoJSON object as JSON.

Model now has a vector called <code>_geometryAttributes</code>, a function called <code>_hasGeometryAttributes</code> and a function called <code>_isGeometryAttribute</code>.

As a first attempt it still needs some tests and adjustments, so i'm sharing it now to have some feedback and ideas on the changes that are needed.