### PR TITLE
Parse dates as UTC instead of local timezone

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -448,7 +448,7 @@ DATE.prototype.validate = function(value) {
 };
 
 DATE.prototype.$applyTimezone = function (date, options) {
-  date = moment(date);
+  date = moment.utc(date);
 
   if (options.timezone) {
     if (moment.tz.zone(options.timezone)) {

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -380,6 +380,18 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
 
+      it('should be able to find a row using equal with dates', function() {
+        return this.User.findAll({
+          where: {
+            theDate: '2013-01-10 12:00'
+          }
+        }).then(function(users) {
+          expect(users.length).to.equal(1);
+          expect(users[0].username).to.equal('boo2');
+          expect(users[0].intVal).to.equal(10);
+        });
+      });
+
       it('should be able to find a row using greater than or equal to', function() {
         return this.User.find({
           where: {


### PR DESCRIPTION
Looks like a regression as this wasn't the behaviour in `< 3.14`, I'll look into adding a test when you are :+1: 