### PR TITLE
Fix incorrect paths created for "See:" links in docs generator 

### DIFF
--- a/docs/api/associations.md
+++ b/docs/api/associations.md
@@ -1,6 +1,6 @@
 <a name="mixin"></a>
 # Mixin Mixin
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/associations/mixin.js#L95)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/associations/mixin.js#L96)
 Creating assocations in sequelize is done by calling one of the belongsTo / hasOne / hasMany functions
 on a model (the source), and providing another model as the first argument to the function (the target).
 
@@ -89,7 +89,7 @@ you should either disable some constraints, or rethink your associations complet
 
 <a name="hasone"></a>
 ## `hasOne(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/associations/mixin.js#L145)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/associations/mixin.js#L146)
 Creates an association between this (the source) and the provided target. The foreign key is added on the target.
 
 Example: `User.hasOne(Profile)`. This will add userId to the profile table.
@@ -121,7 +121,7 @@ All methods return a promise
 
 <a name="belongsto"></a>
 ## `belongsTo(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/associations/mixin.js#L170)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/associations/mixin.js#L172)
 Creates an association between this (the source) and the provided target. The foreign key is added on the source.
 
 Example: `Profile.belongsTo(User)`. This will add userId to the profile table.
@@ -142,8 +142,9 @@ All methods return a promise
 | target | Model |  |
 | [options] | object |  |
 | [options.hooks=false] | boolean | Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade. For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking any hooks |
-| [options.as] | string | The alias of this model, in singular form. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the assocition, you should provide the same alias when eager loading and when getting assocated models. Defaults to the singularized name of target |
-| [options.foreignKey] | string &#124; object | The name of the foreign key in the source table or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the colum. Defaults to the name of target + primary key of target |
+| [options.as] | string | The alias of this model, in singular form. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the association, you should provide the same alias when eager loading and when getting assocated models. Defaults to the singularized name of target |
+| [options.foreignKey] | string &#124; object | The name of the foreign key in the source table or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the column. Defaults to the name of target + primary key of target |
+| [options.targetKey] | string | The name of the field to use as the key for the association in the target table. Defaults to the primary key of the target table |
 | [options.onDelete='SET&nbsp;NULL'] | string |  |
 | [options.onUpdate='CASCADE'] | string |  |
 | [options.constraints=true] | boolean | Should on update and on delete constraints be enabled on the foreign key. |
@@ -153,7 +154,7 @@ All methods return a promise
 
 <a name="hasmany"></a>
 ## `hasMany(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/associations/mixin.js#L245)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/associations/mixin.js#L247)
 Create an association that is either 1:m or n:m.
 
 ```js
@@ -206,7 +207,7 @@ user.setProjects([p1, p2], {started: false}) // The default value is false, but 
 
 Similarily, when fetching through a join table with custom attributes, these attributes will be available as an object with the name of the through model.
 ```js
