### PR TITLE
Fix supportShim

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Next
 - [FIXED] Calling set with dot.separated key on a JSON/JSONB attribute will not flag the entire object as changed [#4379](https://github.com/sequelize/sequelize/pull/4379)
 - [ADDED] Expose Association constructor as `Sequelize.Association`
+- [FIXED] Tests shim all methods to test for correct passing of `options.logging`
 
 # 3.9.0
 - [ADDED] beforeRestore/afterRestore hooks [#4371](https://github.com/sequelize/sequelize/issues/4371)

--- a/test/support.js
+++ b/test/support.js
@@ -29,7 +29,7 @@ Sequelize.Promise.onPossiblyUnhandledRejection(function(e, promise) {
 Sequelize.Promise.longStackTraces();
 
 // shim all Sequelize methods for testing for correct `options.logging` passing
-if (!process.env.COVERAGE && false) supportShim(Sequelize);
+if (!process.env.COVERAGE) supportShim(Sequelize);
 
 var Support = {
   Sequelize: Sequelize,

--- a/test/supportShim.js
+++ b/test/supportShim.js
@@ -14,6 +14,10 @@ module.exports = function(Sequelize) {
   shimAll(Sequelize.Model.prototype);
   shimAll(Sequelize.Instance.prototype);
   shimAll(QueryInterface.prototype);
+  shimAll(Sequelize.Association.prototype);
+  _.forIn(Sequelize.Association, function(Association) {
+    shimAll(Association.prototype);
+  });
 
   // Shim Model.prototype to then shim getter/setter methods
   ['hasOne', 'belongsTo', 'hasMany', 'belongsToMany'].forEach(function(type) {


### PR DESCRIPTION
Attention of @mickhansen. This PR fixes the problems with `supportShim` which you ran into on https://github.com/sequelize/sequelize/pull/4177

The problem was that it wasn't shimming the new `HasMany` methods.

This PR relies on https://github.com/sequelize/sequelize/pull/4540 being merged first.