### PR TITLE
Added support for passing domain option to tedious.

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -27,7 +27,6 @@ ConnectionManager.prototype.connect = function(config) {
       userName: config.username,
       password: config.password,
       server: config.host,
-      /* domain: 'DOMAIN' */
       options: {
         port: config.port,
         database: config.database
@@ -38,6 +37,12 @@ ConnectionManager.prototype.connect = function(config) {
       // only set port if no instance name was provided
       if (config.dialectOptions.instanceName) {
         delete connectionConfig.options.port;
+      }
+
+      // The 'tedious' driver needs domain property to be in the main Connection config object
+      if(config.dialectOptions.domain) {
+        connectionConfig.domain = config.dialectOptions.domain;
+        delete config.dialectOptions.domain;
       }
 
       Object.keys(config.dialectOptions).forEach(function(key) {


### PR DESCRIPTION
The current mssql connection manager does not allow for passing in the "domain" to the tedious driver. This patch allows it to pass through by setting it in the dialect options.