### PR TITLE
plugins support

### DIFF
--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,0 +1,56 @@
+'use strict'
+
+var assert = require('assert')
+
+var getPlugins = function(obj){
+  obj = obj || {}
+  var plugins = obj.plugins
+  assert(Array.isArray(plugins) || plugins === undefined,
+    '"plugins" must be an array or undefined'
+  )
+  plugins = plugins || []
+  return plugins
+}
+
+var runPluginHook = function(plugin, hookName, args){
+  args = args || []
+  if (plugin && plugin[hookName]) {
+    assert(typeof plugin[hookName] === 'function',
+      'plugin.' + hookName + ' must be a function'
+    )
+    plugin[hookName].apply(plugin, args)
+  }
+}
+
+var beforeInitHook = function(connectionParams, options){
+  getPlugins(options).forEach(function(plugin){
+    runPluginHook(plugin, 'beforeInit', [ connectionParams, options ])
+  })
+}
+
+var afterInitHook = function(sequelize){
+  getPlugins(sequelize.options).forEach(function(plugin){
+    runPluginHook(plugin, 'afterInit', [ sequelize ])
+  })
+  sequelize.addHook('beforeDefine', 'pluginsBeforeDefine', beforeDefineHook)
+  sequelize.addHook('afterDefine', 'pluginsAfterDefine', afterDefineHook)
+}
+
+var beforeDefineHook = function(attributes, options){
+  getPlugins(options.sequelize.options)
+  .concat(getPlugins(options))
+  .forEach(function(plugin){
+    runPluginHook(plugin, 'beforeDefine', [ attributes, options ])
+  })
+}
+
+var afterDefineHook = function(Model){
+  getPlugins(Model.options)
+  .concat(getPlugins(Model.sequelize.options))
+  .forEach(function(plugin){
+    runPluginHook(plugin, 'afterDefine', [ Model ])
+  })
+}
+
+module.exports.beforeInitHook = beforeInitHook
+module.exports.afterInitHook = afterInitHook

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -13,7 +13,8 @@ var url = require('url')
   , sequelizeErrors = require('./errors')
   , Promise = require('./promise')
   , Hooks = require('./hooks')
-  , Instance = require('./instance');
+  , Instance = require('./instance')
+  , plugins = require('./plugins');
 
 /**
  * This is the main class, the entry point to sequelize. To use it, you just need to import sequelize:
@@ -1233,6 +1234,9 @@ Sequelize.prototype.normalizeAttribute = function(attribute) {
 
   return attribute;
 };
+
+Sequelize.addHook('beforeInit', 'pluginsBeforeInit', plugins.beforeInitHook)
+Sequelize.addHook('afterInit', 'pluginsAfterInit', plugins.afterInitHook)
 
 // Allows the promise to access cls namespaces
 module.exports = Promise.Sequelize = Sequelize;


### PR DESCRIPTION
This small piece of code adds plugin support for Sequelize.

**Writing a plugin**

```js

Sequelize = require('sequelize') // plugin should have peer-dependency on sequelize

// define plugin as js "class"
var MyPlugin = function(options){
  this.options = options || {}
}

// define plugin methods (hooks) - all methods are optional

MyPlugin.prototype.beforeInit = function(dbOptions, options){
  // executed only for db-level plugins
  // executed before new Sequelize(dbOptions, options)
  // you can read/add/modify dbOptions and options
  // ie. options.logging = console.log
  console.log(this.options.customOption + ' -> beforeInit')
}

MyPlugin.prototype.afterInit = function(sequelize){
  // executed only for db-level plugins
  // executed after new Sequelize(dbOptions, options)
  // you can do whatever you want with sequelize instance
  // ie. this.PluginModel = sequelize.define('PluginModel', {}) 
  console.log(this.options.customOption + ' -> afterInit')
}

MyPlugin.prototype.beforeDefine = function(attributes, options){
  // executed for both db-level and model-level plugins
  // executed before sequelize.define(modelName, attributes, options)
  // you can read/modify/add attributes and options
  // ie. attributes.pluginAttr = { type: Sequelize.INTEGER }
  console.log(this.options.customOption + ' -> beforeDefine( ' + options.name.singular + ' )')
}

MyPlugin.prototype.afterDefine = function(Model){
  // executed for both db-level and model-level plugins
  // executed after sequelize.define(modelName, attributes, options)
  // you can do whatever you want with Model
  // ie. Model.hasMany(this.PluginModel)
  console.log(this.options.customOption + ' -> afterDefine( ' + Model.name + ' )')
}

// export plugin as function which creates plugin instance with options
module.exports = function(options){
  return new MyPlugin(options)
}

```

**Using a plugin**

```js
var Sequelize = require('sequelize')
var myPlugin = require('my-plugin') // require plugin you want to use

// use db-level plugin
var sequelize = new Sequelize('postgres://localhost/db', {
  plugins: [ myPlugin({ customOption: 'db-level' }) /*, anotherPlugin(), ... */ ]
})

sequelize.define('User', {}, {})

// use model-level plugin
sequelize.define('Post', {}, {
  plugins: [ myPlugin({ customOption: 'model-level' }) /*, anotherPlugin(), ... */ ]
})
```

**output**

```
db-level -> beforeInit
db-level -> afterInit
db-level -> beforeDefine( User )
db-level -> afterDefine( User )
db-level -> beforeDefine( Post )
model-level -> beforeDefine( Post )
model-level -> afterDefine( Post )
db-level -> afterDefine( Post )
```

**Notes**

* plugin can be passed in *plugins* option passed to options object in `new Sequelize(dbOptions, options)` (db-level plugin)
* plugin can be passed in *plugins* option passed to options in `sequelize.define(modelName, attributes, options)` (model-level plugin)
* *plugins* option must be an array or undefined
* *beforeDefine* method of db-level plugin is executed before same method of model-level plugin
* *afterDefine* method of db-level plugin is executed after same method of model-level plugin
* plugins (their methods) are executed  in order they were passed in *plugins* option
* for db-level plugin *beforeDefine* and *afterDefine* methods will be called for every call to `sequelize.define(...)` (for every models)
* *beforeInit* and *afterInit* methods will be called only for db-level plugins

**TODO**

* write tests
* there is one issue which has to be investigated: when plugin defines new model, and it implicitly calls `beforeDefine` on this model which causes another plugin hook to be called. It must be investigated if there is no chance for infinite loop.
* probably there should be another option that could be passed to sequelize.define() like `globalPlugins: false` to omit db-level plugin hooks for particular model.
* are model-level plugins necessary? It is always possible to just pass "modelName" as option to db-level plugin so it (plugin) can just check it in *beforeDefine* / *afterDefine* methods