### PR TITLE
Clone instance options 

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -172,11 +172,12 @@ Instance.prototype.setDataValue = function(key, value) {
  * If key is given and a field or virtual getter is present for the key it will call that getter - else it will return the value for key.
  *
  * @param {String} [key]
- * @param {Object} [options]
+ * @param {Object} [options] This object will be cloned
  * @param {Boolean} [options.plain=false] If set to true, included instances will be returned as plain objects
  * @return {Object|any}
  */
 Instance.prototype.get = function(key, options) { // testhint options:none
+  var options = _.cloneDeep(options);
   if (options === undefined && typeof key === 'object') {
     options = key;
     key = undefined;
@@ -241,7 +242,7 @@ Instance.prototype.get = function(key, options) { // testhint options:none
  * @see {Model#find} for more information about includes
  * @param {String|Object} key
  * @param {any} value
- * @param {Object} [options]
+ * @param {Object} [options] This object will be cloned
  * @param {Boolean} [options.raw=false] If set to true, field and virtual setters will be ignored
  * @param {Boolean} [options.reset=false] Clear all previously set data values
  * @alias setAttributes
@@ -251,7 +252,8 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
     , originalValue
     , keys
     , i
-    , length;
+    , length
+    , options = _.cloneDeep(options);
 
   if (typeof key === 'object' && key !== null) {
     values = key;
@@ -469,7 +471,7 @@ Instance.prototype._setInclude = function(key, value, options) {
  * On success, the callback will be called with this instance. On validation error, the callback will be called with an instance of `Sequelize.ValidationError`.
  * This error will have a property for each of the fields for which validation failed, with the error message for that field.
  *
- * @param {Object} [options]
+ * @param {Object} [options] This object will be cloned
  * @param {Object} [options.fields] An optional array of strings, representing database columns. If fields is provided, only those columns will be validated and saved.
  * @param {Boolean} [options.silent=false] If true, the updatedAt timestamp will not be updated.
  * @param {Boolean} [options.validate=true] If false, validations won't be run.
@@ -482,6 +484,8 @@ Instance.prototype.save = function(options) {
   if (arguments.length > 1) {
     throw new Error('The second argument was removed in favor of the options object.');
   }
+
+  var options = _.cloneDeep(options);
   options = _.defaults(options || {}, {
     hooks: true,
     validate: true
@@ -719,11 +723,12 @@ Instance.prototype.save = function(options) {
 * all references to the Instance are updated with the new data and no new objects are created.
 *
 * @see {Model#find}
-* @param {Object} [options] Options that are passed on to `Model.find`
+* @param {Object} [options] Options that are passed on to `Model.find`. This object will be cloned
 * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
 * @return {Promise<this>}
 */
 Instance.prototype.reload = function(options) {
+  var options = _.cloneDeep(options);
   options = _.defaults(options || {}, {
     where: this.where(),
     limit: 1,
@@ -743,7 +748,7 @@ Instance.prototype.reload = function(options) {
  *
  * Emits null if and only if validation successful; otherwise an Error instance containing { field name : [error msgs] } entries.
  *
- * @param {Object} [options] Options that are passed to the validator
+ * @param {Object} [options] Options that are passed to the validator. This object will be cloned
  * @param {Array} [options.skip] An array of strings. All properties that are in this array will not be validated
  * @see {InstanceValidator}
  *
@@ -772,7 +777,8 @@ Instance.prototype.update = function(values, options) {
   var changedBefore = this.changed() || []
     , sideEffects
     , fields
-    , setOptions;
+    , setOptions
+    , options = _.cloneDeep(options);
 
   options = options || {};
   if (Array.isArray(options)) options = {fields: options};
@@ -797,7 +803,7 @@ Instance.prototype.updateAttributes = Instance.prototype.update;
 /**
  * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will either be completely deleted, or have its deletedAt timestamp set to the current time.
  *
- * @param {Object}      [options={}]
+ * @param {Object}      [options={}] This object will be cloned 
  * @param {Boolean}     [options.force=false] If set to true, paranoid models will actually be deleted
  * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
@@ -805,6 +811,7 @@ Instance.prototype.updateAttributes = Instance.prototype.update;
  * @return {Promise<undefined>}
  */
 Instance.prototype.destroy = function(options) {
+  var options = _.cloneDeep(options);
   options = Utils._.extend({
     hooks: true,
     force: false
@@ -850,6 +857,7 @@ Instance.prototype.destroy = function(options) {
  */
 Instance.prototype.restore = function(options) {
   if (!this.Model._timestampAttributes.deletedAt) throw new Error('Model is not paranoid');
+  var options = _.cloneDeep(options);
 
   options = Utils._.extend({
     hooks: true,
@@ -888,7 +896,7 @@ Instance.prototype.restore = function(options) {
  *
  * @see {Instance#reload}
  * @param {String|Array|Object} fields If a string is provided, that column is incremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is incremented by the value given.
- * @param {Object} [options]
+ * @param {Object} [options] This object will be cloned
  * @param {Integer} [options.by=1] The number to increment by
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
@@ -896,10 +904,12 @@ Instance.prototype.restore = function(options) {
  * @return {Promise<this>}
  */
 Instance.prototype.increment = function(fields, options) {
+
   var identifier = this.where()
     , updatedAtAttr = this.Model._timestampAttributes.updatedAt
     , values = {}
-    , where;
+    , where
+    , options = _.cloneDeep(options);
 
   if (identifier) {
     for (var attrName in identifier) {
@@ -961,7 +971,7 @@ Instance.prototype.increment = function(fields, options) {
  *
  * @see {Instance#reload}
  * @param {String|Array|Object} fields If a string is provided, that column is decremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is decremented by the value given
- * @param {Object} [options]
+ * @param {Object} [options] This object will be cloned
  * @param {Integer} [options.by=1] The number to decrement by
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
@@ -969,6 +979,7 @@ Instance.prototype.increment = function(fields, options) {
  * @return {Promise}
  */
 Instance.prototype.decrement = function(fields, options) {
+  var options = _.cloneDeep(options);
   options = _.defaults(options || {}, {
     by: 1
   });

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -803,7 +803,7 @@ Instance.prototype.updateAttributes = Instance.prototype.update;
 /**
  * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will either be completely deleted, or have its deletedAt timestamp set to the current time.
  *
- * @param {Object}      [options={}] This object will be cloned 
+ * @param {Object}      [options={}] This object will be cloned
  * @param {Boolean}     [options.force=false] If set to true, paranoid models will actually be deleted
  * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -76,6 +76,13 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       });
     });
 
+    it('should not alter options', function() {
+      var options = {};
+      return this.User.build({ username: 'user' }).save(options).then(function() {
+        expect(options).to.be.deep.equal({});
+      });
+    });
+
     it('returns false for created objects', function() {
       return this.User.create({ username: 'user' }).then(function(user) {
         expect(user.isNewRecord).to.not.be.ok;
@@ -147,6 +154,17 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(0);
           });
+        });
+      });
+    });
+
+    it('should not alter options', function() {
+      var self = this;
+      return this.User.findById(1).then(function(user1) {
+        var options = { by: 2, where: { bNumber: 1 } };
+        var optionsToCheck = { by: 2, where: { bNumber: 1 } };
+        return user1.increment(['aNumber'], options).then(function() {
+          expect(options).to.be.deep.equal(optionsToCheck);
         });
       });
     });
@@ -289,6 +307,17 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       });
     });
 
+    it('should not alter options', function() {
+      var self = this;
+      return this.User.findById(1).then(function(user1) {
+        var options = { by: 2 };
+        var optionsToCheck = { by: 2 };
+        return user1.decrement(['aNumber'], options).then(function() {
+          expect(options).to.be.deep.equal(optionsToCheck);
+        });
+      });
+    });
+
     it('with single field', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
@@ -406,6 +435,17 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         return originalUser.updateAttributes({ username: 'Doe John' }).then(function() {
           return originalUser.reload().then(function(updatedUser) {
             expect(originalUser === updatedUser).to.be.true;
+          });
+        });
+      });
+    });
+
+    it('should not alter options', function() {
+      return this.User.create({ username: 'John Doe' }).then(function(originalUser) {
+        return originalUser.updateAttributes({ username: 'Doe John' }).then(function() {
+          var options = {};
+          return originalUser.reload(options).then(function() {
+            expect(options).to.be.deep.equal({});
           });
         });
       });
@@ -977,6 +1017,17 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           }).then(function(user1) {
             expect(user1.updatedAt).to.equalDate(updatedAt);
           });
+        });
+      });
+    });
+
+    it('should not alter options', function() {
+      return this.User.create({ username: 'user' }).then(function(user) {
+        var options = {};
+        return user.update({
+          username: 'userman'
+        }, options).then(function() {
+          expect(options).to.be.deep.equal({});
         });
       });
     });
@@ -1560,6 +1611,18 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         return self.ParanoidUser.findAll().then(function(users) {
           return users[0].destroy().then(function(user) {
             expect(user.deletedAt.getMonth).to.exist;
+          });
+        });
+      });
+    });
+
+    it('should not alter options', function() {
+      var self = this;
+      return this.ParanoidUser.create({ username: 'fnord' }).then(function() {
+        return self.ParanoidUser.findAll().then(function(users) {
+          var options = {};
+          return users[0].destroy(options).then(function() {
+            expect(options).to.be.deep.equal({});
           });
         });
       });


### PR DESCRIPTION
Hi,
The other day I ran into a code that was using the same options object to make several calls to ```instance.save(options)```. Taking a look at ```save``` and some other methods, I found out that options are being modified inside methods like this: 

```javascript
  if (!options.fields) {
    if (this.isNewRecord) {
      options.fields = Object.keys(this.Model.attributes);
    } else {
      options.fields = _.intersection(this.changed(), Object.keys(this.Model.attributes));
    }

    options.defaultFields = options.fields;
  }
```

Facing this problem, I implemented some code to clone the options object from save and some other methods trying to avoid this behavior. What you guys think about this?