### PR TITLE
Respect custom field names when ordering

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Next
 - [FIXED] Show indexes query on Postgres fails to return functional indexes [#3911](https://github.com/sequelize/sequelize/issues/3911)
+- [FIXED] Custom field names when ordering [#4167](https://github.com/sequelize/sequelize/issues/4167)
 - [FIXED] Custom field names in json queries
 - [FIXED] JSON cast key using the equality operator. [#3824](https://github.com/sequelize/sequelize/issues/3824)
 - [FIXED] Map column names with `.field` in scopes with includes. [#4210](https://github.com/sequelize/sequelize/issues/4210)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -801,7 +801,7 @@ var QueryGenerator = {
       }
 
       // add 1st string as quoted, 2nd as unquoted raw
-      var sql = (i > 0 ? this.quoteIdentifier(tableNames.join('.')) + '.' : (Utils._.isString(obj[0]) && parent ? this.quoteIdentifier(parent.name) + '.' : '')) + this.quote(obj[i], parent, force);
+      var sql = (i > 0 ? this.quoteIdentifier(tableNames.join('.') + '.'  + this.quote(obj[i], parent, force)) : this.quote(obj[i], parent, force));
       if (i < len - 1) {
         if (obj[i + 1]._isSequelizeMethod) {
           sql += this.handleSequelizeMethod(obj[i + 1]);

--- a/test/integration/dialects/mysql/query-generator.test.js
+++ b/test/integration/dialects/mysql/query-generator.test.js
@@ -194,7 +194,7 @@ if (Support.dialectIsMySQL()) {
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['id', 'DESC']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC;',
+          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `id` DESC;',
           context: QueryGenerator,
           needsSequelize: true
         }, {

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -298,7 +298,7 @@ if (dialect.match(/^postgres/)) {
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['id', 'DESC']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM "myTable" AS "myTable" ORDER BY "myTable"."id" DESC;',
+          expectation: 'SELECT * FROM "myTable" AS "myTable" ORDER BY "id" DESC;',
           context: QueryGenerator,
           needsSequelize: true
         }, {

--- a/test/integration/dialects/sqlite/query-generator.test.js
+++ b/test/integration/dialects/sqlite/query-generator.test.js
@@ -177,7 +177,7 @@ if (dialect === 'sqlite') {
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['id', 'DESC']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC;',
+          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `id` DESC;',
           context: QueryGenerator,
           needsSequelize: true
         }, {

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -134,8 +134,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       }, {
         default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM ('+
           [
-            '(SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 1 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
-            '(SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 5 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
+            '(SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 1 ORDER BY [last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
+            '(SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 5 ORDER BY [last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
         +') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id];'
       });


### PR DESCRIPTION
Before:
```
SELECT "User"."id", "User"."last_name" AS "lastName", "User"."createdAt", "User"."updatedAt", 
"User"."CompanyId", "Company"."id" AS "Company.id", "Company"."combined_rank" AS 
"Company.combinedRank", "Company"."createdAt" AS "Company.createdAt", "Company"."updatedAt" 
AS "Company.updatedAt" FROM "Users" AS "User" LEFT OUTER JOIN "Companies" AS "Company" 
ON "User"."CompanyId" = "Company"."id" 
ORDER BY "Company"."rank" ASC, "User"."lastName" DESC 
LIMIT 5;
```

After:
```
SELECT "User"."id", "User"."last_name" AS "lastName", "User"."createdAt", "User"."updatedAt", 
"User"."CompanyId", "Company"."id" AS "Company.id", "Company"."combined_rank" AS 
"Company.combinedRank", "Company"."createdAt" AS "Company.createdAt", "Company"."updatedAt" 
AS "Company.updatedAt" FROM "Users" AS "User" LEFT OUTER JOIN "Companies" AS "Company" 
ON "User"."CompanyId" = "Company"."id" 
ORDER BY "Company.combinedRank" ASC, "lastName" 
DESC LIMIT 5;
```

When this approach seems good to you I'll make the other tests pass.

Fixes https://github.com/sequelize/sequelize/issues/4167