### PR TITLE
Lowercase onDelete option before cheking its value

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # NEXT
 - [FIXED] Mark unscoped model as `.scoped`, to prevent injection of default scope on includes [#4663](https://github.com/sequelize/sequelize/issues/4663)
+- [ADDED/FIXED] Lower case `onDelete` option to allow the use of `onDelete: 'CASCADE', hooks: true`.
 
 # 3.12.1
 - [FIXED] Mark postgres connection as invalid if the connection is reset [#4661](https://github.com/sequelize/sequelize/pull/4661)

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -629,13 +629,15 @@ QueryInterface.prototype.delete = function(instance, tableName, identifier, opti
   // Check for a restrict field
   if (!!instance.Model && !!instance.Model.associations) {
     var keys = Object.keys(instance.Model.associations)
-      , length = keys.length;
+      , length = keys.length
+      , association;
 
     for (var i = 0; i < length; i++) {
-      if (instance.Model.associations[keys[i]].options && instance.Model.associations[keys[i]].options.onDelete) {
-        if (instance.Model.associations[keys[i]].options.onDelete === 'cascade' && instance.Model.associations[keys[i]].options.useHooks === true) {
-          cascades.push(instance.Model.associations[keys[i]].accessors.get);
-        }
+      association = instance.Model.associations[keys[i]];
+      if (association.options && association.options.onDelete &&
+        association.options.onDelete.toLowerCase() === 'cascade' &&
+        association.options.useHooks === true) {
+        cascades.push(association.accessors.get);
       }
     }
   }

--- a/test/integration/hooks.test.js
+++ b/test/integration/hooks.test.js
@@ -1122,7 +1122,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
             title: DataTypes.STRING
           });
 
-          this.Projects.hasOne(this.Tasks, {onDelete: 'cascade', hooks: true});
+          this.Projects.hasOne(this.Tasks, {onDelete: 'CASCADE', hooks: true});
           this.Tasks.belongsTo(this.Projects);
 
           return this.sequelize.sync({ force: true });


### PR DESCRIPTION
This allow to define association using uppercase onDelete option: `{ onDelete: 'CASCADE', hooks: true }`. Default values for constraints are uppercase in the doc.