### PR TITLE
add support for named timezones

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -1,7 +1,7 @@
 'use strict';
 
 /* jshint -W110 */
-var moment = require('moment')
+var moment = require('moment-timezone')
   , isArrayBufferView
   , SqlString = exports;
 
@@ -165,7 +165,11 @@ SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
 };
 
 SqlString.dateToString = function(date, timeZone, dialect) {
-  date = moment(date).utcOffset(timeZone);
+  if (moment.tz.zone(timeZone)) {
+    date = moment(date).tz(timeZone);
+  } else {
+    date = moment(date).utcOffset(timeZone);
+  }
 
   if (dialect === 'mysql' || dialect === 'mariadb') {
     return date.format('YYYY-MM-DD HH:mm:ss');

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "inflection": "^1.6.0",
     "lodash": "^3.5.0",
     "moment": "^2.9.0",
+    "moment-timezone": "^0.3.1",
     "node-uuid": "~1.4.1",
     "toposort-class": "~0.3.0",
     "validator": "^3.34.0"

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -15,6 +15,9 @@ if (dialect !== 'sqlite') {
       this.sequelizeWithTimezone = Support.createSequelizeInstance({
         timezone: '+07:00'
       });
+      this.sequelizeWithNamedTimezone = Support.createSequelizeInstance({
+        timezone: 'America/New_York'
+      });
     });
 
     it('returns the same value for current timestamp', function() {
@@ -50,6 +53,21 @@ if (dialect !== 'sqlite') {
           // This difference is expected since two instances, configured for each their timezone is trying to read the same timestamp
           // this test does not apply to PG, since it stores the timezone along with the timestamp.
           expect(normalUser.createdAt.getTime() - this.timezonedUser.createdAt.getTime()).to.be.closeTo(60 * 60 * 7 * 1000, 50);
+        });
+      });
+
+      it('handles named timezones', function() {
+        var NormalUser = this.sequelize.define('user', {})
+          , TimezonedUser = this.sequelizeWithNamedTimezone.define('user', {});
+
+        return this.sequelize.sync({ force: true }).bind(this).then(function() {
+          return TimezonedUser.create({});
+        }).then(function(timezonedUser) {
+          this.timezonedUser = timezonedUser;
+          return NormalUser.find(timezonedUser.id);
+        }).then(function(normalUser) {
+          // Expect 7 hours difference, in milliseconds, +/- 1 hour for DST
+          expect(normalUser.createdAt.getTime() - this.timezonedUser.createdAt.getTime()).to.be.closeTo(60 * 60 * 4 * 1000 * -1, 60 * 60 * 1000);
         });
       });
     }


### PR DESCRIPTION
Hello,

Sequelize does not appear to support named timezones (such as `America/Los_Angeles`), so an application using Sequelize must manually change the `timezone` option if the database's UTC offset changes (such as when daylight savings kicks in).

Although the documentation does not mention support for this, digging around I found issue #2059, which seems to imply support for this behavior. However, using a named timezone identifier as an option (no matter what the timezone) results in the data always being inserted as UTC (wheras using a numeric offset, such as `-07:00` works as expected).

I'm a little curious as to whether this was ever supported, or if I'm just misunderstanding things. If I'm on the right track with this, let me know if you’d like me to clean up the testing and docs for this (and any other feedback you have, since this is a bit of a WIP).

Thanks!
Derek