### PR TITLE
Fixed 'define' method parameter in example for building instances

### DIFF
--- a/docs/docs/instances.md
+++ b/docs/docs/instances.md
@@ -19,7 +19,7 @@ Built instances will automatically get default values when they were defined&col
 
 ```js
 // first define the model
-var Task = sequelize.define('Project', {
+var Task = sequelize.define('Task', {
   title: Sequelize.STRING,
   rating: { type: Sequelize.STRING, defaultValue: 3 }
 })


### PR DESCRIPTION
Edits a potentially confusing typo in a code example.

**steps to repro:**
1. go to http://docs.sequelizejs.com/en/latest/docs/instances/
2. scroll to section that says "Built instances will automatically get default values when they were defined."

**expected:**
code example should say
```
var Task = sequelize.define('Task', {
  title: Sequelize.STRING,
  rating: { type: Sequelize.STRING, defaultValue: 3 }
})
```
**actual:**
code example has **Project** instead of **Task** as the first param in the `sequelize.define` method when defining the Task class. 
```
var Task = sequelize.define('Project', {
  title: Sequelize.STRING,
  rating: { type: Sequelize.STRING, defaultValue: 3 }
})
```

See screenshot of existing problem below:
![image](https://cloud.githubusercontent.com/assets/729524/9844673/fc6ee436-5a79-11e5-8ec6-d0fbc62f0b20.png)
