### PR TITLE
Fix bug in SqlString.escape which caused the function to be recursive…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 - [ADDED] `validationFailed` hook [#1626](https://github.com/sequelize/sequelize/issues/1626)
 - [FIXED] Mark index as `unique: true` when `type: 'UNIQUE'`. Fixes [#5351](https://github.com/sequelize/sequelize/issues/5351)
 - [ADDED[ Support for IEEE floating point literals in postgres and sqlite [#5194](https://github.com/sequelize/sequelize/issues/5194)
+- [FIXED] Improper escaping of bound arrays of strings on Postgres, SQLite, and Microsoft SQL Server
 
 # 3.19.3
 - [FIXED] `updatedAt` and `createdAt` values are now set before validation [#5367](https://github.com/sequelize/sequelize/pull/5367)

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -48,7 +48,7 @@ SqlString.escape = function(val, timeZone, dialect, format) {
   }
 
   if (Array.isArray(val)) {
-    var escape = _.partialRight(SqlString.escape, timeZone, dialect);
+    var escape = _.partial(SqlString.escape, _, timeZone, dialect, format);
     if (dialect === 'postgres' && !format) {
       return dataTypes.ARRAY.prototype.stringify(val, {escape: escape});
     }

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -583,6 +583,15 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       });
     });
 
+    if (dialect === 'postgres' || dialect === 'sqlite' || dialect === 'mssql') {
+      it ('does not improperly escape arrays of strings bound to named parameters', function() {
+        var logSql;
+        return this.sequelize.query('select :stringArray as foo', { raw: true, replacements: { stringArray: [ '"string"' ] }, logging: function(s) { logSql = s; } }).then(function(result) {
+          expect(result[0]).to.deep.equal([{ foo: '"string"' }]);
+        });
+      });
+    }
+
     it('throw an exception when binds passed with object and numeric $1 is also present', function() {
       var self = this;
       var typeCast = (dialect === 'postgres') ? '::int' : '';

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -299,7 +299,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         attributes: ['*'],
         having: ['name IN (?)', [1, 'test', 3, "derp"]]
       }), {
-        default: "SELECT * FROM [User] HAVING name IN (1,'test',3,'derp');"
+        default: "SELECT * FROM [User] HAVING name IN (1,'test',3,'derp');",
+        mssql: "SELECT * FROM [User] HAVING name IN (1,N'test',3,N'derp');"
       });
     });
   });


### PR DESCRIPTION
…ly called with the wrong parameters when passed an array of strings. This would cause the incorrect escape algorithm to be used on the strings within the array when the dialect was set to postgres, sqlite, or mssql.

Greetings,

We ran into this bug today when attempting to upgrade from 3.0.1 to 3.19.2, hoping to pick up the security fix introduced in 3.17.0.

We believe this probably fixes #4912, but the issue lacks a reproducible test case, so we can't be sure.

The crux of the issue is that a format parameter was added to SqlString.escape in commit 12057dc which added a format parameter to the function, but this function calls itself recursively when passed an array, and this recursive call was not updated with the new parameter. This resulted in the dialect parameter containing the original array passed to the function, rather than the dialect. The dialect parameter was then used to determine if the database being used was postgres, sqlite, or mssql, and if so, to use a different algorithm to escape the strings. Because the parameter was an array, this check was always returning false, even when targeting one of these three database dialects.

The end result was that strings within these arrays were getting escaped improperly for their dialect. We found the bug because it was escaping double quotes within our strings, which were used to store JSON, so when we read them back out, we got invalid JSON.

We've also made the recursive call a bit more explicit and added a test to help ensure this doesn't happen again. Thank you.