### PR TITLE
Code fixes for jshint@2.9.1

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -109,17 +109,6 @@ var groupJoinData = function(rows, includeOptions, options) {
         includeMap[previousPiece] = $current;
       }
     }
-    // Calcuate the last item in the array prefix ('Results' for 'User.Results.id')
-    , lastKeyPrefixMemo = {}
-    , lastKeyPrefix = function (key) {
-      if (!lastKeyPrefixMemo[key]) {
-        var prefix = keyPrefix(key)
-          , length = prefix.length;
-
-        lastKeyPrefixMemo[key] = !length ? '' : prefix[length - 1];
-      }
-      return lastKeyPrefixMemo[key];
-    }
     // Calculate the string prefix of a key ('User.Results' for 'User.Results.id')
     , keyPrefixStringMemo = {}
     , keyPrefixString = function (key, memo) {
@@ -149,6 +138,17 @@ var groupJoinData = function(rows, includeOptions, options) {
         keyPrefixMemo[key] = keyPrefixMemo[prefixString];
       }
       return keyPrefixMemo[key];
+    }
+    // Calcuate the last item in the array prefix ('Results' for 'User.Results.id')
+    , lastKeyPrefixMemo = {}
+    , lastKeyPrefix = function (key) {
+      if (!lastKeyPrefixMemo[key]) {
+        var prefix = keyPrefix(key)
+          , length = prefix.length;
+
+        lastKeyPrefixMemo[key] = !length ? '' : prefix[length - 1];
+      }
+      return lastKeyPrefixMemo[key];
     }
     , getUniqueKeyAttributes = function (model) {
         var uniqueKeyAttributes = Utils._.chain(model.uniqueKeys);

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -213,9 +213,11 @@ QueryInterface.prototype.dropTable = function(tableName, options) {
 };
 
 QueryInterface.prototype.dropAllTables = function(options) {
-  var self = this;
+  var self = this
+    , skip;
 
   options = options || {};
+  skip = options.skip || [];
 
   var dropAllTables = function(tableNames) {
     return Promise.each(tableNames, function(tableName) {
@@ -226,7 +228,6 @@ QueryInterface.prototype.dropAllTables = function(options) {
     });
   };
 
-  var skip = options.skip || [];
   return self.showAllTables(options).then(function(tableNames) {
     if (self.sequelize.options.dialect === 'sqlite') {
       return self.sequelize.query('PRAGMA foreign_keys;', options).then(function(result) {

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -90,14 +90,14 @@ describe(Support.getTestDialectTeaser('Transaction'), function() {
                 field: 'value'
               }
             })
+          , self = this
           , transTest = function (val) {
               return self.sequelize.transaction({isolationLevel: 'SERIALIZABLE'}, function(t) {
                 return SumSumSum.sum('value', {transaction: t}).then(function (balance) {
                   return SumSumSum.create({value: -val}, {transaction: t});
                 });
               });
-            }
-          , self = this;
+            };
         // Attention: this test is a bit racy. If you find a nicer way to test this: go ahead
         return SumSumSum.sync({force: true}).then(function () {
           return (expect(Promise.join(transTest(80), transTest(80), transTest(80))).to.eventually.be.rejectedWith('could not serialize access due to read/write dependencies among transactions'));
@@ -239,7 +239,7 @@ describe(Support.getTestDialectTeaser('Transaction'), function() {
       });
     });
   }
-  
+
   if (current.dialect.supports.transactionOptions.type) {
     describe('transaction types', function() {
       it('should support default transaction type DEFERRED', function() {
@@ -250,7 +250,7 @@ describe(Support.getTestDialectTeaser('Transaction'), function() {
           });
         });
       });
-      
+
       Object.keys(Transaction.TYPES).forEach(function(key) {
         it('should allow specification of ' + key + ' type', function() {
           return this.sequelize.transaction({
@@ -262,7 +262,7 @@ describe(Support.getTestDialectTeaser('Transaction'), function() {
           });
         });
       });
-      
+
     });
   }
 


### PR DESCRIPTION
Minor code fixes to prevent ```[variable] was used before it was defined``` error introduced by jshint@2.9.1.
If any modification is needed, just let me know.