### PR TITLE
Model.beforeSync, Model.afterSync, sequelize.beforeBulkSync, sequelize.afterBulkSync

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,3 +177,13 @@ var num  = 1
 
 #### 6.3. Semicolons ####
 Yes
+
+# Publishing to NPM
+
+1. Ensure that latest build on master is green
+2. Ensure your local code is up to date (`git pull origin master`)
+3. `npm version patch|minor|major` (see SemVer)
+4. Update changelog to match version number, commit changelog
+5. `git push --tags origin master`
+6. `npm publish .`
+7. Copy changelog for version to release notes for version on github 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,7 +178,7 @@ var num  = 1
 #### 6.3. Semicolons ####
 Yes
 
-# Publishing to NPM
+# Publishing a release
 
 1. Ensure that latest build on master is green
 2. Ensure your local code is up to date (`git pull origin master`)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [FIXED] Calling set with dot.separated key on a JSON/JSONB attribute will not flag the entire object as changed [#4379](https://github.com/sequelize/sequelize/pull/4379)
+
 # 3.9.0
 - [ADDED] beforeRestore/afterRestore hooks [#4371](https://github.com/sequelize/sequelize/issues/4371)
 - [ADDED] Map raw fields back to attributes names when using `mapToModel` or `returning` [#3995](https://github.com/sequelize/sequelize/pull/3995)

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,13 @@
-# Next
+# 3.9.0
 - [ADDED] beforeRestore/afterRestore hooks [#4371](https://github.com/sequelize/sequelize/issues/4371)
-- [ADDED] beforeSync/afterSync/beforeBulkSync/afterBulksync hooks [#4479](https://github.com/sequelize/sequelize/issues/4479)
+- [ADDED] Map raw fields back to attributes names when using `mapToModel` or `returning` [#3995](https://github.com/sequelize/sequelize/pull/3995)
+- [ADDED] `skip` now supports filtering out modewl validators [#4528](https://github.com/sequelize/sequelize/pull/4528)
+>>>>>>> 189a1e6... changelog for 3.9.0
 - [INTERNALS] `options` has been renamed to `$options` in instance.js [#4429](https://github.com/sequelize/sequelize/pull/4429)
 - [FIXED] Reload doesn't synchronize a null include [#4353](https://github.com/sequelize/sequelize/issues/4353)
 - [FIXED] commit/rollback multiple times on same transaction [#4491](https://github.com/sequelize/sequelize/issues/4491)
 - [FIXED] memory leak / options mangle for scopes with include [#4470](https://github.com/sequelize/sequelize/issues/4470)
 - [FIXED] custom `targetKey` for belongsTo on a target with a primary key will now correctly create foreign key constraints [#4455](https://github.com/sequelize/sequelize/issues/4455)
-- [ADDED] Map raw fields back to attributes names when using `mapToModel` or `returning` [#3995](https://github.com/sequelize/sequelize/pull/3995)
-- [ADDED] `skip` now supports filtering out modewl validators [#4528](https://github.com/sequelize/sequelize/pull/4528)
 
 # 3.8.0
 - [ADDED] `version` on `Sequelize` returning the current npm/package.json version [#4459](https://github.com/sequelize/sequelize/pull/4459)

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - [FIXED] memory leak / options mangle for scopes with include [#4470](https://github.com/sequelize/sequelize/issues/4470)
 - [FIXED] custom `targetKey` for belongsTo on a target with a primary key will now correctly create foreign key constraints [#4455](https://github.com/sequelize/sequelize/issues/4455)
 - [ADDED] Map raw fields back to attributes names when using `mapToModel` or `returning` [#3995](https://github.com/sequelize/sequelize/pull/3995)
+- [ADDED] `skip` now supports filtering out modewl validators [#4528](https://github.com/sequelize/sequelize/pull/4528)
 
 # 3.8.0
 - [ADDED] `version` on `Sequelize` returning the current npm/package.json version [#4459](https://github.com/sequelize/sequelize/pull/4459)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Next
 - [ADDED] beforeRestore/afterRestore hooks [#4371](https://github.com/sequelize/sequelize/issues/4371)
+- [ADDED] beforeSync/afterSync/beforeBulkSync/afterBulksync hooks [#4479](https://github.com/sequelize/sequelize/issues/4479)
 - [INTERNALS] `options` has been renamed to `$options` in instance.js [#4429](https://github.com/sequelize/sequelize/pull/4429)
 - [FIXED] Reload doesn't synchronize a null include [#4353](https://github.com/sequelize/sequelize/issues/4353)
 - [FIXED] commit/rollback multiple times on same transaction [#4491](https://github.com/sequelize/sequelize/issues/4491)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@
 - [FIXED] commit/rollback multiple times on same transaction [#4491](https://github.com/sequelize/sequelize/issues/4491)
 - [FIXED] memory leak / options mangle for scopes with include [#4470](https://github.com/sequelize/sequelize/issues/4470)
 - [FIXED] custom `targetKey` for belongsTo on a target with a primary key will now correctly create foreign key constraints [#4455](https://github.com/sequelize/sequelize/issues/4455)
+- [ADDED] Map raw fields back to attributes names when using `mapToModel` or `returning` [#3995](https://github.com/sequelize/sequelize/pull/3995)
 
 # 3.8.0
 - [ADDED] `version` on `Sequelize` returning the current npm/package.json version [#4459](https://github.com/sequelize/sequelize/pull/4459)

--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -154,7 +154,7 @@ This will create a new model called UserProject with with the equivalent foreign
 
 Defining `through` is required. Sequelize would previously attempt to autogenerate names but that would not always lead to the most logical setups.
 
-This will add methods `getUsers`, `setUsers`, `addUsers` to `Project`, and `getProjects`, `setProjects` and `addProject` to `User`.
+This will add methods `getUsers`, `setUsers`, `addUser`,`addUsers` to `Project`, and `getProjects`, `setProjects` and `addProject`, `addProjects` to `User`.
 
 Sometimes you may want to rename your models when using them in associations. Let's define users as workers and projects as tasks by using the alias (`as`) option. We will also manually define the foreign keys to use:
 ```js

--- a/docs/docs/models-usage.md
+++ b/docs/docs/models-usage.md
@@ -1,6 +1,8 @@
 ## Data retrieval / Finders
 
-Finder methods are designed to get data from the database&period; The returned data isn't just a plain object&comma; but instances of one of the defined classes&period; Check the next major chapter about instances for further information&period; But as those things are instances&comma; you can e&period;g&period; use the just describe expanded instance methods&period; So&comma; here is what you can do&colon;
+Finder methods are intended to query data from the database&period; They do *not* return plain objects but instead return model instances&period; Because finder methods return model instances you can call any model instance member on the result as described in the documentation for [*instances*](http://docs.sequelizejs.com/en/latest/docs/instances/)&period;
+
+In this document we'll explore what finder methods can do&colon;
 
 ### find - Search for one specific element in the database
 ```js

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1268,7 +1268,7 @@ var QueryGenerator = {
               , subQueryWhere;
 
             associationWhere[association.identifierField] = {
-              $raw: self.quoteTable(parentTable) + '.' + self.quoteIdentifier(association.source.primaryKeyAttribute)
+              $raw: self.quoteTable(parentTable) + '.' + self.quoteIdentifier(association.source.primaryKeyField)
             };
 
             if (!options.where) options.where = {};

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -389,6 +389,8 @@ var QueryGenerator = {
             query += selectFromTmp;
         }
       } else if (this._dialect.supports.returnValues && options.returning) {
+        // ensure that the return output is properly mapped to model fields.
+        options.mapToModel = true;
         query += ' RETURNING *';
       }
     }

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -548,7 +548,19 @@ AbstractQuery.prototype.isUpdateQuery = function() {
 
 AbstractQuery.prototype.handleSelectQuery = function(results) {
   var result = null;
-
+  // Map raw fields to names if a mapping is provided
+  if (this.options.fieldMap) {
+    var fieldMap = this.options.fieldMap;
+    results = Utils._.map(results, function(result) {
+      return Utils._.reduce(fieldMap, function(result, name, field) {
+        if (result[field] !== undefined) {
+          result[name] = result[field];
+          delete result[field];
+        }
+        return result;
+      }, result);
+    });
+  }
   // Raw queries
   if (this.options.raw) {
     result = results.map(function(result) {
@@ -598,7 +610,6 @@ AbstractQuery.prototype.handleSelectQuery = function(results) {
   if (this.options.plain) {
     result = (result.length === 0) ? null : result[0];
   }
-
   return result;
 };
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -62,7 +62,11 @@ var hookTypes = {
   beforeDefine: {params: 2, sync: true},
   afterDefine: {params: 1, sync: true},
   beforeInit: {params: 2, sync: true},
-  afterInit: {params: 1, sync: true}
+  afterInit: {params: 1, sync: true},
+  beforeSync: {params: 1},
+  afterSync: {params: 1},
+  beforeBulkSync: {params: 1},
+  afterBulkSync: {params: 1}
 };
 
 var hookAliases = {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -403,6 +403,34 @@ Hooks.hasHooks = Hooks.hasHook;
  * @name afterInit
  */
 
+ /**
+  * A hook that is run before Model.sync call
+  * @param {String}   name
+  * @param {Function} fn   A callback function that is called with options passed to Model.sync
+  * @name beforeSync
+  */
+
+ /**
+  * A hook that is run after Model.sync call
+  * @param {String}   name
+  * @param {Function} fn   A callback function that is called with options passed to Model.sync
+  * @name afterSync
+  */
+
+  /**
+   * A hook that is run before sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name beforeBulkSync
+   */
+
+  /**
+   * A hook that is run after sequelize.sync call
+   * @param {String}   name
+   * @param {Function} fn   A callback function that is called with options passed to sequelize.sync
+   * @name afterBulkSync
+   */
+
 module.exports = {
   hooks: hookTypes,
   hookAliases: hookAliases,

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -133,13 +133,13 @@ InstanceValidator.prototype._builtinValidators = function() {
  * @private
  */
 InstanceValidator.prototype._customValidators = function() {
-
-
   var validators = [];
   var self = this;
-  Utils._.each(this.modelInstance.$modelOptions.validate, function(validator,
-    validatorType) {
-
+  Utils._.each(this.modelInstance.$modelOptions.validate, function(validator, validatorType) {
+    if (self.options.skip.indexOf(validatorType) >= 0) {
+      return;
+    }
+    
     var valprom = self._invokeCustomValidator(validator, validatorType)
       // errors are handled in settling, stub this
       .catch(function() {});

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -322,8 +322,11 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
           // If attribute is not in model definition, return
           if (!this._isAttribute(key)) {
             if (key.indexOf('.') > -1 && this.Model._isJsonAttribute(key.split('.')[0])) {
-              Dottie.set(this.dataValues, key, value);
-              this.changed(key, true);
+              var previousDottieValue = Dottie.get(this.dataValues, key);
+              if (!_.isEqual(previousDottieValue, value)) {
+                Dottie.set(this.dataValues, key, value);
+                this.changed(key.split('.')[0], true);
+              }
             }
             return;
           }

--- a/lib/model.js
+++ b/lib/model.js
@@ -870,6 +870,13 @@ Model.prototype.refreshAttributes = function() {
       delete definition.index;
     }
   });
+  // Create a map of field to attribute names
+  this.fieldAttributeMap = Utils._.reduce(this.fieldRawAttributesMap, function(map, value, key) {
+    if (key !== value.fieldName) {
+      map[key] = value.fieldName;
+    }
+    return map;
+  }, {});
 
   this.uniqueKeys = this.options.uniqueKeys;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2552,7 +2552,7 @@ Model.prototype.$getDefaultTimestamp = function(attr) {
 // Inject current scope into options. Includes should have been conformed (conformOptions) before calling this
 Model.$injectScope = function (scope, options) {
   scope = optClone(scope);
-  
+
   var filteredScope = _.omit(scope, 'include'); // Includes need special treatment
 
   _.defaults(options, filteredScope);
@@ -2572,9 +2572,6 @@ Model.$injectScope = function (scope, options) {
         }
         return sameModel;
       })) {
-        // Do not inject Model.$scope.include directly,
-        // make a shallow copy (#4470).
-        scopeInclude = _.clone(scopeInclude);
         options.include.push(scopeInclude);
       }
     });

--- a/lib/model.js
+++ b/lib/model.js
@@ -955,14 +955,15 @@ Model.prototype.removeAttribute = function(attribute) {
  * @return {Promise<this>}
  */
 Model.prototype.sync = function(options) {
-  options = Utils._.extend({}, this.options, options || {});
-  var runHooks = options ? (typeof options.hooks === 'undefined' ? true : !!options.hooks) : true;
+  options = options || {};
+  options.hooks = options.hooks === undefined ? true : options.hooks;
+  options = _.defaults(options, this.options);
 
   var self = this
     , attributes = this.tableAttributes;
 
   return Promise.try(function () {
-    if (runHooks) {
+    if (options.hooks) {
       return self.runHooks('beforeSync', options);
     }
   }).then(function () {
@@ -987,7 +988,7 @@ Model.prototype.sync = function(options) {
       return self.QueryInterface.addIndex(self.getTableName(options), _.assign({logging: options.logging}, index), self.tableName);
     });
   }).then(function () {
-    if (runHooks) {
+    if (options.hooks) {
       return self.runHooks('afterSync', options);
     }
   }).return(this);

--- a/lib/model.js
+++ b/lib/model.js
@@ -959,6 +959,10 @@ Model.prototype.sync = function(options) {
     , attributes = this.tableAttributes;
 
   return Promise.try(function () {
+    if (options.hooks) {
+      return self.runHooks('beforeSync', options);
+    }
+  }).then(function () {
     if (options.force) {
       return self.drop(options);
     }
@@ -979,6 +983,10 @@ Model.prototype.sync = function(options) {
     return Promise.map(indexes, function (index) {
       return self.QueryInterface.addIndex(self.getTableName(options), _.assign({logging: options.logging}, index), self.tableName);
     });
+  }).then(function () {
+    if (options.hooks) {
+      return self.runHooks('afterSync', options);
+    }
   }).return(this);
 };
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -954,12 +954,13 @@ Model.prototype.removeAttribute = function(attribute) {
  */
 Model.prototype.sync = function(options) {
   options = Utils._.extend({}, this.options, options || {});
+  var runHooks = options ? (typeof options.hooks === 'undefined' ? true : !!options.hooks) : true;
 
   var self = this
     , attributes = this.tableAttributes;
 
   return Promise.try(function () {
-    if (options.hooks) {
+    if (runHooks) {
       return self.runHooks('beforeSync', options);
     }
   }).then(function () {
@@ -984,7 +985,7 @@ Model.prototype.sync = function(options) {
       return self.QueryInterface.addIndex(self.getTableName(options), _.assign({logging: options.logging}, index), self.tableName);
     });
   }).then(function () {
-    if (options.hooks) {
+    if (runHooks) {
       return self.runHooks('afterSync', options);
     }
   }).return(this);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2551,6 +2551,8 @@ Model.prototype.$getDefaultTimestamp = function(attr) {
 
 // Inject current scope into options. Includes should have been conformed (conformOptions) before calling this
 Model.$injectScope = function (scope, options) {
+  scope = optClone(scope);
+  
   var filteredScope = _.omit(scope, 'include'); // Includes need special treatment
 
   _.defaults(options, filteredScope);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -177,7 +177,26 @@ var Sequelize = function(database, username, password, options) {
   };
 
   try {
-    var Dialect = require('./dialects/' + this.getDialect());
+    var Dialect;
+    // Requiring the dialect in a switch-case to keep the
+    // require calls static. (Browserify fix)
+    switch (this.getDialect()){
+      case 'mariadb':
+        Dialect = require('./dialects/mariadb');
+        break;
+      case 'mssql':
+        Dialect = require('./dialects/mssql');
+        break;
+      case 'mysql':
+        Dialect = require('./dialects/mysql');
+        break;
+      case 'postgres':
+        Dialect = require('./dialects/postgres');
+        break;
+      case 'sqlite':
+        Dialect = require('./dialects/sqlite');
+        break;
+    }
     this.dialect = new Dialect(this);
   } catch (err) {
     throw new Error('The dialect ' + this.getDialect() + ' is not supported. ('+err+')');

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -640,6 +640,8 @@ Sequelize.prototype.import = function(path) {
  * @param {Function}        [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Instance}        [options.instance] A sequelize instance used to build the return instance
  * @param {Model}           [options.model] A sequelize model used to build the returned model instances (used to be called callee)
+ * @param {Object}          [options.mapToModel=false] Map returned fields to model's fields if `options.model` or `options.instance` is present. Mapping will occur before building the model instance.
+ * @param {Object}          [options.fieldMap] Map returned fields to arbitrary names for `SELECT` query type.
  *
  * @return {Promise}
  *
@@ -657,6 +659,11 @@ Sequelize.prototype.query = function(sql, options) {
 
   if (options.instance && !options.model) {
     options.model = options.instance.Model;
+  }
+
+  // Map raw fields to model field names using the `fieldAttributeMap`
+  if (options.model && options.mapToModel && !Utils._.isEmpty(options.model.fieldAttributeMap)) {
+    options.fieldMap =  options.model.fieldAttributeMap;
   }
 
   if (Utils._.isPlainObject(sql)) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -841,14 +841,16 @@ Sequelize.prototype.dropAllSchemas = function(options) {
  * @param {RegEx} [options.match] Match a regex against the database name before syncing, a safety check for cases where force: true is used in tests but not live code
  * @param {Boolean|function} [options.logging=console.log] A function that logs sql queries, or false for no logging
  * @param {String} [options.schema='public'] The schema that the tables should be created in. This can be overriden for each table in sequelize.define
+ * @param {Boolean} [options.hooks=true] If hooks is true then beforeSync, afterSync, beforBulkSync, afterBulkSync hooks will be called
  * @return {Promise}
  */
 Sequelize.prototype.sync = function(options) {
   var self = this;
 
-  options = Utils._.defaults(options || {}, this.options.sync, this.options);
+  options = options || {};
+  options.hooks = options.hooks === undefined ?  true : options.hooks;
   options.logging = options.logging === undefined ? false : options.logging;
-  var runHooks = options ? (typeof options.hooks === 'undefined' ? true : !!options.hooks) : true;
+  options = Utils._.defaults(options, this.options.sync, this.options);
 
   if (options.match) {
     if (!options.match.test(this.config.database)) {
@@ -857,7 +859,7 @@ Sequelize.prototype.sync = function(options) {
   }
 
   return Promise.try(function () {
-    if (runHooks) {
+    if (options.hooks) {
       return self.runHooks('beforeBulkSync', options);
     }
   }).then(function () {
@@ -878,11 +880,11 @@ Sequelize.prototype.sync = function(options) {
     });
 
     return Promise.each(models, function(model) {
-      return model.sync(options);
+      return model.sync(Utils._.extend({}, options, { hooks: runHooks }));
     // return the sequelize instance
     });
   }).then(function () {
-    if (runHooks) {
+    if (options.hooks) {
       return self.runHooks('afterBulkSync', options);
     }
   }).return(self);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -854,14 +854,16 @@ Sequelize.prototype.sync = function(options) {
       return Promise.reject('Database does not match sync match parameter');
     }
   }
-  var when;
-  if (options.force) {
-    when = this.drop(options);
-  } else {
-    when = Promise.resolve();
-  }
 
-  return when.then(function() {
+  return Promise.try(function () {
+    if (options.hooks) {
+      return self.runHooks('beforeBulkSync', options);
+    }
+  }).then(function () {
+    if (options.force) {
+      return self.drop(options);
+    }
+  }).then(function() {
     var models = [];
 
     // Topologically sort by foreign key constraints to give us an appropriate
@@ -877,8 +879,12 @@ Sequelize.prototype.sync = function(options) {
     return Promise.each(models, function(model) {
       return model.sync(options);
     // return the sequelize instance
-    }).return(self);
-  });
+    });
+  }).then(function () {
+    if (options.hooks) {
+      return self.runHooks('afterBulkSync', options);
+    }
+  }).return(self);
 };
 
 /**

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -848,6 +848,7 @@ Sequelize.prototype.sync = function(options) {
 
   options = Utils._.defaults(options || {}, this.options.sync, this.options);
   options.logging = options.logging === undefined ? false : options.logging;
+  var runHooks = options ? (typeof options.hooks === 'undefined' ? true : !!options.hooks) : true;
 
   if (options.match) {
     if (!options.match.test(this.config.database)) {
@@ -856,7 +857,7 @@ Sequelize.prototype.sync = function(options) {
   }
 
   return Promise.try(function () {
-    if (options.hooks) {
+    if (runHooks) {
       return self.runHooks('beforeBulkSync', options);
     }
   }).then(function () {
@@ -881,7 +882,7 @@ Sequelize.prototype.sync = function(options) {
     // return the sequelize instance
     });
   }).then(function () {
-    if (options.hooks) {
+    if (runHooks) {
       return self.runHooks('afterBulkSync', options);
     }
   }).return(self);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS/io.js",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     {

--- a/test/integration/hooks.test.js
+++ b/test/integration/hooks.test.js
@@ -2133,4 +2133,156 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
     });
   });
+
+  describe('Model#sync', function() {
+    describe('on success', function() {
+      it('should run hooks', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+        this.User.beforeSync(beforeHook);
+        this.User.afterSync(afterHook);
+
+        return this.User.sync().then(function() {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        });
+      });
+
+      it('should not run hooks when "hooks = false" option passed', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+        this.User.beforeSync(beforeHook);
+        this.User.afterSync(afterHook);
+
+        return this.User.sync({ hooks: false }).then(function() {
+          expect(beforeHook).to.not.have.been.called;
+          expect(afterHook).to.not.have.been.called;
+        });
+      });
+
+    });
+
+    describe('on error', function() {
+      it('should return an error from before', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+        this.User.beforeSync(function(options) {
+          beforeHook();
+          throw new Error('Whoops!');
+        });
+        this.User.afterSync(afterHook);
+
+        return expect(this.User.sync()).to.be.rejected.then(function(err) {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).not.to.have.been.called;
+        });
+      });
+
+      it('should return an error from after', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+        this.User.beforeSync(beforeHook);
+        this.User.afterSync(function(options) {
+          afterHook();
+          throw new Error('Whoops!');
+        });
+
+        return expect(this.User.sync()).to.be.rejected.then(function(err) {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        });
+      });
+    });
+  });
+
+  describe('sequelize#sync', function() {
+    describe('on success', function() {
+      it('should run hooks', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy()
+          , modelBeforeHook = sinon.spy()
+          , modelAfterHook = sinon.spy();
+
+        this.sequelize.beforeBulkSync(beforeHook);
+        this.User.beforeSync(modelBeforeHook);
+        this.User.afterSync(modelAfterHook);
+        this.sequelize.afterBulkSync(afterHook);
+
+        return this.sequelize.sync().then(function() {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(modelBeforeHook).to.have.been.calledOnce;
+          expect(modelAfterHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        });
+      });
+
+      it('should not run hooks if "hooks = false" option passed', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy()
+          , modelBeforeHook = sinon.spy()
+          , modelAfterHook = sinon.spy();
+
+        this.sequelize.beforeBulkSync(beforeHook);
+        this.User.beforeSync(modelBeforeHook);
+        this.User.afterSync(modelAfterHook);
+        this.sequelize.afterBulkSync(afterHook);
+
+        return this.sequelize.sync({ hooks: false }).then(function() {
+          expect(beforeHook).to.not.have.been.called;
+          expect(modelBeforeHook).to.not.have.been.called;
+          expect(modelAfterHook).to.not.have.been.called;
+          expect(afterHook).to.not.have.been.called;
+        });
+      });
+
+      afterEach(function() {
+        this.sequelize.options.hooks = {};
+      });
+
+    });
+
+    describe('on error', function() {
+
+      it('should return an error from before', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+        this.sequelize.beforeBulkSync(function(options) {
+          beforeHook();
+          throw new Error('Whoops!');
+        });
+        this.sequelize.afterBulkSync(afterHook);
+
+        return expect(this.sequelize.sync()).to.be.rejected.then(function(err) {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).not.to.have.been.called;
+        });
+      });
+
+      it('should return an error from after', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+        this.sequelize.beforeBulkSync(beforeHook);
+        this.sequelize.afterBulkSync(function(options) {
+          afterHook();
+          throw new Error('Whoops!');
+        });
+
+        return expect(this.sequelize.sync()).to.be.rejected.then(function(err) {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        });
+      });
+
+      afterEach(function() {
+        this.sequelize.options.hooks = {};
+      });
+
+    });
+  });
+
 });

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -2,12 +2,20 @@
 
 /* jshint -W030 */
 var Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types');
+  , DataTypes = require(__dirname + '/../../../lib/data-types')
+  , chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , current = Support.sequelize
+  , _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('update', function () {
-    it('should only update the passed fields', function () {
-      var Account = this.sequelize.define('Account', {
+
+    var Account;
+
+    beforeEach(function() {
+      Account = this.sequelize.define('Account', {
         ownerId: {
           type: DataTypes.INTEGER,
           allowNull: false,
@@ -17,20 +25,44 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           type: DataTypes.STRING
         }
       });
+      return Account.sync({force: true});
+    });
 
-      return Account.sync({force: true}).then(function () {
+    it('should only update the passed fields', function () {
+      return Account.create({
+        ownerId: 2
+      }).then(function (account) {
+        return Account.update({
+          name: Math.random().toString()
+        }, {
+          where: {
+            id: account.get('id')
+          }
+        });
+      });
+    });
+
+
+    if (_.get(current.dialect.supports, 'returnValues.returning')) {
+      it('should return the updated record', function () {
         return Account.create({
           ownerId: 2
         }).then(function (account) {
           return Account.update({
-            name: Math.random().toString()
+            name: 'FooBar'
           }, {
             where: {
               id: account.get('id')
-            }
+            },
+            returning: true
+          }).spread(function(count, accounts) {
+            var account = accounts[0];
+            expect(account.ownerId).to.be.equal(2);
+            expect(account.name).to.be.equal('FooBar');
           });
         });
       });
-    });
+    }
+
   });
 });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -225,11 +225,16 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
     beforeEach(function() {
       this.User = this.sequelize.define('User', {
-        username: DataTypes.STRING
+        username: DataTypes.STRING,
+        emailAddress: {
+          type: DataTypes.STRING,
+          field: 'email_address'
+        }
       });
 
-      this.insertQuery = 'INSERT INTO ' + qq(this.User.tableName) + ' (username, ' + qq('createdAt') + ', ' +
-        qq('updatedAt') + ") VALUES ('john', '2012-01-01 10:10:10', '2012-01-01 10:10:10')";
+      this.insertQuery = 'INSERT INTO ' + qq(this.User.tableName) + ' (username, email_address, ' +
+        qq('createdAt') + ', ' + qq('updatedAt') +
+        ") VALUES ('john', 'john@gmail.com', '2012-01-01 10:10:10', '2012-01-01 10:10:10')";
 
       return this.User.sync({ force: true });
     });
@@ -311,6 +316,29 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
         });
       }).then(function(users) {
         expect(users[0].Model).to.equal(this.User);
+      });
+    });
+
+    it('maps the field names to attributes based on the passed model', function() {
+      return this.sequelize.query(this.insertQuery).bind(this).then(function() {
+        return this.sequelize.query('SELECT * FROM ' + qq(this.User.tableName) + ';', {
+          model: this.User,
+          mapToModel: true
+        });
+      }).then(function(users) {
+        expect(users[0].emailAddress).to.be.equal('john@gmail.com');
+      });
+    });
+
+    it('arbitrarily map the field names', function() {
+      return this.sequelize.query(this.insertQuery).bind(this).then(function() {
+        return this.sequelize.query('SELECT * FROM ' + qq(this.User.tableName) + ';', {
+          type: 'SELECT',
+          fieldMap: {username: 'userName', email_address: 'email'}
+        });
+      }).then(function(users) {
+        expect(users[0].userName).to.be.equal('john');
+        expect(users[0].email).to.be.equal('john@gmail.com');
       });
     });
 

--- a/test/unit/instance/changed.test.js
+++ b/test/unit/instance/changed.test.js
@@ -94,5 +94,61 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       user.set('meta', meta);
       expect(user.changed('meta')).to.equal(true);
     });
+
+    it('should return true for JSON dot.separated key with changed values', function() {
+      var user = this.User.build({
+        meta: {
+          city: 'Stockholm'
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.city', 'Gothenburg');
+      expect(user.changed('meta')).to.equal(true);
+    });
+
+    it('should return false for JSON dot.separated key with same value', function() {
+      var user = this.User.build({
+        meta: {
+          city: 'Gothenburg'
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.city', 'Gothenburg');
+      expect(user.changed('meta')).to.equal(false);
+    });
+
+    it('should return true for JSON dot.separated key with object', function() {
+      var user = this.User.build({
+        meta: {
+          address: { street: 'Main street', number: '40' }
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.address', { street: 'Second street', number: '1' } );
+      expect(user.changed('meta')).to.equal(true);
+    });
+
+    it('should return false for JSON dot.separated key with same object', function() {
+      var user = this.User.build({
+        meta: {
+          address: { street: 'Main street', number: '40' }
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('meta.address', { street: 'Main street', number: '40' } );
+      expect(user.changed('meta')).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
* before/afterSync hooks on Model executed before/after Model.sync(...)
* before/afterBulkSync hooks on sequelize (instance) executed before/after sequelize.sync(...)
* useful for plugins (for example to create a trigger after model table has beem created etc)
* TODO: add new tests

```js
var Sequelize = require('sequelize')

var sequelize = new Sequelize('postgres://localhost/sequelize_test', {
  logging: false
})

// executed "before" `sequelize.sync(...)`
sequelize.addHook('beforeBulkSync', function (options) {
  // this = sequelize instance
  console.log('beforeBulkSync')
})

// executed "after" `sequelize.sync(...)`
sequelize.addHook('afterBulkSync', function (options) {
  // this = sequelize instance
  console.log('afterBulkSync')
})

var Model = sequelize.define('Model', {}, {
  hooks: {
    // executed "before" `Model.sync(...)`
    beforeSync: function (options) {
      // this = Model
      console.log('beforeSync')
    },
    // executed "after" `Model.sync(...)`
    afterSync: function (options) {
      // this = Model
      console.log('afterSync')
    }
  }
})

sequelize.sync()
.then(function(){
  console.log('done')
})
```

output

```
beforeBulkSync
beforeSync
afterSync
afterBulkSync
done

```