-user.getProjects().success(function (projects) {
+user.getProjects().then(function (projects) {
   var p1 = projects[0]
   p1.userprojects.started // Is this project started yet?
 })
@@ -236,7 +237,7 @@ user.getProjects().success(function (projects) {
 
 <a name="belongstomany"></a>
 ## `belongsToMany(target, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/associations/mixin.js#L339)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/associations/mixin.js#L341)
 Create an N:M association with a join table
 
 ```js

--- a/docs/api/datatypes.md
+++ b/docs/api/datatypes.md
@@ -1,6 +1,6 @@
 <a name="datatypes"></a>
 # Class DataTypes
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L37)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L38)
 A convenience class holding commonly used data types. The datatypes are used when definining a new model using `Sequelize.define`, like this:
 ```js
 sequelize.define('model', {
@@ -33,7 +33,7 @@ sequelize.define('model', {
 
 <a name="string"></a>
 ## `STRING()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L55)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L64)
 A variable length string. Default length 255
 
 Available properties: `BINARY`
@@ -43,7 +43,7 @@ Available properties: `BINARY`
 
 <a name="char"></a>
 ## `CHAR()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L88)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L97)
 A fixed length string. Default length 255
 
 Available properties: `BINARY`
@@ -53,14 +53,14 @@ Available properties: `BINARY`
 
 <a name="text"></a>
 ## `TEXT()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L109)
-An unlimited length text column
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L117)
+An (un)limited length text column. Available lengths: `tiny`, `medium`, `long`
 
 ***
 
 <a name="integer"></a>
 ## `INTEGER()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L169)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L192)
 A 32 bit integer.
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -70,7 +70,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="bigint"></a>
 ## `BIGINT()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L188)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L211)
 A 64 bit integer.
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -80,7 +80,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="float"></a>
 ## `FLOAT()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L206)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L229)
 Floating point number (4-byte precision). Accepts one or two arguments for precision
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -90,7 +90,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="real"></a>
 ## `REAL()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L225)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L248)
 Floating point number (4-byte precision). Accepts one or two arguments for precision
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -100,7 +100,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="double"></a>
 ## `DOUBLE()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L244)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L267)
 Floating point number (8-byte precision). Accepts one or two arguments for precision
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -110,7 +110,7 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="decimal"></a>
 ## `DECIMAL()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L263)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L286)
 Decimal number. Accepts one or two arguments for precision
 
 Available properties: `UNSIGNED`, `ZEROFILL`
@@ -120,63 +120,63 @@ Available properties: `UNSIGNED`, `ZEROFILL`
 
 <a name="boolean"></a>
 ## `BOOLEAN()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L286)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L309)
 A boolean / tinyint column, depending on dialect
 
 ***
 
 <a name="time"></a>
 ## `TIME()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L302)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L325)
 A time column
 
 ***
 
 <a name="date"></a>
 ## `DATE()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L317)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L340)
 A datetime column
 
 ***
 
 <a name="dateonly"></a>
 ## `DATEONLY()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L333)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L356)
 A date only column
 
 ***
 
 <a name="hstore"></a>
 ## `HSTORE()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L349)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L372)
 A key / value column. Only available in postgres.
 
 ***
 
 <a name="json"></a>
 ## `JSON()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L361)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L384)
 A JSON string column. Only available in postgres.
 
 ***
 
 <a name="jsonb"></a>
 ## `JSONB()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L373)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L396)
 A pre-processed JSON data column. Only available in postgres.
 
 ***
 
 <a name="now"></a>
 ## `NOW()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L385)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L408)
 A default value of the current timestamp
 
 ***
 
 <a name="blob"></a>
 ## `BLOB()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L399)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L422)
 Binary storage. Available lengths: `tiny`, `medium`, `long`
 
 
@@ -184,7 +184,7 @@ Binary storage. Available lengths: `tiny`, `medium`, `long`
 
 <a name="range"></a>
 ## `RANGE()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L429)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L452)
 Range types are data types representing a range of values of some element type (called the range's subtype).
 Only available in postgres.
 See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres documentation} for more details
@@ -193,28 +193,28 @@ See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres do
 
 <a name="uuid"></a>
 ## `UUID()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L458)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L481)
 A column storing a unique univeral identifier. Use with `UUIDV1` or `UUIDV4` for default values.
 
 ***
 
 <a name="uuidv1"></a>
 ## `UUIDV1()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L471)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L494)
 A default unique universal identifier generated following the UUID v1 standard
 
 ***
 
 <a name="uuidv4"></a>
 ## `UUIDV4()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L484)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L507)
 A default unique universal identifier generated following the UUID v2 standard
 
 ***
 
 <a name="virtual"></a>
 ## `VIRTUAL()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L519)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L542)
 A virtual value that is not stored in the DB. This could for example be useful if you want to provide a default value in your model that is returned to the user but not stored in the DB.
 
 You could also use it to validate a value before permuting and storing it. Checking password length before hashing it for example:
@@ -244,7 +244,7 @@ __Aliases:__ NONE
 
 <a name="enum"></a>
 ## `ENUM()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L532)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L555)
 An enumeration. `DataTypes.ENUM('value', 'another value')`.
 
 
@@ -252,7 +252,7 @@ An enumeration. `DataTypes.ENUM('value', 'another value')`.
 
 <a name="array"></a>
 ## `ARRAY()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/data-types.js#L549)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/data-types.js#L572)
 An array of `type`, e.g. `DataTypes.ARRAY(DataTypes.DECIMAL)`. Only available in postgres.
 
 ***

--- a/docs/api/deferrable.md
+++ b/docs/api/deferrable.md
@@ -1,6 +1,6 @@
 <a name="deferrable"></a>
 ## `Deferrable()` -> `object`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/deferrable.js#L39)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/deferrable.js#L39)
 A collection of properties related to deferrable constraints. It can be used to
 make foreign key constraints deferrable and to set the constaints within a
 transaction. This is only supported in PostgreSQL.
@@ -36,7 +36,7 @@ sequelize.transaction({
 
 <a name="initially_deferred"></a>
 ## `INITIALLY_DEFERRED()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/deferrable.js#L59)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/deferrable.js#L59)
 A property that will defer constraints checks to the end of transactions.
 
 
@@ -44,7 +44,7 @@ A property that will defer constraints checks to the end of transactions.
 
 <a name="initially_immediate"></a>
 ## `INITIALLY_IMMEDIATE()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/deferrable.js#L76)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/deferrable.js#L76)
 A property that will trigger the constraint checks immediately
 
 
@@ -52,7 +52,7 @@ A property that will trigger the constraint checks immediately
 
 <a name="not"></a>
 ## `NOT()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/deferrable.js#L95)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/deferrable.js#L95)
 A property that will set the constraints to not deferred. This is
 the default in PostgreSQL and it make it impossible to dynamically
 defer the constraints within a transaction.
@@ -62,7 +62,7 @@ defer the constraints within a transaction.
 
 <a name="set_deferred"></a>
 ## `SET_DEFERRED(constraints)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/deferrable.js#L114)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/deferrable.js#L114)
 A property that will trigger an additional query at the beginning of a
 transaction which sets the constraints to deferred.
 
@@ -78,7 +78,7 @@ transaction which sets the constraints to deferred.
 
 <a name="set_immediate"></a>
 ## `SET_IMMEDIATE(constraints)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/deferrable.js#L135)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/deferrable.js#L135)
 A property that will trigger an additional query at the beginning of a
 transaction which sets the constraints to immediately.
 

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -1,6 +1,6 @@
 <a name="errors"></a>
 # Class Errors
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L11)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L11)
 Sequelize provides a host of custom error classes, to allow you to do easier debugging. All of these errors are exposed on the sequelize object and the sequelize constructor.
 All sequelize errors inherit from the base JS error object.
 
@@ -9,7 +9,7 @@ All sequelize errors inherit from the base JS error object.
 
 <a name="baseerror"></a>
 ## `new BaseError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L20)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L20)
 The Base Error all Sequelize Errors inherit from.
 
 __Aliases:__ Error
@@ -18,7 +18,7 @@ __Aliases:__ Error
 
 <a name="validationerror"></a>
 ## `new ValidationError(message, [errors])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L41)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L41)
 Validation Error. Thrown when the sequelize validation has failed. The error contains an `errors` property,
 which is an array with 1 or more ValidationErrorItems, one for each validation that failed.
 
@@ -37,14 +37,14 @@ __Extends:__ BaseError
 
 <a name="errors"></a>
 ## `errors`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L49)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L49)
 An array of ValidationErrorItems
 
 ***
 
 <a name="get"></a>
 ## `get(path)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L70)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L70)
 Gets all validation error items for the path / field specified.
 
 
@@ -59,7 +59,7 @@ Gets all validation error items for the path / field specified.
 
 <a name="databaseerror"></a>
 ## `new DatabaseError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L84)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L84)
 A base class for all database related errors.
 
 __Extends:__ BaseError
@@ -68,49 +68,49 @@ __Extends:__ BaseError
 
 <a name="parent"></a>
 ## `parent`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L92)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L92)
 The database specific error which triggered this one
 
 ***
 
 <a name="sql"></a>
 ## `sql`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L98)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L98)
 The SQL that triggered the error
 
 ***
 
 <a name="message"></a>
 ## `message()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L104)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L104)
 The message from the DB.
 
 ***
 
 <a name="fields"></a>
 ## `fields()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L109)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L109)
 The fields of the unique constraint
 
 ***
 
 <a name="value"></a>
 ## `value()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L114)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L114)
 The value(s) which triggered the error
 
 ***
 
 <a name="index"></a>
 ## `index()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L119)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L119)
 The name of the index that triggered the error
 
 ***
 
 <a name="timeouterror"></a>
 ## `new TimeoutError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L127)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L127)
 Thrown when a database query times out because of a deadlock
 
 __Extends:__ DatabaseError
@@ -119,7 +119,7 @@ __Extends:__ DatabaseError
 
 <a name="uniqueconstrainterror"></a>
 ## `new UniqueConstraintError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L138)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L138)
 Thrown when a unique constraint is violated in the database
 
 __Extends:__ DatabaseError
@@ -128,7 +128,7 @@ __Extends:__ DatabaseError
 
 <a name="foreignkeyconstrainterror"></a>
 ## `new ForeignKeyConstraintError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L157)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L157)
 Thrown when a foreign key constraint is violated in the database
 
 __Extends:__ DatabaseError
@@ -137,7 +137,7 @@ __Extends:__ DatabaseError
 
 <a name="exclusionconstrainterror"></a>
 ## `new ExclusionConstraintError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L177)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L177)
 Thrown when an exclusion constraint is violated in the database
 
 __Extends:__ DatabaseError
@@ -146,7 +146,7 @@ __Extends:__ DatabaseError
 
 <a name="validationerroritem"></a>
 ## `new ValidationErrorItem(message, type, path, value)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L201)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L201)
 Validation Error Item
 Instances of this class are included in the `ValidationError.errors` property.
 
@@ -165,7 +165,7 @@ Instances of this class are included in the `ValidationError.errors` property.
 
 <a name="connectionerror"></a>
 ## `new ConnectionError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L213)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L213)
 A base class for all connection related errors.
 
 __Extends:__ BaseError
@@ -174,14 +174,14 @@ __Extends:__ BaseError
 
 <a name="parent"></a>
 ## `parent`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L220)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L220)
 The connection specific error which triggered this one
 
 ***
 
 <a name="connectionrefusederror"></a>
 ## `new ConnectionRefusedError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L230)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L230)
 Thrown when a connection to a database is refused
 
 __Extends:__ ConnectionError
@@ -190,7 +190,7 @@ __Extends:__ ConnectionError
 
 <a name="accessdeniederror"></a>
 ## `new AccessDeniedError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L241)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L241)
 Thrown when a connection to a database is refused due to insufficient privileges
 
 __Extends:__ ConnectionError
@@ -199,7 +199,7 @@ __Extends:__ ConnectionError
 
 <a name="hostnotfounderror"></a>
 ## `new HostNotFoundError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L252)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L252)
 Thrown when a connection to a database has a hostname that was not found
 
 __Extends:__ ConnectionError
@@ -208,7 +208,7 @@ __Extends:__ ConnectionError
 
 <a name="hostnotreachableerror"></a>
 ## `new HostNotReachableError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L263)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L263)
 Thrown when a connection to a database has a hostname that was not reachable
 
 __Extends:__ ConnectionError
@@ -217,7 +217,7 @@ __Extends:__ ConnectionError
 
 <a name="invalidconnectionerror"></a>
 ## `new InvalidConnectionError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L274)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L274)
 Thrown when a connection to a database has invalid values for any of the connection parameters
 
 __Extends:__ ConnectionError
@@ -226,7 +226,7 @@ __Extends:__ ConnectionError
 
 <a name="connectiontimedouterror"></a>
 ## `new ConnectionTimedOutError()`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/errors.js#L285)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/errors.js#L285)
 Thrown when a connection to a database times out
 
 __Extends:__ ConnectionError

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -1,6 +1,6 @@
 <a name="hooks"></a>
 # Mixin Hooks
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L39)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L39)
 Hooks are function that are called before and after  (bulk-) creation/updating/deletion and validation. Hooks can be added to you models in three ways:
 
 1. By specifying them as options in `sequelize.define`
@@ -31,14 +31,14 @@ Model.afterBulkUpdate(function () {})
 
 **See:**
 
-* [Sequelize#define](api/sequelize#define)
+* [Sequelize#define](sequelize#define)
 
 
 ***
 
 <a name="addhook"></a>
 ## `addHook(hooktype, [name], fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L152)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L152)
 Add a hook to the model
 
 
@@ -55,22 +55,24 @@ __Aliases:__ hook
 ***
 
 <a name="removehook"></a>
-## `removeHook(hooktype, name)`
-[View code](https://github.com/sequelize/sequelize/blob/008312999ffa7e2ee462162573b32e7c60e7f9f7/lib/hooks.js#L171)
-Remove a hook from the model
+## `removeHook(hookType, name)`
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L171)
+Remove hook from the model
+
 
 **Params:**
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| hooktype | String |  |
-| name | String | Hook's name you want to remove. |
+| hookType | String |  |
+| name | String |  |
+
 
 ***
 
 <a name="hashook"></a>
 ## `hasHook(hookType)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L172)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L197)
 Check whether the mode has any hooks of this type
 
 
@@ -86,7 +88,7 @@ __Aliases:__ hasHooks
 
 <a name="beforevalidate"></a>
 ## `beforeValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L185)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L210)
 A hook that is run before validation
 
 **Params:**
@@ -101,7 +103,7 @@ A hook that is run before validation
 
 <a name="aftervalidate"></a>
 ## `afterValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L192)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L217)
 A hook that is run after validation
 
 **Params:**
@@ -116,7 +118,7 @@ A hook that is run after validation
 
 <a name="beforecreate"></a>
 ## `beforeCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L199)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L224)
 A hook that is run before creating a single instance
 
 **Params:**
@@ -131,7 +133,7 @@ A hook that is run before creating a single instance
 
 <a name="aftercreate"></a>
 ## `afterCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L206)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L231)
 A hook that is run after creating a single instance
 
 **Params:**
@@ -146,7 +148,7 @@ A hook that is run after creating a single instance
 
 <a name="beforedestroy"></a>
 ## `beforeDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L215)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L240)
 A hook that is run before destroying a single instance
 
 **Params:**
@@ -162,7 +164,7 @@ __Aliases:__ beforeDelete
 
 <a name="afterdestroy"></a>
 ## `afterDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L224)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L249)
 A hook that is run after destroying a single instance
 
 **Params:**
@@ -178,7 +180,7 @@ __Aliases:__ afterDelete
 
 <a name="beforeupdate"></a>
 ## `beforeUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L231)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L256)
 A hook that is run before updating a single instance
 
 **Params:**
@@ -193,7 +195,7 @@ A hook that is run before updating a single instance
 
 <a name="afterupdate"></a>
 ## `afterUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L238)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L263)
 A hook that is run after updating a single instance
 
 **Params:**
@@ -208,7 +210,7 @@ A hook that is run after updating a single instance
 
 <a name="beforebulkcreate"></a>
 ## `beforeBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L245)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L270)
 A hook that is run before creating instances in bulk
 
 **Params:**
@@ -223,7 +225,7 @@ A hook that is run before creating instances in bulk
 
 <a name="afterbulkcreate"></a>
 ## `afterBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L252)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L277)
 A hook that is run after creating instances in bulk
 
 **Params:**
@@ -238,7 +240,7 @@ A hook that is run after creating instances in bulk
 
 <a name="beforebulkdestroy"></a>
 ## `beforeBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L261)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L286)
 A hook that is run before destroying instances in bulk
 
 **Params:**
@@ -254,7 +256,7 @@ __Aliases:__ beforeBulkDelete
 
 <a name="afterbulkdestroy"></a>
 ## `afterBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L270)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L295)
 A hook that is run after destroying instances in bulk
 
 **Params:**
@@ -270,7 +272,7 @@ __Aliases:__ afterBulkDelete
 
 <a name="beforebulkupdate"></a>
 ## `beforeBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L277)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L302)
 A hook that is run after updating instances in bulk
 
 **Params:**
@@ -285,7 +287,7 @@ A hook that is run after updating instances in bulk
 
 <a name="afterbulkupdate"></a>
 ## `afterBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L284)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L309)
 A hook that is run after updating instances in bulk
 
 **Params:**
@@ -300,7 +302,7 @@ A hook that is run after updating instances in bulk
 
 <a name="beforefind"></a>
 ## `beforeFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L291)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L316)
 A hook that is run before a find (select) query
 
 **Params:**
@@ -315,7 +317,7 @@ A hook that is run before a find (select) query
 
 <a name="beforefindafterexpandincludeall"></a>
 ## `beforeFindAfterExpandIncludeAll(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L298)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L323)
 A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
 
 **Params:**
@@ -330,7 +332,7 @@ A hook that is run before a find (select) query, after any { include: {all: ...}
 
 <a name="beforefindafteroptions"></a>
 ## `beforeFindAfterOptions(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L305)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L330)
 A hook that is run before a find (select) query, after all option parsing is complete
 
 **Params:**
@@ -345,7 +347,7 @@ A hook that is run before a find (select) query, after all option parsing is com
 
 <a name="afterfind"></a>
 ## `afterFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L312)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L337)
 A hook that is run after a find (select) query
 
 **Params:**
@@ -360,7 +362,7 @@ A hook that is run after a find (select) query
 
 <a name="beforedefine"></a>
 ## `beforeDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L319)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L344)
 A hook that is run before a define call
 
 **Params:**
@@ -375,7 +377,7 @@ A hook that is run before a define call
 
 <a name="afterdefine"></a>
 ## `afterDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L326)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L351)
 A hook that is run after a define call
 
 **Params:**
@@ -390,7 +392,7 @@ A hook that is run after a define call
 
 <a name="beforeinit"></a>
 ## `beforeInit(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L333)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L358)
 A hook that is run before Sequelize() call
 
 **Params:**
@@ -405,7 +407,7 @@ A hook that is run before Sequelize() call
 
 <a name="afterinit"></a>
 ## `afterInit`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/hooks.js#L341)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/hooks.js#L366)
 A hook that is run after Sequelize() call
 
 **Params:**

--- a/docs/api/instance.md
+++ b/docs/api/instance.md
@@ -1,6 +1,6 @@
 <a name="instance"></a>
 # Class Instance
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L34)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L85)
 This class represents an single instance, a database row. You might see it referred to as both Instance and instance. You should not
 instantiate the Instance class directly, instead you access it using the finder and creation methods on the model.
 
@@ -19,45 +19,45 @@ Accessing properties directly or using `get` is preferred for regular use, `getD
 
 **See:**
 
-* [Sequelize#define](api/sequelize#define)
+* [Sequelize#define](sequelize#define)
 
 
 ***
 
 <a name="isnewrecord"></a>
 ## `isNewRecord` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L47)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L98)
 Returns true if this instance has not yet been persisted to the database
 
 ***
 
 <a name="model"></a>
 ## `Model()` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L56)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L107)
 Returns the Model the instance was created from.
 
 **See:**
 
-* [Model](api/model)
+* [Model](model)
 
 
 ***
 
 <a name="sequelize"></a>
 ## `sequelize()` -> `Sequelize`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L65)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L116)
 A reference to the sequelize instance
 
 **See:**
 
-* [Sequelize](api/sequelize)
+* [Sequelize](sequelize)
 
 
 ***
 
 <a name="where"></a>
 ## `where()` -> `Object`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L75)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L126)
 Get an object representing the query for this instance, use with `options.where`
 
 
@@ -65,7 +65,7 @@ Get an object representing the query for this instance, use with `options.where`
 
 <a name="getdatavalue"></a>
 ## `getDataValue(key)` -> `any`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L99)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L150)
 Get the value of the underlying data value
 
 
@@ -80,7 +80,7 @@ Get the value of the underlying data value
 
 <a name="setdatavalue"></a>
 ## `setDataValue(key, value)`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L109)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L160)
 Update the underlying data value
 
 
@@ -96,7 +96,7 @@ Update the underlying data value
 
 <a name="get"></a>
 ## `get([key], [options])` -> `Object|any`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L128)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L179)
 If no key is given, returns all values of the instance, also invoking virtual getters.
 
 If key is given and a field or virtual getter is present for the key it will call that getter - else it will return the value for key.
@@ -115,7 +115,7 @@ If key is given and a field or virtual getter is present for the key it will cal
 
 <a name="set"></a>
 ## `set(key, value, [options])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L210)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L249)
 Set is used to update values on the instance (the sequelize representation of the instance that is, remember that nothing will be persisted before you actually call `save`).
 In its most basic form `set` will update a value stored in the underlying `dataValues` object. However, if a custom setter function is defined for the key, that function
 will be called instead. To bypass the setter, you can pass `raw: true` in the options object.
@@ -134,7 +134,7 @@ If called with a dot.seperated key on a JSON/JSONB attribute it will set the val
 
 **See:**
 
-* [Model#find](api/model#find)
+* [Model#find](model#find)
 
 
 **Params:**
@@ -153,7 +153,7 @@ __Aliases:__ setAttributes
 
 <a name="changed"></a>
 ## `changed([key])` -> `Boolean|Array`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L351)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L389)
 If changed is called with a string it will return a boolean indicating whether the value of that key in `dataValues` is different from the value in `_previousDataValues`.
 
 If changed is called without an argument, it will return an array of keys that have changed.
@@ -172,7 +172,7 @@ If changed is called without an argument and no keys have changed, it will retur
 
 <a name="previous"></a>
 ## `previous(key)` -> `any`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L372)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L410)
 Returns the previous value for key from `_previousDataValues`.
 
 **Params:**
@@ -186,7 +186,7 @@ Returns the previous value for key from `_previousDataValues`.
 
 <a name="save"></a>
 ## `save([options])` -> `Promise.<this|Errors.ValidationError>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L433)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L471)
 Validate this instance, and if the validation passes, persist it to the database.
 
 On success, the callback will be called with this instance. On validation error, the callback will be called with an instance of `Sequelize.ValidationError`.
@@ -209,7 +209,7 @@ This error will have a property for each of the fields for which validation fail
 
 <a name="reload"></a>
 ## `reload([options])` -> `Promise.<this>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L676)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L715)
 Refresh the current instance in-place, i.e. update the object with current data from the DB and return the same object.
 This is different from doing a `find(Instance.id)`, because that would create and return a new instance. With this method,
 all references to the Instance are updated with the new data and no new objects are created.
@@ -217,7 +217,7 @@ all references to the Instance are updated with the new data and no new objects 
 
 **See:**
 
-* [Model#find](api/model#find)
+* [Model#find](model#find)
 
 
 **Params:**
@@ -232,7 +232,7 @@ all references to the Instance are updated with the new data and no new objects 
 
 <a name="validate"></a>
 ## `validate([options])` -> `Promise.<Errors.ValidationError|undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L705)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L744)
 Validate the attribute of this instance according to validation rules set in the model definition.
 
 Emits null if and only if validation successful; otherwise an Error instance containing { field name : [error msgs] } entries.
@@ -240,7 +240,7 @@ Emits null if and only if validation successful; otherwise an Error instance con
 
 **See:**
 
-* [InstanceValidator](api/instancevalidator)
+* [InstanceValidator](instancevalidator)
 
 
 **Params:**
@@ -255,14 +255,14 @@ Emits null if and only if validation successful; otherwise an Error instance con
 
 <a name="update"></a>
 ## `update(updates, options)` -> `Promise.<this>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L724)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L763)
 This is the same as calling `set` and then calling `save`.
 
 
 **See:**
 
-* [Instance#set](api/instance#set)
-* [Instance#save](api/instance#save)
+* [Instance#set](instance#set)
+* [Instance#save](instance#save)
 
 
 **Params:**
@@ -278,7 +278,7 @@ __Aliases:__ updateAttributes
 
 <a name="destroy"></a>
 ## `destroy([options={}])` -> `Promise.<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L757)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L796)
 Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will either be completely deleted, or have its deletedAt timestamp set to the current time.
 
 
@@ -296,7 +296,7 @@ Destroy the row corresponding to this instance. Depending on your setting for pa
 
 <a name="restore"></a>
 ## `restore([options={}])` -> `Promise.<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L801)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L840)
 Restore the row corresponding to this instance. Only available for paranoid models.
 
 
@@ -313,7 +313,7 @@ Restore the row corresponding to this instance. Only available for paranoid mode
 
 <a name="increment"></a>
 ## `increment(fields, [options])` -> `Promise.<this>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L848)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L887)
 Increment the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The increment is done using a
 ```sql
 SET column = column + X
@@ -330,7 +330,7 @@ instance.increment({ answer: 42, tries: 1}, { by: 2 }) // increment answer by 42
 
 **See:**
 
-* [Instance#reload](api/instance#reload)
+* [Instance#reload](instance#reload)
 
 
 **Params:**
@@ -348,7 +348,7 @@ instance.increment({ answer: 42, tries: 1}, { by: 2 }) // increment answer by 42
 
 <a name="decrement"></a>
 ## `decrement(fields, [options])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L921)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L960)
 Decrement the value of one or more columns. This is done in the database, which means it does not use the values currently stored on the Instance. The decrement is done using a
 ```sql
 SET column = column - X
@@ -365,7 +365,7 @@ instance.decrement({ answer: 42, tries: 1}, { by: 2 }) // decrement answer by 42
 
 **See:**
 
-* [Instance#reload](api/instance#reload)
+* [Instance#reload](instance#reload)
 
 
 **Params:**
@@ -383,7 +383,7 @@ instance.decrement({ answer: 42, tries: 1}, { by: 2 }) // decrement answer by 42
 
 <a name="equals"></a>
 ## `equals(other)` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L943)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L982)
 Check whether all values of this and `other` Instance are the same
 
 
@@ -398,7 +398,7 @@ Check whether all values of this and `other` Instance are the same
 
 <a name="equalsoneof"></a>
 ## `equalsOneOf(others)` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L963)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L1006)
 Check if this is eqaul to one of `others` by calling equals
 
 
@@ -413,13 +413,13 @@ Check if this is eqaul to one of `others` by calling equals
 
 <a name="tojson"></a>
 ## `toJSON()` -> `object`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/instance.js#L981)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/instance.js#L1024)
 Convert the instance to a JSON representation. Proxies to calling `get` with no keys. This means get all values gotten from the DB, and apply all custom getters.
 
 
 **See:**
 
-* [Instance#get](api/instance#get)
+* [Instance#get](instance#get)
 
 
 ***

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -1,7 +1,7 @@
 <a name="model"></a>
 # Class Model
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L24)
-A Model represents a table in the database. Sometimes you might also see it refererred to as model, or simply as factory.
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L23)
+A Model represents a table in the database. Sometimes you might also see it referred to as model, or simply as factory.
 This class should _not_ be instantiated directly, it is created using `sequelize.define`, and already created models can be loaded using `sequelize.import`
 
 ### Mixes:
@@ -12,7 +12,7 @@ This class should _not_ be instantiated directly, it is created using `sequelize
 
 <a name="removeattribute"></a>
 ## `removeAttribute([attribute])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L404)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L849)
 Remove attribute from model definition
 
 **Params:**
@@ -26,19 +26,19 @@ Remove attribute from model definition
 
 <a name="sync"></a>
 ## `sync()` -> `Promise.<this>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L414)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L859)
 Sync this Model to the DB, that is create the table. Upon success, the callback will be called with the model instance (this)
 
 **See:**
 
-* [Sequelize#sync](api/sequelize#sync)
+* [Sequelize#sync](sequelize#sync)
 
 
 ***
 
 <a name="drop"></a>
 ## `drop([options])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L451)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L896)
 Drop the table represented by this Model
 
 **Params:**
@@ -54,7 +54,7 @@ Drop the table represented by this Model
 
 <a name="schema"></a>
 ## `schema(schema, [options])` -> `hi`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L469)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L914)
 Apply a schema to this model. For postgres, this will actually place the schema in front of the table name - `"schema"."tableName"`,
 while the schema will be prepended to the table name for mysql and sqlite - `'schema.tablename'`.
 
@@ -73,7 +73,7 @@ while the schema will be prepended to the table name for mysql and sqlite - `'sc
 
 <a name="gettablename"></a>
 ## `getTableName([options])` -> `String|Object`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L493)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L938)
 Get the tablename of the model, taking schema into account. The method will return The name as a string if the model has no schema,
 or an object with `tableName`, `schema` and `delimiter` properties.
 
@@ -90,14 +90,14 @@ or an object with `tableName`, `schema` and `delimiter` properties.
 
 <a name="unscoped"></a>
 ## `unscoped()` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L500)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L945)
 
 
 ***
 
 <a name="scope"></a>
 ## `scope(options*)` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L550)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L995)
 Apply a scope created in `define` to the model. First let's look at how to create scopes:
 ```js
 var Model = sequelize.define('model', attributes, {
@@ -153,7 +153,7 @@ __Returns:__ A reference to the model, with the scope(s) applied. Calling scope 
 
 <a name="findall"></a>
 ## `findAll([options])` -> `Promise.<Array.<Instance>>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L701)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1146)
 Search for multiple instances.
 
 __Simple search using AND and =__
@@ -192,7 +192,7 @@ Model.findAll({
 ```sql
 WHERE attr1 > 50 AND attr2 <= 45 AND attr3 IN (1,2,3) AND attr4 != 5
 ```
-Possible options are: `gt, gte, lt, lte, ne, between/.., nbetween/notbetween/!.., in, not, like, nlike/notlike`
+Possible options are: `$ne, $in, $not, $notIn, $gte, $gt, $lte, $lt, $like, $ilike/$iLike, $notLike, $notILike, '..'/$between, '!..'/$notBetween, '&&'/$overlap, '@>'/$contains, '<@'/$contained`
 
 __Queries using OR__
 ```js
@@ -215,7 +215,7 @@ The success listener is called with an array of instances if the query succeeds.
 
 **See:**
 
-* [Sequelize#query](api/sequelize#query)
+* [Sequelize#query](sequelize#query)
 
 
 **Params:**
@@ -239,7 +239,7 @@ The success listener is called with an array of instances if the query succeeds.
 | [options.order] | String &#124; Array &#124; Sequelize.fn | Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide several columns / functions to order by. Each element can be further wrapped in a two-element array. The first element is the column / function to order by, the second is the direction. For example: `order: [['name', 'DESC']]`. In this way the column will be escaped, but the direction will not. |
 | [options.limit] | Number |  |
 | [options.offset] | Number |  |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under |
 | [options.lock] | String &#124; Object | Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](api/transaction#lock) |
 | [options.raw] | Boolean | Return raw result. See sequelize.query for more information. |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql. |
@@ -251,13 +251,13 @@ __Aliases:__ all
 
 <a name="findbyid"></a>
 ## `findById([options], ')` -> `Promise.<Instance>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L779)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1224)
 Search for a single instance by its primary key. This applies LIMIT 1, so the listener will always be called with a single instance.
 
 
 **See:**
 
-* [Model#findAll](api/model#findall)
+* [Model#findAll](model#findall)
 
 
 **Params:**
@@ -266,7 +266,7 @@ Search for a single instance by its primary key. This applies LIMIT 1, so the li
 | ---- | ---- | ----------- |
 | [options] | Number &#124; String &#124; Buffer | A hash of options to describe the scope of the search, or a number to search by id. |
 | ' | Object | [options] |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under  |
 
 __Aliases:__ findByPrimary
 
@@ -274,13 +274,13 @@ __Aliases:__ findByPrimary
 
 <a name="findone"></a>
 ## `findOne([options])` -> `Promise.<Instance>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L813)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1258)
 Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single instance.
 
 
 **See:**
 
-* [Model#findAll](api/model#findall)
+* [Model#findAll](model#findall)
 
 
 **Params:**
@@ -288,7 +288,7 @@ Search for a single instance. This applies LIMIT 1, so the listener will always 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | [options] | Object | A hash of options to describe the scope of the search |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under  |
 
 __Aliases:__ find
 
@@ -296,7 +296,7 @@ __Aliases:__ find
 
 <a name="aggregate"></a>
 ## `aggregate(field, aggregateFunction, [options])` -> `Promise.<options.dataType|object>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L842)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1290)
 Run an aggregation method on the specified field
 
 
@@ -311,7 +311,7 @@ Run an aggregation method on the specified field
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql. |
 | [options.dataType] | DataType &#124; String | The type of the result. If `field` is a field in this Model, the default will be the type of that field, otherwise defaults to float. |
 | [options.distinct] | boolean | Applies DISTINCT to the field being aggregated over |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under |
 | [options.plain] | boolean | When `true`, the first returned value of `aggregateFunction` is cast to `dataType` and returned. If additional attributes are specified, along with `group` clauses, set `plain` to `false` to return all values of all returned rows. Defaults to `true`  |
 
 __Returns:__ Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in which case the complete data result is returned.
@@ -320,7 +320,7 @@ __Returns:__ Returns the aggregate result cast to `options.dataType`, unless `op
 
 <a name="count"></a>
 ## `count([options])` -> `Promise.<Integer>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L882)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1330)
 Count the number of records matching the provided where clause.
 
 If you provide an `include` option, the number of matching associations will be counted instead.
@@ -343,7 +343,7 @@ If you provide an `include` option, the number of matching associations will be 
 
 <a name="findandcount"></a>
 ## `findAndCount([findOptions])` -> `Promise.<Object>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L923)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1372)
 Find all the rows matching your query, within a specified offset / limit, and get the total number of rows matching your query. This is very usefull for paging
 
 ```js
@@ -351,7 +351,8 @@ Model.findAndCountAll({
   where: ...,
   limit: 12,
   offset: 12
-}).success(function (result) {
+}).then(function (result) {
+  ...
 })
 ```
 In the above example, `result.rows` will contain rows 13 through 24, while `result.count` will return the total number of rows that matched your query.
@@ -359,7 +360,7 @@ In the above example, `result.rows` will contain rows 13 through 24, while `resu
 
 **See:**
 
-* [Model#findAll](api/model#findall)
+* [Model#findAll](model#findall)
 
 
 **Params:**
@@ -374,13 +375,13 @@ __Aliases:__ findAndCountAll
 
 <a name="max"></a>
 ## `max(field, [options])` -> `Promise.<Any>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L979)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1430)
 Find the maximum value of field
 
 
 **See:**
 
-* [Model#aggregate](api/model#aggregate)
+* [Model#aggregate](model#aggregate)
 
 
 **Params:**
@@ -395,13 +396,13 @@ Find the maximum value of field
 
 <a name="min"></a>
 ## `min(field, [options])` -> `Promise.<Any>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L992)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1443)
 Find the minimum value of field
 
 
 **See:**
 
-* [Model#aggregate](api/model#aggregate)
+* [Model#aggregate](model#aggregate)
 
 
 **Params:**
@@ -416,13 +417,13 @@ Find the minimum value of field
 
 <a name="sum"></a>
 ## `sum(field, [options])` -> `Promise.<Number>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1005)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1456)
 Find the sum of field
 
 
 **See:**
 
-* [Model#aggregate](api/model#aggregate)
+* [Model#aggregate](model#aggregate)
 
 
 **Params:**
@@ -437,7 +438,7 @@ Find the sum of field
 
 <a name="build"></a>
 ## `build(values, [options])` -> `Instance`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1020)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1471)
 Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
 
 
@@ -456,14 +457,14 @@ Builds a new model instance. Values is an object of key value pairs, must be def
 
 <a name="create"></a>
 ## `create(values, [options])` -> `Promise.<Instance>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1088)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1539)
 Builds a new model instance and calls save on it.
 
 
 **See:**
 
-* [Instance#build](api/instance#build)
-* [Instance#save](api/instance#save)
+* [Instance#build](instance#build)
+* [Instance#save](instance#save)
 
 
 **Params:**
@@ -477,7 +478,7 @@ Builds a new model instance and calls save on it.
 | [options.fields] | Array | If set, only columns matching those in fields will be saved |
 | [options.include] | Array | an array of include options - Used to build prefetched/included model instances |
 | [options.onDuplicate] | String |  |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql.  |
 
 
@@ -485,7 +486,7 @@ Builds a new model instance and calls save on it.
 
 <a name="findorinitialize"></a>
 ## `findOrInitialize` -> `Promise.<Instance>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1113)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1564)
 Find a row that matches the query, or build (but don't save) the row if none is found.
 The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
 
@@ -506,13 +507,18 @@ __Aliases:__ findOrBuild
 
 <a name="findorcreate"></a>
 ## `findOrCreate(options)` -> `Promise.<Instance, created>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1155)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1606)
 Find a row that matches the query, or build and save the row if none is found
 The successfull result of the promise will be (instance, created) - Make sure to use .spread()
 
 If no transaction is passed in the `options` object, a new transaction will be created internally, to prevent the race condition where a matching row is created by another connection after the find but before the insert call.
 However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has comitted. In this case, an instance of sequelize.TimeoutError will be thrown instead.
 If a transaction is created, a savepoint will be created instead, and any unique constraint violation will be handled internally.
+
+
+**See:**
+
+* [Model#findAll](model#findall)
 
 
 **Params:**
@@ -522,14 +528,14 @@ If a transaction is created, a savepoint will be created instead, and any unique
 | options | Object |  |
 | options.where | Object | where A hash of search attributes. |
 | [options.defaults] | Object | Default values to use if creating a new instance |
-| [options.logging=false] | Function | A function that gets executed while running the query to log the sql.  |
+| [options.transaction] | Transaction | Transaction to run query under |
 
 
 ***
 
 <a name="upsert"></a>
 ## `upsert(values, [options])` -> `Promise.<created>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1244)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1695)
 Insert or update a single row. An update will be executed if a row which matches the supplied values on either the primary key or a unique key is found. Note that the unique index must be defined in your sequelize model and not just in the table. Otherwise you may experience a unique constraint violation, because sequelize fails to identify the row that should be updated.
 
 **Implementation details:**
@@ -558,7 +564,7 @@ __Aliases:__ insertOrUpdate
 
 <a name="bulkcreate"></a>
 ## `bulkCreate(records, [options])` -> `Promise.<Array.<Instance>>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1299)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1752)
 Create and insert multiple instances in bulk.
 
 The success handler is passed an array of instances, but please notice that these may not completely represent the state of the rows in the DB. This is because MySQL
@@ -578,15 +584,38 @@ To obtain Instances for the newly created values, you will need to query for the
 | [options.individualHooks=false] | Boolean | Run before / after create hooks for each individual Instance? BulkCreate hooks will still be run if options.hooks is true. |
 | [options.ignoreDuplicates=false] | Boolean | Ignore duplicate values for primary keys? (not supported by postgres) |
 | [options.updateOnDuplicate] | Array | Fields to update if row key already exists (on duplicate key update)? (only supported by mysql & mariadb). By default, all fields are updated. |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql.  |
 
 
 ***
 
+<a name="truncate"></a>
+## `truncate([options])` -> `Promise`
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1900)
+Truncate all instances of the model. This is a convenient method for Model.destroy({ truncate: true }).
+
+
+**See:**
+
+* [Model#destroy](model#destroy)
+
+
+**Params:**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [options] | object | The options passed to Model.destroy in addition to truncate |
+| [options.transaction] | Boolean &#124; function | Transaction to run query under |
+| [options.cascade | Boolean &#124; function | = false] Only used in conjuction with TRUNCATE. Truncates all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE. |
+| [options.logging] | Boolean &#124; function | A function that logs sql queries, or false for no logging |
+
+
+***
+
 <a name="destroy"></a>
-## `destroy(options)` -> `Promise.<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1450)
+## `destroy(options)` -> `Promise.<Integer>`
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1921)
 Delete multiple instances, or set their deletedAt timestamp to the current time if `paranoid` is enabled.
 
 
@@ -602,15 +631,16 @@ Delete multiple instances, or set their deletedAt timestamp to the current time 
 | [options.force=false] | Boolean | Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled) |
 | [options.truncate=false] | Boolean | If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored |
 | [options.cascade=false] | Boolean | Only used in conjuction with TRUNCATE. Truncates all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE. |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql. |
 
+__Returns:__ The number of destroyed rows
 
 ***
 
 <a name="restore"></a>
 ## `restore(options)` -> `Promise.<undefined>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1527)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L1998)
 Restore multiple instances if `paranoid` is enabled.
 
 
@@ -624,14 +654,14 @@ Restore multiple instances if `paranoid` is enabled.
 | [options.individualHooks=false] | Boolean | If set to true, restore will find all records within the where parameter and will execute before / after bulkRestore hooks on each row |
 | [options.limit] | Number | How many rows to undelete |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql. |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under  |
 
 
 ***
 
 <a name="update"></a>
 ## `update(values, options)` -> `Promise.<Array.<affectedCount, affectedRows>>`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1600)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L2071)
 Update multiple instances that match the where options. The promise returns an array with one or two elements. The first element is always the number
 of affected rows, while the second element is the actual affected rows (only supported in postgres with `options.returning` true.)
 
@@ -651,14 +681,14 @@ of affected rows, while the second element is the actual affected rows (only sup
 | [options.returning=false] | Boolean | Return the affected rows (only for postgres) |
 | [options.limit] | Number | How many rows to update (only for mysql and mariadb) |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql. |
-| [options.transaction] | Transaction |  |
+| [options.transaction] | Transaction | Transaction to run query under  |
 
 
 ***
 
 <a name="describe"></a>
 ## `describe()` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/model.js#L1788)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/model.js#L2259)
 Run a describe query on the table. The result will be return to the listener as a hash of attributes and their types.
 
 

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -1,6 +1,6 @@
 <a name="sequelize"></a>
 # Class Sequelize
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L29)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L29)
 This is the main class, the entry point to sequelize. To use it, you just need to import sequelize:
 
 ```js
@@ -14,7 +14,7 @@ In addition to sequelize, the connection library for the dialect you want to use
 
 <a name="sequelize"></a>
 ## `new Sequelize(database, [username=null], [password=null], [options={}])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L84)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L83)
 Instantiate sequelize with name of database, username and password
 
 #### Example usage
@@ -45,7 +45,7 @@ var sequelize = new Sequelize('mysql://localhost:3306/database', {})
 | [username=null] | String | The username which is used to authenticate against the database. |
 | [password=null] | String | The password which is used to authenticate against the database. |
 | [options={}] | Object | An object with options. |
-| [options.dialect='mysql'] | String | The dialect of the database you are connecting to. One of mysql, postgres, sqlite, mariadb and mssql |
+| [options.dialect='mysql'] | String | The dialect of the database you are connecting to. One of mysql, postgres, sqlite, mariadb and mssql. |
 | [options.dialectModulePath=null] | String | If specified, load the dialect library from this path. For example, if you want to use pg.js instead of pg when connecting to a pg database, you should specify 'pg.js' here |
 | [options.dialectOptions] | Object | An object of additional options, which are passed directly to the connection library |
 | [options.storage] | String | Only used by sqlite. Defaults to ':memory:' |
@@ -74,7 +74,7 @@ var sequelize = new Sequelize('mysql://localhost:3306/database', {})
 
 <a name="sequelize"></a>
 ## `new Sequelize(uri, [options={}])`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L93)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L92)
 Instantiate sequelize with an URI
 
 **Params:**
@@ -89,57 +89,57 @@ Instantiate sequelize with an URI
 
 <a name="models"></a>
 ## `models`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L190)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L189)
 Models are stored here under the name given to `sequelize.define`
 
 ***
 
 <a name="sequelize"></a>
 ## `Sequelize`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L217)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L216)
 A reference to Sequelize constructor from sequelize. Useful for accessing DataTypes, Errors etc.
 
 **See:**
 
-* [Sequelize](api/sequelize)
+* [Sequelize](sequelize)
 
 
 ***
 
 <a name="utils"></a>
 ## `Utils`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L224)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L223)
 A reference to sequelize utilities. Most users will not need to use these utils directly. However, you might want to use `Sequelize.Utils._`, which is a reference to the lodash library, if you don't already have it imported in your project.
 
 **See:**
 
-* [Utils](api/utils)
+* [Utils](utils)
 
 
 ***
 
 <a name="promise"></a>
 ## `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L231)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L230)
 A modified version of bluebird promises, that allows listening for sql events
 
 **See:**
 
-* [Promise](api/promise)
+* [Promise](promise)
 
 
 ***
 
 <a name="querytypes"></a>
 ## `QueryTypes`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L237)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L236)
 Available query types for use with `sequelize.query`
 
 ***
 
 <a name="validator"></a>
 ## `Validator`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L244)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L243)
 Exposes the validator.js object, so you can extend it with custom validation functions. The validator is exposed both on the instance, and on the constructor.
 
 **See:**
@@ -151,225 +151,225 @@ Exposes the validator.js object, so you can extend it with custom validation fun
 
 <a name="transaction"></a>
 ## `Transaction`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L264)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L263)
 A reference to the sequelize transaction class. Use this to access isolationLevels when creating a transaction
 
 **See:**
 
-* [Transaction](api/transaction)
-* [Sequelize#transaction](api/sequelize#transaction)
+* [Transaction](transaction)
+* [Sequelize#transaction](sequelize#transaction)
 
 
 ***
 
 <a name="deferrable"></a>
 ## `Deferrable`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L272)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L271)
 A reference to the deferrable collection. Use this to access the different deferrable options.
 
 **See:**
 
-* [Deferrable](api/deferrable)
-* [Sequelize#transaction](api/sequelize#transaction)
+* [Deferrable](deferrable)
+* [Sequelize#transaction](sequelize#transaction)
 
 
 ***
 
 <a name="instance"></a>
 ## `Instance`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L279)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L278)
 A reference to the sequelize instance class.
 
 **See:**
 
-* [Instance](api/instance)
+* [Instance](instance)
 
 
 ***
 
 <a name="error"></a>
 ## `Error`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L292)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L291)
 A general error class
 
 **See:**
 
-* [Errors#BaseError](api/errors#baseerror)
+* [Errors#BaseError](errors#baseerror)
 
 
 ***
 
 <a name="validationerror"></a>
 ## `ValidationError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L300)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L299)
 Emitted when a validation fails
 
 **See:**
 
-* [Errors#ValidationError](api/errors#validationerror)
+* [Errors#ValidationError](errors#validationerror)
 
 
 ***
 
 <a name="validationerroritem"></a>
 ## `ValidationErrorItem`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L308)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L307)
 Describes a validation error on an instance path
 
 **See:**
 
-* [Errors#ValidationErrorItem](api/errors#validationerroritem)
+* [Errors#ValidationErrorItem](errors#validationerroritem)
 
 
 ***
 
 <a name="databaseerror"></a>
 ## `DatabaseError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L315)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L314)
 A base class for all database related errors.
 
 **See:**
 
-* [Errors#DatabaseError](api/errors#databaseerror)
+* [Errors#DatabaseError](errors#databaseerror)
 
 
 ***
 
 <a name="timeouterror"></a>
 ## `TimeoutError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L322)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L321)
 Thrown when a database query times out because of a deadlock
 
 **See:**
 
-* [Errors#TimeoutError](api/errors#timeouterror)
+* [Errors#TimeoutError](errors#timeouterror)
 
 
 ***
 
 <a name="uniqueconstrainterror"></a>
 ## `UniqueConstraintError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L329)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L328)
 Thrown when a unique constraint is violated in the database
 
 **See:**
 
-* [Errors#UniqueConstraintError](api/errors#uniqueconstrainterror)
+* [Errors#UniqueConstraintError](errors#uniqueconstrainterror)
 
 
 ***
 
 <a name="exclusionconstrainterror"></a>
 ## `ExclusionConstraintError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L336)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L335)
 Thrown when an exclusion constraint is violated in the database
 
 **See:**
 
-* [Errors#ExclusionConstraintError](api/errors#exclusionconstrainterror)
+* [Errors#ExclusionConstraintError](errors#exclusionconstrainterror)
 
 
 ***
 
 <a name="foreignkeyconstrainterror"></a>
 ## `ForeignKeyConstraintError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L343)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L342)
 Thrown when a foreign key constraint is violated in the database
 
 **See:**
 
-* [Errors#ForeignKeyConstraintError](api/errors#foreignkeyconstrainterror)
+* [Errors#ForeignKeyConstraintError](errors#foreignkeyconstrainterror)
 
 
 ***
 
 <a name="connectionerror"></a>
 ## `ConnectionError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L350)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L349)
 A base class for all connection related errors.
 
 **See:**
 
-* [Errors#ConnectionError](api/errors#connectionerror)
+* [Errors#ConnectionError](errors#connectionerror)
 
 
 ***
 
 <a name="connectionrefusederror"></a>
 ## `ConnectionRefusedError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L357)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L356)
 Thrown when a connection to a database is refused
 
 **See:**
 
-* [Errors#ConnectionRefusedError](api/errors#connectionrefusederror)
+* [Errors#ConnectionRefusedError](errors#connectionrefusederror)
 
 
 ***
 
 <a name="accessdeniederror"></a>
 ## `AccessDeniedError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L364)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L363)
 Thrown when a connection to a database is refused due to insufficient access
 
 **See:**
 
-* [Errors#AccessDeniedError](api/errors#accessdeniederror)
+* [Errors#AccessDeniedError](errors#accessdeniederror)
 
 
 ***
 
 <a name="hostnotfounderror"></a>
 ## `HostNotFoundError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L371)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L370)
 Thrown when a connection to a database has a hostname that was not found
 
 **See:**
 
-* [Errors#HostNotFoundError](api/errors#hostnotfounderror)
+* [Errors#HostNotFoundError](errors#hostnotfounderror)
 
 
 ***
 
 <a name="hostnotreachableerror"></a>
 ## `HostNotReachableError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L378)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L377)
 Thrown when a connection to a database has a hostname that was not reachable
 
 **See:**
 
-* [Errors#HostNotReachableError](api/errors#hostnotreachableerror)
+* [Errors#HostNotReachableError](errors#hostnotreachableerror)
 
 
 ***
 
 <a name="invalidconnectionerror"></a>
 ## `InvalidConnectionError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L385)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L384)
 Thrown when a connection to a database has invalid values for any of the connection parameters
 
 **See:**
 
-* [Errors#InvalidConnectionError](api/errors#invalidconnectionerror)
+* [Errors#InvalidConnectionError](errors#invalidconnectionerror)
 
 
 ***
 
 <a name="connectiontimedouterror"></a>
 ## `ConnectionTimedOutError`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L392)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L391)
 Thrown when a connection to a database times out
 
 **See:**
 
-* [Errors#ConnectionTimedOutError](api/errors#connectiontimedouterror)
+* [Errors#ConnectionTimedOutError](errors#connectiontimedouterror)
 
 
 ***
 
 <a name="getdialect"></a>
 ## `getDialect()` -> `String`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L400)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L399)
 Returns the specified dialect.
 
 __Returns:__ The specified dialect.
@@ -378,13 +378,13 @@ __Returns:__ The specified dialect.
 
 <a name="getqueryinterface"></a>
 ## `getQueryInterface()` -> `QueryInterface`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L412)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L411)
 Returns an instance of QueryInterface.
 
 
 **See:**
 
-* [QueryInterface](api/queryinterface)
+* [QueryInterface](queryinterface)
 
 __Returns:__ An instance (singleton) of QueryInterface. 
 
@@ -392,7 +392,7 @@ __Returns:__ An instance (singleton) of QueryInterface.
 
 <a name="define"></a>
 ## `define(modelName, attributes, [options])` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L515)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L514)
 Define a new model, representing a table in the DB.
 
 The table columns are define by the hash that is given as the second argument. Each attribute of the hash represents a column. A short table definition might look like this:
@@ -433,8 +433,8 @@ For more about validation, see http://docs.sequelizejs.com/en/latest/docs/models
 
 **See:**
 
-* [DataTypes](api/datatypes)
-* [Hooks](api/hooks)
+* [DataTypes](datatypes)
+* [Hooks](hooks)
 
 
 **Params:**
@@ -501,7 +501,7 @@ For more about validation, see http://docs.sequelizejs.com/en/latest/docs/models
 
 <a name="model"></a>
 ## `model(modelName)` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L561)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L560)
 Fetch a Model which is already defined
 
 
@@ -516,7 +516,7 @@ Fetch a Model which is already defined
 
 <a name="isdefined"></a>
 ## `isDefined(modelName)` -> `Boolean`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L575)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L574)
 Checks whether a model with the given name is defined
 
 
@@ -531,7 +531,7 @@ Checks whether a model with the given name is defined
 
 <a name="import"></a>
 ## `import(path)` -> `Model`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L589)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L588)
 Imports a model defined in another file
 
 Imported models are cached, so multiple calls to import with the same path will not load the file multiple times
@@ -549,7 +549,7 @@ See https://github.com/sequelize/sequelize/blob/master/examples/using-multiple-m
 
 <a name="query"></a>
 ## `query(sql, [options={}])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L646)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L641)
 Execute a query on the DB, with the posibility to bypass all the sequelize goodness.
 
 By default, the function will return two arguments: an array of results, and a metadata object, containing number of affected rows etc. Use `.spread` to access the results.
@@ -569,7 +569,7 @@ sequelize.query('SELECT...', { type: sequelize.QueryTypes.SELECT }).then(functio
 
 **See:**
 
-* [Model#build](api/model#build)
+* [Model#build](model#build)
 
 
 **Params:**
@@ -594,7 +594,7 @@ sequelize.query('SELECT...', { type: sequelize.QueryTypes.SELECT }).then(functio
 
 <a name="set"></a>
 ## `set(variables, options)` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L740)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L735)
 Execute a query which would set an environment or user variable. The variables are set per connection, so this function needs a transaction.
 Only works for MySQL.
 
@@ -612,7 +612,7 @@ Only works for MySQL.
 
 <a name="escape"></a>
 ## `escape(value)` -> `String`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L774)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L769)
 Escape value.
 
 
@@ -627,7 +627,7 @@ Escape value.
 
 <a name="createschema"></a>
 ## `createSchema(schema, options={})` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L790)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L785)
 Create a new database schema.
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -636,7 +636,7 @@ not a database table. In mysql and sqlite, this command will do nothing.
 
 **See:**
 
-* [Model#schema](api/model#schema)
+* [Model#schema](model#schema)
 
 
 **Params:**
@@ -652,7 +652,7 @@ not a database table. In mysql and sqlite, this command will do nothing.
 
 <a name="showallschemas"></a>
 ## `showAllSchemas(options={})` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L803)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L798)
 Show all defined schemas
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -670,7 +670,7 @@ not a database table. In mysql and sqlite, this will show all tables.
 
 <a name="dropschema"></a>
 ## `dropSchema(schema, options={})` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L817)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L812)
 Drop a single schema
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -689,7 +689,7 @@ not a database table. In mysql and sqlite, this drop a table matching the schema
 
 <a name="dropallschemas"></a>
 ## `dropAllSchemas(options={})` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L830)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L825)
 Drop all schemas
 
 Note,that this is a schema in the [postgres sense of the word](http://www.postgresql.org/docs/9.1/static/ddl-schemas.html),
@@ -707,7 +707,7 @@ not a database table. In mysql and sqlite, this is the equivalent of drop all ta
 
 <a name="sync"></a>
 ## `sync([options={}])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L844)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L839)
 Sync all defined models to the DB.
 
 
@@ -724,14 +724,37 @@ Sync all defined models to the DB.
 
 ***
 
+<a name="truncate"></a>
+## `truncate([options])` -> `Promise`
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L888)
+Truncate all tables defined through the sequelize models. This is done
+by calling Model.truncate() on each model.
+
+
+**See:**
+
+* [Model#truncate](model#truncate)
+
+
+**Params:**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| [options] | object | The options passed to Model.destroy in addition to truncate |
+| [options.transaction] | Boolean &#124; function |  |
+| [options.logging] | Boolean &#124; function | A function that logs sql queries, or false for no logging |
+
+
+***
+
 <a name="drop"></a>
 ## `drop(options)` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L890)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L910)
 Drop all tables defined through this sequelize instance. This is done by calling Model.drop on each model
 
 **See:**
 
-* [Model#drop](api/model#drop)
+* [Model#drop](model#drop)
 
 
 **Params:**
@@ -746,7 +769,7 @@ Drop all tables defined through this sequelize instance. This is done by calling
 
 <a name="authenticate"></a>
 ## `authenticate()` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L912)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L932)
 Test the connection by trying to authenticate
 
 __Aliases:__ validate
@@ -755,7 +778,7 @@ __Aliases:__ validate
 
 <a name="fn "></a>
 ## `fn (fn, args)` -> `Sequelize.fn`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L947)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L967)
 Creates a object representing a database function. This can be used in search queries, both in where and order parts, and as default values in column definitions.
 If you want to refer to columns in your function, you should use `sequelize.col`, so that the columns are properly interpreted as columns and not a strings.
 
@@ -769,10 +792,10 @@ instance.updateAttributes({
 
 **See:**
 
-* [Model#find](api/model#find)
-* [Model#findAll](api/model#findall)
-* [Model#define](api/model#define)
-* [Sequelize#col](api/sequelize#col)
+* [Model#find](model#find)
+* [Model#findAll](model#findall)
+* [Model#define](model#define)
+* [Sequelize#col](sequelize#col)
 
 
 **Params:**
@@ -787,12 +810,12 @@ instance.updateAttributes({
 
 <a name="col"></a>
 ## `col(col)` -> `Sequelize.col`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L960)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L980)
 Creates a object representing a column in the DB. This is often useful in conjunction with `sequelize.fn`, since raw string arguments to fn will be escaped.
 
 **See:**
 
-* [Sequelize#fn](api/sequelize#fn)
+* [Sequelize#fn](sequelize#fn)
 
 
 **Params:**
@@ -806,7 +829,7 @@ Creates a object representing a column in the DB. This is often useful in conjun
 
 <a name="cast"></a>
 ## `cast(val, type)` -> `Sequelize.cast`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L974)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L994)
 Creates a object representing a call to the cast function.
 
 
@@ -822,7 +845,7 @@ Creates a object representing a call to the cast function.
 
 <a name="literal"></a>
 ## `literal(val)` -> `Sequelize.literal`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L987)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L1007)
 Creates a object representing a literal, i.e. something that will not be escaped.
 
 
@@ -838,12 +861,12 @@ __Aliases:__ asIs
 
 <a name="and"></a>
 ## `and(args)` -> `Sequelize.and`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L1000)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L1020)
 An AND query
 
 **See:**
 
-* [Model#find](api/model#find)
+* [Model#find](model#find)
 
 
 **Params:**
@@ -857,12 +880,12 @@ An AND query
 
 <a name="or"></a>
 ## `or(args)` -> `Sequelize.or`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L1013)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L1033)
 An OR query
 
 **See:**
 
-* [Model#find](api/model#find)
+* [Model#find](model#find)
 
 
 **Params:**
@@ -876,12 +899,12 @@ An OR query
 
 <a name="json"></a>
 ## `json(conditions, [value])` -> `Sequelize.json`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L1026)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L1046)
 Creates an object representing nested where conditions for postgres's json data-type.
 
 **See:**
 
-* [Model#find](api/model#find)
+* [Model#find](model#find)
 
 
 **Params:**
@@ -896,7 +919,7 @@ Creates an object representing nested where conditions for postgres's json data-
 
 <a name="where"></a>
 ## `where(attr, [comparator='='], logic)` -> `Sequelize.where`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L1048)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L1068)
 A way of specifying attr = condition.
 
 The attr can either be an object taken from `Model.rawAttributes` (for example `Model.rawAttributes.id` or `Model.rawAttributes.name`). The
@@ -907,7 +930,7 @@ For string attributes, use the regular `{ where: { attr: something }}` syntax. I
 
 **See:**
 
-* [Model#find](api/model#find)
+* [Model#find](model#find)
 
 
 **Params:**
@@ -924,7 +947,7 @@ __Aliases:__ condition
 
 <a name="transaction"></a>
 ## `transaction([options={}])` -> `Promise`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/sequelize.js#L1101)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/sequelize.js#L1121)
 Start a transaction. When using transactions, you should pass the transaction in the options argument in order for the query to happen under that transaction
 
 ```js
@@ -966,7 +989,7 @@ Note, that CLS is enabled for all sequelize instances, and all instances will sh
 
 **See:**
 
-* [Transaction](api/transaction)
+* [Transaction](transaction)
 
 
 **Params:**

--- a/docs/api/transaction.md
+++ b/docs/api/transaction.md
@@ -1,6 +1,6 @@
 <a name="transaction"></a>
 # Class Transaction
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/transaction.js#L18)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/transaction.js#L19)
 The transaction object is used to identify a running transaction. It is created by calling `Sequelize.transaction()`.
 
 To run a query under a transaction, you should pass the transaction in the options object.
@@ -20,10 +20,11 @@ To run a query under a transaction, you should pass the transaction in the optio
 
 <a name="isolation_levels"></a>
 ## `ISOLATION_LEVELS`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/transaction.js#L53)
-The possible isolations levels to use when starting a transaction.
-Can be set per-transaction by passing `options.isolationLevel` to `sequelize.transaction`.
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/transaction.js#L71)
+Isolations levels can be set per-transaction by passing `options.isolationLevel` to `sequelize.transaction`.
 Default to `REPEATABLE_READ` but you can override the default isolation level by passing `options.isolationLevel` in `new Sequelize`.
+
+The possible isolations levels to use when starting a transaction:
 
 ```js
 {
@@ -34,12 +35,28 @@ Default to `REPEATABLE_READ` but you can override the default isolation level by
 }
 ```
 
+Pass in the desired level as the first argument:
+
+```js
+return sequelize.transaction({
+  isolationLevel: Sequelize.Transaction.SERIALIZABLE
+}, function (t) {
+
+ // your transactions
+
+}).then(function(result) {
+  // transaction has been committed. Do something after the commit if required.
+}).catch(function(err) {
+  // do something with the err.
+});
+```
+
 
 ***
 
 <a name="lock"></a>
 ## `LOCK`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/transaction.js#L97)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/transaction.js#L115)
 Possible options for row locking. Used in conjuction with `find` calls:
 
 ```js
@@ -79,7 +96,7 @@ UserModel will be locked but TaskModel won't!
 
 <a name="commit"></a>
 ## `commit()` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/transaction.js#L109)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/transaction.js#L127)
 Commit the transaction
 
 
@@ -87,7 +104,7 @@ Commit the transaction
 
 <a name="rollback"></a>
 ## `rollback()` -> `this`
-[View code](https://github.com/sequelize/sequelize/blob/cc8687539fe96f7f64887a04ddf5d48f159f5e92/lib/transaction.js#L130)
+[View code](https://github.com/sequelize/sequelize/blob/2c4a9f3cf9887fb33c31e397e758dd4aa3374d01/lib/transaction.js#L148)
 Rollback (abort) the transaction
 
 

--- a/docs/docs-generator.js
+++ b/docs/docs-generator.js
@@ -200,7 +200,7 @@ var parseComments = function (comments, file) {
           if (see.local) {
             link = see.local.match(/{(.*?(?:|#.*?))}/)[1];
 
-            comment.putLine('* [' + link + '](api/' + link.toLowerCase() + ')');
+            comment.putLine('* [' + link + '](' + link.toLowerCase() + ')');
           } else {
             comment.putLine('* [' + see.title | see.url + '](' + see.url + ')');
           }


### PR DESCRIPTION
None of the current links referenced in the **See:** sections of the [docs](http://docs.sequelizejs.com/en/latest/) are working. For example, clicking on [Sequelize#sync](http://docs.sequelizejs.com/en/latest/api/api/sequelize#sync) under the [Model documentation](http://docs.sequelizejs.com/en/latest/api/model/#sync) for `sync()`:  
![screen shot 2015-06-19 at 9 16 23 am](https://cloud.githubusercontent.com/assets/4349348/8254129/dfc3f31c-1663-11e5-9dc6-057010446c40.png)

brings you to to a page not found.

The issue is that the link automatically generated has repeated `/api` (see http://docs.sequelizejs.com/en/latest/api/api/sequelize#sync for an example where `/api` is repeated).

This PR removes the repeated `api/` from `docs-generator.js` and re-creates the associated documentation.