### PR TITLE
Show that sequelize supports geometry on documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ We're glad to get pull request if any functionality is missing or something is b
 Still interested? Coolio! Here is how to get started:
 
 ### 1. Prepare your environment
-Here comes a little surprise: You need [Node.JS](http://nodejs.org). In order to be a productive developer, I would recommend the latest v0.10.
+Here comes a little surprise: You need [Node.JS](http://nodejs.org).
 
 ### 2. Install the dependencies
 

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -811,6 +811,11 @@ var helpers = {
   SCALE: [DECIMAL]
 };
 
+/**
+ * A geometry datatype represents two dimensional spacial objects.
+ * @property GEOMETRY
+ */
+
 var GEOMETRY = ABSTRACT.inherits(function(type, srid) {
   var options = _.isPlainObject(type) ? type : {
     type: type,


### PR DESCRIPTION
Geometry was introduced but is not on the documentation http://docs.sequelizejs.com/en/latest/api/datatypes