### PR TITLE
fix: nested create: belongsTo with foreignKey

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] nested belongsTo create with foreignKey constraints [#5089](https://github.com/sequelize/sequelize/pull/5089)
 - [FIXED] calling Model.update() modifies passed values  [#4520](https://github.com/sequelize/sequelize/issues/4520)
 
 # 3.15.0

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -555,6 +555,26 @@ Instance.prototype.save = function(options) {
   }
 
   return Promise.bind(this).then(function() {
+      // Nested creation for BelongsTo relations
+      // Needs to be executed before validation because of foreign key constraints
+      if (!options.fields.length) return this;
+      if (!this.isNewRecord) return this;
+      if (!this.$options.include || !this.$options.include.length) return this;
+
+      return Promise.map(this.$options.include.filter(function (include) {
+        return include.association instanceof BelongsTo;
+      }), function (include) {
+        var instance = self.get(include.as);
+        if (!instance) return Promise.resolve();
+
+        return instance.save({
+          transaction: options.transaction,
+          logging: options.logging
+        }).then(function () {
+          return self[include.association.accessors.set](instance, {save: false, logging: options.logging});
+        });
+      });
+    }).then(function() {
     // Validate
     if (options.validate) {
       return Promise.bind(this).then(function () {
@@ -613,26 +633,6 @@ Instance.prototype.save = function(options) {
         });
       }
     }).then(function() {
-      if (!options.fields.length) return this;
-      if (!this.isNewRecord) return this;
-      if (!this.$options.include || !this.$options.include.length) return this;
-
-      // Nested creation for BelongsTo relations
-      return Promise.map(this.$options.include.filter(function (include) {
-        return include.association instanceof BelongsTo;
-      }), function (include) {
-        var instance = self.get(include.as);
-        if (!instance) return Promise.resolve();
-
-        return instance.save({
-          transaction: options.transaction,
-          logging: options.logging
-        }).then(function () {
-          return self[include.association.accessors.set](instance, {save: false, logging: options.logging});
-        });
-      });
-    })
-    .then(function() {
       if (!options.fields.length) return this;
       if (!this.changed() && !this.isNewRecord) return this;
 


### PR DESCRIPTION
Hey,

nested creates ([#3386](https://github.com/sequelize/sequelize/pull/3386/files)) are awesome! 

I played around a bit with them and found that when using `belongsTo` relations and a foreignKey constraint (e.g. `allowNull: false`), I get a validation error as the source model is validated _before_ the target model is created.

Hence I propose to move the nested `belongsTo` before the validation -> about 60 lines up.
It shouldn't make a difference as the targeted model was already created before and with transaction there is rollback support. However we could define a default transaction that could be used for this behavior if this is wanted.

Moreover I added some tests to show my problem and check for this in the future ;-)
