### PR TITLE
Revert scopeInclude clone. Better fixed by #4518

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2542,7 +2542,7 @@ Model.prototype.$getDefaultTimestamp = function(attr) {
 // Inject current scope into options. Includes should have been conformed (conformOptions) before calling this
 Model.$injectScope = function (scope, options) {
   scope = optClone(scope);
-  
+
   var filteredScope = _.omit(scope, 'include'); // Includes need special treatment
 
   _.defaults(options, filteredScope);
@@ -2562,9 +2562,6 @@ Model.$injectScope = function (scope, options) {
         }
         return sameModel;
       })) {
-        // Do not inject Model.$scope.include directly,
-        // make a shallow copy (#4470).
-        scopeInclude = _.clone(scopeInclude);
         options.include.push(scopeInclude);
       }
     });


### PR DESCRIPTION
@mickhansen the fix contained in #4518 is really better than the one reverted by this commit because it use `optClone` which take care of Sequelize objects. Moreover, the integration test add by my previous commit ensure no regression.