### PR TITLE
Update spelling in line 4 of sequelize/docs/api/datatypes.md

### DIFF
--- a/docs/api/datatypes.md
+++ b/docs/api/datatypes.md
@@ -1,7 +1,7 @@
 <a name="datatypes"></a>
 # Class DataTypes
 [View code](https://github.com/sequelize/sequelize/blob/f678009d7514b81a6f87e12b86360e9a597e3ca8/lib/data-types.js#L39)
-A convenience class holding commonly used data types. The datatypes are used when definining a new model using `Sequelize.define`, like this:
+A convenience class holding commonly used data types. The datatypes are used when defining a new model using `Sequelize.define`, like this:
 ```js
 sequelize.define('model', {
   column: DataTypes.INTEGER


### PR DESCRIPTION
Changed "The datatypes are used when definining a new model using" to "The datatypes are used when defining a new model using".

![screen shot 2015-09-12 at 3 33 09 pm](https://cloud.githubusercontent.com/assets/1657304/9834146/9c44d366-5963-11e5-9c28-47f86c8463ba.png)
