### PR TITLE
Fixes issue #5344: Replaced _.cloneDeep with _.cloneDeepWith.

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1649,7 +1649,7 @@ Model.prototype.findAndCount = function(options) {
   conformOptions(countOptions, this);
 
   if (countOptions.include) {
-    countOptions.include = _.cloneDeep(countOptions.include, function (element) {
+    countOptions.include = _.cloneDeepWith(countOptions.include, function (element) {
       if (element instanceof Model) return element;
       if (element instanceof Association) return element;
       return undefined;


### PR DESCRIPTION
This fixes issue #5344, where `findAndCount` with eagerly loaded model is broken when using Sequelize with pg. In lodash 4.x, `cloneDeep` does not accept a customizer function, but a new function `cloneDeepWith` does.