### PR TITLE
update should pass options to set

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -770,12 +770,15 @@ Instance.prototype.hookValidate = function(options) {
 Instance.prototype.update = function(values, options) {
   var changedBefore = this.changed() || []
     , sideEffects
-    , fields;
+    , fields
+    , setOptions;
 
   options = options || {};
   if (Array.isArray(options)) options = {fields: options};
 
-  this.set(values, {attributes: options.fields});
+  setOptions = this.$Model.$optClone(options);
+  setOptions.attributes = options.fields;
+  this.set(values, setOptions);
 
   // Now we need to figure out which fields were actually affected by the setter.
   sideEffects = _.without.apply(this, [this.changed() || []].concat(changedBefore));

--- a/lib/model.js
+++ b/lib/model.js
@@ -285,7 +285,7 @@ var conformOptions = function(options, self) {
   });
 };
 
-var optClone = Model.prototype.__optClone = function(options) {
+var optClone = Model.prototype.__optClone = Model.prototype.$optClone = function(options) {
   options = options || {};
   return Utils.cloneDeep(options, function(elem) {
     // The InstanceFactories used for include are pass by ref, so don't clone them.


### PR DESCRIPTION
Currently the options are not passed along, which breaks ssaclAttributeRoles and might break other plugins.
Generally all options should just be propagated (unless they need to removed cause they will break the method).