### PR TITLE
handle hasOne onDelete cascade when no associate

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -651,6 +651,10 @@ QueryInterface.prototype.delete = function(instance, tableName, identifier, opti
       if (!Array.isArray(instances)) instances = [instances];
 
       return Promise.each(instances, function (instance) {
+        if (!instance) {
+          return Promise.resolve();
+        }
+
         return instance.destroy({
           transaction: options.transaction,
           logging: options.logging

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -648,13 +648,14 @@ QueryInterface.prototype.delete = function(instance, tableName, identifier, opti
       transaction: options.transaction,
       logging: options.logging
     }).then(function (instances) {
+      // Check for hasOne relationship with non-existing associate ("has zero")
+      if (!instances) {
+        return Promise.resolve();
+      }
+
       if (!Array.isArray(instances)) instances = [instances];
 
       return Promise.each(instances, function (instance) {
-        if (!instance) {
-          return Promise.resolve();
-        }
-
         return instance.destroy({
           transaction: options.transaction,
           logging: options.logging

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -381,6 +381,21 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
       });
     });
 
+    it('works when cascading a delete with hooks but there is no associate (i.e. "has zero")', function() {
+      var Task = this.sequelize.define('Task', { title: Sequelize.STRING })
+        , User = this.sequelize.define('User', { username: Sequelize.STRING });
+
+      User.hasOne(Task, {onDelete: 'cascade', hooks: true});
+
+      return User.sync({ force: true }).then(function() {
+        return Task.sync({ force: true }).then(function() {
+          return User.create({ username: 'foo' }).then(function(user) {
+            return user.destroy();
+          });
+        });
+      });
+    });
+
     // NOTE: mssql does not support changing an autoincrement primary key
     if (Support.getTestDialect() !== 'mssql') {
       it('can cascade updates', function() {


### PR DESCRIPTION
hasOne actually means "has zero or one".

The current behavior of {onDelete:'cascade',hooks:true} looks for an associate and fails to execute ${non-existent instance}.destroy().

This patch checks for the non-existence and aborts gracefully.