### PR TITLE
Fix CLS propagation for all Bluebird methods

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -11,8 +11,10 @@ function shimCLS(object, functionName, fnArgs){
       if (Promise.Sequelize && Promise.Sequelize.cls) {
         var ns = Promise.Sequelize.cls;
         for(var x=0; x<fnArgs.length; x++) {
-          var argIndex = x < 0 ? arguments.length + x : x;
-          if ( argIndex < arguments.length && typeof arguments[argIndex] === 'function' ) arguments[argIndex] = ns.bind( arguments[argIndex] );
+          var argIndex = fnArgs[x] < 0 ? arguments.length + fnArgs[x] : fnArgs[x];
+          if ( argIndex < arguments.length && typeof arguments[argIndex] === 'function' ) {
+            arguments[argIndex] = ns.bind( arguments[argIndex] );
+          }
         }
       }
 
@@ -23,8 +25,6 @@ function shimCLS(object, functionName, fnArgs){
 
 // Core
 shimCLS(Promise, 'join', [-1]);
-shimCLS(Promise, 'try', [0]);
-shimCLS(Promise, 'method', [0]);
 shimCLS(Promise.prototype, 'then', [0, 1, 2]);
 shimCLS(Promise.prototype, 'spread', [0, 1]);
 shimCLS(Promise.prototype, 'catch', [-1]);
@@ -39,6 +39,5 @@ shimCLS(Promise.prototype, 'each', [0]);
 
 // Utility
 shimCLS(Promise.prototype, 'tap', [0]);
-
 
 module.exports = Promise;

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,17 +1,44 @@
 'use strict';
 
 var Promise = require('bluebird')
-  , _then = Promise.prototype._then;
+  , shimmer = require('shimmer');
 
-Promise.prototype._then = function (didFulfill, didReject, didProgress, receiver, internalData) {
-  if (Promise.Sequelize.cls) {
-    var ns = Promise.Sequelize.cls;
-    if (typeof didFulfill === 'function') didFulfill = ns.bind(didFulfill);
-    if (typeof didReject === 'function') didReject = ns.bind(didReject);
-    if (typeof didProgress === 'function') didProgress = ns.bind(didProgress);
-  }
-  
-  return _then.call(this, didFulfill, didReject, didProgress, receiver, internalData);
-};
+// functionName: The Promise function that should be shimmed
+// fnArgs: The arguments index that should be CLS enabled (typically all callbacks). Offset from last if negative
+function shimCLS(object, functionName, fnArgs){
+  shimmer.wrap(object, functionName, function(fn) {
+    return function () {
+      if (Promise.Sequelize && Promise.Sequelize.cls) {
+        var ns = Promise.Sequelize.cls;
+        for(var x=0; x<fnArgs.length; x++) {
+          var argIndex = x < 0 ? arguments.length + x : x;
+          if ( argIndex < arguments.length && typeof arguments[argIndex] === 'function' ) arguments[argIndex] = ns.bind( arguments[argIndex] );
+        }
+      }
+
+      return fn.apply(this, arguments);
+    };
+  });
+}
+
+// Core
+shimCLS(Promise, 'join', [-1]);
+shimCLS(Promise, 'try', [0]);
+shimCLS(Promise, 'method', [0]);
+shimCLS(Promise.prototype, 'then', [0, 1, 2]);
+shimCLS(Promise.prototype, 'spread', [0, 1]);
+shimCLS(Promise.prototype, 'catch', [-1]);
+shimCLS(Promise.prototype, 'error', [0]);
+shimCLS(Promise.prototype, 'finally', [0]);
+
+// Collections
+shimCLS(Promise.prototype, 'map', [0]);
+shimCLS(Promise.prototype, 'reduce', [0]);
+shimCLS(Promise.prototype, 'filter', [0]);
+shimCLS(Promise.prototype, 'each', [0]);
+
+// Utility
+shimCLS(Promise.prototype, 'tap', [0]);
+
 
 module.exports = Promise;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "moment": "^2.9.0",
     "node-uuid": "~1.4.1",
     "toposort-class": "~0.3.0",
-    "validator": "^3.34.0"
+    "validator": "^3.34.0",
+    "shimmer": "1.0.0"
   },
   "devDependencies": {
     "chai": "^2.1.2",

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -138,5 +138,155 @@ if (current.dialect.supports.transactions) {
         });
       });
     });
+
+    describe('bluebird shims', function () {
+      beforeEach(function () {
+        // Make sure we have some data so the each, map, filter, ... actually run and validate asserts
+        return this.sequelize.Promise.all([this.User.create({ name: 'bob' }), this.User.create({ name: 'joe' })]);
+      });
+
+      it('join', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.sequelize.Promise.join(self.User.findAll(), function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('then fulfilled', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().then(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('then rejected', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.sequelize.Promise.reject('test rejection handler').then(null,function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('spread', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().spread(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          },function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('catch', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.sequelize.Promise.try(function () {
+            throw new Error('To test catch');
+          }).catch(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('error', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.sequelize.Promise.try(function () {
+            throw new self.sequelize.Promise.OperationalError('To test catch');
+          }).error(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('finally', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().finally( function(){
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('map', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().map(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('reduce', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().reduce(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('filter', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().filter(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('each', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().each(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+      it('tap', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().tap(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
+
+
+    });
+
   });
 }


### PR DESCRIPTION
This is a fix for https://github.com/sequelize/sequelize/issues/3686.

I decided to shim only the documented bluebird API so it's less likely to break due to internal changes.
I basically shimmed all bluebird methods that accepts functions except `try` and `method` since the former call the function synchronously and the later just wrap the function.

I tested the change with my code base and it works. To be honest, I most probably have no idea what I'm doing here so a thorough review is more than welcome.