### PR TITLE
Add geography support - postgis

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -836,6 +836,31 @@ GEOMETRY.prototype.$stringify = function (value) {
   return 'GeomFromText(\'' + Wkt.stringify(value) + '\')';
 };
 
+/**
+ * A geography datatype represents two dimensional spacial objects in an elliptic coord system.
+ * @property GEOGRAPHY
+ */
+
+var GEOGRAPHY = ABSTRACT.inherits(function(type, srid) {
+  var options = _.isPlainObject(type) ? type : {
+    type: type,
+    srid: srid
+  };
+
+  if (!(this instanceof GEOGRAPHY)) return new GEOGRAPHY(options);
+
+  this.options = options;
+  this.type = options.type;
+  this.srid = options.srid;
+});
+
+GEOGRAPHY.prototype.key = GEOGRAPHY.key = 'GEOGRAPHY';
+
+GEOGRAPHY.prototype.escape = false;
+GEOGRAPHY.prototype.$stringify = function (value) {
+  return 'GeomFromText(\'' + Wkt.stringify(value) + '\')';
+};
+
 Object.keys(helpers).forEach(function (helper) {
   helpers[helper].forEach(function (DataType) {
     if (!DataType[helper]) {
@@ -883,7 +908,8 @@ var dataTypes = {
   REAL: REAL,
   DOUBLE: DOUBLE,
   'DOUBLE PRECISION': DOUBLE,
-  GEOMETRY: GEOMETRY
+  GEOMETRY: GEOMETRY,
+  GEOGRAPHY: GEOGRAPHY
 };
 
 _.each(dataTypes, function (dataType) {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -140,7 +140,7 @@ ConnectionManager.prototype.connect = function(config) {
 
     // oids for hstore and geometry are dynamic - so select them at connection time
     if (dataTypes.HSTORE.types.postgres.oids.length === 0) {
-      query += 'SELECT typname, oid, typarray FROM pg_type WHERE typtype = \'b\' AND typname IN (\'hstore\', \'geometry\')';
+      query += 'SELECT typname, oid, typarray FROM pg_type WHERE typtype = \'b\' AND typname IN (\'hstore\', \'geometry\',\'geography\')';
     }
 
     return new Promise(function (resolve, reject) {
@@ -152,6 +152,8 @@ ConnectionManager.prototype.connect = function(config) {
           type = dataTypes.postgres.GEOMETRY;
         } else if (row.typname === 'hstore') {
           type = dataTypes.postgres.HSTORE;
+        } else if (row.typname === 'geography') {
+          type = dataTypes.postgres.GEOGRAPHY;
         }
 
         type.types.postgres.oids.push(row.oid);

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -269,6 +269,38 @@ module.exports = function (BaseTypes) {
     return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
   };
 
+  var GEOGRAPHY = BaseTypes.GEOGRAPHY.inherits();
+
+  GEOGRAPHY.prototype.toSql = function() {
+    var result = 'GEOGRAPHY';
+
+    if (this.type){
+      result += '(' + this.type;
+
+      if (this.srid){
+        result += ',' + this.srid;
+      }
+
+      result += ')';
+    }
+
+    return result;
+  };
+
+  BaseTypes.GEOGRAPHY.types.postgres = {
+    oids: [],
+    array_oids: []
+  };
+
+  GEOGRAPHY.parse = GEOGRAPHY.prototype.parse = function(value) {
+    var b = new Buffer(value, 'hex');
+    return wkx.Geometry.parse(b).toGeoJSON();
+  };
+
+  GEOGRAPHY.prototype.$stringify = function (value) {
+    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
+  };
+
   var hstore;
   var HSTORE = BaseTypes.HSTORE.inherits(function () {
     if (!(this instanceof HSTORE)) return new HSTORE();
@@ -373,6 +405,7 @@ module.exports = function (BaseTypes) {
     'DOUBLE PRECISION': DOUBLE,
     FLOAT: FLOAT,
     GEOMETRY: GEOMETRY,
+    GEOGRAPHY: GEOGRAPHY,
     HSTORE: HSTORE,
     RANGE: RANGE
   };


### PR DESCRIPTION
Add the GEOGRAPHY datatype support from postgis based on http://postgis.net/docs/using_postgis_dbmanagement.html#PostGIS_Geography which is indeed very similar to the GEOMETRY datatype but takes the roundness of the earth into account.

This is very useful for setting geographical points with a high degree of exactitude.