### PR TITLE
[WIP] Allow built instance as bulkCreate argument

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,11 +31,6 @@ before_script:
 script:
   - "make test"
 
-branches:
-  only:
-    - master
-    - 1.7.0
-
 matrix:
   fast_finish: true
   include:

--- a/lib/model.js
+++ b/lib/model.js
@@ -1829,7 +1829,11 @@ Model.prototype.bulkCreate = function(records, options) {
     , now = Utils.now(self.modelManager.sequelize.options.dialect);
 
   var instances = records.map(function(values) {
-    return self.build(values, {isNewRecord: true});
+    if (values instanceof Instance) {
+      return values;
+    } else {
+      return self.build(values, {isNewRecord: true});
+    }
   });
 
   return Promise.try(function() {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1374,6 +1374,39 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    it('should save instances', function() {
+      var User = this.sequelize.define('User', {
+        username: {
+          type: Sequelize.STRING,
+          allowNull: false,
+          validate: {
+            notEmpty: true
+          }
+        }
+      });
+
+      var instances = User.build([
+        { username: 'alice' },
+        { username: 'bob' },
+        { username: 'carol' }
+      ]);
+
+      return User.bulkCreate(instances, {
+        validate: true,
+        individualHooks: true
+      }).then(function(users) {
+        expect(users[0].get('username')).to.equal('alice');
+        expect(users[1].get('username')).to.equal('bob');
+        expect(users[2].get('username')).to.equal('carol');
+
+        return User.findAll({order: 'username ASC'});
+      }).then(function(users) {
+        expect(users[0].get('username')).to.equal('alice');
+        expect(users[1].get('username')).to.equal('bob');
+        expect(users[2].get('username')).to.equal('carol');
+      });
+    });
+
     it('properly handles disparate field lists', function() {
       var self = this
         , data = [{username: 'Peter', secretValue: '42', uniqueName: '1' },

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1446,8 +1446,11 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           return member.setOrganization(org, { save: false });
         }));
       }).then(function() {
+        console.log(org, "----------------------", members);
         return org.save();
       }).then(function() {
+        console.log("----------------------", org, "----------------------", members);
+
         return Member.bulkCreate(members, {
           validate: true,
           individualHooks: true


### PR DESCRIPTION
This PR allows users to give built instances as `bulkCreate` argument. It works as if it is "`bulkSave`"

Example:

```javascript
var users = [];
users.push(sequelize.models.User.build({
  username: "Alice",
  password: "foobar"
}));

users.push(sequelize.models.User.build({
  username: "Bob",
  password: "tetete"
}));

sequelize.models.User.bulkCreate(users);

```

This PR is not completed yet. (requires docs)