### PR TITLE
Fix count when scope contains attributes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Next
 - [FIXED] Apply scopes to `aggregate` [#4764](https://github.com/sequelize/sequelize/issues/4764)
 - [ADDED/FIXED] Lower case `onDelete` option to allow the use of `onDelete: 'CASCADE', hooks: true`.
+- [FIXED] Ignore attributes in `count` [#4566](https://github.com/sequelize/sequelize/issues/4566)
 
 # 3.13.0
 - [FIXED] timestamp columns are no longer undefined for associations loaded with `separate`. [#4740](https://github.com/sequelize/sequelize/issues/4740)
@@ -32,7 +33,7 @@
 - [FIXED] Include all with scopes [#4584](https://github.com/sequelize/sequelize/issues/4584)
 - [INTERNALS] Corrected spelling seperate -> separate
 - [ADDED] Added `include` and `exclude` to `options.attributes`. [#4074](https://github.com/sequelize/sequelize/issues/4074)
-- [FIXED/INTERNALS] Only recurse on plain objects in `mapOptionFieldNames`. [#4596](https://github.com/sequelize/sequelize/issues/4596) 
+- [FIXED/INTERNALS] Only recurse on plain objects in `mapOptionFieldNames`. [#4596](https://github.com/sequelize/sequelize/issues/4596)
 
 # 3.10.0
 - [ADDED] support `search_path` for postgres with lots of schemas [#4534](https://github.com/sequelize/sequelize/pull/4534)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1569,6 +1569,7 @@ Model.prototype.count = function(options) {
   options.limit = null;
   options.offset = null;
   options.order = null;
+  options.attributes = [];
 
   return this.aggregate(col, 'count', options);
 };

--- a/test/integration/model/scope/findAndCount.test.js
+++ b/test/integration/model/scope/findAndCount.test.js
@@ -9,7 +9,9 @@ var chai = require('chai')
 
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('scope', function () {
-    describe('count', function () {
+
+    describe('findAndCount', function () {
+
       beforeEach(function () {
         this.ScopeMe = this.sequelize.define('ScopeMe', {
           username: Sequelize.STRING,
@@ -51,27 +53,47 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
 
       it('should apply defaultScope', function () {
-        return expect(this.ScopeMe.count()).to.eventually.equal(2);
+        return this.ScopeMe.findAndCount().then(function(result) {
+          expect(result.count).to.equal(2);
+          expect(result.rows.length).to.equal(2);
+        });
       });
 
       it('should be able to override default scope', function () {
-        return expect(this.ScopeMe.count({ where: { access_level: { gt: 5 }}})).to.eventually.equal(1);
+        return this.ScopeMe.findAndCount({ where: { access_level: { gt: 5 }}})
+          .then(function(result) {
+            expect(result.count).to.equal(1);
+            expect(result.rows.length).to.equal(1);
+          });
       });
 
       it('should be able to unscope', function () {
-        return expect(this.ScopeMe.unscoped().count()).to.eventually.equal(4);
+        return this.ScopeMe.unscoped().findAndCount({ limit: 1 })
+          .then(function(result) {
+            expect(result.count).to.equal(4);
+            expect(result.rows.length).to.equal(1);
+          });
       });
 
       it('should be able to apply other scopes', function () {
-        return expect(this.ScopeMe.scope('lowAccess').count()).to.eventually.equal(3);
+        return this.ScopeMe.scope('lowAccess').findAndCount()
+          .then(function(result) {
+            expect(result.count).to.equal(3);
+          });
       });
 
       it('should be able to merge scopes with where', function () {
-        return expect(this.ScopeMe.scope('lowAccess').count({ where: { username: 'dan'}})).to.eventually.equal(1);
+        return this.ScopeMe.scope('lowAccess')
+          .findAndCount({ where: { username: 'dan'}}).then(function(result) {
+            expect(result.count).to.equal(1);
+          });
       });
 
       it('should ignore the order option if it is found within the scope', function () {
-        return expect(this.ScopeMe.scope('withOrder').count()).to.eventually.equal(4);
+        return this.ScopeMe.scope('withOrder').findAndCount()
+          .then(function(result) {
+            expect(result.count).to.equal(4);
+          });
       });
     });
   });


### PR DESCRIPTION
This fixes #4566 by specifically ignoring attributes in `count` (and therefore `findAndCount`). Attributes are mostly likely added by a scope, and when present cause the SQL error
```
SequelizeDatabaseError: column "ScopeMe.username" must appear in the GROUP BY clause or be used in an aggregate function
```
because a bad query is produced (see issue for details).