### PR TITLE
WIP: Add dialect version parameter

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -208,17 +208,18 @@ module.exports = (function() {
         // Mostly for internal use, so we expect the user to know what he's doing!
         // pg_temp functions are private per connection, so we never risk this function interfering with another one.
 
-        // <= 9.1
-        //options.exception = 'WHEN unique_violation THEN NULL;';
-        //valueQuery = 'CREATE OR REPLACE FUNCTION pg_temp.testfunc() RETURNS SETOF <%= table %> AS $body$ BEGIN RETURN QUERY ' + valueQuery + '; EXCEPTION ' + options.exception + ' END; $body$ LANGUAGE plpgsql; SELECT * FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc();';
+        if (this.sequelize.options.dialectVersion === 0 || this.sequelize.options.dialectVersion >= 9.2) {
+          // >= 9.2 - Use a UUID but prefix with 'func_' (numbers first not allowed)
+          var delimiter = '$func_' + uuid.v4().replace(/-/g, '') + '$';
 
-        // >= 9.2 - Use a UUID but prefix with 'func_' (numbers first not allowed)
-        var delimiter = '$func_' + uuid.v4().replace(/-/g, '') + '$';
-
-        options.exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
-        valueQuery = 'CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response <%= table %>, OUT sequelize_caught_exception text) RETURNS RECORD AS ' + delimiter +
-          ' BEGIN ' + valueQuery + ' INTO response; EXCEPTION ' + options.exception + ' END ' + delimiter +
-          ' LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()';
+          options.exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
+          valueQuery = 'CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response <%= table %>, OUT sequelize_caught_exception text) RETURNS RECORD AS ' + delimiter +
+            ' BEGIN ' + valueQuery + ' INTO response; EXCEPTION ' + options.exception + ' END ' + delimiter +
+            ' LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()';
+        } else {
+          options.exception = 'WHEN unique_violation THEN NULL;';
+          valueQuery = 'CREATE OR REPLACE FUNCTION pg_temp.testfunc() RETURNS SETOF <%= table %> AS $body$ BEGIN RETURN QUERY ' + valueQuery + '; EXCEPTION ' + options.exception + ' END; $body$ LANGUAGE plpgsql; SELECT * FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc();';
+        }
       }
 
       if (this._dialect.supports['ON DUPLICATE KEY'] && options.onDuplicate) {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -94,8 +94,11 @@ ConnectionManager.prototype.connect = function(config) {
       connection._invalid = true;
     });
   }).tap(function (connection) {
+    var query = '';
     // Disable escape characters in strings, see https://github.com/sequelize/sequelize/issues/3545
-    var query = 'SET standard_conforming_strings=on;';
+    if (this.sequelize.options.dialectVersion === 0 || this.sequelize.options.dialectVersion >= 8.2) {
+      query += 'SET standard_conforming_strings=on;';
+    }
 
     if (!self.sequelize.config.keepDefaultTimezone) {
       query += 'SET client_min_messages TO warning; SET TIME ZONE INTERVAL \'' + self.sequelize.options.timezone + '\' HOUR TO MINUTE';

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -142,7 +142,8 @@ module.exports = (function() {
       pool: {},
       quoteIdentifiers: true,
       hooks: {},
-      isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ
+      isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ,
+      dialectVersion: 0,
     }, options || {});
 
     if (this.options.dialect === 'postgresql') {


### PR DESCRIPTION
This is an initial commit for adding specific dialect version functions

I know there are some problems with old mssql versions and the data-types right now and there's probably more (So please leave a comment if you remember something else :) ).

Besides that: I think it would be nicer to use `SELECT version();` instead of using the parameter. So I think it would be best to read the version and use that. In case of the `standard_conforming_strings` this has a shortcoming, since we have to set that after we know the version. 