### PR TITLE
Add CLS support to `done` promise method

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [FIXED] Fix `Promise#nodeify()` and `Promise#done()` not passing CLS context
+
 # 3.2.0
 - [FEATURE] Add support for new option `targetKey` in a belongs-to relationship for situations where the target key is not the id field.
 - [FEATURE] Add support for keyword `after` in options of a field (useful for migrations), only for MySQL. [#3166](https://github.com/sequelize/sequelize/pull/3166)

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -47,4 +47,7 @@ shimCLS(Promise.prototype, 'nodeify', [0]);
 // Utility
 shimCLS(Promise.prototype, 'tap', [0]);
 
+// Error management configuration
+shimCLS(Promise.prototype, 'done', [0, 1]);
+
 module.exports = Promise;

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -339,8 +339,45 @@ if (current.dialect.supports.transactions) {
         });
       });
 
+      it('done fulfilled', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return new Promise(function (resolve, reject) {
+            self.User.findAll().done(function () {
+              try {
+                expect(self.ns.get('transaction').id).to.be.ok;
+                expect(self.ns.get('transaction').id).to.equal(tid);
+                resolve();
+              } catch (err) {
+                reject(err);
+              }
+            }, function (err) {
+              reject(err);
+            });
+          });
+        });
+      });
 
-
+      it('done rejected', function () {
+        var self = this;
+        return this.sequelize.transaction(function () {
+          var tid = self.ns.get('transaction').id;
+          return new Promise(function (resolve, reject) {
+            Promise.reject('test rejection handler').done(function () {
+              reject(new Error('Should not have called first done handler'));
+            }, function (err) {
+              try {
+                expect(self.ns.get('transaction').id).to.be.ok;
+                expect(self.ns.get('transaction').id).to.equal(tid);
+                resolve();
+              } catch (err) {
+                reject(err);
+              }
+            });
+          });
+        });
+      });
     });
 
   });


### PR DESCRIPTION
Fixes https://github.com/sequelize/sequelize/issues/3909

Calling `.done()` on a promise was losing CLS context.
