### PR TITLE
Support custom field names in json queries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Next
+- [FIXED] Custom field names in json queries
 - [FIXED] JSON cast key using the equality operator. [#3824](https://github.com/sequelize/sequelize/issues/3824)
 - [FIXED] Map column names with `.field` in scopes with includes. [#4210](https://github.com/sequelize/sequelize/issues/4210)
 - [FIXED] `addScope` when the model does not have any initial scopes [#4243](https://github.com/sequelize/sequelize/issues/4243)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1820,7 +1820,7 @@ var QueryGenerator = {
         value = {};
 
         Dottie.set(value, key.split('.').slice(1), tmp);
-        key = key.split('.')[0];
+        key = field.field || key.split('.')[0];
       }
     }
 

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -657,6 +657,20 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         }, {
           default: '[data] @> \'{"company":"Magnafone"}\''
         });
+
+        testsql('metaData.nested.attribute', 'value', {
+          model: {
+            rawAttributes: {
+              metaData: {
+                field: 'meta_data',
+                fieldName: 'metaData',
+                type: new DataTypes.JSONB()
+              }
+            }
+          }
+        }, {
+          default: "([meta_data]#>>'{nested, attribute}') = 'value'"
+        });
       });
     }
 


### PR DESCRIPTION
Respect custom field names when doing nested json queries like:
```
{
  "metaData.audio.length": {
    $gt: 20
  }
}
```
where `metaData` has a custom field name defined.