### PR TITLE
[MSSQL] Fix connection manager domain usage

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -53,7 +53,6 @@ ConnectionManager.prototype.connect = function(config) {
       // The 'tedious' driver needs domain property to be in the main Connection config object
       if(config.dialectOptions.domain) {
         connectionConfig.domain = config.dialectOptions.domain;
-        delete config.dialectOptions.domain;
       }
 
       Object.keys(config.dialectOptions).forEach(function(key) {

--- a/test/unit/dialects/mssql/connection-manager.js
+++ b/test/unit/dialects/mssql/connection-manager.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var chai = require('chai')
+  , expect = chai.expect
+  , Sequelize = require(__dirname + '/../../../../index');
+
+
+var tedious = require('tedious')
+  , sinon = require('sinon')
+  , connectionStub = sinon.stub(tedious, 'Connection');
+
+connectionStub.returns({on: function () {}});
+
+describe('[MSSQL] Connection Manager', function () {
+  var instance
+    , config;
+  beforeEach(function () {
+    config = {
+      dialect: 'mssql',
+      database: 'none',
+      username: 'none',
+      password: 'none',
+      host: 'localhost',
+      port: 2433,
+      pool: {},
+      dialectOptions: {
+        domain: 'TEST.COM'
+      }
+    };
+    instance = new Sequelize(config.database
+                             , config.username
+                             , config.password
+                             , config);    
+  });
+  
+  it('connectionManager.$connect() Does not delete `domain` from config.dialectOptions',
+     function () {
+       expect(config.dialectOptions.domain).to.equal('TEST.COM');
+       instance.dialect.connectionManager.$connect(config);
+       expect(config.dialectOptions.domain).to.equal('TEST.COM');
+     });
+});


### PR DESCRIPTION
API for the Tedious driver requires that an entry for `domain`, if present,
be at the root level of the config option passed to the constructor. This
was added in commit 91fc76be10b12e0e5a2c4a9299e5bc05a2956d58.

However, that commit deleted `dialectOptions.domain` from the config object
passed into the Sequelize constructor. Since most config objects are singletons,
this mutation of the config object breaks any subsequent calls to the instance's
`connectionManager.$connect`.

This commit simply removes the call to delete the domain entry.
Fixes #4918