### PR TITLE
Added validationFailed hook

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- [ADDED] validationFailed hook [#1626](https://github.com/sequelize/sequelize/issues/1626)
+
 # 3.17.1
 - [FIXED] Reverted benchmarking feature since it does not compile on Node v4.0
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -1,6 +1,6 @@
 <a name="hooks"></a>
 # Mixin Hooks
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L39)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L39)
 
 Hooks are function that are called before and after  (bulk-) creation/updating/deletion and validation. Hooks can be added to you models in three ways:
 
@@ -38,7 +38,7 @@ Model.afterBulkUpdate(function () {})
 
 <a name="addhook"></a>
 ## `addHook(hooktype, [name], fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L160)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L161)
 
 Add a hook to the model
 
@@ -56,7 +56,7 @@ __Aliases:__ hook
 
 <a name="removehook"></a>
 ## `removeHook(hookType, name)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L179)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L180)
 
 Remove hook from the model
 
@@ -72,7 +72,7 @@ Remove hook from the model
 
 <a name="hashook"></a>
 ## `hasHook(hookType)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L205)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L206)
 
 Check whether the mode has any hooks of this type
 
@@ -88,7 +88,7 @@ __Aliases:__ hasHooks
 
 <a name="beforevalidate"></a>
 ## `beforeValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L218)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L219)
 
 A hook that is run before validation
 
@@ -104,7 +104,7 @@ A hook that is run before validation
 
 <a name="aftervalidate"></a>
 ## `afterValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L225)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L226)
 
 A hook that is run after validation
 
@@ -118,9 +118,25 @@ A hook that is run after validation
 
 ***
 
+<a name="validationfailed"></a>
+## `validationFailed(name, fn)`
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L234)
+
+A hook that is run when validation fails
+
+**Params:**
+
+| Name | Type | Description |
+| ---- | ---- | ----------- |
+| name | String |  |
+| fn | Function | A callback function that is called with instance, options, error. Error is the SequelizeValidationError. If the callback throws an error, it will replace the original validation error. |
+
+
+***
+
 <a name="beforecreate"></a>
 ## `beforeCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L232)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L241)
 
 A hook that is run before creating a single instance
 
@@ -136,7 +152,7 @@ A hook that is run before creating a single instance
 
 <a name="aftercreate"></a>
 ## `afterCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L239)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L248)
 
 A hook that is run after creating a single instance
 
@@ -152,7 +168,7 @@ A hook that is run after creating a single instance
 
 <a name="beforedestroy"></a>
 ## `beforeDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L248)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L257)
 
 A hook that is run before destroying a single instance
 
@@ -169,7 +185,7 @@ __Aliases:__ beforeDelete
 
 <a name="afterdestroy"></a>
 ## `afterDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L257)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L266)
 
 A hook that is run after destroying a single instance
 
@@ -186,7 +202,7 @@ __Aliases:__ afterDelete
 
 <a name="beforerestore"></a>
 ## `beforeRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L265)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L274)
 
 A hook that is run before restoring a single instance
 
@@ -202,7 +218,7 @@ A hook that is run before restoring a single instance
 
 <a name="afterrestore"></a>
 ## `afterRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L273)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L282)
 
 A hook that is run after restoring a single instance
 
@@ -218,7 +234,7 @@ A hook that is run after restoring a single instance
 
 <a name="beforeupdate"></a>
 ## `beforeUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L280)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L289)
 
 A hook that is run before updating a single instance
 
@@ -234,7 +250,7 @@ A hook that is run before updating a single instance
 
 <a name="afterupdate"></a>
 ## `afterUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L287)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L296)
 
 A hook that is run after updating a single instance
 
@@ -250,7 +266,7 @@ A hook that is run after updating a single instance
 
 <a name="beforebulkcreate"></a>
 ## `beforeBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L294)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L303)
 
 A hook that is run before creating instances in bulk
 
@@ -266,7 +282,7 @@ A hook that is run before creating instances in bulk
 
 <a name="afterbulkcreate"></a>
 ## `afterBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L301)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L310)
 
 A hook that is run after creating instances in bulk
 
@@ -282,7 +298,7 @@ A hook that is run after creating instances in bulk
 
 <a name="beforebulkdestroy"></a>
 ## `beforeBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L310)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L319)
 
 A hook that is run before destroying instances in bulk
 
