### PR TITLE
Add support for keyword `after` in options of a field. Closes #3166

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Next
+- [FEATURE] Add support for keyword `after` in options of a field (useful for migrations), only for MySQL. [#3166](https://github.com/sequelize/sequelize/pull/3166)
 - [FIXED] Fix a case where `type` in `sequelize.query` was not being set to raw. [#3800](https://github.com/sequelize/sequelize/pull/3800)
 - [FIXED] Fix an issue where include all was not being properly expanded for self-references [#3804](https://github.com/sequelize/sequelize/issues/3804)
 

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -291,6 +291,10 @@ module.exports = (function() {
         template += ' PRIMARY KEY';
       }
 
+      if (attribute.after) {
+        template += ' AFTER ' + this.quoteIdentifier(attribute.after);
+      }
+
       if (attribute.references) {
         attribute = Utils.formatReferences(attribute);
         template += ' REFERENCES ' + this.quoteTable(attribute.references.model);

--- a/test/integration/dialects/mysql/query-generator.test.js
+++ b/test/integration/dialects/mysql/query-generator.test.js
@@ -43,6 +43,10 @@ if (Support.dialectIsMySQL()) {
           arguments: [{id: {type: 'INTEGER', unique: true}}],
           expectation: {id: 'INTEGER UNIQUE'}
         },
+        {
+          arguments: [{id: {type: 'INTEGER', after: 'Bar'}}],
+          expectation: {id: 'INTEGER AFTER `Bar`'}
+        },
 
         // Old references style
         {


### PR DESCRIPTION
I took the freedom to do this since @sitexw did not respond anymore.