### PR TITLE
Fix 5092

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-# FUTURE
+# Future
 - [ADDED] Support silent: true in bulk update [#5200](https://github.com/sequelize/sequelize/issues/5200)
+- [FIXED] Postgres destroy with `where` fails on JSONB data [#5092](https://github.com/sequelize/sequelize/issues/5092)
 
 # 3.17.3
 - [FIXED] Regression with array values from security fix in 3.17.2

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -375,7 +375,7 @@ var QueryGenerator = {
 
     var replacements = {
       table: this.quoteIdentifiers(tableName),
-      where: this.getWhereConditions(where),
+      where: this.getWhereConditions(where, null, model, options),
       limit: !!options.limit ? ' LIMIT ' + this.escape(options.limit) : '',
       primaryKeys: primaryKeys[tableName].length > 1 ? '(' + pks + ')' : pks,
       primaryKeysSelection: pks

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -312,6 +312,14 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
 
       it('should be possible to destroy with where', function () {
+        var conditionSearch = {
+          where: {
+            data: {
+              employment : 'Hacker'
+            }
+          }
+        };
+
         return Promise.join(
           this.Event.create({
             data: {
@@ -330,16 +338,23 @@ describe(Support.getTestDialectTeaser('Model'), function() {
               },
               employment: 'Hacker'
             }
+          }),
+          this.Event.create({
+            data: {
+              name: {
+                first: ' Tyrell',
+                last: 'Wellick'
+              },
+              employment: 'CTO'
+            }
           })
         ).bind(this).then(function () {
-          return this.Event.destroy({
-            where: {
-              data: {
-                employment : 'Hacker'
-              }
-            }
+            return expect(this.Event.findAll(conditionSearch)).to.eventually.have.length(2);
+          }).then(function() {
+            return this.Event.destroy(conditionSearch);
+          }).then(function(){
+            return expect(this.Event.findAll(conditionSearch)).to.eventually.have.length(0);
           });
-        });
       });
 
     });

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -310,6 +310,38 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           });
         });
       });
+
+      it('should be possible to destroy with where', function () {
+        return Promise.join(
+          this.Event.create({
+            data: {
+              name: {
+                first: 'Elliot',
+                last: 'Alderson'
+              },
+              employment: 'Hacker'
+            }
+          }),
+          this.Event.create({
+            data: {
+              name: {
+                first: 'Christian',
+                last: 'Slater'
+              },
+              employment: 'Hacker'
+            }
+          })
+        ).bind(this).then(function () {
+          return this.Event.destroy({
+            where: {
+              data: {
+                employment : 'Hacker'
+              }
+            }
+          });
+        });
+      });
+
     });
   }
 });


### PR DESCRIPTION
Fix #5092 , where `destroy` fails on `JSONB` data with where condition. 