### PR TITLE
Fixed instance.destroy not working for models with "paranoid" and defaultValue of deletedAt set to non-null.

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -830,11 +830,12 @@ Instance.prototype.destroy = function(options) {
     var where = this.where();
 
     if (this.Model._timestampAttributes.deletedAt && options.force === false) {
-      var field = this.Model.rawAttributes[this.Model._timestampAttributes.deletedAt].field || this.Model._timestampAttributes.deletedAt;
-      var values = {};
+      var attribute = this.Model.rawAttributes[this.Model._timestampAttributes.deletedAt]
+        , field = attribute.field || this.Model._timestampAttributes.deletedAt
+        , values = {};
 
       values[field] = new Date();
-      where[field] = null;
+      where[field] = attribute.hasOwnProperty('defaultValue') ? attribute.defaultValue : null;
 
       this.setDataValue(field, values[field]);
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -1483,8 +1483,13 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
             expect(Number(user.deletedAt)).to.equal(epoch);
             return user.destroy();
           }).then(function(destroyedUser) {
+            expect(destroyedUser.deletedAt).to.exist;
             expect(Number(destroyedUser.deletedAt)).not.to.equal(epoch);
-            return destroyedUser.restore();
+            return User.findById(destroyedUser.id, { paranoid: false });
+          }).then(function(fetchedDestroyedUser) {
+            expect(fetchedDestroyedUser.deletedAt).to.exist;
+            expect(Number(fetchedDestroyedUser.deletedAt)).not.to.equal(epoch);
+            return fetchedDestroyedUser.restore();
           }).then(function(restoredUser) {
             expect(Number(restoredUser.deletedAt)).to.equal(epoch);
             return User.destroy({where: {


### PR DESCRIPTION
Function of my PR #4490 was broken by PR #4316 at [this line](https://github.com/sequelize/sequelize/pull/4316/files#diff-a5b70841c2143e5d2e0fd98dd3b4cefeR827) .
My tests were not sufficient.

With this PR, instance.destroy will work again, with models having "paranoid" and deletedAt with non-null defaultValue.
Fixed the tests too.

