### PR TITLE
Fix bug on joining with sub-query

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1194,6 +1194,11 @@ module.exports = (function() {
               , joinOn
               , subQueryJoinOn;
 
+            // Use association.identifier as attrLeft on joining with sub-query
+            if (subQuery && primaryKeysLeft.indexOf(attrLeft) && tableLeft === mainTableAs) {
+              attrLeft = association.identifier;
+            }
+
             // Filter statement
             // Used by both join and where
             if (subQuery && !include.subQuery && include.parent.subQuery && (include.hasParentRequired || include.hasParentWhere || include.parent.hasIncludeRequired || include.parent.hasIncludeWhere)) {


### PR DESCRIPTION
Hi, I have an issue with using sequelize, and below is my case:
- Code for model defining:

``` js
sequelize.define('share', {
  lecturer_id: {
    field: 'lecturer',
    type: Sequelize.INTEGER,
  },
}, {
  freezeTableName: true
});
sequelize.define('mituser', {
  name: Sequelize.STRING,
}, {
});
sequelize.define('reltag', {
  objid: Sequelize.INTEGER,
}, {
  freezeTableName: true
});
```
- Code for associations:

``` js
models.share.belongsTo(models.mituser, { as: 'lecturer' });
models.share.hasMany(models.reltag, { as: 'tags' });
```
- Code for query:

``` js
  models.share.findAll({
    include: [
      models.share.associations.lecturer,
      association: models.share.associations.tags,
    ],
    order: 'start DESC',
    limit: 10,
  }).then(res.json.bind(res)).catch(next);
```

And the problem is this generates wrong SQL:

``` sql
SELECT
    `share`.*, `lecturer`.`id` AS `lecturer.id`,
    `lecturer`.`name` AS `lecturer.name`,
    `tags`.`id` AS `tags.id`,
    `tags`.`objid` AS `tags.objid`,
FROM
    (
        SELECT
            `share`.`id`,
            `share`.`lecturer` AS `lecturer_id`,
        FROM
            `share` AS `share`
        LIMIT 10
    ) AS `share`
LEFT OUTER JOIN `mituser` AS `lecturer` ON `share`.`lecturer` = `lecturer`.`id`
LEFT OUTER JOIN `reltag` AS `tags` ON `share`.`id` = `tags`.`objid`
ORDER BY
    start DESC
```

And the line

``` sql
LEFT OUTER JOIN `mituser` AS `lecturer` ON `share`.`lecturer` = `lecturer`.`id`
```

should be

``` sql
LEFT OUTER JOIN `mituser` AS `lecturer` ON `share`.`lecturer_id` = `lecturer`.`id`
```

So I dived in this and fix this with this PR. Happy merging?
