### PR TITLE
prevent sequelize.sync from dropping tables

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -924,7 +924,8 @@ Sequelize.prototype.sync = function(options) {
   options = options || {};
   options.hooks = options.hooks === undefined ? true : !!options.hooks;
   options.logging = options.logging === undefined ? false : options.logging;
-  options = Utils._.defaults(options, this.options.sync, this.options);
+
+  options = Utils._.defaults(options, this.options.sync, this.options, { sync: false });
 
   if (options.match) {
     if (!options.match.test(this.config.database)) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -924,7 +924,6 @@ Sequelize.prototype.sync = function(options) {
   options = options || {};
   options.hooks = options.hooks === undefined ? true : !!options.hooks;
   options.logging = options.logging === undefined ? false : options.logging;
-
   options = Utils._.defaults(options, this.options.sync, this.options, { sync: false });
 
   if (options.match) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -924,7 +924,7 @@ Sequelize.prototype.sync = function(options) {
   options = options || {};
   options.hooks = options.hooks === undefined ? true : !!options.hooks;
   options.logging = options.logging === undefined ? false : options.logging;
-  options = Utils._.defaults(options, this.options.sync, this.options, { sync: false });
+  options = Utils._.defaults(options, this.options.sync, this.options, { force: false });
 
   if (options.match) {
     if (!options.match.test(this.config.database)) {


### PR DESCRIPTION
Currently if you add do
```javascript
sequelize.sync({
    force: undefined
});
```
all tables will get dropped. By default there should be a fallback to `false` if there is a wrong value send.
