### PR TITLE
Detect primary key in describe table

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -80,7 +80,8 @@ module.exports = (function() {
         result[_result.Field] = {
           type: _result.Type.toUpperCase(),
           allowNull: (_result.Null === 'YES'),
-          defaultValue: _result.Default
+          defaultValue: _result.Default,
+          primaryKey: _result.Key === 'PRI'
         };
       });
     } else if (this.isShowIndexesQuery()) {


### PR DESCRIPTION
Previously, the presence of a primary key in a MySQL DESCRIBE was not being detected.