### PR TITLE
Stop caching modules on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ node_js:
 
 sudo: false
 
-cache:
-  directories:
-    - node_modules
-
 env:
   - DIALECT=mysql
   - DIALECT=postgres


### PR DESCRIPTION
The cache hides test failures when dependencies are updated.

Related https://github.com/sequelize/sequelize/pull/4339