### PR TITLE
Check if ENUM value exists before ALTER TYPE

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -9,7 +9,8 @@ var Utils = require('../../utils')
   , SqlString = require('../../sql-string')
   , AbstractQueryGenerator = require('../abstract/query-generator')
   , primaryKeys = {}
-  , _ = require('lodash');
+  , _ = require('lodash')
+  , semver = require('semver');
 
 var QueryGenerator = {
   options: {},
@@ -805,8 +806,12 @@ var QueryGenerator = {
   },
 
   pgEnumAdd: function(tableName, attr, value, options) {
-    var enumName = this.pgEnumName(tableName, attr)
-      , sql = 'ALTER TYPE ' + enumName + ' ADD VALUE ' + this.escape(value);
+    var enumName = this.pgEnumName(tableName, attr);
+    var sql = 'ALTER TYPE ' + enumName + ' ADD VALUE';
+    if (semver.gte(this.sequelize.options.databaseVersion, '9.3.0')) {
+      sql += 'IF NOT EXISTS';
+    }
+    sql +=  this.escape(value)
 
     if (!!options.before) {
       sql += ' BEFORE ' + this.escape(options.before);

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -7,7 +7,8 @@ var chai = require('chai')
   , Support = require(__dirname + '/../../support')
   , dialect = Support.getTestDialect()
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , sequelize = require(__dirname + '/../../../../lib/sequelize');
+  , sequelize = require(__dirname + '/../../../../lib/sequelize')
+  , semver = require('semver');
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] DAO', function() {
@@ -390,14 +391,23 @@ if (dialect.match(/^postgres/)) {
           return User.sync({
             logging: function (sql) {
               if (sql.indexOf('neutral') > -1) {
-                expect(sql.indexOf("ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE 'neutral' BEFORE 'happy'")).to.not.be.equal(-1);
+                var cmd = semver.gte(this.sequelize.options.databaseVersion, '9.3.0')
+                            ? "ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE IF NOT EXISTS 'neutral' BEFORE 'happy'"
+                            : "ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE 'neutral' BEFORE 'happy'"
+                expect(sql.indexOf(cmd)).to.not.be.equal(-1);
                 count++;
               }
               else if (sql.indexOf('ecstatic') > -1) {
-                expect(sql.indexOf("ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE 'ecstatic' BEFORE 'meh'")).to.not.be.equal(-1);
+                var cmd = semver.gte(this.sequelize.options.databaseVersion, '9.3.0')
+                            ? "ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE IF NOT EXISTS 'ecstatic' BEFORE 'meh'"
+                            : "ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE 'ecstatic' BEFORE 'meh'"
+                expect(sql.indexOf(cmd)).to.not.be.equal(-1);
                 count++;
               }
               else if (sql.indexOf('joyful') > -1) {
+                var cmd = semver.gte(this.sequelize.options.databaseVersion, '9.3.0')
+                            ? "ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE IF NOT EXISTS 'joyful' AFTER 'meh'"
+                            : "ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE 'joyful' AFTER 'meh'"
                 expect(sql.indexOf("ALTER TYPE \"enum_UserEnums_mood\" ADD VALUE 'joyful' AFTER 'meh'")).to.not.be.equal(-1);
                 count++;
               }


### PR DESCRIPTION
Currently sequelize will not check if an `ENUM` value exists before attempting to alter the type. As it stands it can throw an error such as:

```
SequelizeDatabaseError: enum label "[labelName]" already exists
      at [object Object].Query.formatError (node_modules/sequelize/lib/dialects/postgres/query.js:433:14)
      at [object Object].<anonymous> (node_modules/sequelize/lib/dialects/postgres/query.js:108:19)
      at [object Object].Query.handleError (node_modules/pg/lib/query.js:108:8)
      at [object Object].<anonymous> (node_modules/pg/lib/client.js:171:26)
      at Socket.<anonymous> (node_modules/pg/lib/connection.js:109:12)
      at readableAddChunk (_stream_readable.js:146:16)
      at Socket.Readable.push (_stream_readable.js:110:10)
      at TCP.onread (net.js:523:20)
```

By adding the `IF NOT EXISTS` qualifier it will only throw a `NOTICE` that the enum label exists and skip it.