### PR TITLE
don't overwrite options.foreignKey in associations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [FIXED] Don't overwrite options.foreignKey in associations [#4927](https://github.com/sequelize/sequelize/pull/4927)
+
 # 3.14.1
 - [FIXED] Issue with transaction options leaking and certain queries running outside of the transaction connection.
 

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -323,8 +323,8 @@ BelongsToMany.prototype.injectAttributes = function() {
     , targetKey = this.target.rawAttributes[this.target.primaryKeyAttribute]
     , targetKeyType = targetKey.type
     , targetKeyField = targetKey.field || this.target.primaryKeyAttribute
-    , sourceAttribute = _.defaults(this.foreignKeyAttribute, { type: sourceKeyType })
-    , targetAttribute = _.defaults(this.otherKeyAttribute, { type: targetKeyType });
+    , sourceAttribute = _.defaults({}, this.foreignKeyAttribute, { type: sourceKeyType })
+    , targetAttribute = _.defaults({}, this.otherKeyAttribute, { type: targetKeyType });
 
   if (this.primaryKeyDeleted === true) {
     targetAttribute.primaryKey = sourceAttribute.primaryKey = true;

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -109,7 +109,7 @@ util.inherits(BelongsTo, Association);
 BelongsTo.prototype.injectAttributes = function() {
   var newAttributes = {};
 
-  newAttributes[this.foreignKey] = _.defaults(this.foreignKeyAttribute, {
+  newAttributes[this.foreignKey] = _.defaults({}, this.foreignKeyAttribute, {
     type: this.options.keyType || this.target.rawAttributes[this.targetKey].type,
     allowNull : true
   });

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -202,7 +202,7 @@ util.inherits(HasMany, Association);
 HasMany.prototype.injectAttributes = function() {
   var newAttributes = {};
   var constraintOptions = _.clone(this.options); // Create a new options object for use with addForeignKeyConstraints, to avoid polluting this.options in case it is later used for a n:m
-  newAttributes[this.foreignKey] = _.defaults(this.foreignKeyAttribute, {
+  newAttributes[this.foreignKey] = _.defaults({}, this.foreignKeyAttribute, {
     type: this.options.keyType || this.source.rawAttributes[this.source.primaryKeyAttribute].type,
     allowNull : true
   });

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -103,7 +103,7 @@ HasOne.prototype.injectAttributes = function() {
   var newAttributes = {}
     , keyType = this.source.rawAttributes[this.source.primaryKeyAttribute].type;
 
-  newAttributes[this.foreignKey] = _.defaults(this.foreignKeyAttribute, {
+  newAttributes[this.foreignKey] = _.defaults({}, this.foreignKeyAttribute, {
     type: this.options.keyType || keyType,
     allowNull : true
   });

--- a/test/unit/associations/dont-modify-options.test.js
+++ b/test/unit/associations/dont-modify-options.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , DataTypes = require(__dirname + '/../../../lib/data-types')
+  , Sequelize = require('../../../index');
+
+describe(Support.getTestDialectTeaser('associations'), function() {
+  describe('Test options.foreignKey', function() {
+    beforeEach(function() {
+
+      this.A = this.sequelize.define('A', {
+        id: {
+          type: DataTypes.CHAR(20),
+          primaryKey: true
+        }
+      });
+      this.B = this.sequelize.define('B', {
+        id: {
+          type: Sequelize.CHAR(20),
+          primaryKey: true
+        }
+      });
+      this.C = this.sequelize.define('C', {});
+    });
+
+    it('should not be overwritten for belongsTo', function(){
+      var self = this;
+      var reqValidForeignKey = { foreignKey: { allowNull: false }};
+      self.A.belongsTo(self.B, reqValidForeignKey);
+      self.A.belongsTo(self.C, reqValidForeignKey);
+      expect(self.A.attributes.CId.type).to.deep.equal(self.C.attributes.id.type);
+    });
+    it('should not be overwritten for belongsToMany', function(){
+      var self = this;
+      var reqValidForeignKey = { foreignKey: { allowNull: false }, through: 'ABBridge'};
+      self.B.belongsToMany(self.A, reqValidForeignKey);
+      self.A.belongsTo(self.C, reqValidForeignKey);
+      expect(self.A.attributes.CId.type).to.deep.equal(self.C.attributes.id.type);
+    });
+    it('should not be overwritten for hasOne', function(){
+      var self = this;
+      var reqValidForeignKey = { foreignKey: { allowNull: false }};
+      self.B.hasOne(self.A, reqValidForeignKey);
+      self.A.belongsTo(self.C, reqValidForeignKey);
+      expect(self.A.attributes.CId.type).to.deep.equal(self.C.attributes.id.type);
+    });
+    it('should not be overwritten for hasMany', function(){
+      var self = this;
+      var reqValidForeignKey = { foreignKey: { allowNull: false }};
+      self.B.hasMany(self.A, reqValidForeignKey);
+      self.A.belongsTo(self.C, reqValidForeignKey);
+      expect(self.A.attributes.CId.type).to.deep.equal(self.C.attributes.id.type);
+    });
+  });
+});


### PR DESCRIPTION
I use sequelize quite often and just discovered are rare case where it doesn't exactly do what imho it is supposed to do. Let's assume we have three tables, where A & B have a string ID and C has an integer ID. Now when we try to connect B and C with A, we run into the problem that if a foreignKey is given as input, it will be *modified* by the associations. Hence this to this weird behavior:

```
var Sequelize = require('sequelize');
var sequelize = new Sequelize('database', 'username', 'password', {
    dialect: 'sqlite',
    storage: 'foo.sqlite'
});

var A = sequelize.define('A', {
    id: {
        type: Sequelize.CHAR(20),
        primaryKey: true
    }
});
var B = sequelize.define('B', {
    id: {
        type: Sequelize.CHAR(20),
        primaryKey: true
    }
});
var C = sequelize.define('C', {});
var reqValidForeignKey = { foreignKey: { allowNull: false }};

//B.hasMany(A, reqValidForeignKey); // other associations also modify the options.foreignKey
A.belongsTo(B, reqValidForeignKey);
A.belongsTo(C, reqValidForeignKey);
var QueryGenerator = A.modelManager.sequelize.queryInterface.QueryGenerator;
console.log(QueryGenerator.attributesToSQL(A.rawAttributes, {
    context: 'createTable'
}));
//{ id: 'CHAR(20) PRIMARY KEY',
//  createdAt: 'DATETIME NOT NULL',
//  updatedAt: 'DATETIME NOT NULL',
//  BId: 'CHAR(20) NOT NULL REFERENCES `Bs` (`id`) ON DELETE CASCADE ON UPDATE CASCADE',
//  CId: 'CHAR(20) NOT NULL REFERENCES `Cs` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE' }
```

Note: CId should be an integer.

This is due to the fact that we use the same `foreignKey` object which is passed into the function and modify. In my use case I discovered this because both tables are required to have foreign keys.

This PR adds a very simple fix for this problem and also a test case to check for this ;-)