### PR TITLE
fix usign hstore without model instance

### DIFF
--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -281,11 +281,19 @@ module.exports = function (BaseTypes) {
   });
 
   HSTORE.parse = function (value) {
+    if (!hstore) {
+      // All datatype files are loaded at import - make sure we don't load the hstore parser before a hstore is instantiated
+      hstore = require('./hstore');
+    }
     return hstore.parse(value);
   };
 
   HSTORE.prototype.escape = false;
   HSTORE.prototype.$stringify = function (value) {
+    if (!hstore) {
+      // All datatype files are loaded at import - make sure we don't load the hstore parser before a hstore is instantiated
+      hstore = require('./hstore');
+    }
     return "'" + hstore.stringify(value) + "'";
   };
 


### PR DESCRIPTION
I tried to think of a test that is this bug, but could not find an acceptable place in the current suite.

It happens when you just have to connect and make a query to a table with hstore