### PR TITLE
Make `references` an object

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [CHANGED] The `references` property of model attributes has been transformed to an object: `{type: Sequelize.INTEGER, references: { model: SomeModel, key: 'some_key' }}`. The former format is deprecated.
+
 # 3.0.0
 
 3.0.0 cleans up a lot of deprecated code, making it easier for us to develop and maintain features in the future.

--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -590,8 +590,10 @@ Series = sequelize.define('Series', {
   // Set FK relationship (hasMany) with `Trainer`
   trainer_id: {
     type: DataTypes.INTEGER,
-    references: "Trainers",
-    referencesKey: "id"
+    references: {
+      model: "Trainers",
+      key: "id"
+    }
   }
 })
  
@@ -609,8 +611,10 @@ Video = sequelize.define('Video', {
   // set relationship (hasOne) with `Series`
   series_id: {
     type: DataTypes.INTEGER,
-    references: Series, // Can be both a string representing the table name, or a reference to the model
-    referencesKey: "id"
+    references: {
+      model: Series, // Can be both a string representing the table name, or a reference to the model
+      key:   "id"
+    }
   }
 });
  

--- a/examples/enforce-referential-integrity/models/Series.js
+++ b/examples/enforce-referential-integrity/models/Series.js
@@ -15,8 +15,10 @@ module.exports = function(sequelize, DataTypes) {
         // Set FK relationship (hasMany) with `Trainer`
         trainer_id: {
             type: DataTypes.INTEGER,
-            references: "Trainer",
-            referencesKey: 'id'
+            references: {
+              model: 'Trainer',
+              key:   'id'
+            }
         }
     }, {
         // don't need timestamp attributes for this model

--- a/examples/enforce-referential-integrity/models/Video.js
+++ b/examples/enforce-referential-integrity/models/Video.js
@@ -15,8 +15,10 @@ module.exports = function(sequelize, DataTypes) {
         // set relationship (hasOne) with `Series`
         series_id: {
             type: DataTypes.INTEGER,
-            references: "Series",
-            referencesKey: 'id'
+            references: {
+              model: 'Series',
+              key:   'id'
+            }
         }
     }, {
         // don't need timestamp attributes for this model

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -225,8 +225,10 @@ module.exports = (function() {
     }
 
     if (this.options.constraints !== false) {
-      sourceAttribute.references = this.source.getTableName();
-      sourceAttribute.referencesKey = sourceKeyField;
+      sourceAttribute.references = {
+        model: this.source.getTableName(),
+        key:   sourceKeyField
+      };
       // For the source attribute the passed option is the priority
       sourceAttribute.onDelete = this.options.onDelete || this.through.model.rawAttributes[this.identifier].onDelete;
       sourceAttribute.onUpdate = this.options.onUpdate || this.through.model.rawAttributes[this.identifier].onUpdate;
@@ -234,9 +236,10 @@ module.exports = (function() {
       if (!sourceAttribute.onDelete) sourceAttribute.onDelete = 'CASCADE';
       if (!sourceAttribute.onUpdate) sourceAttribute.onUpdate = 'CASCADE';
 
-
-      targetAttribute.references = this.target.getTableName();
-      targetAttribute.referencesKey = targetKeyField;
+      targetAttribute.references = {
+        model: this.target.getTableName(),
+        key:   targetKeyField
+      };
       // But the for target attribute the previously defined option is the priority (since it could've been set by another belongsToMany call)
       targetAttribute.onDelete = this.through.model.rawAttributes[this.foreignIdentifier].onDelete || this.options.onDelete;
       targetAttribute.onUpdate = this.through.model.rawAttributes[this.foreignIdentifier].onUpdate || this.options.onUpdate;

--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -26,18 +26,20 @@ module.exports = {
 
       if (primaryKeys.length === 1) {
         if (!!source.options.schema) {
-          newAttribute.references = source.modelManager.sequelize.queryInterface.QueryGenerator.addSchema({
-            tableName: source.tableName,
-            options: {
-              schema: source.options.schema,
-              schemaDelimiter: source.options.schemaDelimiter
-            }
-          });
+          newAttribute.references = {
+            model: source.modelManager.sequelize.queryInterface.QueryGenerator.addSchema({
+              tableName: source.tableName,
+              options: {
+                schema: source.options.schema,
+                schemaDelimiter: source.options.schemaDelimiter
+              }
+            })
+          };
         } else {
-          newAttribute.references = source.tableName;
+          newAttribute.references = { model: source.tableName };
         }
 
-        newAttribute.referencesKey = primaryKeys[0];
+        newAttribute.references.key = primaryKeys[0];
         newAttribute.onDelete = options.onDelete;
         newAttribute.onUpdate = options.onUpdate;
       }

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -333,7 +333,7 @@ module.exports = (function() {
       }
 
       // handle self referential constraints
-      if (attribute.Model && attribute.Model.tableName === attribute.references) {
+      if (attribute.Model && attribute.references && attribute.Model.tableName === attribute.references.model) {
         this.sequelize.log('MSSQL does not support self referencial constraints, '
           + 'we will remove it but we recommend restructuring your query');
         attribute.onDelete = '';
@@ -380,10 +380,10 @@ module.exports = (function() {
       }
 
       if (attribute.references) {
-        template += ' REFERENCES ' + this.quoteTable(attribute.references);
+        template += ' REFERENCES ' + this.quoteTable(attribute.references.model);
 
-        if (attribute.referencesKey) {
-          template += ' (' + this.quoteIdentifier(attribute.referencesKey) + ')';
+        if (attribute.references.key) {
+          template += ' (' + this.quoteIdentifier(attribute.references.key) + ')';
         } else {
           template += ' (' + this.quoteIdentifier('id') + ')';
         }
@@ -410,12 +410,12 @@ module.exports = (function() {
         attribute = attributes[key];
 
         if (attribute.references) {
-          if (existingConstraints.indexOf(attribute.references.toString()) !== -1) {
+          if (existingConstraints.indexOf(attribute.references.model.toString()) !== -1) {
             // no cascading constraints to a table more than once
             attribute.onDelete = '';
             attribute.onUpdate = '';
           } else {
-            existingConstraints.push(attribute.references.toString());
+            existingConstraints.push(attribute.references.model.toString());
 
             // NOTE: this really just disables cascading updates for all
             //       definitions. Can be made more robust to support the

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -333,11 +333,15 @@ module.exports = (function() {
       }
 
       // handle self referential constraints
-      if (attribute.Model && attribute.references && attribute.Model.tableName === attribute.references.model) {
-        this.sequelize.log('MSSQL does not support self referencial constraints, '
-          + 'we will remove it but we recommend restructuring your query');
-        attribute.onDelete = '';
-        attribute.onUpdate = '';
+      if (attribute.references) {
+        attribute = Utils.formatReferences(attribute);
+
+        if (attribute.Model && attribute.Model.tableName === attribute.references.model) {
+          this.sequelize.log('MSSQL does not support self referencial constraints, '
+            + 'we will remove it but we recommend restructuring your query');
+          attribute.onDelete = '';
+          attribute.onUpdate = '';
+        }
       }
 
       var template;
@@ -410,6 +414,8 @@ module.exports = (function() {
         attribute = attributes[key];
 
         if (attribute.references) {
+          attribute = Utils.formatReferences(attributes[key]);
+
           if (existingConstraints.indexOf(attribute.references.model.toString()) !== -1) {
             // no cascading constraints to a table more than once
             attribute.onDelete = '';

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -292,10 +292,10 @@ module.exports = (function() {
       }
 
       if (attribute.references) {
-        template += ' REFERENCES ' + this.quoteTable(attribute.references);
+        template += ' REFERENCES ' + this.quoteTable(attribute.references.model);
 
-        if (attribute.referencesKey) {
-          template += ' (' + this.quoteIdentifier(attribute.referencesKey) + ')';
+        if (attribute.references.key) {
+          template += ' (' + this.quoteIdentifier(attribute.references.key) + ')';
         } else {
           template += ' (' + this.quoteIdentifier('id') + ')';
         }

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -292,6 +292,7 @@ module.exports = (function() {
       }
 
       if (attribute.references) {
+        attribute = Utils.formatReferences(attribute);
         template += ' REFERENCES ' + this.quoteTable(attribute.references.model);
 
         if (attribute.references.key) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -510,6 +510,7 @@ module.exports = (function() {
       }
 
       if (attribute.references) {
+        attribute = Utils.formatReferences(attribute);
         template += ' REFERENCES <%= referencesTable %> (<%= referencesKey %>)';
         replacements.referencesTable = this.quoteTable(attribute.references.model);
 

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -511,10 +511,10 @@ module.exports = (function() {
 
       if (attribute.references) {
         template += ' REFERENCES <%= referencesTable %> (<%= referencesKey %>)';
-        replacements.referencesTable = this.quoteTable(attribute.references);
+        replacements.referencesTable = this.quoteTable(attribute.references.model);
 
-        if (attribute.referencesKey) {
-          replacements.referencesKey = this.quoteIdentifiers(attribute.referencesKey);
+        if (attribute.references.key) {
+          replacements.referencesKey = this.quoteIdentifiers(attribute.references.key);
         } else {
           replacements.referencesKey = this.quoteIdentifier('id');
         }

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -251,6 +251,7 @@ module.exports = (function() {
           }
 
           if(dataType.references) {
+            dataType = Utils.formatReferences(dataType);
             template += ' REFERENCES <%= referencesTable %> (<%= referencesKey %>)';
             replacements.referencesTable = this.quoteTable(dataType.references.model);
 

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -252,10 +252,10 @@ module.exports = (function() {
 
           if(dataType.references) {
             template += ' REFERENCES <%= referencesTable %> (<%= referencesKey %>)';
-            replacements.referencesTable = this.quoteTable(dataType.references);
+            replacements.referencesTable = this.quoteTable(dataType.references.model);
 
-            if(dataType.referencesKey) {
-              replacements.referencesKey = this.quoteIdentifier(dataType.referencesKey);
+            if(dataType.references.key) {
+              replacements.referencesKey = this.quoteIdentifier(dataType.references.key);
             } else {
               replacements.referencesKey = this.quoteIdentifier('id');
             }

--- a/lib/model-manager.js
+++ b/lib/model-manager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Toposort = require('toposort-class')
+  , Utils = require('./utils')
   , _ = require('lodash');
 
 module.exports = (function() {
@@ -67,13 +68,16 @@ module.exports = (function() {
 
       for (var attrName in model.rawAttributes) {
         if (model.rawAttributes.hasOwnProperty(attrName)) {
-          if (model.rawAttributes[attrName].references) {
-            dep = model.rawAttributes[attrName].references.model;
+          var attribute = model.rawAttributes[attrName];
+
+          if (attribute.references) {
+            attribute = Utils.formatReferences(attribute);
+            dep       = attribute.references.model;
 
             if (_.isObject(dep)) {
               dep = dep.schema + '.' + dep.tableName;
             }
-            
+
             deps.push(dep);
           }
         }

--- a/lib/model-manager.js
+++ b/lib/model-manager.js
@@ -68,11 +68,12 @@ module.exports = (function() {
       for (var attrName in model.rawAttributes) {
         if (model.rawAttributes.hasOwnProperty(attrName)) {
           if (model.rawAttributes[attrName].references) {
-            dep = model.rawAttributes[attrName].references;
+            dep = model.rawAttributes[attrName].references.model;
 
             if (_.isObject(dep)) {
               dep = dep.schema + '.' + dep.tableName;
             }
+            
             deps.push(dep);
           }
         }

--- a/lib/model.js
+++ b/lib/model.js
@@ -74,8 +74,8 @@ module.exports = (function() {
       }
       attribute = this.sequelize.normalizeAttribute(attribute);
 
-      if (attribute.references instanceof Model) {
-        attribute.references = attribute.references.tableName;
+      if (attribute.references && (attribute.references.model instanceof Model)) {
+        attribute.references.model = attribute.references.model.tableName;
       }
 
       if (attribute.type === undefined) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -72,10 +72,15 @@ module.exports = (function() {
       if (!Utils._.isPlainObject(attribute)) {
         attribute = { type: attribute };
       }
+
       attribute = this.sequelize.normalizeAttribute(attribute);
 
-      if (attribute.references && (attribute.references.model instanceof Model)) {
-        attribute.references.model = attribute.references.model.tableName;
+      if (attribute.references) {
+        attribute = Utils.formatReferences(attribute);
+
+        if (attribute.references.model instanceof Model) {
+          attribute.references.model = attribute.references.model.tableName;
+        }
       }
 
       if (attribute.type === undefined) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -456,8 +456,9 @@ module.exports = (function() {
    * @param {String}                  [attributes.column.field=null] If set, sequelize will map the attribute name to a different name in the database
    * @param {Boolean}                 [attributes.column.autoIncrement=false]
    * @param {String}                  [attributes.column.comment=null]
-   * @param {String|Model}            [attributes.column.references] If this column references another table, provide it here as a Model, or a string
-   * @param {String}                  [attributes.column.referencesKey='id'] The column of the foreign table that this column references
+   * @param {String|Model}            [attributes.column.references=null] An object with reference configurations
+   * @param {String|Model}            [attributes.column.references.model] If this column references another table, provide it here as a Model, or a string
+   * @param {String}                  [attributes.column.references.key='id'] The column of the foreign table that this column references
    * @param {String}                  [attributes.column.onUpdate] What should happen when the referenced key is updated. One of CASCADE, RESTRICT, SET DEFAULT, SET NULL or NO ACTION
    * @param {String}                  [attributes.column.onDelete] What should happen when the referenced key is deleted. One of CASCADE, RESTRICT, SET DEFAULT, SET NULL or NO ACTION
    * @param {Function}                [attributes.column.get] Provide a custom getter for this column. Use `this.getDataValue(String)` to manipulate the underlying values.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,8 @@ var DataTypes = require('./data-types')
   , inflection = require('inflection')
   , _ = require('lodash')
   , dottie = require('dottie')
-  , uuid = require('node-uuid');
+  , uuid = require('node-uuid')
+  , deprecate = require('depd')('Utils');
 
 var Utils = module.exports = {
   inflection: inflection,
@@ -394,24 +395,13 @@ var Utils = module.exports = {
   },
 
   formatReferences: function (obj) {
-    var references = {};
-
-    if (!obj || !_.isPlainObject(obj) || !obj.references) {
-      return obj;
+    if (!_.isPlainObject(obj.references)) {
+      deprecate('Non-object references property found. Support for that will be removed in version 4. Expected { references: { model: "value", key: "key" } } instead of { references: "value", referencesKey: "key" }.');
+      obj.references = { model: obj.references, key: obj.referencesKey };
+      obj.referencesKey = undefined;
     }
 
-    if (_.isPlainObject(obj.references)) {
-      references = obj.references;
-    } else {
-      references.model = obj.references;
-    }
-
-    if (obj.referencesKey) {
-      references.key = obj.referencesKey;
-      delete obj.referencesKey;
-    }
-
-    return _.extend(obj, { references: references });
+    return obj;
   }
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -255,7 +255,6 @@ var Utils = module.exports = {
     return true;
   },
 
-
   removeNullValuesFromHash: function(hash, omitNull, options) {
     var result = hash;
 
@@ -392,6 +391,27 @@ var Utils = module.exports = {
 
   validateParameter: function(value, expectation, options) {
     return ParameterValidator.check(value, expectation, options);
+  },
+
+  formatReferences: function (obj) {
+    var references = {};
+
+    if (!obj || !_.isPlainObject(obj) || !obj.references) {
+      return obj;
+    }
+
+    if (_.isPlainObject(obj.references)) {
+      references = obj.references;
+    } else {
+      references.model = obj.references;
+    }
+
+    if (obj.referencesKey) {
+      references.key = obj.referencesKey;
+      delete obj.referencesKey;
+    }
+
+    return _.extend(obj, { references: references });
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "bluebird": "~2.9.24",
+    "depd": "^1.0.1",
     "dottie": "^0.3.1",
     "generic-pool": "2.2.0",
     "inflection": "^1.6.0",
@@ -40,9 +41,9 @@
     "moment": "^2.9.0",
     "moment-timezone": "^0.3.1",
     "node-uuid": "~1.4.1",
+    "shimmer": "1.0.0",
     "toposort-class": "~0.3.0",
-    "validator": "^3.34.0",
-    "shimmer": "1.0.0"
+    "validator": "^3.34.0"
   },
   "devDependencies": {
     "chai": "^2.1.2",

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -1885,8 +1885,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
 
         var UserProjects = User.belongsToMany(Project, { foreignKey: { name: 'user_id', defaultValue: 42 }, through: 'UserProjects' });
         expect(UserProjects.through.model.rawAttributes.user_id).to.be.ok;
-        expect(UserProjects.through.model.rawAttributes.user_id.references).to.equal(User.getTableName());
-        expect(UserProjects.through.model.rawAttributes.user_id.referencesKey).to.equal('uid');
+        expect(UserProjects.through.model.rawAttributes.user_id.references.model).to.equal(User.getTableName());
+        expect(UserProjects.through.model.rawAttributes.user_id.references.key).to.equal('uid');
         expect(UserProjects.through.model.rawAttributes.user_id.defaultValue).to.equal(42);
       });
     });

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -637,8 +637,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
 
         expect(Task.rawAttributes.uid).to.be.ok;
         expect(Task.rawAttributes.uid.allowNull).to.be.false;
-        expect(Task.rawAttributes.uid.references).to.equal(User.getTableName());
-        expect(Task.rawAttributes.uid.referencesKey).to.equal('id');
+        expect(Task.rawAttributes.uid.references.model).to.equal(User.getTableName());
+        expect(Task.rawAttributes.uid.references.key).to.equal('id');
       });
 
       it('works when taking a column directly from the object', function() {
@@ -658,8 +658,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
         Profile.belongsTo(User, { foreignKey: Profile.rawAttributes.user_id});
 
         expect(Profile.rawAttributes.user_id).to.be.ok;
-        expect(Profile.rawAttributes.user_id.references).to.equal(User.getTableName());
-        expect(Profile.rawAttributes.user_id.referencesKey).to.equal('uid');
+        expect(Profile.rawAttributes.user_id.references.model).to.equal(User.getTableName());
+        expect(Profile.rawAttributes.user_id.references.key).to.equal('uid');
         expect(Profile.rawAttributes.user_id.allowNull).to.be.false;
       });
 

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -907,8 +907,8 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
 
         expect(Task.rawAttributes.uid).to.be.ok;
         expect(Task.rawAttributes.uid.allowNull).to.be.false;
-        expect(Task.rawAttributes.uid.references).to.equal(User.getTableName());
-        expect(Task.rawAttributes.uid.referencesKey).to.equal('id');
+        expect(Task.rawAttributes.uid.references.model).to.equal(User.getTableName());
+        expect(Task.rawAttributes.uid.references.key).to.equal('id');
       });
 
       it('works when taking a column directly from the object', function() {
@@ -928,8 +928,8 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
         User.hasMany(Project, { foreignKey: Project.rawAttributes.user_id});
 
         expect(Project.rawAttributes.user_id).to.be.ok;
-        expect(Project.rawAttributes.user_id.references).to.equal(User.getTableName());
-        expect(Project.rawAttributes.user_id.referencesKey).to.equal('uid');
+        expect(Project.rawAttributes.user_id.references.model).to.equal(User.getTableName());
+        expect(Project.rawAttributes.user_id.references.key).to.equal('uid');
         expect(Project.rawAttributes.user_id.defaultValue).to.equal(42);
       });
 

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -530,8 +530,8 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
         });
 
         expect(Profile.rawAttributes.uid).to.be.ok;
-        expect(Profile.rawAttributes.uid.references).to.equal(User.getTableName());
-        expect(Profile.rawAttributes.uid.referencesKey).to.equal('id');
+        expect(Profile.rawAttributes.uid.references.model).to.equal(User.getTableName());
+        expect(Profile.rawAttributes.uid.references.key).to.equal('id');
         expect(Profile.rawAttributes.uid.allowNull).to.be.false;
 
         // Let's clear it
@@ -544,8 +544,8 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
         });
 
         expect(Profile.rawAttributes.uid).to.be.ok;
-        expect(Profile.rawAttributes.uid.references).to.equal(User.getTableName());
-        expect(Profile.rawAttributes.uid.referencesKey).to.equal('id');
+        expect(Profile.rawAttributes.uid.references.model).to.equal(User.getTableName());
+        expect(Profile.rawAttributes.uid.references.key).to.equal('id');
         expect(Profile.rawAttributes.uid.allowNull).to.be.false;
       });
 
@@ -566,8 +566,8 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
         User.hasOne(Profile, { foreignKey: Profile.rawAttributes.user_id});
 
         expect(Profile.rawAttributes.user_id).to.be.ok;
-        expect(Profile.rawAttributes.user_id.references).to.equal(User.getTableName());
-        expect(Profile.rawAttributes.user_id.referencesKey).to.equal('uid');
+        expect(Profile.rawAttributes.user_id.references.model).to.equal(User.getTableName());
+        expect(Profile.rawAttributes.user_id.references.key).to.equal('uid');
         expect(Profile.rawAttributes.user_id.allowNull).to.be.false;
       });
 
@@ -589,8 +589,8 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
 
         expect(Project.rawAttributes.userUid).to.be.ok;
         expect(Project.rawAttributes.userUid.allowNull).to.be.false;
-        expect(Project.rawAttributes.userUid.references).to.equal(User.getTableName());
-        expect(Project.rawAttributes.userUid.referencesKey).to.equal('uid');
+        expect(Project.rawAttributes.userUid.references.model).to.equal(User.getTableName());
+        expect(Project.rawAttributes.userUid.references.key).to.equal('uid');
         expect(Project.rawAttributes.userUid.defaultValue).to.equal(42);
       });
     });

--- a/test/integration/dialects/mysql/query-generator.test.js
+++ b/test/integration/dialects/mysql/query-generator.test.js
@@ -44,23 +44,23 @@ if (Support.dialectIsMySQL()) {
           expectation: {id: 'INTEGER UNIQUE'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`)'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar', key: 'pk' }}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`pk`)'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onDelete: 'CASCADE'}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON DELETE CASCADE'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON UPDATE RESTRICT'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT'}
         }
       ],

--- a/test/integration/dialects/mysql/query-generator.test.js
+++ b/test/integration/dialects/mysql/query-generator.test.js
@@ -43,6 +43,30 @@ if (Support.dialectIsMySQL()) {
           arguments: [{id: {type: 'INTEGER', unique: true}}],
           expectation: {id: 'INTEGER UNIQUE'}
         },
+
+        // Old references style
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`id`)'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`pk`)'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON DELETE CASCADE'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON UPDATE RESTRICT'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT'}
+        },
+
+        // New references style
         {
           arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`)'}
@@ -62,7 +86,7 @@ if (Support.dialectIsMySQL()) {
         {
           arguments: [{id: {type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT'}
-        }
+        },
       ],
 
       createTableQuery: [

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -57,6 +57,57 @@ if (dialect.match(/^postgres/)) {
           arguments: [{id: {type: 'INTEGER', unique: true}}],
           expectation: {id: 'INTEGER UNIQUE'}
         },
+
+        // Old references style
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          expectation: {id: 'INTEGER REFERENCES "Bar" ("id")'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          expectation: {id: 'INTEGER REFERENCES "Bar" ("pk")'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          expectation: {id: 'INTEGER REFERENCES "Bar" ("id") ON DELETE CASCADE'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER REFERENCES "Bar" ("id") ON UPDATE RESTRICT'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES "Bar" ("id") ON DELETE CASCADE ON UPDATE RESTRICT'}
+        },
+
+        // Variants when quoteIdentifiers is false
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          expectation: {id: 'INTEGER REFERENCES Bar (id)'},
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          expectation: {id: 'INTEGER REFERENCES Bar (pk)'},
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          expectation: {id: 'INTEGER REFERENCES Bar (id) ON DELETE CASCADE'},
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER REFERENCES Bar (id) ON UPDATE RESTRICT'},
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES Bar (id) ON DELETE CASCADE ON UPDATE RESTRICT'},
+          context: {options: {quoteIdentifiers: false}}
+        },
+
+        // New references style
         {
           arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }}}],
           expectation: {id: 'INTEGER REFERENCES "Bar" ("id")'}
@@ -104,7 +155,6 @@ if (dialect.match(/^postgres/)) {
           expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES Bar (id) ON DELETE CASCADE ON UPDATE RESTRICT'},
           context: {options: {quoteIdentifiers: false}}
         }
-
       ],
 
       createTableQuery: [

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -58,49 +58,49 @@ if (dialect.match(/^postgres/)) {
           expectation: {id: 'INTEGER UNIQUE'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }}}],
           expectation: {id: 'INTEGER REFERENCES "Bar" ("id")'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar', key: 'pk' }}}],
           expectation: {id: 'INTEGER REFERENCES "Bar" ("pk")'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onDelete: 'CASCADE'}}],
           expectation: {id: 'INTEGER REFERENCES "Bar" ("id") ON DELETE CASCADE'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER REFERENCES "Bar" ("id") ON UPDATE RESTRICT'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES "Bar" ("id") ON DELETE CASCADE ON UPDATE RESTRICT'}
         },
 
         // Variants when quoteIdentifiers is false
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }}}],
           expectation: {id: 'INTEGER REFERENCES Bar (id)'},
           context: {options: {quoteIdentifiers: false}}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar', key: 'pk' }}}],
           expectation: {id: 'INTEGER REFERENCES Bar (pk)'},
           context: {options: {quoteIdentifiers: false}}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onDelete: 'CASCADE'}}],
           expectation: {id: 'INTEGER REFERENCES Bar (id) ON DELETE CASCADE'},
           context: {options: {quoteIdentifiers: false}}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER REFERENCES Bar (id) ON UPDATE RESTRICT'},
           context: {options: {quoteIdentifiers: false}}
         },
         {
-          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES Bar (id) ON DELETE CASCADE ON UPDATE RESTRICT'},
           context: {options: {quoteIdentifiers: false}}
         }

--- a/test/integration/dialects/sqlite/query-generator.test.js
+++ b/test/integration/dialects/sqlite/query-generator.test.js
@@ -54,23 +54,23 @@ if (dialect === 'sqlite') {
           expectation: {id: 'INTEGER UNIQUE'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`)'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar', key: 'pk' }}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`pk`)'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onDelete: 'CASCADE'}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON DELETE CASCADE'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }, onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON UPDATE RESTRICT'}
         },
         {
-          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT'}
         }
       ],

--- a/test/integration/dialects/sqlite/query-generator.test.js
+++ b/test/integration/dialects/sqlite/query-generator.test.js
@@ -53,6 +53,30 @@ if (dialect === 'sqlite') {
           arguments: [{id: {type: 'INTEGER', unique: true}}],
           expectation: {id: 'INTEGER UNIQUE'}
         },
+
+        // Old references style
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`id`)'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', referencesKey: 'pk'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`pk`)'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onDelete: 'CASCADE'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON DELETE CASCADE'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', references: 'Bar', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER REFERENCES `Bar` (`id`) ON UPDATE RESTRICT'}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: 'Bar', onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
+          expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT'}
+        },
+
+        // New references style
         {
           arguments: [{id: {type: 'INTEGER', references: { model: 'Bar' }}}],
           expectation: {id: 'INTEGER REFERENCES `Bar` (`id`)'}
@@ -72,7 +96,7 @@ if (dialect === 'sqlite') {
         {
           arguments: [{id: {type: 'INTEGER', allowNull: false, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT'}}],
           expectation: {id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT'}
-        }
+        },
       ],
 
       createTableQuery: [

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -1241,8 +1241,10 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), function() {
         },
         UserId: {
           type: Sequelize.INTEGER,
-          references: UserModel,
-          referencesKey: 'Id'
+          references: {
+            model: UserModel,
+            key:   'Id'
+          }
         },
         Name: Sequelize.STRING,
         Contact: Sequelize.STRING,

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -1212,6 +1212,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), function() {
   });
 
   describe('findOne', function() {
+    ([ true, false ]).forEach(function (useNewReferencesStyle) {
     it('should work with schemas', function() {
       var self = this;
       var UserModel = this.sequelize.define('User', {
@@ -1234,18 +1235,17 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), function() {
         timestamps: false
       });
 
+      var UserIdColumn = useNewReferencesStyle
+        ? { type: Sequelize.INTEGER, references: UserModel, referencesKey: 'Id' }
+        : { type: Sequelize.INTEGER, references: { model: UserModel, key: 'Id' } }
+        ;
+
       var ResumeModel = this.sequelize.define('Resume', {
         Id: {
           type: Sequelize.INTEGER,
           primaryKey: true
         },
-        UserId: {
-          type: Sequelize.INTEGER,
-          references: {
-            model: UserModel,
-            key:   'Id'
-          }
-        },
+        UserId: UserIdColumn,
         Name: Sequelize.STRING,
         Contact: Sequelize.STRING,
         School: Sequelize.STRING,
@@ -1284,6 +1284,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), function() {
           });
         });
       });
+    });
     });
   });
 });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -2178,17 +2178,17 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    ([ true, false ]).forEach(function (useNewReferencesStyle) {
     it('uses an existing dao factory and references the author table', function() {
+      var authorIdColumn = useNewReferencesStyle
+        ? { type: Sequelize.INTEGER, references: this.Author, referencesKey: 'id' }
+        : { type: Sequelize.INTEGER, references: { model: this.Author, key: 'id' } }
+        ;
+
       var Post = this.sequelize.define('post', {
-            title: Sequelize.STRING,
-            authorId: {
-              type: Sequelize.INTEGER,
-              references: {
-                model: this.Author,
-                key:   'id'
-              }
-            }
-          });
+        title: Sequelize.STRING,
+        authorId: authorIdColumn
+      });
 
       this.Author.hasMany(Post);
       Post.belongsTo(this.Author);
@@ -2210,17 +2210,13 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('uses a table name as a string and references the author table', function() {
+      var authorIdColumn = useNewReferencesStyle
+        ? { type: Sequelize.INTEGER, references: 'authors', referencesKey: 'id' }
+        : { type: Sequelize.INTEGER, references: { model: 'authors', key: 'id' } }
+        ;
+
       var self = this
-        , Post = self.sequelize.define('post', {
-            title: Sequelize.STRING,
-            authorId: {
-              type: Sequelize.INTEGER,
-              references: {
-                model: 'authors',
-                key:   'id'
-              }
-            }
-          });
+        , Post = self.sequelize.define('post', { title: Sequelize.STRING, authorId: authorIdColumn });
 
       this.Author.hasMany(Post);
       Post.belongsTo(this.Author);
@@ -2242,16 +2238,12 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('emits an error event as the referenced table name is invalid', function() {
-      var Post = this.sequelize.define('post', {
-            title: Sequelize.STRING,
-            authorId: {
-              type: Sequelize.INTEGER,
-              references: {
-                model: '4uth0r5',
-                key:   'id'
-              }
-            }
-          });
+      var authorIdColumn = useNewReferencesStyle
+        ? { type: Sequelize.INTEGER, references: '4uth0r5', referencesKey: 'id' }
+        : { type: Sequelize.INTEGER, references: { model: '4uth0r5', key: 'id' } }
+        ;
+
+      var Post = this.sequelize.define('post', { title: Sequelize.STRING, authorId: authorIdColumn });
 
       this.Author.hasMany(Post);
       Post.belongsTo(this.Author);
@@ -2288,22 +2280,26 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     it('works with comments', function() {
       // Test for a case where the comment was being moved to the end of the table when there was also a reference on the column, see #1521
       // jshint ignore:start
-      var Member = this.sequelize.define('Member', {})
-        , Profile = this.sequelize.define('Profile', {
-            id: {
-              type: Sequelize.INTEGER,
-              primaryKey: true,
-              references: {
-                model: Member,
-                key:   'id'
-              },
-              autoIncrement: false,
-              comment: 'asdf'
-            }
-          });
+      var Member = this.sequelize.define('Member', {});
+      var idColumn = {
+        type: Sequelize.INTEGER,
+        primaryKey: true,
+        autoIncrement: false,
+        comment: 'asdf'
+      };
+
+      if (useNewReferencesStyle) {
+        idColumn.references = { model: Member, key: 'id' };
+      } else {
+        idColumn.references = Member;
+        idColumn.referencesKey = 'id';
+      }
+
+      var Profile = this.sequelize.define('Profile', { id: idColumn });
       // jshint ignore:end
 
       return this.sequelize.sync({ force: true });
+    });
     });
   });
 

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -2183,8 +2183,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             title: Sequelize.STRING,
             authorId: {
               type: Sequelize.INTEGER,
-              references: this.Author,
-              referencesKey: 'id'
+              references: {
+                model: this.Author,
+                key:   'id'
+              }
             }
           });
 
@@ -2213,8 +2215,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             title: Sequelize.STRING,
             authorId: {
               type: Sequelize.INTEGER,
-              references: 'authors',
-              referencesKey: 'id'
+              references: {
+                model: 'authors',
+                key:   'id'
+              }
             }
           });
 
@@ -2242,8 +2246,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             title: Sequelize.STRING,
             authorId: {
               type: Sequelize.INTEGER,
-              references: '4uth0r5',
-              referencesKey: 'id'
+              references: {
+                model: '4uth0r5',
+                key:   'id'
+              }
             }
           });
 
@@ -2284,15 +2290,17 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       // jshint ignore:start
       var Member = this.sequelize.define('Member', {})
         , Profile = this.sequelize.define('Profile', {
-        id: {
-          type: Sequelize.INTEGER,
-          primaryKey: true,
-          references: Member,
-          referencesKey: 'id',
-          autoIncrement: false,
-          comment: 'asdf'
-        }
-      });
+            id: {
+              type: Sequelize.INTEGER,
+              primaryKey: true,
+              references: {
+                model: Member,
+                key:   'id'
+              },
+              autoIncrement: false,
+              comment: 'asdf'
+            }
+          });
       // jshint ignore:end
 
       return this.sequelize.sync({ force: true });
@@ -2571,8 +2579,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     var project = this.sequelize.define('project', {
       UserId: {
         type: Sequelize.STRING,
-        references: 'Users',
-        referencesKey: 'UUID'
+        references: {
+          model: 'Users',
+          key:   'UUID'
+        }
       }
     });
 

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -456,8 +456,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         return this.sequelize.sync({ force: true })
         .then(function() {
           var attrs = this.Task.tableAttributes;
-          expect(attrs.user_id.references).to.equal('users');
-          expect(attrs.user_id.referencesKey).to.equal('userId');
+          expect(attrs.user_id.references.model).to.equal('users');
+          expect(attrs.user_id.references.key).to.equal('userId');
         }.bind(this));
       });
 

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -406,8 +406,10 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
       }).bind(this).then(function() {
         return this.queryInterface.addColumn('users', 'level_id', {
           type: DataTypes.INTEGER,
-          references: 'level',
-          referenceKey: 'id',
+          references: {
+            model: 'level',
+            key:   'id'
+          },
           onUpdate: 'cascade',
           onDelete: 'set null'
         }, {logging: log});
@@ -466,19 +468,25 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
           },
           admin: {
             type: DataTypes.INTEGER,
-            references: 'users',
-            referenceKey: 'id'
+            references: {
+              model: 'users',
+              key:   'id'
+            }
           },
           operator: {
             type: DataTypes.INTEGER,
-            references: 'users',
-            referenceKey: 'id',
+            references: {
+              model: 'users',
+              key:   'id'
+            },
             onUpdate: 'cascade'
           },
           owner: {
             type: DataTypes.INTEGER,
-            references: 'users',
-            referenceKey: 'id',
+            references: {
+              model: 'users',
+              key:   'id'
+            },
             onUpdate: 'cascade',
             onDelete: 'set null'
           }

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -737,7 +737,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
       it('returns an error correctly if unable to sync a foreign key referenced model', function() {
         this.sequelize.define('Application', {
-          authorID: { type: Sequelize.BIGINT, allowNull: false, references: 'User', referencesKey: 'id' }
+          authorID: { type: Sequelize.BIGINT, allowNull: false, references: { model: 'User', key: 'id' } }
         });
 
         return this.sequelize.sync().catch(function(error) {

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -189,4 +189,26 @@ describe(Support.getTestDialectTeaser('Utils'), function() {
       expect(Utils.singularize('status')).to.equal('status');
     });
   });
+
+  describe('formatReferences', function () {
+    ([
+      [undefined, undefined],
+      [false, false],
+      [null, null],
+      ['a', 'a'],
+      [{}, {}],
+      [{a: 1}, {a: 1}],
+      [{referencesKey: 1}, {referencesKey: 1}],
+      [{references: 'a'}, {references: {model: 'a'}}],
+      [{references: 'a', referencesKey: 1}, {references: {model: 'a', key: 1}}],
+      [{references: {model: 1}}, {references: {model: 1}}]
+    ]).forEach(function (test) {
+      var input  = test[0];
+      var output = test[1];
+
+      it('converts ' + JSON.stringify(input) + ' to ' + JSON.stringify(output), function () {
+        expect(Utils.formatReferences(input)).to.deep.equal(output);
+      });
+    });
+  });
 });

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -189,26 +189,4 @@ describe(Support.getTestDialectTeaser('Utils'), function() {
       expect(Utils.singularize('status')).to.equal('status');
     });
   });
-
-  describe('formatReferences', function () {
-    ([
-      [undefined, undefined],
-      [false, false],
-      [null, null],
-      ['a', 'a'],
-      [{}, {}],
-      [{a: 1}, {a: 1}],
-      [{referencesKey: 1}, {referencesKey: 1}],
-      [{references: 'a'}, {references: {model: 'a'}}],
-      [{references: 'a', referencesKey: 1}, {references: {model: 'a', key: 1}}],
-      [{references: {model: 1}}, {references: {model: 1}}]
-    ]).forEach(function (test) {
-      var input  = test[0];
-      var output = test[1];
-
-      it('converts ' + JSON.stringify(input) + ' to ' + JSON.stringify(output), function () {
-        expect(Utils.formatReferences(input)).to.deep.equal(output);
-      });
-    });
-  });
 });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+/* jshint -W030 */
+/* jshint -W110 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Utils = require(__dirname + '/../../lib/utils')
+  , Support = require(__dirname + '/support');
+
+describe(Support.getTestDialectTeaser('Utils'), function() {
+  describe('formatReferences', function () {
+    ([
+      [{referencesKey: 1}, {references: {model: undefined, key: 1}, referencesKey: undefined}],
+      [{references: 'a'}, {references: {model: 'a', key: undefined}, referencesKey: undefined}],
+      [{references: 'a', referencesKey: 1}, {references: {model: 'a', key: 1}, referencesKey: undefined}],
+      [{references: {model: 1}}, {references: {model: 1}}]
+    ]).forEach(function (test) {
+      var input  = test[0];
+      var output = test[1];
+
+      it('converts ' + JSON.stringify(input) + ' to ' + JSON.stringify(output), function () {
+        expect(Utils.formatReferences(input)).to.deep.equal(output);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR transforms the `references` property of a model column into an object and groups the key property below it, too.

Relates to https://github.com/sequelize/sequelize/pull/3702