### PR TITLE
feat(datatypes) Support fractional DATETIME columns in MySQL 5.6+, fixes #4205

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -410,7 +410,16 @@ TIME.prototype.toSql = function() {
  * A datetime column
  * @property DATE
  */
-var DATE = ABSTRACT.inherits();
+var DATE = ABSTRACT.inherits(function (length) {
+  var options = typeof length === 'object' && length || {
+      length: length
+    };
+
+  if (!(this instanceof DATE)) return new DATE(options);
+
+  this.options = options;
+  this._length = options.length || '';
+});
 
 DATE.prototype.key = DATE.key = 'DATE';
 DATE.prototype.toSql = function() {

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -25,9 +25,17 @@ module.exports = function (BaseTypes) {
 
   var DATE = BaseTypes.DATE.inherits();
 
-  DATE.prototype.$stringify = function (date, options) {
-    date = BaseTypes.DATE.prototype.$applyTimezone(date, options);
+  DATE.prototype.toSql = function () {
+    return 'DATETIME' + (this._length ? '(' + this._length + ')' : '');
+  };
 
+  DATE.prototype.$stringify = function (date, options) {
+    // Fractional DATETIMEs only supported on MySQL 5.6.4+
+    if (this._length) {
+      return BaseTypes.DATE.prototype.$stringify(date, options);
+    }
+
+    date = BaseTypes.DATE.prototype.$applyTimezone(date, options);
     return date.format('YYYY-MM-DD HH:mm:ss');
   };
 

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -174,6 +174,13 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         sqlite: 'DATETIME'
       });
 
+      testsql('DATE(6)', DataTypes.DATE(6), {
+        postgres: 'TIMESTAMP WITH TIME ZONE',
+        mssql: 'DATETIME2',
+        mysql: 'DATETIME(6)',
+        sqlite: 'DATETIME'
+      });
+
       suite('validate', function () {
         test('should throw an error if `value` is invalid', function() {
           var type = DataTypes.DATE();


### PR DESCRIPTION
fixes #4205 for fractional DATETIME support. Perhaps I should add the same functionality for TIME columns also?