### PR TITLE
Fix generating JSONB arrays in postgres.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 - [FEATURE] There's a new sequelize.truncate function to truncate all tables defined through the sequelize models [#2671](https://github.com/sequelize/sequelize/pull/2671)
 - [FEATURE] Add support for MySQLs TINYTEXT, MEDIUMTEXT and LONGTEXT. [#3836](https://github.com/sequelize/sequelize/pull/3836)
 - [FEATURE] Provide warnings if you misuse data types. [#3839](https://github.com/sequelize/sequelize/pull/3839)
+- [FIXED] Fix a case where Postgres arrays containing JSONB type was being generated as JSON type.
 - [FIXED] Fix a case where `type` in `sequelize.query` was not being set to raw. [#3800](https://github.com/sequelize/sequelize/pull/3800)
 - [FIXED] Fix an issue where include all was not being properly expanded for self-references [#3804](https://github.com/sequelize/sequelize/issues/3804)
 - [FIXED] Fix instance.changed regression to not return false negatives for not changed null values [#3812](https://github.com/sequelize/sequelize/issues/3812)

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -890,12 +890,13 @@ var QueryGenerator = {
       else if (DataTypes.ARRAY.is(field.type, DataTypes.RANGE)) { // escape array of ranges
         return 'ARRAY[' + Utils._.map(value, function(v){return "'" + range.stringify(v) + "'";}).join(',') + ']::' + field.type.toString();
       }
-    } else if (field && (field.type instanceof DataTypes.JSON || field.type instanceof DataTypes.JSONB)) {
+    } else if (field && field.type instanceof DataTypes.JSON) {
       value = JSON.stringify(value);
     } else if (Array.isArray(value) && field && DataTypes.ARRAY.is(field.type, DataTypes.JSON)) {
+      var jsonType = field.type.type; // type may be JSON or JSONB
       return 'ARRAY[' + value.map(function (v) {
         return SqlString.escape(JSON.stringify(v), false, this.options.timezone, this.dialect, field);
-      }, this).join(',') + ']::JSON[]';
+      }, this).join(',') + ']::' + jsonType.key + '[]';
     }
 
     return SqlString.escape(value, false, this.options.timezone, this.dialect, field);

--- a/test/unit/sql/json.test.js
+++ b/test/unit/sql/json.test.js
@@ -40,6 +40,15 @@ if (current.dialect.supports.JSON) {
             postgres: 'ARRAY[\'{"some":"nested","more":{"nested":true},"answer":42}\',\'43\',\'"joe"\']::JSON[]'
           });
         });
+        test('array of JSONB', function () {
+          expectsql(sql.escape([
+            { some: 'nested', more: { nested: true }, answer: 42 },
+            43,
+            'joe'
+          ], { type: DataTypes.ARRAY(DataTypes.JSONB)}), {
+            postgres: 'ARRAY[\'{"some":"nested","more":{"nested":true},"answer":42}\',\'43\',\'"joe"\']::JSONB[]'
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
Currently, generating an array of JSONB elements in postgres incorrectly specifies the type as `::JSON[]` in the generated query, resulting in an error:

```
SequelizeDatabaseError: column "my_array_column" is of type jsonb[] but expression is of type json[]
```

Since `DataTypes.JSONB` inherits from `DataTypes.JSON`, both cases fall into the same clause, which doesn't handle `JSONB`.