### PR TITLE
Fix for onDuplicateKeyUpdate in mysql

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -167,7 +167,7 @@ var QueryGenerator = {
     return this.insertQuery(tableName, insertValues, rawAttributes, options);
   },
 
-  bulkInsertQuery: function(tableName, attrValueHashes, options) {
+  bulkInsertQuery: function(tableName, attrValueHashes, options, rawAttributes) {
     var query = 'INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %><%= onDuplicateKeyUpdate %>;'
       , tuples = []
       , allAttributes = []
@@ -189,7 +189,8 @@ var QueryGenerator = {
 
     if (options && options.updateOnDuplicate) {
       onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + options.updateOnDuplicate.map(function(attr) {
-        var key = this.quoteIdentifier(attr);
+        var field = rawAttributes && rawAttributes[attr] && rawAttributes[attr].field || attr;
+        var key = this.quoteIdentifier(field);
         return key + '=VALUES(' + key + ')';
       }.bind(this)).join(',');
     }

--- a/test/unit/sql/insert.js
+++ b/test/unit/sql/insert.js
@@ -35,4 +35,41 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
     });
 
   });
+
+  describe('bulkCreate', function () {
+    it('bulk create with onDuplicateKeyUpdate', function () {
+      // Skip mssql for now, it seems broken
+      if (Support.getTestDialect() === 'mssql') {
+        return;
+      }
+
+      var User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name'
+        },
+        password: {
+          type: DataTypes.STRING,
+          field: 'pass_word'
+        },
+        createdAt: {
+          type: DataTypes.DATE,
+          field: 'created_at'
+        },
+        updatedAt: {
+          type: DataTypes.DATE,
+          field: 'updated_at'
+        }
+      },{
+        timestamps:true
+      });
+
+      expectsql(sql.bulkInsertQuery(User.tableName, [{ user_name: 'testuser', pass_word: '12345' }], { updateOnDuplicate: ['username', 'password', 'updatedAt'] }, User.rawAttributes),
+      {
+        default:'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
+        postgres:'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\');',
+        mysql:'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);'
+      });
+    });
+  });
 });


### PR DESCRIPTION
Allow onDuplicateKeyUpdate in mysql for schemas that have field names defined.