### PR TITLE
fix a bug that using `Instance::destroy()` under multiple primary keys

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -836,7 +836,10 @@ module.exports = (function() {
         return this.save(_.extend(_.clone(options), {hooks : false}));
       } else {
         where = {};
-        where[this.Model.rawAttributes[this.Model.primaryKeyAttribute].field] = this.get(this.Model.primaryKeyAttribute, {raw: true});
+        var primaryKeys = this.Model.primaryKeyAttributes;
+        for(var i = 0; i < primaryKeys.length; i++) {
+            where[this.Model.rawAttributes[primaryKeys[i]].field] = this.get(primaryKeys[i], { raw: true });
+        }
         return this.QueryInterface.delete(this, this.Model.getTableName(options), where, _.defaults(options, { type: QueryTypes.DELETE,limit: null}));
       }
     }).tap(function() {

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -1759,6 +1759,38 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         });
       });
     });
+
+    it('delete a record of multiple primary keys table', function() {
+      var MultiPrimary = this.sequelize.define('MultiPrimary', {
+        bilibili: {
+          type: Support.Sequelize.CHAR(2),
+          primaryKey: true
+        },
+
+        guruguru: {
+          type: Support.Sequelize.CHAR(2),
+          primaryKey: true
+        }
+      });
+
+      return MultiPrimary.sync({ force: true }).then(function() {
+        return MultiPrimary.create({ bilibili: 'bl', guruguru: 'gu' }).then(function() {
+          return MultiPrimary.create({ bilibili: 'bl', guruguru: 'ru' }).then(function(m2) {
+            return MultiPrimary.findAll().then(function(ms) {
+              expect(ms.length).to.equal(2);
+              return m2.destroy({
+                logging: function(sql) {
+                  expect(sql).to.exist;
+                  expect(sql.toUpperCase().indexOf('DELETE')).to.be.above(-1);
+                  expect(sql.indexOf('ru')).to.be.above(-1);
+                  expect(sql.indexOf('bl')).to.be.above(-1);
+                }
+              });
+            });
+          });
+        });
+      });
+    });
   });
 
   describe('restore', function() {

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -1785,6 +1785,12 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
                   expect(sql.indexOf('ru')).to.be.above(-1);
                   expect(sql.indexOf('bl')).to.be.above(-1);
                 }
+              }).then(function() {
+                return MultiPrimary.findAll().then(function(ms) {
+                  expect(ms.length).to.equal(1);
+                  expect(ms[0].bilibili).to.equal('bl');
+                  expect(ms[0].guruguru).to.equal('gu');
+                });
               });
             });
           });


### PR DESCRIPTION
If the instance is under multiple primary keys, the `where` section of query string should using multiple primary keys.