### PR TITLE
Fixes #3799 hasOwnProperty is now called through Object.prototype

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -658,15 +658,15 @@ module.exports = (function() {
     }
 
     if (Utils._.isPlainObject(sql)) {
-      if (sql.hasOwnProperty('values')) {
-        if (options.hasOwnProperty('replacements')) {
+      if (Object.prototype.hasOwnProperty.call(sql,'values')) {
+        if (Object.prototype.hasOwnProperty.call(options,'replacements')) {
           throw new Error('Both `sql.values` and `options.replacements` cannot be set at the same time');
         }
 
         options.replacements = sql.values;
       }
 
-      if (sql.hasOwnProperty('query')) {
+      if (Object.prototype.hasOwnProperty.call(sql,'query')) {
         sql = sql.query;
       }
     }

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -156,7 +156,7 @@ SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
       return value;
     }
 
-    if (values.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(values,key)) {
       return SqlString.escape(values[key], false, timeZone, dialect);
     } else {
       throw new Error('Named parameter "' + value + '" has no value in the given object.');


### PR DESCRIPTION
If Object.create('null') is used to create the object, it loses the
prototype. Calling hasOwnProperty through Object.prototype ensures that
hasOwnProperty is safely called. For further details, refer to the
comments on the issue.