### PR TITLE
Don't rollback twice on connection error. Fixes issue #4850.

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1239,6 +1239,9 @@ Sequelize.prototype.transaction = function(options, autoCallback) {
         // If an error occured while commiting a transaction do not try to rollback the transaction
         if (transaction.finished === 'commit') {
           reject(err);
+        } else if (transaction.finished === 'rollback'){
+          // Already in rollback state. Reject with the original error.
+          reject(err);
         } else {
           transaction.rollback().finally(function () {
             reject(err);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1236,11 +1236,8 @@ Sequelize.prototype.transaction = function(options, autoCallback) {
           });
         });
       }).catch(function(err) {
-        // If an error occured while commiting a transaction do not try to rollback the transaction
-        if (transaction.finished === 'commit') {
-          reject(err);
-        } else if (transaction.finished === 'rollback'){
-          // Already in rollback state. Reject with the original error.
+        // If the transaction has already finished (commit, rollback, etc), reject with the original error
+        if (transaction.finished) {
           reject(err);
         } else {
           transaction.rollback().finally(function () {


### PR DESCRIPTION
The rollbacks are getting called twice when a connection error occurs during an autofunc version of `sequelize.transaction(f)` call. This simple fix just rejects with the original connection error.

### Test Case
This should fail before the error and __pass__ after the fix. I forced a connection error by specifying a bogus database.

```js
'use strict';

/* jshint -W030 */
var chai = require('chai')
  , expect = chai.expect
  , Support = require('../support')
  , current = Support.sequelize;

if (current.dialect.supports.transactions) {
  describe(Support.getTestDialectTeaser('Sequelize#transaction.autoFuncErrors'), function() {

  describe('then', function() {

    // This failure is caused by any connection error (I used a bogus database name)
    it('bypasses all promise error-handling and produces uncaught exception', function(done) {

      // None of the following paths gets hit
      try {
        return this.sequelize
        // This call fails and throws an exception:
        // Error: Transaction cannot be rolled back because it has been finished with state: rollback

          .transaction(function (trans) {
            expect(false).to.be.ok;
          })
          .catch(function (err) {
            expect(true).to.be.ok;
          })
          .finally(function () {
            expect(true).to.be.ok;
            done();
          });
      } catch(e){
        expect(false).to.be.ok;
        done();
      }
    });

  });

});

}
```

