### PR TITLE
Replaced function removed from lodash 4

### DIFF
--- a/docs/docs-generator.js
+++ b/docs/docs-generator.js
@@ -48,7 +48,7 @@ Comment.prototype.getTag = function(tagName) {
 };
 
 Comment.prototype.getTags = function(tagName) {
-  return _.where(this.data.tags, { type: tagName });
+  return _.filter(this.data.tags, { type: tagName });
 };
 
 Comment.prototype.hasTag = function(tagName) {


### PR DESCRIPTION
`where` was removed from Lodash 4 in favor of `filter`. Running `npm run docs` errors out with "where is not a function" without this fix.