### PR TITLE
Apply scopes to `aggregate`, fixes #4764

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 - [FIXED] timestamp columns are no longer undefined for associations loaded with `separate`. [#4740](https://github.com/sequelize/sequelize/issues/4740)
 - [FIXED] Mark unscoped model as `.scoped`, to prevent injection of default scope on includes [#4663](https://github.com/sequelize/sequelize/issues/4663)
 - [ADDED] `.previous` now returns and object of previous values when called without `key`. This brings the API in line with `.changed`
+- [FIXED] Apply scopes to `aggregate` [#4764](https://github.com/sequelize/sequelize/issues/4764)
 
 # 3.12.1
 - [FIXED] Mark postgres connection as invalid if the connection is reset [#4661](https://github.com/sequelize/sequelize/pull/4661)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1523,6 +1523,8 @@ Model.prototype.find = Model.prototype.findOne;
  */
 Model.prototype.aggregate = function(field, aggregateFunction, options) {
   options = Utils._.extend({ attributes: [] }, options || {});
+  conformOptions(options, this);
+  Model.$injectScope(this.$scope, options);
 
   var aggregateColumn = this.sequelize.col(field);
   if (options.distinct) {

--- a/test/integration/model/scope/aggregate.test.js
+++ b/test/integration/model/scope/aggregate.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+/* jshint -W030 */
+/* jshint -W110 */
+var chai = require('chai')
+  , Sequelize = require('../../../../index')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../../support');
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+  describe('scope', function () {
+    describe('aggregate', function () {
+      beforeEach(function () {
+        this.ScopeMe = this.sequelize.define('ScopeMe', {
+          username: Sequelize.STRING,
+          email: Sequelize.STRING,
+          access_level: Sequelize.INTEGER,
+          other_value: Sequelize.INTEGER
+        }, {
+          defaultScope: {
+            where: {
+              access_level: {
+                gte: 5
+              }
+            }
+          },
+          scopes: {
+            lowAccess: {
+              where: {
+                access_level: {
+                  lte: 5
+                }
+              }
+            },
+            withOrder: {
+              order: 'username'
+            }
+          }
+        });
+
+        return this.sequelize.sync({force: true}).then(function() {
+          var records = [
+            {username: 'tony', email: 'tony@sequelizejs.com', access_level: 3, other_value: 7},
+            {username: 'tobi', email: 'tobi@fakeemail.com', access_level: 10, other_value: 11},
+            {username: 'dan', email: 'dan@sequelizejs.com', access_level: 5, other_value: 10},
+            {username: 'fred', email: 'fred@foobar.com', access_level: 3, other_value: 7}
+          ];
+          return this.ScopeMe.bulkCreate(records);
+        }.bind(this));
+      });
+
+      it('should apply defaultScope', function () {
+        return expect(this.ScopeMe.aggregate( '*', 'count' )).to.eventually.equal(2);
+      });
+
+      it('should be able to override default scope', function () {
+        return expect(this.ScopeMe.aggregate( '*', 'count', { where: { access_level: { gt: 5 }}})).to.eventually.equal(1);
+      });
+
+      it('should be able to unscope', function () {
+        return expect(this.ScopeMe.unscoped().aggregate( '*', 'count' )).to.eventually.equal(4);
+      });
+
+      it('should be able to apply other scopes', function () {
+        return expect(this.ScopeMe.scope('lowAccess').aggregate( '*', 'count' )).to.eventually.equal(3);
+      });
+
+      it('should be able to merge scopes with where', function () {
+        return expect(this.ScopeMe.scope('lowAccess').aggregate( '*', 'count', { where: { username: 'dan'}})).to.eventually.equal(1);
+      });
+
+      it('should ignore the order option if it is found within the scope', function () {
+        return expect(this.ScopeMe.scope('withOrder').aggregate( '*', 'count' )).to.eventually.equal(4);
+      });
+    });
+  });
+});

--- a/test/integration/model/scope/aggregate.test.js
+++ b/test/integration/model/scope/aggregate.test.js
@@ -68,10 +68,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       it('should be able to merge scopes with where', function () {
         return expect(this.ScopeMe.scope('lowAccess').aggregate( '*', 'count', { where: { username: 'dan'}})).to.eventually.equal(1);
       });
-
-      it('should ignore the order option if it is found within the scope', function () {
-        return expect(this.ScopeMe.scope('withOrder').aggregate( '*', 'count' )).to.eventually.equal(4);
-      });
     });
   });
 });


### PR DESCRIPTION
Applies scopes in Model.aggregate, fixing #4764 