### PR TITLE
Sequelize version number as property of sequelize

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -207,6 +207,12 @@ var Sequelize = function(database, username, password, options) {
   Sequelize.runHooks('afterInit', this);
 };
 
+/**
+ * Sequelize version number.
+ * @property version
+ */
+Sequelize.version = require('../package.json').version;
+
 Sequelize.options = {hooks: {}};
 
 /**


### PR DESCRIPTION
This PR adds `version` property to `Sequelize` - the version number of Sequelize in use.

This is useful e.g. for plugins where API has changed between different versions of Sequelize, and the plugin wishes to support multiple versions. See https://github.com/overlookmotel/sequelize-definer/blob/master/lib/patches.js for an example.