### PR TITLE
Include the error message in the exception to ease debug

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -363,6 +363,7 @@ Query.prototype.formatError = function (err) {
       table = table ? table[1] : undefined;
 
       return new sequelizeErrors.ForeignKeyConstraintError({
+        message: errMessage,
         fields: null,
         index: index,
         table: table,


### PR DESCRIPTION
This simply adds the error message to the exception, so the root problem can more easily be diagnosed.