### PR TITLE
Log which query tried to run on a finished transaction

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -789,7 +789,9 @@ Sequelize.prototype.query = function(sql, options) {
   }
 
   if (options.transaction && options.transaction.finished) {
-    return Promise.reject(new Error(options.transaction.finished+' has been called on this transaction('+options.transaction.id+'), you can no longer use it'));
+    var error = new Error(options.transaction.finished+' has been called on this transaction('+options.transaction.id+'), you can no longer use it. (The rejected query is attached as the \'sql\' property of this error)');
+    error.sql = sql;
+    return Promise.reject(error);
   }
 
   if (this.test.$trackRunningQueries) {


### PR DESCRIPTION
The "commit has been called on this transaction" error message usually indicates a problem with chaining of query promises within a transaction block. In more complex transaction blocks it may not be immediately clear which query is improperly chained and the current error message does not help much. This change logs the query (SQL) that the application attempted to run on a finished transaction. This makes it easy to identify a problem in an application.