### PR TITLE
convert original time to Date object

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -345,6 +345,9 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
             if (!(value instanceof Date)) {
               value = new Date(value);
             }
+            if (!(originalValue instanceof Date)) {
+              originalValue = new Date(originalValue);
+            }
             if (originalValue && value.getTime() === originalValue.getTime()) {
               return;
             }


### PR DESCRIPTION
This should solve the follow error stack, by converting the original time to a Date Object.
```
<h1>originalValue.getTime is not a function</h1>
<h2></h2>
<pre>TypeError: originalValue.getTime is not a function
    at Instance.set (/node_modules/sequelize/lib/instance.js:348:68)
    at Instance.set (/node_modules/sequelize/lib/instance.js:292:16)
    at Instance.update (/node_modules/sequelize/lib/instance.js:791:8)
```