### PR TITLE
pg range handling improved

### DIFF
--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -3,12 +3,34 @@
 var Utils = require('../../utils'),
   moment = require('moment');
 
+function stringifyRangeBound (bound) {
+  if (bound === null) {
+    return '' ;
+  } else if (bound === Infinity || bound === -Infinity) {
+    return bound.toString().toLowerCase();
+  } else {
+    return JSON.stringify(bound);
+  }
+}
+
+function parseRangeBound (bound, parseType) {
+  if (!bound) {
+    return null;
+  } else if (bound === 'infinity') {
+    return Infinity;
+  } else if (bound === '-infinity') {
+    return -Infinity;
+  } else {
+    return parseType(bound);
+  }
+}
+
 function stringify (data) {
   if (data === null) return null;
 
-  if (!Utils._.isArray(data) || data.length !== 2) return '';
-
-  if (Utils._.any(data, Utils._.isNull)) return '';
+  if (!Utils._.isArray(data)) return ''; // will throw error, since '' is not a valid PG range literal
+  if (!data.length) return 'empty';
+  if (data.length !== 2) return ''; // will throw error, since '' is not a valid PG range literal
 
   if (data.hasOwnProperty('inclusive')) {
     if (!data.inclusive) data.inclusive = [false, false];
@@ -24,11 +46,19 @@ function stringify (data) {
     }
   });
 
