### PR TITLE
Fix "the dialect is not supported" error

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -188,31 +188,29 @@ var Sequelize = function(database, username, password, options) {
     dialectOptions: this.options.dialectOptions
   };
 
-  try {
-    var Dialect;
-    // Requiring the dialect in a switch-case to keep the
-    // require calls static. (Browserify fix)
-    switch (this.getDialect()){
-      case 'mariadb':
-        Dialect = require('./dialects/mariadb');
-        break;
-      case 'mssql':
-        Dialect = require('./dialects/mssql');
-        break;
-      case 'mysql':
-        Dialect = require('./dialects/mysql');
-        break;
-      case 'postgres':
-        Dialect = require('./dialects/postgres');
-        break;
-      case 'sqlite':
-        Dialect = require('./dialects/sqlite');
-        break;
-    }
-    this.dialect = new Dialect(this);
-  } catch (err) {
-    throw new Error('The dialect ' + this.getDialect() + ' is not supported. Supported dialects: mariadb, mssql, mysql, postgres, and sqlite. ('+err+')');
+  var Dialect;
+  // Requiring the dialect in a switch-case to keep the
+  // require calls static. (Browserify fix)
+  switch (this.getDialect()){
+    case 'mariadb':
+      Dialect = require('./dialects/mariadb');
+      break;
+    case 'mssql':
+      Dialect = require('./dialects/mssql');
+      break;
+    case 'mysql':
+      Dialect = require('./dialects/mysql');
+      break;
+    case 'postgres':
+      Dialect = require('./dialects/postgres');
+      break;
+    case 'sqlite':
+      Dialect = require('./dialects/sqlite');
+      break;
+    default:
+      throw new Error('The dialect ' + this.getDialect() + ' is not supported. Supported dialects: mariadb, mssql, mysql, postgres, and sqlite.');
   }
+  this.dialect = new Dialect(this);
 
   this.dialect.QueryGenerator.typeValidation = options.typeValidation;
 


### PR DESCRIPTION
This makes it so that, if the provided dialect is a supported dialect (eg. postgres) and requiring the dialect throws an error (eg. the 'pg' package not being installed), the actual underlying error and its accompanying stack trace are thrown to the caller, rather than stringifying the error (losing the stack) and reporting the wrong error.