### PR TITLE
Update querying documentation

### DIFF
--- a/docs/docs/querying.md
+++ b/docs/docs/querying.md
@@ -254,6 +254,15 @@ something.findOne({
 
     // Will order by  otherfunction(`col1`, 12, 'lalala') DESC
     [sequelize.fn('otherfunction', sequelize.col('col1'), 12, 'lalala'), 'DESC'],
+    
+    // Will order by name on an associated User
+    [User, 'name', 'DESC'],
+    
+    // Will order by name on an associated User aliased as Friend
+    [{model: User, as: 'Friend'}, 'name', 'DESC'],
+    
+    // Will order by name on a nested associated Company of an associated User
+    [User, Company, 'name', 'DESC'],
   ]
   // All the following statements will be treated literally so should be treated with care
   order: 'convert(user_name using gbk)'


### PR DESCRIPTION
`order` supports both ordering by an instance's associate's fields as well as any nested associate's fields. `order` also supports aliased associates too. This update adds an example of this functionality to the documentation, so that users are both aware of and how to use this feature.