### PR TITLE
Standardize `findAndCount` arguments

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1394,14 +1394,14 @@ Model.prototype.count = function(options) {
  * @return {Promise<Object>}
  * @alias findAndCountAll
  */
-Model.prototype.findAndCount = function(findOptions) { // testhint options:1
-  if (findOptions !== undefined && !_.isPlainObject(findOptions)) {
+Model.prototype.findAndCount = function(options) {
+  if (options !== undefined && !_.isPlainObject(options)) {
     throw new Error('The argument passed to findAndCount must be an options object, use findById if you wish to pass a single primary key value');
   }
 
   var self = this
     // no limit, offset, order, attributes for the options given to count()
-    , countOptions = _.omit(_.clone(findOptions), ['offset', 'limit', 'order', 'attributes']);
+    , countOptions = _.omit(_.clone(options), ['offset', 'limit', 'order', 'attributes']);
 
   conformOptions(countOptions, this);
 
@@ -1438,7 +1438,7 @@ Model.prototype.findAndCount = function(findOptions) { // testhint options:1
         rows: []
       };
     }
-    return self.findAll(findOptions).then(function(results) {
+    return self.findAll(options).then(function(results) {
       return {
         count: count || 0,
         rows: (results && Array.isArray(results) ? results : [])


### PR DESCRIPTION
Changes the name of the argument taken by `Model#findAndCount()` to `options`. Was previously `findOptions`.

This makes no functional difference - just brings it into line with the rest of the codebase.