### PR TITLE
Update query-interface.js to handle schemas in postgresql

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -193,8 +193,16 @@ QueryInterface.prototype.dropTable = function(tableName, options) {
   options = options || {};
   options.cascade = options.cascade || options.force || false;
 
-  var sql = this.QueryGenerator.dropTableQuery(tableName, options)
-    , self = this;
+  var self = this;
+
+  if (!tableName.schema && options.schema) {
+    tableName = self.QueryGenerator.addSchema({
+      tableName: tableName,
+      schema: options.schema
+    });
+  }
+
+  var sql = this.QueryGenerator.dropTableQuery(tableName, options);
 
   return this.sequelize.query(sql, options).then(function() {
     var promises = [];


### PR DESCRIPTION
Possible fix for https://github.com/sequelize/sequelize/issues/4422

Please note there are likely many more functions that need to be made schema-freindly, for example `QueryInterface.prototype.renameTable`, the `QueryInterface.prototype.xxxColumn` functions and the `QueryInterface.prototype.xxxIndex` ones.
