### PR TITLE
Add a CLS shim for Promise.each

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -35,6 +35,7 @@ shimCLS(Promise.prototype, 'finally', [0]);
 shimCLS(Promise.prototype, 'map', [0]);
 shimCLS(Promise.prototype, 'reduce', [0]);
 shimCLS(Promise.prototype, 'filter', [0]);
+shimCLS(Promise, 'each', [-1]);
 shimCLS(Promise.prototype, 'each', [0]);
 
 // Utility

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -273,6 +273,17 @@ if (current.dialect.supports.transactions) {
         });
       });
 
+      it('Promise.each', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return Promise.each([self.User.findAll()], function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
       it('tap', function () {
         var self = this;
         return this.sequelize.transaction(function () {


### PR DESCRIPTION
I discovered that transactions via CLS were unavailable in hooks and traced it to the use of `Promise.each` when running the hooks. I added a test that fails when `Promise.each` is not shimmed for CLS and added the shim to `lib/promise.js`.