### PR TITLE
fix: describe query should not uppercase the enum type

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -91,8 +91,9 @@ Query.prototype.formatResults = function(data) {
     result = {};
 
     data.forEach(function(_result) {
+      var enumRegex = /^enum/i;
       result[_result.Field] = {
-        type: _result.Type.toUpperCase(),
+        type: enumRegex.test(_result.Type) ? _result.Type.replace(enumRegex, 'ENUM') : _result.Type.toUpperCase(),
         allowNull: (_result.Null === 'YES'),
         defaultValue: _result.Default,
         primaryKey: _result.Key === 'PRI'

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -194,6 +194,8 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
           if (dialect === 'postgres' || dialect === 'postgres-native') {
             expect(enumVals.special).to.be.instanceof(Array);
             expect(enumVals.special).to.have.length(2);
+          } else if (dialect === 'mysql') {
+            expect(enumVals.type).to.eql('ENUM(\'hello\',\'world\')');
           }
         });
       });


### PR DESCRIPTION
Our team relies on the result of `describeTable` method to generate migrations automatically. However, we found that enum types are uppercased by sequellize by mistake.

For example, we have a field with the type of `enum('admin', 'member', 'guest')`, the result of `describeTable` will be `ENUM('ADMIN', 'MEMBER', 'GUEST')`, which is obviously not as same as the former one.

After the changes, the result will become `ENUM('admin', 'member', 'guest')`.