### PR TITLE
Remove outdated reference to v2.0

### DIFF
--- a/docs/docs/models-definition.md
+++ b/docs/docs/models-definition.md
@@ -359,7 +359,7 @@ Validations can also be defined to check the model after the field-specific vali
 
 Model validator methods are called with the model object's context and are deemed to fail if they throw an error&comma; otherwise pass&period; This is just the same as with custom field-specific validators&period;
 
-Any error messages collected are put in the validation result object alongside the field validation errors&comma; with keys named after the failed validation method's key in the `validate` option object&period; Even though there can only be one error message for each model validation method at any one time&comma; it is presented as a single string error in an array&comma; to maximize consistency with the field errors&period; &lpar;Note that the structure of `validate()`'s output is scheduled to change in `v2.0`to avoid this awkward situation&period; In the mean time&comma; an error is issued if a field exists with the same name as a custom model validation&period;&rpar;
+Any error messages collected are put in the validation result object alongside the field validation errors&comma; with keys named after the failed validation method's key in the `validate` option object&period; Even though there can only be one error message for each model validation method at any one time&comma; it is presented as a single string error in an array&comma; to maximize consistency with the field errors&period;
 
 An example&colon;
 


### PR DESCRIPTION
Seeing as we're on 3.11 this seems like it should be removed.