### PR TITLE
isAlpha and isAlphanumeric Validator fix

### DIFF
--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -261,7 +261,7 @@ InstanceValidator.prototype._invokeBuiltinValidator = Promise.method(function(va
   if (!Array.isArray(validatorArgs)) {
     if (validatorType === 'isImmutable') {
       validatorArgs = [validatorArgs, field];
-    } else if (validatorType === 'isIP') {
+    } else if (validatorType === 'isIP' || validatorType === 'isAlpha' || validatorType === 'isAlphanumeric') {
       validatorArgs = [];
     } else {
       validatorArgs = [validatorArgs];


### PR DESCRIPTION
Added extra conditions so that extra arguments will not be passed to 'isAlpha' and 'isAlphanumeric.' Fixes #5377 