### PR TITLE
escaping boolean to 0 or 1 for mssql

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -51,10 +51,7 @@ SqlString.escape = function(val, stringifyObjects, timeZone, dialect, field) {
     // SQLite doesn't have true/false support. MySQL aliases true/false to 1/0
     // for us. Postgres actually has a boolean type with true/false literals,
     // but sequelize doesn't use it yet.
-    if (dialect === 'mssql') {
-      return "'" + val + "'";
-    }
-    if (dialect === 'sqlite') {
+    if (dialect === 'sqlite' || dialect === 'mssql') {
       return +!!val;
     }
     return '' + !!val;

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -131,7 +131,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         $not: true
       }, {
         default: '[deleted] IS NOT true',
-        mssql: "[deleted] IS NOT 'true'",
+        mssql: "[deleted] IS NOT 1",
         sqlite: '`deleted` IS NOT 1'
       });
 


### PR DESCRIPTION
resolves #4619, 

looking for feedback on where the tests live that might be covering this old behavior.