### PR TITLE
Do not automatically add primary key to attributes (or include[].attributes) if raw is set

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -437,7 +437,7 @@ var validateIncludedElements = function(options, tableNames) {
   // validate all included elements
   var includes = options.include;
   for (var index = 0; index < includes.length; index++) {
-    var include = includes[index] = validateIncludedElement.call(this, includes[index], tableNames, options.raw);
+    var include = includes[index] = validateIncludedElement.call(this, includes[index], tableNames, options);
 
     include.parent = options;
     // associations that are required or have a required child and is not a ?:M association are candidates for the subquery
@@ -461,7 +461,7 @@ var validateIncludedElements = function(options, tableNames) {
 };
 Model.$validateIncludedElements = validateIncludedElements;
 
-validateIncludedElement = function(include, tableNames, raw) {
+validateIncludedElement = function(include, tableNames, options) {
   if (!include.hasOwnProperty('model') && !include.hasOwnProperty('association')) {
     throw new Error('Include malformed. Expected attributes: model or association');
   }
@@ -476,7 +476,7 @@ validateIncludedElement = function(include, tableNames, raw) {
 
   tableNames[include.model.getTableName()] = true;
 
-  if (include.attributes && !raw) {
+  if (include.attributes && !options.raw) {
     include.originalAttributes = include.attributes.slice(0);
 
     if (include.attributes.length) {
@@ -536,7 +536,7 @@ validateIncludedElement = function(include, tableNames, raw) {
 
     // Validate child includes
     if (include.hasOwnProperty('include')) {
-      validateIncludedElements.call(include.model, include, tableNames, raw);
+      validateIncludedElements.call(include.model, include, tableNames, options);
     }
 
     return include;

--- a/lib/model.js
+++ b/lib/model.js
@@ -437,7 +437,7 @@ var validateIncludedElements = function(options, tableNames) {
   // validate all included elements
   var includes = options.include;
   for (var index = 0; index < includes.length; index++) {
-    var include = includes[index] = validateIncludedElement.call(this, includes[index], tableNames);
+    var include = includes[index] = validateIncludedElement.call(this, includes[index], tableNames, options.raw);
 
     include.parent = options;
     // associations that are required or have a required child and is not a ?:M association are candidates for the subquery
@@ -461,7 +461,7 @@ var validateIncludedElements = function(options, tableNames) {
 };
 Model.$validateIncludedElements = validateIncludedElements;
 
-validateIncludedElement = function(include, tableNames) {
+validateIncludedElement = function(include, tableNames, raw) {
   if (!include.hasOwnProperty('model') && !include.hasOwnProperty('association')) {
     throw new Error('Include malformed. Expected attributes: model or association');
   }
@@ -476,17 +476,17 @@ validateIncludedElement = function(include, tableNames) {
 
   tableNames[include.model.getTableName()] = true;
 
-  if (include.attributes) {
+  if (include.attributes && !raw) {
     include.originalAttributes = include.attributes.slice(0);
 
     if (include.attributes.length) {
-      include.model.primaryKeyAttributes.forEach(function(attr) {
+      include.model.primaryKeyAttributes.forEach(function (attr) {
         if (include.attributes.indexOf(attr) === -1) {
           include.attributes.unshift(attr);
         }
       });
     }
-  } else {
+  } else if (!include.attributes) {
     include.attributes = Object.keys(include.model.tableAttributes);
   }
 
@@ -536,7 +536,7 @@ validateIncludedElement = function(include, tableNames) {
 
     // Validate child includes
     if (include.hasOwnProperty('include')) {
-      validateIncludedElements.call(include.model, include, tableNames);
+      validateIncludedElements.call(include.model, include, tableNames, raw);
     }
 
     return include;
@@ -1178,7 +1178,8 @@ Model.prototype.findAll = function(options) {
 
         validateIncludedElements.call(this, options, tableNames);
 
-        if (options.attributes) {
+        // If we're not raw, we have to make sure we include the primary key for deduplication
+        if (options.attributes && !options.raw) {
           if (options.attributes.indexOf(this.primaryKeyAttribute) === -1) {
             options.originalAttributes = options.attributes;
             options.attributes = [this.primaryKeyAttribute].concat(options.attributes);

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -1957,8 +1957,6 @@ describe(Support.getTestDialectTeaser('Include'), function() {
         expect(posts.length).to.equal(1);
 
         var post = posts[0];
-
-        console.log("** " + JSON.stringify(post));
         expect(post.id).not.to.be.ok;
         expect(parseInt(post["comments.commentCount"], 10)).to.equal(3);
       });

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -1920,5 +1920,48 @@ describe(Support.getTestDialectTeaser('Include'), function() {
         expect(parseInt(post.get('commentCount'), 10)).to.equal(3);
       });
     });
+
+    it('should not add primary key when including and aggregating with raw: true', function () {
+      var Post = this.sequelize.define('Post', {
+          title: DataTypes.STRING
+        })
+        , Comment = this.sequelize.define('Comment', {
+          content: DataTypes.TEXT
+        });
+
+      Post.Comments = Post.hasMany(Comment, {as: 'comments'});
+
+      return this.sequelize.sync({force: true}).bind(this).then(function () {
+        return Post.create({
+          title: Math.random().toString(),
+          comments: [
+            {content: Math.random().toString()},
+            {content: Math.random().toString()},
+            {content: Math.random().toString()},
+          ]
+        }, {
+          include: [Post.Comments]
+        });
+      }).then(function () {
+        return Post.findAll({
+          attributes: [],
+          include: [
+            {
+              association: Post.Comments,
+              attributes: [[this.sequelize.fn('COUNT', this.sequelize.col('comments.id')), 'commentCount']]
+            }
+          ],
+          raw: true
+        });
+      }).then(function (posts) {
+        expect(posts.length).to.equal(1);
+
+        var post = posts[0];
+
+        console.log("** " + JSON.stringify(post));
+        expect(post.id).not.to.be.ok;
+        expect(parseInt(post["comments.commentCount"], 10)).to.equal(3);
+      });
+    });
   });
 });


### PR DESCRIPTION
This bring in the changes discussed in #3920, disabling the automatic addition of the primary key field to the attributes returned by a query, and thereby allowing aggregation in more cases, when raw is set to true.

This includes the changes and tests. Is there any documentation anywhere that needs to be updated in line with this?