### PR TITLE
Update dependencies 2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,10 @@
 - [FIXED] BTM would remove any previously added association getters [#4268](https://github.com/sequelize/sequelize/pull/4268)
 - [FIXED] Pass through connection mode options to sqlite
 [#4288](https://github.com/sequelize/sequelize/issues/4288)
+- [INTERNALS] Updated dependencies [#4332](https://github.com/sequelize/sequelize/pull/4332)
+    + toposort-class@1.0.1
+    + validator@4.0.2
+    + wkx@0.1.0
 
 # 3.5.1
 - [FIXED] Fix bug with nested includes where a middle include results in a null value which breaks $findSeperate.

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
     "node-uuid": "~1.4.1",
     "semver": "^5.0.1",
     "shimmer": "1.0.0",
-    "toposort-class": "~0.3.0",
-    "validator": "^3.34.0",
+    "toposort-class": "^1.0.1",
+    "validator": "^4.0.2",
     "wellknown": "^0.3.1",
-    "wkx": "0.0.7"
+    "wkx": "0.1.0"
   },
   "devDependencies": {
     "chai": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "semver": "^5.0.1",
     "shimmer": "1.0.0",
     "toposort-class": "^1.0.1",
-    "validator": "4.0.2",
+    "validator": "^4.0.4",
     "wellknown": "^0.3.1",
     "wkx": "0.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "semver": "^5.0.1",
     "shimmer": "1.0.0",
     "toposort-class": "^1.0.1",
-    "validator": "^4.0.2",
+    "validator": "4.0.2",
     "wellknown": "^0.3.1",
     "wkx": "0.1.0"
   },


### PR DESCRIPTION
Follows #4332 and #4339.  Passes tests locally.

This PR resolves bad score of [dependency status (david-dm.org)](https://david-dm.org/sequelize/sequelize)

- MAJOR : toposort-class@1.0.1 - No breaking changes known - [Release notes](https://github.com/gustavohenke/toposort/releases)
- MAJOR : validator@4.0.2 - No breaking changes known for [4.0.2](https://github.com/chriso/validator.js/commits/master) (:warning: Breaking changes/bugs introduced in 4.0.3 : #4339 )
- MAJOR : wkx@0.1.0 - No breaking changes known - [See commits history](https://github.com/cschwarz/wkx/commits/master)
- Changelog