### PR TITLE
Fix #5222: prevent race condition after transaction finished

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Future
+- [FIXED] Prevent race condition after transaction finished [#5222](https://github.com/sequelize/sequelize/issues/5222)
+
+# Future
 - [FIXED] Fixed Instance.reload issues ([#4844](https://github.com/sequelize/sequelize/issues/4844) and [#4452](https://github.com/sequelize/sequelize/issues/4452))
 
 # 3.18.0

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -902,8 +902,11 @@ QueryInterface.prototype.commitTransaction = function(transaction, options) {
   });
 
   var sql = this.QueryGenerator.commitTransactionQuery(transaction);
+  var promise = this.sequelize.query(sql, options);
 
-  return this.sequelize.query(sql, options);
+  transaction.finished = 'commit';
+
+  return promise;
 };
 
 QueryInterface.prototype.rollbackTransaction = function(transaction, options) {
@@ -917,8 +920,11 @@ QueryInterface.prototype.rollbackTransaction = function(transaction, options) {
   });
 
   var sql = this.QueryGenerator.rollbackTransactionQuery(transaction);
+  var promise = this.sequelize.query(sql, options);
 
-  return this.sequelize.query(sql, options);
+  transaction.finished = 'rollback';
+
+  return promise;
 };
 
 module.exports = QueryInterface;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -211,11 +211,10 @@ Transaction.prototype.rollback = function() {
     .getQueryInterface()
     .rollbackTransaction(this, this.options)
     .finally(function() {
-      self.finished = 'rollback';
       if (!self.parent) {
         return self.cleanup();
       }
-      return null;
+      return self;
     });
 };
 


### PR DESCRIPTION
Fixes issue #5222. 
Moves ```transaction.finished = 'rollback'``` assignment to ```QueryInterface.rollbackTransaction()``` after rollback query call.