### PR TITLE
errDetail may be undefined in Postgres formatError

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -303,9 +303,7 @@ Query.prototype.formatError = function (err) {
     case '23505':
       // there are multiple different formats of error messages for this error code
       // this regex should check at least two
-      match = errDetail.replace(/"/g, '').match(/Key \((.*?)\)=\((.*?)\)/);
-
-      if (match) {
+      if (errDetail && (match = errDetail.replace(/"/g, '').match(/Key \((.*?)\)=\((.*?)\)/))) {
         fields = _.zipObject(match[1].split(', '), match[2].split(', '));
         errors = [];
         message = 'Validation error';


### PR DESCRIPTION
This trivial fix tests whether errDetail is defined before applying the regex. With my configuration, PostgreSQL 8.4 and latest node-postgres, errDetail is undefined.