### PR TITLE
always need to join data when hasJoin is true not matter what options…

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -549,6 +549,16 @@ AbstractQuery.prototype.isUpdateQuery = function() {
 AbstractQuery.prototype.handleSelectQuery = function(results) {
   var result = null;
 
+  //always need to join data when hasJoin is true not matter what options.raw setting..
+  if (this.options.hasJoin === true) {
+    results = groupJoinData(results, {
+      model: this.model,
+      includeMap: this.options.includeMap,
+      includeNames: this.options.includeNames
+    }, {
+      checkExisting: this.options.hasMultiAssociation
+    });
+  }
   // Raw queries
   if (this.options.raw) {
     result = results.map(function(result) {
@@ -568,14 +578,6 @@ AbstractQuery.prototype.handleSelectQuery = function(results) {
     }, this);
   // Queries with include
   } else if (this.options.hasJoin === true) {
-    results = groupJoinData(results, {
-      model: this.model,
-      includeMap: this.options.includeMap,
-      includeNames: this.options.includeNames
-    }, {
-      checkExisting: this.options.hasMultiAssociation
-    });
-
     result = this.model.bulkBuild(results, {
       isNewRecord: false,
       include: this.options.include,


### PR DESCRIPTION
In handleSelectQuery , we always need to join data when hasJoin is true.
not matter the options.raw setting. 