### PR TITLE
quick fix for #4481 , paranoid uses defaultValue of deletedAt

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -863,7 +863,11 @@ Instance.prototype.restore = function(options) {
       return this.Model.runHooks('beforeRestore', this, options);
     }
   }).then(function() {
-    this.setDataValue(this.Model._timestampAttributes.deletedAt, null);
+    var deletedAtCol = this.Model._timestampAttributes.deletedAt
+      , deletedAtAttribute = this.Model.rawAttributes[deletedAtCol]
+      , deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
+
+    this.setDataValue(deletedAtCol, deletedAtDefaultValue);
     return this.save(_.extend({}, options, {hooks : false, omitNull : false}));
   }).tap(function() {
     // Run after hook

--- a/lib/model.js
+++ b/lib/model.js
@@ -136,9 +136,11 @@ var paranoidClause = function(model, options) {
   }
 
   var deletedAtCol = model._timestampAttributes.deletedAt
-    , deletedAtObject = {};
+    , deletedAtAttribute = model.rawAttributes[deletedAtCol]
+    , deletedAtObject = {}
+    , deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-  deletedAtObject[model.rawAttributes[deletedAtCol].field || deletedAtCol] = null;
+  deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 
   if (Utils._.isEmpty(options.where)) {
     options.where = deletedAtObject;
@@ -2286,8 +2288,12 @@ Model.prototype.restore = function(options) {
     }
   }).then(function() {
     // Run undelete query
-    var attrValueHash = {};
-    attrValueHash[self._timestampAttributes.deletedAt] = null;
+    var attrValueHash = {}
+      , deletedAtCol = self._timestampAttributes.deletedAt
+      , deletedAtAttribute = self.rawAttributes[deletedAtCol]
+      , deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
+
+    attrValueHash[deletedAtCol] = deletedAtDefaultValue;
     options.omitNull = false;
     return self.QueryInterface.bulkUpdate(self.getTableName(options), attrValueHash, options.where, options, self._timestampAttributes.deletedAt);
   }).tap(function() {


### PR DESCRIPTION
This is a quick fix for #4481.
With this modification, `defaultValue` of deletedAt  is used instead of `NULL`, in functions `paranoidClause` and `restore`.

I am having trouble setting up Docker and haven't written tests yet, but they are working fine with the site I am currently developing.
I will look more into testing if it's a necessary step.

