### PR TITLE
Add failing test case for findAndCountAll with a include and where

### DIFF
--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -180,5 +180,43 @@ describe(Support.getTestDialectTeaser('Include'), function() {
         expect(result.rows.length).to.equal(2);
       });
     });
+
+    it.only('should return the correct count and rows when using a required belongsTo with a where condition and a limit', function() {
+      var s = this.sequelize
+        , Foo = s.define('Foo', {})
+        , Bar = s.define('Bar', {m: DataTypes.STRING(40)});
+
+      Foo.hasMany(Bar);
+      Bar.belongsTo(Foo);
+
+      return s.sync({ force: true }).then(function() {
+        // Make five instances of Foo
+        return Foo.bulkCreate([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}]);
+      }).then(function() {
+        // Make four instances of Bar, related to the last four instances of Foo
+        return Bar.bulkCreate([{'FooId': 1, m:'yes'}, {'FooId': 1, m:'yes'}, {'FooId': 1, m: 'no'}, {'FooId': 2, m: 'yes'}]);
+      }).then(function() {
+        // Query for the first instance of Foo which have related Bars with m === 'yes'
+        return Foo.findAndCountAll({
+          include: [{ model: Bar, required: true, where: { m: 'yes' } }],
+          limit: 1
+        }).tap(function() {
+          // Check for what should be returned as the `count` of the result
+          return Foo.findAll({
+            include: [{ model: Bar, required: true, where: { m: 'yes' } }]
+          }).then(function(items) {
+            expect(items.length).to.equal(2);
+          });
+        });
+      }).then(function(result) {
+        // There should be 2 instances matching the query (Instances 1 and 2),
+        // see the findAll statement
+        expect(result.count).to.equal(2);
+
+        // The first one of those should be returned due to the limit (Foo
+        // instance 1)
+        expect(result.rows.length).to.equal(1);
+      });
+    });
   });
 });


### PR DESCRIPTION
This is a test case for `findAndCountAll` returning an incorrect value for `result.count`, as the where statement in the include makes the `count()` sql function counts all rows instead (3 in this case) of only matching `Foo`s (2 in this case).

See issue #4015