### PR TITLE
Fixed typo in code comments

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -67,7 +67,7 @@ var url = require('url')
  * @param {Object}   [options.query={}] Default options for sequelize.query
  * @param {Object}   [options.set={}] Default options for sequelize.set
  * @param {Object}   [options.sync={}] Default options for sequelize.sync
- * @param {String}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a javascript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM.
+ * @param {String}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM.
  * @param {Function} [options.logging=console.log] A function that gets executed everytime Sequelize would log something.
  * @param {Boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
  * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
@@ -458,7 +458,7 @@ Sequelize.prototype.getQueryInterface = function() {
  * @param {String|DataType|Object}  attributes.column The description of a database column
  * @param {String|DataType}         attributes.column.type A string or a data type
  * @param {Boolean}                 [attributes.column.allowNull=true] If false, the column will have a NOT NULL constraint, and a not null validation will be run before an instance is saved.
- * @param {Any}                     [attributes.column.defaultValue=null] A literal default value, a javascript function, or an SQL function (see `sequelize.fn`)
+ * @param {Any}                     [attributes.column.defaultValue=null] A literal default value, a JavaScript function, or an SQL function (see `sequelize.fn`)
  * @param {String|Boolean}          [attributes.column.unique=false] If true, the column will get a unique constraint. If a string is provided, the column will be part of a composite unique index. If multiple columns have the same string, they will be part of the same unique index
  * @param {Boolean}                 [attributes.column.primaryKey=false]
  * @param {String}                  [attributes.column.field=null] If set, sequelize will map the attribute name to a different name in the database


### PR DESCRIPTION
Fixed javascript casing to JavaScript in comments as per instructions given here: https://github.com/sequelize/sequelize/pull/3907 . No changes to markdown syntax were made.