### PR TITLE
Add in escapeValues option for raw queries

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -685,7 +685,7 @@ Sequelize.prototype.import = function(path) {
  * @param {Boolean}         [options.supportsSearchPath] If false do not prepend the query with the search_path (Postgres only)
  * @param {Object}          [options.mapToModel=false] Map returned fields to model's fields if `options.model` or `options.instance` is present. Mapping will occur before building the model instance.
  * @param {Object}          [options.fieldMap] Map returned fields to arbitrary names for `SELECT` query type.
- *
+ * @param {Boolean}         [options.escapeValues=true] When inserting named replacements, perform auto escaping on all String replacement values first (example convert all ' to '')
  * @return {Promise}
  *
  * @see {Model#build} for more information about instance option.
@@ -740,12 +740,21 @@ Sequelize.prototype.query = function(sql, options) {
   if (options.replacements && options.bind) {
     throw new Error('Both `replacements` and `bind` cannot be set at the same time');
   }
+
+  // If no escapeValues option given, default to true to keep original behavior intact
+  if (options.escapeValues === undefined) {
+    options.escapeValues = true;
+  }
+
   if (options.replacements) {
     if (Array.isArray(options.replacements)) {
       sql = Utils.format([sql].concat(options.replacements), this.options.dialect);
     }
     else {
-      sql = Utils.formatNamedParameters(sql, options.replacements, this.options.dialect);
+      sql = Utils.formatNamedParameters(sql, options.replacements, {
+        dialect: this.options.dialect,
+        escapeValues: options.escapeValues
+      });
     }
   }
   var bindParameters;

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -82,14 +82,26 @@ SqlString.format = function(sql, values, timeZone, dialect) {
   });
 };
 
-SqlString.formatNamedParameters = function(sql, values, timeZone, dialect) {
+/**
+ * Formats name replacements passed to a raw query
+ * @param  {String} sql                   The sql query with named replacement tags
+ * @param  {Object} values                (replacementName: value) The values to replace the tags with
+ * @param  {Object} options               Contains other optional values to pass in
+ * @param  {String} options.dialect       The SQL dialct to use (postgres, mysql, etc...)
+ * @param  {Bool}   options.escapeValues  Auto escape values before inserting into sql
+ * @param  {String} [options.timeZone]    Optional timezone to pass in
+ * @return {String} Updated sql query with replaced tags
+ */
+SqlString.formatNamedParameters = function(sql, values, options) {
   return sql.replace(/\:+(?!\d)(\w+)/g, function(value, key) {
-    if ('postgres' === dialect && '::' === value.slice(0, 2)) {
+    if ('postgres' === options.dialect && '::' === value.slice(0, 2)) {
       return value;
     }
 
-    if (values[key] !== undefined) {
-      return SqlString.escape(values[key], timeZone, dialect);
+    if (values[key] !== undefined && options.escapeValues) {
+      return SqlString.escape(values[key], options.timeZone, options.dialect);
+    } else if (values[key] !== undefined) {
+      return values[key];
     } else {
       throw new Error('Named parameter "' + value + '" has no value in the given object.');
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -59,9 +59,8 @@ var Utils = module.exports = {
     // Make a clone of the array beacuse format modifies the passed args
     return SqlString.format(arr[0], arr.slice(1), timeZone, dialect);
   },
-  formatNamedParameters: function(sql, parameters, dialect) {
-    var timeZone = null;
-    return SqlString.formatNamedParameters(sql, parameters, timeZone, dialect);
+  formatNamedParameters: function(sql, parameters, options) {
+    return SqlString.formatNamedParameters(sql, parameters, options);
   },
   cloneDeep: function(obj, fn) {
     return _.cloneDeep(obj, function (elem) {

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -226,4 +226,31 @@ describe(Support.getTestDialectTeaser('Utils'), function() {
       expect(Utils.singularize('status')).to.equal('status');
     });
   });
+
+  describe('formatNamedParameters', function() {
+    it('should escape named param values by default', function() {
+      Utils.formatNamedParameters('SELECT * FROM Users WHERE name IN (:names)', {
+        names: "'leia', 'luke', 'skywalker'"
+      }, {
+        escapeValues: true
+      })
+      .should.equal("SELECT * FROM Users WHERE name IN ('\\'leia\\', \\'luke\\', \\'skywalker\\'')");
+    });
+    it('should not escape named param values by default', function() {
+      Utils.formatNamedParameters('SELECT * FROM Users WHERE name IN (:names)', {
+        names: "'leia', 'luke', 'skywalker'"
+      }, {
+        escapeValues: false
+      })
+      .should.equal("SELECT * FROM Users WHERE name IN ('leia', 'luke', 'skywalker')");
+    });
+    it('should escape named param values by default', function() {
+      Utils.formatNamedParameters('SELECT * FROM Users WHERE name IN (:names)', {
+        names: ["'leia'", "'luke'", "'skywalker'"]
+      }, {
+        escapeValues: false
+      })
+      .should.equal("SELECT * FROM Users WHERE name IN ('leia','luke','skywalker')");
+    });
+  });
 });


### PR DESCRIPTION
Ran into an issue when trying to execute a raw query with an IN statement where arrays get converted to `Array[]` in the query and so I decided to go around this by doing `array.join("', '")` but it turns out that all `'` are auto escaped without the option to disable that. This PR adds in the option `escapeValues` for named replacements in raw queries. The default value for this option is `true` for backwards compatibility, but setting to `false` will skip all value escaping so that you can pass single quotes in around values an not have to worry about them being escaped.

Also updated docs as I added in some method comments for this option.

```js
sql.query("SELECT * FROM User WHERE name IN (:names)", {
  replacements: {
    names: "'leia', 'luke', 'skywalker'" // or `'${array.join("', '")}'` with es6
  }
}, {
  escapeValues: false
});
// = SELECT * FROM User WHERE name IN ('leia', 'luke', 'skywalker');
```

Added test cases to demonstrate the new option. This PR should provided a work around for issues: #3769 and #1969.