### PR TITLE
Updated the fix for user defined attributes overwriting builtins.

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -196,9 +196,7 @@ Instance.prototype.get = function(key, options) { // testhint options:none
         return this.dataValues[key];
       }
     }
-		if (this.dataValues) {
-			return this.dataValues[key];
-		}
+		return this.dataValues[key];
   }
 
   if (this._hasCustomGetters || (options && options.plain && this.$options.include) || (options && options.clone)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -925,7 +925,7 @@ Model.prototype.refreshAttributes = function() {
   this.Instance.prototype._hasCustomSetters = Object.keys(this.Instance.prototype._customSetters).length;
 
   Object.keys(attributeManipulation).forEach((function(key){
-    if (this.Instance.prototype[key] !== undefined) {
+    if (Instance.prototype.hasOwnProperty(key)) {
       this.sequelize.log("Not overriding built-in method from model attribute: " + key);
       return;
     }


### PR DESCRIPTION
More appropriate fix for the merge: https://github.com/sequelize/sequelize/pull/5219
Now uses hasOwnProperty to more accurately check if the user attribute
matches a builtin.