### PR TITLE
Type warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 - [FEATURE] Add support for keyword `after` in options of a field (useful for migrations), only for MySQL. [#3166](https://github.com/sequelize/sequelize/pull/3166)
 - [FEATURE] There's a new sequelize.truncate function to truncate all tables defined through the sequelize models [#2671](https://github.com/sequelize/sequelize/pull/2671)
 - [FEATURE] Add support for MySQLs TINYTEXT, MEDIUMTEXT and LONGTEXT. [#3836](https://github.com/sequelize/sequelize/pull/3836)
+- [FEATURE] Provide warnings if you misuse data types. [#3839](https://github.com/sequelize/sequelize/pull/3839)
 - [FIXED] Fix a case where `type` in `sequelize.query` was not being set to raw. [#3800](https://github.com/sequelize/sequelize/pull/3800)
 - [FIXED] Fix an issue where include all was not being properly expanded for self-references [#3804](https://github.com/sequelize/sequelize/issues/3804)
 - [FIXED] Fix instance.changed regression to not return false negatives for not changed null values [#3812](https://github.com/sequelize/sequelize/issues/3812)

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var util = require('util')
-  , _ = require('lodash');
+  , _ = require('lodash')
+  , warnings = {};
 
 /**
  * A convenience class holding commonly used data types. The datatypes are used when definining a new model using `Sequelize.define`, like this:
@@ -38,11 +39,19 @@ var ABSTRACT = function(options) {
 
 };
 
+ABSTRACT.prototype.dialectTypes = '';
+
 ABSTRACT.prototype.toString = function() {
   return this.toSql();
 };
 ABSTRACT.prototype.toSql = function() {
   return this.key;
+};
+ABSTRACT.prototype.warn = function(text) {
+  if (!warnings[text]) {
+    warnings[text] = true;
+    console.warn('>> WARNING:', text, '\n>> Check:', this.dialectTypes);
+  }
 };
 
 /**

--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -4,6 +4,8 @@ var BaseTypes = require('../../data-types')
   , util = require('util')
   , _ = require('lodash');
 
+BaseTypes.ABSTRACT.prototype.dialectTypes = 'https://msdn.microsoft.com/en-us/library/ms187752%28v=sql.110%29.aspx';
+
 var STRING = function() {
   if (!(this instanceof STRING)) return new STRING();
   BaseTypes.STRING.apply(this, arguments);
@@ -21,8 +23,12 @@ STRING.prototype.toSql = function() {
 BaseTypes.TEXT.prototype.toSql = function() {
   // TEXT is deprecated in mssql and it would normally be saved as a non-unicode string.
   // Using unicode is just future proof
-  if (this._length.toLowerCase() === 'tiny') {
-    return 'NVARCHAR(256)'; // tiny text should be 2^8 < 8000
+  if (this._length) {
+    if (this._length.toLowerCase() === 'tiny') { // tiny = 2^8
+      this.warn('MSSQL does not support TEXT with the `length` = `tiny` option. `NVARCHAR(256)` will be used instead.');
+      return 'NVARCHAR(256)';
+    }
+    this.warn('MSSQL does not support TEXT with the `length` option. `NVARCHAR(MAX)` will be used instead.');
   }
   return 'NVARCHAR(MAX)';
 };
@@ -38,8 +44,12 @@ BOOLEAN.prototype.toSql = function() {
 };
 
 BaseTypes.BLOB.prototype.toSql = function() {
-  if (this._length.toLowerCase() === 'tiny') {
-    return 'VARBINARY(256)'; // tiny blobs should be 2^8 < 8000
+  if (this._length) {
+    if (this._length.toLowerCase() === 'tiny') { // tiny = 2^8
+      this.warn('MSSQL does not support BLOB with the `length` = `tiny` option. `VARBINARY(256)` will be used instead.');
+      return 'VARBINARY(256)';
+    }
+    this.warn('MSSQL does not support BLOB with the `length` option. `VARBINARY(MAX)` will be used instead.');
   }
   return 'VARBINARY(MAX)';
 };
@@ -78,11 +88,14 @@ var INTEGER = function() {
   if (!(this instanceof INTEGER)) return new INTEGER();
   BaseTypes.INTEGER.apply(this, arguments);
 
-  // MSSQL does not support any parameters for integer
-  this._length = undefined;
-  this.options.length = undefined;
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  // MSSQL does not support any options for integer
+  if (this._length || this.options.length || this._unsigned || this._zerofill) {
+    this.warn('MSSQL does not support INTEGER with options. Plain `INTEGER` will be used instead.');
+    this._length = undefined;
+    this.options.length = undefined;
+    this._unsigned = undefined;
+    this._zerofill = undefined;
+  }
 };
 util.inherits(INTEGER, BaseTypes.INTEGER);
 
@@ -90,11 +103,14 @@ var BIGINT = function() {
   if (!(this instanceof BIGINT)) return new BIGINT();
   BaseTypes.BIGINT.apply(this, arguments);
 
-  // MSSQL does not support any parameters for bigint
-  this._length = undefined;
-  this.options.length = undefined;
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  // MSSQL does not support any options for bigint
+  if (this._length || this.options.length || this._unsigned || this._zerofill) {
+    this.warn('MSSQL does not support BIGINT with options. Plain `BIGINT` will be used instead.');
+    this._length = undefined;
+    this.options.length = undefined;
+    this._unsigned = undefined;
+    this._zerofill = undefined;
+  }
 };
 util.inherits(BIGINT, BaseTypes.BIGINT);
 
@@ -102,11 +118,14 @@ var REAL = function() {
   if (!(this instanceof REAL)) return new REAL();
   BaseTypes.REAL.apply(this, arguments);
 
-  // MSSQL does not support any parameters for real
-  this._length = undefined;
-  this.options.length = undefined;
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  // MSSQL does not support any options for real
+  if (this._length || this.options.length || this._unsigned || this._zerofill) {
+    this.warn('MSSQL does not support REAL with options. Plain `REAL` will be used instead.');
+    this._length = undefined;
+    this.options.length = undefined;
+    this._unsigned = undefined;
+    this._zerofill = undefined;
+  }
 };
 util.inherits(REAL, BaseTypes.REAL);
 
@@ -114,15 +133,23 @@ var FLOAT = function() {
   if (!(this instanceof FLOAT)) return new FLOAT();
   BaseTypes.FLOAT.apply(this, arguments);
 
-  // MSSQL does only support lengths as parameter.
+  // MSSQL does only support lengths as option.
   // Values between 1-24 result in 7 digits precision (4 bytes storage size)
   // Values between 25-53 result in 15 digits precision (8 bytes storage size)
+  // If decimals are provided remove these and print a warning
   if (this._decimals) {
+    this.warn('MSSQL does not support Float with decimals. Plain `FLOAT` will be used instead.');
     this._length = undefined;
     this.options.length = undefined;
   }
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  if (this._unsigned) {
+    this.warn('MSSQL does not support Float unsigned. `UNSIGNED` was removed.');
+    this._unsigned = undefined;
+  }
+  if (this._zerofill) {
+    this.warn('MSSQL does not support Float zerofill. `ZEROFILL` was removed.');
+    this._zerofill = undefined;
+  }
 };
 util.inherits(FLOAT, BaseTypes.FLOAT);
 

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -4,6 +4,8 @@ var BaseTypes = require('../../data-types')
   , util = require('util')
   , _ = require('lodash');
 
+BaseTypes.ABSTRACT.prototype.dialectTypes = 'https://dev.mysql.com/doc/refman/5.7/en/data-types.html';
+
 var UUID = function() {
   if (!(this instanceof UUID)) return new UUID();
   BaseTypes.UUID.apply(this, arguments);

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -4,6 +4,8 @@ var BaseTypes = require('../../data-types')
   , util = require('util')
   , _ = require('lodash');
 
+BaseTypes.ABSTRACT.prototype.dialectTypes = 'http://www.postgresql.org/docs/9.4/static/datatype.html';
+
 var STRING = function() {
   if (!(this instanceof STRING)) return new STRING();
   BaseTypes.STRING.apply(this, arguments);
@@ -18,6 +20,10 @@ STRING.prototype.toSql = function() {
 };
 
 BaseTypes.TEXT.prototype.toSql = function() {
+  if (this._length) {
+    this.warn('PostgreSQL does not support TEXT with options. Plain `TEXT` will be used instead.');
+    this._length = undefined;
+  }
   return 'TEXT';
 };
 
@@ -59,10 +65,13 @@ var INTEGER = function() {
   BaseTypes.INTEGER.apply(this, arguments);
 
   // POSTGRES does not support any parameters for integer
-  this._length = undefined;
-  this.options.length = undefined;
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  if (this._length || this.options.length || this._unsigned || this._zerofill) {
+    this.warn('PostgreSQL does not support INTEGER with options. Plain `INTEGER` will be used instead.');
+    this._length = undefined;
+    this.options.length = undefined;
+    this._unsigned = undefined;
+    this._zerofill = undefined;
+  }
 };
 util.inherits(INTEGER, BaseTypes.INTEGER);
 
@@ -71,10 +80,13 @@ var BIGINT = function() {
   BaseTypes.BIGINT.apply(this, arguments);
 
   // POSTGRES does not support any parameters for bigint
-  this._length = undefined;
-  this.options.length = undefined;
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  if (this._length || this.options.length || this._unsigned || this._zerofill) {
+    this.warn('PostgreSQL does not support BIGINT with options. Plain `BIGINT` will be used instead.');
+    this._length = undefined;
+    this.options.length = undefined;
+    this._unsigned = undefined;
+    this._zerofill = undefined;
+  }
 };
 util.inherits(BIGINT, BaseTypes.BIGINT);
 
@@ -83,10 +95,13 @@ var REAL = function() {
   BaseTypes.REAL.apply(this, arguments);
 
   // POSTGRES does not support any parameters for real
-  this._length = undefined;
-  this.options.length = undefined;
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  if (this._length || this.options.length || this._unsigned || this._zerofill) {
+    this.warn('PostgreSQL does not support REAL with options. Plain `REAL` will be used instead.');
+    this._length = undefined;
+    this.options.length = undefined;
+    this._unsigned = undefined;
+    this._zerofill = undefined;
+  }
 };
 util.inherits(REAL, BaseTypes.REAL);
 
@@ -95,10 +110,13 @@ var DOUBLE = function() {
   BaseTypes.DOUBLE.apply(this, arguments);
 
   // POSTGRES does not support any parameters for double
-  this._length = undefined;
-  this.options.length = undefined;
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  if (this._length || this.options.length || this._unsigned || this._zerofill) {
+    this.warn('PostgreSQL does not support DOUBLE with options. Plain `DOUBLE` will be used instead.');
+    this._length = undefined;
+    this.options.length = undefined;
+    this._unsigned = undefined;
+    this._zerofill = undefined;
+  }
 };
 util.inherits(DOUBLE, BaseTypes.DOUBLE);
 
@@ -109,17 +127,29 @@ var FLOAT = function() {
   // POSTGRES does only support lengths as parameter.
   // Values between 1-24 result in REAL
   // Values between 25-53 result in DOUBLE PRECISION
+  // If decimals are provided remove these and print a warning
   if (this._decimals) {
+    this.warn('PostgreSQL does not support FLOAT with decimals. Plain `FLOAT` will be used instead.');
     this._length = undefined;
     this.options.length = undefined;
     this._decimals = undefined;
   }
-  this._unsigned = undefined;
-  this._zerofill = undefined;
+  if (this._unsigned) {
+    this.warn('PostgreSQL does not support FLOAT unsigned. `UNSIGNED` was removed.');
+    this._unsigned = undefined;
+  }
+  if (this._zerofill) {
+    this.warn('PostgreSQL does not support FLOAT zerofill. `ZEROFILL` was removed.');
+    this._zerofill = undefined;
+  }
 };
 util.inherits(FLOAT, BaseTypes.FLOAT);
 
 BaseTypes.BLOB.prototype.toSql = function() {
+  if (this._length) {
+    this.warn('PostgreSQL does not support BLOB (BYTEA) with options. Plain `BYTEA` will be used instead.');
+    this._length = undefined;
+  }
   return 'BYTEA';
 };
 

--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -4,6 +4,8 @@ var BaseTypes = require('../../data-types')
   , util = require('util')
   , _ = require('lodash');
 
+BaseTypes.ABSTRACT.prototype.dialectTypes = 'https://www.sqlite.org/datatype3.html';
+
 var STRING = function() {
   if (!(this instanceof STRING)) return new STRING();
   BaseTypes.STRING.apply(this, arguments);
@@ -19,6 +21,10 @@ STRING.prototype.toSql = function() {
 };
 
 BaseTypes.TEXT.prototype.toSql = function() {
+  if (this._length) {
+    this.warn('SQLite does not support TEXT with options. Plain `TEXT` will be used instead.');
+    this._length = undefined;
+  }
   return 'TEXT';
 };
 

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -560,6 +560,13 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
 
+    // TODO: Fix Enums and add more tests
+    // suite('ENUM', function () {
+    //   testsql('ENUM("value 1", "value 2")', DataTypes.ENUM('value 1', 'value 2'), {
+    //     default: 'ENUM'
+    //   });
+    // });
+
     suite('BLOB', function () {
       testsql('BLOB', DataTypes.BLOB, {
         default: 'BLOB',


### PR DESCRIPTION
This is on top of #3836 and I wanted to get your feedback what you think about the implementation. So you only have to look at the "Initial commit" changes.

If someone uses a data type in a way that is not supported we'd now warn the user about it including what we do instead and presenting the link to the data types as they are in the current dialect.