### PR TITLE
Join with limit fix

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -873,9 +873,7 @@ module.exports = (function() {
         , mainAttributes = options.attributes && options.attributes.slice(0)
         , mainJoinQueries = []
         // We'll use a subquery if we have a hasMany association and a limit
-        , subQuery = options.subQuery === undefined ?
-                     limit && options.hasMultiAssociation :
-                     options.subQuery
+        , subQuery = limit && (options.hasIncludeWhere || options.hasIncludeRequired || options.hasMultiAssociation) && options.subQuery !== false && options.doSubQuery===true
         , subQueryItems = []
         , subQueryAttributes = null
         , subJoinQueries = []


### PR DESCRIPTION
This fixes a bug (#3462) when using a join (belongsToMany) and limit. The limit was placed within the subquery, now it is placed correctly. Referencing:

http://stackoverflow.com/questions/26021965/sequelize-with-nodejs-cant-join-tables-with-limit