### PR TITLE
Fix QueryInterface#showIndex not passing transaction

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 - [FIXED] Fix an issue where include all was not being properly expanded for self-references [#3804](https://github.com/sequelize/sequelize/issues/3804)
 - [FIXED] Fix instance.changed regression to not return false negatives for not changed null values [#3812](https://github.com/sequelize/sequelize/issues/3812)
 - [FIXED] Fix isEmail validator to allow args: true [#3770](https://github.com/sequelize/sequelize/issues/3770)
+- [FIXED] Fix `QueryInterface#showIndex()` to correctly pass on `options.transaction`
 
 # 3.1.1
 - [FIXED] Always quote aliases, even when quoteIdentifiers is false [#1589](https://github.com/sequelize/sequelize/issues/1589)

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -454,6 +454,7 @@ module.exports = (function() {
     var sql = this.QueryGenerator.showIndexesQuery(tableName, options);
     options = options || {};
     return this.sequelize.query(sql, {
+      transaction: options.transaction,
       logging: options.logging,
       type: QueryTypes.SHOWINDEXES
     });


### PR DESCRIPTION
`QueryInterface#showIndex()` does not pass `options.transaction` to its call to `sequelize.query()`.

This PR fixes that.

Please see also issue https://github.com/sequelize/sequelize/issues/3834