### PR TITLE
Rewriting of the benchmarking feature

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] Benchmarking feature [#2494](https://github.com/sequelize/sequelize/issues/2494)
 - [ADDED] `beforeCount` hook [#5209](https://github.com/sequelize/sequelize/pull/5209)
 - [ADDED] `validationFailed` hook [#1626](https://github.com/sequelize/sequelize/issues/1626)
 - [FIXED] Mark index as `unique: true` when `type: 'UNIQUE'`. Fixes [#5351](https://github.com/sequelize/sequelize/issues/5351)

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -484,11 +484,6 @@ AbstractQuery.prototype.checkLoggingOption = function() {
     console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
     this.options.logging = console.log;
   }
-
-  if (this.options.logging === console.log) {
-    // using just console.log will break in node < 0.6
-    this.options.logging = function(s) { console.log(s); };
-  }
 };
 
 /**

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -34,10 +34,10 @@ Query.prototype.run = function(sql, parameters) {
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
 
-  if (!benchmark) {
-    this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
-  } else {
+  if (benchmark) {
     var queryBegin = Date.now();
+  } else {
+    this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
   }
 
   var promise = new Utils.Promise(function(resolve, reject) {
@@ -73,7 +73,7 @@ Query.prototype.run = function(sql, parameters) {
         var request = new self.connection.lib.Request(self.sql, function(err) {
 
           if (benchmark) {
-            self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql + ' in ' + (Date.now() - queryBegin) + 'ms', self.options);
+            self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
           }
 
           if (err) {

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -30,17 +30,17 @@ Query.prototype.run = function(sql, parameters) {
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
 
-  if (!benchmark) {
-    this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
-  } else {
+  if (benchmark) {
     var queryBegin = Date.now();
+  } else {
+    this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
   }
 
   var promise = new Utils.Promise(function(resolve, reject) {
     self.connection.query(self.sql, function(err, results) {
 
       if (benchmark) {
-        self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql + ' in ' + (Date.now() - queryBegin) + 'ms', self.options);
+        self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
       }
 
       if (err) {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -64,11 +64,11 @@ Query.prototype.run = function(sql, parameters) {
 
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
-  
-  if (!benchmark) {
-    this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
-  } else {
+
+  if (benchmark) {
     var queryBegin = Date.now();
+  } else {
+    this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
   }
 
   var promise = new Promise(function(resolve, reject) {
@@ -91,7 +91,7 @@ Query.prototype.run = function(sql, parameters) {
     query.on('end', function(result) {
 
       if (benchmark) {
-        self.sequelize.log('Executed (' + (self.client.uuid || 'default') + '): ' + self.sql + ' in ' + (Date.now() - queryBegin) + 'ms', self.options);
+        self.sequelize.log('Executed (' + (self.client.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
       }
 
       if (receivedError) {

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -86,11 +86,11 @@ Query.prototype.run = function(sql, parameters) {
 
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
-  
-  if (!benchmark) {
-    this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
-  } else {
+
+  if (benchmark) {
     var queryBegin = Date.now();
+  } else {
+    this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
   }
 
   promise = new Promise(function(resolve) {
@@ -104,7 +104,7 @@ Query.prototype.run = function(sql, parameters) {
             var afterExecute = function(err, results) {
 
               if (benchmark) {
-                self.sequelize.log('Executed (' + (self.database.uuid || 'default') + '): ' + self.sql + ' in ' + (Date.now() - queryBegin) + 'ms', self.options);
+                self.sequelize.log('Executed (' + (self.database.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
               }
 
               if (err) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1031,7 +1031,7 @@ Model.prototype.sync = function(options) {
  * @param {Object}   [options]
  * @param {Boolean}  [options.cascade=false]   Also drop all objects depending on this table, such as views. Only works in postgres
  * @param {Function} [options.logging=false]   A function that gets executed while running the query to log the sql.
- * @param {Boolean}  [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
+ * @param {Boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @return {Promise}
  */
 Model.prototype.drop = function(options) {
@@ -1050,7 +1050,7 @@ Model.prototype.dropSchema = function(schema) {
  * @param {Object} [options]
  * @param {String} [options.schemaDelimiter='.'] The character(s) that separates the schema name from the table name
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
- * @param {Boolean}  [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
+ * @param {Boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @return {this}
  */
 Model.prototype.schema = function(schema, options) { // testhint options:none
@@ -1084,7 +1084,7 @@ Model.prototype.schema = function(schema, options) { // testhint options:none
  *
  * @param {Object}   [options] The hash of options from any query. You can use one model to access tables with matching schemas by overriding `getTableName` and using custom key/values to alter the name of the table. (eg. subscribers_1, subscribers_2)
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
- * @param {Boolean}  [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
+ * @param {Boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @return {String|Object}
  */
 Model.prototype.getTableName = function(options) { // testhint options:none
@@ -1330,9 +1330,9 @@ Model.prototype.all = function(options) {
  * @param  {String|Object}             [options.lock] Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](transaction#lock)
  * @param  {Boolean}                   [options.raw] Return raw result. See sequelize.query for more information.
  * @param  {Function}                  [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param  {Boolean}                   [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param  {Object}                    [options.having]
  * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
- * @param  {Boolean}                   [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
  *
  * @see    {Sequelize#query}
  * @return {Promise<Array<Instance>>}
@@ -1529,11 +1529,11 @@ Model.prototype.find = Model.prototype.findOne;
  * @param {Object}          [options] Query options. See sequelize.query for full options
  * @param {Object}          [options.where] A hash of search attributes.
  * @param {Function}        [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Boolean}         [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param {DataType|String} [options.dataType] The type of the result. If `field` is a field in this Model, the default will be the type of that field, otherwise defaults to float.
  * @param {boolean}         [options.distinct] Applies DISTINCT to the field being aggregated over
  * @param {Transaction}     [options.transaction] Transaction to run query under
  * @param {Boolean}         [options.plain] When `true`, the first returned value of `aggregateFunction` is cast to `dataType` and returned. If additional attributes are specified, along with `group` clauses, set `plain` to `false` to return all values of all returned rows.  Defaults to `true`
- * @param {Boolean}         [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
  *
  * @return {Promise<options.dataType|object>}                Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in which case the complete data result is returned.
  */
@@ -1586,8 +1586,8 @@ Model.prototype.aggregate = function(attribute, aggregateFunction, options) {
  * @param {Object}        [options.group] For creating complex counts. Will return multiple rows as needed.
  * @param {Transaction}   [options.transaction] Transaction to run query under
  * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Boolean}       [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param {String}        [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
- * @param {Boolean}       [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
  *
  * @return {Promise<Integer>}
  */
@@ -1831,8 +1831,8 @@ Model.prototype.bulkBuild = function(valueSets, options) { // testhint options:n
  * @param {String}        [options.onDuplicate]
  * @param {Transaction}   [options.transaction] Transaction to run query under
  * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Boolean}       [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param {String}        [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
- * @param {Boolean}       [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
  *
  * @return {Promise<Instance>}
  */
@@ -1857,7 +1857,7 @@ Model.prototype.create = function(values, options) {
  * @param {Object}   [options.defaults] Default values to use if building a new instance
  * @param {Object}   [options.transaction] Transaction to run query under
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
- * @param {Boolean}  [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
+ * @param {Boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  *
  * @return {Promise<Instance,initialized>}
  * @alias findOrBuild
@@ -2033,8 +2033,8 @@ Model.prototype.findCreateFind = function(options) {
  * @param  {Array}        [options.fields=Object.keys(this.attributes)] The fields to insert / update. Defaults to all fields
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
- * @param  {Boolean}      [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
  *
  * @alias insertOrUpdate
  * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated.
@@ -2096,9 +2096,9 @@ Model.prototype.insertOrUpdate = Model.prototype.upsert;
  * @param  {Array}        [options.updateOnDuplicate]      Fields to update if row key already exists (on duplicate key update)? (only supported by mysql & mariadb). By default, all fields are updated.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Function}     [options.logging=false]          A function that gets executed while running the query to log the sql.
+ * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param  {Boolean}      [options.returning=false] Append RETURNING * to get back auto generated values (Postgres only)
  * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
- * @param  {Boolean}      [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
  *
  * @return {Promise<Array<Instance>>}
  */
@@ -2248,8 +2248,8 @@ Model.prototype.bulkCreate = function(records, options) {
  * @param {Boolean|function} [options.cascade = false] Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
  * @param {Transaction}      [options.transaction] Transaction to run query under
  * @param {Boolean|function} [options.logging] A function that logs sql queries, or false for no logging
+ * @param {Boolean}          [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param {String}           [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
- * @param {Boolean}          [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
  *
  * @return {Promise}
  *
@@ -2274,7 +2274,7 @@ Model.prototype.truncate = function(options) {
  * @param  {Boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
- * @param  {Boolean}      [options.benchmark=false]       Print query execution time in milliseconds when logging SQL.
+ * @param  {Boolean}      [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @return {Promise<Integer>} The number of destroyed rows
  */
 Model.prototype.destroy = function(options) {
@@ -2354,7 +2354,7 @@ Model.prototype.destroy = function(options) {
  * @param  {Boolean}      [options.individualHooks=false] If set to true, restore will find all records within the where parameter and will execute before / after bulkRestore hooks on each row
  * @param  {Number}       [options.limit]                 How many rows to undelete
  * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
- * @param  {Boolean}      [options.benchmark=false]       Print query execution time in milliseconds when logging SQL.
+ * @param  {Boolean}      [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  *
  * @return {Promise<undefined>}
@@ -2432,7 +2432,7 @@ Model.prototype.restore = function(options) {
  * @param  {Boolean}      [options.returning=false]       Return the affected rows (only for postgres)
  * @param  {Number}       [options.limit]                 How many rows to update (only for mysql and mariadb)
  * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
- * @param  {Boolean}      [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
+ * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param  {Transaction}  [options.transaction] Transaction to run query under
  * @param  {Boolean}      [options.silent=false] If true, the updatedAt timestamp will not be updated.
  *

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -71,6 +71,7 @@ var url = require('url')
  * @param {Object}   [options.sync={}] Default options for sequelize.sync
  * @param {String}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.
  * @param {Function} [options.logging=console.log] A function that gets executed every time Sequelize would log something.
+ * @param {Boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param {Boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
  * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
  * @param {Boolean}  [options.replication=false] Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database`
@@ -86,7 +87,6 @@ var url = require('url')
  * @param {Array}    [options.retry.match] Only retry a query if the error matches one of these strings.
  * @param {Integer}  [options.retry.max] How many times a failing query is automatically retried.  Set to 0 to disable retrying on SQL_BUSY error.
  * @param {Boolean}  [options.typeValidation=false] Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like.
- * @param {Boolean}  [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
 */
 
 /**
@@ -1297,6 +1297,11 @@ Sequelize.prototype.log = function() {
     if (options.logging === true) {
       console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
       options.logging = console.log;
+    }
+
+    // second argument is sql-timings, when benchmarking option enabled
+    if ((this.options.benchmark || options.benchmark) && options.logging === console.log) {
+      args = [args[0] + ' Elapsed time: ' + args[1] + 'ms'];
     }
 
     options.logging.apply(null, args);

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -223,6 +223,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
   describe('query', function() {
     afterEach(function() {
       this.sequelize.options.quoteIdentifiers = true;
+
+      console.log.restore && console.log.restore();
     });
 
     beforeEach(function() {
@@ -247,6 +249,57 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
     it('executes a query if only the sql is passed', function() {
       return this.sequelize.query(this.insertQuery);
+    });
+
+    it('executes a query with global benchmarking option and default logger', function() {
+      var logger = sinon.spy(console, 'log');
+      var sequelize = Support.createSequelizeInstance({
+        logging: logger,
+        benchmark: true
+      });
+
+      return sequelize.query('select 1;').then(function() {
+        expect(logger.calledOnce).to.be.true;
+        expect(logger.args[0][0]).to.be.match(/Executed \(default\): select 1; Elapsed time: \d+ms/);
+      });
+    });
+
+    it('executes a query with global benchmarking option and custom logger', function() {
+      var logger = sinon.spy();
+      var sequelize = Support.createSequelizeInstance({
+        logging: logger,
+        benchmark: true
+      });
+
+      return sequelize.query('select 1;').then(function() {
+        expect(logger.calledOnce).to.be.true;
+        expect(logger.args[0][0]).to.be.equal('Executed (default): select 1;');
+        expect(typeof logger.args[0][1] === 'number').to.be.true;
+      });
+    });
+
+    it('executes a query with benchmarking option and default logger', function() {
+      var logger = sinon.spy(console, 'log');
+      return this.sequelize.query('select 1;', {
+        logging: logger,
+        benchmark: true
+      }).then(function() {
+        expect(logger.calledOnce).to.be.true;
+        expect(logger.args[0][0]).to.be.match(/Executed \(default\): select 1; Elapsed time: \d+ms/);
+      });
+    });
+
+    it('executes a query with benchmarking option and custom logger', function() {
+      var logger = sinon.spy();
+
+      return this.sequelize.query('select 1;', {
+        logging: logger,
+        benchmark: true
+      }).then(function() {
+        expect(logger.calledOnce).to.be.true;
+        expect(logger.args[0][0]).to.be.equal('Executed (default): select 1;');
+        expect(typeof logger.args[0][1] === 'number').to.be.true;
+      });
     });
 
     it('executes select queries correctly', function() {

--- a/test/integration/sequelize/log.test.js
+++ b/test/integration/sequelize/log.test.js
@@ -39,7 +39,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
         });
 
         it('logs an empty string as info event', function() {
-          this.sequelize.log();
+          this.sequelize.log('');
           expect(this.spy.calledOnce).to.be.true;
         });
       });


### PR DESCRIPTION
Refs to https://github.com/sequelize/sequelize/issues/2494
I rewrote benchmark logic. Query execution timing now passed as second argument to logger function.
If default (console.log) is used, message will shown as:
```log
 SELECT "User"."id" FROM "users" AS "User" WHERE "User"."id" = 123; 1
```
In custom logger function developer can write own logic based on this timing:
```js
function logger (sql, time /*ms*/) {
    if (time > 100) {
        // log to file or do any other action
    }
}
```