### PR TITLE
optimize index lookup when schema is known

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -436,18 +436,22 @@ var QueryGenerator = {
   },
 
   showIndexesQuery: function(tableName) {
+    var schemaJoin = '', schemaWhere = '';
     if (!Utils._.isString(tableName)) {
+      schemaJoin = ', pg_namespace s';
+      schemaWhere = Utils._.template(" AND s.oid = t.relnamespace AND s.nspname = '<%= schemaName %>'")({schemaName: tableName.schema});
       tableName = tableName.tableName;
     }
 
     // This is ARCANE!
     var query = 'SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, ' +
       'array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) ' +
-      'AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a ' +
-      'WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND '+
-      "t.relkind = 'r' and t.relname = '<%= tableName %>' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;";
+      'AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a<%= schemaJoin%> ' +
+      'WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND ' +
+      "t.relkind = 'r' and t.relname = '<%= tableName %>'<%= schemaWhere%> " +
+      'GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;';
 
-    return Utils._.template(query)({ tableName: tableName });
+    return Utils._.template(query)({tableName: tableName, schemaJoin: schemaJoin, schemaWhere: schemaWhere});
   },
 
   removeIndexQuery: function(tableName, indexNameOrAttributes) {

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -125,5 +125,26 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         });
       });
     }
+
+    if (current.dialect.name === 'postgres') {
+      test('show indexes', function () {
+        expectsql(sql.showIndexesQuery('table'), {
+          postgres: 'SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, ' +
+          'array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) ' +
+          'AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a ' +
+          'WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND ' +
+          't.relkind = \'r\' and t.relname = \'table\' GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;'
+        });
+
+        expectsql(sql.showIndexesQuery({tableName: 'table', schema: 'schema'}), {
+          postgres: 'SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, ' +
+          'array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) ' +
+          'AS definition FROM pg_class t, pg_class i, pg_index ix, pg_attribute a, pg_namespace s ' +
+          'WHERE t.oid = ix.indrelid AND i.oid = ix.indexrelid AND a.attrelid = t.oid AND ' +
+          't.relkind = \'r\' and t.relname = \'table\' AND s.oid = t.relnamespace AND s.nspname = \'schema\' ' +
+          'GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;'
+        });
+      });
+    }
   });
 });


### PR DESCRIPTION
The performance of the existing showIndexes postgres query is very poor if you have many identical table names across multiple schemas. I have added a restriction to the query to filter by schema name when a schema is present on the tableName object.