### PR TITLE
removed trailing comma from mssql connection manager connection config.

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -30,7 +30,7 @@ ConnectionManager.prototype.connect = function(config) {
       /* domain: 'DOMAIN' */
       options: {
         port: config.port,
-        database: config.database,
+        database: config.database
       }
     };
 


### PR DESCRIPTION
Hi.

I saw a use-less trailing comma in mssql's connection manager, in constructor where default connection config is declared. I removed it! :laughing: 