### PR TITLE
Return null to tell Bluebird non-return is intentional

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -97,6 +97,7 @@ ConnectionManager.prototype.initPools = function () {
       },
       destroy: function(connection) {
         self.$disconnect(connection);
+        return null;
       },
       max: config.pool.max,
       min: config.pool.min,
@@ -174,6 +175,7 @@ ConnectionManager.prototype.initPools = function () {
       },
       destroy: function(connection) {
         self.$disconnect(connection);
+        return null;
       },
       validate: config.pool.validate,
       max: config.pool.max,
@@ -191,6 +193,7 @@ ConnectionManager.prototype.initPools = function () {
       },
       destroy: function(connection) {
         self.$disconnect(connection);
+        return null;
       },
       validate: config.pool.validate,
       max: config.pool.max,
@@ -221,6 +224,7 @@ ConnectionManager.prototype.getConnection = function(options) {
           self.versionPromise = null;
 
           self.$disconnect(connection);
+          return null;
         });
       }).catch(function (err) {
         self.versionPromise = null;

--- a/lib/model.js
+++ b/lib/model.js
@@ -2446,6 +2446,7 @@ Model.prototype.update = function(values, options) {
         delete options.attributes;
       });
     }
+    return null;
   }).then(function() {
     valuesUse = values;
 


### PR DESCRIPTION
Another fix to prevent warnings like http://bluebirdjs.com/docs/warning-explanations.html#warning-a-promise-was-created-in-a-handler-but-none-were-returned-from-it