### PR TITLE
Expose Association constructor as `Sequelize.Association`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Next
 - [FIXED] Calling set with dot.separated key on a JSON/JSONB attribute will not flag the entire object as changed [#4379](https://github.com/sequelize/sequelize/pull/4379)
+- [ADDED] Expose Association constructor as `Sequelize.Association`
 
 # 3.9.0
 - [ADDED] beforeRestore/afterRestore hooks [#4371](https://github.com/sequelize/sequelize/issues/4371)

--- a/lib/associations/index.js
+++ b/lib/associations/index.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var Association = require('./base');
+Association.BelongsTo = require('./belongs-to');
+Association.HasOne = require('./has-one');
+Association.HasMany = require('./has-many');
+Association.BelongsToMany = require('./belongs-to-many');
+
+module.exports = Association;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -13,7 +13,8 @@ var url = require('url')
   , sequelizeErrors = require('./errors')
   , Promise = require('./promise')
   , Hooks = require('./hooks')
-  , Instance = require('./instance');
+  , Instance = require('./instance')
+  , Association = require('./associations/index');
 
 /**
  * This is the main class, the entry point to sequelize. To use it, you just need to import sequelize:
@@ -302,6 +303,13 @@ Sequelize.prototype.Deferrable = Sequelize.Deferrable = Deferrable;
  * @see {Instance}
  */
 Sequelize.prototype.Instance = Sequelize.Instance = Instance;
+
+/**
+ * A reference to the sequelize association class.
+ * @property Association
+ * @see {Association}
+ */
+Sequelize.prototype.Association = Sequelize.Association = Association;
 
 /**
  * Allow hooks to be defined on Sequelize + on sequelize instance as universal hooks to run on all models


### PR DESCRIPTION
This PR exposes the `Association` constructor as `Sequelize.Association`. The different association constructors are also exposed as `Sequelize.Association.BelongsTo`, `Sequelize.Association.HasMany` etc.

This is useful for things like:

```js
if (obj instanceof Sequelize.Association) { /* do something */ }
if (association instanceof Sequelize.Association.HasMany) { /* do something */ }
```