### PR TITLE
Allow instance with primary key of 0 to update

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -538,7 +538,7 @@ Instance.prototype.save = function(options) {
   }
 
   if (this.isNewRecord === false) {
-    if (primaryKeyName && !this.get(primaryKeyName, {raw: true})) {
+    if (primaryKeyName && this.get(primaryKeyName, {raw: true}) === undefined) {
       throw new Error('You attempted to save an instance with no primary key, this is not allowed since it would result in a global update');
     }
   }

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -898,6 +898,38 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       });
     });
 
+    it('handles an entry with primaryKey of zero', function() {
+      var username = 'user'
+        , newUsername = 'newUser'
+        , User2 = this.sequelize.define('User2',
+          {
+            id: {
+              type: DataTypes.INTEGER.UNSIGNED,
+              autoIncrement: false,
+              primaryKey: true
+            },
+            username: { type: DataTypes.STRING }
+          });
+
+      return User2.sync().then(function () {
+        return User2.create({id: 0, username: username}).then(function (user){
+          expect(user).to.be.ok;
+          expect(user.id).to.equal(0);
+          expect(user.username).to.equal(username);
+          return User2.findById(0).then(function (user) {
+            expect(user).to.be.ok;
+            expect(user.id).to.equal(0);
+            expect(user.username).to.equal(username);
+            return user.updateAttributes({username: newUsername}).then(function (user) {
+              expect(user).to.be.ok;
+              expect(user.id).to.equal(0);
+              expect(user.username).to.equal(newUsername);
+            });
+          });
+        });
+      });
+    });
+
     it('updates the timestamps', function() {
       var now = Date.now()
         , user = null


### PR DESCRIPTION
When creating an instance, there is no 'truthiness' check performed on the primary key, which allows creating an instance with a primary key of 0.

This instance can be queried for with no issues, but, currently, the instance cannot be updated, because there is a simple boolean check and a value of 0 fails. This pull request changes the check to look for `undefined`.

I'm not sure if the unit test I wrote is sufficient. Let me know how else I could check it.