### PR TITLE
Throw the original error from authenticate

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -932,7 +932,7 @@ Sequelize.prototype.drop = function(options) {
  */
 Sequelize.prototype.authenticate = function(options) {
   return this.query('SELECT 1+1 AS result', Utils._.assign({ raw: true, plain: true }, options)).return().catch(function(err) {
-    throw new Error(err);
+    throw err;
   });
 };
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -931,9 +931,7 @@ Sequelize.prototype.drop = function(options) {
  * @return {Promise}
  */
 Sequelize.prototype.authenticate = function(options) {
-  return this.query('SELECT 1+1 AS result', Utils._.assign({ raw: true, plain: true }, options)).return().catch(function(err) {
-    throw err;
-  });
+  return this.query('SELECT 1+1 AS result', Utils._.assign({ raw: true, plain: true }, options)).return();
 };
 
 Sequelize.prototype.databaseVersion = function(options) {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -106,6 +106,18 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
             });
         });
 
+        it('triggers an actual RangeError or ConnectionError', function() {
+          return this
+            .sequelizeWithInvalidConnection
+            .authenticate()
+            .catch(function(err) {
+              expect(
+                err instanceof RangeError ||
+                err instanceof Sequelize.ConnectionError
+              ).to.be.ok;
+            });
+        });
+
         it('triggers the actual adapter error', function() {
           return this
             .sequelizeWithInvalidConnection
@@ -114,10 +126,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
               expect(
                 err.message.match(/connect ECONNREFUSED/) ||
                 err.message.match(/invalid port number/) ||
-                err.message.match(/RangeError: Port should be > 0 and < 65536/) ||
-                err.message.match(/RangeError: port should be > 0 and < 65536/) ||
-                err.message.match(/RangeError: port should be >= 0 and < 65536: 99999/) ||
-                err.message.match(/ConnectionError: Login failed for user/)
+                err.message.match(/Port should be > 0 and < 65536/) ||
+                err.message.match(/port should be > 0 and < 65536/) ||
+                err.message.match(/port should be >= 0 and < 65536: 99999/) ||
+                err.message.match(/Login failed for user/)
               ).to.be.ok;
             });
         });
@@ -134,6 +146,15 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
             .authenticate()
             .catch(function(err) {
               expect(err).to.not.be.null;
+            });
+        });
+
+        it('triggers an actual sequlize error', function() {
+          return this
+            .sequelizeWithInvalidCredentials
+            .authenticate()
+            .catch(function(err) {
+              expect(err).to.be.instanceof(Sequelize.Error);
             });
         });
 


### PR DESCRIPTION
When the authenticate method catches errors, it wraps those errors in a new Error() call, rather than just throwing the original error. This gobbles up the original name and message into the new error's message parameter, making it more difficult to make use of the error result than necessary.

What's currently happening:
```javascript
var seqError = new sequelize.Error('YOLO');
try {
  throw new Error(seqError);
} catch (e) {
  if (e instanceof sequelize.Error) {
    console.log('Hooray, I can tell this is a Sequelize error!');
  } else {
    console.log('Bummer. I cannot easily distinguish this from a generic error.');
  }
}
```

```
Bummer. I cannot easily distinguish this from a generic error.
```

What would be preferred:

```javascript
var seqError = new sequelize.Error('YOLO');
try {
  throw seqError;
} catch (e) {
  console.log(util.inspect(e));
  if (e instanceof sequelize.Error) {
    console.log('Hooray, I can tell this is a Sequelize error!');
  } else {
    console.log('Bummer. I cannot easily distinguish this from a generic error.');
  }
}
```

```
Hooray, I can tell this is a Sequelize error!
```