### PR TITLE
Feature #488 : Added benchmarking support in query logs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Future
 - [FIXED] MySQL throws error when null GEOMETRY data results in empty buffer [#4953](https://github.com/sequelize/sequelize/issues/4953)
+- [ADDED] Support for benchmarking the execution time for SQL queries [#488](https://github.com/sequelize/sequelize/issues/488)
 
 # 3.16.0
 - [ADDED] PostgreSQL tsrange (Range of timestamp without time zone) data type support.

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -3,7 +3,8 @@
 var Utils = require('../../utils')
   , AbstractQuery = require('../abstract/query')
   , sequelizeErrors = require('../../errors.js')
-  , parserStore = require('../parserStore')('mssql');
+  , parserStore = require('../parserStore')('mssql')
+  , microtime = require('microtime');
 
 var Query = function(connection, sequelize, options) {
   this.connection = connection;
@@ -30,7 +31,14 @@ Query.prototype.run = function(sql, parameters) {
   var self = this;
   this.sql = sql;
 
-  this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
+  //do we need benchmark for this query execution
+  var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
+
+  if (!benchmark) {
+    this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
+  } else {
+    var queryBegin = microtime.now();
+  }
 
   var promise = new Utils.Promise(function(resolve, reject) {
       // TRANSACTION SUPPORT
@@ -63,6 +71,11 @@ Query.prototype.run = function(sql, parameters) {
         var results = [];
 
         var request = new self.connection.lib.Request(self.sql, function(err) {
+
+          if (benchmark) {
+            self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql + ' in ' + (microtime.now() - queryBegin) + 'μs', self.options);
+          }
+
           if (err) {
             err.sql = sql;
             reject(self.formatError(err));

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -3,7 +3,8 @@
 var Utils = require('../../utils')
   , AbstractQuery = require('../abstract/query')
   , uuid = require('node-uuid')
-  , sequelizeErrors = require('../../errors.js');
+  , sequelizeErrors = require('../../errors.js')
+  , microtime = require('microtime');
 
 var Query = function(connection, sequelize, options) {
   this.connection = connection;
@@ -26,10 +27,22 @@ Query.prototype.run = function(sql, parameters) {
   var self = this;
   this.sql = sql;
 
-  this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
+  //do we need benchmark for this query execution
+  var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
+
+  if (!benchmark) {
+    this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
+  } else {
+    var queryBegin = microtime.now();
+  }
 
   var promise = new Utils.Promise(function(resolve, reject) {
     self.connection.query(self.sql, function(err, results) {
+
+      if (benchmark) {
+        self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql + ' in ' + (microtime.now() - queryBegin) + 'μs', self.options);
+      }
+
       if (err) {
         err.sql = sql;
 

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -5,7 +5,8 @@ var Utils = require('../../utils')
   , QueryTypes = require('../../query-types')
   , Promise = require('../../promise')
   , sequelizeErrors = require('../../errors.js')
-  , _ = require('lodash');
+  , _ = require('lodash')
+  , microtime = require('microtime');
 
 var Query = function(client, sequelize, options) {
   this.client = client;
@@ -62,7 +63,14 @@ Query.prototype.run = function(sql, parameters) {
     , query = ((parameters && parameters.length) ? this.client.query(this.sql, parameters) : this.client.query(this.sql))
     , rows = [];
 
-  this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
+  //do we need benchmark for this query execution
+  var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
+  
+  if (!benchmark) {
+    this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
+  } else {
+    var queryBegin = microtime.now();
+  }
 
   var promise = new Promise(function(resolve, reject) {
     query.on('row', function(row) {
@@ -82,6 +90,11 @@ Query.prototype.run = function(sql, parameters) {
     });
 
     query.on('end', function(result) {
+
+      if (benchmark) {
+        self.sequelize.log('Executed (' + (self.client.uuid || 'default') + '): ' + self.sql + ' in ' + (microtime.now() - queryBegin) + 'μs', self.options);
+      }
+
       if (receivedError) {
         return;
       }

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -6,7 +6,8 @@ var Utils = require('../../utils')
   , AbstractQuery = require('../abstract/query')
   , QueryTypes = require('../../query-types')
   , sequelizeErrors = require('../../errors.js')
-  , parserStore = require('../parserStore')('sqlite');
+  , parserStore = require('../parserStore')('sqlite')
+  , microtime = require('microtime');
 
 var Query = function(database, sequelize, options) {
   this.database = database;
@@ -84,7 +85,14 @@ Query.prototype.run = function(sql, parameters) {
     this.sql = sql;
   }
 
-  this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
+  //do we need benchmark for this query execution
+  var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
+  
+  if (!benchmark) {
+    this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
+  } else {
+    var queryBegin = microtime.now();
+  }
 
   promise = new Promise(function(resolve) {
     var columnTypes = {};
@@ -95,6 +103,11 @@ Query.prototype.run = function(sql, parameters) {
         } else {
           resolve(new Promise(function(resolve, reject) {
             var afterExecute = function(err, results) {
+
+              if (benchmark) {
+                self.sequelize.log('Executed (' + (self.database.uuid || 'default') + '): ' + self.sql + ' in ' + (microtime.now() - queryBegin) + 'μs', self.options);
+              }
+
               if (err) {
                 err.sql = self.sql;
                 reject(self.formatError(err));

--- a/lib/model.js
+++ b/lib/model.js
@@ -992,7 +992,7 @@ Model.prototype.sync = function(options) {
     });
 
     return Promise.map(indexes, function (index) {
-      return self.QueryInterface.addIndex(self.getTableName(options), _.assign({logging: options.logging}, index), self.tableName);
+      return self.QueryInterface.addIndex(self.getTableName(options), _.assign({logging: options.logging, benchmark: options.benchmark}, index), self.tableName);
     });
   }).then(function () {
     if (options.hooks) {
@@ -1003,9 +1003,10 @@ Model.prototype.sync = function(options) {
 
 /**
  * Drop the table represented by this Model
- * @param {Object}  [options]
- * @param {Boolean} [options.cascade=false] Also drop all objects depending on this table, such as views. Only works in postgres
- * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Object}   [options]
+ * @param {Boolean}  [options.cascade=false]   Also drop all objects depending on this table, such as views. Only works in postgres
+ * @param {Function} [options.logging=false]   A function that gets executed while running the query to log the sql.
+ * @param {Boolean}  [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  * @return {Promise}
  */
 Model.prototype.drop = function(options) {
@@ -1021,9 +1022,10 @@ Model.prototype.dropSchema = function(schema) {
  * while the schema will be prepended to the table name for mysql and sqlite - `'schema.tablename'`.
  *
  * @param {String} schema The name of the schema
- * @param {Object} [options]
- * @param {String} [options.schemaDelimiter='.'] The character(s) that separates the schema name from the table name
+ * @param {Object}   [options]
+ * @param {String}   [options.schemaDelimiter='.'] The character(s) that separates the schema name from the table name
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Boolean}  [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  * @return {this}
  */
 Model.prototype.schema = function(schema, options) { // testhint options:none
@@ -1057,6 +1059,7 @@ Model.prototype.schema = function(schema, options) { // testhint options:none
  *
  * @param {Object}   [options] The hash of options from any query. You can use one model to access tables with matching schemas by overriding `getTableName` and using custom key/values to alter the name of the table. (eg. subscribers_1, subscribers_2)
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Boolean}  [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  * @return {String|Object}
  */
 Model.prototype.getTableName = function(options) { // testhint options:none
@@ -1304,6 +1307,7 @@ Model.prototype.all = function(options) {
  * @param  {Function}                  [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param  {Object}                    [options.having]
  * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param  {Boolean}                   [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  *
  * @see    {Sequelize#query}
  * @return {Promise<Array<Instance>>}
@@ -1502,9 +1506,10 @@ Model.prototype.find = Model.prototype.findOne;
  * @param {Object}          [options.where] A hash of search attributes.
  * @param {Function}        [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {DataType|String} [options.dataType] The type of the result. If `field` is a field in this Model, the default will be the type of that field, otherwise defaults to float.
- * @param {boolean}         [options.distinct] Applies DISTINCT to the field being aggregated over
+ * @param {Boolean}         [options.distinct] Applies DISTINCT to the field being aggregated over
  * @param {Transaction}     [options.transaction] Transaction to run query under
- * @param {boolean}         [options.plain] When `true`, the first returned value of `aggregateFunction` is cast to `dataType` and returned. If additional attributes are specified, along with `group` clauses, set `plain` to `false` to return all values of all returned rows.  Defaults to `true`
+ * @param {Boolean}         [options.plain] When `true`, the first returned value of `aggregateFunction` is cast to `dataType` and returned. If additional attributes are specified, along with `group` clauses, set `plain` to `false` to return all values of all returned rows.  Defaults to `true`
+ * @param {Boolean}         [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  *
  * @return {Promise<options.dataType|object>}                Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in which case the complete data result is returned.
  */
@@ -1558,6 +1563,7 @@ Model.prototype.aggregate = function(attribute, aggregateFunction, options) {
  * @param {Transaction}   [options.transaction] Transaction to run query under
  * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {String}        [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {Boolean}       [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  *
  * @return {Promise<Integer>}
  */
@@ -1792,7 +1798,8 @@ Model.prototype.bulkBuild = function(valueSets, options) { // testhint options:n
  * @param {String}        [options.onDuplicate]
  * @param {Transaction}   [options.transaction] Transaction to run query under
  * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
- * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {String}        [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {Boolean}       [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  *
  * @return {Promise<Instance>}
  */
@@ -1817,6 +1824,7 @@ Model.prototype.create = function(values, options) {
  * @param {Object}   [options.defaults] Default values to use if building a new instance
  * @param {Object}   [options.transaction] Transaction to run query under
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Boolean}  [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  *
  * @return {Promise<Instance,initialized>}
  * @alias findOrBuild
@@ -1993,6 +2001,7 @@ Model.prototype.findCreateFind = function(options) {
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param  {Boolean}      [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  *
  * @alias insertOrUpdate
  * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated.
@@ -2056,6 +2065,7 @@ Model.prototype.insertOrUpdate = Model.prototype.upsert;
  * @param  {Function}     [options.logging=false]          A function that gets executed while running the query to log the sql.
  * @param  {Boolean}      [options.returning=false] Append RETURNING * to get back auto generated values (Postgres only)
  * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param  {Boolean}      [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  *
  * @return {Promise<Array<Instance>>}
  */
@@ -2205,7 +2215,9 @@ Model.prototype.bulkCreate = function(records, options) {
  * @param {Boolean|function} [options.cascade = false] Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
  * @param {Transaction}      [options.transaction] Transaction to run query under
  * @param {Boolean|function} [options.logging] A function that logs sql queries, or false for no logging
- * @param  {String}          [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {String}           [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {Boolean}          [options.benchmark=false] Print query execution time in microseconds when logging SQL.
+ *
  * @return {Promise}
  *
  * @see {Model#destroy} for more information
@@ -2227,8 +2239,9 @@ Model.prototype.truncate = function(options) {
  * @param  {Boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
  * @param  {Boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored
  * @param  {Boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
- * @param  {Transaction}  [options.transaction] Transaction to run query under
+ * @param  {Transaction}  [options.transaction]           Transaction to run query under
  * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
+ * @param  {Boolean}      [options.benchmark=false]       Print query execution time in microseconds when logging SQL.
  * @return {Promise<Integer>} The number of destroyed rows
  */
 Model.prototype.destroy = function(options) {
@@ -2259,7 +2272,7 @@ Model.prototype.destroy = function(options) {
   }).then(function() {
     // Get daos and run beforeDestroy hook on each record individually
     if (options.individualHooks) {
-      return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging}).map(function(instance) {
+      return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark}).map(function(instance) {
         return self.runHooks('beforeDestroy', instance, options).then(function() {
           return instance;
         });
@@ -2308,6 +2321,7 @@ Model.prototype.destroy = function(options) {
  * @param  {Boolean}      [options.individualHooks=false] If set to true, restore will find all records within the where parameter and will execute before / after bulkRestore hooks on each row
  * @param  {Number}       [options.limit]                 How many rows to undelete
  * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
+ * @param  {Boolean}      [options.benchmark=false]       Print query execution time in microseconds when logging SQL.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  *
  * @return {Promise<undefined>}
@@ -2335,7 +2349,7 @@ Model.prototype.restore = function(options) {
   }).then(function() {
     // Get daos and run beforeRestore hook on each record individually
     if (options.individualHooks) {
-      return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging, paranoid: false}).map(function(instance) {
+      return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark, paranoid: false}).map(function(instance) {
         return self.runHooks('beforeRestore', instance, options).then(function() {
           return instance;
         });
@@ -2385,6 +2399,7 @@ Model.prototype.restore = function(options) {
  * @param  {Boolean}      [options.returning=false]       Return the affected rows (only for postgres)
  * @param  {Number}       [options.limit]                 How many rows to update (only for mysql and mariadb)
  * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param  {Boolean}      [options.benchmark=false] Print query execution time in microseconds when logging SQL.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  *
  * @return {Promise<Array<affectedCount,affectedRows>>}
@@ -2470,7 +2485,7 @@ Model.prototype.update = function(values, options) {
 
     // Get instances and run beforeUpdate hook on each record individually
     if (options.individualHooks) {
-      return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging}).then(function(_instances) {
+      return self.findAll({where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark}).then(function(_instances) {
         instances = _instances;
         if (!instances.length) {
           return [];

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -81,7 +81,8 @@ var url = require('url')
  * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.
  * @param {String}   [options.transactionType='DEFERRED'] Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
  * @param {String}   [options.isolationLevel='REPEATABLE_READ'] Set the default transaction isolation level. See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options.
- * @param {Boolean}  [options.typeValidation=false] Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like
+ * @param {Boolean}  [options.typeValidation=false] Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like.
+ * @param {Boolean}  [options.benchmark=false] Print query execution time in microseconds when logging SQL.
 */
 
 /**
@@ -147,7 +148,8 @@ var Sequelize = function(database, username, password, options) {
     transactionType: Transaction.TYPES.DEFERRED,
     isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ,
     databaseVersion: 0,
-    typeValidation: false
+    typeValidation: false,
+    benchmark: false
   }, options || {});
 
   if (this.options.dialect === 'postgresql') {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "inflection": "^1.6.0",
     "lodash": "^3.9.3",
     "moment": "^2.11.0",
+    "microtime": "^2.0.0",
     "moment-timezone": "^0.5.0",
     "node-uuid": "~1.4.4",
     "semver": "^5.0.1",


### PR DESCRIPTION
Closes #488 

Added an new option `benchmark` and `node-microtime` library to log time in microseconds it took to execute a SQL statement.