### PR TITLE
SEMVER: Fix findOrCreate logic. Closes #2970 and #2684

### DIFF
--- a/docs/docs/models-definition.md
+++ b/docs/docs/models-definition.md
@@ -600,7 +600,7 @@ Let's assume we have an empty database with a `User` model which has a `username
 
 ```js
 User
-  .findOrCreate({where: {username: 'sdepold'}, defaults: {job: 'Technical Lead JavaScript'}})
+  .findOrCreate({where: {username: 'sdepold'}, defaults: {username: 'sdepold', job: 'Technical Lead JavaScript'}})
   .spread(function(user, created) {
     console.log(user.get({
       plain: true
@@ -626,7 +626,7 @@ User
   .create({ username: 'fnord', job: 'omnomnom' })
   .then(function() {
     User
-      .findOrCreate({where: {username: 'fnord'}, defaults: {job: 'something else'}})
+      .findOrCreate({where: {username: 'fnord'}, defaults: {username: 'fnord', job: 'something else'}})
       .spread(function(user, created) {
         console.log(user.get({
           plain: true

--- a/lib/model.js
+++ b/lib/model.js
@@ -1159,8 +1159,12 @@ module.exports = (function() {
     var self = this
       , internalTransaction = !options.transaction
       // Only use the where object as defaults data if no defaults where set. Otherwise it's not for certain what the user actually intended to do
-      , values = options.defaults || options.where
+      , values = options.where
       , transaction;
+
+    if (options.defaults && Object.keys(options.defaults).length !== 0) {
+      values = options.defaults;
+    }
 
     // Create a transaction or a savepoint, depending on whether a transaction was passed in
     return self.sequelize.transaction(options).then(function (t) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -911,7 +911,6 @@ module.exports = (function() {
    *
    * @param {Object} [findOptions] See findAll
    *
-   * @see {Model#findAll} for a specification of find and query options
    * @return {Promise<Object>}
    * @alias findAndCountAll
    */
@@ -1102,6 +1101,7 @@ module.exports = (function() {
    * @param {Object}   [options.transaction] Transaction to run query under
    * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
    *
+   * @see {Model#findAll} for a specification of find options
    * @return {Promise<Instance>}
    * @alias findOrBuild
    */
@@ -1145,6 +1145,7 @@ module.exports = (function() {
    * @param {Object}   [options.defaults] Default values to use if creating a new instance
    * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
    *
+   * @see {Model#findAll} for a specification of find options
    * @return {Promise<Instance,created>}
    */
   Model.prototype.findOrCreate = function(options) {
@@ -1157,34 +1158,27 @@ module.exports = (function() {
 
     var self = this
       , internalTransaction = !options.transaction
-      , values
-      , whereFields = Object.keys(options.where)
-      , defaultFields
+      // Only use the where object as defaults data if no defaults where set. Otherwise it's not for certain what the user actually intended to do
+      , values = options.defaults || options.where
       , transaction;
 
-    if (options.defaults) defaultFields = Object.keys(options.defaults);
-
     // Create a transaction or a savepoint, depending on whether a transaction was passed in
-    return self.sequelize.transaction(options).bind({}).then(function (t) {
+    return self.sequelize.transaction(options).then(function (t) {
       transaction = t;
       options.transaction = t;
 
       return self.findOne(_.defaults({
-        transaction: transaction
+        transaction: transaction,
+        // lock: options.lock || self.sequelize.dialect.supports.lock ? transaction.LOCK.UPDATE : undefined
       }, options));
     }).then(function(instance) {
       if (instance !== null) {
         return [instance, false];
       }
 
-      values = Utils._.clone(options.defaults) || {};
-      if (Utils._.isPlainObject(options.where)) {
-        values = _.defaults(values, options.where);
-      }
-
       options.exception = true;
 
-      return self.create(values, options).bind(this).then(function(instance) {
+      return self.create(values, options).then(function(instance) {
         if (instance.get(self.primaryKeyAttribute, { raw: true }) === null) {
           // If the query returned an empty result for the primary key, we know that this was actually a unique constraint violation
           throw new self.sequelize.UniqueConstraintError();
@@ -1192,19 +1186,19 @@ module.exports = (function() {
 
         return [instance, true];
       }).catch(self.sequelize.UniqueConstraintError, function (err) {
-        if (defaultFields) {
-          if (!_.intersection(err.fields, whereFields).length && _.intersection(err.fields, defaultFields).length) {
-            throw err;
-          }
+        // If a unique constraint error occured and defaults are set we can't recover from the issue
+        if (options.defaults) {
+          throw err;
         }
-
         // Someone must have created a matching instance inside the same transaction since we last did a find. Let's find it!
         return self.findOne(_.defaults({
           transaction: internalTransaction ? null : transaction
         }, options)).then(function(instance) {
-          // Sanity check, ideally we caught this at the defaultFeilds/err.fields check
+          // Sanity check, ideally we caught this at by checking if defaults are set
           // But if we didn't and instance is null, we will throw
-          if (instance === null) throw err;
+          if (instance === null) {
+            throw err;
+          }
           return [instance, false];
         });
       });
@@ -2122,7 +2116,7 @@ module.exports = (function() {
       return;
     }
 
-	 for (var index = 0; index < includes.length; index++) {
+    for (var index = 0; index < includes.length; index++) {
       var include = includes[index];
 
       if (include.all) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1173,7 +1173,7 @@ module.exports = (function() {
 
       return self.findOne(_.defaults({
         transaction: transaction,
-        // lock: options.lock || self.sequelize.dialect.supports.lock ? transaction.LOCK.UPDATE : undefined
+        lock: self.sequelize.dialect.supports.lock ? options.lock || transaction.LOCK.SHARE : undefined
       }, options));
     }).then(function(instance) {
       if (instance !== null) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1167,7 +1167,7 @@ module.exports = (function() {
     }
 
     // Create a transaction or a savepoint, depending on whether a transaction was passed in
-    return self.sequelize.transaction(options).then(function (t) {
+    return self.sequelize.transaction(options).bind({}).then(function (t) {
       transaction = t;
       options.transaction = t;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1173,7 +1173,7 @@ module.exports = (function() {
 
       return self.findOne(_.defaults({
         transaction: transaction,
-        lock: self.sequelize.dialect.supports.lock ? options.lock || transaction.LOCK.SHARE : undefined
+        // lock: self.sequelize.dialect.supports.lock ? options.lock || transaction.LOCK.SHARE : undefined
       }, options));
     }).then(function(instance) {
       if (instance !== null) {

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -274,7 +274,7 @@ if (dialect.match(/^postgres/)) {
         var self = this;
         var text = "Multi-line '$string' needing \"escaping\" for $$ and $1 type values";
 
-        return this.User.findOrCreate({ where: { username: 'swen' }, defaults: { emergency_contact: { value: text } } })
+        return this.User.findOrCreate({ where: { username: 'swen' }, defaults: { username: 'swen', emergency_contact: { value: text } } })
           .then(function(user) {
             expect(!user.isNewRecord).to.equal(true);
           })

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -325,7 +325,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         };
 
       return this.User.findOrCreate({ where: data, defaults: default_values}).spread(function(user, created) {
-        expect(user.username).to.be.empty;
+        expect(user.username).to.not.exist;
         expect(user.data).to.equal('ThisIsData');
         expect(created).to.be.true;
       });

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -306,12 +306,14 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         defaults: {}
       }).spread(function(user, created) {
         expect(user.dataValues.sequelize_caught_exception).to.be.undefined;
+        expect(user.username).to.be.equal('Username');
       }).then(function () {
         return self.User.findOrCreate({
           where: data,
           defaults: {}
         }).spread(function(user, created) {
           expect(user.dataValues.sequelize_caught_exception).to.be.undefined;
+          expect(user.data).to.be.equal('ThisIsData');
         });
       });
     });

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -45,7 +45,17 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       it('supports transactions', function() {
         var self = this;
         return this.sequelize.transaction().then(function(t) {
-          return self.User.findOrCreate({ where: { username: 'Username' }, defaults: { data: 'some data' }, transaction: t }).then(function() {
+          return self.User.findOrCreate({
+            where: {
+              username: {
+                $ne: 'Username'
+              }
+            },
+            defaults: {
+              data: 'some data'
+            },
+            transaction: t
+          }).then(function() {
             return self.User.count().then(function(count) {
               expect(count).to.equal(0);
               return t.commit().then(function() {
@@ -306,7 +316,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
-    it('creates new instance with default value.', function() {
+    it('creates new instance with default value', function() {
       var data = {
           username: 'Username'
         },
@@ -315,7 +325,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         };
 
       return this.User.findOrCreate({ where: data, defaults: default_values}).spread(function(user, created) {
-        expect(user.username).to.equal('Username');
+        expect(user.username).to.be.empty;
         expect(user.data).to.equal('ThisIsData');
         expect(created).to.be.true;
       });
@@ -323,7 +333,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
 
     it('supports .or() (only using default values)', function() {
       return this.User.findOrCreate({
-        where: Sequelize.or({username: 'Fooobzz'}, {secretValue: 'Yolo'}),
+        where: Sequelize.or({ username: 'Fooobzz' }, { secretValue: 'Yolo' }),
         defaults: {username: 'Fooobzz', secretValue: 'Yolo'}
       }).spread(function(user, created) {
         expect(user.username).to.equal('Fooobzz');


### PR DESCRIPTION
Here's a BC: If defaults is set, it will only use the defaults object from now on. This is necessary to be sure what the user actually wants. Otherwise there will always be some problems by combining complex where with the defaults.

Only one test is breaking by this change. Other than that one issue is fixed and from now on it's possible to use complex where statements.

I also inserted a update lock as a default.