### PR TITLE
Comments on columns postgres dialect

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -48,18 +48,17 @@ var QueryGenerator = {
 
     var query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>)<%= comments %>'
       , comments = ''
-      , attrStr = []
-      , i;
+      , attrStr = [];
 
     if (options.comment && Utils._.isString(options.comment)) {
       comments += '; COMMENT ON TABLE <%= table %> IS ' + this.escape(options.comment);
     }
 
     for (var attr in attributes) {
-      if ((i = attributes[attr].indexOf('COMMENT')) !== -1) {
-        // Move comment to a separate query
-        comments += '; ' + attributes[attr].substring(i);
-        attributes[attr] = attributes[attr].substring(0, i);
+      var commentSplit = this.splitAttributeColumn(attributes[attr]);
+      if (commentSplit.comment !== '') {
+        attributes[attr] = commentSplit.attribute;
+        comments += '; ' + this.pgCommentColumn(tableName, attr, commentSplit.comment);
       }
 
       var dataType = this.pgDataTypeMapping(tableName, attr, attributes[attr]);
@@ -178,12 +177,19 @@ var QueryGenerator = {
   },
 
   addColumnQuery: function(table, key, dataType) {
-    var query = 'ALTER TABLE <%= table %> ADD COLUMN <%= attribute %>;'
+    var query = 'ALTER TABLE <%= table %> ADD COLUMN <%= attribute %><%= comment %>;'
       , dbDataType = this.attributeToSQL(dataType, {context: 'addColumn'})
-      , attribute;
+      , attribute
+      , comment = '';
 
     if (dataType.type && dataType.type instanceof DataTypes.ENUM || dataType instanceof DataTypes.ENUM) {
       query = this.pgEnum(table, key, dataType) + query;
+    }
+
+    var commentSplit = this.splitAttributeColumn(dbDataType);
+    if (commentSplit.comment !== '') {
+      dbDataType = commentSplit.attribute;
+      comment = '; ' + this.pgCommentColumn(table, key, commentSplit.comment);
     }
 
     attribute = Utils._.template('<%= key %> <%= definition %>')({
@@ -193,7 +199,8 @@ var QueryGenerator = {
 
     return Utils._.template(query)({
       table: this.quoteTable(table),
-      attribute: attribute
+      attribute: attribute,
+      comment: comment
     });
   },
 
@@ -500,6 +507,10 @@ var QueryGenerator = {
         template += ' <%= deferrable %>';
         replacements.deferrable = attribute.references.deferrable.toString(this);
       }
+    }
+
+    if (attribute.comment && Utils._.isString(attribute.comment) && attribute.comment.length) {
+      template += ' COMMENT ' + this.escape(attribute.comment);
     }
 
     return  Utils._.template(template)(replacements);
@@ -926,6 +937,30 @@ var QueryGenerator = {
 
   geometrySelect: function(column) {
     return this.quoteIdentifiers(column);
+  },
+
+  splitAttributeColumn: function(attribute) {
+    var i;
+    if ((i = attribute.indexOf('COMMENT')) !== -1) {
+      return {
+        attribute: attribute.substring(0, i).trim(),
+        comment: attribute.substring(i + 7).trim()
+      };
+    }
+
+    return {
+      attribute: attribute,
+      comment: ''
+    };
+  },
+
+  pgCommentColumn: function(tableName, attr, comment) {
+    var template = 'COMMENT ON COLUMN <%= table %>.<%= attr %> IS <%= comment %>';
+    return Utils._.template(template)({
+      table: this.quoteTable(tableName),
+      attr: this.quoteIdentifier(attr),
+      comment: comment
+    });
   }
 };
 

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -58,6 +58,16 @@ if (dialect.match(/^postgres/)) {
           expectation: {id: 'INTEGER UNIQUE'}
         },
 
+        // Comments
+        {
+          arguments: [{id: {type: 'INTEGER', comment: 'Test Comment'}}],
+          expectation: {id: 'INTEGER COMMENT \'Test Comment\''}
+        },
+        {
+          arguments: [{id: {type: 'INTEGER', primaryKey: true, autoIncrement: true, comment: 'Test Comment'}}],
+          expectation: {id: 'INTEGER SERIAL PRIMARY KEY COMMENT \'Test Comment\''}
+        },
+
         // Old references style
         {
           arguments: [{id: {type: 'INTEGER', references: 'Bar'}}],
@@ -189,6 +199,16 @@ if (dialect.match(/^postgres/)) {
         {
           arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)', otherId: 'INTEGER REFERENCES "otherTable" ("id") ON DELETE CASCADE ON UPDATE NO ACTION'}],
           expectation: 'CREATE TABLE IF NOT EXISTS \"myTable\" (\"title\" VARCHAR(255), \"name\" VARCHAR(255), \"otherId\" INTEGER REFERENCES \"otherTable\" (\"id\") ON DELETE CASCADE ON UPDATE NO ACTION);'
+        },
+
+        // Comments
+        {
+          arguments: [{tableName: 'myTable', schema: 'mySchema'}, {title: 'VARCHAR(255) COMMENT \'Title Comment\'', name: 'VARCHAR(255) COMMENT \'Name Comment\''}],
+          expectation: 'CREATE TABLE IF NOT EXISTS \"mySchema\".\"myTable\" (\"title\" VARCHAR(255), \"name\" VARCHAR(255)); COMMENT ON COLUMN \"mySchema\".\"myTable\".\"title\" IS \'Title Comment\'; COMMENT ON COLUMN \"mySchema\".\"myTable\".\"name\" IS \'Name Comment\';'
+        },
+        {
+          arguments: [{tableName: 'myTable', schema: 'mySchema'}, {title: 'VARCHAR(255) COMMENT \'Title Comment\'', name: 'VARCHAR(255)'}, {comment: 'Table Comment'}],
+          expectation: 'CREATE TABLE IF NOT EXISTS \"mySchema\".\"myTable\" (\"title\" VARCHAR(255), \"name\" VARCHAR(255)); COMMENT ON TABLE \"mySchema\".\"myTable\" IS \'Table Comment\'; COMMENT ON COLUMN \"mySchema\".\"myTable\".\"title\" IS \'Title Comment\';'
         },
 
         // Variants when quoteIdentifiers is false
@@ -926,6 +946,17 @@ if (dialect.match(/^postgres/)) {
           arguments: ['User', 'mySchema.user_foo_bar'],
           expectation: 'DROP INDEX IF EXISTS mySchema.user_foo_bar',
           context: {options: {quoteIdentifiers: false}}
+        }
+      ],
+
+      addColumnQuery: [
+        {
+          arguments: ['myTable', 'title', {type: 'VARCHAR(255)', allowNull: false}],
+          expectation: 'ALTER TABLE \"myTable\" ADD COLUMN "title" VARCHAR(255) NOT NULL;'
+        },
+        {
+          arguments: [{tableName: 'myTable', schema: 'mySchema'}, 'title', {type: 'VARCHAR(255)', comment: 'Test Comment'}],
+          expectation: 'ALTER TABLE \"mySchema\".\"myTable\" ADD COLUMN "title" VARCHAR(255); COMMENT ON COLUMN \"mySchema\".\"myTable\"."title" IS \'Test Comment\';',
         }
       ]
     };


### PR DESCRIPTION
Adds column commenting for createTable and addColumn for postgres dialect.

Example usage:
```javascript
queryInterface.createTable(
    'test',
    {
        id: {
            type: Sequelize.INTEGER,
            autoIncrement: true,
            primaryKey: true,
            comment: 'Unique identifier'
        }
    },
    {
        schema: 'playground'
    }
);

queryInterface.addColumn(
    {tableName: 'test', schema: 'playground'},
    'testColumn',
    {
        type: Sequelize.STRING,
        allowNull: false,
        comment: 'testing comments'
    }
);
```