### PR TITLE
Postgres IS NULL bug demonstration

### DIFF
--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -444,6 +444,18 @@ if (dialect.match(/^postgres/)) {
           expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" = E'\\\\x53657175656c697a65';",
           context: QueryGenerator
         },
+        {
+          title: 'use IS if field is null',
+          arguments: ['myTable', {where: {field: null}}],
+          expectation: 'SELECT * FROM "myTable" WHERE "myTable"."field" IS NULL;',
+          context: QueryGenerator
+        },
+        {
+          title: 'use IS if field is undefined',
+          arguments: ['myTable', {where: {field: undefined}}],
+          expectation: 'SELECT * FROM "myTable" WHERE "myTable"."field" IS NULL;',
+          context: QueryGenerator
+        },
 
         // Variants when quoteIdentifiers is false
         {


### PR DESCRIPTION
This is a failing unit test for the postgres dialect that demonstrates that the query:

```
{
   where: {
     field: undefined
  }
}
```

Produces the unexpected output of `field = NULL`. This is contradicts postgres's [recommendation](http://www.postgresql.org/docs/8.3/interactive/functions-comparison.html) that such queries never be used. It also breaks with intuition since `field: null`, produces the different (correct) query `field IS NULL`.
