### PR TITLE
Aggregation query doc improvement

### DIFF
--- a/docs/docs/querying.md
+++ b/docs/docs/querying.md
@@ -26,7 +26,7 @@ You can use `sequelize.fn` to do aggregations:
 
 ```js
 Model.findAll({
-  attributes: [sequelize.fn('COUNT', sequelize.col('hats')), 'no_hats']
+  attributes: [[sequelize.fn('COUNT', sequelize.col('hats')), 'no_hats']]
 });
 ```
 ```sql


### PR DESCRIPTION
```js
attributes: [[sequelize.fn('COUNT', sequelize.col('hats')), 'no_hats']]
```
Instead of
```js
attributes: [sequelize.fn('COUNT', sequelize.col('hats')), 'no_hats']
```
in querying docs for aggregation using sequelize.fn