### PR TITLE
Update() modifies the supplied values

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] calling Model.update() modifies passed values  [#4520](https://github.com/sequelize/sequelize/issues/4520)
+
 # 3.15.0
 - [ADDED] Improve support for pg range type to handle unbound ranges, +/-infinity bounds and empty ranges
 - [FIXED] Postgres issue when using named timezone  [#4307](https://github.com/sequelize/sequelize/issues/4307)

--- a/lib/model.js
+++ b/lib/model.js
@@ -2403,6 +2403,9 @@ Model.prototype.update = function(values, options) {
 
   Model.$injectScope(this.$scope, options);
 
+  // Clone values so it doesn't get modified for caller scope
+  values = _.clone(values);
+
   // Remove values that are not in the options.fields
   if (options.fields && options.fields instanceof Array) {
     Object.keys(values).forEach(function(key) {

--- a/test/unit/model/update.test.js
+++ b/test/unit/model/update.test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , current = Support.sequelize
+  , sinon = require('sinon')
+  , Promise = current.Promise
+  , DataTypes = require('../../../lib/data-types')
+  , _ = require('lodash');
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+
+  describe('method update', function () {
+    var User = current.define('User', {
+      name: DataTypes.STRING,
+      secretValue: DataTypes.INTEGER
+    });
+
+    before(function () {
+      this.stubUpdate = sinon.stub(current.getQueryInterface(), 'bulkUpdate', function () {
+        return Promise.resolve([]);
+      });
+    });
+
+    beforeEach(function () {
+      this.updates = { name: 'Batman', secretValue: '7' };
+      this.cloneUpdates = _.clone(this.updates);
+      this.stubUpdate.reset();
+    });
+
+    afterEach(function () {
+      delete this.updates;
+      delete this.cloneUpdates;
+    });
+
+    after(function () {
+      this.stubUpdate.restore();
+    });
+
+    describe('properly clones input values', function () {
+      it('with default options', function() {
+        var self = this;
+        return User.update(self.updates, {where: {secretValue: '1'}}).bind(this).then(function(e) {
+          expect(self.updates).to.be.deep.eql(self.cloneUpdates);
+        });
+      });
+
+      it('when using fields option', function() {
+        var self = this;
+        return User.update(self.updates, {where: {secretValue: '1'}, fields: ['name']}).bind(this).then(function() {
+          expect(self.updates).to.be.deep.eql(self.cloneUpdates);
+        });
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
Fixes #4520 , `values` passed to the `update` method got modified.

As per #4520 whenever we pass the `fields` in options, the caller `values` got modified. It has been fixed. 

While writing tests I discovered `update()` method also add the `updatedAt` key to the caller `values` object. I have added tests for both cases.

I have used cloned version of `values` to fix both issues.