### PR TITLE
Fixed a bug that wrong sql generated when destroying in pg.

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -395,7 +395,9 @@ var QueryGenerator = {
     primaryKeys[tableName] = primaryKeys[tableName] || [];
 
     if (!!model && primaryKeys[tableName].length < 1) {
-      primaryKeys[tableName] = Object.keys(model.primaryKeys);
+      primaryKeys[tableName] = Utils._.map(Object.keys(model.primaryKeys), function(k){
+        return model.primaryKeys[k].field;
+      });
     }
 
     if (options.limit) {

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -1,0 +1,49 @@
+'use strict';
+
+/* jshint -W110 */
+var Support   = require(__dirname + '/../support')
+  , util = require('util')
+  , expectsql = Support.expectsql
+  , current   = Support.sequelize
+  , Sequelize = Support.Sequelize
+  , sql       = current.dialect.QueryGenerator;
+
+// Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
+
+suite(Support.getTestDialectTeaser('SQL'), function() {
+  suite('delete', function () {
+
+    suite('delete when the primary key has a different field name', function () {
+
+      var User = current.define('test_user', {
+        id: {
+          type:       Sequelize.INTEGER,
+          primaryKey: true,
+          field:      "test_user_id",
+        }
+      }, { freezeTableName: true, timestamps:false });
+
+      var options = {
+        table: 'test_user',
+        where: { 'test_user_id': 100 }
+      };
+
+      test(util.inspect(options, {depth: 2}), function () {
+        return expectsql(
+          sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            User
+          ), {
+            postgres: 'DELETE FROM "test_user" WHERE "test_user_id" IN (SELECT "test_user_id" FROM "test_user" WHERE "test_user_id" = 100 LIMIT 1)',
+            sqlite:   'DELETE FROM `test_user` WHERE `test_user_id` = 100',
+            mssql:    'DELETE TOP(1) FROM [test_user] WHERE [test_user_id] = 100; SELECT @@ROWCOUNT AS AFFECTEDROWS;',
+            default:  'DELETE FROM [test_user] WHERE [test_user_id] = 100 LIMIT 1'
+          }
+        );
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
Hi.

When I tried like following code, sequelize generated wrong SQL.

    var Sequelize = require('sequelize');

    var sequelize = new Sequelize('db', 'user', 'pass', { host: 'localhost', dialect: 'postgres' });

    var User = sequelize.define('test_user', {
      id: {
        type:       Sequelize.INTEGER,
        primaryKey: true,
        field:      "test_user_id",
      }
    }, { freezeTableName: true, timestamps:false });

    User.create({id: 1}).then(function(u) {
      console.log(u.id);
      u.destroy().then(function(){
        console.log('delete success !!');
      }); // error
    });

    /* Log ---
    Executing (default): INSERT INTO "test_user" ("test_user_id") VALUES (1) RETURNING *;
    1
    Executing (default): DELETE FROM "test_user" WHERE "id" IN (SELECT "id" FROM "test_user" WHERE "test_user_id" = 1 LIMIT 1) // *** WRONG SQL HERE
    Unhandled rejection SequelizeDatabaseError: column "id" does not exist
    */

WIth these changes, sequelize generated collect SQL.

    /* Log ---
    Executing (default): INSERT INTO "test_user" ("test_user_id") VALUES (1) RETURNING *;
    1
    Executing (default): DELETE FROM "test_user" WHERE "test_user_id" IN (SELECT "test_user_id" FROM "test_user" WHERE "test_user_id" = 1 LIMIT 1)
    delete success !!
    */