### PR TITLE
Fixing isolation level undefined error

### DIFF
--- a/docs/api/transaction.md
+++ b/docs/api/transaction.md
@@ -39,7 +39,7 @@ Pass in the desired level as the first argument:
 
 ```js
 return sequelize.transaction({
-  isolationLevel: Sequelize.Transaction.SERIALIZABLE
+  isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.SERIALIZABLE
 }, function (t) {
 
  // your transactions


### PR DESCRIPTION
The isolation levels are available in the Sequelize.Transaction.ISOLATION_LEVELS map. Sequelize.Transaction.READ_COMMITTED resolves to undefined. This is w.r.t Sequelize v2.0.5.