### PR TITLE
Improve `previous()` instance method

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -420,7 +420,13 @@ Instance.prototype.changed = function(key, value) {
  * @return {any}
  */
 Instance.prototype.previous = function(key) {
-  return this._previousDataValues[key];
+  if (key) {
+    return this._previousDataValues[key];
+  }
+
+  return _.pick(this._previousDataValues, function(value, key) {
+    return this.changed(key);
+  }, this);
 };
 
 Instance.prototype._setInclude = function(key, value, options) {

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -450,6 +450,23 @@ describe(Support.getTestDialectTeaser('DAO'), function() {
     });
 
     describe('previous', function() {
+      it('should return an object with the previous values', function() {
+        var User = this.sequelize.define('User', {
+          name: { type: DataTypes.STRING },
+          title: { type: DataTypes.STRING }
+        });
+
+        var user = User.build({
+          name: 'Jan Meier',
+          title: 'Mr'
+        });
+
+        user.set('name', 'Mick Hansen');
+        user.set('title', 'Dr');
+
+        expect(user.previous()).to.eql({ name: 'Jan Meier', title: 'Mr' });
+      });
+
       it('should return the previous value', function() {
         var User = this.sequelize.define('User', {
           name: {type: DataTypes.STRING}


### PR DESCRIPTION
This PR improves the `previous()` method by returning an object of the previous values when no `key` is given.