### PR TITLE
added query params to docs

### DIFF
--- a/docs/docs/models-usage.md
+++ b/docs/docs/models-usage.md
@@ -166,6 +166,8 @@ Project.findAll({ where: { id: [1,2,3] } }).then(function(projects) {
 Project.findAll({
   where: {
     id: {
+      $and: {a: 5}           // AND (a = 5)
+      $or: [{a: 5}, {a: 6}]  // (a = 5 OR a = 6)
       $gt: 6,                // id > 6
       $gte: 6,               // id >= 6
       $lt: 10,               // id < 10
@@ -182,6 +184,7 @@ Project.findAll({
       $overlap: [1, 2]       // && [1, 2] (PG array overlap operator)
       $contains: [1, 2]      // @> [1, 2] (PG array contains operator)
       $contained: [1, 2]     // <@ [1, 2] (PG array contained by operator)
+      $any: [2,3]            // ANY ARRAY[2, 3]::INTEGER (PG only)
     },
     status: {
       $not: false,           // status NOT FALSE

--- a/docs/docs/querying.md
+++ b/docs/docs/querying.md
@@ -45,6 +45,8 @@ Post.update({
 ### Operators
 
 ```js
+$and: {a: 5}           // AND (a = 5)
+$or: [{a: 5}, {a: 6}]  // (a = 5 OR a = 6)
 $gt: 6,                // id > 6
 $gte: 6,               // id >= 6
 $lt: 10,               // id < 10


### PR DESCRIPTION
Changed:
- `docs/docs/querying.md`: added `$and` and `$or` to list of operators
- `docs/docs/models-usage.md`: added `$and` and `$or` to list of operators
- `docs/docs/models-usage.md`: added `$any` to keep consistent with `docs/docs/querying.md`