### PR TITLE
Do not add a transaction in findOrCreate if there is none. Fixes #4133

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# NEXT
+- [FIXED] Fix findOrCreate regression trying to add a transaction even if there is none
+
+# 3.4.1
+- [FIXED] Fix belongs-to-many ambigious id when through model has id
+
 # 3.4.0
 - [ADDED] `countAssociations` for hasMany and belongsToMany
 - [ADDED] Geometry support for postgres

--- a/lib/model.js
+++ b/lib/model.js
@@ -1651,7 +1651,10 @@ Model.prototype.findOrCreate = function(options) {
   }
 
   if (options.transaction === undefined && this.sequelize.constructor.cls) {
-    options.transaction = this.sequelize.constructor.cls.get('transaction');
+    var t = this.sequelize.constructor.cls.get('transaction');
+    if (t) {
+      options.transaction = t;
+    }
   }
 
   var self = this

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -118,6 +118,11 @@ if (current.dialect.supports.transactions) {
         return this.User.findOrCreate({
           where: {
             name: 'Kafka'
+          },
+          logging: function (sql) {
+            if (/default/.test(sql)) {
+              throw new Error('The transaction was not properly assigned');
+            }
           }
         }).then(function () {
           return self.User.findAll();


### PR DESCRIPTION
This fixes the issue. Sometimes the transaction from cls might be null and therefor should not be added.

I'll try to find a nice test too.