### PR TITLE
Don't override lodash includes() function.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,11 +15,6 @@ var Utils = module.exports = {
     var _ = lodash;
 
     _.mixin({
-      includes: function(str, needle){
-        if (needle === '') return true;
-        if (str === null) return false;
-        return String(str).indexOf(needle) !== -1;
-      },
       camelizeIf: function(string, condition) {
         var result = string;
 


### PR DESCRIPTION
lib/utils.js currently breaks lodash's includes() function in a project by mixing in its own includes() function. See example below (full example at https://github.com/appropos/sequelize-lodash-includes-bug)

    var _ = require('lodash');

    // Passes
    assert(!_.includes(['foo-9', 'foo-10'], 'foo-1'));

    require('sequelize');

    // Fails
    assert(!_.includes(['foo-9', 'foo-10'], 'foo-1'));

This PR simply removes the custom includes() function in favor of lodash's function. lodash's function works the same except for when `needle === ''` and `str` is falsy. So for the following examples, lodash will return `false` while the (current) custom function will return `true`:

    Utils._.includes(undefined, '')
    Utils._.includes(null, '')
    Utils._.includes('', '')

At present, includes() appears to only be called with non-empty strings when used internally, so this change shouldn't break any code in the project.