### PR TITLE
include with separate:true fails if id is not part of the attributes list

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -610,6 +610,10 @@ validateIncludedElement = function(include, tableNames, options) {
     include.duplicating = false;
   }
 
+  if (include.separate === true && options.attributes && options.attributes.length && !_.includes(options.attributes, association.source.primaryKeyAttribute)) {
+    options.attributes.push(association.source.primaryKeyAttribute);
+  }
+
   // Validate child includes
   if (include.hasOwnProperty('include')) {
     validateIncludedElements.call(include.model, include, tableNames, options);


### PR DESCRIPTION
Should sequelize attempt to include the missing id field? Should it raise an appropriate error?