### PR TITLE
Fix `options.logging` not being passed within Sequelize

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
 - [FIXED] Fix an issue where include all was not being properly expanded for self-references [#3804](https://github.com/sequelize/sequelize/issues/3804)
 - [FIXED] Fix instance.changed regression to not return false negatives for not changed null values [#3812](https://github.com/sequelize/sequelize/issues/3812)
 - [FIXED] Fix isEmail validator to allow args: true [#3770](https://github.com/sequelize/sequelize/issues/3770)
-- [FIXED] Fix some occasions where `options.logging` was not used correctly
+- [FIXED] Fix all occasions where `options.logging` was not used correctly [#3834](https://github.com/sequelize/sequelize/issues/3834)
 - [FIXED] Fix `Model#destroy()` to correctly use `options.transaction`
 - [FIXED] Fix `QueryInterface#showIndex()` to correctly pass on `options.transaction`
 

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -278,9 +278,9 @@ HasMany.prototype.injectSetter = function(obj) {
 
   obj[this.accessors.remove] = function(oldAssociatedObject, options) {
     var instance = this;
-    return instance[association.accessors.get]({
+    return instance[association.accessors.get](_.assign({
       scope: false
-    }, options).then(function(currentAssociatedObjects) {
+    }, options)).then(function(currentAssociatedObjects) {
       var newAssociations = [];
 
       if (!(oldAssociatedObject instanceof association.target.Instance)) {
@@ -303,9 +303,9 @@ HasMany.prototype.injectSetter = function(obj) {
 
   obj[this.accessors.removeMultiple] = function(oldAssociatedObjects, options) {
     var instance = this;
-    return instance[association.accessors.get]({
+    return instance[association.accessors.get](_.assign({
       scope: false
-    }, options).then(function(currentAssociatedObjects) {
+    }, options)).then(function(currentAssociatedObjects) {
       var newAssociations = [];
 
       // Ensure the oldAssociatedObjects array is an array of target instances

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -65,7 +65,7 @@ var changeColumn = function(tableName, attributes, options) {
     , self = this;
   options = options || {};
 
-  return this.describeTable(tableName).then(function(fields) {
+  return this.describeTable(tableName, options).then(function(fields) {
     fields[attributeName] = attributes[attributeName];
 
     var sql = self.QueryGenerator.removeColumnQuery(tableName, fields)
@@ -99,7 +99,7 @@ var renameColumn = function(tableName, attrNameBefore, attrNameAfter, options) {
   var self = this;
   options = options || {};
 
-  return this.describeTable(tableName).then(function(fields) {
+  return this.describeTable(tableName, options).then(function(fields) {
     fields[attrNameAfter] = Utils._.clone(fields[attrNameBefore]);
     delete fields[attrNameBefore];
 

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -617,7 +617,7 @@ Instance.prototype.save = function(options) {
           transaction: options.transaction,
           logging: options.logging
         }).then(function () {
-          return self[include.association.accessors.set](instance, {save: false});
+          return self[include.association.accessors.set](instance, {save: false, logging: options.logging});
         });
       });
     })

--- a/lib/model.js
+++ b/lib/model.js
@@ -881,7 +881,7 @@ Model.prototype.sync = function(options) {
     });
 
     return Promise.map(indexes, function (index) {
-      return self.QueryInterface.addIndex(self.getTableName(options), index, self.tableName);
+      return self.QueryInterface.addIndex(self.getTableName(options), _.assign({logging: options.logging}, index), self.tableName);
     });
   }).return(this);
 };
@@ -2255,8 +2255,8 @@ Model.prototype.update = function(values, options) {
  *
  * @return {Promise}
  */
-Model.prototype.describe = function(schema) {
-  return this.QueryInterface.describeTable(this.tableName, schema || this.options.schema || undefined);
+Model.prototype.describe = function(schema, options) {
+  return this.QueryInterface.describeTable(this.tableName, _.assign({schema: schema || this.options.schema || undefined}, options));
 };
 
 Model.prototype.$getDefaultTimestamp = function(attr) {

--- a/lib/plugins/counter-cache.js
+++ b/lib/plugins/counter-cache.js
@@ -65,31 +65,31 @@ CounterCache.prototype.injectHooks = function() {
     previousTargetId;
 
   CounterUtil = {
-    update: function (targetId) {
+    update: function (targetId, options) {
       var query = CounterUtil._targetQuery(targetId);
 
-      return association.target.count({ where: query }).then(function (count) {
+      return association.target.count({ where: query, logging: options && options.logging }).then(function (count) {
         var newValues = {};
 
         query = CounterUtil._sourceQuery(targetId);
 
         newValues[counterCacheInstance.columnName] = count;
 
-        return association.source.update(newValues, { where: query });
+        return association.source.update(newValues, { where: query, logging: options && options.logging });
       });
     },
-    increment: function (targetId) {
+    increment: function (targetId, options) {
       var query = CounterUtil._sourceQuery(targetId);
 
-      return association.source.find({ where: query }).then(function (instance) {
-        return instance.increment(counterCacheInstance.columnName, { by: 1 });
+      return association.source.find({ where: query, logging: options && options.logging }).then(function (instance) {
+        return instance.increment(counterCacheInstance.columnName, { by: 1, logging: options && options.logging });
       });
     },
-    decrement: function (targetId) {
+    decrement: function (targetId, options) {
       var query = CounterUtil._sourceQuery(targetId);
 
-      return association.source.find({ where: query }).then(function (instance) {
-        return instance.decrement(counterCacheInstance.columnName, { by: 1 });
+      return association.source.find({ where: query, logging: options && options.logging }).then(function (instance) {
+        return instance.decrement(counterCacheInstance.columnName, { by: 1, logging: options && options.logging });
       });
     },
     // helpers
@@ -109,51 +109,51 @@ CounterCache.prototype.injectHooks = function() {
     }
   };
 
-  fullUpdateHook = function (target) {
+  fullUpdateHook = function (target, options) {
     var targetId = target.get(association.identifier)
       , promises = [];
 
     if (targetId) {
-      promises.push(CounterUtil.update(targetId));
+      promises.push(CounterUtil.update(targetId, options));
     }
 
     if (previousTargetId && previousTargetId !== targetId) {
-      promises.push(CounterUtil.update(previousTargetId));
+      promises.push(CounterUtil.update(previousTargetId, options));
     }
 
     return Promise.all(promises).return(undefined);
   };
 
   atomicHooks = {
-    create: function (target) {
+    create: function (target, options) {
       var targetId = target.get(association.identifier);
 
       if (targetId) {
-        return CounterUtil.increment(targetId);
+        return CounterUtil.increment(targetId, options);
       }
     },
-    update: function (target) {
+    update: function (target, options) {
       var targetId = target.get(association.identifier)
         , promises = [];
 
       if (targetId && !previousTargetId) {
-        promises.push(CounterUtil.increment(targetId));
+        promises.push(CounterUtil.increment(targetId, options));
       }
       if (!targetId && previousTargetId) {
-        promises.push(CounterUtil.decrement(targetId));
+        promises.push(CounterUtil.decrement(targetId, options));
       }
       if (previousTargetId && targetId && previousTargetId !== targetId) {
-        promises.push(CounterUtil.increment(targetId));
-        promises.push(CounterUtil.decrement(previousTargetId));
+        promises.push(CounterUtil.increment(targetId, options));
+        promises.push(CounterUtil.decrement(previousTargetId, options));
       }
 
       return Promise.all(promises);
     },
-    destroy: function (target) {
+    destroy: function (target, options) {
       var targetId = target.get(association.identifier);
 
       if (targetId) {
-        return CounterUtil.decrement(targetId);
+        return CounterUtil.decrement(targetId, options);
       }
     }
   };

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -243,7 +243,7 @@ QueryInterface.prototype.dropAllTables = function(options) {
   };
 
   var skip = options.skip || [];
-  return self.showAllTables().then(function(tableNames) {
+  return self.showAllTables({logging: options.logging}).then(function(tableNames) {
     if (self.sequelize.options.dialect === 'sqlite') {
       return self.sequelize.query('PRAGMA foreign_keys;', options).then(function(result) {
         var foreignKeysAreEnabled = result.foreign_keys === 1;
@@ -259,7 +259,7 @@ QueryInterface.prototype.dropAllTables = function(options) {
         }
       });
     } else {
-      return self.getForeignKeysForTables(tableNames).then(function(foreignKeys) {
+      return self.getForeignKeysForTables(tableNames, {logging: options.logging}).then(function(foreignKeys) {
         var promises = [];
 
         tableNames.forEach(function(tableName) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -929,8 +929,8 @@ Sequelize.prototype.drop = function(options) {
  * @alias validate
  * @return {Promise}
  */
-Sequelize.prototype.authenticate = function() {
-  return this.query('SELECT 1+1 AS result', { raw: true, plain: true }).return().catch(function(err) {
+Sequelize.prototype.authenticate = function(options) {
+  return this.query('SELECT 1+1 AS result', Utils._.assign({ raw: true, plain: true }, options)).return().catch(function(err) {
     throw new Error(err);
   });
 };

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -39,7 +39,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
               count = 0;
               expect(tableNames).to.have.length(1);
               return self.queryInterface.dropAllTables({logging: log}).then(function() {
-                expect(count).to.be.equal(1);
+                expect(count).to.be.at.least(1);
                 count = 0;
                 return self.queryInterface.showAllTables().then(function(tableNames) {
                   expect(tableNames).to.be.empty;
@@ -72,7 +72,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
     beforeEach(function() {
       var self = this;
       return this.queryInterface.dropTable('Group', {logging: log}).then(function() {
-        expect(count).to.be.equal(1);
+        expect(count).to.be.at.least(1);
         count = 0;
         return self.queryInterface.createTable('Group', {
           username: DataTypes.STRING,
@@ -156,7 +156,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
 
       return Users.sync({ force: true }).then(function() {
         return self.queryInterface.describeTable('_Users', {logging: log}).then(function(metadata) {
-          expect(count).to.be.equal(1);
+          expect(count).to.be.at.least(1);
           count = 0;
 
           var username = metadata.username;


### PR DESCRIPTION
This PR fixes all the places in the codebase where `options.logging` was not being passed from one method call to child method calls. These cases resulted in the `options.logging` function not being called when SQL queries are executed.

All these cases were found using PR https://github.com/sequelize/sequelize/pull/3843.