### PR TITLE
Fixes typo in associations doc regarding Mixins (specifiy -> specify)

### DIFF
--- a/docs/api/associations.md
+++ b/docs/api/associations.md
@@ -6,7 +6,7 @@ on a model (the source), and providing another model as the first argument to th
 
 * hasOne - adds a foreign key to target
 * belongsTo - add a foreign key to source
-* hasMany - adds a foreign key to target, unless you also specifiy that target hasMany source, in which case a junction table is created with sourceId and targetId
+* hasMany - adds a foreign key to target, unless you also specify that target hasMany source, in which case a junction table is created with sourceId and targetId
 
 Creating an association will add a foreign key constraint to the attributes. All associations use `CASCADE` on update and `SET NULL` on delete, except for n:m, which also uses `CASCADE` on delete.
 

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -12,7 +12,7 @@ var Utils = require('./../utils')
  *
  * * hasOne - adds a foreign key to target
  * * belongsTo - add a foreign key to source
- * * hasMany - adds a foreign key to target, unless you also specifiy that target hasMany source, in which case a junction table is created with sourceId and targetId
+ * * hasMany - adds a foreign key to target, unless you also specify that target hasMany source, in which case a junction table is created with sourceId and targetId
  *
  * Creating an association will add a foreign key constraint to the attributes. All associations use `CASCADE` on update and `SET NULL` on delete, except for n:m, which also uses `CASCADE` on delete.
  *


### PR DESCRIPTION
Current typo as seen in the hasMany bullet:

![screen shot 2015-05-28 at 7 37 09 pm](https://cloud.githubusercontent.com/assets/7923322/7875374/28549b9e-0571-11e5-9cce-e33ceb72b08f.png)
