### PR TITLE
Disables setting AUTOCOMMIT for Postgres >= 9.4.0

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -877,8 +877,14 @@ var QueryGenerator = {
       return;
     }
 
-    // POSTGRES does not support setting AUTOCOMMIT = OFF
-    if (!value) {
+    // POSTGRES does not support setting AUTOCOMMIT = OFF as of 9.4.0
+    // Additionally it does not support AUTOCOMMIT at all starting at v9.5
+    // The assumption is that it won't be returning in future versions either
+    // If you are on a Pg version that is not semver compliant e.g. '9.5.0beta2', which fails due to the 'beta' qualification, then you need to pass
+    // the database version as "9.5.0" explicitly through the options param passed when creating the Sequelize instance under the key "databaseVersion"
+    // otherwise Pg version "9.4.0" is assumed by default as per Sequelize 3.14.2.
+    // For Pg versions that are semver compliant, this is auto-detected upon the first connection.
+    if (!value || semver.gte(this.sequelize.options.databaseVersion, '9.4.0')) {
       return;
     }
 


### PR DESCRIPTION
Fixes issue https://github.com/sequelize/sequelize/issues/4631
User needs to supply "databaseVersion" key in options object
when instantiating the Sequelize class in case version is not semver
compliant e.g. "9.5.0beta2" should be passed as "9.5.0"