### PR TITLE
Fix various typos/misspellings/formatting issues in the docs

### DIFF
--- a/docs/articles/heroku.md
+++ b/docs/articles/heroku.md
@@ -31,7 +31,7 @@ Next step: Deploy the application to Heroku.
 
 ## Deployment to Heroku
 
-First of all, we need to add the right version of Node.JS and NPM to the `package.json`. The file should look similiar to this:
+First of all, we need to add the right version of Node.JS and NPM to the `package.json`. The file should look similar to this:
     
 ```js
 {

--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -202,7 +202,7 @@ UserProjects = sequelize.define('UserProjects', {
 ```
 
 ## Scopes
-This section concerns association scopes. For a definition of assocation scopes vs. scopes on associated models, see [Scopes](scopes).
+This section concerns association scopes. For a definition of association scopes vs. scopes on associated models, see [Scopes](scopes).
 
 Association scopes allow you to place a scope (a set of default attributes for `get` and `create`) on the association. Scopes can be placed both on the associated model (the target of the association), and on the through table for n:m relations.
 
@@ -264,7 +264,7 @@ image.addComment(comment);
 UPDATE comments SET commentable_id = 42, commentable = 'image'
 ```
 
-The `getItem` utility function on `Comment` completes the picture - it simply converts the `commentable` string into a call to etiher `getImage` or `getPost`, providing an abstraction over whether a comment belongs to a post or an image.
+The `getItem` utility function on `Comment` completes the picture - it simply converts the `commentable` string into a call to either `getImage` or `getPost`, providing an abstraction over whether a comment belongs to a post or an image.
 
 #### n:m
 Continuing with the idea of a polymorphic model, consider a tag table - an item can have multiple tags, and a tag can be related to several items.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -83,7 +83,7 @@ var Post = sequelize.define('post', {}, {
 ```
 
 ## Promises
