### PR TITLE
JSON: Cast key when using the equality operator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Next
+- [FIXED] JSON cast key using the equality operator. [#3824](https://github.com/sequelize/sequelize/issues/3824)
 - [FIXED] Map column names with `.field` in scopes with includes. [#4210](https://github.com/sequelize/sequelize/issues/4210)
 - [FIXED] `addScope` when the model does not have any initial scopes [#4243](https://github.com/sequelize/sequelize/issues/4243)
 - [FIXED] Fixed destroy with limit in PG when the primary key is aliassed [#4027](https://github.com/sequelize/sequelize/pull/4027)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1959,7 +1959,8 @@ var QueryGenerator = {
             , $key
             , $cast
             , $baseKey
-            , $tmp;
+            , $tmp
+            , castKey;
 
           if (path[path.length - 1].indexOf('::') > -1) {
             $tmp = path[path.length - 1].split('::');
@@ -1979,25 +1980,31 @@ var QueryGenerator = {
 
           $baseKey = '('+$baseKey+')';
 
+          castKey = function ($item) {
+            var key = $baseKey;
+
+            if (!$cast) {
+              if (typeof $item === 'number') {
+                $cast = 'double precision';
+              }
+
+              if ($item instanceof Date) {
+                $cast = 'timestamptz';
+              }
+            }
+
+            if ($cast) {
+              key += '::'+$cast;
+            }
+
+            return key;
+          };
+
           if (_.isPlainObject(item)) {
             _.forOwn(item, function ($item, $prop) {
               if ($prop.indexOf('$') === 0) {
                 $where[$prop] = $item;
-                $key = $baseKey;
-
-                if (!$cast) {
-                  if (typeof $item === 'number') {
-                    $cast = 'double precision';
-                  }
-
-                  if ($item instanceof Date) {
-                    $cast = 'timestamptz';
-                  }
-                }
-
-                if ($cast) {
-                  $key += '::'+$cast;
-                }
+                $key = castKey($item);
 
                 $items.push(self.whereItemQuery(new Utils.literal($key), $where/*, _.pick(options, 'prefix')*/));
               } else {
@@ -2006,9 +2013,9 @@ var QueryGenerator = {
             });
           } else {
             $where.$eq = item;
+            $key = castKey(item);
 
-            $key = new Utils.literal($baseKey);
-            $items.push(self.whereItemQuery($key, $where/*, _.pick(options, 'prefix')*/));
+            $items.push(self.whereItemQuery(new Utils.literal($key), $where/*, _.pick(options, 'prefix')*/));
           }
         };
 

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -577,6 +577,18 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           default: "([data]#>>'{nested, attribute}') = 'value'"
         });
 
+        testsql('data.nested.attribute', 4, {
+          model: {
+            rawAttributes: {
+              data: {
+                type: new DataTypes.JSONB()
+              }
+            }
+          }
+        }, {
+          default: "([data]#>>'{nested, attribute}')::double precision = 4"
+        });
+
         testsql('data.nested.attribute', {
           $in: [3, 7]
         }, {


### PR DESCRIPTION
Fixed `operator does not exist` exception when using queries like:
```js
{
  'data.age': 4
}
```

Fixes: https://github.com/sequelize/sequelize/issues/3824