### PR TITLE
.equals() should compare dataValues directly

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -993,12 +993,15 @@ Instance.prototype.decrement = function(fields, options) {
  */
 Instance.prototype.equals = function(other) {
   var result = true;
+  
+  if(!other || !other.dataValues)
+    return false;
 
   Utils._.each(this.dataValues, function(value, key) {
-    if (Utils._.isDate(value) && Utils._.isDate(other[key])) {
-      result = result && (value.getTime() === other[key].getTime());
+    if (Utils._.isDate(value) && Utils._.isDate(other.dataValues[key])) {
+      result = result && (value.getTime() === other.dataValues[key].getTime());
     } else {
-      result = result && (value === other[key]);
+      result = result && (value === other.dataValues[key]);
     }
   });
 

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -994,8 +994,9 @@ Instance.prototype.decrement = function(fields, options) {
 Instance.prototype.equals = function(other) {
   var result = true;
   
-  if(!other || !other.dataValues)
+  if (!other || !other.dataValues) {
     return false;
+  }
 
   Utils._.each(this.dataValues, function(value, key) {
     if (Utils._.isDate(value) && Utils._.isDate(other.dataValues[key])) {


### PR DESCRIPTION
Avoids changes created by other's getters