### PR TITLE
Added locales support for localized validations

### DIFF
--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -250,18 +250,34 @@ InstanceValidator.prototype._invokeCustomValidator = Promise.method(function(val
  * @private
  */
 InstanceValidator.prototype._invokeBuiltinValidator = Promise.method(function(value, test, validatorType, field) {
+  var self = this;
   // check if Validator knows that kind of validation test
   if (typeof validator[validatorType] !== 'function') {
     throw new Error('Invalid validator function: ' + validatorType);
   }
+  var validatorArgs = self._extractValidatorArgs(test, validatorType, field);
+  if (!validator[validatorType].apply(validator, [value].concat(validatorArgs))) {
+  // extract the error msg
+    throw new Error(test.msg || 'Validation ' + validatorType + ' failed');
+  }
+});
 
-  // extract extra arguments for the validator
+/**
+ * Will extract arguments for the validator.
+ *
+ * @param {*} test The test case.
+ * @param {string} validatorType One of known to Sequelize validators.
+ * @param {string} field The field that is being validated.
+ * @private
+ */
+InstanceValidator.prototype._extractValidatorArgs = function(test, validatorType, field) {
   var validatorArgs = test.args || test;
+  var isLocalizedValidator = typeof(validatorArgs) !== 'string' && (validatorType === 'isAlpha' || validatorType === 'isAlphanumeric' || validatorType === 'isMobilePhone');
 
   if (!Array.isArray(validatorArgs)) {
     if (validatorType === 'isImmutable') {
       validatorArgs = [validatorArgs, field];
-    } else if (validatorType === 'isIP' || validatorType === 'isAlpha' || validatorType === 'isAlphanumeric') {
+    } else if (isLocalizedValidator || validatorType === 'isIP') {
       validatorArgs = [];
     } else {
       validatorArgs = [validatorArgs];
@@ -269,12 +285,8 @@ InstanceValidator.prototype._invokeBuiltinValidator = Promise.method(function(va
   } else {
     validatorArgs = validatorArgs.slice(0);
   }
-
-  if (!validator[validatorType].apply(validator, [value].concat(validatorArgs))) {
-  // extract the error msg
-    throw new Error(test.msg || 'Validation ' + validatorType + ' failed');
-  }
-});
+  return validatorArgs;
+};
 
 /**
  * Will validate a single field against its schema definition (isnull).

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -46,10 +46,14 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
         pass: 'fe80:0000:0000:0000:0204:61ff:fe9d:f156'
       }
     , isAlpha: {
+        stringOrBoolean: true,
+        spec: { args: 'en-GB' },
         fail: '012',
         pass: 'abc'
       }
     , isAlphanumeric: {
+        stringOrBoolean: true,
+        spec: { args: 'en-GB' },
         fail: '_abc019',
         pass: 'abc019'
       }
@@ -183,12 +187,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
           var validations = {}
             , message = validator + '(' + failingValue + ')';
 
-          if (validatorDetails.spec) {
-            validations[validator] = validatorDetails.spec;
-          } else {
-            validations[validator] = {};
-          }
-
+          validations[validator] = validatorDetails.spec || {};
           validations[validator].msg = message;
 
           var UserFail = this.sequelize.define('User' + config.rand(), {
@@ -210,19 +209,16 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
       , applyPassTest = function applyPassTest(validatorDetails, j, validator, type) {
           var succeedingValue = validatorDetails.pass[j];
           it('correctly specifies an instance as valid using a value of "' + succeedingValue + '" for the validation "' + validator + '"', function() {
-            var validations = {};
+            var validations = {}
+              , message = validator + '(' + succeedingValue + ')';
 
-            if (validatorDetails.spec !== undefined) {
-              validations[validator] = validatorDetails.spec;
-            } else {
-              validations[validator] = {};
-            }
+            validations[validator] = validatorDetails.spec || {};
 
             if (type === 'msg') {
-              validations[validator].msg = validator + '(' + succeedingValue + ')';
+              validations[validator].msg = message;
             } else if (type === 'args') {
               validations[validator].args = validations[validator].args || true;
-              validations[validator].msg = validator + '(' + succeedingValue + ')';
+              validations[validator].msg = message;
             } else if (type === 'true') {
               validations[validator] = true;
             }
@@ -260,7 +256,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
             applyPassTest(validatorDetails, i, validator);
             applyPassTest(validatorDetails, i, validator, 'msg');
             applyPassTest(validatorDetails, i, validator, 'args');
-            if (validatorDetails.spec === undefined) {
+            if (validatorDetails.stringOrBoolean || (validatorDetails.spec === undefined)) {
               applyPassTest(validatorDetails, i, validator, 'true');
             }
           }


### PR DESCRIPTION
* Added locales to `isAlpha`, `isAlphanumeric` and `isMobilePhone`.

* ex:
`isAlpha: 'de-DE'`
`isAlphanumeric: 'de-DE'`