### PR TITLE
Calling set with dot.separated key on a JSON/JSONB attribute will not flag the entire object as changed

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [FIXED] Calling set with dot.separated key on a JSON/JSONB attribute will not flag the entire object as changed [#4379](https://github.com/sequelize/sequelize/pull/4379)
+
 # 3.9.0
 - [ADDED] beforeRestore/afterRestore hooks [#4371](https://github.com/sequelize/sequelize/issues/4371)
 - [ADDED] Map raw fields back to attributes names when using `mapToModel` or `returning` [#3995](https://github.com/sequelize/sequelize/pull/3995)

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -322,8 +322,11 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
           // If attribute is not in model definition, return
           if (!this._isAttribute(key)) {
             if (key.indexOf('.') > -1 && this.Model._isJsonAttribute(key.split('.')[0])) {
-              Dottie.set(this.dataValues, key, value);
-              this.changed(key, true);
+              var previousDottieValue = Dottie.get(this.dataValues, key);
+              if (!_.isEqual(previousDottieValue, value)) {
+                Dottie.set(this.dataValues, key, value);
+                this.changed(key.split('.')[0], true);
+              }
             }
             return;
           }

--- a/test/unit/instance/changed.test.js
+++ b/test/unit/instance/changed.test.js
@@ -94,5 +94,61 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       user.set('meta', meta);
       expect(user.changed('meta')).to.equal(true);
     });
+
+    it('should return true for JSON dot.separated key with changed values', function() {
+      var user = this.User.build({
+        meta: {
+          city: 'Stockholm'
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.city', 'Gothenburg');
+      expect(user.changed('meta')).to.equal(true);
+    });
+
+    it('should return false for JSON dot.separated key with same value', function() {
+      var user = this.User.build({
+        meta: {
+          city: 'Gothenburg'
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.city', 'Gothenburg');
+      expect(user.changed('meta')).to.equal(false);
+    });
+
+    it('should return true for JSON dot.separated key with object', function() {
+      var user = this.User.build({
+        meta: {
+          address: { street: 'Main street', number: '40' }
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.address', { street: 'Second street', number: '1' } );
+      expect(user.changed('meta')).to.equal(true);
+    });
+
+    it('should return false for JSON dot.separated key with same object', function() {
+      var user = this.User.build({
+        meta: {
+          address: { street: 'Main street', number: '40' }
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.address', { street: 'Main street', number: '40' } );
+      expect(user.changed('meta')).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
I'm using a JSONB attribute but I'm not able to save the data using set() on my instance object. When reading the documentation is says that using a dot.separated key should change the instance and flag the entire object as changed. If I inspect the instance object I can see that the "_changed" property now contains my dot.separated keys not the entire object key as expected.

Looking at the source code for instance.js I found a problem in the way changed is called when using a det.separated key. I have attached a pull request that actually flag the entire object as changed and I also make sure only to flag if a property has changed.