### PR TITLE
Fix for bug #4755

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -495,20 +495,23 @@ QueryInterface.prototype.insert = function(instance, tableName, values, options)
   });
 };
 
-QueryInterface.prototype.upsert = function(tableName, values, updateValues, model, options) {
+QueryInterface.prototype.upsert = function(tableName, valuesByField, updateValues, model, options) {
   var wheres = []
     , where
     , indexFields
     , indexes = []
-    , attributes = Object.keys(values);
+    , attributes = Object.keys(valuesByField);
 
-  where = {};
-  for (var i = 0; i < model.primaryKeyAttributes.length; i++) {
-    var key = model.primaryKeyAttributes[i];
-    if(key in values){
-      where[key] = values[key];
+  where = model.primaryKeyAttributes.reduce(function (where, key) {
+    var attribute = model.rawAttributes[key];
+
+    if (attribute.field && attribute.field in valuesByField) {
+      where[attribute.field] = valuesByField[attribute.field];
+    } else if (key in valuesByField) {
+      where[key] = valuesByField[key];
     }
-  }
+    return where;
+  }, {} );
 
   if (!Utils._.isEmpty(where)) {
     wheres.push(where);
@@ -536,7 +539,7 @@ QueryInterface.prototype.upsert = function(tableName, values, updateValues, mode
     if (Utils._.intersection(attributes, index).length === index.length) {
       where = {};
       index.forEach(function (field) {
-        where[field] = values[field];
+        where[field] = valuesByField[field];
       });
       wheres.push(where);
     }
@@ -547,7 +550,7 @@ QueryInterface.prototype.upsert = function(tableName, values, updateValues, mode
   options.type = QueryTypes.UPSERT;
   options.raw = true;
 
-  var sql = this.QueryGenerator.upsertQuery(tableName, values, updateValues, where, model.rawAttributes, options);
+  var sql = this.QueryGenerator.upsertQuery(tableName, valuesByField, updateValues, where, model.rawAttributes, options);
   return this.sequelize.query(sql, options).then(function (rowCount) {
     if (rowCount === undefined) {
       return rowCount;


### PR DESCRIPTION
`QueryInterface.upsert` accepts values by field name (`.field`) but picked primary key values for the where clause using attribute name. I modified `upsert` so that `.field` is taken into account when collecting data for the upsert where clause. I've also added a failing test case which now passes.