### PR TITLE
	Fixes a bug with user defined attribute names overwriting builtins

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -196,7 +196,11 @@ Instance.prototype.get = function(key, options) { // testhint options:none
         return this.dataValues[key];
       }
     }
-    return this.dataValues[key];
+		if (this.dataValues) {
+			return this.dataValues[key];
+		} else {
+			return undefined;
+		}
   }
 
   if (this._hasCustomGetters || (options && options.plain && this.$options.include) || (options && options.clone)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -75,9 +75,6 @@ var Model = function(name, attributes, options) {
   });
 
   this.attributes = this.rawAttributes = Utils._.mapValues(attributes, function(attribute, name) {
-    if (!Utils._.isPlainObject(attribute)) {
-      attribute = { type: attribute };
-    }
 
     attribute = this.sequelize.normalizeAttribute(attribute);
 
@@ -923,7 +920,14 @@ Model.prototype.refreshAttributes = function() {
   this.Instance.prototype._hasCustomGetters = Object.keys(this.Instance.prototype._customGetters).length;
   this.Instance.prototype._hasCustomSetters = Object.keys(this.Instance.prototype._customSetters).length;
 
-  Object.defineProperties(this.Instance.prototype, attributeManipulation);
+  Object.keys(attributeManipulation).forEach((function(key){
+    if( this.Instance.prototype[key] !== undefined ) {
+      this.sequelize.log("Not overriding built-in method from model attribute: " + key);
+      return;
+    }
+    Object.defineProperty(this.Instance.prototype, key, attributeManipulation[key]);
+  }).bind(this));
+
 
   this.Instance.prototype.rawAttributes = this.rawAttributes;
   this.Instance.prototype.attributes = Object.keys(this.Instance.prototype.rawAttributes);


### PR DESCRIPTION
If you define an attribute on a model with the same name as a built-in
instance method the attribute's automatically created get/set methods
will overwriting the built-in causing much hilarity.