### PR TITLE
Slightly enhance styling of API Docs tables

### DIFF
--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -25,6 +25,10 @@ tr:nth-child(2n) {
   background-color: #f8f8f8;
 }
 
+.rst-content table.docutils td {
+  vertical-align: top;
+}
+
 .docutils tr > td:first-child {
   white-space: nowrap;
 }

--- a/docs/css/custom.css
+++ b/docs/css/custom.css
@@ -25,6 +25,10 @@ tr:nth-child(2n) {
   background-color: #f8f8f8;
 }
 
+.docutils tr > td:first-child {
+  white-space: nowrap;
+}
+
 #teaser-home {
   height: 250px;
   position: relative;


### PR DESCRIPTION
Before:
![screen shot 2015-07-30 at 13 20 31](https://cloud.githubusercontent.com/assets/2244375/8982072/dd4d2a66-36bd-11e5-9278-9980d4c588fe.png)

After:
![screen shot 2015-07-30 at 13 21 08](https://cloud.githubusercontent.com/assets/2244375/8982067/d72bffcc-36bd-11e5-9fa2-57c4f6ff842f.png)

This breaks the tables on very small screens, but they were already unusable before. To make the page fully responsive, could be tackled with more time.