### PR TITLE
Feature/pg schema deletequery

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# 3.14.2
+# NEXT
  - [FIXED] Model.destroy({ truncate: true }) fails when using postgres and schemas
 
 # 3.14.2

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # 3.14.2
+ - [FIXED] Model.destroy({ truncate: true }) fails when using postgres and schemas
+
+# 3.14.2
 - [FIXED] Model.aggregate methods now support attributes and where conditions with fields. [#4935](https://github.com/sequelize/sequelize/issues/4935)
 - [FIXED] Don't overwrite options.foreignKey in associations [#4927](https://github.com/sequelize/sequelize/pull/4927)
 - [FIXED] Support nested `$col` keys. [#4849](https://github.com/sequelize/sequelize/issues/4849)

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -331,7 +331,7 @@ var QueryGenerator = {
       , tableDetails = this.extractTableDetails(tableName, options);
 
     if (options.truncate === true) {
-      query = 'TRUNCATE ' + QueryGenerator.quoteIdentifier(tableDetails.schema) + tableDetails.delimiter + QueryGenerator.quoteIdentifier(tableDetails.tableName);
+      query = 'TRUNCATE ' + this.quoteTable(this.extractTableDetails(tableName, options));
 
       if (options.cascade) {
         query += ' CASCADE';
@@ -368,7 +368,7 @@ var QueryGenerator = {
     }
 
     var replacements = {
-      table: this.quoteIdentifiers(tableName),
+      table: this.quoteTable(this.extractTableDetails(tableName, options)),
       where: this.getWhereConditions(where),
       limit: !!options.limit ? ' LIMIT ' + this.escape(options.limit) : '',
       primaryKeys: primaryKeys[tableName].length > 1 ? '(' + pks + ')' : pks,

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -325,14 +325,13 @@ var QueryGenerator = {
   },
 
   deleteQuery: function(tableName, where, options, model) {
-    var query;
-
     options = options || {};
 
-    tableName = Utils.removeTicks(this.quoteTable(tableName), '"');
+    var query
+        , tableDetails = this.extractTableDetails(tableName, options);
 
     if (options.truncate === true) {
-      query = 'TRUNCATE ' + QueryGenerator.quoteIdentifier(tableName);
+      query = 'TRUNCATE ' + QueryGenerator.quoteIdentifier(tableDetails.schema) + tableDetails.delimiter + QueryGenerator.quoteIdentifier(tableDetails.tableName);
 
       if (options.cascade) {
         query += ' CASCADE';

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -325,10 +325,9 @@ var QueryGenerator = {
   },
 
   deleteQuery: function(tableName, where, options, model) {
-    options = options || {};
+    var query;
 
-    var query
-      , tableDetails = this.extractTableDetails(tableName, options);
+    options = options || {};
 
     if (options.truncate === true) {
       query = 'TRUNCATE ' + this.quoteTable(this.extractTableDetails(tableName, options));

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -328,7 +328,7 @@ var QueryGenerator = {
     options = options || {};
 
     var query
-        , tableDetails = this.extractTableDetails(tableName, options);
+      , tableDetails = this.extractTableDetails(tableName, options);
 
     if (options.truncate === true) {
       query = 'TRUNCATE ' + QueryGenerator.quoteIdentifier(tableDetails.schema) + tableDetails.delimiter + QueryGenerator.quoteIdentifier(tableDetails.tableName);

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -861,10 +861,10 @@ if (dialect.match(/^postgres/)) {
           expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"public\".\"myTable\" WHERE \"name\" = 'foo'';DROP TABLE myTable;' LIMIT 10)"
         }, {
           arguments: ['mySchema.myTable', {name: 'foo'}],
-          expectation: "DELETE FROM \"mySchema\".\"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
+          expectation: "DELETE FROM \"public\".\"mySchema.myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"public\".\"mySchema.myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
         }, {
           arguments: ['mySchema.myTable', {name: "foo';DROP TABLE mySchema.myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM \"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)"
+          expectation: "DELETE FROM \"public\".\"mySchema.myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"public\".\"mySchema.myTable\" WHERE \"name\" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)"
         }, {
           arguments: ['myTable', {name: 'foo'}, {limit: null}],
           expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"name\" = 'foo'"
@@ -889,11 +889,11 @@ if (dialect.match(/^postgres/)) {
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['mySchema.myTable', {name: 'foo'}],
-          expectation: "DELETE FROM mySchema.myTable WHERE id IN (SELECT id FROM mySchema.myTable WHERE name = 'foo' LIMIT 1)",
+          expectation: "DELETE FROM public.mySchema.myTable WHERE id IN (SELECT id FROM public.mySchema.myTable WHERE name = 'foo' LIMIT 1)",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['mySchema.myTable', {name: "foo';DROP TABLE mySchema.myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM mySchema.myTable WHERE id IN (SELECT id FROM mySchema.myTable WHERE name = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)",
+          expectation: "DELETE FROM public.mySchema.myTable WHERE id IN (SELECT id FROM public.mySchema.myTable WHERE name = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {name: 'foo'}, {limit: null}],

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -840,52 +840,52 @@ if (dialect.match(/^postgres/)) {
       deleteQuery: [
         {
           arguments: ['myTable', {name: 'foo'}],
-          expectation: "DELETE FROM \"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
+          expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
         }, {
           arguments: ['myTable', 1],
-          expectation: 'DELETE FROM \"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"id\" = 1 LIMIT 1)'
+          expectation: 'DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"id\" = 1 LIMIT 1)'
         }, {
           arguments: ['myTable', undefined, {truncate: true}],
-          expectation: 'TRUNCATE \"myTable\"'
+          expectation: 'TRUNCATE \"public\".\"myTable\"'
         }, {
           arguments: ['myTable', undefined, {truncate: true, cascade: true}],
-          expectation: 'TRUNCATE \"myTable\" CASCADE'
+          expectation: 'TRUNCATE \"public\".\"myTable\" CASCADE'
         }, {
           arguments: ['myTable', 1, {limit: 10, truncate: true}],
-          expectation: 'TRUNCATE \"myTable\"'
+          expectation: 'TRUNCATE \"public\".\"myTable\"'
         }, {
           arguments: ['myTable', 1, {limit: 10}],
-          expectation: 'DELETE FROM \"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"id\" = 1 LIMIT 10)'
+          expectation: 'DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"id\" = 1 LIMIT 10)'
         }, {
           arguments: ['myTable', {name: "foo';DROP TABLE myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM \"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"name\" = 'foo'';DROP TABLE myTable;' LIMIT 10)"
+          expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"name\" = 'foo'';DROP TABLE myTable;' LIMIT 10)"
         }, {
           arguments: ['mySchema.myTable', {name: 'foo'}],
-          expectation: "DELETE FROM \"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
+          expectation: "DELETE FROM \"public\".\"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
         }, {
           arguments: ['mySchema.myTable', {name: "foo';DROP TABLE mySchema.myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM \"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)"
+          expectation: "DELETE FROM \"public\".\"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)"
         }, {
           arguments: ['myTable', {name: 'foo'}, {limit: null}],
-          expectation: "DELETE FROM \"myTable\" WHERE \"name\" = 'foo'"
+          expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"name\" = 'foo'"
         },
 
         // Variants when quoteIdentifiers is false
         {
           arguments: ['myTable', {name: 'foo'}],
-          expectation: "DELETE FROM myTable WHERE id IN (SELECT id FROM myTable WHERE name = 'foo' LIMIT 1)",
+          expectation: "DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE name = 'foo' LIMIT 1)",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', 1],
-          expectation: 'DELETE FROM myTable WHERE id IN (SELECT id FROM myTable WHERE id = 1 LIMIT 1)',
+          expectation: 'DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE id = 1 LIMIT 1)',
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', 1, {limit: 10}],
-          expectation: 'DELETE FROM myTable WHERE id IN (SELECT id FROM myTable WHERE id = 1 LIMIT 10)',
+          expectation: 'DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE id = 1 LIMIT 10)',
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {name: "foo';DROP TABLE myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM myTable WHERE id IN (SELECT id FROM myTable WHERE name = 'foo'';DROP TABLE myTable;' LIMIT 10)",
+          expectation: "DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE name = 'foo'';DROP TABLE myTable;' LIMIT 10)",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['mySchema.myTable', {name: 'foo'}],
@@ -897,7 +897,7 @@ if (dialect.match(/^postgres/)) {
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {name: 'foo'}, {limit: null}],
-          expectation: "DELETE FROM myTable WHERE name = 'foo'",
+          expectation: "DELETE FROM public.myTable WHERE name = 'foo'",
           context: {options: {quoteIdentifiers: false}}
         }
       ],

--- a/test/integration/dialects/postgres/query-generator.test.js
+++ b/test/integration/dialects/postgres/query-generator.test.js
@@ -840,10 +840,10 @@ if (dialect.match(/^postgres/)) {
       deleteQuery: [
         {
           arguments: ['myTable', {name: 'foo'}],
-          expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
+          expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"public\".\"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
         }, {
           arguments: ['myTable', 1],
-          expectation: 'DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"id\" = 1 LIMIT 1)'
+          expectation: 'DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"public\".\"myTable\" WHERE \"id\" = 1 LIMIT 1)'
         }, {
           arguments: ['myTable', undefined, {truncate: true}],
           expectation: 'TRUNCATE \"public\".\"myTable\"'
@@ -855,16 +855,16 @@ if (dialect.match(/^postgres/)) {
           expectation: 'TRUNCATE \"public\".\"myTable\"'
         }, {
           arguments: ['myTable', 1, {limit: 10}],
-          expectation: 'DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"id\" = 1 LIMIT 10)'
+          expectation: 'DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"public\".\"myTable\" WHERE \"id\" = 1 LIMIT 10)'
         }, {
           arguments: ['myTable', {name: "foo';DROP TABLE myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"myTable\" WHERE \"name\" = 'foo'';DROP TABLE myTable;' LIMIT 10)"
+          expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"public\".\"myTable\" WHERE \"name\" = 'foo'';DROP TABLE myTable;' LIMIT 10)"
         }, {
           arguments: ['mySchema.myTable', {name: 'foo'}],
-          expectation: "DELETE FROM \"public\".\"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
+          expectation: "DELETE FROM \"mySchema\".\"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo' LIMIT 1)"
         }, {
           arguments: ['mySchema.myTable', {name: "foo';DROP TABLE mySchema.myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM \"public\".\"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)"
+          expectation: "DELETE FROM \"mySchema\".\"myTable\" WHERE \"id\" IN (SELECT \"id\" FROM \"mySchema\".\"myTable\" WHERE \"name\" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)"
         }, {
           arguments: ['myTable', {name: 'foo'}, {limit: null}],
           expectation: "DELETE FROM \"public\".\"myTable\" WHERE \"name\" = 'foo'"
@@ -873,19 +873,19 @@ if (dialect.match(/^postgres/)) {
         // Variants when quoteIdentifiers is false
         {
           arguments: ['myTable', {name: 'foo'}],
-          expectation: "DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE name = 'foo' LIMIT 1)",
+          expectation: "DELETE FROM public.myTable WHERE id IN (SELECT id FROM public.myTable WHERE name = 'foo' LIMIT 1)",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', 1],
-          expectation: 'DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE id = 1 LIMIT 1)',
+          expectation: 'DELETE FROM public.myTable WHERE id IN (SELECT id FROM public.myTable WHERE id = 1 LIMIT 1)',
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', 1, {limit: 10}],
-          expectation: 'DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE id = 1 LIMIT 10)',
+          expectation: 'DELETE FROM public.myTable WHERE id IN (SELECT id FROM public.myTable WHERE id = 1 LIMIT 10)',
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {name: "foo';DROP TABLE myTable;"}, {limit: 10}],
-          expectation: "DELETE FROM public.myTable WHERE id IN (SELECT id FROM myTable WHERE name = 'foo'';DROP TABLE myTable;' LIMIT 10)",
+          expectation: "DELETE FROM public.myTable WHERE id IN (SELECT id FROM public.myTable WHERE name = 'foo'';DROP TABLE myTable;' LIMIT 10)",
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['mySchema.myTable', {name: 'foo'}],

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -36,10 +36,85 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
             options,
             User
           ), {
-            postgres: 'DELETE FROM "test_user" WHERE "test_user_id" IN (SELECT "test_user_id" FROM "test_user" WHERE "test_user_id" = 100 LIMIT 1)',
+            postgres: 'DELETE FROM "public"."test_user" WHERE "test_user_id" IN (SELECT "test_user_id" FROM "public"."test_user" WHERE "test_user_id" = 100 LIMIT 1)',
             sqlite:   'DELETE FROM `test_user` WHERE `test_user_id` = 100',
             mssql:    'DELETE TOP(1) FROM [test_user] WHERE [test_user_id] = 100; SELECT @@ROWCOUNT AS AFFECTEDROWS;',
             default:  'DELETE FROM [test_user] WHERE [test_user_id] = 100 LIMIT 1'
+          }
+        );
+      });
+
+    });
+
+    suite('include the correct schema during bulk delete when appropriate', function () {
+
+      var User = current.define('test_user', {
+        id: {
+          type:       Sequelize.INTEGER,
+          primaryKey: true,
+          field:      "test_user_id",
+        }
+      }, {
+        schema: 'web',
+        freezeTableName: true,
+        timestamps:false
+      });
+
+      var options = {
+        table: 'test_user',
+        schema: 'web',
+        where: {
+          'test_user_id': 100
+        }
+      };
+
+      test(util.inspect(options, {depth: 2}), function () {
+        return expectsql(
+          sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            User
+          ), {
+            postgres: 'DELETE FROM "web"."test_user" WHERE "test_user_id" IN (SELECT "test_user_id" FROM "web"."test_user" WHERE "test_user_id" = 100 LIMIT 1)',
+            sqlite:   'DELETE FROM `test_user` WHERE `test_user_id` = 100',
+            mssql:    'DELETE TOP(1) FROM [test_user] WHERE [test_user_id] = 100; SELECT @@ROWCOUNT AS AFFECTEDROWS;',
+            default:  'DELETE FROM [test_user] WHERE [test_user_id] = 100 LIMIT 1'
+          }
+        );
+      });
+
+    });
+
+    suite('include the correct schema during bulk delete + truncate when appropriate', function () {
+
+      var User = current.define('test_user', {
+        id: {
+          type:       Sequelize.INTEGER,
+          primaryKey: true,
+          field:      "test_user_id",
+        }
+      }, {
+        freezeTableName: true,
+        timestamps:false
+      });
+
+      var options = {
+        table: 'test_user',
+        truncate: true
+      };
+
+      test(util.inspect(options, {depth: 2}), function () {
+        return expectsql(
+          sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            User
+          ), {
+            postgres: 'TRUNCATE "public"."test_user"',
+            sqlite:   'TRUNCATE `test_user`',
+            default:  'TRUNCATE [test_user]'
           }
         );
       });


### PR DESCRIPTION
`Model.destroy({ truncate: true })` fails when one is using PG and non-standard schemas.

This PR fixes the issue using the good ol' `extractTableDetails` method added in one of my previous PR's.