### PR TITLE
Fixed association accessor when it's object.

### DIFF
--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -94,6 +94,18 @@ var Utils = require('./../utils')
  */
 var Mixin = module.exports = function() {};
 
+var getAssociationAccessor = function(accessor) {
+  if (Utils._.isString(accessor)) {
+    return accessor;
+  }
+
+  if (accessor.plural) {
+    return accessor.plural;
+  } else {
+    return accessor.singular;
+  }
+};
+
 // The logic for hasOne and belongsTo is exactly the same
 var singleLinked = function (Type) {
   return function(targetModel, options) {
@@ -110,7 +122,7 @@ var singleLinked = function (Type) {
 
     // the id is in the foreign table
     var association = new Type(sourceModel, targetModel, Utils._.extend(options, sourceModel.options));
-    sourceModel.associations[association.associationAccessor] = association.injectAttributes();
+    sourceModel.associations[getAssociationAccessor(association.associationAccessor)] = association.injectAttributes();
 
     association.injectGetter(sourceModel.Instance.prototype);
     association.injectSetter(sourceModel.Instance.prototype);
@@ -119,6 +131,7 @@ var singleLinked = function (Type) {
     return association;
   };
 };
+
 /**
  * Creates an association between this (the source) and the provided target. The foreign key is added on the target.
  *
@@ -258,7 +271,7 @@ Mixin.hasMany = function(targetModel, options) {
 
   // the id is in the foreign table or in a connecting table
   var association = new HasMany(sourceModel, targetModel, options);
-  sourceModel.associations[association.associationAccessor] = association.injectAttributes();
+  sourceModel.associations[getAssociationAccessor(association.associationAccessor)] = association.injectAttributes();
 
   association.injectGetter(sourceModel.Instance.prototype);
   association.injectSetter(sourceModel.Instance.prototype);
@@ -352,7 +365,7 @@ Mixin.belongsToMany = function(targetModel, options) {
 
   // the id is in the foreign table or in a connecting table
   var association = new BelongsToMany(sourceModel, targetModel, options);
-  sourceModel.associations[association.associationAccessor] = association.injectAttributes();
+  sourceModel.associations[getAssociationAccessor(association.associationAccessor)] = association.injectAttributes();
 
   association.injectGetter(sourceModel.Instance.prototype);
   association.injectSetter(sourceModel.Instance.prototype);


### PR DESCRIPTION
Hi there.
I've faced with issue, when my model has multiple associations and they have alias as object.
As result, the latest association override previous one and I have only one association.