### PR TITLE
Update connection-manager.js to support sqlcipher

### DIFF
--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -55,6 +55,16 @@ ConnectionManager.prototype.getConnection = function(options) {
       // explicitly disallowed. It's still opt-in per relation
       connection.run('PRAGMA FOREIGN_KEYS=ON');
     }
+    
+    // PRAGMA commands to support sqlcipher database encryption
+    if (self.sequelize.options.key) {
+			connection.run('PRAGMA KEY = \'' + self.sequelize.options.key + '\'');
+		}
+		
+		if (self.sequelize.options.cipher) {
+			connection.run('PRAGMA CIPHER = \'' + self.sequelize.options.cipher + '\'');
+		}		
+    
   });
 };
 


### PR DESCRIPTION
Add support for sqlcipher for use with sqlite databases

What you are doing: Adding the necessary PRAGMA commands to support sqlcipher (key and cipher)

What do you expect to happen: When the connection is started it will issue the PRAGMA commands which will allow for reading/writing to the encrypted database.

What is actually happening: What is stated above

Which dialect you are using: sqlite

Which sequelize version you are using: 3.X

