### PR TITLE
Add support for unique constraint custom error message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Next
 - [FIXED] Fix `Promise#nodeify()` and `Promise#done()` not passing CLS context
+- [ADDED] Unique constraints may now include custom error messages
 
 # 3.2.0
 - [FEATURE] Add support for new option `targetKey` in a belongs-to relationship for situations where the target key is not the id field.

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -414,6 +414,19 @@ AbstractQuery.prototype.findTableNameInAttribute = function(attribute) {
   }
 };
 
+AbstractQuery.prototype.getUniqueConstraintErrorMessage = function(field) {
+  var message = field + ' must be unique';
+  var self = this;
+  Object.keys(self.model.uniqueKeys).forEach(function(key) {
+    if (self.model.uniqueKeys[key].fields.indexOf(field.replace(/"/g, '')) >= 0) {
+      if (self.model.uniqueKeys[key].hasOwnProperty('msg')) {
+        message = self.model.uniqueKeys[key].msg;
+      }
+    }
+  });
+  return message;
+};
+
 AbstractQuery.prototype.isRawQuery = function () {
   return this.options.type === QueryTypes.RAW;
 };

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -185,9 +185,11 @@ Query.prototype.formatError = function (err) {
     }
 
     var errors = [];
+    var self = this;
     Utils._.forOwn(fields, function(value, field) {
       errors.push(new sequelizeErrors.ValidationErrorItem(
-        field + ' must be unique', 'unique violation', field, value));
+        self.getUniqueConstraintErrorMessage(field),
+        'unique violation', field, value));
     });
 
     return new sequelizeErrors.UniqueConstraintError({

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -123,9 +123,11 @@ Query.prototype.formatError = function (err) {
       }
 
       var errors = [];
+      var self = this;
       Utils._.forOwn(fields, function(value, field) {
         errors.push(new sequelizeErrors.ValidationErrorItem(
-          field + ' must be unique', 'unique violation', field, value));
+          self.getUniqueConstraintErrorMessage(field),
+          'unique violation', field, value));
       });
 
       return new sequelizeErrors.UniqueConstraintError({

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -134,10 +134,11 @@ Query.prototype.run = function(sql) {
 
     if (rows[0] && rows[0].sequelize_caught_exception !== undefined) {
       if (rows[0].sequelize_caught_exception !== null) {
-        throw new self.formatError({
+        var err = self.formatError({
           code: '23505',
           detail: rows[0].sequelize_caught_exception
         });
+        throw err;
       } else {
         rows = rows.map(function (row) {
           delete row.sequelize_caught_exception;
@@ -343,7 +344,8 @@ Query.prototype.formatError = function (err) {
     , index
     , fields
     , errors
-    , message;
+    , message
+    , self = this;
 
   var code = err.code || err.sqlState
     , errMessage = err.message || err.messagePrimary
@@ -374,7 +376,8 @@ Query.prototype.formatError = function (err) {
 
         Utils._.forOwn(fields, function(value, field) {
           errors.push(new sequelizeErrors.ValidationErrorItem(
-            field + ' must be unique', 'unique violation', field, value));
+            self.getUniqueConstraintErrorMessage(field),
+            'unique violation', field, value));
         });
 
         if (this.model && this.model.uniqueKeys) {

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -215,7 +215,8 @@ Query.prototype.formatError = function (err) {
 
       fields.forEach(function(field) {
         errors.push(new sequelizeErrors.ValidationErrorItem(
-          field + ' must be unique', 'unique violation', field, self.instance && self.instance[field]));
+          self.getUniqueConstraintErrorMessage(field),
+          'unique violation', field, self.instance && self.instance[field]));
       });
 
       if (this.model) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1866,6 +1866,7 @@ Model.prototype.bulkCreate = function(records, options) {
       }
 
       // Insert all records at once
+      options.model = self;
       return self.QueryInterface.bulkInsert(self.getTableName(options), records, options, attributes).then(function (results) {
         if (Array.isArray(results)) {
           results.forEach(function (result, i) {

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -79,7 +79,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
       });
     });
 
-    it('should enforce a unque constraint', function() {
+    it('should enforce a unique constraint', function() {
       var Model = this.sequelize.define('model', {
         uniqueName: { type: Sequelize.STRING, unique: true }
       });
@@ -101,6 +101,34 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
           expect(err.errors).to.have.length(1);
           expect(err.errors[0].path).to.include('uniqueName');
           expect(err.errors[0].message).to.include('must be unique');
+        });
+    });
+
+    it('should allow a custom unique constraint error message', function() {
+      var Model = this.sequelize.define('model', {
+        uniqueName: {
+          type: Sequelize.STRING,
+          unique: { msg: 'custom unique error message' }
+        }
+      });
+      var records = [
+        { uniqueName: 'unique name one' },
+        { uniqueName: 'unique name two' }
+      ];
+      return Model.sync({ force: true })
+        .then(function() {
+          return Model.create(records[0]);
+        }).then(function(instance) {
+          expect(instance).to.be.ok;
+          return Model.create(records[1]);
+        }).then(function(instance) {
+          expect(instance).to.be.ok;
+          return expect(Model.update(records[0], { where: { id: instance.id } })).to.be.rejected;
+        }).then(function(err) {
+          expect(err).to.be.an.instanceOf(Error);
+          expect(err.errors).to.have.length(1);
+          expect(err.errors[0].path).to.include('uniqueName');
+          expect(err.errors[0].message).to.equal('custom unique error message');
         });
     });
   });


### PR DESCRIPTION
Unique constraint errors always returned a message in the form of `[fieldname] Must be unique`. This allows users to specify custom failure messages consistent with the style of other built-in validators.

Example:
```
var Model = Sequelize.define('model', {
  name: { 
    type: Sequelize.STRING, 
    unique: { args: true, msg: 'custom unique error message' }
  }
});