### PR TITLE
Force the client to be reaped if an ECONNRESET is returned on query [postgres]

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -107,6 +107,12 @@ Query.prototype.run = function(sql) {
     });
 
     query.on('error', function(err) {
+
+      // set the client so that it will be reaped if the connection resets while executing
+      if(err.code === 'ECONNRESET') {
+        self.client._invalid = true;
+      }
+
       receivedError = true;
       err.sql = sql;
       reject(self.formatError(err));


### PR DESCRIPTION
## Here's the scenario being addressed

1. Consistent SQL requests are being made through Sequelize, utilizing the postgres dialect and a pool size of 5.
2. A database failover occurs, which resets all active connections to the database server.

## What's expected

The pool members will get invalidated, and are able to reconnect when the database is accessible. 


## Without this PR

1. The Query on error will return a parsed ECONNRESET error message.
2. The client from pool is never marked invalid, so it returned on the next request for a handle.
3. The next query is requested to run on the client from the pool, however it never returns from the request. At this stage, all clients from the pool are active, but will never return, completely locking the system down.

## With this PR

1. The Query will mark the client as invalid.
2. The next query requested asks for a client from the pool. generic-pool validate function is run, reaping this client.
3. A new client is created with the proper connection credentials and database requests resume.

## Why

We faced this exact scenario in a production environment this week when an automatic database failover occurred. This PR addresses the scenario, utilizing the existing generic-pool validation methods, coupled with the ````_invalid```` variable which was introduced [here](https://github.com/sequelize/sequelize/blob/master/lib/dialects/postgres/connection-manager.js#L94) to address connection issues while the database server is unreachable. 

In the scenario outlined above, the ````connection.on('error')```` is never called, only the query received the event regarding the ECONNRESET. 

## Testing

This scenario is difficult to replicate in a unit testing environment. Beyond the unit tests passing, I could not think of a test suite to test this scenario.

Here is the manual testing which was performed against this PR:

1. Run API server, which utilizes postgres and sequelize.
2. Create a steady flood of requests to the server to ensure no idle reaping of connections occurred. (e.g. [script](https://gist.github.com/robraux/ffba98e810568a5559b6))
3. For a database restart, or failover. (e.g  ````aws rds reboot-db-instance --force-failover --db-instance-identifier psql-testing````)
4. Observe the flood script start returning 500's as ECONNRESETS happen, then errors when the database is still starting up. Finally, after approximately a minute in our scenario, the API is responding to requests with a 200.



