### PR TITLE
upsert overwrites data with default values on update

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1706,24 +1706,27 @@ Model.prototype.upsert = function (values, options) {
 
   return instance.hookValidate(options).bind(this).then(function () {
     // Map field names
-    values = Utils.mapValueFieldNames(instance.dataValues, options.fields, this);
+    var updatedDataValues = _.pick(instance.dataValues, Object.keys(instance._changed))
+      , insertValues = Utils.mapValueFieldNames(instance.dataValues, options.fields, this)
+      , updateValues = Utils.mapValueFieldNames(updatedDataValues, options.fields, this)
+      , now = Utils.now(this.sequelize.options.dialect);
 
-    var now = Utils.now(this.sequelize.options.dialect);
-
-    if (createdAtAttr && !values[createdAtAttr]) {
-      values[createdAtAttr] = this.$getDefaultTimestamp(createdAtAttr) || now;
+    // Attach createdAt
+    if (createdAtAttr && !updateValues[createdAtAttr]) {
+      insertValues[createdAtAttr] = this.$getDefaultTimestamp(createdAtAttr) || now;
     }
-    if (updatedAtAttr && !values[updatedAtAttr]) {
-      values[updatedAtAttr] = this.$getDefaultTimestamp(updatedAtAttr) || now;
+    if (updatedAtAttr && !insertValues[updatedAtAttr]) {
+      insertValues[updatedAtAttr] = updateValues[updatedAtAttr] = this.$getDefaultTimestamp(updatedAtAttr) || now;
     }
 
     // Build adds a null value for the primary key, if none was given by the user.
     // We need to remove that because of some Postgres technicalities.
     if (!hadPrimary && this.primaryKeyAttribute && !this.rawAttributes[this.primaryKeyAttribute].defaultValue) {
-      delete values[this.primaryKeyField];
+      delete insertValues[this.primaryKeyField];
+      delete updateValues[this.primaryKeyField];
     }
 
-    return this.QueryInterface.upsert(this.getTableName(options), values, this, options);
+    return this.QueryInterface.upsert(this.getTableName(options), insertValues, updateValues, this, options);
   });
 };
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -507,12 +507,11 @@ QueryInterface.prototype.insert = function(instance, tableName, values, options)
   });
 };
 
-QueryInterface.prototype.upsert = function(tableName, values, model, options) {
+QueryInterface.prototype.upsert = function(tableName, values, updateValues, model, options) {
   var wheres = []
     , where
     , indexFields
     , indexes = []
-    , updateValues
     , attributes = Object.keys(values);
 
   where = {};
@@ -559,16 +558,6 @@ QueryInterface.prototype.upsert = function(tableName, values, model, options) {
 
   options.type = QueryTypes.UPSERT;
   options.raw = true;
-
-
-  if (model._timestampAttributes.createdAt) {
-    // If we are updating an existing row, we shouldn't set createdAt
-    updateValues = Utils.cloneDeep(values);
-
-    delete updateValues[model._timestampAttributes.createdAt];
-  } else {
-    updateValues = values;
-  }
 
   var sql = this.QueryGenerator.upsertQuery(tableName, values, updateValues, where, model.rawAttributes, options);
   return this.sequelize.query(sql, options).then(function (rowCount) {

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -24,7 +24,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       },
       baz: {
         type: DataTypes.STRING,
-        field: 'zab'
+        field: 'zab',
+        defaultValue: 'BAZ_DEFAULT_VALUE'
       },
       blob: DataTypes.BLOB
     });
@@ -245,6 +246,25 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           expect(user.createdAt).to.be.ok;
           expect(user.username).to.equal('doe');
           expect(user.foo).to.equal('MIXEDCASE2');
+        });
+      });
+
+      it('does not update using default values', function() {
+        return this.User.create({ id: 42, username: 'john', baz: 'new baz value'}).bind(this).then(function() {
+          return this.User.findById(42);
+        }).then(function(user) {
+          // 'username' should be 'john' since it was set
+          expect(user.username).to.equal('john');
+          // 'baz' should be 'new baz value' since it was set
+          expect(user.baz).to.equal('new baz value');
+          return this.User.upsert({ id: 42, username: 'doe'});
+        }).then(function() {
+          return this.User.findById(42);
+        }).then(function(user) {
+          // 'username' was updated
+          expect(user.username).to.equal('doe');
+          // 'baz' should still be 'new baz value' since it was not updated
+          expect(user.baz).to.equal('new baz value');
         });
       });
 


### PR DESCRIPTION
Currently, a `defaultValue` set on the model will be used in every upsert operation. This is fine for when upsert INSERTs, since that is when default values are used/needed. However, upsert is also using defaultValue on INSERT, which is causing data to be overwritten and lost by the default values. 

~~I've included a test that is currently broken by this bug, I haven't had time to look into a fix yet.~~ EDIT: fix also added

/cc @mickhansen @janmeier (from the last upsert issue we worked on)