### PR TITLE
Fix Model.destroy() returning undefined (MSSQL)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Fix Model.destroy() returning undefined in MSSQL #5239
+
 # 3.17.3
 - [FIXED] Regression with array values from security fix in 3.17.2
 

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -166,7 +166,7 @@ Query.prototype.formatResults = function(data) {
   } else if (this.isBulkUpdateQuery()) {
     result = data.length;
   } else if (this.isBulkDeleteQuery()){
-    result = data[0] && data[0].AFFECTEDROWS;
+    result = data[0] && data[0].hasOwnProperty('AFFECTEDROWS') ? data[0].AFFECTEDROWS : data.length;
   } else if (this.isVersionQuery()) {
     result = data[0].version;
   } else if (this.isForeignKeysQuery()) {


### PR DESCRIPTION
When calling `Model.destroy()` on a model with `paranoid = true` (/ a deletedAt timestamp) with MSSQL as database the response will be `undefined` instead of the number of destroyed rows as expected (http://docs.sequelizejs.com/en/latest/api/model/#destroyoptions-promiseinteger).

While all destroy queries are considered BulkDelete queries internally, they are actually DELETE queries for non-paranoid models and UPDATE for paranoid models. This fix changes the BulkDelete query behaviour to first check for the expected result of a DELETE query and if that doesn't exist, return the result as if it were an UPDATE query. (Note: would it be better to actually check the exact query type rather than just assume it was an UPDATE query if the results aren't as expected for a DELETE query?)