### PR TITLE
Fix addAssociations() API docs: null argument does nothing

### DIFF
--- a/docs/api/associations/belongs-to-many.md
+++ b/docs/api/associations/belongs-to-many.md
@@ -74,9 +74,9 @@ Associate several instances with this.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [newAssociations] | Array.&lt;Instance &#124; String &#124; Number&gt; | An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations. |
-| [options] | Object | Options passed to `through.findAll`, `bulkCreate`, and `update` `destroy`. Can also hold additional attributes for the join table |
-| [options.validate] | Object | Run validation for the join model |
+| [newAssociations] | Array.&lt;Instance &#124; String &#124; Number&gt; | An array of instances or primary key of instances to associate with this. |
+| [options] | Object | Options passed to `through.findAll`, `bulkCreate` and `update`. Can also hold additional attributes for the join table. |
+| [options.validate] | Object | Run validation for the join model. |
 
 
 ***
@@ -85,15 +85,15 @@ Associate several instances with this.
 ## `addAssociation([newAssociation], [options])` -> `Promise`
 [View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/associations/belongs-to-many.js#L239)
 
-Associate several instances with this.
+Associate one instance with this.
 
 **Params:**
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [newAssociation] | Instance &#124; String &#124; Number | An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations. |
-| [options] | Object | Options passed to `through.findAll`, `bulkCreate` and `update`. Can also hold additional attributes for the join table |
-| [options.validate] | Object | Run validation for the join model |
+| [newAssociation] | Instance &#124; String &#124; Number | An instance or primary key of instance to associate with this. |
+| [options] | Object | Options passed to `through.findAll`, `bulkCreate` and `update`. Can also hold additional attributes for the join table. |
+| [options.validate] | Object | Run validation for the join model. |
 
 
 ***

--- a/docs/api/associations/has-many.md
+++ b/docs/api/associations/has-many.md
@@ -53,9 +53,9 @@ Associate several instances with this.
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [newAssociations] | Array.&lt;Instance &#124; String &#124; Number&gt; | An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations. |
+| [newAssociations] | Array.&lt;Instance &#124; String &#124; Number&gt; | An array of instances or primary key of instances to associate with this. |
 | [options] | Object | Options passed to `target.update`. |
-| [options.validate] | Object | Run validation for the join model |
+| [options.validate] | Object | Run validation for the join model. |
 
 
 ***
@@ -64,15 +64,15 @@ Associate several instances with this.
 ## `addAssociation([newAssociation], [options])` -> `Promise`
 [View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/associations/has-many.js#L134)
 
-Associate several instances with this.
+Associate one instance with this.
 
 **Params:**
 
 | Name | Type | Description |
 | ---- | ---- | ----------- |
-| [newAssociation] | Instance &#124; String &#124; Number | An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations. |
+| [newAssociation] | Instance &#124; String &#124; Number | An instance or primary key of instance to associate with this. |
 | [options] | Object | Options passed to `target.update`. |
-| [options.validate] | Object | Run validation for the join model |
+| [options.validate] | Object | Run validation for the join model. |
 
 
 ***

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -220,19 +220,19 @@ var BelongsToMany = function(source, target, options) {
     /**
      * Associate several instances with this.
      *
-     * @param {Array<Instance|String|Number>} [newAssociations] An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations.
-     * @param {Object} [options] Options passed to `through.findAll`, `bulkCreate`, and `update` `destroy`. Can also hold additional attributes for the join table
-     * @param {Object} [options.validate] Run validation for the join model
+     * @param {Array<Instance|String|Number>} [newAssociations] An array of instances or primary key of instances to associate with this.
+     * @param {Object} [options] Options passed to `through.findAll`, `bulkCreate` and `update`. Can also hold additional attributes for the join table.
+     * @param {Object} [options.validate] Run validation for the join model.
      * @return {Promise}
      * @method addAssociations
      */
     addMultiple: 'add' + plural,
     /**
-     * Associate several instances with this.
+     * Associate one instance with this.
      *
-     * @param {Instance|String|Number} [newAssociation] An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations.
-     * @param {Object} [options] Options passed to `through.findAll`, `bulkCreate` and `update`. Can also hold additional attributes for the join table
-     * @param {Object} [options.validate] Run validation for the join model
+     * @param {Instance|String|Number} [newAssociation] An instance or primary key of instance to associate with this.
+     * @param {Object} [options] Options passed to `through.findAll`, `bulkCreate` and `update`. Can also hold additional attributes for the join table.
+     * @param {Object} [options.validate] Run validation for the join model.
      * @return {Promise}
      * @method addAssociation
      */

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -115,19 +115,19 @@ var HasMany = function(source, target, options) {
     /**
      * Associate several instances with this.
      *
-     * @param {Array<Instance|String|Number>} [newAssociations] An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations.
+     * @param {Array<Instance|String|Number>} [newAssociations] An array of instances or primary key of instances to associate with this.
      * @param {Object} [options] Options passed to `target.update`.
-     * @param {Object} [options.validate] Run validation for the join model
+     * @param {Object} [options.validate] Run validation for the join model.
      * @return {Promise}
      * @method addAssociations
      */
     addMultiple: 'add' + plural,
     /**
-     * Associate several instances with this.
+     * Associate one instance with this.
      *
-     * @param {Instance|String|Number} [newAssociation] An array of instances or primary key of instances to associate with this. Pass `null` or `undefined` to remove all associations.
+     * @param {Instance|String|Number} [newAssociation] An instance or primary key of instance to associate with this.
      * @param {Object} [options] Options passed to `target.update`.
-     * @param {Object} [options.validate] Run validation for the join model
+     * @param {Object} [options.validate] Run validation for the join model.
      * @return {Promise}
      * @method addAssociation
      */


### PR DESCRIPTION
In the API docs for associations, the `addAssociation()` and `addAssociations()` are incorrectly documented: it is stated that passing `null` as the association argument will remove associations from the entity / object, whereas in fact it will do nothing (i.e., the call will be a no-op).

This is probably due to a cut & paste bug from the `setAssociations()` methods.