### PR TITLE
Allow update Date fields if they holds non-Date values.

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -343,7 +343,7 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
             if (!(value instanceof Date)) {
               value = new Date(value);
             }
-            if (originalValue && value.getTime() === originalValue.getTime()) {
+            if (originalValue && originalValue instanceof Date && value.getTime() === originalValue.getTime()) {
               return;
             }
           }

--- a/test/unit/instance/changed.test.js
+++ b/test/unit/instance/changed.test.js
@@ -94,5 +94,21 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       user.set('meta', meta);
       expect(user.changed('meta')).to.equal(true);
     });
+
+    it('should return true if it happenned that original value is not of Date type', function () {
+      var firstDate = '2015-08-01';
+      var secondDate = new Date(1436921941099);
+
+      var user = this.User.build({
+        birthdate: firstDate
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('birthdate', secondDate);
+      expect(user.changed('birthdate')).to.equal(true);
+    });
+
   });
 });


### PR DESCRIPTION
When updating fields there is a special logic that check if DB call is needed, e.g. if new value is the same
as original - there is no need to issue update statement to DB.

There is a special case when we are updating field of DATE type, in that case we check if epochs are the same for new and old values.

That was done as part of following commit:

https://github.com/sequelize/sequelize/commit/8eafb4e9bf44ad8d9d4d78c22e1cb767e2ef9a56

But there is an issue with that fix, Sequelize allows to have non-Date values in DATE fields.

As a result "undefined is not a function" exception is thrown on attempt to update DATE field with new Date value when its old value was non-Date.