### PR TITLE
Create query and dialect options for prepending schema search_path in Postgres

### DIFF
--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -46,7 +46,8 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(Abstract.prototype.supp
   GEOMETRY: true,
   JSON: true,
   JSONB: true,
-  deferrableConstraints: true
+  deferrableConstraints: true,
+  searchPath : true
 });
 
 ConnectionManager.prototype.defaultVersion = '9.4.0';

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -15,6 +15,11 @@ var QueryGenerator = {
   options: {},
   dialect: 'postgres',
 
+  setSearchPath: function(searchPath) {
+    var query = 'SET search_path to <%= searchPath%>;';
+    return Utils._.template(query)({searchPath: searchPath});
+  },
+
   createSchema: function(schema) {
     var query = 'CREATE SCHEMA <%= schema%>;';
     return Utils._.template(query)({schema: schema});

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -90,9 +90,13 @@ Query.prototype.parseDialectSpecificFields = parseDialectSpecificFields;
 Query.prototype.run = function(sql) {
   this.sql = sql;
 
+  if(!Utils._.isEmpty(this.options.searchPath)){
+    this.sql = this.sequelize.queryInterface.QueryGenerator.setSearchPath(this.options.searchPath) + sql;
+  }
+
   var self = this
     , receivedError = false
-    , query = this.client.query(sql)
+    , query = this.client.query(this.sql)
     , rows = [];
 
   this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -478,6 +478,7 @@ Instance.prototype._setInclude = function(key, value, options) {
  * @param {Boolean} [options.validate=true] If false, validations won't be run.
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<this|Errors.ValidationError>}
  */
@@ -804,6 +805,7 @@ Instance.prototype.updateAttributes = Instance.prototype.update;
  * @param {Boolean}     [options.force=false] If set to true, paranoid models will actually be deleted
  * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<undefined>}
  */
@@ -900,6 +902,7 @@ Instance.prototype.restore = function(options) {
  * @param {Integer} [options.by=1] The number to increment by
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<this>}
  */
@@ -973,6 +976,7 @@ Instance.prototype.increment = function(fields, options) {
  * @param {Integer} [options.by=1] The number to decrement by
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise}
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -1291,6 +1291,7 @@ Model.prototype.all = function(options) {
  * @param  {Boolean}                   [options.raw] Return raw result. See sequelize.query for more information.
  * @param  {Function}                  [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param  {Object}                    [options.having]
+ * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @see    {Sequelize#query}
  * @return {Promise<Array<Instance>>}
@@ -1422,6 +1423,7 @@ Model.$findSeperate = function(results, options) {
 * @param  {Number|String|Buffer}      [options] A hash of options to describe the scope of the search, or a number to search by id.
 * @param  {Object}             '      [options]
 * @param  {Transaction}               [options.transaction] Transaction to run query under
+* @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
 *
 * @see {Model#findAll}           for an explanation of options
 * @return {Promise<Instance>}
@@ -1454,6 +1456,7 @@ Model.prototype.findByPrimary = Model.prototype.findById;
 *
 * @param  {Object}                    [options] A hash of options to describe the scope of the search
 * @param  {Transaction}               [options.transaction] Transaction to run query under
+* @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
 *
 * @see {Model#findAll}           for an explanation of options
 * @return {Promise<Instance>}
@@ -1529,6 +1532,7 @@ Model.prototype.aggregate = function(field, aggregateFunction, options) {
  * @param {Object}        [options.group] For creating complex counts. Will return multiple rows as needed.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<Integer>}
  */
@@ -1760,6 +1764,7 @@ Model.prototype.bulkBuild = function(valueSets, options) { // testhint options:n
  * @param {String}        [options.onDuplicate]
  * @param {Transaction}   [options.transaction] Transaction to run query under
  * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<Instance>}
  */
@@ -1959,6 +1964,7 @@ Model.prototype.findCreateFind = function(options) {
  * @param  {Array}        [options.fields=Object.keys(this.attributes)] The fields to insert / update. Defaults to all fields
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @alias insertOrUpdate
  * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated.
@@ -2020,6 +2026,7 @@ Model.prototype.insertOrUpdate = Model.prototype.upsert;
  * @param  {Array}        [options.updateOnDuplicate]      Fields to update if row key already exists (on duplicate key update)? (only supported by mysql & mariadb). By default, all fields are updated.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Function}     [options.logging=false]          A function that gets executed while running the query to log the sql.
+ * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<Array<Instance>>}
  */
@@ -2169,6 +2176,7 @@ Model.prototype.bulkCreate = function(records, options) {
  * @param {Boolean|function} [options.cascade = false] Only used in conjuction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
  * @param {Transaction}      [options.transaction] Transaction to run query under
  * @param {Boolean|function} [options.logging] A function that logs sql queries, or false for no logging
+ * @param  {String}          [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  * @return {Promise}
  *
  * @see {Model#destroy} for more information

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -147,6 +147,7 @@ QueryInterface.prototype.createTable = function(tableName, attributes, options, 
                 else if (!!vals[idx - 1]) {
                   options.after = vals[idx - 1];
                 }
+                options.supportsSearchPath = false;
                 promises.push(self.sequelize.query(self.QueryGenerator.pgEnumAdd(tableName, keys[i], value, options), options));
               }
             });
@@ -214,6 +215,7 @@ QueryInterface.prototype.dropTable = function(tableName, options) {
         for (i = 0; i < keyLen; i++) {
           if (instanceTable.rawAttributes[keys[i]].type instanceof DataTypes.ENUM) {
             sql = self.QueryGenerator.pgEnumDrop(getTableName, keys[i]);
+            options.supportsSearchPath = false;
             promises.push(self.sequelize.query(sql, { logging: options.logging, raw: true, transaction : options.transaction }));
           }
         }
@@ -442,7 +444,7 @@ QueryInterface.prototype.addIndex = function(tableName, attributes, options, raw
   options = options || {};
   options.fields = attributes;
   var sql = this.QueryGenerator.addIndexQuery(tableName, options, rawTablename);
-  return this.sequelize.query(sql, { logging: options.logging });
+  return this.sequelize.query(sql, { logging: options.logging, supportsSearchPath: false });
 };
 
 QueryInterface.prototype.showIndex = function(tableName, options) {
@@ -901,7 +903,8 @@ QueryInterface.prototype.commitTransaction = function(transaction, options) {
 
   options = Utils._.extend({
     transaction: transaction,
-    parent: options.transaction
+    parent: options.transaction,
+    supportsSearchPath: false
   }, options || {});
 
   var sql = this.QueryGenerator.commitTransactionQuery(options);
@@ -920,7 +923,8 @@ QueryInterface.prototype.rollbackTransaction = function(transaction, options) {
 
   options = Utils._.extend({
     transaction: transaction,
-    parent: options.transaction
+    parent: options.transaction,
+    supportsSearchPath: false
   }, options || {});
 
   var sql = this.QueryGenerator.rollbackTransactionQuery(transaction, options);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -667,6 +667,8 @@ Sequelize.prototype.import = function(path) {
  * @param {Function}        [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Instance}        [options.instance] A sequelize instance used to build the return instance
  * @param {Model}           [options.model] A sequelize model used to build the returned model instances (used to be called callee)
+ * @param {String}          [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {Boolean}         [options.supportsSearchPath] If false do not prepend the query with the search_path (Postgres only)
  * @param {Object}          [options.mapToModel=false] Map returned fields to model's fields if `options.model` or `options.instance` is present. Mapping will occur before building the model instance.
  * @param {Object}          [options.fieldMap] Map returned fields to arbitrary names for `SELECT` query type.
  *
@@ -724,7 +726,8 @@ Sequelize.prototype.query = function(sql, options) {
 
   options = Utils._.extend(Utils._.clone(this.options.query), options);
   options = Utils._.defaults(options, {
-    logging: this.options.hasOwnProperty('logging') ? this.options.logging : console.log
+    logging: this.options.hasOwnProperty('logging') ? this.options.logging : console.log,
+    searchPath: this.options.hasOwnProperty('searchPath') ? this.options.searchPath : 'DEFAULT',
   });
 
   if (options.transaction === undefined && Sequelize.cls) {
@@ -745,6 +748,17 @@ Sequelize.prototype.query = function(sql, options) {
 
   if (this.test.$trackRunningQueries) {
     this.test.$runningQueries++;
+  }
+
+  //if dialect doesn't support search_path or dialect option
+  //to prepend searchPath is not true delete the searchPath option
+  if (!self.dialect.supports.searchPath || !this.options.dialectOptions || !this.options.dialectOptions.prependSearchPath ||
+    options.supportsSearchPath === false) {
+    delete options.searchPath;
+  } else if (!options.searchPath) {
+    //if user wants to always prepend searchPath (dialectOptions.preprendSearchPath = true)
+    //then set to DEFAULT if none is provided
+    options.searchPath = 'DEFAULT';
   }
 
   return Promise.resolve(
@@ -875,6 +889,7 @@ Sequelize.prototype.dropAllSchemas = function(options) {
  * @param {RegEx} [options.match] Match a regex against the database name before syncing, a safety check for cases where force: true is used in tests but not live code
  * @param {Boolean|function} [options.logging=console.log] A function that logs sql queries, or false for no logging
  * @param {String} [options.schema='public'] The schema that the tables should be created in. This can be overriden for each table in sequelize.define
+ * @param  {String} [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  * @param {Boolean} [options.hooks=true] If hooks is true then beforeSync, afterSync, beforBulkSync, afterBulkSync hooks will be called
  * @return {Promise}
  */

--- a/test/integration/model/searchPath.test.js
+++ b/test/integration/model/searchPath.test.js
@@ -1,0 +1,469 @@
+'use strict';
+
+/* jshint -W030 */
+/* jshint -W110 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , DataTypes = require(__dirname + '/../../../lib/data-types');
+var SEARCH_PATH_ONE = 'schema_one,public';
+var SEARCH_PATH_TWO = 'schema_two,public';
+
+var current = Support.createSequelizeInstance({
+  dialectOptions: {
+    prependSearchPath: true
+  }
+});
+
+var locationId;
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+  if (current.dialect.supports.searchPath) {
+
+    describe('SEARCH PATH', function() {
+      before(function() {
+        this.Restaurant = current.define('restaurant', {
+            foo: DataTypes.STRING,
+            bar: DataTypes.STRING
+          },
+          {tableName: "restaurants"});
+        this.Location = current.define('location', {
+            name: DataTypes.STRING
+          },
+          {tableName: "locations"});
+        this.Employee = current.define('employee', {
+            first_name: DataTypes.STRING,
+            last_name: DataTypes.STRING
+          },
+          {tableName: "employees"});
+        this.Restaurant.belongsTo(this.Location,
+          {
+            foreignKey: 'location_id',
+            constraints: false
+          });
+        this.Employee.belongsTo(this.Restaurant,
+          {
+            foreignKey: 'restaurant_id',
+            constraints: false
+          });
+        this.Restaurant.hasMany(this.Employee, {
+          foreignKey: 'restaurant_id',
+          constraints: false
+        });
+      });
+
+
+      beforeEach('build restaurant tables', function() {
+        var Restaurant = this.Restaurant;
+        return current.createSchema('schema_one').then(function() {
+          return current.createSchema('schema_two');
+        }).then(function() {
+          return Restaurant.sync({force: true, searchPath: SEARCH_PATH_ONE});
+        }).then(function() {
+          return Restaurant.sync({force: true, searchPath: SEARCH_PATH_TWO});
+        }).catch(function(err) {
+          expect(err).to.be.null;
+        });
+      });
+
+      afterEach('drop schemas', function() {
+        return current.dropSchema('schema_one').then(function() {
+          return current.dropSchema('schema_two');
+        });
+      });
+
+      describe('Add data via model.create, retrieve via model.findOne', function() {
+        it('should be able to insert data into the table in schema_one using create', function() {
+          var Restaurant = this.Restaurant;
+          var restaurantId;
+
+          return Restaurant.create({
+            foo: 'one',
+            location_id: locationId
+          }, {searchPath: SEARCH_PATH_ONE})
+            .then(function() {
+              return Restaurant.findOne({
+                where: {foo: 'one'}, searchPath: SEARCH_PATH_ONE
+              });
+            }).then(function(obj) {
+              expect(obj).to.not.be.null;
+              expect(obj.foo).to.equal('one');
+              restaurantId = obj.id;
+              return Restaurant.findById(restaurantId, {searchPath: SEARCH_PATH_ONE});
+            }).then(function(obj) {
+              expect(obj).to.not.be.null;
+              expect(obj.foo).to.equal('one');
+            });
+        });
+
+        it('should fail to insert data into schema_two using create', function() {
+          var Restaurant = this.Restaurant;
+
+          return Restaurant.create({
+            foo: 'test'
+          }, {searchPath: SEARCH_PATH_TWO}).catch(function(err) {
+            expect(err).to.not.be.null;
+          });
+        });
+
+        it('should be able to insert data into the table in schema_two using create', function() {
+          var Restaurant = this.Restaurant;
+          var restaurantId;
+
+          return Restaurant.create({
+            foo: 'two',
+            location_id: locationId
+          }, {searchPath: SEARCH_PATH_TWO})
+            .then(function() {
+              return Restaurant.findOne({
+                where: {foo: 'two'}, searchPath: SEARCH_PATH_TWO
+              });
+            }).then(function(obj) {
+              expect(obj).to.not.be.null;
+              expect(obj.foo).to.equal('two');
+              restaurantId = obj.id;
+              return Restaurant.findById(restaurantId, {searchPath: SEARCH_PATH_TWO});
+            }).then(function(obj) {
+              expect(obj).to.not.be.null;
+              expect(obj.foo).to.equal('two');
+            });
+        });
+
+
+        it('should fail to find schema_one object in schema_two', function() {
+          var Restaurant = this.Restaurant;
+
+          return Restaurant.findOne({where: {foo: 'one'}, searchPath: SEARCH_PATH_TWO}).then(function(RestaurantObj) {
+            expect(RestaurantObj).to.be.null;
+          });
+        });
+
+        it('should fail to find schema_two object in schema_one', function() {
+          var Restaurant = this.Restaurant;
+
+          return Restaurant.findOne({where: {foo: 'two'}, searchPath: SEARCH_PATH_ONE}).then(function(RestaurantObj) {
+            expect(RestaurantObj).to.be.null;
+          });
+        });
+      });
+
+      describe('Add data via instance.save, retrieve via model.findAll', function() {
+        it('should be able to insert data into both schemas using instance.save and retrieve it via findAll', function() {
+          var Restaurant = this.Restaurant;
+
+          var restaurauntModel = Restaurant.build({bar: 'one.1'});
+
+          return restaurauntModel.save({searchPath: SEARCH_PATH_ONE})
+            .then(function() {
+              restaurauntModel = Restaurant.build({bar: 'one.2'});
+              return restaurauntModel.save({searchPath: SEARCH_PATH_ONE});
+            }).then(function() {
+              restaurauntModel = Restaurant.build({bar: 'two.1'});
+              return restaurauntModel.save({searchPath: SEARCH_PATH_TWO});
+            }).then(function() {
+              restaurauntModel = Restaurant.build({bar: 'two.2'});
+              return restaurauntModel.save({searchPath: SEARCH_PATH_TWO});
+            }).then(function() {
+              restaurauntModel = Restaurant.build({bar: 'two.3'});
+              return restaurauntModel.save({searchPath: SEARCH_PATH_TWO});
+            }).then(function() {
+              return Restaurant.findAll({searchPath: SEARCH_PATH_ONE});
+            }).then(function(restaurantsOne) {
+              expect(restaurantsOne).to.not.be.null;
+              expect(restaurantsOne.length).to.equal(2);
+              restaurantsOne.forEach(function(restaurant) {
+                expect(restaurant.bar).to.contain('one');
+              });
+              return Restaurant.findAndCountAll({searchPath: SEARCH_PATH_ONE});
+            }).then(function(restaurantsOne) {
+              expect(restaurantsOne).to.not.be.null;
+              expect(restaurantsOne.rows.length).to.equal(2);
+              expect(restaurantsOne.count).to.equal(2);
+              restaurantsOne.rows.forEach(function(restaurant) {
+                expect(restaurant.bar).to.contain('one');
+              });
+              return Restaurant.findAll({searchPath: SEARCH_PATH_TWO});
+            }).then(function(restaurantsTwo) {
+              expect(restaurantsTwo).to.not.be.null;
+              expect(restaurantsTwo.length).to.equal(3);
+              restaurantsTwo.forEach(function(restaurant) {
+                expect(restaurant.bar).to.contain('two');
+              });
+              return Restaurant.findAndCountAll({searchPath: SEARCH_PATH_TWO});
+            }).then(function(restaurantsTwo) {
+              expect(restaurantsTwo).to.not.be.null;
+              expect(restaurantsTwo.rows.length).to.equal(3);
+              expect(restaurantsTwo.count).to.equal(3);
+              restaurantsTwo.rows.forEach(function(restaurant) {
+                expect(restaurant.bar).to.contain('two');
+              });
+            });
+        });
+      });
+
+      describe('Add data via instance.save, retrieve via model.count and model.find', function() {
+        it('should be able to insert data into both schemas using instance.save count it and retrieve it via findAll with where', function() {
+          var Restaurant = this.Restaurant;
+
+          var restaurauntModel = Restaurant.build({bar: 'one.1'});
+
+          return restaurauntModel.save({searchPath: SEARCH_PATH_ONE}).then(function() {
+            restaurauntModel = Restaurant.build({bar: 'one.2'});
+            return restaurauntModel.save({searchPath: SEARCH_PATH_ONE});
+          }).then(function() {
+            restaurauntModel = Restaurant.build({bar: 'two.1'});
+            return restaurauntModel.save({searchPath: SEARCH_PATH_TWO});
+          }).then(function() {
+            restaurauntModel = Restaurant.build({bar: 'two.2'});
+            return restaurauntModel.save({searchPath: SEARCH_PATH_TWO});
+          }).then(function() {
+            restaurauntModel = Restaurant.build({bar: 'two.3'});
+            return restaurauntModel.save({searchPath: SEARCH_PATH_TWO});
+          }).then(function() {
+            return Restaurant.findAll({
+              where: {bar: {$like: 'one%'}},
+              searchPath: SEARCH_PATH_ONE
+            });
+          }).then(function(restaurantsOne) {
+            expect(restaurantsOne).to.not.be.null;
+            expect(restaurantsOne.length).to.equal(2);
+            restaurantsOne.forEach(function(restaurant) {
+              expect(restaurant.bar).to.contain('one');
+            });
+            return Restaurant.count({searchPath: SEARCH_PATH_ONE});
+          }).then(function(count) {
+            expect(count).to.not.be.null;
+            expect(count).to.equal(2);
+            return Restaurant.findAll({
+              where: {bar: {$like: 'two%'}},
+              searchPath: SEARCH_PATH_TWO
+            });
+          }).then(function(restaurantsTwo) {
+            expect(restaurantsTwo).to.not.be.null;
+            expect(restaurantsTwo.length).to.equal(3);
+            restaurantsTwo.forEach(function(restaurant) {
+              expect(restaurant.bar).to.contain('two');
+            });
+            return Restaurant.count({searchPath: SEARCH_PATH_TWO});
+          }).then(function(count) {
+            expect(count).to.not.be.null;
+            expect(count).to.equal(3);
+          });
+        });
+      });
+
+
+      describe('Get associated data in public schema via include', function() {
+        beforeEach(function() {
+          var Location = this.Location;
+
+          return Location.sync({force: true})
+            .then(function() {
+              return Location.create({name: 'HQ'}).then(function() {
+                return Location.findOne({where: {name: 'HQ'}}).then(function(obj) {
+                  expect(obj).to.not.be.null;
+                  expect(obj.name).to.equal('HQ');
+                  locationId = obj.id;
+                });
+              });
+            })
+            .catch(function(err) {
+              expect(err).to.be.null;
+            });
+        });
+
+        it('should be able to insert and retrieve associated data into the table in schema_one', function() {
+          var Restaurant = this.Restaurant;
+          var Location = this.Location;
+
+          return Restaurant.create({
+            foo: 'one',
+            location_id: locationId
+          }, {searchPath: SEARCH_PATH_ONE}).then(function() {
+            return Restaurant.findOne({
+              where: {foo: 'one'}, include: [{
+                model: Location, as: 'location'
+              }], searchPath: SEARCH_PATH_ONE
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.foo).to.equal('one');
+            expect(obj.location).to.not.be.null;
+            expect(obj.location.name).to.equal('HQ');
+          });
+        });
+
+
+        it('should be able to insert and retrieve associated data into the table in schema_two', function() {
+          var Restaurant = this.Restaurant;
+          var Location = this.Location;
+
+          return Restaurant.create({
+            foo: 'two',
+            location_id: locationId
+          }, {searchPath: SEARCH_PATH_TWO}).then(function() {
+            return Restaurant.findOne({
+              where: {foo: 'two'}, include: [{
+                model: Location, as: 'location'
+              }], searchPath: SEARCH_PATH_TWO
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.foo).to.equal('two');
+            expect(obj.location).to.not.be.null;
+            expect(obj.location.name).to.equal('HQ');
+          });
+        });
+      });
+
+
+      describe('Get schema specific associated data via include', function() {
+        beforeEach(function() {
+          var Employee = this.Employee;
+          return Employee.sync({force: true, searchPath: SEARCH_PATH_ONE})
+            .then(function() {
+              return Employee.sync({force: true, searchPath: SEARCH_PATH_TWO});
+            })
+            .catch(function(err) {
+              expect(err).to.be.null;
+            });
+        });
+
+        it('should be able to insert and retrieve associated data into the table in schema_one', function() {
+          var Restaurant = this.Restaurant;
+          var Employee = this.Employee;
+          var restaurantId;
+
+          return Restaurant.create({
+            foo: 'one'
+          }, {searchPath: SEARCH_PATH_ONE}).then(function() {
+            return Restaurant.findOne({
+              where: {foo: 'one'}, searchPath: SEARCH_PATH_ONE
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.foo).to.equal('one');
+            restaurantId = obj.id;
+            return Employee.create({
+              first_name: 'Restaurant',
+              last_name: 'one',
+              restaurant_id: restaurantId
+            }, {searchPath: SEARCH_PATH_ONE});
+          }).then(function() {
+            return Restaurant.findOne({
+              where: {foo: 'one'}, searchPath: SEARCH_PATH_ONE, include: [{
+                model: Employee, as: 'employees'
+              }]
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.employees).to.not.be.null;
+            expect(obj.employees.length).to.equal(1);
+            expect(obj.employees[0].last_name).to.equal('one');
+            return obj.getEmployees({searchPath: SEARCH_PATH_ONE});
+          }).then(function(employees) {
+            expect(employees.length).to.equal(1);
+            expect(employees[0].last_name).to.equal('one');
+            return Employee.findOne({
+              where: {last_name: 'one'}, searchPath: SEARCH_PATH_ONE, include: [{
+                model: Restaurant, as: 'restaurant'
+              }]
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.restaurant).to.not.be.null;
+            expect(obj.restaurant.foo).to.equal('one');
+            return obj.getRestaurant({searchPath: SEARCH_PATH_ONE});
+          }).then(function(restaurant) {
+            expect(restaurant).to.not.be.null;
+            expect(restaurant.foo).to.equal('one');
+          });
+        });
+
+
+        it('should be able to insert and retrieve associated data into the table in schema_two', function() {
+          var Restaurant = this.Restaurant;
+          var Employee = this.Employee;
+          var restaurantId;
+
+          return Restaurant.create({
+            foo: 'two'
+          }, {searchPath: SEARCH_PATH_TWO}).then(function() {
+            return Restaurant.findOne({
+              where: {foo: 'two'}, searchPath: SEARCH_PATH_TWO
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.foo).to.equal('two');
+            restaurantId = obj.id;
+            return Employee.create({
+              first_name: 'Restaurant',
+              last_name: 'two',
+              restaurant_id: restaurantId
+            }, {searchPath: SEARCH_PATH_TWO});
+          }).then(function() {
+            return Restaurant.findOne({
+              where: {foo: 'two'}, searchPath: SEARCH_PATH_TWO, include: [{
+                model: Employee, as: 'employees'
+              }]
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.employees).to.not.be.null;
+            expect(obj.employees.length).to.equal(1);
+            expect(obj.employees[0].last_name).to.equal('two');
+            return obj.getEmployees({searchPath: SEARCH_PATH_TWO});
+          }).then(function(employees) {
+            expect(employees.length).to.equal(1);
+            expect(employees[0].last_name).to.equal('two');
+            return Employee.findOne({
+              where: {last_name: 'two'}, searchPath: SEARCH_PATH_TWO, include: [{
+                model: Restaurant, as: 'restaurant'
+              }]
+            });
+          }).then(function(obj) {
+            expect(obj).to.not.be.null;
+            expect(obj.restaurant).to.not.be.null;
+            expect(obj.restaurant.foo).to.equal('two');
+            return obj.getRestaurant({searchPath: SEARCH_PATH_TWO});
+          }).then(function(restaurant) {
+            expect(restaurant).to.not.be.null;
+            expect(restaurant.foo).to.equal('two');
+          });
+        });
+      });
+
+      describe('concurency tests', function() {
+        it('should build and persist instances to 2 schemas concurrently in any order', function() {
+          var Restaurant = this.Restaurant;
+
+          var restaurauntModelSchema1 = Restaurant.build({bar: 'one.1'});
+          var restaurauntModelSchema2 = Restaurant.build({bar: 'two.1'});
+
+          return restaurauntModelSchema1.save({searchPath: SEARCH_PATH_ONE})
+            .then(function() {
+              restaurauntModelSchema1 = Restaurant.build({bar: 'one.2'});
+              return restaurauntModelSchema2.save({searchPath: SEARCH_PATH_TWO});
+            }).then(function() {
+              return restaurauntModelSchema1.save({searchPath: SEARCH_PATH_ONE});
+            }).then(function() {
+              return Restaurant.findAll({searchPath: SEARCH_PATH_ONE});
+            }).then(function(restaurantsOne) {
+              expect(restaurantsOne).to.not.be.null;
+              expect(restaurantsOne.length).to.equal(2);
+              restaurantsOne.forEach(function(restaurant) {
+                expect(restaurant.bar).to.contain('one');
+              });
+              return Restaurant.findAll({searchPath: SEARCH_PATH_TWO});
+            }).then(function(restaurantsTwo) {
+              expect(restaurantsTwo).to.not.be.null;
+              expect(restaurantsTwo.length).to.equal(1);
+              restaurantsTwo.forEach(function(restaurant) {
+                expect(restaurant.bar).to.contain('two');
+              });
+            });
+        });
+      });
+    });
+  }
+});


### PR DESCRIPTION
When you have a multi-tenant application that has the same database models across multiple schemas the current sequelize model paradigm forces you to create a separate model for each schema that is identical except for the schema property of the tableName object. This change adds a dialect option called prependSearchPath that will allow you to pass a searchPath option to any query that will be prepend the query with "SET search_path to ". If the prependSearchPath options is enabled and no searchPath query option is provided it will use DEFAULT which should be the same behavior as before.  By supporting a searchPath option I can now define a common set of models and use them across tenant schemas by passing the correct searchPath. If the prependSearchPath dialect option is not explicitly passed as true than the code works exactly as it did before.

On the surface this functionality would appear to be possible by using model.schema() but this does not work well when the same model needs to be used against multiple schemas concurrently in the same application as it changes the schema option on the model itself which can lead to inconsistent results. Specifically the following use cases do no work well.

1. Create an instance with model.schema('a').build, create another instance with model.schema('b').build, try and save the first instance. The expected behavior would be that it would be saved in schema 'a' but it will actually be saved in schema 'b'.

2. Since calling .schema() changes the schema option on the model itself this can lead to unexpected behavior if schema is not specified on every usage of the model. If i do model.schema('a').findAll and then later do model.findAll it will use whatever the last schema value that was set rather than a default schema. While this may be expected behavior since .schema() is essentially just a glorified setter of the schema option it is still dangerous and could lead to mixed tenant data.

3. Even when chaining .schema() directly a small window exists where if you were calling .schema() on the same model concurrently you could get unexpected results.