### PR TITLE
	Fixes a bug with user defined attribute names overwriting builtins

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -196,6 +196,7 @@ Instance.prototype.get = function(key, options) { // testhint options:none
         return this.dataValues[key];
       }
     }
+
     return this.dataValues[key];
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -75,9 +75,6 @@ var Model = function(name, attributes, options) {
   });
 
   this.attributes = this.rawAttributes = Utils._.mapValues(attributes, function(attribute, name) {
-    if (!Utils._.isPlainObject(attribute)) {
-      attribute = { type: attribute };
-    }
 
     attribute = this.sequelize.normalizeAttribute(attribute);
 
@@ -923,7 +920,14 @@ Model.prototype.refreshAttributes = function() {
   this.Instance.prototype._hasCustomGetters = Object.keys(this.Instance.prototype._customGetters).length;
   this.Instance.prototype._hasCustomSetters = Object.keys(this.Instance.prototype._customSetters).length;
 
-  Object.defineProperties(this.Instance.prototype, attributeManipulation);
+  Object.keys(attributeManipulation).forEach((function(key){
+    if( this.Instance.prototype[key] !== undefined ) {
+      this.sequelize.log("Not overriding built-in method from model attribute: " + key);
+      return;
+    }
+    Object.defineProperty(this.Instance.prototype, key, attributeManipulation[key]);
+  }).bind(this));
+
 
   this.Instance.prototype.rawAttributes = this.rawAttributes;
   this.Instance.prototype.attributes = Object.keys(this.Instance.prototype.rawAttributes);

--- a/test/regressions/overwriting-builtins.test.js
+++ b/test/regressions/overwriting-builtins.test.js
@@ -1,0 +1,34 @@
+'use strict';
+
+/* jshint -W030 */
+/* jshint -W110 */
+var chai = require('chai')
+  , Sequelize = require('../../index')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , DataTypes = require(__dirname + '/../../lib/data-types')
+  , dialect = Support.getTestDialect()
+  , sinon = require('sinon')
+  , _ = require('lodash')
+  , moment = require('moment')
+  , Promise = require('bluebird')
+  , current = Support.sequelize;
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+
+  describe('not breaking built-ins', function() {
+    it('test set breakage', function() {
+      var User = this.sequelize.define('FrozenUser', {set:DataTypes.STRING}, { freezeTableName: true, timestamps: false, underscored: true });
+
+			return this.sequelize.sync({force:true}).then(function(){
+				var testuser = User.build({set:'value'});
+				expect(testuser.getDataValue('set')).to.equal('value');
+				testuser.save().then(function(){
+					testuser.reload().then(function(){
+						expect(testuser.getDataValue('set')).to.equal('value');
+					});
+				});
+			});
+    });
+	});
+});


### PR DESCRIPTION
If you define an attribute on a model with the same name as a built-in
instance method the attribute's automatically created get/set methods
will overwriting the built-in causing much hilarity.