### PR TITLE
Implement SMALLINT and TINYINT datatypes.

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -273,6 +273,56 @@ INTEGER.prototype.validate = function(value) {
 };
 
 /**
+ * A 16 bit integer.
+ *
+ * Available properties: `UNSIGNED`, `ZEROFILL`
+ *
+ * @property SMALLINT
+ */
+var SMALLINT = function(length) {
+  var options = typeof length === 'object' && length || {
+    length: length
+  };
+  if (!(this instanceof SMALLINT)) return new SMALLINT(options);
+  NUMBER.call(this, options);
+};
+util.inherits(SMALLINT, NUMBER);
+
+SMALLINT.prototype.key = SMALLINT.key = 'SMALLINT';
+SMALLINT.prototype.validate = function(value) {
+  if (!Validator.isInt(value)) {
+    throw new sequelizeErrors.ValidationError(util.format('%j is not a valid smallint', value));
+  }
+
+  return true;
+};
+
+/**
+ * A 8 bit integer.
+ *
+ * Available properties: `UNSIGNED`, `ZEROFILL`
+ *
+ * @property TINYINT
+ */
+var TINYINT = function(length) {
+  var options = typeof length === 'object' && length || {
+    length: length
+  };
+  if (!(this instanceof TINYINT)) return new TINYINT(options);
+  NUMBER.call(this, options);
+};
+util.inherits(TINYINT, NUMBER);
+
+TINYINT.prototype.key = TINYINT.key = 'TINYINT';
+TINYINT.prototype.validate = function(value) {
+  if (!Validator.isInt(value)) {
+    throw new sequelizeErrors.ValidationError(util.format('%j is not a valid tinyint', value));
+  }
+
+  return true;
+};
+
+/**
  * A 64 bit integer.
  *
  * Available properties: `UNSIGNED`, `ZEROFILL`
@@ -859,6 +909,8 @@ var dataTypes = {
   TEXT: TEXT,
   NUMBER: NUMBER,
   INTEGER: INTEGER,
+  SMALLINT: SMALLINT,
+  TINYINT: TINYINT,
   BIGINT: BIGINT,
   FLOAT: FLOAT,
   TIME: TIME,

--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -113,6 +113,34 @@ module.exports = function (BaseTypes) {
     }
   });
 
+  var SMALLINT = BaseTypes.SMALLINT.inherits(function() {
+    if (!(this instanceof SMALLINT)) return new SMALLINT();
+    BaseTypes.SMALLINT.apply(this, arguments);
+
+    // MSSQL does not support any options for smallint
+    if (this._length || this.options.length || this._unsigned || this._zerofill) {
+      warn('MSSQL does not support SMALLINT with options. Plain `SMALLINT` will be used instead.');
+      this._length = undefined;
+      this.options.length = undefined;
+      this._unsigned = undefined;
+      this._zerofill = undefined;
+    }
+  });
+
+  var TINYINT = BaseTypes.TINYINT.inherits(function() {
+    if (!(this instanceof TINYINT)) return new TINYINT();
+    BaseTypes.TINYINT.apply(this, arguments);
+
+    // MSSQL does not support any options for tinyint
+    if (this._length || this.options.length || this._unsigned || this._zerofill) {
+      this.warn('MSSQL does not support TINYINT with options. Plain `TINYINT` will be used instead.');
+      this._length = undefined;
+      this.options.length = undefined;
+      this._unsigned = undefined;
+      this._zerofill = undefined;
+    }
+  });
+
   var BIGINT = BaseTypes.BIGINT.inherits(function() {
     if (!(this instanceof BIGINT)) return new BIGINT();
     BaseTypes.BIGINT.apply(this, arguments);

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -133,6 +133,54 @@ module.exports = function (BaseTypes) {
     array_oids: [1007]
   };
 
+  var SMALLINT = BaseTypes.SMALLINT.inherits(function() {
+    if (!(this instanceof SMALLINT)) return new SMALLINT();
+    BaseTypes.SMALLINT.apply(this, arguments);
+
+    // POSTGRES does not support any parameters for smallint
+    if (this._length || this.options.length || this._unsigned || this._zerofill) {
+      warn('PostgreSQL does not support SMALLINT with options. Plain `SMALLINT` will be used instead.');
+      this._length = undefined;
+      this.options.length = undefined;
+      this._unsigned = undefined;
+      this._zerofill = undefined;
+    }
+  });
+
+  SMALLINT.parse = function (value) {
+    return parseInt(value, 10);
+  };
+
+  // int2
+  BaseTypes.SMALLINT.types.postgres = {
+    oids: [21],
+    array_oids: [1005]
+  };
+
+  var TINYINT = BaseTypes.TINYINT.inherits(function() {
+    if (!(this instanceof TINYINT)) return new TINYINT();
+    BaseTypes.TINYINT.apply(this, arguments);
+
+    // POSTGRES does not support any parameters for tinyint
+    if (this._length || this.options.length || this._unsigned || this._zerofill) {
+      warn('PostgreSQL does not support TINYINT with options. Plain `TINYINT` will be used instead.');
+      this._length = undefined;
+      this.options.length = undefined;
+      this._unsigned = undefined;
+      this._zerofill = undefined;
+    }
+  });
+
+  TINYINT.parse = function (value) {
+    return parseInt(value, 10);
+  };
+
+  // int2
+  BaseTypes.TINYINT.types.postgres = {
+    oids: [21],
+    array_oids: [1005]
+  };
+
   var BIGINT = BaseTypes.BIGINT.inherits(function() {
     if (!(this instanceof BIGINT)) return new BIGINT();
     BaseTypes.BIGINT.apply(this, arguments);

--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -93,6 +93,30 @@ module.exports = function (BaseTypes) {
     return NUMBER.prototype.toSql.call(this);
   };
 
+  var SMALLINT = BaseTypes.SMALLINT.inherits(function(length) {
+    var options = typeof length === 'object' && length || {
+      length: length
+    };
+    if (!(this instanceof SMALLINT)) return new SMALLINT(options);
+    BaseTypes.SMALLINT.call(this, options);
+  });
+  SMALLINT.prototype.key = SMALLINT.key = 'SMALLINT';
+  SMALLINT.prototype.toSql = function() {
+    return NUMBER.prototype.toSql.call(this);
+  };
+
+  var TINYINT = BaseTypes.TINYINT.inherits(function(length) {
+    var options = typeof length === 'object' && length || {
+      length: length
+    };
+    if (!(this instanceof TINYINT)) return new TINYINT(options);
+    BaseTypes.TINYINT.call(this, options);
+  });
+  TINYINT.prototype.key = TINYINT.key = 'TINYINT';
+  TINYINT.prototype.toSql = function() {
+    return NUMBER.prototype.toSql.call(this);
+  };
+
   var BIGINT = BaseTypes.BIGINT.inherits(function(length) {
     var options = typeof length === 'object' && length || {
       length: length

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -369,6 +369,155 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
 
+    suite('SMALLINT', function () {
+      testsql('SMALLINT', DataTypes.SMALLINT, {
+        default: 'SMALLINT'
+      });
+
+      testsql('SMALLINT.UNSIGNED', DataTypes.SMALLINT.UNSIGNED, {
+        default: 'SMALLINT UNSIGNED',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      testsql('SMALLINT.UNSIGNED.ZEROFILL', DataTypes.SMALLINT.UNSIGNED.ZEROFILL, {
+        default: 'SMALLINT UNSIGNED ZEROFILL',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      testsql('SMALLINT(11)', DataTypes.SMALLINT(11), {
+        default: 'SMALLINT(11)',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      testsql('SMALLINT({ length: 11 })', DataTypes.SMALLINT({ length: 11 }), {
+        default: 'SMALLINT(11)',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      testsql('SMALLINT(11).UNSIGNED', DataTypes.SMALLINT(11).UNSIGNED, {
+        default: 'SMALLINT(11) UNSIGNED',
+        sqlite: 'SMALLINT UNSIGNED(11)',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      testsql('SMALLINT(11).UNSIGNED.ZEROFILL', DataTypes.SMALLINT(11).UNSIGNED.ZEROFILL, {
+        default: 'SMALLINT(11) UNSIGNED ZEROFILL',
+        sqlite: 'SMALLINT UNSIGNED ZEROFILL(11)',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      testsql('SMALLINT(11).ZEROFILL', DataTypes.SMALLINT(11).ZEROFILL, {
+        default: 'SMALLINT(11) ZEROFILL',
+        sqlite: 'SMALLINT ZEROFILL(11)',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      testsql('SMALLINT(11).ZEROFILL.UNSIGNED', DataTypes.SMALLINT(11).ZEROFILL.UNSIGNED, {
+        default: 'SMALLINT(11) UNSIGNED ZEROFILL',
+        sqlite: 'SMALLINT UNSIGNED ZEROFILL(11)',
+        postgres: 'SMALLINT',
+        mssql: 'SMALLINT'
+      });
+
+      suite('validate', function () {
+        test('should throw an error if `value` is invalid', function() {
+          var type = DataTypes.SMALLINT();
+
+          expect(function () {
+            type.validate('foobar');
+          }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid integer');
+        });
+
+        test('should return `true` if `value` is a valid integer', function() {
+          var type = DataTypes.SMALLINT();
+
+          expect(type.validate(12345)).to.equal(true);
+        });
+      });
+    });
+
+    suite('TINYINT', function () {
+      testsql('TINYINT', DataTypes.TINYINT, {
+        default: 'TINYINT',
+        postgres: 'SMALLINT'
+      });
+
+      testsql('TINYINT.UNSIGNED', DataTypes.TINYINT.UNSIGNED, {
+        default: 'TINYINT UNSIGNED',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      testsql('TINYINT.UNSIGNED.ZEROFILL', DataTypes.TINYINT.UNSIGNED.ZEROFILL, {
+        default: 'TINYINT UNSIGNED ZEROFILL',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      testsql('TINYINT(11)', DataTypes.TINYINT(11), {
+        default: 'TINYINT(11)',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      testsql('TINYINT({ length: 11 })', DataTypes.TINYINT({ length: 11 }), {
+        default: 'TINYINT(11)',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      testsql('TINYINT(11).UNSIGNED', DataTypes.TINYINT(11).UNSIGNED, {
+        default: 'TINYINT(11) UNSIGNED',
+        sqlite: 'TINYINT UNSIGNED(11)',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      testsql('TINYINT(11).UNSIGNED.ZEROFILL', DataTypes.TINYINT(11).UNSIGNED.ZEROFILL, {
+        default: 'TINYINT(11) UNSIGNED ZEROFILL',
+        sqlite: 'TINYINT UNSIGNED ZEROFILL(11)',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      testsql('TINYINT(11).ZEROFILL', DataTypes.TINYINT(11).ZEROFILL, {
+        default: 'TINYINT(11) ZEROFILL',
+        sqlite: 'TINYINT ZEROFILL(11)',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      testsql('TINYINT(11).ZEROFILL.UNSIGNED', DataTypes.TINYINT(11).ZEROFILL.UNSIGNED, {
+        default: 'TINYINT(11) UNSIGNED ZEROFILL',
+        sqlite: 'TINYINT UNSIGNED ZEROFILL(11)',
+        postgres: 'SMALLINT',
+        mssql: 'TINYINT'
+      });
+
+      suite('validate', function () {
+        test('should throw an error if `value` is invalid', function() {
+          var type = DataTypes.TINYINT();
+
+          expect(function () {
+            type.validate('foobar');
+          }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid integer');
+        });
+
+        test('should return `true` if `value` is a valid integer', function() {
+          var type = DataTypes.TINYINT();
+
+          expect(type.validate(123)).to.equal(true);
+        });
+      });
+    });
+
     suite('BIGINT', function () {
       testsql('BIGINT', DataTypes.BIGINT, {
         default: 'BIGINT'


### PR DESCRIPTION
I'd like to see support for SMALLINT and TINYINT.

I 'wrote' the code for them. However I haven't tested them myself since my machine doesn't have the requirements to `npm install` Sequelize's `devDependencies`.
