### PR TITLE
Revert "Update dependencies"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,10 +10,6 @@
 - [FIXED] BTM would remove any previously added association getters [#4268](https://github.com/sequelize/sequelize/pull/4268)
 - [FIXED] Pass through connection mode options to sqlite
 [#4288](https://github.com/sequelize/sequelize/issues/4288)
-- [INTERNALS] Updated dependencies [#4332](https://github.com/sequelize/sequelize/pull/4332)
-    + toposort-class@1.0.1
-    + validator@4.0.2
-    + wkx@0.1.0
 
 # 3.5.1
 - [FIXED] Fix bug with nested includes where a middle include results in a null value which breaks $findSeperate.

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "node-uuid": "~1.4.1",
     "semver": "^5.0.1",
     "shimmer": "1.0.0",
-    "toposort-class": "^1.0.1",
-    "validator": "^4.0.2",
+    "toposort-class": "~0.3.0",
+    "validator": "^3.34.0",
     "wellknown": "^0.3.1",
-    "wkx": "0.1.0"
+    "wkx": "0.0.7"
   },
   "devDependencies": {
     "chai": "^3.0.0",


### PR DESCRIPTION
Reverts sequelize/sequelize#4332

Appearently travis did not properly test the updated deps because of node_modules caching, so I'll have to revert this

@josephpage Didn't your experience any problems when running the tests locally?