### PR TITLE
fixes problem with order in scope when counting

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1345,6 +1345,7 @@ Model.prototype.count = function(options) {
   options.dataType = new DataTypes.INTEGER();
   options.includeIgnoreAttributes = false;
   options.limit = null;
+  options.offset = null;
   options.order = null;
 
   return this.aggregate(col, 'count', options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1345,6 +1345,7 @@ Model.prototype.count = function(options) {
   options.dataType = new DataTypes.INTEGER();
   options.includeIgnoreAttributes = false;
   options.limit = null;
+  options.order = null;
 
   return this.aggregate(col, 'count', options);
 };

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1670,15 +1670,15 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       var options, aggregateSpy;
 
       beforeEach(function () {
-        options = { where: ['username = ?', 'user1']};
+        options = { where: { username: 'user1'}};
 
         aggregateSpy = sinon.spy(this.User, "aggregate");
       });
 
       afterEach(function () {
-        var optsArg = aggregateSpy.args[0][2];
-
-        expect(optsArg.where).to.deep.equal(['username = ?', 'user1']);
+        expect(aggregateSpy).to.have.been.calledWith(
+          sinon.match.any, sinon.match.any,
+          sinon.match.object.and(sinon.match.has('where', { username: 'user1'})));
 
         aggregateSpy.restore();
       });
@@ -1687,9 +1687,9 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         options.limit = 5;
 
         return this.User.count(options).then(function() {
-          var optsArg = aggregateSpy.args[0][2];
-
-          expect(optsArg.limit).to.equal(null);
+          expect(aggregateSpy).to.have.been.calledWith(
+            sinon.match.any, sinon.match.any,
+            sinon.match.object.and(sinon.match.has('limit', null)));
         });
       });
 
@@ -1697,9 +1697,9 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         options.offset = 10;
 
         return this.User.count(options).then(function() {
-          var optsArg = aggregateSpy.args[0][2];
-
-          expect(optsArg.offset).to.equal(null);
+          expect(aggregateSpy).to.have.been.calledWith(
+            sinon.match.any, sinon.match.any,
+            sinon.match.object.and(sinon.match.has('offset', null)));
         });
       });
 
@@ -1707,9 +1707,9 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         options.order = "username";
 
         return this.User.count(options).then(function() {
-          var optsArg = aggregateSpy.args[0][2];
-
-          expect(optsArg.order).to.equal(null);
+          expect(aggregateSpy).to.have.been.calledWith(
+            sinon.match.any, sinon.match.any,
+            sinon.match.object.and(sinon.match.has('order', null)));
         });
       });
     });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1693,6 +1693,16 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
 
+      it('modifies option "offset" by setting it to null', function() {
+        options.offset = 10;
+
+        return this.User.count(options).then(function() {
+          var optsArg = aggregateSpy.args[0][2];
+
+          expect(optsArg.offset).to.equal(null);
+        });
+      });
+
       it('modifies option "order" by setting it to null', function() {
         options.order = "username";
 

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1641,6 +1641,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
     });
+
     it('returns multiple rows when using group', function() {
       var self = this;
       return this.User.bulkCreate([
@@ -1662,6 +1663,44 @@ describe(Support.getTestDialectTeaser('Model'), function() {
 
       return this.User.count(options).then(function() {
         expect(options).to.deep.equal({ where: ['username = ?', 'user1']});
+      });
+    });
+
+    describe("options sent to aggregate", function () {
+      var options, aggregateSpy;
+
+      beforeEach(function () {
+        options = { where: ['username = ?', 'user1']};
+
+        aggregateSpy = sinon.spy(this.User, "aggregate");
+      });
+
+      afterEach(function () {
+        var optsArg = aggregateSpy.args[0][2];
+
+        expect(optsArg.where).to.deep.equal(['username = ?', 'user1']);
+
+        aggregateSpy.restore();
+      });
+
+      it('modifies option "limit" by setting it to null', function() {
+        options.limit = 5;
+
+        return this.User.count(options).then(function() {
+          var optsArg = aggregateSpy.args[0][2];
+
+          expect(optsArg.limit).to.equal(null);
+        });
+      });
+
+      it('modifies option "order" by setting it to null', function() {
+        options.order = "username";
+
+        return this.User.count(options).then(function() {
+          var optsArg = aggregateSpy.args[0][2];
+
+          expect(optsArg.order).to.equal(null);
+        });
       });
     });
 

--- a/test/integration/model/scope/count.test.js
+++ b/test/integration/model/scope/count.test.js
@@ -31,6 +31,9 @@ describe(Support.getTestDialectTeaser('Model'), function() {
                   lte: 5
                 }
               }
+            },
+            withOrder: {
+              order: 'username'
             }
           }
         });
@@ -64,6 +67,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
 
       it('should be able to merge scopes with where', function () {
         return expect(this.ScopeMe.scope('lowAccess').count({ where: { username: 'dan'}})).to.eventually.equal(1);
+      });
+
+      it('should ignore the order option if it is found within the scope', function () {
+        return expect(this.ScopeMe.scope('withOrder').count()).to.eventually.equal(4);
       });
     });
   });


### PR DESCRIPTION
having order option in model’s scope when performing a count kicked out
this error:

SequelizeDatabaseError: column “xxxx” must appear in the GROUP BY
clause or be used in an aggregate function