### PR TITLE
Update moment-timezone to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "inflection": "^1.6.0",
     "lodash": "^3.9.3",
     "moment": "^2.9.0",
-    "moment-timezone": "^0.3.1",
+    "moment-timezone": "^0.4.0",
     "node-uuid": "~1.4.1",
     "shimmer": "1.0.0",
     "toposort-class": "~0.3.0",


### PR DESCRIPTION
moment-timezone is the only package out-dated today : https://david-dm.org/sequelize/sequelize

Changelog : https://github.com/moment/moment-timezone/blob/0.4.0/changelog.md
(for main part new IANA TZDB data)

Thanks !