### PR TITLE
Fix recursively inject 'where' with defaultScope and paranoid:true

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2541,6 +2541,8 @@ Model.prototype.$getDefaultTimestamp = function(attr) {
 
 // Inject current scope into options. Includes should have been conformed (conformOptions) before calling this
 Model.$injectScope = function (scope, options) {
+  scope = optClone(scope);
+  
   var filteredScope = _.omit(scope, 'include'); // Includes need special treatment
 
   _.defaults(options, filteredScope);


### PR DESCRIPTION
Fix recursively inject 'where' with defaultScope and paranoid:true #4456