### PR TITLE
Fix Instance.reload issues

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Fixed Instance.reload issues ([#4844](https://github.com/sequelize/sequelize/issues/4844) and [#4452](https://github.com/sequelize/sequelize/issues/4452))
+
 # 3.18.0
 - [ADDED] Support silent: true in bulk update [#5200](https://github.com/sequelize/sequelize/issues/5200)
 - [ADDED] `retry` object now part of global settings and can be overridden per call.  The default is 5 retries with a backoff function.  `retry` object can be passed to options with max: 0 to turn off this behavior.

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -287,3 +287,15 @@ error.ConnectionTimedOutError = function (parent) {
   this.name = 'SequelizeConnectionTimedOutError';
 };
 util.inherits(error.ConnectionTimedOutError, error.ConnectionError);
+
+/**
+ * Thrown when a some problem occurred with Instance methods (see message for details)
+ * @extends BaseError
+ * @constructor
+ */
+error.InstanceError = function (message) {
+  error.BaseError.apply(this, arguments);
+  this.name = 'SequelizeInstanceError';
+  this.message = message;
+};
+util.inherits(error.InstanceError, error.BaseError);

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -5,6 +5,7 @@ var Utils = require('./utils')
   , BelongsToMany = require('./associations/belongs-to-many')
   , InstanceValidator = require('./instance-validator')
   , QueryTypes = require('./query-types')
+  , sequelizeErrors = require('./errors')
   , Dottie = require('dottie')
   , Promise = require('./promise')
   , _ = require('lodash')
@@ -742,7 +743,18 @@ Instance.prototype.reload = function(options) {
     include: this.$options.include || null
   });
 
-  return this.Model.findOne(options).bind(this).then(function(reload) {
+  return this.Model.findOne(options).bind(this)
+  .tap(function (reload) {
+    if (!reload) {
+      throw new sequelizeErrors.InstanceError(
+        'Instance could not be reloaded because it does not exist anymore (find call returned null)'
+      );
+    }
+  })
+  .then(function(reload) {
+    // update the internal options of the instance
+    this.$options = reload.$options;
+    // re-set instance values
     this.set(reload.dataValues, {
       raw: true,
       reset: true && !options.attributes

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -436,6 +436,14 @@ Sequelize.prototype.InvalidConnectionError = Sequelize.InvalidConnectionError =
 Sequelize.prototype.ConnectionTimedOutError = Sequelize.ConnectionTimedOutError =
   sequelizeErrors.ConnectionTimedOutError;
 
+/**
+ * Thrown when a some problem occurred with Instance methods (see message for details)
+ * @see {Errors#InstanceError}
+ */
+Sequelize.prototype.InstanceError = Sequelize.InstanceError =
+  sequelizeErrors.InstanceError;
+
+
 Sequelize.prototype.refreshTypes = function () {
   this.connectionManager.refreshTypeParser(DataTypes);
 };


### PR DESCRIPTION
Refs to https://github.com/sequelize/sequelize/issues/4844 and https://github.com/sequelize/sequelize/issues/4452

1. properly updates Instance options after reload, that allows access to included association via ```.get({ plain: true}).settings``` or dot notation ```user.settings```
2. throws a error when reloaded instance is not exist in DB