### PR TITLE
Hotfix: Wrap referenced options arguments in _.clone

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1236,7 +1236,7 @@ Model.prototype.findById = function(param, options) {
     return Promise.resolve(null);
   }
 
-  options = options || {};
+  options = optClone(options) || {};
 
   if (typeof param === 'number' || typeof param === 'string' || Buffer.isBuffer(param)) {
     options.where = {};
@@ -1724,7 +1724,7 @@ Model.prototype.findOrCreate = function(options) {
  * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated.
  */
 Model.prototype.upsert = function (values, options) {
-  options = options || {};
+  options = optClone(options) || {};
 
   if (!options.fields) {
     options.fields = Object.keys(this.attributes);
@@ -1932,7 +1932,7 @@ Model.prototype.bulkCreate = function(records, options) {
  * @see {Model#destroy} for more information
  */
 Model.prototype.truncate = function(options) {
-  options = options || {};
+  options = optClone(options) || {};
   options.truncate = true;
   return this.destroy(options);
 };


### PR DESCRIPTION
In upgrading from `2.1.3` to `3.x`, I noticed a bug.

I structure my service code written in Hapi in such a way that I declare my query options outside of specific request handlers. It looks something like this:
```js
// object literal is a singleton
const opts = { /* my opts */}

export function handlerFoo(request, reply) {
  MyModel.findById(opts)
    .then((data) => reply(data));
}

export function handlerBar(request, reply) {
  MyModel.findAll(opts)
    .then((data) => reply(data));
}
```
The way the code is currently written, the internals of `Model#findById` and similar calls actually modify in place the options passed to them. This is generally fine if the options were declared in the execution context of the request handler, but any *long-lived* objects are modified permanently, creating pretty serious bugs. For instance:

* User calls Collection#findById – internally this applies `options.limit = 1;`
* User calls Collection#findAll – The options from the previous call to findById are still set, and findAll returns only 1 result.

This PR wraps the most obvious instances of this with the already available `Utils._.clone`.