### PR TITLE
Failing test assertion

### DIFF
--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -1071,15 +1071,25 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     });
 
     it('does not update timestamps when passing silent=true', function() {
+      var self = this;
+
       return this.User.create({ username: 'user' }).then(function(user) {
         var updatedAt = user.updatedAt;
         return this.sequelize.Promise.delay(2000).then(function() {
+
+          user.set({
+            updatedAt: new Date(Date.now() - 7200000)
+          }, { raw: true });
+
           return user.update({
             username: 'userman'
           }, {
             silent: true
           }).then(function(user1) {
             expect(user1.updatedAt).to.equalTime(updatedAt);
+            return self.User.findById(user1.id);
+          }).then(function(user2) {
+            expect(user2.updatedAt).to.equalTime(updatedAt);
           });
         });
       });


### PR DESCRIPTION
When trying to set `updatedAt`, the instance returned from save via the promise fulfillment does not properly reflect the saved data.

Run test using:

``` bash
make test-integration-sqlite GREP="does not update timestamps when passing"
```

Refer to https://github.com/sequelize/sequelize/issues/3759#issuecomment-165292388

> `Instance.save()` trips up here but returns the instance with the set attribute: https://github.com/sequelize/sequelize/blob/master/lib/instance.js#L637

In the test, you get a successful promise fulfillment from save containing an attribute that was not committed to the database. The reason I have the 2nd assertion after re-querying the database is because that one will actually pass (if the test was able to get to it, it fails the first assertion).
