### PR TITLE
Call stacks are computed properly

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -294,11 +294,11 @@ var Utils = module.exports = {
   },
 
 
-  stack: function() {
+  stack: function _stackGrabber() {
     var orig = Error.prepareStackTrace;
     Error.prepareStackTrace = function(_, stack) { return stack; };
     var err = new Error();
-    Error.captureStackTrace(err, this);
+    Error.captureStackTrace(err, _stackGrabber);
     var errStack = err.stack;
     Error.prepareStackTrace = orig;
     return errStack;

--- a/test/unit/utils.js
+++ b/test/unit/utils.js
@@ -114,4 +114,30 @@ suite(Support.getTestDialectTeaser('Utils'), function() {
       });
     });
   });
+
+
+  suite('stack', function() {
+    test('stack trace starts after call to Util.stack()', function this_here_test() {
+
+      function a() {
+        return b();
+      }
+
+      function b() {
+        return c();
+      }
+
+      function c() {
+        return Utils.stack();
+      }
+
+      var stack = a();
+
+      expect(stack[0].getFunctionName()).to.eql('c');
+      expect(stack[1].getFunctionName()).to.eql('b');
+      expect(stack[2].getFunctionName()).to.eql('a');
+      expect(stack[3].getFunctionName()).to.eql('this_here_test');
+    });
+  });
+
 });


### PR DESCRIPTION
This pull request implements the fix mentioned here:

https://github.com/sequelize/sequelize/issues/3016

Basically, the call to Error.captureStackTrace(...) was in 'this' as the 2nd parameter.  However, 'this' was not actually a reference to the function itself; instead, it was a reference to the object that owned the function.  Consequently, the 'stack' function was not filtered from the stacktrace properly.
