### PR TITLE
Set updatedAt and createdAt values before validation

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -525,9 +525,10 @@ Instance.prototype.save = function(options) {
     , updatedAtAttr = this.Model._timestampAttributes.updatedAt
     , createdAtAttr = this.Model._timestampAttributes.createdAt
     , hook = self.isNewRecord ? 'Create' : 'Update'
-    , wasNewRecord = this.isNewRecord;
+    , wasNewRecord = this.isNewRecord
+    , now = Utils.now(this.sequelize.options.dialect);
 
-  if (updatedAtAttr && options.fields.indexOf(updatedAtAttr) === -1) {
+  if (updatedAtAttr && options.fields.length && options.fields.indexOf(updatedAtAttr) === -1) {
     options.fields.push(updatedAtAttr);
   }
 
@@ -553,6 +554,14 @@ Instance.prototype.save = function(options) {
     if (primaryKeyName && this.get(primaryKeyName, {raw: true}) === undefined) {
       throw new Error('You attempted to save an instance with no primary key, this is not allowed since it would result in a global update');
     }
+  }
+
+  if (updatedAtAttr && !options.silent && options.fields.indexOf(updatedAtAttr) !== -1) {
+    this.dataValues[updatedAtAttr] = this.Model.$getDefaultTimestamp(updatedAtAttr) || now;
+  }
+
+  if (this.isNewRecord && createdAtAttr && !this.dataValues[createdAtAttr]) {
+    this.dataValues[createdAtAttr] = this.Model.$getDefaultTimestamp(createdAtAttr) || now;
   }
 
   return Promise.bind(this).then(function() {
@@ -639,16 +648,7 @@ Instance.prototype.save = function(options) {
 
       var values = Utils.mapValueFieldNames(this.dataValues, options.fields, this.Model)
         , query = null
-        , args = []
-        , now = Utils.now(this.sequelize.options.dialect);
-
-      if (updatedAtAttr && !options.silent) {
-        self.dataValues[updatedAtAttr] = values[self.Model.rawAttributes[updatedAtAttr].field || updatedAtAttr] = self.Model.$getDefaultTimestamp(updatedAtAttr) || now;
-      }
-
-      if (self.isNewRecord && createdAtAttr && !values[createdAtAttr]) {
-        self.dataValues[createdAtAttr] = values[self.Model.rawAttributes[createdAtAttr].field || createdAtAttr] = self.Model.$getDefaultTimestamp(createdAtAttr) || now;
-      }
+        , args = [];
 
       if (self.isNewRecord) {
         query = 'insert';

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -1172,6 +1172,9 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
             self.clock.tick(2000);
             return user.save().then(function(newlySavedUser) {
               expect(newlySavedUser.updatedAt).to.equalTime(updatedAt);
+              return self.User.findOne({ username: 'John' }).then(function(newlySavedUser) {
+                expect(newlySavedUser.updatedAt).to.equalTime(updatedAt);
+              });
             });
           });
         });
@@ -1239,6 +1242,28 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           return User2.create({ username: 'john doe' }).then(function(johnDoe) {
             expect(johnDoe.createdAt).to.be.undefined;
             expect(now).to.be.beforeTime(johnDoe.updatedAt);
+          });
+        });
+      });
+
+      it('works with `allowNull: false` on createdAt and updatedAt columns', function() {
+        var User2 = this.sequelize.define('User2', {
+          username: DataTypes.STRING,
+          createdAt: {
+            type: DataTypes.DATE,
+            allowNull: false
+          },
+          updatedAt: {
+            type: DataTypes.DATE,
+            allowNull: false
+          }
+        }, { timestamps: true });
+
+        return User2.sync().then(function() {
+          return User2.create({ username: 'john doe' }).then(function(johnDoe) {
+            expect(johnDoe.createdAt).to.be.an.instanceof(Date);
+            expect( ! isNaN(johnDoe.createdAt.valueOf()) ).to.be.ok;
+            expect(johnDoe.createdAt).to.equalTime(johnDoe.updatedAt);
           });
         });
       });


### PR DESCRIPTION
If model has `updatedAt` or `createdAt` fields without allowing nulls:

```javascript
        createdAt: {
            type: DataTypes.DATE,
            allowNull: false,
            field: 'created_at'
        },
        updatedAt: {
            type: DataTypes.DATE,
            allowNull: false,
            field: 'update_at'
        },
```

then I'm receiving this error:

> { [SequelizeValidationError: notNull Violation: createdAt cannot be null,
notNull Violation: updatedAt cannot be null]
  name: 'SequelizeValidationError',
  message: 'notNull Violation: createdAt cannot be null,\nnotNull Violation: updatedAt cannot be null',
  errors:
   [ { message: 'createdAt cannot be null',
       type: 'notNull Violation',
       path: 'createdAt',
       value: null },
     { message: 'updatedAt cannot be null',
       type: 'notNull Violation',
       path: 'updatedAt',
       value: null } ] }

My proposal is to set `updatedAt` and `createdAt` values before doing validation.