-Sequelize uses promises to control async control-flow. If you are unfamilar with how promises work, now might be a good time to brush up on them, [here](https://github.com/wbinnssmith/awesome-promises) and [here](https://github.com/petkaantonov/bluebird#what-are-promises-and-why-should-i-use-them)
+Sequelize uses promises to control async control-flow. If you are unfamiliar with how promises work, now might be a good time to brush up on them, [here](https://github.com/wbinnssmith/awesome-promises) and [here](https://github.com/petkaantonov/bluebird#what-are-promises-and-why-should-i-use-them)
 
 Basically a promise represents a value which will be present at some point - "I promise you I will give you a result or an error at some point". This means that
 

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -51,7 +51,7 @@ OPTIONS
 
 ## Skeleton
 
-The following skeleton shows a typical migration file&period; All migrations are expected to be located in a folder called `migrations` at the very top of the project&period; The sequelize binary can generate a migration skeleton&period; See the aboves section for more details&period;
+The following skeleton shows a typical migration file. All migrations are expected to be located in a folder called `migrations` at the very top of the project. The sequelize binary can generate a migration skeleton. See the above section for more details.
 
 ```js
 module.exports = {
@@ -65,7 +65,7 @@ module.exports = {
 }
 ```
 
-The passed `queryInterface` object can be used to modify the database&period; The `Sequelize` object stores the available data types such as `STRING` or `INTEGER`&period; The third parameter is a callback function which needs to be called once everything was executed&period; The first parameter of the callback function can be used to pass a possible error&period; In that case&comma; the migration will be marked as failed&period; Here is some code&colon;
+The passed `queryInterface` object can be used to modify the database. The `Sequelize` object stores the available data types such as `STRING` or `INTEGER`. The third parameter is a callback function which needs to be called once everything was executed. The first parameter of the callback function can be used to pass a possible error. In that case, the migration will be marked as failed. Here is some code:
 
 ```js
 module.exports = {
@@ -75,15 +75,15 @@ module.exports = {
 }
 ```
 
-The available methods of the queryInterface object are the following&period;
+The available methods of the queryInterface object are the following.
 
 ## Functions
 
-Using the `queryInterface` object describe before&comma; you will have access to most of already introduced functions&period; Furthermore there are some other methods&comma; which are designed to actually change the database schema&period;
+Using the `queryInterface` object describe before, you will have access to most of already introduced functions. Furthermore there are some other methods, which are designed to actually change the database schema.
 
-### createTable&lpar;tableName&comma; attributes&comma; options&rpar;
+### createTable(tableName, attributes, options)
 
-This method allows creation of new tables&period; It is allowed to pass simple or complex attribute definitions&period; You can define the encoding of the table and the table's engine via options
+This method allows creation of new tables. It is allowed to pass simple or complex attribute definitions. You can define the encoding of the table and the table's engine via options
 
 ```js
 queryInterface.createTable(
@@ -115,41 +115,41 @@ queryInterface.createTable(
 )
 ```
 
-### dropTable&lpar;tableName&comma; options&rpar;
+### dropTable(tableName, options)
 
-This method allows deletion of an existing table&period;
+This method allows deletion of an existing table.
 
 ```js
 queryInterface.dropTable('nameOfTheExistingTable')
 ```
 
-### dropAllTables&lpar;options&rpar;
+### dropAllTables(options)
 
-This method allows deletion of all existing tables in the database&period;
+This method allows deletion of all existing tables in the database.
 
 ```js
 queryInterface.dropAllTables()
 ```
 
-### renameTable&lpar;before&comma; after&comma; options&rpar;
+### renameTable(before, after, options)
 
-This method allows renaming of an existing table&period;
+This method allows renaming of an existing table.
 
 ```js
 queryInterface.renameTable('Person', 'User')
 ```
 
-### showAllTables&lpar;options&rpar;
+### showAllTables(options)
 
-This method returns the name of all existing tables in the database&period;
+This method returns the name of all existing tables in the database.
 
 ```js
 queryInterface.showAllTables().then(function(tableNames) {})
 ```
 
-### describeTable&lpar;tableName&comma; options&rpar;
+### describeTable(tableName, options)
 
-This method returns an array of hashes containing information about all attributes in the table&period;
+This method returns an array of hashes containing information about all attributes in the table.
 
 ```js
 queryInterface.describeTable('Person').then(function(attributes) {
@@ -172,9 +172,9 @@ queryInterface.describeTable('Person').then(function(attributes) {
 })
 ```
 
-### addColumn&lpar;tableName&comma; attributeName&comma; dataTypeOrOptions&comma; options&rpar;
+### addColumn(tableName, attributeName, dataTypeOrOptions, options)
 
-This method allows adding columns to an existing table&period; The data type can be simple or complex&period;
+This method allows adding columns to an existing table. The data type can be simple or complex.
 
 ```js
 queryInterface.addColumn(
@@ -195,15 +195,15 @@ queryInterface.addColumn(
 )
 ```
 
-### removeColumn&lpar;tableName&comma; attributeName&comma; options&rpar;
+### removeColumn(tableName, attributeName, options)
 
-This method allows deletion of a specific column of an existing table&period;
+This method allows deletion of a specific column of an existing table.
 
 ```js
 queryInterface.removeColumn('Person', 'signature')
 ```
 
-### changeColumn&lpar;tableName&comma; attributeName&comma; dataTypeOrOptions&comma; options&rpar;
+### changeColumn(tableName, attributeName, dataTypeOrOptions, options)
 
 This method changes the meta data of an attribute. It is possible to change the default value, allowance of null or the data type. Please make sure, that you are completely describing the new data type.
 
@@ -219,17 +219,17 @@ queryInterface.changeColumn(
 )
 ```
 
-### renameColumn&lpar;tableName&comma; attrNameBefore&comma; attrNameAfter&comma; options&rpar;
+### renameColumn(tableName, attrNameBefore, attrNameAfter, options)
 
-This methods allows renaming attributes&period;
+This methods allows renaming attributes.
 
 ```js
 queryInterface.renameColumn('Person', 'signature', 'sig')
 ```
 
-### addIndex&lpar;tableName&comma; attributes&comma; options&rpar;
+### addIndex(tableName, attributes, options)
 
-This methods creates indexes for specific attributes of a table&period; The index name will be automatically generated if it is not passed via in the options &lpar;see below&rpar;&period;
+This methods creates indexes for specific attributes of a table. The index name will be automatically generated if it is not passed via in the options (see below).
 
 ```js
 // This example will create the index person_firstname_lastname
@@ -252,9 +252,9 @@ queryInterface.addIndex(
 )
 ```
 
-### removeIndex&lpar;tableName&comma; indexNameOrAttributes&comma; options&rpar;
+### removeIndex(tableName, indexNameOrAttributes, options)
 
-This method deletes an existing index of a table&period;
+This method deletes an existing index of a table.
 
 ```js
 queryInterface.removeIndex('Person', 'SuperDuperIndex')

--- a/docs/docs/models-definition.md
+++ b/docs/docs/models-definition.md
@@ -150,7 +150,7 @@ Sequelize.INTEGER(11).ZEROFILL.UNSIGNED // INTEGER(11) UNSIGNED ZEROFILL
 Sequelize.INTEGER(11).UNSIGNED.ZEROFILL // INTEGER(11) UNSIGNED ZEROFILL
 ```
 
-_The examples above only show integer&comma; but the same can be done with bigint and float_
+_The examples above only show integer, but the same can be done with bigint and float_
 
 Usage in object notation:
 
@@ -274,7 +274,7 @@ function(title) {
 
 ## Validations
 
-Model validations, allow you to specify format&sol;content&sol;inheritance validations for each attribute of the model&period;
+Model validations, allow you to specify format/content/inheritance validations for each attribute of the model.
 
 Validations are automatically run on `create`, `update` and `save`. You can also call `validate()` to manually validate an instance.
 
@@ -332,9 +332,9 @@ var ValidateMe = sequelize.define('Foo', {
 })
 ```
 
-Note that where multiple arguments need to be passed to the built-in validation functions&comma; the arguments to be passed must be in an array&period; But if a single array argument is to be passed&comma; for instance an array of acceptable strings for `isIn`, this will be interpreted as multiple string arguments instead of one array argument&period; To work around this pass a single-length array of arguments&comma; such as `[['one', 'two']]` as shown above&period;
+Note that where multiple arguments need to be passed to the built-in validation functions, the arguments to be passed must be in an array. But if a single array argument is to be passed, for instance an array of acceptable strings for `isIn`, this will be interpreted as multiple string arguments instead of one array argument. To work around this pass a single-length array of arguments, such as `[['one', 'two']]` as shown above.
 
-To use a custom error message instead of that provided by validator.js&comma; use an object instead of the plain value or array of arguments&comma; for example a validator which needs no argument can be given a custom message with
+To use a custom error message instead of that provided by validator.js, use an object instead of the plain value or array of arguments, for example a validator which needs no argument can be given a custom message with
 
 ```js
 isInt: {
@@ -342,7 +342,7 @@ isInt: {
 }
 ```
 
-or if arguments need to also be passed add an`args`property&colon;
+or if arguments need to also be passed add an`args`property:
 
 ```js
 isIn: {
@@ -351,25 +351,25 @@ isIn: {
 }
 ```
 
-When using custom validator functions the error message will be whatever message the thrown`Error`object holds&period;
+When using custom validator functions the error message will be whatever message the thrown`Error`object holds.
 
-See [the validator.js project][3] for more details on the built in validation methods&period;
+See [the validator.js project][3] for more details on the built in validation methods.
 
-**Hint&colon; **You can also define a custom function for the logging part&period; Just pass a function&period; The first parameter will be the string that is logged&period;
+**Hint: **You can also define a custom function for the logging part. Just pass a function. The first parameter will be the string that is logged.
 
 ### Validators and `allowNull`
 
-If a particular field of a model is set to allow null &lpar;with `allowNull: true`&rpar; and that value has been set to `null` &comma; its validators do not run&period; This means you can&comma; for instance&comma; have a string field which validates its length to be at least 5 characters&comma; but which also allows`null`&period;
+If a particular field of a model is set to allow null (with `allowNull: true`) and that value has been set to `null` , its validators do not run. This means you can, for instance, have a string field which validates its length to be at least 5 characters, but which also allows`null`.
 
 ### Model validations
 
-Validations can also be defined to check the model after the field-specific validators&period; Using this you could&comma; for example&comma; ensure either neither of `latitude` and `longitude` are set or both&comma; and fail if one but not the other is set&period;
+Validations can also be defined to check the model after the field-specific validators. Using this you could, for example, ensure either neither of `latitude` and `longitude` are set or both, and fail if one but not the other is set.
 
-Model validator methods are called with the model object's context and are deemed to fail if they throw an error&comma; otherwise pass&period; This is just the same as with custom field-specific validators&period;
+Model validator methods are called with the model object's context and are deemed to fail if they throw an error, otherwise pass. This is just the same as with custom field-specific validators.
 
-Any error messages collected are put in the validation result object alongside the field validation errors&comma; with keys named after the failed validation method's key in the `validate` option object&period; Even though there can only be one error message for each model validation method at any one time&comma; it is presented as a single string error in an array&comma; to maximize consistency with the field errors&period;
+Any error messages collected are put in the validation result object alongside the field validation errors, with keys named after the failed validation method's key in the `validate` option object. Even though there can only be one error message for each model validation method at any one time, it is presented as a single string error in an array, to maximize consistency with the field errors.
 
-An example&colon;
+An example:
 
 ```js
 var Pub = Sequelize.define('Pub', {
@@ -398,7 +398,7 @@ var Pub = Sequelize.define('Pub', {
 })
 ```
 
-In this simple case an object fails validation if either latitude or longitude is given&comma; but not both&period; If we try to build one with an out-of-range latitude and nolongitude, `raging_bullock_arms.validate()` might return
+In this simple case an object fails validation if either latitude or longitude is given, but not both. If we try to build one with an out-of-range latitude and no longitude, `raging_bullock_arms.validate()` might return
 
 ```js
 {
@@ -409,7 +409,7 @@ In this simple case an object fails validation if either latitude or longitude i
 
 ## Configuration
 
-You can also influence the way Sequelize handles your column names&colon;
+You can also influence the way Sequelize handles your column names:
 
 ```js
 var Bar = sequelize.define('Bar', { /* bla */ }, {
@@ -425,7 +425,7 @@ var Bar = sequelize.define('Bar', { /* bla */ }, {
   // so updatedAt will be updated_at
   underscored: true,
 
-  // disable the modification of tablenames; By default, sequelize will automatically
+  // disable the modification of table names; By default, sequelize will automatically
   // transform all passed model names (first parameter of define) into plural.
   // if you don't want that, set the following
   freezeTableName: true,
@@ -454,7 +454,7 @@ var Foo = sequelize.define('Foo',  { /* bla */ }, {
 })
 ```
 
-You can also change the database engine&comma; e&period;g&period; to MyISAM&period; InnoDB is the default.
+You can also change the database engine, e.g. to MyISAM. InnoDB is the default.
 
 ```js
 var Person = sequelize.define('Person', { /* attributes */ }, {
@@ -467,7 +467,7 @@ var sequelize = new Sequelize(db, user, pw, {
 })
 ```
 
-Finaly you can specify a comment for the table in MySQL and PG
+Finally you can specify a comment for the table in MySQL and PG
 
 ```js
 var Person = sequelize.define('Person', { /* attributes */ }, {
@@ -477,7 +477,7 @@ var Person = sequelize.define('Person', { /* attributes */ }, {
 
 ## Import
 
-You can also store your model definitions in a single file using the `import` method&period; The returned object is exactly the same as defined in the imported file's function&period; Since `v1:5.0` of Sequelize the import is cached&comma; so you won't run into troubles when calling the import of a file twice or more often&period;
+You can also store your model definitions in a single file using the `import` method. The returned object is exactly the same as defined in the imported file's function. Since `v1:5.0` of Sequelize the import is cached, so you won't run into troubles when calling the import of a file twice or more often.
 
 ```js
 // in your server file - e.g. app.js
@@ -493,7 +493,7 @@ module.exports = function(sequelize, DataTypes) {
 }
 ```
 
-The `import` method can also accept a callback as an argument&period;
+The `import` method can also accept a callback as an argument.
 
 ```js
 sequelize.import('Project', function(sequelize, DataTypes) {
@@ -506,7 +506,7 @@ sequelize.import('Project', function(sequelize, DataTypes) {
 
 ## Database synchronization
 
-When starting a new project you won't have a database structure and using Sequelize you won't need to&period; Just specify your model structures and let the library do the rest&period; Currently supported is the creation and deletion of tables&colon;
+When starting a new project you won't have a database structure and using Sequelize you won't need to. Just specify your model structures and let the library do the rest. Currently supported is the creation and deletion of tables:
 
 ```js
 // Create the tables:
@@ -528,7 +528,7 @@ Project.[sync|drop]().then(function() {
 })
 ```
 
-Because synchronizing and dropping all of your tables might be a lot of lines to write&comma; you can also let Sequelize do the work for you&colon;
+Because synchronizing and dropping all of your tables might be a lot of lines to write, you can also let Sequelize do the work for you:
 
 ```js
 // Sync all models that aren't already in the database
@@ -559,7 +559,7 @@ sequelize.sync({ force: true, match: /_test$/ });
 
 ## Expansion of models
 
-Sequelize allows you to pass custom methods to a model and its instances&period; Just do the following&colon;
+Sequelize allows you to pass custom methods to a model and its instances. Just do the following:
 
 ```js
 var Foo = sequelize.define('Foo', { /* attributes */}, {
@@ -576,7 +576,7 @@ Foo.method1()
 Foo.build().method2()
 ```
 
-Of course you can also access the instance's data and generate virtual getters&colon;
+Of course you can also access the instance's data and generate virtual getters:
 
 ```js
 var User = sequelize.define('User', { firstname: Sequelize.STRING, lastname: Sequelize.STRING }, {
@@ -591,7 +591,7 @@ var User = sequelize.define('User', { firstname: Sequelize.STRING, lastname: Seq
 User.build({ firstname: 'foo', lastname: 'bar' }).getFullname() // 'foo bar'
 ```
 
-You can also set custom methods to all of your models during the instantiation&colon;
+You can also set custom methods to all of your models during the instantiation:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {

--- a/docs/docs/models-usage.md
+++ b/docs/docs/models-usage.md
@@ -1,8 +1,8 @@
 ## Data retrieval / Finders
 
-Finder methods are intended to query data from the database&period; They do *not* return plain objects but instead return model instances&period; Because finder methods return model instances you can call any model instance member on the result as described in the documentation for [*instances*](http://docs.sequelizejs.com/en/latest/docs/instances/)&period;
+Finder methods are intended to query data from the database. They do *not* return plain objects but instead return model instances. Because finder methods return model instances you can call any model instance member on the result as described in the documentation for [*instances*](http://docs.sequelizejs.com/en/latest/docs/instances/).
 
-In this document we'll explore what finder methods can do&colon;
+In this document we'll explore what finder methods can do:
 
 ### find - Search for one specific element in the database
 ```js
@@ -29,7 +29,7 @@ Project.findOne({
 
 ### findOrCreate - Search for a specific element or create it if not available
 
-The method `findOrCreate` can be used to check if a certain element already exists in the database&period; If that is the case the method will result in a respective instance&period; If the element does not yet exist&comma; it will be created.
+The method `findOrCreate` can be used to check if a certain element already exists in the database. If that is the case the method will result in a respective instance. If the element does not yet exist, it will be created.
 
 Let's assume we have an empty database with a `User` model which has a `username` and a `job`.
 
@@ -55,7 +55,7 @@ User
   })
 ```
 
-The code created a new instance&period; So when we already have an instance &period;&period;&period;
+The code created a new instance. So when we already have an instance ...
 ```js
 User
   .create({ username: 'fnord', job: 'omnomnom' })
@@ -82,11 +82,11 @@ User
   })
 ```
 
-&period;&period;&period; the existing entry will not be changed&period; See the `job` of the second user&comma; and the fact that created was false&period;
+... the existing entry will not be changed. See the `job` of the second user, and the fact that created was false.
 
-### findAndCountAll - Search for multiple elements in the database&comma; returns both data and total count
+### findAndCountAll - Search for multiple elements in the database, returns both data and total count
 
-This is a convienience method that combines`findAll` and `count` (see below) this is useful when dealing with queries related to pagination where you want to retrieve data with a `limit` and `offset` but also need to know the total number of records that match the query:
+This is a convenience method that combines`findAll` and `count` (see below) this is useful when dealing with queries related to pagination where you want to retrieve data with a `limit` and `offset` but also need to know the total number of records that match the query:
 
 The success handler will always receive an object with two properties:
 
@@ -263,7 +263,7 @@ LIMIT 1;
 
 ### Manipulating the dataset with limit, offset, order and group
 
-To get more relevant data&comma; you can use limit&comma; offset&comma; order and grouping&colon;
+To get more relevant data, you can use limit, offset, order and grouping:
 
 ```js
 // limit the results of the query
@@ -276,7 +276,7 @@ Project.findAll({ offset: 10 })
 Project.findAll({ offset: 10, limit: 2 })
 ```
 
-The syntax for grouping and ordering are equal&comma; so below it is only explained with a single example for group&comma; and the rest for order&period; Everything you see below can also be done for group
+The syntax for grouping and ordering are equal, so below it is only explained with a single example for group, and the rest for order. Everything you see below can also be done for group
 
 ```js
 Project.findAll({order: 'title DESC'})
@@ -286,7 +286,7 @@ Project.findAll({group: 'name'})
 // yields GROUP BY name
 ```
 
-Notice how in the two examples above&comma; the string provided is inserted verbatim into the query&comma; i&period;e&period; column names are not escaped&period; When you provide a string to order &sol; group&comma; this will always be the case. If you want to escape column names&comma; you should provide an array of arguments&comma; even though you only want to order &sol; group by a single column
+Notice how in the two examples above, the string provided is inserted verbatim into the query, i.e. column names are not escaped. When you provide a string to order/group, this will always be the case. If you want to escape column names, you should provide an array of arguments, even though you only want to order/group by a single column
 
 ```js
 something.findOne({
@@ -311,18 +311,18 @@ something.findOne({
 })
 ```
 
-To recap&comma; the elements of the order &sol; group array can be the following&colon;
+To recap, the elements of the order/group array can be the following:
 
 * String - will be quoted
-* Array - first element will be qouted&comma; second will be appended verbatim
+* Array - first element will be quoted, second will be appended verbatim
 * Object -
   * Raw will be added verbatim without quoting
-  * Everything else is ignored&comma; and if raw is not set&comma; the query will fail
-* Sequelize&period;fn and Sequelize&period;col returns functions and quoted cools
+  * Everything else is ignored, and if raw is not set, the query will fail
+* Sequelize.fn and Sequelize.col returns functions and quoted cools
 
 ### Raw queries
 
-Sometimes you might be expecting a massive dataset that you just want to display, without manipulation. For each row you select, Sequelize creates an instance with functions for update, delete, get associations etc. If you have thousands of rows&comma; this might take some time&period; If you only need the raw data and don't want to update anything&comma; you can do like this to get the raw data&period;
+Sometimes you might be expecting a massive dataset that you just want to display, without manipulation. For each row you select, Sequelize creates an instance with functions for update, delete, get associations etc. If you have thousands of rows, this might take some time. If you only need the raw data and don't want to update anything, you can do like this to get the raw data.
 
 ```js
 // Are you expecting a massive dataset from the DB,
@@ -331,9 +331,9 @@ Sometimes you might be expecting a massive dataset that you just want to display
 Project.findAll({ where: { ... }, raw: true })
 ```
 
-### count - Count the occurences of elements in the database
+### count - Count the occurrences of elements in the database
 
-There is also a method for counting database objects&colon;
+There is also a method for counting database objects:
 
 ```js
 Project.count().then(function(c) {
@@ -347,7 +347,7 @@ Project.count({ where: ["id > ?", 25] }).then(function(c) {
 
 ### max - Get the greatest value of a specific attribute within a specific table
 
-And here is a method for getting the max value of an attribute&colon;f
+And here is a method for getting the max value of an attribute:f
 
 ```js
 /*
@@ -367,7 +367,7 @@ Project.max('age', { where: { age: { lt: 20 } } }).then(function(max) {
 
 ### min - Get the least value of a specific attribute within a specific table
 
-And here is a method for getting the min value of an attribute&colon;
+And here is a method for getting the min value of an attribute:
 
 ```js
 /*
@@ -424,7 +424,7 @@ sequelize.sync().then(function() {
 })
 ```
 
-OK&period; So&comma; first of all&comma; let's load all tasks with their associated user&period;
+OK. So, first of all, let's load all tasks with their associated user.
 
 ```js
 Task.findAll({ include: [ User ] }).then(function(tasks) {
@@ -448,9 +448,9 @@ Task.findAll({ include: [ User ] }).then(function(tasks) {
 })
 ```
 
-Notice that the accessor (the `User` property in the resulting instance) is singular because the association is one-to-something&period;
+Notice that the accessor (the `User` property in the resulting instance) is singular because the association is one-to-something.
 
-Next thing&colon; Loading of data with many-to-something associations&excl;
+Next thing: Loading of data with many-to-something associations!
 
 ```js
 User.findAll({ include: [ Task ] }).then(function(users) {
@@ -474,10 +474,10 @@ User.findAll({ include: [ Task ] }).then(function(users) {
 })
 ```
 
-Notice that the accessor (the `Tasks` property in the resulting instance) is plural because the association is many-to-something&period;
+Notice that the accessor (the `Tasks` property in the resulting instance) is plural because the association is many-to-something.
 
 
-If an association is aliased (using the `as` option), you must specify this alias when including the model&period; Notice how the user's `Tool`s are aliased as `Instruments` above&period; In order to get that right you have to specify the model you want to load&comma; as well as the alias&colon;
+If an association is aliased (using the `as` option), you must specify this alias when including the model. Notice how the user's `Tool`s are aliased as `Instruments` above. In order to get that right you have to specify the model you want to load, as well as the alias:
 
 ```js
 User.findAll({ include: [{ model: Tool, as: 'Instruments' }] }).then(function(users) {

--- a/docs/docs/raw-queries.md
+++ b/docs/docs/raw-queries.md
@@ -32,7 +32,7 @@ sequelize.query('SELECT * FROM projects', { model: Projects }).then(function(pro
 Replacements in a query can be done in two different ways, either using named parameters (starting with `:`), or unnamed, represented by a `?`. Replacements are passed in the options object.
 
 * If an array is passed, `?` will be replaced in the order that they appear in the array
-* If an object is passed, `:key` will be replaced with the keys from that object. If the object contains keys not found in the query or vice verca, an exception will be thrown.
+* If an object is passed, `:key` will be replaced with the keys from that object. If the object contains keys not found in the query or vice versa, an exception will be thrown.
 
 ```js
 sequelize.query('SELECT * FROM projects WHERE status = ?',
@@ -49,9 +49,9 @@ sequelize.query('SELECT * FROM projects WHERE status = :status ',
 ```
 
 # Bind Parameter
-Bind parameters are like replacemnets. Except replacements are escaped and inserted into the query by sequelize before the query is sent to the database, while bind parameters are sent to the database outside the sql query text. A query can have either bind parameters or replacments.
+Bind parameters are like replacements. Except replacements are escaped and inserted into the query by sequelize before the query is sent to the database, while bind parameters are sent to the database outside the SQL query text. A query can have either bind parameters or replacements.
 
-Only Sqlite and Postgresql support bind parameters. Other dialects will insert them into the sql query in the same way it is done for replacements. Bind parameters are referred to by either $1, $2, ... (numeric) or $key (alpha-numeric). This is independent of the dialect.
+Only SQLite and PostgreSQL support bind parameters. Other dialects will insert them into the SQL query in the same way it is done for replacements. Bind parameters are referred to by either $1, $2, ... (numeric) or $key (alpha-numeric). This is independent of the dialect.
 
 * If an array is passed, `$1` will be bound to the 1st element in the array (`bind[0]`)
 * If an object is passed, `$key` will be bound to `object['key']`. Each key must have a none numeric char. `$1` is not a valid key, even if `object['1']` exists.
@@ -59,7 +59,7 @@ Only Sqlite and Postgresql support bind parameters. Other dialects will insert t
 
 All bound values must be present in the array/object or an exception will be thrown. This applies even to cases in which the database may ignore the bound parameter.
 
-The database may add further restrictions to this. Bind parameters can not be sql keywords, nor table or column names. They are also ignored in quoted text/data. In Postgresql it may also be needed to typecast them, if the type can not be inferred from the context `$1::varchar`.
+The database may add further restrictions to this. Bind parameters cannot be SQL keywords, nor table or column names. They are also ignored in quoted text/data. In PostgreSQL it may also be needed to typecast them, if the type cannot be inferred from the context `$1::varchar`.
 
 ```js
 sequelize.query('SELECT *, "text with literal $$1 and literal $$status" as t FROM projects WHERE status = $1',

--- a/docs/docs/scopes.md
+++ b/docs/docs/scopes.md
@@ -85,7 +85,7 @@ SELECT * FROM projects WHERE someNumber = 42 AND accessLevel >= 19
 ```
 
 ## Merging
-Several scopes can be applied simultaneously by passing an array of scopes to `.scope`, or by passing the scopes as consequtive arguments.
+Several scopes can be applied simultaneously by passing an array of scopes to `.scope`, or by passing the scopes as consecutive arguments.
 
 ```js
 // These two are equivalent
@@ -137,7 +137,7 @@ Calling `.scope('scope1', 'scope2')` will yield the following query
 WHERE firstName = 'bob' AND age > 30 LIMIT 10
 ```
 
-Note how `limit` and `age` are overwritten by `scope2`, whíle `firstName` is preserved. `limit`, `offset`, `order`, `paranoid`, `lock` and `raw` are overwritten, while `where` and `include` are shallowly merged. This means that identical keys in the where objects, and subsequent includes of the same model will both overwrite each other.
+Note how `limit` and `age` are overwritten by `scope2`, while `firstName` is preserved. `limit`, `offset`, `order`, `paranoid`, `lock` and `raw` are overwritten, while `where` and `include` are shallowly merged. This means that identical keys in the where objects, and subsequent includes of the same model will both overwrite each other.
 
 The same merge logic applies when passing a find object directly to findAll on a scoped model:
 
@@ -157,8 +157,8 @@ Here the `deleted` scope is merged with the finder. If we were to pass `where: {
 # Associations
 Sequelize has two different but related scope concepts in relation to associations. The difference is subtle but important:
 
-* **Assocation scopes** Allow you to specify default attributes when getting and setting associations - useful when implementing polymorphic associations. This scope is only invoked on the association between the two models, when using the `get`, `set`, `add` and `create` associated model functions
-* **Scopes on associated models** Allows you to apply default and other scopes when fetching associations, and allows you to pass a scoped model when creating associtaions. These scopes both apply to regular finds on the model and to find through the association.
+* **Association scopes** Allow you to specify default attributes when getting and setting associations - useful when implementing polymorphic associations. This scope is only invoked on the association between the two models, when using the `get`, `set`, `add` and `create` associated model functions
+* **Scopes on associated models** Allows you to apply default and other scopes when fetching associations, and allows you to pass a scoped model when creating associations. These scopes both apply to regular finds on the model and to find through the association.
 
 As an example, consider the models Post and Comment. Comment is associated to several other models (Image, Video etc.) and the association between Comment and other models is polymorphic, which means that Comment stores a `commentable` column, in addition to the foreign key `commentable_id`.
 

--- a/docs/docs/transactions.md
+++ b/docs/docs/transactions.md
@@ -7,9 +7,9 @@ The key difference is that the managed transaction uses a callback that expects 
 
 # Managed transaction (auto-callback)
 
-Managed transactions handle comitting or rolling back the transaction automagically. You start a managed transaction by passing a callback to `sequelize.transaction`.
+Managed transactions handle committing or rolling back the transaction automagically. You start a managed transaction by passing a callback to `sequelize.transaction`.
 
-Notice how the callback passed to `transaction` returns a promise chain, and does not explicitly call `t.commit()` nor `t.rollback()`. If all promises in the returned chain are resolved successfully the transaction is comitted. If one or several of the promises are rejected, the transaction is rolled back.
+Notice how the callback passed to `transaction` returns a promise chain, and does not explicitly call `t.commit()` nor `t.rollback()`. If all promises in the returned chain are resolved successfully the transaction is committed. If one or several of the promises are rejected, the transaction is rolled back.
 
 ```js
 return sequelize.transaction(function (t) {

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -1,11 +1,11 @@
 ## Basic usage
 
-To get the ball rollin' you first have to create an instance of Sequelize&period; Use it the following way&colon;
+To get the ball rollin' you first have to create an instance of Sequelize. Use it the following way:
 
 ```js
 var sequelize = new Sequelize('database', 'username'[, 'password'])
 ```
-This will save the passed database credentials and provide all further methods&period; Furthermore you can specify a non-default host&sol;port&colon;
+This will save the passed database credentials and provide all further methods. Furthermore you can specify a non-default host/port:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
@@ -14,7 +14,7 @@ var sequelize = new Sequelize('database', 'username', 'password', {
 })
 ```
 
-If you just don't have a password&colon;
+If you just don't have a password:
 
 ```js
 var sequelize = new Sequelize('database', 'username')
@@ -22,7 +22,7 @@ var sequelize = new Sequelize('database', 'username')
 var sequelize = new Sequelize('database', 'username', null)
 ```
 
-You can also use a connection string&colon;
+You can also use a connection string:
 
 ```js
 var sequelize = new Sequelize('mysql://user:pass@example.com:9821/dbname', {
@@ -32,7 +32,7 @@ var sequelize = new Sequelize('mysql://user:pass@example.com:9821/dbname', {
 
 ## Options
 
-Besides the host and the port&comma; Sequelize comes with a whole bunch of options&period; Here they are&colon;
+Besides the host and the port, Sequelize comes with a whole bunch of options. Here they are:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
@@ -96,7 +96,7 @@ var sequelize = new Sequelize('database', 'username', 'password', {
     timestamps: true
   },
  
-  // similiar for sync: you can define this to always force sync for models
+  // similar for sync: you can define this to always force sync for models
   sync: { force: true },
  
   // sync after each association (see below). If set to false, you need to sync manually after setting all associations. Default: true
@@ -120,11 +120,11 @@ var sequelize = new Sequelize('database', 'username', 'password', {
 })
 ```
 
-**Hint&colon;** You can also define a custom function for the logging part&period; Just pass a function&period; The first parameter will be the string that is logged&period;
+**Hint:** You can also define a custom function for the logging part. Just pass a function. The first parameter will be the string that is logged.
 
 ## Read replication
 
-Sequelize supports read replication&comma; i&period;e&period; having multiple servers that you can connect to when you want to do a SELECT query&period; When you do read replication&comma; you specify one or more servers to act as read replicas&comma; and one server to act as the write master&comma; which handles all writes and updates and propagates them to the replicas &lpar;note that the actual replication process is **not** handled by Sequelize&comma; but should be set up in MySql&rpar;&period;
+Sequelize supports read replication, i.e. having multiple servers that you can connect to when you want to do a SELECT query. When you do read replication, you specify one or more servers to act as read replicas, and one server to act as the write master, which handles all writes and updates and propagates them to the replicas (note that the actual replication process is **not** handled by Sequelize, but should be set up in MySql).
 
 ```js
 var sequelize = new Sequelize('database', null, null, {
@@ -144,9 +144,9 @@ var sequelize = new Sequelize('database', null, null, {
 })
 ```
 
-If you have any general settings that apply to all replicas you do not need to provide them for each instance&period; In the code above&comma; database name and port is propagated to all replicas&period; The same will happen for user and password&comma; if you leave them out for any of the replicas&period; Each replica has the following options&colon;`host`&comma;`port`&comma;`username`&comma;`password`&comma;`database`.
+If you have any general settings that apply to all replicas you do not need to provide them for each instance. In the code above, database name and port is propagated to all replicas. The same will happen for user and password, if you leave them out for any of the replicas. Each replica has the following options:`host`,`port`,`username`,`password`,`database`.
 
-Sequelize uses a pool to manage connections to your replicas&period; The default options are&colon;
+Sequelize uses a pool to manage connections to your replicas. The default options are:
 
 ```js
 {
@@ -156,22 +156,22 @@ Sequelize uses a pool to manage connections to your replicas&period; The default
 }
 ```
 
-If you want to modify these&comma; you can pass pool as an options when instantiating Sequelize&comma; as shown above&period;
+If you want to modify these, you can pass pool as an options when instantiating Sequelize, as shown above.
 
-**Note&colon;** Read replication only works for MySQL at the moment&excl;
+**Note:** Read replication only works for MySQL at the moment!
 
 ## Dialects
 
-With the release of Sequelize`1.6.0`&comma; the library got independent from specific dialects&period; This means&comma; that you'll have to add the respective connector library to your project yourself. Version 1.7.0 stable has been released in bundles with the connector libraries (sequelize-mysql, sequelize-postgres etc.) but these bundles are not maintained, and will not be released for 2.0.0 upwards.
+With the release of Sequelize`1.6.0`, the library got independent from specific dialects. This means, that you'll have to add the respective connector library to your project yourself. Version 1.7.0 stable has been released in bundles with the connector libraries (sequelize-mysql, sequelize-postgres etc.) but these bundles are not maintained, and will not be released for 2.0.0 upwards.
 
 ### MySQL
 
-In order to get Sequelize working nicely together with MySQL&comma; you'll need to install`mysql@~2.5.0`or higher. Once that's done you can use it like this&colon;
+In order to get Sequelize working nicely together with MySQL, you'll need to install`mysql@~2.5.0`or higher. Once that's done you can use it like this:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
   // mysql is the default dialect, but you know...
-  // for demo purporses we are defining it nevertheless :)
+  // for demo purposes we are defining it nevertheless :)
   // so: we want mysql!
   dialect: 'mysql'
 })
@@ -194,7 +194,7 @@ var sequelize = new Sequelize('database', 'username', 'password', {
 
 ### SQLite
 
-For SQLite compatibility you'll need`sqlite3@~3.0.0`. Configure Sequelize like this&colon;
+For SQLite compatibility you'll need`sqlite3@~3.0.0`. Configure Sequelize like this:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
@@ -209,7 +209,7 @@ var sequelize = new Sequelize('database', 'username', 'password', {
 
 ### PostgreSQL
 
-The library for PostgreSQL is`pg@~3.6.0` You'll just need to define the dialect&colon;
+The library for PostgreSQL is`pg@~3.6.0` You'll just need to define the dialect:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
@@ -220,7 +220,7 @@ var sequelize = new Sequelize('database', 'username', 'password', {
 
 ### MSSQL
 
-The library for MSSQL is`tedious@^1.7.0` You'll just need to define the dialect&colon;
+The library for MSSQL is`tedious@^1.7.0` You'll just need to define the dialect:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
@@ -230,7 +230,7 @@ var sequelize = new Sequelize('database', 'username', 'password', {
 
 ## Executing raw SQL queries
 
-As there are often use cases in which it is just easier to execute raw &sol; already prepared SQL queries, you can utilize the function `sequelize.query`.
+As there are often use cases in which it is just easier to execute raw / already prepared SQL queries, you can utilize the function `sequelize.query`.
 
 Here is how it works:
 
@@ -244,7 +244,7 @@ sequelize.query("SELECT * FROM myTable").then(function(myTableRows) {
 })
 
 // If you want to return sequelize instances use the model options.
-// This allows you to easily map a query to a predefined model for sequelizejs e.g:
+// This allows you to easily map a query to a predefined model for sequelize e.g:
 sequelize
   .query('SELECT * FROM projects', { model: Projects })
   .then(function(projects){
@@ -286,7 +286,7 @@ The syntax used depends on the replacements option passed to the function:
 
 * If an array is passed, `?` will be replaced in the order that they appear in the array
 * If an object is passed, `:key` will be replaced with the keys from that object.
-If the object contains keys not found in the query or vice verca, an exception
+If the object contains keys not found in the query or vice versa, an exception
 will be thrown.
 
 ```js

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -249,7 +249,7 @@ var BelongsToMany = function(source, target, options) {
     /**
      * Un-associate the instance.
      *
-     * @param {Instace|String|Number} [oldAssociated] Can be an Instance or its primary key
+     * @param {Instance|String|Number} [oldAssociated] Can be an Instance or its primary key
      * @param {Object} [options] Options passed to `through.destroy`
      * @return {Promise}
      * @method removeAssociation
@@ -258,7 +258,7 @@ var BelongsToMany = function(source, target, options) {
     /**
      * Un-associate several instances.
      *
-     * @param {Array<Instace|String|Number>} [oldAssociated] Can be an array of instances or their primary keys
+     * @param {Array<Instance|String|Number>} [oldAssociated] Can be an array of instances or their primary keys
      * @param {Object} [options] Options passed to `through.destroy`
      * @return {Promise}
      * @method removeAssociations
@@ -267,7 +267,7 @@ var BelongsToMany = function(source, target, options) {
     /**
      * Check if an instance is associated with this.
      *
-     * @param {Instace|String|Number} [instance] Can be an Instance or its primary key
+     * @param {Instance|String|Number} [instance] Can be an Instance or its primary key
      * @param {Object} [options] Options passed to getAssociations
      * @return {Promise}
      * @method hasAssociation
@@ -276,7 +276,7 @@ var BelongsToMany = function(source, target, options) {
     /**
      * Check if all instances are associated with this.
      *
-     * @param {Array<Instace|String|Number>} [instances] Can be an array of instances or their primary keys
+     * @param {Array<Instance|String|Number>} [instances] Can be an array of instances or their primary keys
      * @param {Object} [options] Options passed to getAssociations
      * @return {Promise}
      * @method hasAssociations

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -10,7 +10,7 @@ var Utils = require('./../utils')
 /**
  * One-to-many association
  *
- * In the API reference below, replace `Assocation(s)` with the actual name of your association, e.g. for `User.hasMany(Project)` the getter will be `user.getProjects()`.
+ * In the API reference below, replace `Association(s)` with the actual name of your association, e.g. for `User.hasMany(Project)` the getter will be `user.getProjects()`.
  *
  * @mixin HasMany
  */
@@ -144,7 +144,7 @@ var HasMany = function(source, target, options) {
     /**
      * Un-associate the instance.
      *
-     * @param {Instace|String|Number} [oldAssociated] Can be an Instance or its primary key
+     * @param {Instance|String|Number} [oldAssociated] Can be an Instance or its primary key
      * @param {Object} [options] Options passed to `target.update`
      * @return {Promise}
      * @method removeAssociation
@@ -153,7 +153,7 @@ var HasMany = function(source, target, options) {
     /**
      * Un-associate several instances.
      *
-     * @param {Array<Instace|String|Number>} [oldAssociatedArray] Can be an array of instances or their primary keys
+     * @param {Array<Instance|String|Number>} [oldAssociatedArray] Can be an array of instances or their primary keys
      * @param {Object} [options] Options passed to `through.destroy`
      * @return {Promise}
      * @method removeAssociations
@@ -162,7 +162,7 @@ var HasMany = function(source, target, options) {
     /**
      * Check if an instance is associated with this.
      *
-     * @param {Instace|String|Number} [instance] Can be an Instance or its primary key
+     * @param {Instance|String|Number} [instance] Can be an Instance or its primary key
      * @param {Object} [options] Options passed to getAssociations
      * @return {Promise}
      * @method hasAssociation
@@ -171,7 +171,7 @@ var HasMany = function(source, target, options) {
     /**
      * Check if all instances are associated with this.
      *
-     * @param {Array<Instace|String|Number>} [instances] Can be an array of instances or their primary keys
+     * @param {Array<Instance|String|Number>} [instances] Can be an array of instances or their primary keys
      * @param {Object} [options] Options passed to getAssociations
      * @return {Promise}
      * @method hasAssociations

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -9,7 +9,7 @@ var Utils = require('./../utils')
 /**
  * One-to-one association
  *
- * In the API reference below, replace `Assocation` with the actual name of your association, e.g. for `User.hasOne(Project)` the getter will be `user.getProject()`.
+ * In the API reference below, replace `Association` with the actual name of your association, e.g. for `User.hasOne(Project)` the getter will be `user.getProject()`.
  * This is almost the same as `belongsTo` with one exception. The foreign key will be defined on the target model.
  *
  * @mixin HasOne
@@ -79,7 +79,7 @@ var HasOne = function(srcModel, targetModel, options) {
      * Set the associated model.
      *
      * @param {Instance|String|Number} [newAssociation] An instance or the primary key of an instance to associate with this. Pass `null` or `undefined` to remove the association.
-     * @param {Object} [options] Options passed to getAssocation and `target.save`
+     * @param {Object} [options] Options passed to getAssociation and `target.save`
      * @return {Promise}
      * @method setAssociation
      */

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -8,7 +8,7 @@ var Utils = require('./../utils')
   , BelongsTo = require('./belongs-to');
 
 /**
- * Creating assocations in sequelize is done by calling one of the belongsTo / hasOne / hasMany / belongsToMany functions on a model (the source), and providing another model as the first argument to the function (the target).
+ * Creating associations in sequelize is done by calling one of the belongsTo / hasOne / hasMany / belongsToMany functions on a model (the source), and providing another model as the first argument to the function (the target).
  *
  * * hasOne - adds a foreign key to the target and singular association mixins to the source.
  * * belongsTo - add a foreign key and singular association mixins to the source.
@@ -54,7 +54,7 @@ var Utils = require('./../utils')
  * })
  * ```
  *
- * This specifies that the `uid` column can not be null. In most cases this will already be covered by the foreign key costraints, which sequelize creates automatically, but can be useful in case where the foreign keys are disabled, e.g. due to circular references (see `constraints: false` below).
+ * This specifies that the `uid` column cannot be null. In most cases this will already be covered by the foreign key constraints, which sequelize creates automatically, but can be useful in case where the foreign keys are disabled, e.g. due to circular references (see `constraints: false` below).
  *
  * When fetching associated models, you can limit your query to only load some models. These queries are written in the same way as queries to `find`/`findAll`. To only get pictures in JPG, you can do:
  *
@@ -66,7 +66,7 @@ var Utils = require('./../utils')
  * })
  * ```
  *
- * There are several ways to update and add new assoications. Continuing with our example of users and pictures:
+ * There are several ways to update and add new associations. Continuing with our example of users and pictures:
  * ```js
  * user.addPicture(p) // Add a single picture
  * user.setPictures([p1, p2]) // Associate user with ONLY these two picture, all other associations will be deleted
@@ -122,8 +122,8 @@ var singleLinked = function (Type) {
  * @param {Model}           target
  * @param {object}          [options]
  * @param {boolean}         [options.hooks=false] Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade. For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking any hooks
- * @param {string}          [options.as] The alias of this model, in singular form. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the assocition, you should provide the same alias when eager loading and when getting assocated models. Defaults to the singularized name of target
- * @param {string|object}   [options.foreignKey] The name of the foreign key in the target table or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the colum. Defaults to the name of source + primary key of source
+ * @param {string}          [options.as] The alias of this model, in singular form. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the association, you should provide the same alias when eager loading and when getting associated models. Defaults to the singularized name of target
+ * @param {string|object}   [options.foreignKey] The name of the foreign key in the target table or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the column. Defaults to the name of source + primary key of source
  * @param {string}          [options.onDelete='SET&nbsp;NULL|CASCADE'] SET NULL if foreignKey allows nulls, CASCADE if otherwise
  * @param {string}          [options.onUpdate='CASCADE']
  * @param {boolean}         [options.constraints=true] Should on update and on delete constraints be enabled on the foreign key.
@@ -139,7 +139,7 @@ Mixin.hasOne = singleLinked(HasOne);
  * @param {Model}           target
  * @param {object}          [options]
  * @param {boolean}         [options.hooks=false] Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade. For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking any hooks
- * @param {string}          [options.as] The alias of this model, in singular form. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the association, you should provide the same alias when eager loading and when getting assocated models. Defaults to the singularized name of target
+ * @param {string}          [options.as] The alias of this model, in singular form. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the association, you should provide the same alias when eager loading and when getting associated models. Defaults to the singularized name of target
  * @param {string|object}   [options.foreignKey] The name of the foreign key in the source table or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the column. Defaults to the name of target + primary key of target
  * @param {string}          [options.targetKey] The name of the field to use as the key for the association in the target table. Defaults to the primary key of the target table
  * @param {string}          [options.onDelete='SET&nbsp;NULL|NO&nbsp;ACTION'] SET NULL if foreignKey allows nulls, NO ACTION if otherwise
@@ -156,7 +156,7 @@ Mixin.belongsTo = singleLinked(BelongsTo);
  * @param {Model}               target
  * @param {object}              [options]
  * @param {boolean}             [options.hooks=false] Set to true to run before-/afterDestroy hooks when an associated model is deleted because of a cascade. For example if `User.hasOne(Profile, {onDelete: 'cascade', hooks:true})`, the before-/afterDestroy hooks for profile will be called when a user is deleted. Otherwise the profile will be deleted without invoking any hooks
- * @param {string|object}       [options.as] The alias of this model. If you provide a string, it should be plural, and will be singularized using node.inflection. If you want to control the singular version yourself, provide an object with `plural` and `singular` keys. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the assocition, you should provide the same alias when eager loading and when getting assocated models. Defaults to the pluralized name of target
+ * @param {string|object}       [options.as] The alias of this model. If you provide a string, it should be plural, and will be singularized using node.inflection. If you want to control the singular version yourself, provide an object with `plural` and `singular` keys. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the association, you should provide the same alias when eager loading and when getting associated models. Defaults to the pluralized name of target
  * @param {string|object}       [options.foreignKey] The name of the foreign key in the target table or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the column. Defaults to the name of source + primary key of source
  * @param {object}              [options.scope] A key/value set that will be used for association create and find defaults on the target. (sqlite not supported for N:M)
  * @param {string}              [options.onDelete='SET&nbsp;NULL|CASCADE'] SET NULL if foreignKey allows nulls, CASCADE if otherwise
@@ -218,7 +218,7 @@ Mixin.hasMany = function(target, options) { // testhint options:none
  * user.setProjects([p1, p2], {started: false}) // The default value is false, but p1 overrides that.
  * ```
  *
- * Similarily, when fetching through a join table with custom attributes, these attributes will be available as an object with the name of the through model.
+ * Similarly, when fetching through a join table with custom attributes, these attributes will be available as an object with the name of the through model.
  * ```js
  * user.getProjects().then(function (projects) {
  *   var p1 = projects[0]
@@ -233,9 +233,9 @@ Mixin.hasMany = function(target, options) { // testhint options:none
  * @param {Model}               [options.through.model] The model used to join both sides of the N:M association.
  * @param {object}              [options.through.scope] A key/value set that will be used for association create and find defaults on the through model. (Remember to add the attributes to the through model)
  * @param {boolean}             [options.through.unique=true] If true a unique key will be generated from the foreign keys used (might want to turn this off and create specific unique keys when using scopes)
- * @param {string|object}       [options.as] The alias of this association. If you provide a string, it should be plural, and will be singularized using node.inflection. If you want to control the singular version yourself, provide an object with `plural` and `singular` keys. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the assocition, you should provide the same alias when eager loading and when getting assocated models. Defaults to the pluralized name of target
- * @param {string|object}       [options.foreignKey] The name of the foreign key in the join table (representing the source model) or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the colum. Defaults to the name of source + primary key of source
- * @param {string|object}       [options.otherKey] The name of the foreign key in the join table (representing the target model) or an object representing the type definition for the other column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the colum. Defaults to the name of target + primary key of target
+ * @param {string|object}       [options.as] The alias of this association. If you provide a string, it should be plural, and will be singularized using node.inflection. If you want to control the singular version yourself, provide an object with `plural` and `singular` keys. See also the `name` option passed to `sequelize.define`. If you create multiple associations between the same tables, you should provide an alias to be able to distinguish between them. If you provide an alias when creating the association, you should provide the same alias when eager loading and when getting associated models. Defaults to the pluralized name of target
+ * @param {string|object}       [options.foreignKey] The name of the foreign key in the join table (representing the source model) or an object representing the type definition for the foreign column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the column. Defaults to the name of source + primary key of source
+ * @param {string|object}       [options.otherKey] The name of the foreign key in the join table (representing the target model) or an object representing the type definition for the other column (see `Sequelize.define` for syntax). When using an object, you can add a `name` property to set the name of the column. Defaults to the name of target + primary key of target
  * @param {object}              [options.scope] A key/value set that will be used for association create and find defaults on the target. (sqlite not supported for N:M)
  * @param {boolean}             [options.timestamps=sequelize.options.timestamps] Should the join model have timestamps
  * @param {string}              [options.onDelete='SET&nbsp;NULL|CASCADE'] Cascade if this is a n:m, and set null if it is a 1:m

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -628,7 +628,7 @@ RANGE.prototype.validate = function(value) {
 
 
 /**
- * A column storing a unique univeral identifier. Use with `UUIDV1` or `UUIDV4` for default values.
+ * A column storing a unique universal identifier. Use with `UUIDV1` or `UUIDV4` for default values.
  * @property UUID
  */
 var UUID = ABSTRACT.inherits();
@@ -707,8 +707,8 @@ UUIDV4.prototype.validate = function(value) {
  * ```
  *
  * VIRTUAL also takes a return type and dependency fields as arguments
- * If a virtual attribute is present in `attributes` it will automatically pull in the extra fields aswell.
- * Return type is mostly usefull for setups that rely on types like GraphQL.
+ * If a virtual attribute is present in `attributes` it will automatically pull in the extra fields as well.
+ * Return type is mostly useful for setups that rely on types like GraphQL.
  * ```js
  * {
  *   active: {

--- a/lib/deferrable.js
+++ b/lib/deferrable.js
@@ -5,7 +5,7 @@ var util = require('util');
 
 /**
  * A collection of properties related to deferrable constraints. It can be used to
- * make foreign key constraints deferrable and to set the constaints within a
+ * make foreign key constraints deferrable and to set the constraints within a
  * transaction. This is only supported in PostgreSQL.
  *
  * The foreign keys can be configured like this. It will create a foreign key

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -235,7 +235,7 @@ Instance.prototype.get = function(key, options) { // testhint options:none
  * When using set with associations you need to make sure the property key matches the alias of the association
  * while also making sure that the proper include options have been set (from .build() or .find())
  *
- * If called with a dot.seperated key on a JSON/JSONB attribute it will set the value nested and flag the entire object as changed.
+ * If called with a dot.separated key on a JSON/JSONB attribute it will set the value nested and flag the entire object as changed.
  *
  * @see {Model#find} for more information about includes
  * @param {String|Object} key
@@ -1018,7 +1018,7 @@ Instance.prototype.equals = function(other) {
 };
 
 /**
- * Check if this is eqaul to one of `others` by calling equals
+ * Check if this is equal to one of `others` by calling equals
  *
  * @param {Array} others
  * @return {Boolean}

--- a/lib/model.js
+++ b/lib/model.js
@@ -1544,7 +1544,7 @@ Model.prototype.aggregate = function(attribute, aggregateFunction, options) {
  * @param {Object}        [options.where] A hash of search attributes.
  * @param {Object}        [options.include] Include options. See `find` for details
  * @param {boolean}       [options.distinct] Apply COUNT(DISTINCT(col))
- * @param {Object}        [options.attributes] Used in conjustion with `group`
+ * @param {Object}        [options.attributes] Used in conjunction with `group`
  * @param {Object}        [options.group] For creating complex counts. Will return multiple rows as needed.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
@@ -1578,7 +1578,7 @@ Model.prototype.count = function(options) {
 };
 
 /**
- * Find all the rows matching your query, within a specified offset / limit, and get the total number of rows matching your query. This is very usefull for paging
+ * Find all the rows matching your query, within a specified offset / limit, and get the total number of rows matching your query. This is very useful for paging
  *
  * ```js
  * Model.findAndCountAll({
@@ -1800,7 +1800,7 @@ Model.prototype.create = function(values, options) {
 
 /**
  * Find a row that matches the query, or build (but don't save) the row if none is found.
- * The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
+ * The successful result of the promise will be (instance, initialized) - Make sure to use .spread()
  *
  * @param {Object}   options
  * @param {Object}   options.where A hash of search attributes.
@@ -1840,10 +1840,10 @@ Model.prototype.findOrInitialize = Model.prototype.findOrBuild = function(option
 
 /**
  * Find a row that matches the query, or build and save the row if none is found
- * The successfull result of the promise will be (instance, created) - Make sure to use .spread()
+ * The successful result of the promise will be (instance, created) - Make sure to use .spread()
  *
  * If no transaction is passed in the `options` object, a new transaction will be created internally, to prevent the race condition where a matching row is created by another connection after the find but before the insert call.
- * However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has comitted. In this case, an instance of sequelize.TimeoutError will be thrown instead.
+ * However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has committed. In this case, an instance of sequelize.TimeoutError will be thrown instead.
  * If a transaction is created, a savepoint will be created instead, and any unique constraint violation will be handled internally.
  *
  * @param {Object}      options
@@ -1930,7 +1930,7 @@ Model.prototype.findOrCreate = function(options) {
 };
 
 /**
- * A more performant findOrCreate that will not work under a transaction (atleast not in postgres)
+ * A more performant findOrCreate that will not work under a transaction (at least not in postgres)
  * Will execute a find call, if empty then attempt to create, if unique constraint then attempt to find again
  *
  * @param {Object}      options
@@ -2191,7 +2191,7 @@ Model.prototype.bulkCreate = function(records, options) {
  *
  * @param {object} [options] The options passed to Model.destroy in addition to truncate
  * @param {Boolean|function} [options.transaction] Transaction to run query under
- * @param {Boolean|function} [options.cascade = false] Only used in conjuction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
+ * @param {Boolean|function} [options.cascade = false] Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
  * @param {Transaction}      [options.transaction] Transaction to run query under
  * @param {Boolean|function} [options.logging] A function that logs sql queries, or false for no logging
  * @param  {String}          [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
@@ -2215,7 +2215,7 @@ Model.prototype.truncate = function(options) {
  * @param  {Number}       [options.limit]                 How many rows to delete
  * @param  {Boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
  * @param  {Boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored
- * @param  {Boolean}      [options.cascade=false]         Only used in conjuction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
+ * @param  {Boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
  * @return {Promise<Integer>} The number of destroyed rows

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -69,7 +69,7 @@ var url = require('url')
  * @param {Object}   [options.set={}] Default options for sequelize.set
  * @param {Object}   [options.sync={}] Default options for sequelize.sync
  * @param {String}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.
- * @param {Function} [options.logging=console.log] A function that gets executed everytime Sequelize would log something.
+ * @param {Function} [options.logging=console.log] A function that gets executed every time Sequelize would log something.
  * @param {Boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
  * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
  * @param {Boolean}  [options.replication=false] Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database`
@@ -517,11 +517,11 @@ Sequelize.prototype.getQueryInterface = function() {
  * @param {Object}                  [options] These options are merged with the default define options provided to the Sequelize constructor
  * @param {Object}                  [options.defaultScope] Define the default search scope to use for this model. Scopes have the same form as the options passed to find / findAll
  * @param {Object}                  [options.scopes] More scopes, defined in the same way as defaultScope above. See `Model.scope` for more information about how scopes are defined, and what you can do with them
- * @param {Boolean}                 [options.omitNull] Don't persits null values. This means that all columns with null values will not be saved
+ * @param {Boolean}                 [options.omitNull] Don't persist null values. This means that all columns with null values will not be saved
  * @param {Boolean}                 [options.timestamps=true] Adds createdAt and updatedAt timestamps to the model.
  * @param {Boolean}                 [options.paranoid=false] Calling `destroy` will not delete the model, but instead set a `deletedAt` timestamp if this is true. Needs `timestamps=true` to work
  * @param {Boolean}                 [options.underscored=false] Converts all camelCased columns to underscored if true
- * @param {Boolean}                 [options.underscoredAll=false] Converts camelCased model names to underscored tablenames if true
+ * @param {Boolean}                 [options.underscoredAll=false] Converts camelCased model names to underscored table names if true
  * @param {Boolean}                 [options.freezeTableName=false] If freezeTableName is true, sequelize will not try to alter the DAO name to get the table name. Otherwise, the model name will be pluralized
  * @param {Object}                  [options.name] An object with two attributes, `singular` and `plural`, which are used when this model is associated to others.
  * @param {String}                  [options.name.singular=inflection.singularize(modelName)]
@@ -548,7 +548,7 @@ Sequelize.prototype.getQueryInterface = function() {
  * @param {String}                  [options.collate]
  * @param {String}                  [options.initialAutoIncrement] Set the initial AUTO_INCREMENT value for the table in MySQL.
  * @param {Object}                  [options.hooks] An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate, afterBulkCreate, afterBulkDestory and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions.
- * @param {Object}                  [options.validate] An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is asumed to be async, and is called with a callback that accepts an optional error.
+ * @param {Object}                  [options.validate] An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error.
  *
  * @return {Model}
  */
@@ -645,7 +645,7 @@ Sequelize.prototype.import = function(path) {
 };
 
 /**
- * Execute a query on the DB, with the posibility to bypass all the sequelize goodness.
+ * Execute a query on the DB, with the possibility to bypass all the sequelize goodness.
  *
  * By default, the function will return two arguments: an array of results, and a metadata object, containing number of affected rows etc. Use `.spread` to access the results.
  *
@@ -1178,14 +1178,14 @@ Sequelize.where = Sequelize.condition = Sequelize.prototype.condition = Sequeliz
  *     return user.updateAttributes(..., { transaction: t});
  *   });
  * }).then(function () {
- *   // Commited
+ *   // Committed
  * }).catch(function (err) {
  *   // Rolled back
  *   console.error(err);
  * });
  * ```
  *
- * If you have [CLS](https://github.com/othiym23/node-continuation-local-storage) enabled, the transaction will automatically be passed to any query that runs witin the callback.
+ * If you have [CLS](https://github.com/othiym23/node-continuation-local-storage) enabled, the transaction will automatically be passed to any query that runs within the callback.
  * To enable CLS, add it do your project, create a namespace and set it on the sequelize constructor:
  *
  * ```js

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -79,7 +79,7 @@ Transaction.ISOLATION_LEVELS = {
 };
 
 /**
- * Possible options for row locking. Used in conjuction with `find` calls:
+ * Possible options for row locking. Used in conjunction with `find` calls:
  *
  * ```js
  * t1 // is a transaction


### PR DESCRIPTION
I noticed a misspelling when reading the docs, so I ran a spellcheck on all the doc files and found lots of typos.

I also noticed some of the doc files used character entity names (`&period;`, `&comma;`, `&lpar;`, `&rpar;` etc.) in places where they were unnecessary, so I replaced those instances with the actual characters.

The second commit in this PR is just the result of running `npm run docs`.