### PR TITLE
add a beforeCount hook

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -59,6 +59,7 @@ var hookTypes = {
   beforeFindAfterExpandIncludeAll: {params: 1},
   beforeFindAfterOptions: {params: 1},
   afterFind: {params: 2},
+  beforeCount: {params: 1},
   beforeDefine: {params: 2, sync: true},
   afterDefine: {params: 1, sync: true},
   beforeInit: {params: 2, sync: true},
@@ -373,6 +374,13 @@ Hooks.hasHooks = Hooks.hasHook;
  * @param {String}   name
  * @param {Function} fn   A callback function that is called with instance(s), options
  * @name afterFind
+ */
+
+/**
+ * A hook that is run before a count query
+ * @param {String}   name
+ * @param {Function} fn   A callback function that is called with options
+ * @name beforeCount
  */
 
 /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -1569,28 +1569,37 @@ Model.prototype.aggregate = function(attribute, aggregateFunction, options) {
  */
 Model.prototype.count = function(options) {
   options = Utils._.clone(options || {});
-  conformOptions(options, this);
-  this.$injectScope(options);
+
+  _.defaults(options, { hooks: true });
 
   var col = '*';
 
-  if (options.include) {
-    col = this.name + '.' + this.primaryKeyField;
-    expandIncludeAll.call(this, options);
-    validateIncludedElements.call(this, options);
-  }
+  return Promise.bind(this).then(function() {
+    conformOptions(options, this);
+    this.$injectScope(options);
 
-  Utils.mapOptionFieldNames(options, this);
+    if (options.hooks) {
+      return this.runHooks('beforeCount', options);
+    }
+  }).then(function() {
+    if (options.include) {
+      col = this.name + '.' + this.primaryKeyField;
+      expandIncludeAll.call(this, options);
+      validateIncludedElements.call(this, options);
+    }
 
-  options.plain = options.group ? false : true;
-  options.dataType = new DataTypes.INTEGER();
-  options.includeIgnoreAttributes = false;
-  options.limit = null;
-  options.offset = null;
-  options.order = null;
-  options.attributes = [];
+    Utils.mapOptionFieldNames(options, this);
 
-  return this.aggregate(col, 'count', options);
+    options.plain = options.group ? false : true;
+    options.dataType = new DataTypes.INTEGER();
+    options.includeIgnoreAttributes = false;
+    options.limit = null;
+    options.offset = null;
+    options.order = null;
+    options.attributes = [];
+
+    return this.aggregate(col, 'count', options);
+  });
 };
 
 /**

--- a/test/integration/hooks.test.js
+++ b/test/integration/hooks.test.js
@@ -990,52 +990,6 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     describe('on success', function() {
       it('hook runs', function() {
         var beforeHook = false;
-        this.User.beforeCount(function() {
-          beforeHook = true;
-        });
-
-        return this.User.count().then(function(count) {
-          expect(count).to.equal(3);
-          expect(beforeHook).to.be.true;
-        });
-      });
-
-      it('beforeCount hook can change options', function() {
-        this.User.beforeCount(function(options) {
-          options.where.username = 'adam';
-        });
-
-        return this.User.count({where: {username: 'joe'}}).then(function(count) {
-          expect(count).to.equal(1);
-        });
-      });
-    });
-
-    describe('on error', function() {
-      it('in beforeCount hook returns error', function() {
-        this.User.beforeCount(function() {
-          throw new Error('Oops!');
-        });
-
-        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
-          expect(err.message).to.equal('Oops!');
-        });
-      });
-    });
-  });
-
-  describe('#count', function() {
-    beforeEach(function() {
-      return this.User.bulkCreate([
-        {username: 'adam', mood: 'happy'},
-        {username: 'joe', mood: 'sad'},
-        {username: 'joe', mood: 'happy'}
-      ]);
-    });
-
-    describe('on success', function() {
-      it('hook runs', function() {
-        var beforeHook = false;
 
         this.User.beforeCount(function() {
           beforeHook = true;
@@ -1052,9 +1006,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           options.where.username = 'adam';
         });
 
-        return this.User.count({where: {username: 'joe'}}).then(function(count) {
-          expect(count).to.equal(1);
-        });
+        return expect(this.User.count({where: {username: 'joe'}})).to.eventually.equal(1);
       });
     });
 
@@ -1064,9 +1016,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
-          expect(err.message).to.equal('Oops!');
-        });
+        return expect(this.User.count({where: {username: 'adam'}})).to.be.rejectedWith('Oops!');
       });
     });
   });

--- a/test/integration/hooks.test.js
+++ b/test/integration/hooks.test.js
@@ -978,6 +978,99 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     });
   });
 
+  describe('#count', function() {
+    beforeEach(function() {
+      return this.User.bulkCreate([
+        {username: 'adam', mood: 'happy'},
+        {username: 'joe', mood: 'sad'},
+        {username: 'joe', mood: 'happy'}
+      ]);
+    });
+
+    describe('on success', function() {
+      it('hook runs', function() {
+        var beforeHook = false;
+        this.User.beforeCount(function() {
+          beforeHook = true;
+        });
+
+        return this.User.count().then(function(count) {
+          expect(count).to.equal(3);
+          expect(beforeHook).to.be.true;
+        });
+      });
+
+      it('beforeCount hook can change options', function() {
+        this.User.beforeCount(function(options) {
+          options.where.username = 'adam';
+        });
+
+        return this.User.count({where: {username: 'joe'}}).then(function(count) {
+          expect(count).to.equal(1);
+        });
+      });
+    });
+
+    describe('on error', function() {
+      it('in beforeCount hook returns error', function() {
+        this.User.beforeCount(function() {
+          throw new Error('Oops!');
+        });
+
+        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
+          expect(err.message).to.equal('Oops!');
+        });
+      });
+    });
+  });
+
+  describe('#count', function() {
+    beforeEach(function() {
+      return this.User.bulkCreate([
+        {username: 'adam', mood: 'happy'},
+        {username: 'joe', mood: 'sad'},
+        {username: 'joe', mood: 'happy'}
+      ]);
+    });
+
+    describe('on success', function() {
+      it('hook runs', function() {
+        var beforeHook = false;
+
+        this.User.beforeCount(function() {
+          beforeHook = true;
+        });
+
+        return this.User.count().then(function(count) {
+          expect(count).to.equal(3);
+          expect(beforeHook).to.be.true;
+        });
+      });
+
+      it('beforeCount hook can change options', function() {
+        this.User.beforeCount(function(options) {
+          options.where.username = 'adam';
+        });
+
+        return this.User.count({where: {username: 'joe'}}).then(function(count) {
+          expect(count).to.equal(1);
+        });
+      });
+    });
+
+    describe('on error', function() {
+      it('in beforeCount hook returns error', function() {
+        this.User.beforeCount(function() {
+          throw new Error('Oops!');
+        });
+
+        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
+          expect(err.message).to.equal('Oops!');
+        });
+      });
+    });
+  });
+
   describe('#define', function() {
     before(function() {
       this.sequelize.addHook('beforeDefine', function(attributes, options) {


### PR DESCRIPTION
This provides a solution to #4683. This provides a beforeCount hook to the count query, allowing for the user to change the options of count before the database is queried.

I attempted to add an afterCount hook but, because the count is not attached to the model itself, changing it after the database return would require more substantial (probably breaking) changes. Additionally, can't think of a good use case for changing the count after we have queried the database.

Long time user, first time contributor. Hoping to give back more to this great community!