### PR TITLE
Reenable iojs v2 testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "iojs-v1.8"
- # - "iojs" # iojs 2.0 is failing because of pg-native and nan
+  - "iojs-v1"
+  - "iojs-v2"
 
 sudo: false
 


### PR DESCRIPTION
See #3653
io.js v2 is working again on Travis!

I've changed .travis.yml to track against the latest version of the last two major releases. When 3.0 is released, I think there would be a good case for changing travis support to test against v2.x and v3.x.