### PR TITLE
Feature #4527 "skip" option for custom validators

### DIFF
--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -133,13 +133,13 @@ InstanceValidator.prototype._builtinValidators = function() {
  * @private
  */
 InstanceValidator.prototype._customValidators = function() {
-
-
   var validators = [];
   var self = this;
-  Utils._.each(this.modelInstance.$modelOptions.validate, function(validator,
-    validatorType) {
-
+  Utils._.each(this.modelInstance.$modelOptions.validate, function(validator, validatorType) {
+    if (self.options.skip.indexOf(validatorType) >= 0) {
+      return;
+    }
+    
     var valprom = self._invokeCustomValidator(validator, validatorType)
       // errors are handled in settling, stub this
       .catch(function() {});


### PR DESCRIPTION
Enable .validate(options.skip) to skip specific model/custom validators #4527
Return false to exit iteration early when using _.each and _.forIn , as per lodash docs