### PR TITLE
Made unsupported dialect error message clearer.

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -202,7 +202,7 @@ var Sequelize = function(database, username, password, options) {
     }
     this.dialect = new Dialect(this);
   } catch (err) {
-    throw new Error('The dialect ' + this.getDialect() + ' is not supported. ('+err+')');
+    throw new Error('The dialect ' + this.getDialect() + ' is not supported. Supported dialects: mariadb, mssql, mysql, postgres, and sqlite. ('+err+')');
   }
 
   this.dialect.QueryGenerator.typeValidation = options.typeValidation;

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -57,7 +57,7 @@ describe(Support.getTestDialectTeaser('Configuration'), function() {
     it('when we don\'t have a valid dialect.', function() {
       expect(function() {
         new Sequelize(config[dialect].database, config[dialect].username, config[dialect].password, {host: '0.0.0.1', port: config[dialect].port, dialect: undefined});
-      }).to.throw(Error, 'The dialect undefined is not supported.');
+      }).to.throw(Error, 'The dialect undefined is not supported. Supported dialects: mariadb, mssql, mysql, postgres, and sqlite.');
     });
   });
 


### PR DESCRIPTION
In response to #4747.

I considered re-writing the code thus that the supported dialects were all defined in one place (e.g in an array), but ultimately decided to [_KISS_](https://en.wikipedia.org/wiki/KISS_principle).

I ran Mocha on the effected file. Something so simple shouldn't introduce a regression but let's what Travis has to say :smirk: 

