### PR TITLE
Fix transactions not rolling back properly

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1142,18 +1142,18 @@ module.exports = (function() {
           var result = autoCallback(transaction);
           if (!result || !result.then) return reject(new Error('You need to return a promise chain/thenable to the sequelize.transaction() callback'));
 
-          result.then(function (result) {
+          return result.then(function (result) {
             return transaction.commit().then(function () {
               resolve(result);
             });
-          }).then(null, function (err) {
-            transaction.rollback().then(function () {
-              reject(err);
-            }, function () {
-              reject(err);
-            });
           });
-        }).catch(reject);
+        }).catch(function(err) {
+          transaction.rollback().then(function () {
+            reject(err);
+          }, function () {
+            reject(err);
+          });
+        });
       };
 
       if (ns) {

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -45,9 +45,13 @@ describe(Support.getTestDialectTeaser('Transaction'), function() {
       });
     });
     it('supports automatically rolling back with a thrown error', function() {
-      return expect(this.sequelize.transaction(function() {
+      var t;
+      return (expect(this.sequelize.transaction(function(transaction) {
+        t = transaction;
         throw new Error('Yolo');
-      })).to.eventually.be.rejected;
+      })).to.eventually.be.rejected).then(function() {
+        expect(t.finished).to.be.equal('rollback');
+      });
     });
     it('supports automatically rolling back with a rejection', function() {
       return expect(this.sequelize.transaction(function() {


### PR DESCRIPTION
The pool of transactions will be drained if errors occur in the transaction block. 

Without the patch the following will result in:
```javascript
sequelize.transactions(function(t) {
    throw new Error('test');
});
```
Executing (280fa819-4f22-4c4d-a511-3a262e1040a0): START TRANSACTION;
Executing (280fa819-4f22-4c4d-a511-3a262e1040a0): SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
Executing (280fa819-4f22-4c4d-a511-3a262e1040a0): SET autocommit = 1;

----
Missing: `Executing (280fa819-4f22-4c4d-a511-3a262e1040a0): ROLLBACK;`