### PR TITLE
Update spelling in line 11 of sequelize/lib/data-types.js

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -8,7 +8,7 @@ var util = require('util')
   , Validator = require('validator');
 
 /**
- * A convenience class holding commonly used data types. The datatypes are used when definining a new model using `Sequelize.define`, like this:
+ * A convenience class holding commonly used data types. The datatypes are used when defining a new model using `Sequelize.define`, like this:
  * ```js
  * sequelize.define('model', {
  *   column: DataTypes.INTEGER


### PR DESCRIPTION
Changed "The datatypes are used when definining a new model using" to "The datatypes are used when defining a new model using".

![screen shot 2015-09-12 at 3 33 09 pm](https://cloud.githubusercontent.com/assets/1657304/9839097/bb0e4b72-5a23-11e5-8a0b-930ece89a0ec.png)
