### PR TITLE
Fix removeColumnQuery for mssql dialect

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -170,7 +170,7 @@ var QueryGenerator = {
   },
 
   removeColumnQuery: function(tableName, attributeName) {
-    var query = 'ALTER TABLE <%= tableName %> DROP <%= attributeName %>;';
+    var query = 'ALTER TABLE <%= tableName %> DROP COLUMN <%= attributeName %>;';
     return Utils._.template(query)({
       tableName: this.quoteTable(tableName),
       attributeName: this.quoteIdentifier(attributeName)

--- a/test/unit/sql/remove-column.test.js
+++ b/test/unit/sql/remove-column.test.js
@@ -15,7 +15,7 @@ if (current.dialect.name !== 'sqlite') {
           schema: 'archive',
           tableName: 'user'
         }, 'email'), {
-          mssql: 'ALTER TABLE [archive].[user] DROP [email];',
+          mssql: 'ALTER TABLE [archive].[user] DROP COLUMN [email];',
           mysql: 'ALTER TABLE `archive.user` DROP `email`;',
           postgres: 'ALTER TABLE "archive"."user" DROP COLUMN "email";',
         });


### PR DESCRIPTION
* As per the syntax tree at:

  https://msdn.microsoft.com/en-gb/library/ms190273.aspx

  the correct syntax for removing a column is:
    ALTER TABLE users DROP COLUMN name;
  instead of:
    ALTER TABLE users DROP name;
  which is instead the syntax to drop the 'name' constraint.

----
I noticed this wasn't working for our migrations against an MSSQL DB.

I haven't implemented any tests yet -- I'd like to check this change is sound in principle before going any further.

It looks like I could implement some tests at:
>test/integration/dialects/mssql/query-generator.test.js

(note that it looks like there are no mssql integration tests yet)

Are there any other places I should add tests?