### PR TITLE
Fix setting postgres timezone while fetching hstore oids.

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -132,7 +132,7 @@ ConnectionManager.prototype.connect = function(config) {
     if (!self.sequelize.config.keepDefaultTimezone) {
       var isZone = !!moment.tz.zone(self.sequelize.options.timezone);
       if (isZone) {
-        query += 'SET client_min_messages TO warning; SET TIME ZONE \'' + self.sequelize.options.timezone + '\'';
+        query += 'SET client_min_messages TO warning; SET TIME ZONE \'' + self.sequelize.options.timezone + '\';';
       } else {
         query += 'SET client_min_messages TO warning; SET TIME ZONE INTERVAL \'' + self.sequelize.options.timezone + '\' HOUR TO MINUTE;';
       }

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -10,8 +10,8 @@ var chai = require('chai')
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES] Sequelize', function() {
-    it('should correctly parse the moment based timezone', function() {
-      var options = _.extend(this.sequelize.options, { timezone: 'Asia/Kolkata', timestamps: true });
+    function checkTimezoneParsing(baseOptions) {
+      var options = _.extend({}, baseOptions, { timezone: 'Asia/Kolkata', timestamps: true });
       var sequelize = Support.createSequelizeInstance(options);
 
       var tzTable = sequelize.define('tz_table', { foo: DataTypes.STRING });
@@ -20,6 +20,17 @@ if (dialect.match(/^postgres/)) {
           expect(row).to.be.not.null;
         });
       });
+    }
+
+    it('should correctly parse the moment based timezone', function() {
+      return checkTimezoneParsing(this.sequelize.options);
+    });
+
+    it('should correctly parse the moment based timezone while fetching hstore oids', function() {
+      // reset oids so we need to refetch them
+      DataTypes.HSTORE.types.postgres.oids = [];
+      DataTypes.HSTORE.types.postgres.array_oids = [];
+      return checkTimezoneParsing(this.sequelize.options);
     });
   });
 }


### PR DESCRIPTION
Missing semicolon causes a query in the postgres connection manager to fail. Only crops up when fetching hstore oids, since another statement is added without a semicolon in-between.