### PR TITLE
Bug fix: #3266 - belongsToMany junction table timestamp

### DIFF
--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -347,8 +347,9 @@ Mixin.belongsToMany = function(targetModel, options) {
   options = options || {};
   options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
   options.useHooks = options.hooks;
-
-  options = Utils._.extend(options, Utils._.omit(sourceModel.options, ['hooks']));
+  options.timestamps = options.timestamps === undefined ? this.sequelize.options.timestamps : options.timestamps;
+  
+  options = Utils._.extend(options, Utils._.omit(sourceModel.options, ['hooks', 'timestamps']));
 
   // the id is in the foreign table or in a connecting table
   var association = new BelongsToMany(sourceModel, targetModel, options);


### PR DESCRIPTION
Very small fix, it's now possible to control belongsToMany association timestamps, by default it uses global timestamp option value.
````js
Model.belongsToMany(Model, {
    foreignKey:  'model_id'
    through: 'my_through_table',
    timestamps: false
});
````