### PR TITLE
Update devDependencies

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,8 +12,12 @@
 [#4288](https://github.com/sequelize/sequelize/issues/4288)
 - [INTERNALS] Updated dependencies [#4332](https://github.com/sequelize/sequelize/pull/4332)
     + toposort-class@1.0.1
-    + validator@4.0.2
+    + validator@4.0.4
     + wkx@0.1.0
+- [INTERNALS] Updated devDependencies [#4336](https://github.com/sequelize/sequelize/pull/4336)
+    + chai-spies@0.7.0
+    + dox@0.8.0
+    + mysql@2.8.0
 
 # 3.5.1
 - [FIXED] Fix bug with nested includes where a middle include results in a null value which breaks $findSeperate.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "chai-datetime": "~1.4.0",
-    "chai-spies": "~0.6.0",
+    "chai-spies": "~0.7.0",
     "coffee-script": "~1.9.1",
     "commander": "^2.6.0",
     "continuation-local-storage": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "coffee-script": "~1.9.1",
     "commander": "^2.6.0",
     "continuation-local-storage": "^3.1.4",
-    "dox": "0.7.1",
+    "dox": "~0.8.0",
     "git": "^0.1.5",
     "hints": "^0.2.0",
     "istanbul": "~0.3.0",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jshint": ">=2.4.2",
     "lcov-result-merger": "~1.0.0",
     "mocha": "^2.2.1",
-    "mysql": "~2.6.2",
+    "mysql": "~2.8.0",
     "pg": "^4.2.0",
     "pg-hstore": "^2.3.1",
     "pg-native": "^1.8.0",


### PR DESCRIPTION
- [x] MAJOR : chai-spies@0.7.0 - [Release Notes](https://github.com/chaijs/chai-spies/releases/tag/0.7.0)
- [x] MAJOR - dox@0.8.0 - [Release Notes](https://github.com/tj/dox/blob/master/History.md) (`npm run docs` still generates good docs with success)
- [x] minor - mysql@2.8.0 - [Release Notes](https://github.com/felixge/node-mysql/blob/master/Changes.md)
- [x] update changelog.md

Generating docs :
```
> docker-compose run sequelize npm run docs
npm info it worked if it ends with ok
npm info using npm@2.7.5
npm info using node@v1.6.4
npm info predocs sequelize@3.5.1
npm info docs sequelize@3.5.1

> sequelize@3.5.1 docs /sequelize
> node docs/docs-generator.js

/sequelize/docs/api/hooks.md
/sequelize/docs/api/errors.md
/sequelize/docs/api/sequelize.md
/sequelize/docs/api/model.md
/sequelize/docs/api/instance.md
/sequelize/docs/api/associations/belongs-to.md
/sequelize/docs/api/associations/index.md
/sequelize/docs/api/associations/belongs-to-many.md
/sequelize/docs/api/transaction.md
/sequelize/docs/api/deferrable.md
/sequelize/docs/api/datatypes.md
/sequelize/docs/api/associations/has-many.md
/sequelize/docs/api/associations/has-one.md
npm info postdocs sequelize@3.5.1
npm info ok 
```