### PR TITLE
Allow updating virtual setter side effects from Model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1596,6 +1596,7 @@ module.exports = (function() {
    * @param  {Array}        [options.fields]                Fields to update (defaults to all fields)
    * @param  {Boolean}      [options.validate=true]         Should each row be subject to validation before it is inserted. The whole insert will fail if one row fails validation
    * @param  {Boolean}      [options.hooks=true]            Run before / after bulk update hooks?
+   * @param  {Boolean}      [options.persistSideEffects=true] Whether or not to update the side effects of any virtual setters.
    * @param  {Boolean}      [options.individualHooks=false] Run before / after update hooks?. If true, this will execute a SELECT followed by individual UPDATEs. A select is needed, because the row data needs to be passed to the hooks
    * @param  {Boolean}      [options.returning=false]       Return the affected rows (only for postgres)
    * @param  {Number}       [options.limit]                 How many rows to update (only for mysql and mariadb)
@@ -1615,7 +1616,8 @@ module.exports = (function() {
       hooks: true,
       individualHooks: false,
       returning: false,
-      force: false
+      force: false,
+      persistSideEffects: true
     }, options || {});
 
     options.type = QueryTypes.BULKUPDATE;
@@ -1649,6 +1651,11 @@ module.exports = (function() {
       if (options.validate) {
         var build = self.build(values);
         build.set(self._timestampAttributes.updatedAt, values[self._timestampAttributes.updatedAt], { raw: true });
+
+        if ( options.persistSideEffects ) {
+          values = Utils._.assign(values, Utils._.pick(build.get(), build.changed()));
+          options.fields = Utils._.union(options.fields, Object.keys(values));
+        }
 
         // We want to skip validations for all other fields
         options.skip = Utils._.difference(Object.keys(self.attributes), Object.keys(values));


### PR DESCRIPTION
So when using `Model.prototype.update` to update the table there's an issue if you're using some kind of magic setter like so:

```js
var User = sequelize.define('User', {
    name: DataTypes.STRING,
    age: DataTypes.INTEGER,
    details: {
        type: DataTypes.VIRTUAL,
        set: function (value) {
            this.set('name', value.name);
            this.set('age', value.age);
        }
     }
}
```

This isn't a tremendously salient example but it comes up quite frequently when you're trying to obfuscate complex data types from an API. My line of thought is that the following:

```js
Model.User.update({ details: { 'age' : 40, 'name' : 'Bill' } }, { where: { name: 'Tim' } });
```

Should have the effect of updating age and name through the details setter. At the moment it doesn't as update doesn't have an impact on side effect attributes. This has been changed for instances (https://github.com/sequelize/sequelize/pull/3393) (previously updating an instance wouldn't trigger an update on side effect attributes) and so I'm proposing this change for models as well.

I've also included a flag `options.persistSideEffects` that defaults to `true` which can be switched if this isn't desired behaviour.