### PR TITLE
PostgreSQL tsrange data type support.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] PostgreSQL tsrange (Range of timestamp without time zone) data type support.
 - [FIXED] Support Unicode strings in mssql [#3752](https://github.com/sequelize/sequelize/issues/3752)
 
 # 3.15.1

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -37,7 +37,7 @@ var util = require('util')
  * })
  * ```
  * There may be times when you want to generate your own UUID conforming to some other algorithm. This is accomplised
- * using the defaultValue property as well, but instead of specifying one of the supplied UUID types, you return a value 
+ * using the defaultValue property as well, but instead of specifying one of the supplied UUID types, you return a value
  * from a function.
  * ```js
  * sequelize.define('model', {
@@ -617,7 +617,8 @@ var pgRangeSubtypes = {
   bigint: 'int8range',
   decimal: 'numrange',
   dateonly: 'daterange',
-  date: 'tstzrange'
+  date: 'tstzrange',
+  datenotz: 'tsrange'
 };
 
 RANGE.prototype.key = RANGE.key = 'RANGE';

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "inflection": "^1.6.0",
     "lodash": "^3.9.3",
     "moment": "^2.9.0",
-    "moment-timezone": "^0.4.1",
+    "moment-timezone": "^0.5.0",
     "node-uuid": "~1.4.4",
     "semver": "^5.0.1",
     "shimmer": "1.1.0",


### PR DESCRIPTION
There are already other range data types for PostgreSQL, but tsrange is missing. See [Range Types on PostgreSQL doc](http://www.postgresql.org/docs/9.4/static/rangetypes.html).

This patch competes range types.

Regards,