### PR TITLE
tsrange data type is added.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] PostgreSQL tsrange (Range of timestamp without time zone) data type support.
 - [FIXED] attributes from multiple scopes does not merge  [#4856](https://github.com/sequelize/sequelize/issues/4856)
 - [FIXED] Support Unicode strings in mssql [#3752](https://github.com/sequelize/sequelize/issues/3752)
 

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -37,7 +37,7 @@ var util = require('util')
  * })
  * ```
  * There may be times when you want to generate your own UUID conforming to some other algorithm. This is accomplised
- * using the defaultValue property as well, but instead of specifying one of the supplied UUID types, you return a value 
+ * using the defaultValue property as well, but instead of specifying one of the supplied UUID types, you return a value
  * from a function.
  * ```js
  * sequelize.define('model', {
@@ -617,7 +617,8 @@ var pgRangeSubtypes = {
   bigint: 'int8range',
   decimal: 'numrange',
   dateonly: 'daterange',
-  date: 'tstzrange'
+  date: 'tstzrange',
+  datenotz: 'tsrange'
 };
 
 RANGE.prototype.key = RANGE.key = 'RANGE';


### PR DESCRIPTION
tsrange is range of timestamp without time zone for PostgreSQL. This makes range types complete as of PostgreSQL 9.5.