### PR TITLE
Set updatedAt and createdAt values before validation

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -526,7 +526,7 @@ Instance.prototype.save = function(options) {
     , hook = self.isNewRecord ? 'Create' : 'Update'
     , wasNewRecord = this.isNewRecord;
 
-  if (updatedAtAttr && options.fields.indexOf(updatedAtAttr) === -1) {
+  if (updatedAtAttr && options.fields.length && options.fields.indexOf(updatedAtAttr) === -1) {
     options.fields.push(updatedAtAttr);
   }
 
@@ -552,6 +552,14 @@ Instance.prototype.save = function(options) {
     if (primaryKeyName && this.get(primaryKeyName, {raw: true}) === undefined) {
       throw new Error('You attempted to save an instance with no primary key, this is not allowed since it would result in a global update');
     }
+  }
+
+  if (updatedAtAttr && !options.silent && options.fields.indexOf(updatedAtAttr) !== -1) {
+    this.dataValues[updatedAtAttr] = this.Model.$getDefaultTimestamp(updatedAtAttr) || Utils.now(this.sequelize.options.dialect);
+  }
+
+  if (this.isNewRecord && createdAtAttr && !this.dataValues[createdAtAttr]) {
+    this.dataValues[createdAtAttr] = this.Model.$getDefaultTimestamp(createdAtAttr) || Utils.now(this.sequelize.options.dialect);
   }
 
   return Promise.bind(this).then(function() {
@@ -638,16 +646,7 @@ Instance.prototype.save = function(options) {
 
       var values = Utils.mapValueFieldNames(this.dataValues, options.fields, this.Model)
         , query = null
-        , args = []
-        , now = Utils.now(this.sequelize.options.dialect);
-
-      if (updatedAtAttr && !options.silent) {
-        self.dataValues[updatedAtAttr] = values[self.Model.rawAttributes[updatedAtAttr].field || updatedAtAttr] = self.Model.$getDefaultTimestamp(updatedAtAttr) || now;
-      }
-
-      if (self.isNewRecord && createdAtAttr && !values[createdAtAttr]) {
-        self.dataValues[createdAtAttr] = values[self.Model.rawAttributes[createdAtAttr].field || createdAtAttr] = self.Model.$getDefaultTimestamp(createdAtAttr) || now;
-      }
+        , args = [];
 
       if (self.isNewRecord) {
         query = 'insert';

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -1103,6 +1103,9 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
             self.clock.tick(2000);
             return user.save().then(function(newlySavedUser) {
               expect(newlySavedUser.updatedAt).to.equalTime(updatedAt);
+              return self.User.findOne({ username: 'John' }).then(function(newlySavedUser) {
+                expect(newlySavedUser.updatedAt).to.equalTime(updatedAt);
+              });
             });
           });
         });
@@ -1166,6 +1169,29 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           return User2.create({ username: 'john doe' }).then(function(johnDoe) {
             expect(johnDoe.createdAt).to.be.undefined;
             expect(now).to.be.below(johnDoe.updatedAt.getTime());
+          });
+        });
+      });
+
+      it('works with `allowNull: false` on createdAt and updatedAt columns', function() {
+        var User2 = this.sequelize.define('User2', {
+          username: DataTypes.STRING,
+          createdAt: {
+            type: DataTypes.DATE,
+            allowNull: false
+          },
+          updatedAt: {
+            type: DataTypes.DATE,
+            allowNull: false
+          }
+        }, { timestamps: true });
+
+        return User2.sync().then(function() {
+          return User2.create({ username: 'john doe' }).then(function(johnDoe) {
+            expect(johnDoe.createdAt).to.be.an.instanceof(Date);
+            expect(johnDoe.updatedAt).to.be.an.instanceof(Date);
+            expect( ! isNaN(johnDoe.createdAt.valueOf())).to.be.ok;
+            expect( ! isNaN(johnDoe.updatedAt.valueOf())).to.be.ok;
           });
         });
       });


### PR DESCRIPTION
If model has `updatedAt` or `createdAt` fields without allowing nulls:

```javascript
        createdAt: {
            type: DataTypes.DATE,
            allowNull: false,
            field: 'created_at'
        },
        updatedAt: {
            type: DataTypes.DATE,
            allowNull: false,
            field: 'update_at'
        },
```

then I'm receiving this error:

> { [SequelizeValidationError: notNull Violation: createdAt cannot be null,
notNull Violation: updatedAt cannot be null]
  name: 'SequelizeValidationError',
  message: 'notNull Violation: createdAt cannot be null,\nnotNull Violation: updatedAt cannot be null',
  errors:
   [ { message: 'createdAt cannot be null',
       type: 'notNull Violation',
       path: 'createdAt',
       value: null },
     { message: 'updatedAt cannot be null',
       type: 'notNull Violation',
       path: 'updatedAt',
       value: null } ] }

My proposal is to set `updatedAt` and `createdAt` values before doing validation.