### PR TITLE
Change wrong comment in `project.getTasks()` example

### DIFF
--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -399,9 +399,8 @@ project.getTasks({ where: 'id > 10' }).then(function(tasks) {
 })
  
 // You can also only retrieve certain fields of a associated object.
-// This example will retrieve the attributes "title" and "id"
 project.getTasks({attributes: ['title']}).then(function(tasks) {
-  // tasks with an id greater than 10 :)
+    // retreive tasks with the attributes "title" and "id"
 })
 ```
 

--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -400,7 +400,7 @@ project.getTasks({ where: 'id > 10' }).then(function(tasks) {
  
 // You can also only retrieve certain fields of a associated object.
 project.getTasks({attributes: ['title']}).then(function(tasks) {
-    // retreive tasks with the attributes "title" and "id"
+    // retrieve tasks with the attributes "title" and "id"
 })
 ```
 


### PR DESCRIPTION
There was a wrong comment in the `project.getTasks()` example saying that `project.getTasks({attributes: ['title']})` would retrieve articles with an id higher than 10, which was not true, I updated the comment. 