### PR TITLE
Remove usage of "limit" in some places where it's unnecessary

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Next
 - [Fixed] Mark postgres connection as invalid if the connection is reset [#4661](https://github.com/sequelize/sequelize/pull/4661)
+- [FIXED] Remove usage of "limit" in cases where it's unnecessary, which fixes some of the cases mentioned in [#4404] (https://github.com/sequelize/sequelize/issues/4404)
 
 # 3.12.0
 - [ADDED] Preliminary support for `include.on`.

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -729,7 +729,6 @@ Instance.prototype.save = function(options) {
 Instance.prototype.reload = function(options) {
   options = _.defaults({}, options, {
     where: this.where(),
-    limit: 1,
     include: this.$options.include || null
   });
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1466,10 +1466,8 @@ Model.prototype.findById = function(param, options) {
     throw new Error('Argument passed to findById is invalid: '+param);
   }
 
-  // Bypass a possible overloaded findAll.
-  return Model.prototype.findAll.call(this, _.defaults(options, {
-    plain: true
-  }));
+  // Bypass a possible overloaded findOne
+  return Model.prototype.findOne.call(this, options);
 };
 Model.prototype.findByPrimary = Model.prototype.findById;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1440,19 +1440,19 @@ Model.$findSeparate = function(results, options) {
 };
 
 /**
-* Search for a single instance by its primary key. This applies LIMIT 1, so the listener will always be called with a single instance.
+* Search for a single instance by its primary key.
 *
-* @param  {Number|String|Buffer}      [options] A hash of options to describe the scope of the search, or a number to search by id.
-* @param  {Object}             '      [options]
+* @param  {Number|String|Buffer}      id The value of the desired instance's primary key.
+* @param  {Object}                    [options]
 * @param  {Transaction}               [options.transaction] Transaction to run query under
 * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
 *
-* @see {Model#findAll}           for an explanation of options
+* @see {Model#findAll}           for a full explanation of options
 * @return {Promise<Instance>}
 * @alias findByPrimary
 */
 Model.prototype.findById = function(param, options) {
-  // For sanity findById will never return if no options are passed
+  // return Promise resolved with null if no arguments are passed
   if ([null, undefined].indexOf(param) !== -1) {
     return Promise.resolve(null);
   }


### PR DESCRIPTION
The queries for `Model.findById` and `Instance.reload` don't need to specify a limit of one record, since we're querying with the primary key anyway. Including the limit in the generated SQL is redundant and adds unnecessary complication to the queries.

This is also somewhat related to [issue 4404] (https://github.com/sequelize/sequelize/issues/4404) -- these changes allow `findById` and `reload` to work on MS SQL Server versions before 2012, where previously they were broken due to the `OFFSET FETCH` issue. 4404 isn't completely fixed though, because queries that actually need the `offset` and `limit` options are still broken.
