### PR TITLE
io.js has been merged into node.js so it doesn't need to be mentioned separately anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 
 node_js:
-  - "0.10"
+  - "node"
+  - "4.2"
   - "0.12"
-  - "iojs-v1"
-  - "iojs-v2"
+  - "0.10"
 
 sudo: false
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=955&style=bounties_received)](https://www.bountysource.com/teams/sequelize/issues?utm_source=Sequelize&utm_medium=shield&utm_campaign=bounties_received)
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com)
 
-Sequelize is a promise-based Node.js/io.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.
+Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.
 
 [Documentation](http://sequelize.readthedocs.org/en/latest/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
   <span>Sequelize</span>
 </div>
 
-Sequelize is a promise-based ORM for Node.js and io.js. It supports the dialects PostgreSQL, MySQL,
+Sequelize is a promise-based ORM for Node.js. It supports the dialects PostgreSQL, MySQL,
 MariaDB, SQLite and MSSQL and features solid transaction support, relations, read replication and
 more.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
-site_name: Sequelize | The Node.js / io.js ORM for PostgreSQL, MySQL, SQLite and MSSQL
-site_description: Sequelize is an ORM for Node.js and io.js. It supports the dialects PostgreSQL, MySQL, MariaDB, SQLite and MSSQL.
+site_name: Sequelize | The Node.js ORM for PostgreSQL, MySQL, SQLite and MSSQL
+site_description: Sequelize is an ORM for Node.js. It supports the dialects PostgreSQL, MySQL, MariaDB, SQLite and MSSQL.
 repo_url: https://github.com/sequelize/sequelize
 site_favicon: favicon.ico
 site_url: http://docs.sequelizejs.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize",
-  "description": "Multi dialect ORM for Node.JS/io.js",
+  "description": "Multi dialect ORM for Node.JS",
   "version": "3.13.0",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [


### PR DESCRIPTION
Also alter the Travis config: switch from io.js v1,2 to node.js v4.2 (LTS) and 'node' (currently v5)