### PR TITLE
Add 'mssql' as dialect option in API docs (replaces #3754)

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -56,7 +56,7 @@ module.exports = (function() {
    * @param {String}   [username=null] The username which is used to authenticate against the database.
    * @param {String}   [password=null] The password which is used to authenticate against the database.
    * @param {Object}   [options={}] An object with options.
-   * @param {String}   [options.dialect='mysql'] The dialect of the database you are connecting to. One of mysql, postgres, sqlite and mariadb
+   * @param {String}   [options.dialect='mysql'] The dialect of the database you are connecting to. One of mysql, postgres, sqlite, mariadb and mssql.
    * @param {String}   [options.dialectModulePath=null] If specified, load the dialect library from this path. For example, if you want to use pg.js instead of pg when connecting to a pg database, you should specify 'pg.js' here
    * @param {Object}   [options.dialectOptions] An object of additional options, which are passed directly to the connection library
    * @param {String}   [options.storage] Only used by sqlite. Defaults to ':memory:'


### PR DESCRIPTION
PR #3754 was an horrible attempt to edit the API docs.
This PR is the correct one.