-  return (data.inclusive[0] ? '[' : '(') + JSON.stringify(data[0]) + ',' + JSON.stringify(data[1]) + (data.inclusive[1] ? ']' : ')');
+  var lowerBound = stringifyRangeBound(data[0]);
+  var upperBound = stringifyRangeBound(data[1]);
+
+  return (data.inclusive[0] ? '[' : '(') + lowerBound + ',' + upperBound + (data.inclusive[1] ? ']' : ')');
 }
 
 function parse (value, AttributeType) {
   if (value === null) return null;
+  if (value === 'empty') {
+    var empty = [];
+    empty.inclusive = [];
+    return empty;
+  }
 
   if(typeof AttributeType === 'function') AttributeType = new AttributeType();
   AttributeType = AttributeType || ''; // if attribute is not defined, assign empty string in order to prevent
@@ -43,13 +73,13 @@ function parse (value, AttributeType) {
     .map(function (value) {
       switch (AttributeType.toString()) {
         case 'int4range':
-          return parseInt(value, 10);
+          return parseRangeBound(value, function(value) { return parseInt(value, 10); });
         case 'numrange':
-          return parseFloat(value);
+          return parseRangeBound(value, parseFloat);
         case 'daterange':
         case 'tsrange':
         case 'tstzrange':
-          return moment(value).toDate();
+          return parseRangeBound(value, function (value) { return moment(value).toDate(); });
       }
 
       return value;

--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -28,9 +28,9 @@ function parseRangeBound (bound, parseType) {
 function stringify (data) {
   if (data === null) return null;
 
-  if (!Utils._.isArray(data)) return ''; // will throw error, since '' is not a valid PG range literal
+  if (!Utils._.isArray(data)) throw new Error('range must be an array');
   if (!data.length) return 'empty';
-  if (data.length !== 2) return ''; // will throw error, since '' is not a valid PG range literal
+  if (data.length !== 2) throw new Error('range array length must be 0 (empty) or 2 (lower and upper bounds)');
 
   if (data.hasOwnProperty('inclusive')) {
     if (!data.inclusive) data.inclusive = [false, false];
@@ -79,7 +79,17 @@ function parse (value, AttributeType) {
         case 'daterange':
         case 'tsrange':
         case 'tstzrange':
-          return parseRangeBound(value, function (value) { return moment(value).toDate(); });
+          return parseRangeBound(value, function (value) {
+            if (value.charAt(0) === '"') {
+              value = value.substr(1, value.length-2); // remove quotes around date
+            }
+            if (value.match(/[\+\-]\d\d$/)) {
+              // PG returns date in "2016-01-01 08:00:00-04" format
+              // It must be transformed to "2016-01-01 08:00:00-0400" ("00 at the end) to be recognized by moment.js
+              value = value + '00';
+            }
+            return moment(value).toDate();
+          });
       }
 
       return value;

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -6,7 +6,7 @@ var chai    = require('chai')
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
   , dialect = Support.getTestDialect()
   , range   = require('../../../../lib/dialects/postgres/range')
-  , _       = require(__dirname + '/../../support').Sequelize.Utils._;
+  , _       = require('lodash');
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] range datatype', function () {
@@ -29,15 +29,15 @@ if (dialect.match(/^postgres/)) {
         expect(range.stringify([-Infinity, Infinity])).to.equal('(-infinity,infinity)');
       });
 
-      it('should return empty string when boundaries array of invalid size', function () {
-        expect(range.stringify([1])).to.equal('');
-        expect(range.stringify([1, 2, 3])).to.equal('');
+      it('should throw error when array length is no 0 or 2', function () {
+        expect(function () { range.stringify([1]) }).to.throw();
+        expect(function () { range.stringify([1, 2, 3]) }).to.throw();
       });
 
-      it('should return empty string when non-array parameter is passed', function () {
-        expect(range.stringify({})).to.equal('');
-        expect(range.stringify('test')).to.equal('');
-        expect(range.stringify(undefined)).to.equal('');
+      it('should throw error when non-array parameter is passed', function () {
+        expect(function () { range.stringify({}) }).to.throw();
+        expect(function () { range.stringify('test') }).to.throw();
+        expect(function () { range.stringify(undefined) }).to.throw();
       });
 
       it('should handle array of objects with `inclusive` and `value` properties', function () {
@@ -98,6 +98,11 @@ if (dialect.match(/^postgres/)) {
       it('should return raw value if not range is returned', function () {
         expect(range.parse('some_non_array')).to.deep.equal('some_non_array');
       });
+
+      it('should handle native postgres timestamp format', function () {
+        expect(range.parse('(2016-01-01 08:00:00-04,)', 'tstzrange')[0].toISOString()).to.equal('2016-01-01T12:00:00.000Z');
+      });
+
     });
     describe('stringify and parse', function () {
       it('should stringify then parse back the same structure', function () {

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -30,14 +30,14 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should throw error when array length is no 0 or 2', function () {
-        expect(function () { range.stringify([1]) }).to.throw();
-        expect(function () { range.stringify([1, 2, 3]) }).to.throw();
+        expect(function () { range.stringify([1]); }).to.throw();
+        expect(function () { range.stringify([1, 2, 3]); }).to.throw();
       });
 
       it('should throw error when non-array parameter is passed', function () {
-        expect(function () { range.stringify({}) }).to.throw();
-        expect(function () { range.stringify('test') }).to.throw();
-        expect(function () { range.stringify(undefined) }).to.throw();
+        expect(function () { range.stringify({}); }).to.throw();
+        expect(function () { range.stringify('test'); }).to.throw();
+        expect(function () { range.stringify(undefined); }).to.throw();
       });
 
       it('should handle array of objects with `inclusive` and `value` properties', function () {


### PR DESCRIPTION
@janmeier @mickhansen I've improved pg ranges to handle unbound ranges, +/-infinity bounds and empty ranges:

```js
range.stringify([]) == 'empty'
range.stringify([null, 1]) == '(,1)'
range.stringify([1, null]) == '(1,)'
range.stringify([null, null]) == '(,)'
range.stringify([-Infinity, 10]) == '(-infinity,10)'
range.stringify([-Infinity, Infinity]) == '(-infinity,infinity)'

range.parse('empty', 'int4range') == [] // inclusive: []
range.parse('(,1)', 'int4range') == [null, 1] // inclusive: [false, false]
range.parse('(1,)', 'int4range') == [1, null] // inclusive: [false, false]
range.parse('(,)', 'int4range') == [null, null] // inclusive: [false, false]
range.parse('(-infinity,10)', 'int4range') == [-Infinity, 10] // inclusive: [false, false]
range.parse('(-infinity,infinity)', 'int4range') == [-Infinity, Infinity] // inclusive: [false, false]
```

I've also added/modified proper tests. However there is one thing I am not sure of - before my PR if any bound in an array was null or passed range was not an array at all, then `range.stringify()` returned empty string, which is not a valid PG range literal and caused PG error `ERROR:  malformed range literal: ""`. I am not sure if it is bug or intensional, but I partially left this behaviour:

```js
function stringify (data) {
  if (data === null) return null;
  if (!Utils._.isArray(data)) return ''; // will throw error, since '' is not a valid PG range literal
  if (!data.length) return 'empty';
  if (data.length !== 2) return ''; // will throw error, since '' is not a valid PG range literal
  ...
```
So if range is not an array OR it's not empty array (which means empty range) OR range.length is not 2 then it will throw error as I described above. It could stay as is, but maybe it would be good idea to throw some validation error here instead of leaving this for postgres?