### PR TITLE
Fixes a bug with user defined attribute names overwriting builtins.

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -196,7 +196,9 @@ Instance.prototype.get = function(key, options) { // testhint options:none
         return this.dataValues[key];
       }
     }
-    return this.dataValues[key];
+		if (this.dataValues) {
+			return this.dataValues[key];
+		}
   }
 
   if (this._hasCustomGetters || (options && options.plain && this.$options.include) || (options && options.clone)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -74,10 +74,11 @@ var Model = function(name, attributes, options) {
     }
   });
 
-  this.attributes = this.rawAttributes = Utils._.mapValues(attributes, function(attribute, name) {
-    if (!Utils._.isPlainObject(attribute)) {
-      attribute = { type: attribute };
-    }
+ this.attributes = this.rawAttributes = Utils._.mapValues(attributes, function(attribute, name) {
+   if (!Utils._.isPlainObject(attribute)) {
+     attribute = { type: attribute };
+   }
+
 
     attribute = this.sequelize.normalizeAttribute(attribute);
 
@@ -923,7 +924,14 @@ Model.prototype.refreshAttributes = function() {
   this.Instance.prototype._hasCustomGetters = Object.keys(this.Instance.prototype._customGetters).length;
   this.Instance.prototype._hasCustomSetters = Object.keys(this.Instance.prototype._customSetters).length;
 
-  Object.defineProperties(this.Instance.prototype, attributeManipulation);
+  Object.keys(attributeManipulation).forEach((function(key){
+    if (this.Instance.prototype[key] !== undefined) {
+      this.sequelize.log("Not overriding built-in method from model attribute: " + key);
+      return;
+    }
+    Object.defineProperty(this.Instance.prototype, key, attributeManipulation[key]);
+  }).bind(this));
+
 
   this.Instance.prototype.rawAttributes = this.rawAttributes;
   this.Instance.prototype.attributes = Object.keys(this.Instance.prototype.rawAttributes);

--- a/test/unit/model/overwriting-builtins.test.js
+++ b/test/unit/model/overwriting-builtins.test.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/* jshint -W030 */
+/* jshint -W110 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../../support')
+  , DataTypes = require(__dirname + '/../../../lib/data-types');
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+
+  describe('not breaking built-ins', function() {
+    it('it should not break instance.set by defining a model set attribute', function() {
+      var User = this.sequelize.define('OverWrittenKeys', {
+        set:DataTypes.STRING
+      });
+
+      var user = User.build({set: 'A'});
+      expect(user.get('set')).to.equal('A');
+      user.set('set', 'B');
+      expect(user.get('set')).to.equal('B');
+    });
+  });
+});


### PR DESCRIPTION
If you define an attribute on a model with the same name as a built-in
instance method the attribute's automatically created get/set methods
will overwriting the built-in causing much hilarity.