### PR TITLE
add hint at migration path to `.then` to 2.1.0 notes.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@
     + bluebird@2.9.24
 
 #### Backwards compatibility changes
-- Events support have been removed so using `.on('success')` or `.success()` is no longer supported.
+- Events support have been removed so using `.on('success')` or `.success()` is no longer supported. Try using `.then()` instead.
 - Trying to apply a scope that does not exist will always throw an error
 
 # 2.0.6

--- a/changelog.md
+++ b/changelog.md
@@ -17,7 +17,7 @@
     + bluebird@2.9.24
 
 #### Backwards compatibility changes
-- Events support have been removed so using `.on('succes')` or `.succes()` is no longer supported.
+- Events support have been removed so using `.on('success')` or `.success()` is no longer supported.
 - Trying to apply a scope that does not exist will always throw an error
 
 # 2.0.6


### PR DESCRIPTION
* first commit fixes a typo in the changelog
* second commit adds a hint at a migration path from `.success` to `.then` to the notes for the 2.1.0 release.