### PR TITLE
String validation fix

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -83,7 +83,7 @@ STRING.prototype.toSql = function() {
   return 'VARCHAR(' + this._length + ')' + ((this._binary) ? ' BINARY' : '');
 };
 STRING.prototype.validate = function(value) {
-  if (typeof value !== 'string') {
+  if (Object.prototype.toString.call(myvar) != '[object String]') {
     if (this.options.binary) {
       if (Buffer.isBuffer(value)) {
         return true;

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -83,7 +83,7 @@ STRING.prototype.toSql = function() {
   return 'VARCHAR(' + this._length + ')' + ((this._binary) ? ' BINARY' : '');
 };
 STRING.prototype.validate = function(value) {
-  if (Object.prototype.toString.call(myvar) != '[object String]') {
+  if (Object.prototype.toString.call(value) !== '[object String]') {
     if (this.options.binary) {
       if (Buffer.isBuffer(value)) {
         return true;

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -63,7 +63,9 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           var type = DataTypes.STRING();
 
           expect(type.validate('foobar')).to.equal(true);
+          /*jshint -W053 */
           expect(type.validate(new String('foobar'))).to.equal(true);
+          /*jshint +W053 */
         });
       });
     });

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -63,6 +63,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           var type = DataTypes.STRING();
 
           expect(type.validate('foobar')).to.equal(true);
+          expect(type.validate(new String('foobar'))).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
Validating if a value is a string using typeof fails if the string has been created using `new String` this fixes this.

```javascript
var test1 = 'my test';
var test2 = new String(10);

console.log(typeof test1); # string
console.log(typeof test2); # object

console.log(Object.prototype.toString.call(test1)); # [object String]
console.log(Object.prototype.toString.call(test2)); # [object String]
```

I also have added a new assertion to cover that case.