### PR TITLE
Fix broken links to api/ pages in the documentation.

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -240,7 +240,7 @@ The success listener is called with an array of instances if the query succeeds.
 | [options.limit] | Number |  |
 | [options.offset] | Number |  |
 | [options.transaction] | Transaction | Transaction to run query under |
-| [options.lock] | String &#124; Object | Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](api/transaction#lock) |
+| [options.lock] | String &#124; Object | Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](transaction#lock) |
 | [options.raw] | Boolean | Return raw result. See sequelize.query for more information. |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql. |
 | [options.having] | Object |  |

--- a/docs/docs/models-definition.md
+++ b/docs/docs/models-definition.md
@@ -72,7 +72,7 @@ The comment option can also be used on a table, see [model configuration][0]
 
 ## Data types
 
-Below are some of the datatypes supported by sequelize. For a full and updated list, see [DataTypes](api/datatypes).
+Below are some of the datatypes supported by sequelize. For a full and updated list, see [DataTypes](../api/datatypes).
 
 ```js
 Sequelize.STRING                      // VARCHAR(255)
@@ -212,7 +212,7 @@ Employee
 
 ### Defining as part of the model options
 
-Below is an example of defining the getters and setters in the model options. The `fullName` getter,  is an example of how you can define pseudo properties on your models - attributes which are not actually part of your database schema. In fact, pseudo properties can be defined in two ways: using model getters, or by using a column with the [`VIRTUAL` datatype](api/datatypes#virtual). Virtual datatypes can have validations, while getters for virtual attributes cannot.
+Below is an example of defining the getters and setters in the model options. The `fullName` getter,  is an example of how you can define pseudo properties on your models - attributes which are not actually part of your database schema. In fact, pseudo properties can be defined in two ways: using model getters, or by using a column with the [`VIRTUAL` datatype](../api/datatypes#virtual). Virtual datatypes can have validations, while getters for virtual attributes cannot.
 
 Note that the `this.firstname` and `this.lastname` references in the `fullName` getter function will trigger a call to the respective getter functions. If you do not want that then use the `getDataValue()` method to access the raw value (see below).
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1142,7 +1142,7 @@ Model.prototype.all = function(options) {
  * @param  {Number}                    [options.limit]
  * @param  {Number}                    [options.offset]
  * @param  {Transaction}               [options.transaction] Transaction to run query under
- * @param  {String|Object}             [options.lock] Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](api/transaction#lock)
+ * @param  {String|Object}             [options.lock] Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](transaction#lock)
  * @param  {Boolean}                   [options.raw] Return raw result. See sequelize.query for more information.
  * @param  {Function}                  [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param  {Object}                    [options.having]


### PR DESCRIPTION
Here's a few fixes to broken links that point to the documents in the api/ directory.

To ease review I didn't run the api doc update script as it would've made the diff quite verbose. Instead I made the changes directly to both the jsdoc comment in lib/model.js and the generated file.