### PR TITLE
Pass through connection mode options to sqlite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@
 - [FIXED] Clone the options object in `increment`, `decrement`, `destroy`, `reload`, `restore`, and `save`. [#4023](https://github.com/sequelize/sequelize/pull/4023)
 - [FIXED] Throw a `Sequelize.Error` when `authenticate` fails [#4209](https://github.com/sequelize/sequelize/pull/4209)
 - [FIXED] BTM would remove any previously added association getters [#4268](https://github.com/sequelize/sequelize/pull/4268)
+- [FIXED] Pass through connection mode options to sqlite
+[#4288](https://github.com/sequelize/sequelize/issues/4288)
 
 # 3.5.1
 - [FIXED] Fix bug with nested includes where a middle include results in a null value which breaks $findSeperate.

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -4,8 +4,7 @@ var AbstractConnectionManager = require('../abstract/connection-manager')
   , ConnectionManager
   , Utils = require('../../utils')
   , Promise = require('../../promise')
-  , sequelizeErrors = require('../../errors')
-  , sqlite3 = require('sqlite3');
+  , sequelizeErrors = require('../../errors');
 
 ConnectionManager = function(dialect, sequelize) {
   this.sequelize = sequelize;
@@ -41,7 +40,7 @@ ConnectionManager.prototype.getConnection = function(options) {
   return new Promise(function (resolve, reject) {
     self.connections[options.inMemory || options.uuid] = new self.lib.Database(
       self.sequelize.options.storage || self.sequelize.options.host || ':memory:',
-      options.readWriteMode || (sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE), // default mode
+      options.readWriteMode || (self.lib.OPEN_READWRITE | self.lib.OPEN_CREATE), // default mode
       function(err) {
         if (err) {
           if (err.code === 'SQLITE_CANTOPEN') return reject(new sequelizeErrors.ConnectionError(err));

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -4,7 +4,8 @@ var AbstractConnectionManager = require('../abstract/connection-manager')
   , ConnectionManager
   , Utils = require('../../utils')
   , Promise = require('../../promise')
-  , sequelizeErrors = require('../../errors');
+  , sequelizeErrors = require('../../errors')
+  , sqlite3 = require('sqlite3');
 
 ConnectionManager = function(dialect, sequelize) {
   this.sequelize = sequelize;
@@ -30,16 +31,25 @@ ConnectionManager.prototype.getConnection = function(options) {
   options.uuid = options.uuid || 'default';
   options.inMemory = ((self.sequelize.options.storage || self.sequelize.options.host || ':memory:') === ':memory:') ? 1 : 0;
 
-  if (self.connections[options.inMemory || options.uuid]) return Promise.resolve(self.connections[options.inMemory || options.uuid]);
+  var dialectOptions = self.sequelize.options.dialectOptions;
+  options.readWriteMode = dialectOptions && dialectOptions.mode;
+
+  if (self.connections[options.inMemory || options.uuid]) {
+    return Promise.resolve(self.connections[options.inMemory || options.uuid]);
+  }
 
   return new Promise(function (resolve, reject) {
-    self.connections[options.inMemory || options.uuid] = new self.lib.Database(self.sequelize.options.storage || self.sequelize.options.host || ':memory:', function(err) {
-      if (err) {
-        if (err.code === 'SQLITE_CANTOPEN') return reject(new sequelizeErrors.ConnectionError(err));
-        return reject(new sequelizeErrors.ConnectionError(err));
+    self.connections[options.inMemory || options.uuid] = new self.lib.Database(
+      self.sequelize.options.storage || self.sequelize.options.host || ':memory:',
+      options.readWriteMode || (sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE), // default mode
+      function(err) {
+        if (err) {
+          if (err.code === 'SQLITE_CANTOPEN') return reject(new sequelizeErrors.ConnectionError(err));
+          return reject(new sequelizeErrors.ConnectionError(err));
+        }
+        resolve(self.connections[options.inMemory || options.uuid]);
       }
-      resolve(self.connections[options.inMemory || options.uuid]);
-    });
+    );
   }).tap(function (connection) {
     if (self.sequelize.options.foreignKeys !== false) {
       // Make it possible to define and use foreign key constraints unless

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -6,7 +6,12 @@ var chai = require('chai')
   , config = require(__dirname + '/../config/config')
   , Support = require(__dirname + '/support')
   , dialect = Support.getTestDialect()
-  , Sequelize = require(__dirname + '/../../index');
+  , Sequelize = require(__dirname + '/../../index')
+  , sqlite3 = require('sqlite3')
+  , fs = require('fs')
+  , path = require('path');
+
+
 
 describe(Support.getTestDialectTeaser('Configuration'), function() {
   describe('Connections problems should fail with a nice message', function() {
@@ -107,7 +112,7 @@ describe(Support.getTestDialectTeaser('Configuration'), function() {
     });
   });
 
-  describe('Intantiation with arguments', function() {
+  describe('Instantiation with arguments', function() {
     it('should accept two parameters (database, username)', function() {
       var sequelize = new Sequelize('dbname', 'root');
       var config = sequelize.config;
@@ -142,6 +147,76 @@ describe(Support.getTestDialectTeaser('Configuration'), function() {
       expect(config.dialectOptions.supportBigNumbers).to.be.true;
       expect(config.dialectOptions.bigNumberStrings).to.be.true;
     });
+
+    if (dialect === 'sqlite') {
+      it('should respect READONLY / READWRITE connection modes', function() {
+        var p = path.join(__dirname, '../tmp', 'foo.sqlite');
+        var createTableFoo = 'CREATE TABLE foo (faz TEXT);';
+        var createTableBar = 'CREATE TABLE bar (baz TEXT);';
+
+        return Sequelize.Promise.promisify(fs.unlink)(p)
+        .catch(function(err) {
+          expect(err.code).to.equal('ENOENT');
+        })
+        .then(function() {
+          var sequelizeReadOnly = new Sequelize('sqlite://foo', {
+            storage: p,
+            dialectOptions: {
+              mode: sqlite3.OPEN_READONLY
+            }
+          });
+          var sequelizeReadWrite = new Sequelize('sqlite://foo', {
+            storage: p,
+            dialectOptions: {
+              mode: sqlite3.OPEN_READWRITE
+            }
+          });
+
+          expect(sequelizeReadOnly.config.dialectOptions.mode).to.equal(sqlite3.OPEN_READONLY);
+          expect(sequelizeReadWrite.config.dialectOptions.mode).to.equal(sqlite3.OPEN_READWRITE);
+
+          return Sequelize.Promise.join(
+            sequelizeReadOnly.query(createTableFoo)
+              .should.be.rejectedWith(Error, 'SQLITE_CANTOPEN: unable to open database file'),
+            sequelizeReadWrite.query(createTableFoo)
+              .should.be.rejectedWith(Error, 'SQLITE_CANTOPEN: unable to open database file')
+          );
+        })
+        .then(function() {
+          // By default, sqlite creates a connection that's READWRITE | CREATE
+          var sequelize = new Sequelize('sqlite://foo', {
+            storage: p
+          });
+          return sequelize.query(createTableFoo);
+        })
+        .then(function() {
+          return Sequelize.Promise.promisify(fs.access)(p, fs.R_OK | fs.W_OK);
+        })
+        .then(function() {
+          var sequelizeReadOnly = new Sequelize('sqlite://foo', {
+            storage: p,
+            dialectOptions: {
+              mode: sqlite3.OPEN_READONLY
+            }
+          });
+          var sequelizeReadWrite = new Sequelize('sqlite://foo', {
+            storage: p,
+            dialectOptions: {
+              mode: sqlite3.OPEN_READWRITE
+            }
+          });
+
+          return Sequelize.Promise.join(
+            sequelizeReadOnly.query(createTableBar)
+              .should.be.rejectedWith(Error, 'SQLITE_READONLY: attempt to write a readonly database'),
+            sequelizeReadWrite.query(createTableBar)
+          );
+        })
+        .finally(function() {
+          return Sequelize.Promise.promisify(fs.unlink)(p);
+        });
+      });
+    }
   });
 
 });


### PR DESCRIPTION
SQLite allows different connection modes (READONLY, READWRITE, CREATE). This PR allows passing through these options via `dialectOptions.mode` which was kind of expected in the first place. By default is sets the connection mode to sqlite's default which is READWRITE | CREATE.

Added some tests to verify the same. Did not update documentation since my expectation was that this should work via `dialectOptions` already.

Not sure how to get rid of query console logging:
```
Executing (default): CREATE TABLE foo (faz TEXT);
```