### PR TITLE
Prefix table names on geometry fields where multiple tables are selected

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -992,7 +992,7 @@ var QueryGenerator = {
       }
 
       if (mainModel && mainModel._isGeometryAttribute(attr)) {
-        return self.geometrySelect(attr);
+        attr = self.geometrySelect(attr);
       }
 
       if (Array.isArray(attr) && attr.length === 2) {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -168,17 +168,16 @@ Transaction.prototype.prepareEnvironment = function() {
   ).then(function (connection) {
     self.connection = connection;
     self.connection.uuid = self.id;
-
-    if (self.sequelize.constructor.cls) {
-      self.sequelize.constructor.cls.set('transaction', self);
-    }
   }).then(function () {
     return self.begin();
   }).then(function () {
     return self.setDeferrable();
   }).then(function () {
     return self.setIsolationLevel();
-  }).then(function () {
+  }).then(function () {    
+    if (self.sequelize.constructor.cls) {
+      self.sequelize.constructor.cls.set('transaction', self);
+    }
     return self.setAutocommit();
   });
 };


### PR DESCRIPTION
Say I have two associated tables, `A` and `B`, which both have a `location` field of the Geometry type.

If I were to select `A`, including `B`, then an attribute ambiguity error is thrown because neither of the references to `location` in the query are prefixed with the table name.

Here, I am ensuring that the table name is prefixed.