### PR TITLE
[docs] Fixed beforeBulkUpdate explanation.

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -334,7 +334,7 @@ Hooks.hasHooks = Hooks.hasHook;
  */
 
 /**
- * A hook that is run after updating instances in bulk
+ * A hook that is run before updating instances in bulk
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with options
  * @name beforeBulkUpdate


### PR DESCRIPTION
Docs for `beforeBulkUpdate` read:
"A hook that is run **after** updating instances in bulk"

It looks like this line was a simple, accidental copy-and-paste from it's sibling, `afterBulkUpdate`.

This commit changes `beforeBulkUpdate` to read correctly:
"A hook that is run **before** updating instances in bulk"

Thanks for your work on Sequelize!