### PR TITLE
Add CLS support to `nodeify` promise method

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -41,6 +41,9 @@ shimCLS(Promise.prototype, 'reduce', [0]);
 shimCLS(Promise.prototype, 'filter', [0]);
 shimCLS(Promise.prototype, 'each', [0]);
 
+// Promisification
+shimCLS(Promise.prototype, 'nodeify', [0]);
+
 // Utility
 shimCLS(Promise.prototype, 'tap', [0]);
 

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -317,6 +317,17 @@ if (current.dialect.supports.transactions) {
         });
       });
 
+      it('nodeify', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return self.User.findAll().nodeify(function () {
+            expect(self.ns.get('transaction').id).to.be.ok;
+            expect(self.ns.get('transaction').id).to.equal(tid);
+          });
+        });
+      });
+
       it('tap', function () {
         var self = this;
         return this.sequelize.transaction(function () {


### PR DESCRIPTION
Calling `.nodeify()` on a promise loses CLS context.

This PR fixes this.