### PR TITLE
Correct type in documentation in instance save()

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -480,7 +480,7 @@ Instance.prototype._setInclude = function(key, value, options) {
  * This error will have a property for each of the fields for which validation failed, with the error message for that field.
  *
  * @param {Object} [options]
- * @param {Object} [options.fields] An optional array of strings, representing database columns. If fields is provided, only those columns will be validated and saved.
+ * @param {string[]} [options.fields] An optional array of strings, representing database columns. If fields is provided, only those columns will be validated and saved.
  * @param {Boolean} [options.silent=false] If true, the updatedAt timestamp will not be updated.
  * @param {Boolean} [options.validate=true] If false, validations won't be run.
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.


### PR DESCRIPTION
The type is an array of strings for the property names, indeed as described in the comment. Not an object as typed. The documentation page end up contradicting each other.