### PR TITLE
Rename Instance private options and __options

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -86,8 +86,8 @@ var Instance = function(values, options) {
   this.dataValues = {};
   this._previousDataValues = {};
   this._changed = {};
-  this.__options = this.Model.options;
-  this.options = options || {};
+  this.$modelOptions = this.Model.options;
+  this.$options = options || {};
   this.hasPrimaryKeys = this.Model.options.hasPrimaryKeys;
   this.__eagerlyLoadedAssociations = [];
   /**
@@ -132,7 +132,7 @@ Instance.prototype.where = function() {
   }.bind(this), {});
 
   if (_.size(where) === 0) {
-    return this.__options.whereCollection;
+    return this.$modelOptions.whereCollection;
   }
   return where;
 };
@@ -186,7 +186,7 @@ Instance.prototype.get = function(key, options) { // testhint options:none
     if (this._customGetters[key]) {
       return this._customGetters[key].call(this, key);
     }
-    if (options && options.plain && this.options.include && this.options.includeNames.indexOf(key) !== -1) {
+    if (options && options.plain && this.$options.include && this.$options.includeNames.indexOf(key) !== -1) {
       if (Array.isArray(this.dataValues[key])) {
         return this.dataValues[key].map(function (instance) {
           return instance.get({plain: options.plain});
@@ -200,7 +200,7 @@ Instance.prototype.get = function(key, options) { // testhint options:none
     return this.dataValues[key];
   }
 
-  if (this._hasCustomGetters || (options && options.plain && this.options.include) || (options && options.clone)) {
+  if (this._hasCustomGetters || (options && options.plain && this.$options.include) || (options && options.clone)) {
     var values = {}
       , _key;
 
@@ -262,7 +262,7 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
     }
 
     // If raw, and we're not dealing with includes or special attributes, just set it straight on the dataValues object
-    if (options.raw && !(this.options && this.options.include) && !(options && options.attributes) && !this.Model._hasBooleanAttributes && !this.Model._hasDateAttributes) {
+    if (options.raw && !(this.$options && this.$options.include) && !(options && options.attributes) && !this.Model._hasBooleanAttributes && !this.Model._hasDateAttributes) {
       if (Object.keys(this.dataValues).length) {
         this.dataValues = _.extend(this.dataValues, values);
       } else {
@@ -279,8 +279,8 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
           keys = keys.concat(this.Model._virtualAttributes);
         }
 
-        if (this.options.includeNames) {
-          keys = keys.concat(this.options.includeNames);
+        if (this.$options.includeNames) {
+          keys = keys.concat(this.$options.includeNames);
         }
 
         for (i = 0, length = keys.length; i < length; i++) {
@@ -312,7 +312,7 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
     } else {
       // Check if we have included models, and if this key matches the include model names/aliases
 
-      if (this.options && this.options.include && this.options.includeNames.indexOf(key) !== -1 && value) {
+      if (this.$options && this.$options.include && this.$options.includeNames.indexOf(key) !== -1 && value) {
         // Pass it on to the include handler
         this._setInclude(key, value, options);
         return;
@@ -429,7 +429,7 @@ Instance.prototype._setInclude = function(key, value, options) {
     });
   }
 
-  var include = this.options.includeMap[key]
+  var include = this.$options.includeMap[key]
     , association = include.association
     , self = this
     , accessor = key
@@ -602,10 +602,10 @@ Instance.prototype.save = function(options) {
     }).then(function() {
       if (!options.fields.length) return this;
       if (!this.isNewRecord) return this;
-      if (!this.options.include || !this.options.include.length) return this;
+      if (!this.$options.include || !this.$options.include.length) return this;
 
       // Nested creation for BelongsTo relations
-      return Promise.map(this.options.include.filter(function (include) {
+      return Promise.map(this.$options.include.filter(function (include) {
         return include.association instanceof BelongsTo;
       }), function (include) {
         var instance = self.get(include.as);
@@ -681,10 +681,10 @@ Instance.prototype.save = function(options) {
         })
         .tap(function() {
           if (!wasNewRecord) return;
-          if (!self.options.include || !self.options.include.length) return;
+          if (!self.$options.include || !self.$options.include.length) return;
 
           // Nested creation for HasOne/HasMany/BelongsToMany relations
-          return Promise.map(self.options.include.filter(function (include) {
+          return Promise.map(self.$options.include.filter(function (include) {
             return !(include.association instanceof BelongsTo);
           }), function (include) {
             var instances = self.get(include.as);
@@ -727,7 +727,7 @@ Instance.prototype.reload = function(options) {
   options = _.defaults({}, options, {
     where: this.where(),
     limit: 1,
-    include: this.options.include || null
+    include: this.$options.include || null
   });
 
   return this.Model.findOne(options).bind(this).then(function(reload) {


### PR DESCRIPTION
- Possibly fix #4423
- Rename Instance `options` to `$options` to prevent value
  overwriting with models that have a column named `options`
- Also rename Instance `__options` to `$modelOptions` to avoid confusion
  between $options and __options.