### PR TITLE
Must quote reserved keywords after AS to avoid SQL syntax error

### DIFF
--- a/test/integration/model/quoteIdentifiers.test.js
+++ b/test/integration/model/quoteIdentifiers.test.js
@@ -1,0 +1,44 @@
+'use strict';
+
+/* jshint -W030 */
+/* jshint -W110 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , DataTypes = require(__dirname + '/../../../lib/data-types');
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+  beforeEach(function() {
+    this.sequelize.options.quoteIdentifiers = false;
+
+    // This is purposefully named 'User', as it's an SQL reserved keyword
+    this.User = this.sequelize.define('User', {
+      username: DataTypes.STRING,
+      secretValue: DataTypes.STRING,
+      data: DataTypes.STRING,
+      intVal: DataTypes.INTEGER,
+      theDate: DataTypes.DATE,
+      aBool: DataTypes.BOOLEAN
+    });
+
+    return this.User.sync({ force: true });
+  });
+
+  afterEach(function() {
+    this.sequelize.options.quoteIdentifiers = undefined;
+  });
+
+  describe('find', function() {
+    describe('general / basic function', function() {
+      beforeEach(function() {
+        return this.User.create({username: 'barfooz'});
+      });
+
+      it('doesn\'t throw an error when finding with reserved keyword in table name', function() {
+        return this.User.findOne().then(function(user) {
+          expect(user.username).to.equal('barfooz');
+        });
+      });
+    });
+  });
+});

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -25,6 +25,29 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
 
+    it('with model', function () {
+      var Post = Support.sequelize.define('Post', {
+        title: DataTypes.STRING
+      });
+      expectsql(sql.selectQuery('Posts', {
+        attributes: ['title']
+      }, Post), {
+        default: 'SELECT [title] FROM [Posts] AS [Post];'
+      });
+    });
+
+    it('with model named with reserved keyword', function () {
+      var User = Support.sequelize.define('User', {
+        name: DataTypes.STRING,
+        age: DataTypes.INTEGER
+      });
+      expectsql(sql.selectQuery('Users', {
+        attributes: ['name', 'age']
+      }, User), {
+        default: 'SELECT [name], [age] FROM [Users] AS [User];'
+      });
+    });
+
     it('include (left outer join)', function () {
       var User = Support.sequelize.define('User', {
         name: DataTypes.STRING,
@@ -80,6 +103,32 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
       }), {
         default: 'SELECT [name], [age] FROM [User];',
         postgres: 'SELECT name, age FROM User;'
+      });
+    });
+
+    it('with model', function () {
+      var Post = Support.sequelize.define('Post', {
+        title: DataTypes.STRING
+      });
+      expectsql(sql.selectQuery('Posts', {
+        attributes: ['title']
+      }, Post), {
+        default: 'SELECT [title] FROM [Posts] AS [Post];',
+        postgres: 'SELECT title FROM Posts AS Post;'
+      });
+    });
+
+    it('with model named with reserved keyword', function () {
+      var User = Support.sequelize.define('User', {
+        name: DataTypes.STRING,
+        age: DataTypes.INTEGER
+      });
+      expectsql(sql.selectQuery('Users', {
+        attributes: ['name', 'age']
+      }, User), {
+        default: 'SELECT [name], [age] FROM [Users] AS [User];',
+        // Must quote the reserved keyword after AS
+        postgres: 'SELECT name, age FROM Users AS [User];'
       });
     });
 


### PR DESCRIPTION
When using Postgres and `quoteIdentifiers: false`, I get a syntax error if the table name is a reserved keyword (in my case, `User`) when attempting to find that model.

The offending SQL generated by sequelize is:

``` sql
SELECT id FROM Users AS User;
```

And it's generated when I run:

``` js
var User = sequelize.define('User');
User.findAll();
```

The same problem occurs if the String passed to `sequelize.define` is any of the reserved keywords listed on this page: http://www.postgresql.org/docs/9.4/static/sql-keywords-appendix.html

I've included failing unit and integration tests.  Not sure which is better, but the integration test seems like such a common use case that maybe it's good to have in there :)
