### PR TITLE
Update JSDoc of Model.prototype.findOrInitialize()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1753,7 +1753,7 @@ Model.prototype.create = function(values, options) {
  * @param {Object}   [options.transaction] Transaction to run query under
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  *
- * @return {Promise<Instance>}
+ * @return {Promise<Instance,initialized>}
  * @alias findOrBuild
  */
 Model.prototype.findOrInitialize = Model.prototype.findOrBuild = function(options) {


### PR DESCRIPTION
The `@return` tag says that this method returns `Promise<Instance>`, while the
real return contains also an `initialized` boolean value.

Even though this behavior is already described in the JSDoc, it's more evident if
it's in the `@return` tag. I relied on it and my tests were breaking because I didn't
read the full docs for that method!