@@ -299,7 +315,7 @@ __Aliases:__ beforeBulkDelete
 
 <a name="afterbulkdestroy"></a>
 ## `afterBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L319)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L328)
 
 A hook that is run after destroying instances in bulk
 
@@ -316,7 +332,7 @@ __Aliases:__ afterBulkDelete
 
 <a name="beforebulkrestore"></a>
 ## `beforeBulkRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L327)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L336)
 
 A hook that is run before restoring instances in bulk
 
@@ -332,7 +348,7 @@ A hook that is run before restoring instances in bulk
 
 <a name="afterbulkrestore"></a>
 ## `afterBulkRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L335)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L344)
 
 A hook that is run after restoring instances in bulk
 
@@ -348,9 +364,9 @@ A hook that is run after restoring instances in bulk
 
 <a name="beforebulkupdate"></a>
 ## `beforeBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L342)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L351)
 
-A hook that is run after updating instances in bulk
+A hook that is run before updating instances in bulk
 
 **Params:**
 
@@ -364,7 +380,7 @@ A hook that is run after updating instances in bulk
 
 <a name="afterbulkupdate"></a>
 ## `afterBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L349)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L358)
 
 A hook that is run after updating instances in bulk
 
@@ -380,7 +396,7 @@ A hook that is run after updating instances in bulk
 
 <a name="beforefind"></a>
 ## `beforeFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L356)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L365)
 
 A hook that is run before a find (select) query
 
@@ -396,7 +412,7 @@ A hook that is run before a find (select) query
 
 <a name="beforefindafterexpandincludeall"></a>
 ## `beforeFindAfterExpandIncludeAll(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L363)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L372)
 
 A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
 
@@ -412,7 +428,7 @@ A hook that is run before a find (select) query, after any { include: {all: ...}
 
 <a name="beforefindafteroptions"></a>
 ## `beforeFindAfterOptions(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L370)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L379)
 
 A hook that is run before a find (select) query, after all option parsing is complete
 
@@ -428,7 +444,7 @@ A hook that is run before a find (select) query, after all option parsing is com
 
 <a name="afterfind"></a>
 ## `afterFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L377)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L386)
 
 A hook that is run after a find (select) query
 
@@ -444,7 +460,7 @@ A hook that is run after a find (select) query
 
 <a name="beforedefine"></a>
 ## `beforeDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L384)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L393)
 
 A hook that is run before a define call
 
@@ -460,7 +476,7 @@ A hook that is run before a define call
 
 <a name="afterdefine"></a>
 ## `afterDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L391)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L400)
 
 A hook that is run after a define call
 
@@ -476,7 +492,7 @@ A hook that is run after a define call
 
 <a name="beforeinit"></a>
 ## `beforeInit(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L398)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L407)
 
 A hook that is run before Sequelize() call
 
@@ -492,7 +508,7 @@ A hook that is run before Sequelize() call
 
 <a name="afterinit"></a>
 ## `afterInit(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L405)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L414)
 
 A hook that is run after Sequelize() call
 
@@ -508,7 +524,7 @@ A hook that is run after Sequelize() call
 
 <a name="beforesync"></a>
 ## `beforeSync(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L412)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L421)
 
 A hook that is run before Model.sync call
 
@@ -524,7 +540,7 @@ A hook that is run before Model.sync call
 
 <a name="aftersync"></a>
 ## `afterSync(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L419)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L428)
 
 A hook that is run after Model.sync call
 
@@ -540,7 +556,7 @@ A hook that is run after Model.sync call
 
 <a name="beforebulksync"></a>
 ## `beforeBulkSync(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L426)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L435)
 
 A hook that is run before sequelize.sync call
 
@@ -556,7 +572,7 @@ A hook that is run before sequelize.sync call
 
 <a name="afterbulksync"></a>
 ## `afterBulkSync`
-[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L434)
+[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L443)
 
 A hook that is run after sequelize.sync call
 

--- a/docs/api/hooks.md
+++ b/docs/api/hooks.md
@@ -1,6 +1,6 @@
 <a name="hooks"></a>
 # Mixin Hooks
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L39)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L39)
 
 Hooks are function that are called before and after  (bulk-) creation/updating/deletion and validation. Hooks can be added to you models in three ways:
 
@@ -38,7 +38,7 @@ Model.afterBulkUpdate(function () {})
 
 <a name="addhook"></a>
 ## `addHook(hooktype, [name], fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L161)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L160)
 
 Add a hook to the model
 
