### PR TITLE
Fix MySQL failed connection test

### DIFF
--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -21,10 +21,8 @@ describe(Support.getTestDialectTeaser('Configuration'), function() {
       if (dialect === 'sqlite') {
         // SQLite doesn't have a breakdown of error codes, so we are unable to discern between the different types of errors.
         return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith(seq.ConnectionError, 'SQLITE_CANTOPEN: unable to open database file');
-      } else if (dialect === 'mssql' || dialect === 'postgres') {
-        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith([seq.HostNotReachableError, seq.InvalidConnectionError]);
       } else {
-        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith(seq.InvalidConnectionError, 'connect EINVAL');
+        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith([seq.HostNotReachableError, seq.InvalidConnectionError]);
       }
     });
 


### PR DESCRIPTION
On my local machine (OS X 10.9.5, MySQL 5.6.19, Node 0.12.2, Sequelize latest master), the test for "Connections problems should fail with a nice message when we don\'t have the correct server details" was failing consistently.

This fixes it on my machine, but not sure if this may work otherwise on other machines.