### PR TITLE
Change postgres delimiter

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -281,7 +281,7 @@ module.exports = (function() {
       language = language || 'plpgsql';
       returns = returns || 'SETOF ' + this.quoteTable(tableName);
 
-      var query = 'CREATE OR REPLACE FUNCTION pg_temp.<%= fnName %>() RETURNS <%= returns %> AS $$ BEGIN <%= body %> END; $$ LANGUAGE <%= language %>; SELECT * FROM pg_temp.<%= fnName %>();';
+      var query = 'CREATE OR REPLACE FUNCTION pg_temp.<%= fnName %>() RETURNS <%= returns %> AS $func$ BEGIN <%= body %> END; $func$ LANGUAGE <%= language %>; SELECT * FROM pg_temp.<%= fnName %>();';
 
       return Utils._.template(query)({
         fnName: fnName,
@@ -600,11 +600,11 @@ module.exports = (function() {
 
     createFunction: function(functionName, params, returnType, language, body, options) {
       var sql = ['CREATE FUNCTION <%= functionName %>(<%= paramList %>)'
-          , 'RETURNS <%= returnType %> AS $$'
+          , 'RETURNS <%= returnType %> AS $func$'
           , 'BEGIN'
           , '\t<%= body %>'
           , 'END;'
-          , "$$ language '<%= language %>'<%= options %>;"
+          , "$func$ language '<%= language %>'<%= options %>;"
       ].join('\n');
 
       return Utils._.template(sql)({


### PR DESCRIPTION
Hi,

Actually the postgres delimiter for define a function is $$.
An error are returned if we have this delimiter in the query ('joey bada$$' for example)

So I propose to change the delimiter $$ to $func$ which is less common