@@ -56,7 +56,7 @@ __Aliases:__ hook
 
 <a name="removehook"></a>
 ## `removeHook(hookType, name)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L180)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L179)
 
 Remove hook from the model
 
@@ -72,7 +72,7 @@ Remove hook from the model
 
 <a name="hashook"></a>
 ## `hasHook(hookType)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L206)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L205)
 
 Check whether the mode has any hooks of this type
 
@@ -88,7 +88,7 @@ __Aliases:__ hasHooks
 
 <a name="beforevalidate"></a>
 ## `beforeValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L219)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L218)
 
 A hook that is run before validation
 
@@ -104,7 +104,7 @@ A hook that is run before validation
 
 <a name="aftervalidate"></a>
 ## `afterValidate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L226)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L225)
 
 A hook that is run after validation
 
@@ -118,25 +118,9 @@ A hook that is run after validation
 
 ***
 
-<a name="validationfailed"></a>
-## `validationFailed(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L234)
-
-A hook that is run when validation fails
-
-**Params:**
-
-| Name | Type | Description |
-| ---- | ---- | ----------- |
-| name | String |  |
-| fn | Function | A callback function that is called with instance, options, error. Error is the SequelizeValidationError. If the callback throws an error, it will replace the original validation error. |
-
-
-***
-
 <a name="beforecreate"></a>
 ## `beforeCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L241)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L232)
 
 A hook that is run before creating a single instance
 
@@ -152,7 +136,7 @@ A hook that is run before creating a single instance
 
 <a name="aftercreate"></a>
 ## `afterCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L248)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L239)
 
 A hook that is run after creating a single instance
 
@@ -168,7 +152,7 @@ A hook that is run after creating a single instance
 
 <a name="beforedestroy"></a>
 ## `beforeDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L257)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L248)
 
 A hook that is run before destroying a single instance
 
@@ -185,7 +169,7 @@ __Aliases:__ beforeDelete
 
 <a name="afterdestroy"></a>
 ## `afterDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L266)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L257)
 
 A hook that is run after destroying a single instance
 
@@ -202,7 +186,7 @@ __Aliases:__ afterDelete
 
 <a name="beforerestore"></a>
 ## `beforeRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L274)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L265)
 
 A hook that is run before restoring a single instance
 
@@ -218,7 +202,7 @@ A hook that is run before restoring a single instance
 
 <a name="afterrestore"></a>
 ## `afterRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L282)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L273)
 
 A hook that is run after restoring a single instance
 
@@ -234,7 +218,7 @@ A hook that is run after restoring a single instance
 
 <a name="beforeupdate"></a>
 ## `beforeUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L289)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L280)
 
 A hook that is run before updating a single instance
 
@@ -250,7 +234,7 @@ A hook that is run before updating a single instance
 
 <a name="afterupdate"></a>
 ## `afterUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L296)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L287)
 
 A hook that is run after updating a single instance
 
@@ -266,7 +250,7 @@ A hook that is run after updating a single instance
 
 <a name="beforebulkcreate"></a>
 ## `beforeBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L303)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L294)
 
 A hook that is run before creating instances in bulk
 
@@ -282,7 +266,7 @@ A hook that is run before creating instances in bulk
 
 <a name="afterbulkcreate"></a>
 ## `afterBulkCreate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L310)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L301)
 
 A hook that is run after creating instances in bulk
 
@@ -298,7 +282,7 @@ A hook that is run after creating instances in bulk
 
 <a name="beforebulkdestroy"></a>
 ## `beforeBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L319)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L310)
 
 A hook that is run before destroying instances in bulk
 
@@ -315,7 +299,7 @@ __Aliases:__ beforeBulkDelete
 
 <a name="afterbulkdestroy"></a>
 ## `afterBulkDestroy(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L328)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L319)
 
 A hook that is run after destroying instances in bulk
 
@@ -332,7 +316,7 @@ __Aliases:__ afterBulkDelete
 
 <a name="beforebulkrestore"></a>
 ## `beforeBulkRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L336)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L327)
 
 A hook that is run before restoring instances in bulk
 
@@ -348,7 +332,7 @@ A hook that is run before restoring instances in bulk
 
 <a name="afterbulkrestore"></a>
 ## `afterBulkRestore(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L344)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L335)
 
 A hook that is run after restoring instances in bulk
 
