### PR TITLE
feat(sql): ability to add comments on a SELECT query

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1042,7 +1042,10 @@ var QueryGenerator = {
       , subQueryItems = []
       , subQueryAttributes = null
       , subJoinQueries = []
-      , mainTableAs = null;
+      , mainTableAs = null
+      , queryComment = options.queryComment || this.options.queryComment;
+
+    queryComment = queryComment ? '/* ' + queryComment + ' */ ' : '';
 
     if (options.tableAs) {
       mainTableAs = this.quoteTable(options.tableAs);
@@ -1431,7 +1434,7 @@ var QueryGenerator = {
           mainTableAs = table;
         }
 
-        mainQueryItems.push('SELECT '+mainAttributes.join(', ')+' FROM ('+
+        mainQueryItems.push('SELECT '+ queryComment + mainAttributes.join(', ')+' FROM ('+
           options.groupedLimit.values.map(function (value) {
             var where = _.assign({}, options.where);
             where[options.groupedLimit.on] = value;
@@ -1451,7 +1454,7 @@ var QueryGenerator = {
           )
         +')');
       } else {
-        mainQueryItems.push('SELECT ' + mainAttributes.join(', ') + ' FROM ' + table);
+        mainQueryItems.push('SELECT ' + queryComment + mainAttributes.join(', ') + ' FROM ' + table);
       }
       if (mainTableAs) {
         mainQueryItems.push(' AS ' + mainTableAs);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1313,6 +1313,7 @@ Model.prototype.all = function(options) {
  * @param  {String|Object}             [options.lock] Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](transaction#lock)
  * @param  {Boolean}                   [options.raw] Return raw result. See sequelize.query for more information.
  * @param  {Function}                  [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param  {String}                    [options.queryComment] A string comment that will be added after each SELECT statement.
  * @param  {Object}                    [options.having]
  * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  * @param  {Boolean}                   [options.benchmark=false] Print query execution time in milliseconds when logging SQL.

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -70,6 +70,7 @@ var url = require('url')
  * @param {Object}   [options.sync={}] Default options for sequelize.sync
  * @param {String}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.
  * @param {Function} [options.logging=console.log] A function that gets executed every time Sequelize would log something.
+ * @param {String}   [options.queryComment] A string comment that will be added after each SELECT statement.
  * @param {Boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
  * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
  * @param {Boolean}  [options.replication=false] Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database`

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -935,5 +935,18 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         expect(spy.called).to.be.ok;
       });
     });
+
+    it('should support query comments', function () {
+      var spy = sinon.spy();
+
+      return this.User.findOne({
+        where: {},
+        logging: spy,
+        queryComment: 'interesting statement here'
+      }).then(function () {
+        expect(spy.called).to.be.ok;
+        expect(spy.args[0][0]).to.match(/interesting statement here/);
+      });
+    });
   });
 });

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1389,4 +1389,18 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       expect(spy.called).to.be.ok;
     });
   });
+
+
+  it('should support query commenting', function () {
+    var spy = sinon.spy();
+
+    return this.User.findAll({
+      where: {},
+      logging: spy,
+      queryComment: 'interesting statement here'
+    }).then(function () {
+      expect(spy.called).to.be.ok;
+      expect(spy.args[0][0]).to.match(/interesting statement here/);
+    });
+  });
 });


### PR DESCRIPTION
Possible solution for #4968.
- Added option for `queryComment` on the model for `find` and `findAll`.
- Added option for `queryComment` on the Sequelize options. (I'm using this with express middleware to tag the endpoint to a query).
