### PR TITLE
Update sqlite dev dependency to fix an issue with nan and travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg-native": "^1.8.0",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0",
-    "sqlite3": "^3.0.5",
+    "sqlite3": "^3.0.6",
     "tedious": "^1.7.0",
     "watchr": "~2.4.11"
   },


### PR DESCRIPTION
This should fix the issue that iojs 2.0 does not run the sqlite tests on travis.
Reference #3653