@@ -364,9 +348,9 @@ A hook that is run after restoring instances in bulk
 
 <a name="beforebulkupdate"></a>
 ## `beforeBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L351)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L342)
 
-A hook that is run before updating instances in bulk
+A hook that is run after updating instances in bulk
 
 **Params:**
 
@@ -380,7 +364,7 @@ A hook that is run before updating instances in bulk
 
 <a name="afterbulkupdate"></a>
 ## `afterBulkUpdate(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L358)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L349)
 
 A hook that is run after updating instances in bulk
 
@@ -396,7 +380,7 @@ A hook that is run after updating instances in bulk
 
 <a name="beforefind"></a>
 ## `beforeFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L365)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L356)
 
 A hook that is run before a find (select) query
 
@@ -412,7 +396,7 @@ A hook that is run before a find (select) query
 
 <a name="beforefindafterexpandincludeall"></a>
 ## `beforeFindAfterExpandIncludeAll(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L372)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L363)
 
 A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
 
@@ -428,7 +412,7 @@ A hook that is run before a find (select) query, after any { include: {all: ...}
 
 <a name="beforefindafteroptions"></a>
 ## `beforeFindAfterOptions(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L379)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L370)
 
 A hook that is run before a find (select) query, after all option parsing is complete
 
@@ -444,7 +428,7 @@ A hook that is run before a find (select) query, after all option parsing is com
 
 <a name="afterfind"></a>
 ## `afterFind(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L386)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L377)
 
 A hook that is run after a find (select) query
 
@@ -460,7 +444,7 @@ A hook that is run after a find (select) query
 
 <a name="beforedefine"></a>
 ## `beforeDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L393)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L384)
 
 A hook that is run before a define call
 
@@ -476,7 +460,7 @@ A hook that is run before a define call
 
 <a name="afterdefine"></a>
 ## `afterDefine(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L400)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L391)
 
 A hook that is run after a define call
 
@@ -492,7 +476,7 @@ A hook that is run after a define call
 
 <a name="beforeinit"></a>
 ## `beforeInit(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L407)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L398)
 
 A hook that is run before Sequelize() call
 
@@ -508,7 +492,7 @@ A hook that is run before Sequelize() call
 
 <a name="afterinit"></a>
 ## `afterInit(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L414)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L405)
 
 A hook that is run after Sequelize() call
 
@@ -524,7 +508,7 @@ A hook that is run after Sequelize() call
 
 <a name="beforesync"></a>
 ## `beforeSync(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L421)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L412)
 
 A hook that is run before Model.sync call
 
@@ -540,7 +524,7 @@ A hook that is run before Model.sync call
 
 <a name="aftersync"></a>
 ## `afterSync(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L428)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L419)
 
 A hook that is run after Model.sync call
 
@@ -556,7 +540,7 @@ A hook that is run after Model.sync call
 
 <a name="beforebulksync"></a>
 ## `beforeBulkSync(name, fn)`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L435)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L426)
 
 A hook that is run before sequelize.sync call
 
@@ -572,7 +556,7 @@ A hook that is run before sequelize.sync call
 
 <a name="afterbulksync"></a>
 ## `afterBulkSync`
-[View code](https://github.com/sequelize/sequelize/blob/ea444d318402f5de7f13f2c8dd6512fe0b8a38d8/lib/hooks.js#L443)
+[View code](https://github.com/sequelize/sequelize/blob/0de404640d4c71e2d1f1259356650dfb586a248b/lib/hooks.js#L434)
 
 A hook that is run after sequelize.sync call
 

--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -15,6 +15,8 @@ For a full list of hooks, see [Hooks API](/api/hooks).
   validate
 (3)
   afterValidate(instance, options, fn)
+  - or -
+  validationFailed(instance, options, error, fn)
 (4)
   beforeCreate(instance, options, fn)
   beforeDestroy(instance, options, fn)
@@ -159,7 +161,7 @@ The following hooks will emit whenever you're editing a single object
 
 ```
 beforeValidate
-afterValidate
+afterValidate or validationFailed
 beforeCreate / beforeUpdate  / beforeDestroy
 afterCreate / afterUpdate / afterDestroy
 ```

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -39,6 +39,7 @@ var Utils = require('./utils')
 var hookTypes = {
   beforeValidate: {params: 2},
   afterValidate: {params: 2},
+  validationFailed: {params: 3},
   beforeCreate: {params: 2},
   afterCreate: {params: 2},
   beforeDestroy: {params: 2},
@@ -221,6 +222,13 @@ Hooks.hasHooks = Hooks.hasHook;
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance, options
  * @name afterValidate
+ */
+
+/**
+ * A hook that is run when validation fails
+ * @param {String}   name
+ * @param {Function} fn   A callback function that is called with instance, options, error
+ * @name validationFailed
  */
 
 /**

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -227,7 +227,8 @@ Hooks.hasHooks = Hooks.hasHook;
 /**
  * A hook that is run when validation fails
  * @param {String}   name
- * @param {Function} fn   A callback function that is called with instance, options, error
+ * @param {Function} fn   A callback function that is called with instance, options, error. Error is the
+ * SequelizeValidationError. If the callback throws an error, it will replace the original validation error.
  * @name validationFailed
  */
 

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -80,7 +80,8 @@ InstanceValidator.prototype.validate = function() {
  * Invoke the Validation sequence:
  *   - Before Validation Model Hooks
  *   - Validation
- *   - After Validation Model Hooks
+ *   - On validation success: After Validation Model Hooks
+ *   - On validation failure: Validation Failed Model Hooks
  *
  * @return {Promise}
  */
@@ -89,7 +90,9 @@ InstanceValidator.prototype.hookValidate = function() {
   return self.modelInstance.Model.runHooks('beforeValidate', self.modelInstance, self.options).then(function() {
     return self.validate().then(function(error) {
       if (error) {
-        throw error;
+        return self.modelInstance.Model.runHooks('validationFailed', self.modelInstance, self.options, error).then(function(newError) {
+          throw newError || error;
+        });
       }
     });
   }).then(function() {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -550,7 +550,7 @@ Sequelize.prototype.getQueryInterface = function() {
  * @param {String}                  [options.comment]
  * @param {String}                  [options.collate]
  * @param {String}                  [options.initialAutoIncrement] Set the initial AUTO_INCREMENT value for the table in MySQL.
- * @param {Object}                  [options.hooks] An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate, afterBulkCreate, afterBulkDestory and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions.
+ * @param {Object}                  [options.hooks] An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, validationFailed, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate, afterBulkCreate, afterBulkDestory and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions.
  * @param {Object}                  [options.validate] An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error.
  *
  * @return {Model}

--- a/test/integration/hooks.test.js
+++ b/test/integration/hooks.test.js
@@ -12,7 +12,10 @@ var chai = require('chai')
 describe(Support.getTestDialectTeaser('Hooks'), function() {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
-      username: DataTypes.STRING,
+      username: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
       mood: {
         type: DataTypes.ENUM,
         values: ['happy', 'sad', 'neutral']
@@ -36,6 +39,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     describe('#create', function() {
       it('should return the user', function() {
         this.User.beforeValidate(function(user, options) {
+          user.username = 'Bob';
           user.mood = 'happy';
         });
 
@@ -57,7 +61,37 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           throw new Error('Whoops! Changed user.mood!');
         });
 
-        return expect(this.User.create({mood: 'happy'})).to.be.rejectedWith('Whoops! Changed user.mood!');
+        return expect(this.User.create({username: 'Toni', mood: 'happy'})).to.be.rejectedWith('Whoops! Changed user.mood!');
+      });
+
+      it('should call validationFailed hook', function() {
+        var validationFailedHook = sinon.spy();
+
+        this.User.validationFailed(validationFailedHook);
+
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(function(err) {
+          expect(validationFailedHook).to.have.been.calledOnce;
+        });
+      });
+
+      it('should not replace the validation error in validationFailed hook by default', function() {
+        var validationFailedHook = sinon.stub();
+
+        this.User.validationFailed(validationFailedHook);
+
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(function(err) {
+          expect(err.name).to.equal('SequelizeValidationError');
+        });
+      });
+
+      it('should replace the validation error if validationFailed hook creates a new error', function() {
+        var validationFailedHook = sinon.stub().throws(new Error('Whoops!'));
+
+        this.User.validationFailed(validationFailedHook);
+
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(function(err) {
+          expect(err.message).to.equal('Whoops!');
+        });
       });
     });
   });


### PR DESCRIPTION
See [ afterValidate hook is not called when validation fails #1626 ](https://github.com/sequelize/sequelize/issues/1626)

I added an async validationFailed hook which is called with modelInstance, options and validationError. If the hook throws an error, it replaces the original validation error.