### PR TITLE
Add `IF EXISTS` to Postgres drop schema query

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -23,7 +23,7 @@ var QueryGenerator = {
   },
 
   dropSchema: function(schema) {
-    var query = 'DROP SCHEMA <%= schema%> CASCADE;';
+    var query = 'DROP SCHEMA IF EXISTS <%= schema%> CASCADE;';
     return Utils._.template(query)({schema: schema});
   },
 

--- a/test/unit/sql/create-schema.test.js
+++ b/test/unit/sql/create-schema.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+var Support   = require(__dirname + '/../support')
+  , expectsql = Support.expectsql
+  , current   = Support.sequelize
+  , sql       = current.dialect.QueryGenerator;
+
+describe(Support.getTestDialectTeaser('SQL'), function() {
+  if (current.dialect.name === 'postgres') {
+    describe('dropSchema', function () {
+      test('IF EXISTS', function () {
+        expectsql(sql.dropSchema('foo'), {
+          postgres: 'DROP SCHEMA IF EXISTS foo CASCADE;'
+        });
+      });
+    });
+  }
+});


### PR DESCRIPTION
This PR adds `IF EXISTS` to the "drop schema" query, similar to the "create table" query found [here](https://github.com/seegno-forks/sequelize/blob/342251100f9040cd21cff4d36a0c3edeabd21a8f/lib/dialects/postgres/query-generator.js#L97).