### PR TITLE
Fix `options.logging` not being passed to queries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 - [FIXED] Fix an issue where include all was not being properly expanded for self-references [#3804](https://github.com/sequelize/sequelize/issues/3804)
 - [FIXED] Fix instance.changed regression to not return false negatives for not changed null values [#3812](https://github.com/sequelize/sequelize/issues/3812)
 - [FIXED] Fix isEmail validator to allow args: true [#3770](https://github.com/sequelize/sequelize/issues/3770)
+- [FIXED] Fix some occasions where `options.logging` was not used correctly
+- [FIXED] Fix `Model#destroy()` to correctly use `options.transaction`
 
 # 3.1.1
 - [FIXED] Always quote aliases, even when quoteIdentifiers is false [#1589](https://github.com/sequelize/sequelize/issues/1589)

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -167,6 +167,7 @@ module.exports = (function() {
       if ((fieldsOrOptions || {}).transaction instanceof Transaction) {
         options.transaction = fieldsOrOptions.transaction;
       }
+      options.logging = (fieldsOrOptions || {}).logging;
 
       return association.target.create(values, fieldsOrOptions).then(function(newAssociatedObject) {
         return instance[association.accessors.set](newAssociatedObject, options);

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -257,7 +257,8 @@ module.exports = (function() {
         return instance[association.accessors.get]({
           where: newInstance.where(),
           scope: false,
-          transaction: options.transaction
+          transaction: options.transaction,
+          logging: options.logging
         }).bind(this).then(function(currentAssociatedObjects) {
           if (currentAssociatedObjects.length === 0) {
             newInstance.set(association.identifier, instance.get(instance.Model.primaryKeyAttribute));

--- a/lib/model.js
+++ b/lib/model.js
@@ -1478,7 +1478,7 @@ module.exports = (function() {
     }).then(function() {
       // Get daos and run beforeDestroy hook on each record individually
       if (options.individualHooks) {
-        return self.findAll({where: options.where, transaction: options.transaction}).map(function(instance) {
+        return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging}).map(function(instance) {
           return self.runHooks('beforeDestroy', instance, options).then(function() {
             return instance;
           });
@@ -1550,7 +1550,7 @@ module.exports = (function() {
     }).then(function() {
       // Get daos and run beforeDestroy hook on each record individually
       if (options.individualHooks) {
-        return self.findAll({where: options.where}, {transaction: options.transaction}).map(function(instance) {
+        return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging}).map(function(instance) {
           return self.runHooks('beforeRestore', instance, options).then(function() {
             return instance;
           });
@@ -1676,7 +1676,7 @@ module.exports = (function() {
 
       // Get instances and run beforeUpdate hook on each record individually
       if (options.individualHooks) {
-        return self.findAll({where: options.where, transaction: options.transaction}).then(function(_instances) {
+        return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging}).then(function(_instances) {
           instances = _instances;
           if (!instances.length) {
             return [];


### PR DESCRIPTION
In some cases `options.logging` is not being passed around within Sequelize correctly.

e.g. `Model#destroy()` does not pass `options.logging` to it's internal call to `Model#findAll()`.

This PR fixes these.

However, I'm not confident that I've found them all, and I guess it might need some test coverage. I'm opening a separate issue about this broader question.