### PR TITLE
Add transaction support to all migration queries

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -45,11 +45,11 @@ QueryInterface.prototype.dropAllSchemas = function(options) {
 QueryInterface.prototype.showAllSchemas = function(options) {
   var self = this;
 
-  options = _.assign({
+  options = _.assign({}, options, {
     raw: true,
     type: this.sequelize.QueryTypes.SELECT,
     logging: false
-  }, options || {});
+  });
 
   var showSchemasSql = self.QueryGenerator.showSchemasQuery();
 
@@ -63,9 +63,10 @@ QueryInterface.prototype.showAllSchemas = function(options) {
 };
 
 QueryInterface.prototype.databaseVersion = function(options) {
-  return this.sequelize.query(this.QueryGenerator.versionQuery(), _.assign({
-    type: QueryTypes.VERSION
-  }, options));
+  return this.sequelize.query(
+    this.QueryGenerator.versionQuery(),
+    _.assign({}, options, { type: QueryTypes.VERSION })
+  );
 };
 
 QueryInterface.prototype.createTable = function(tableName, attributes, options, model) {
@@ -96,7 +97,7 @@ QueryInterface.prototype.createTable = function(tableName, attributes, options, 
         sql = self.QueryGenerator.pgListEnums(tableName, attributes[keys[i]].field || keys[i], options);
         promises.push(self.sequelize.query(
           sql,
-          _.assign({ plain: true, raw: true, type: QueryTypes.SELECT }, options)
+          _.assign({}, options, { plain: true, raw: true, type: QueryTypes.SELECT })
         ));
       }
     }
@@ -112,7 +113,7 @@ QueryInterface.prototype.createTable = function(tableName, attributes, options, 
             sql = self.QueryGenerator.pgEnum(tableName, attributes[keys[i]].field || keys[i], attributes[keys[i]], options);
             promises.push(self.sequelize.query(
               sql,
-              _.assign({ raw: true }, options)
+              _.assign({}, options, { raw: true })
             ));
           } else if (!!results[enumIdx] && !!model) {
             var enumVals = self.QueryGenerator.fromArray(results[enumIdx].enum_value)
@@ -201,7 +202,7 @@ QueryInterface.prototype.dropTable = function(tableName, options) {
           if (instanceTable.rawAttributes[keys[i]].type instanceof DataTypes.ENUM) {
             sql = self.QueryGenerator.pgEnumDrop(getTableName, keys[i]);
             options.supportsSearchPath = false;
-            promises.push(self.sequelize.query(sql, _.assign({ raw: true }, options)));
+            promises.push(self.sequelize.query(sql, _.assign({}, options, { raw: true })));
           }
         }
       }
@@ -220,7 +221,7 @@ QueryInterface.prototype.dropAllTables = function(options) {
     return Promise.each(tableNames, function(tableName) {
       // if tableName is not in the Array of tables names then dont drop it
       if (skip.indexOf(tableName.tableName || tableName) === -1) {
-        return self.dropTable(tableName, _.assign({ cascade: true }, options) );
+        return self.dropTable(tableName, _.assign({}, options, { cascade: true }) );
       }
     });
   };
@@ -277,11 +278,11 @@ QueryInterface.prototype.dropAllEnums = function(options) {
 
   return this.sequelize.query(
     sql,
-    _.assign({ plain: false, raw: true, type: QueryTypes.SELECT }, options)
+    _.assign({}, options, { plain: false, raw: true, type: QueryTypes.SELECT })
   ).map(function(result) {
     return self.sequelize.query(
       self.QueryGenerator.pgEnumDrop(null, null, self.QueryGenerator.pgEscapeAndQuote(result.enum_name)),
-      _.assign({ raw: true }, options)
+      _.assign({}, options, { raw: true })
     );
   });
 };
@@ -294,10 +295,10 @@ QueryInterface.prototype.renameTable = function(before, after, options) {
 
 QueryInterface.prototype.showAllTables = function(options) {
   var self = this;
-  options = _.assign({
+  options = _.assign({}, options, {
     raw: true,
     type: QueryTypes.SHOWTABLES
-  }, options || {});
+  });
 
   var showTablesSql = self.QueryGenerator.showTablesQuery();
   return self.sequelize.query(showTablesSql, options).then(function(tableNames) {
@@ -325,7 +326,7 @@ QueryInterface.prototype.describeTable = function(tableName, options) {
 
   return this.sequelize.query(
     sql,
-    _.assign({ type: QueryTypes.DESCRIBE }, options || {})
+    _.assign({}, options, { type: QueryTypes.DESCRIBE })
   ).then(function(data) {
     // If no data is returned from the query, then the table name may be wrong.
     // Query generators that use information_schema for retrieving table info will just return an empty result set,
@@ -432,12 +433,12 @@ QueryInterface.prototype.addIndex = function(tableName, attributes, options, raw
   options = options || {};
   options.fields = attributes;
   var sql = this.QueryGenerator.addIndexQuery(tableName, options, rawTablename);
-  return this.sequelize.query(sql, _.assign({ supportsSearchPath: false }, options));
+  return this.sequelize.query(sql, _.assign({}, options, { supportsSearchPath: false }));
 };
 
 QueryInterface.prototype.showIndex = function(tableName, options) {
   var sql = this.QueryGenerator.showIndexesQuery(tableName, options);
-  return this.sequelize.query(sql, _.assign({ type: QueryTypes.SHOWINDEXES }, options || {}));
+  return this.sequelize.query(sql, _.assign({}, options, { type: QueryTypes.SHOWINDEXES }));
 };
 
 QueryInterface.prototype.nameIndexes = function(indexes, rawTablename) {
@@ -820,7 +821,7 @@ QueryInterface.prototype.setAutocommit = function(transaction, value, options) {
     return Promise.resolve();
   }
 
-  options = _.assign({}, options || {}, {
+  options = _.assign({}, options, {
     transaction: transaction.parent || transaction
   });
 
@@ -842,7 +843,7 @@ QueryInterface.prototype.setIsolationLevel = function(transaction, value, option
     return Promise.resolve();
   }
 
-  options = _.assign({}, options || {}, {
+  options = _.assign({}, options, {
     transaction: transaction.parent || transaction
   });
 
@@ -860,7 +861,7 @@ QueryInterface.prototype.startTransaction = function(transaction, options) {
     throw new Error('Unable to start a transaction without transaction object!');
   }
 
-  options = _.assign({}, options || {}, {
+  options = _.assign({}, options, {
     transaction: transaction.parent || transaction
   });
 
@@ -870,9 +871,9 @@ QueryInterface.prototype.startTransaction = function(transaction, options) {
 };
 
 QueryInterface.prototype.deferConstraints = function (transaction, options) {
-  options = Utils._.extend({
+  options = _.assign({}, options, {
     transaction: transaction.parent || transaction
-  }, options || {});
+  });
 
   var sql = this.QueryGenerator.deferConstraintsQuery(options);
 
@@ -892,7 +893,7 @@ QueryInterface.prototype.commitTransaction = function(transaction, options) {
     return Promise.resolve();
   }
 
-  options = _.assign({}, options || {}, {
+  options = _.assign({}, options, {
     transaction: transaction.parent || transaction,
     supportsSearchPath: false
   });
@@ -907,7 +908,7 @@ QueryInterface.prototype.rollbackTransaction = function(transaction, options) {
     throw new Error('Unable to rollback a transaction without transaction object!');
   }
 
-  options = _.assign({}, options || {}, {
+  options = _.assign({}, options, {
     transaction: transaction.parent || transaction,
     supportsSearchPath: false
   });

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -20,13 +20,13 @@ var QueryInterface = function(sequelize) {
 QueryInterface.prototype.createSchema = function(schema, options) {
   options = options || {};
   var sql = this.QueryGenerator.createSchema(schema);
-  return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+  return this.sequelize.query(sql, options);
 };
 
 QueryInterface.prototype.dropSchema = function(schema, options) {
   options = options || {};
   var sql = this.QueryGenerator.dropSchema(schema);
-  return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+  return this.sequelize.query(sql, options);
 };
 
 QueryInterface.prototype.dropAllSchemas = function(options) {
@@ -34,10 +34,10 @@ QueryInterface.prototype.dropAllSchemas = function(options) {
 
   var self = this;
   if (!this.QueryGenerator._dialect.supports.schemas) {
-    return this.sequelize.drop({logging: options.logging, transaction: options.transaction});
+    return this.sequelize.drop(options);
   } else {
     return this.showAllSchemas(options).map(function(schemaName) {
-      return self.dropSchema(schemaName, { logging: options.logging, transaction: options.transaction });
+      return self.dropSchema(schemaName, options);
     });
   }
 };
@@ -45,7 +45,7 @@ QueryInterface.prototype.dropAllSchemas = function(options) {
 QueryInterface.prototype.showAllSchemas = function(options) {
   var self = this;
 
-  options = Utils._.extend({
+  options = _.assign({
     raw: true,
     type: this.sequelize.QueryTypes.SELECT,
     logging: false
@@ -95,7 +95,8 @@ QueryInterface.prototype.createTable = function(tableName, attributes, options, 
       if (attributes[keys[i]].type instanceof DataTypes.ENUM) {
         sql = self.QueryGenerator.pgListEnums(tableName, attributes[keys[i]].field || keys[i], options);
         promises.push(self.sequelize.query(
-          sql, { plain: true, raw: true, type: QueryTypes.SELECT, logging: options.logging, transaction: options.transaction }
+          sql,
+          _.assign({ plain: true, raw: true, type: QueryTypes.SELECT }, options)
         ));
       }
     }
@@ -110,7 +111,8 @@ QueryInterface.prototype.createTable = function(tableName, attributes, options, 
           if (!results[enumIdx]) {
             sql = self.QueryGenerator.pgEnum(tableName, attributes[keys[i]].field || keys[i], attributes[keys[i]], options);
             promises.push(self.sequelize.query(
-              sql, { raw: true, logging: options.logging, transaction: options.transaction }
+              sql,
+              _.assign({ raw: true }, options)
             ));
           } else if (!!results[enumIdx] && !!model) {
             var enumVals = self.QueryGenerator.fromArray(results[enumIdx].enum_value)
@@ -199,7 +201,7 @@ QueryInterface.prototype.dropTable = function(tableName, options) {
           if (instanceTable.rawAttributes[keys[i]].type instanceof DataTypes.ENUM) {
             sql = self.QueryGenerator.pgEnumDrop(getTableName, keys[i]);
             options.supportsSearchPath = false;
-            promises.push(self.sequelize.query(sql, { logging: options.logging, raw: true, transaction : options.transaction }));
+            promises.push(self.sequelize.query(sql, _.assign({ raw: true }, options)));
           }
         }
       }
@@ -218,13 +220,13 @@ QueryInterface.prototype.dropAllTables = function(options) {
     return Promise.each(tableNames, function(tableName) {
       // if tableName is not in the Array of tables names then dont drop it
       if (skip.indexOf(tableName.tableName || tableName) === -1) {
-        return self.dropTable(tableName, { cascade: true, logging: options.logging, transaction: options.transaction });
+        return self.dropTable(tableName, _.assign({ cascade: true }, options) );
       }
     });
   };
 
   var skip = options.skip || [];
-  return self.showAllTables({logging: options.logging, transaction: options.transaction}).then(function(tableNames) {
+  return self.showAllTables(options).then(function(tableNames) {
     if (self.sequelize.options.dialect === 'sqlite') {
       return self.sequelize.query('PRAGMA foreign_keys;', options).then(function(result) {
         var foreignKeysAreEnabled = result.foreign_keys === 1;
@@ -240,7 +242,7 @@ QueryInterface.prototype.dropAllTables = function(options) {
         }
       });
     } else {
-      return self.getForeignKeysForTables(tableNames, {logging: options.logging, transaction: options.transaction}).then(function(foreignKeys) {
+      return self.getForeignKeysForTables(tableNames, options).then(function(foreignKeys) {
         var promises = [];
 
         tableNames.forEach(function(tableName) {
@@ -275,11 +277,11 @@ QueryInterface.prototype.dropAllEnums = function(options) {
 
   return this.sequelize.query(
     sql,
-    { plain: false, raw: true, type: QueryTypes.SELECT, logging: options.logging, transaction: options.transaction }
+    _.assign({ plain: false, raw: true, type: QueryTypes.SELECT }, options)
   ).map(function(result) {
     return self.sequelize.query(
       self.QueryGenerator.pgEnumDrop(null, null, self.QueryGenerator.pgEscapeAndQuote(result.enum_name)),
-      {logging: options.logging, transaction: options.transaction, raw: true}
+      _.assign({ raw: true }, options)
     );
   });
 };
@@ -287,12 +289,12 @@ QueryInterface.prototype.dropAllEnums = function(options) {
 QueryInterface.prototype.renameTable = function(before, after, options) {
   options = options || {};
   var sql = this.QueryGenerator.renameTableQuery(before, after);
-  return this.sequelize.query(sql, { logging: options.logging, transaction: options.transaction });
+  return this.sequelize.query(sql, options);
 };
 
 QueryInterface.prototype.showAllTables = function(options) {
   var self = this;
-  options = Utils._.extend({
+  options = _.assign({
     raw: true,
     type: QueryTypes.SHOWTABLES
   }, options || {});
@@ -321,11 +323,10 @@ QueryInterface.prototype.describeTable = function(tableName, options) {
 
   var sql = this.QueryGenerator.describeTableQuery(tableName, schema, schemaDelimiter);
 
-  return this.sequelize.query(sql, {
-    type: QueryTypes.DESCRIBE, 
-    logging: options && options.logging,
-    transaction: options && options.transaction
-  }).then(function(data) {
+  return this.sequelize.query(
+    sql,
+    _.assign({ type: QueryTypes.DESCRIBE }, options || {})
+  ).then(function(data) {
     // If no data is returned from the query, then the table name may be wrong.
     // Query generators that use information_schema for retrieving table info will just return an empty result set,
     // it will not throw an error like built-ins do (e.g. DESCRIBE on MySql).
@@ -344,17 +345,17 @@ QueryInterface.prototype.addColumn = function(table, key, attribute, options) {
 
   options = options || {};
   attribute = this.sequelize.normalizeAttribute(attribute);
-  return this.sequelize.query(this.QueryGenerator.addColumnQuery(table, key, attribute), { logging: options.logging, transaction: options.transaction });
+  return this.sequelize.query(this.QueryGenerator.addColumnQuery(table, key, attribute), options);
 };
 
 QueryInterface.prototype.removeColumn = function(tableName, attributeName, options) {
   options = options || {};
   if (this.sequelize.options.dialect === 'sqlite') {
     // sqlite needs some special treatment as it cannot drop a column
-    return SQLiteQueryInterface.removeColumn.call(this, tableName, attributeName, {logging: options.logging, transaction: options.transaction});
+    return SQLiteQueryInterface.removeColumn.call(this, tableName, attributeName, options);
   } else {
     var sql = this.QueryGenerator.removeColumnQuery(tableName, attributeName);
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   }
 };
 
@@ -372,12 +373,12 @@ QueryInterface.prototype.changeColumn = function(tableName, attributeName, dataT
 
   if (this.sequelize.options.dialect === 'sqlite') {
     // sqlite needs some special treatment as it cannot change a column
-    return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes, {logging: options.logging, transaction: options.transaction});
+    return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes, options);
   } else {
     var query = this.QueryGenerator.attributesToSQL(attributes)
       , sql = this.QueryGenerator.changeColumnQuery(tableName, query);
 
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   }
 };
 
@@ -402,14 +403,14 @@ QueryInterface.prototype.renameColumn = function(tableName, attrNameBefore, attr
 
     if (this.sequelize.options.dialect === 'sqlite') {
       // sqlite needs some special treatment as it cannot rename a column
-      return SQLiteQueryInterface.renameColumn.call(this, tableName, attrNameBefore, attrNameAfter, {logging: options.logging, transaction: options.transaction});
+      return SQLiteQueryInterface.renameColumn.call(this, tableName, attrNameBefore, attrNameAfter, options);
     } else {
       var sql = this.QueryGenerator.renameColumnQuery(
         tableName,
         attrNameBefore,
         this.QueryGenerator.attributesToSQL(_options)
       );
-      return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+      return this.sequelize.query(sql, options);
     }
   }.bind(this));
 };
@@ -431,17 +432,12 @@ QueryInterface.prototype.addIndex = function(tableName, attributes, options, raw
   options = options || {};
   options.fields = attributes;
   var sql = this.QueryGenerator.addIndexQuery(tableName, options, rawTablename);
-  return this.sequelize.query(sql, { logging: options.logging, transaction: options.transaction, supportsSearchPath: false });
+  return this.sequelize.query(sql, _.assign({ supportsSearchPath: false }, options));
 };
 
 QueryInterface.prototype.showIndex = function(tableName, options) {
   var sql = this.QueryGenerator.showIndexesQuery(tableName, options);
-  options = options || {};
-  return this.sequelize.query(sql, {
-    transaction: options.transaction,
-    logging: options.logging,
-    type: QueryTypes.SHOWINDEXES
-  });
+  return this.sequelize.query(sql, _.assign({ type: QueryTypes.SHOWINDEXES }, options || {}));
 };
 
 QueryInterface.prototype.nameIndexes = function(indexes, rawTablename) {
@@ -457,7 +453,7 @@ QueryInterface.prototype.getForeignKeysForTables = function(tableNames, options)
   }
 
   return Promise.map(tableNames, function(tableName) {
-    return self.sequelize.query(self.QueryGenerator.getForeignKeysQuery(tableName, self.sequelize.config.database), {logging: options.logging, transaction: options.transaction}).get(0);
+    return self.sequelize.query(self.QueryGenerator.getForeignKeysQuery(tableName, self.sequelize.config.database), options).get(0);
   }).then(function(results) {
     var result = {};
 
@@ -478,7 +474,7 @@ QueryInterface.prototype.getForeignKeysForTables = function(tableNames, options)
 QueryInterface.prototype.removeIndex = function(tableName, indexNameOrAttributes, options) {
   options = options || {};
   var sql = this.QueryGenerator.removeIndexQuery(tableName, indexNameOrAttributes);
-  return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+  return this.sequelize.query(sql, options);
 };
 
 QueryInterface.prototype.insert = function(instance, tableName, values, options) {
@@ -628,10 +624,7 @@ QueryInterface.prototype.delete = function(instance, tableName, identifier, opti
   }
 
   return Promise.each(cascades, function (cascade) {
-    return instance[cascade]({
-      transaction: options.transaction,
-      logging: options.logging
-    }).then(function (instances) {
+    return instance[cascade](options).then(function (instances) {
       // Check for hasOne relationship with non-existing associate ("has zero")
       if (!instances) {
         return Promise.resolve();
@@ -640,10 +633,7 @@ QueryInterface.prototype.delete = function(instance, tableName, identifier, opti
       if (!Array.isArray(instances)) instances = [instances];
 
       return Promise.each(instances, function (instance) {
-        return instance.destroy({
-          transaction: options.transaction,
-          logging: options.logging
-        });
+        return instance.destroy(options);
       });
     });
   }).then(function () {
@@ -729,7 +719,7 @@ QueryInterface.prototype.createTrigger = function(tableName, triggerName, timing
   var sql = this.QueryGenerator.createTrigger(tableName, triggerName, timingType, fireOnArray, functionName, functionParams, optionsArray);
   options = options || {};
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   } else {
     return Promise.resolve();
   }
@@ -740,7 +730,7 @@ QueryInterface.prototype.dropTrigger = function(tableName, triggerName, options)
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   } else {
     return Promise.resolve();
   }
@@ -751,7 +741,7 @@ QueryInterface.prototype.renameTrigger = function(tableName, oldTriggerName, new
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   } else {
     return Promise.resolve();
   }
@@ -762,7 +752,7 @@ QueryInterface.prototype.createFunction = function(functionName, params, returnT
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   } else {
     return Promise.resolve();
   }
@@ -773,7 +763,7 @@ QueryInterface.prototype.dropFunction = function(functionName, params, options) 
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   } else {
     return Promise.resolve();
   }
@@ -784,7 +774,7 @@ QueryInterface.prototype.renameFunction = function(oldFunctionName, params, newF
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
+    return this.sequelize.query(sql, options);
   } else {
     return Promise.resolve();
   }

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -20,13 +20,13 @@ var QueryInterface = function(sequelize) {
 QueryInterface.prototype.createSchema = function(schema, options) {
   options = options || {};
   var sql = this.QueryGenerator.createSchema(schema);
-  return this.sequelize.query(sql, {logging: options.logging});
+  return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
 };
 
 QueryInterface.prototype.dropSchema = function(schema, options) {
   options = options || {};
   var sql = this.QueryGenerator.dropSchema(schema);
-  return this.sequelize.query(sql, {logging: options.logging});
+  return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
 };
 
 QueryInterface.prototype.dropAllSchemas = function(options) {
@@ -34,10 +34,10 @@ QueryInterface.prototype.dropAllSchemas = function(options) {
 
   var self = this;
   if (!this.QueryGenerator._dialect.supports.schemas) {
-    return this.sequelize.drop({ logging: options.logging });
+    return this.sequelize.drop({logging: options.logging, transaction: options.transaction});
   } else {
     return this.showAllSchemas(options).map(function(schemaName) {
-      return self.dropSchema(schemaName, { logging: options.logging });
+      return self.dropSchema(schemaName, { logging: options.logging, transaction: options.transaction });
     });
   }
 };
@@ -218,13 +218,13 @@ QueryInterface.prototype.dropAllTables = function(options) {
     return Promise.each(tableNames, function(tableName) {
       // if tableName is not in the Array of tables names then dont drop it
       if (skip.indexOf(tableName.tableName || tableName) === -1) {
-        return self.dropTable(tableName, { cascade: true, logging: options.logging });
+        return self.dropTable(tableName, { cascade: true, logging: options.logging, transaction: options.transaction });
       }
     });
   };
 
   var skip = options.skip || [];
-  return self.showAllTables({logging: options.logging}).then(function(tableNames) {
+  return self.showAllTables({logging: options.logging, transaction: options.transaction}).then(function(tableNames) {
     if (self.sequelize.options.dialect === 'sqlite') {
       return self.sequelize.query('PRAGMA foreign_keys;', options).then(function(result) {
         var foreignKeysAreEnabled = result.foreign_keys === 1;
@@ -240,7 +240,7 @@ QueryInterface.prototype.dropAllTables = function(options) {
         }
       });
     } else {
-      return self.getForeignKeysForTables(tableNames, {logging: options.logging}).then(function(foreignKeys) {
+      return self.getForeignKeysForTables(tableNames, {logging: options.logging, transaction: options.transaction}).then(function(foreignKeys) {
         var promises = [];
 
         tableNames.forEach(function(tableName) {
@@ -279,7 +279,7 @@ QueryInterface.prototype.dropAllEnums = function(options) {
   ).map(function(result) {
     return self.sequelize.query(
       self.QueryGenerator.pgEnumDrop(null, null, self.QueryGenerator.pgEscapeAndQuote(result.enum_name)),
-      {logging: options.logging, raw: true}
+      {logging: options.logging, transaction: options.transaction, raw: true}
     );
   });
 };
@@ -287,7 +287,7 @@ QueryInterface.prototype.dropAllEnums = function(options) {
 QueryInterface.prototype.renameTable = function(before, after, options) {
   options = options || {};
   var sql = this.QueryGenerator.renameTableQuery(before, after);
-  return this.sequelize.query(sql, { logging: options.logging });
+  return this.sequelize.query(sql, { logging: options.logging, transaction: options.transaction });
 };
 
 QueryInterface.prototype.showAllTables = function(options) {
@@ -321,7 +321,11 @@ QueryInterface.prototype.describeTable = function(tableName, options) {
 
   var sql = this.QueryGenerator.describeTableQuery(tableName, schema, schemaDelimiter);
 
-  return this.sequelize.query(sql, { type: QueryTypes.DESCRIBE, logging: options && options.logging }).then(function(data) {
+  return this.sequelize.query(sql, {
+    type: QueryTypes.DESCRIBE, 
+    logging: options && options.logging,
+    transaction: options && options.transaction
+  }).then(function(data) {
     // If no data is returned from the query, then the table name may be wrong.
     // Query generators that use information_schema for retrieving table info will just return an empty result set,
     // it will not throw an error like built-ins do (e.g. DESCRIBE on MySql).
@@ -340,17 +344,17 @@ QueryInterface.prototype.addColumn = function(table, key, attribute, options) {
 
   options = options || {};
   attribute = this.sequelize.normalizeAttribute(attribute);
-  return this.sequelize.query(this.QueryGenerator.addColumnQuery(table, key, attribute), { logging: options.logging });
+  return this.sequelize.query(this.QueryGenerator.addColumnQuery(table, key, attribute), { logging: options.logging, transaction: options.transaction });
 };
 
 QueryInterface.prototype.removeColumn = function(tableName, attributeName, options) {
   options = options || {};
   if (this.sequelize.options.dialect === 'sqlite') {
     // sqlite needs some special treatment as it cannot drop a column
-    return SQLiteQueryInterface.removeColumn.call(this, tableName, attributeName, {logging: options.logging});
+    return SQLiteQueryInterface.removeColumn.call(this, tableName, attributeName, {logging: options.logging, transaction: options.transaction});
   } else {
     var sql = this.QueryGenerator.removeColumnQuery(tableName, attributeName);
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   }
 };
 
@@ -368,12 +372,12 @@ QueryInterface.prototype.changeColumn = function(tableName, attributeName, dataT
 
   if (this.sequelize.options.dialect === 'sqlite') {
     // sqlite needs some special treatment as it cannot change a column
-    return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes, {logging: options.logging});
+    return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes, {logging: options.logging, transaction: options.transaction});
   } else {
     var query = this.QueryGenerator.attributesToSQL(attributes)
       , sql = this.QueryGenerator.changeColumnQuery(tableName, query);
 
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   }
 };
 
@@ -398,14 +402,14 @@ QueryInterface.prototype.renameColumn = function(tableName, attrNameBefore, attr
 
     if (this.sequelize.options.dialect === 'sqlite') {
       // sqlite needs some special treatment as it cannot rename a column
-      return SQLiteQueryInterface.renameColumn.call(this, tableName, attrNameBefore, attrNameAfter, {logging: options.logging});
+      return SQLiteQueryInterface.renameColumn.call(this, tableName, attrNameBefore, attrNameAfter, {logging: options.logging, transaction: options.transaction});
     } else {
       var sql = this.QueryGenerator.renameColumnQuery(
         tableName,
         attrNameBefore,
         this.QueryGenerator.attributesToSQL(_options)
       );
-      return this.sequelize.query(sql, {logging: options.logging});
+      return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
     }
   }.bind(this));
 };
@@ -427,7 +431,7 @@ QueryInterface.prototype.addIndex = function(tableName, attributes, options, raw
   options = options || {};
   options.fields = attributes;
   var sql = this.QueryGenerator.addIndexQuery(tableName, options, rawTablename);
-  return this.sequelize.query(sql, { logging: options.logging, supportsSearchPath: false });
+  return this.sequelize.query(sql, { logging: options.logging, transaction: options.transaction, supportsSearchPath: false });
 };
 
 QueryInterface.prototype.showIndex = function(tableName, options) {
@@ -453,7 +457,7 @@ QueryInterface.prototype.getForeignKeysForTables = function(tableNames, options)
   }
 
   return Promise.map(tableNames, function(tableName) {
-    return self.sequelize.query(self.QueryGenerator.getForeignKeysQuery(tableName, self.sequelize.config.database), {logging: options.logging}).get(0);
+    return self.sequelize.query(self.QueryGenerator.getForeignKeysQuery(tableName, self.sequelize.config.database), {logging: options.logging, transaction: options.transaction}).get(0);
   }).then(function(results) {
     var result = {};
 
@@ -474,7 +478,7 @@ QueryInterface.prototype.getForeignKeysForTables = function(tableNames, options)
 QueryInterface.prototype.removeIndex = function(tableName, indexNameOrAttributes, options) {
   options = options || {};
   var sql = this.QueryGenerator.removeIndexQuery(tableName, indexNameOrAttributes);
-  return this.sequelize.query(sql, {logging: options.logging});
+  return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
 };
 
 QueryInterface.prototype.insert = function(instance, tableName, values, options) {
@@ -725,7 +729,7 @@ QueryInterface.prototype.createTrigger = function(tableName, triggerName, timing
   var sql = this.QueryGenerator.createTrigger(tableName, triggerName, timingType, fireOnArray, functionName, functionParams, optionsArray);
   options = options || {};
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   } else {
     return Promise.resolve();
   }
@@ -736,7 +740,7 @@ QueryInterface.prototype.dropTrigger = function(tableName, triggerName, options)
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   } else {
     return Promise.resolve();
   }
@@ -747,7 +751,7 @@ QueryInterface.prototype.renameTrigger = function(tableName, oldTriggerName, new
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   } else {
     return Promise.resolve();
   }
@@ -758,7 +762,7 @@ QueryInterface.prototype.createFunction = function(functionName, params, returnT
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   } else {
     return Promise.resolve();
   }
@@ -769,7 +773,7 @@ QueryInterface.prototype.dropFunction = function(functionName, params, options) 
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   } else {
     return Promise.resolve();
   }
@@ -780,7 +784,7 @@ QueryInterface.prototype.renameFunction = function(oldFunctionName, params, newF
   options = options || {};
 
   if (sql) {
-    return this.sequelize.query(sql, {logging: options.logging});
+    return this.sequelize.query(sql, {logging: options.logging, transaction: options.transaction});
   } else {
     return Promise.resolve();
   }


### PR DESCRIPTION
I noticed one of my migrations wasn't honoring the transaction option I passed in, so I took a look at the code, and was surprised to find that the `transaction` option was being ignored for most of the migration queries. Only the `logging` option is being passed through to `sequelize.query` in most cases.

This allows the transaction option to be passed in as well.