### PR TITLE
Added condition to arg passer for validators.

### DIFF
--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -261,7 +261,7 @@ InstanceValidator.prototype._invokeBuiltinValidator = Promise.method(function(va
   if (!Array.isArray(validatorArgs)) {
     if (validatorType === 'isImmutable') {
       validatorArgs = [validatorArgs, field];
-    } else if (validatorType === 'isIP') {
+    } else if (validatorType === 'isIP' || validatorType === 'isAlpha' || validatorType === 'isAlphanumeric') {
       validatorArgs = [];
     } else {
       validatorArgs = [validatorArgs];


### PR DESCRIPTION
I have had failing unit tests for a while, specifically 

      1) correctly specifies an instance as invalid using a value of "012" for the validation "isAlpha"
      2) correctly specifies an instance as valid using a value of "abc" for the validation "isAlpha"
      3) correctly specifies an instance as valid using a value of "abc" for the validation "isAlpha"
      4) correctly specifies an instance as valid using a value of "abc" for the validation "isAlpha"
      5) correctly specifies an instance as valid using a value of "abc" for the validation "isAlpha"
      6) correctly specifies an instance as invalid using a value of "_abc019" for the validation "isAlphanumeric"
      7) correctly specifies an instance as valid using a value of "abc019" for the validation "isAlphanumeric"
      8) correctly specifies an instance as valid using a value of "abc019" for the validation "isAlphanumeric"
      9) correctly specifies an instance as valid using a value of "abc019" for the validation "isAlphanumeric"
      10) correctly specifies an instance as valid using a value of "abc019" for the validation "isAlphanumeric"

I believe this issue is also related #5377. While there seems to be a larger issue of `true` being sent to validators when they are specified in a model definition, this fix allow the unit tests to pass for now. 