### PR TITLE
hooks removing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 - [FIXED] Creating and dropping enums in transaction, only for PostgreSQL [#3782](https://github.com/sequelize/sequelize/issues/3782)
 - [FIXED] $or/$and inside a where clause always expects the input to be an array [#3767](https://github.com/sequelize/sequelize/issues/3767)
 - [ADDED] Unique constraints may now include custom error messages
+- [ADDED] It's possible now to remove a hook by name
 
 # 3.2.0
 - [FEATURE] Add support for new option `targetKey` in a belongs-to relationship for situations where the target key is not the id field.

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -162,6 +162,31 @@ var Hooks = {
     return this;
   },
 
+  /**
+   * Remove hook from the model
+   *
+   * @param {String} hookType
+   * @param {String} name
+   */
+  removeHook: function(hookType, name) {
+    hookType = hookAliases[hookType] || hookType;
+
+    if (!this.hasHook(hookType)) {
+      return this;
+    }
+
+    this.options.hooks[hookType] = this.options.hooks[hookType].filter(function (hook) {
+      // don't remove unnamed hooks
+      if (typeof hook === 'function') {
+        return true;
+      }
+
+      return typeof hook === 'object' && hook.name !== name;
+    });
+
+    return this;
+  },
+
   /*
    * Check whether the mode has any hooks of this type
    *

--- a/test/integration/hooks.test.js
+++ b/test/integration/hooks.test.js
@@ -5623,7 +5623,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
   });
 
   describe('#addHook', function() {
-    it('should add additinoal hook when previous exists', function() {
+    it('should add additional hook when previous exists', function() {
       var hook1 = sinon.spy()
         , hook2 = sinon.spy()
         , Model;
@@ -5642,6 +5642,29 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
         expect(hook1.calledOnce).to.be.ok;
         expect(hook2.calledOnce).to.be.ok;
       });
+    });
+  });
+
+  describe('#removeHook', function() {
+    it('should remove hook', function() {
+      var hook1 = sinon.spy()
+        , Model;
+
+        Model = this.sequelize.define('Model', {
+          name: Sequelize.STRING
+        });
+
+        Model.addHook('beforeCreate', 'myHook', hook1);
+
+        return Model.sync({ force: true }).then(function() {
+          return Model.create({ name: 'sonya' });
+        }).then(function() {
+          expect(hook1.calledOnce).to.be.ok;
+          Model.removeHook('beforeCreate', 'myHook');
+          return Model.create({ name: 'james' });
+        }).then(function() {
+          expect(hook1.calledOnce).to.be.ok;
+        });
     });
   });
 });


### PR DESCRIPTION
issue https://github.com/sequelize/sequelize/issues/3850

Hope I didn't miss anything important :-)

It might hurt performance if there is a lot of hooks in a hookType (doubt anyone can put there so many of 'em :-) ), so maybe it'd better to make a hash that contains position of a models' hooks. M?

There's one more option that's kinda lazy. Calling removeHook we can just mark it to be removed later in runHooks method.
