### PR TITLE
groupJoinData checks UniqueKeys if no PrimaryKey is set

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -149,7 +149,21 @@ var groupJoinData = function(rows, includeOptions, options) {
       }
       return keyPrefixMemo[key];
     }
+    , getUniqueKeyAttributes = function (model) {
+        var uniqueKeyAttributes = Utils._.chain(model.uniqueKeys);
+        uniqueKeyAttributes = uniqueKeyAttributes
+        .result(uniqueKeyAttributes.findKey() + '.fields')
+        .map(function(field){
+          return Utils._.findKey(model.attributes, function(chr) {
+            return chr.field === field;
+          });
+        })
+        .value();
+
+        return uniqueKeyAttributes;
+    }
     , primaryKeyAttributes
+    , uniqueKeyAttributes
     , prefix;
 
   for (rowsI = 0; rowsI < rowsLength; rowsI++) {
@@ -166,12 +180,19 @@ var groupJoinData = function(rows, includeOptions, options) {
 
       // Compute top level hash key (this is usually just the primary key values)
       $length = includeOptions.model.primaryKeyAttributes.length;
+      topHash = '';
       if ($length === 1) {
         topHash = row[includeOptions.model.primaryKeyAttributes[0]];
-      } else {
-        topHash = '';
+      }
+      else if ($length > 1) {
         for ($i = 0; $i < $length; $i++) {
           topHash += row[includeOptions.model.primaryKeyAttributes[$i]];
+        }
+      }
+      else if (!Utils._.isEmpty(includeOptions.model.uniqueKeys)) {
+        uniqueKeyAttributes = getUniqueKeyAttributes(includeOptions.model);
+        for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
+          topHash += row[uniqueKeyAttributes[$i]];
         }
       }
     }
@@ -197,7 +218,6 @@ var groupJoinData = function(rows, includeOptions, options) {
           $keyPrefix.forEach(buildIncludeMap);
         }
       }
-
       // End of key set
       if ($prevKeyPrefix !== undefined && $prevKeyPrefix !== $keyPrefix) {
         if (checkExisting) {
@@ -212,12 +232,19 @@ var groupJoinData = function(rows, includeOptions, options) {
               prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
               primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
               $length = primaryKeyAttributes.length;
+              itemHash = prefix;
               if ($length === 1) {
-                itemHash = prefix+row[prefix+'.'+primaryKeyAttributes[0]];
-              } else {
-                itemHash = prefix;
+                itemHash += row[prefix+'.'+primaryKeyAttributes[0]];
+              }
+              else if ($length > 1) {
                 for ($i = 0; $i < $length; $i++) {
                   itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
+                }
+              }
+              else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
+                uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
+                for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
+                  itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
                 }
               }
               if (!parentHash) {
@@ -292,12 +319,19 @@ var groupJoinData = function(rows, includeOptions, options) {
           prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
           primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
           $length = primaryKeyAttributes.length;
+          itemHash = prefix;
           if ($length === 1) {
-            itemHash = prefix+row[prefix+'.'+primaryKeyAttributes[0]];
-          } else {
-            itemHash = prefix;
+            itemHash += row[prefix+'.'+primaryKeyAttributes[0]];
+          }
+          else if ($length > 0) {
             for ($i = 0; $i < $length; $i++) {
               itemHash += row[prefix+'.'+primaryKeyAttributes[$i]];
+            }
+          }
+          else if (!Utils._.isEmpty(includeMap[prefix].model.uniqueKeys)) {
+            uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
+            for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
+              itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
             }
           }
           if (!parentHash) {


### PR DESCRIPTION
When nesting associations, if the model doesn't have a primary key, the code will now check and see if there is at least one unique key, and if there is, it will use one to create the hash that identifies each different row of results.

This change is in response to #4274 