### PR TITLE
fix showIndexQuery so appropriate indexes are returned when a schema is used

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Next
+- [BUG] fix showIndexQuery so appropriate indexes are returned when a schema is used
 - [BUG] Fix addIndexQuery error when the model has a schema
 
 # 2.1.3

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -426,6 +426,10 @@ module.exports = (function() {
     },
 
     showIndexesQuery: function(tableName) {
+      if (!Utils._.isString(tableName)) {
+        tableName = tableName.tableName;
+      }
+
       // This is ARCANE!
       var query = 'SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, ' +
         'array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) ' +

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -107,6 +107,39 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
       });
     });
 
+    it('works with schemas', function() {
+      var self = this;
+      return self.sequelize.dropAllSchemas({logging: log}).then(function() {
+        return self.sequelize.createSchema('schema', {logging: log});
+      }).then(function() {
+        return self.queryInterface.createTable('table', {
+          name: {
+            type: DataTypes.STRING
+          },
+          isAdmin: {
+            type: DataTypes.STRING
+          }
+        }, {
+          schema: 'schema'
+        });
+      }).then(function() {
+          return self.queryInterface.addIndex({
+            schema: 'schema',
+            tableName: 'table'
+          }, ['name', 'isAdmin'], {
+            logging: log
+          }, 'schema_table').then(function() {
+            return self.queryInterface.showIndex({
+              schema: 'schema',
+              tableName: 'table'
+            }, {logging: log}).then(function(indexes) {
+              expect(indexes.length).to.eq(1);
+              count = 0;
+            });
+          });
+      });
+    });
+
     it('does not fail on reserved keywords', function() {
       return this.queryInterface.addIndex('Group', ['from']);
     });


### PR DESCRIPTION
Fixes #3693

This is part of an effort to get indexing on tables with schemas working.  showIndexesQuery needs to be able to support a tableName when it has a schema (it currently returns incorrect results - an empty set - when there is a schema included).

Since pg_class doesn't contain schemas the fix is to use the tableName only as my investigation shows that this will return the correct indexes for the table.