### PR TITLE
Fixed generated SQL when using find with through.where and required true

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1266,7 +1266,7 @@ var QueryGenerator = {
 
                 if (topInclude.through && Object(topInclude.through.model) === topInclude.through.model) {
                   $query = self.selectQuery(topInclude.through.model.getTableName(), {
-                    attributes: [topInclude.through.model.primaryKeyAttributes[0]],
+                    attributes: [topInclude.through.model.primaryKeyField],
                     include: Model.$validateIncludedElements({
                       model: topInclude.through.model,
                       include: [{
@@ -1277,7 +1277,7 @@ var QueryGenerator = {
                     model: topInclude.through.model,
                     where: { $and: [
                       self.sequelize.asIs([
-                        self.quoteTable(topParent.model.name) + '.' + self.quoteIdentifier(topParent.model.primaryKeyAttributes[0]),
+                        self.quoteTable(topParent.model.name) + '.' + self.quoteIdentifier(topParent.model.primaryKeyField),
                         self.quoteIdentifier(topInclude.through.model.name) + '.' + self.quoteIdentifier(topInclude.association.identifierField)
                       ].join(' = ')),
                       topInclude.through.where

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -586,7 +586,7 @@ var QueryGenerator = {
     if (options.limit || options.offset) {
       if (!options.order || (options.include && !subQueryOrder.length)) {
         fragment += (options.order && !isSubQuery) ? ', ' : ' ORDER BY ';
-        fragment += this.quoteIdentifier(model.primaryKeyAttribute);
+        fragment += this.quoteIdentifier(model.primaryKeyField);
       }
 
       if (options.offset || options.limit) {


### PR DESCRIPTION
when the primary key attribute is different from the primary key field

Kind of relates to ##3940. Using the primaryKeyAttribute generates wrong SQL if the database field and the model attributes are named differently.