### PR TITLE
removed references to getMigrator()

### DIFF
--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -273,25 +273,8 @@ migration.removeIndex('Person', ['firstname', 'lastname'])
 ```
 
 ## Programmatic use
+Sequelize has a [sister library](https://github.com/sequelize/umzug) for programmatically handling execution and logging of migration tasks.
 
-If you need to interact with the migrator within your code, you can easily achieve that via `sequelize.getMigrator`. You can specify the path to your migrations as well as a pattern which represents the files that contain the migrations.
-
-```js
-var migrator = sequelize.getMigrator({
-  path:        process.cwd() + '/database/migrations',
-  filesFilter: /\.coffee$/
-})
-```
-
-Once you have a migrator object, you can run its migration with `migrator.migrate`. By default, this will execute all the up methods within your pending migrations. If you want to rollback a migration, just call it like this:
-
-```js
-migrator
-  .migrate({ method: 'down' })
-  .then(function() {
-    // The migrations have been executed!
-  })
-```
 
 [0]: http://gulpjs.com/
 [1]: https://github.com/sequelize/cli

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -603,10 +603,6 @@ Sequelize.prototype.import = function(path) {
   return this.importCache[path];
 };
 
-Sequelize.prototype.migrate = function(options) {
-  return this.getMigrator().migrate(options);
-};
-
 /**
  * Execute a query on the DB, with the posibility to bypass all the sequelize goodness.
  *


### PR DESCRIPTION
1. Update migrations.md section on programmatic use to point to uzmug
1. Removed Sequelize.prototype.migrate as it call getMigrator() which no longer exists