### PR TITLE
added addProjects and addUser instance methods to documentation for b…

### DIFF
--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -154,7 +154,7 @@ This will create a new model called UserProject with with the equivalent foreign
 
 Defining `through` is required. Sequelize would previously attempt to autogenerate names but that would not always lead to the most logical setups.
 
-This will add methods `getUsers`, `setUsers`, `addUsers` to `Project`, and `getProjects`, `setProjects` and `addProject` to `User`.
+This will add methods `getUsers`, `setUsers`, `addUser`,`addUsers` to `Project`, and `getProjects`, `setProjects` and `addProject`, `addProjects` to `User`.
 
 Sometimes you may want to rename your models when using them in associations. Let's define users as workers and projects as tasks by using the alias (`as`) option. We will also manually define the foreign keys to use:
 ```js


### PR DESCRIPTION
The documentation for belongs-to-many relationships was slightly confusing and did not clearly convey the existence of singular and plural setters ('addProject', 'addProjects', 'addUser', 'addUsers') for both sides of the relationship.

Personally ran into this problem and thought I'd make a small addendum to the docs.