### PR TITLE
Multiple custom unique validation messages being overwritten by the first-defined message

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 - [FIXED] Parsing of dates in MySQL, when a named timezone is used [#4208](https://github.com/sequelize/sequelize/issues/4208)
 - [FIXED] Truncating in Postgres, when table has a schema [#4306](https://github.com/sequelize/sequelize/issues/4306)
 - [FIXED] Moved initialization of scopes later in the model init process. Fixes attribute exclusion in scopes, [#4735](https://github.com/sequelize/sequelize/issues/4735) and [#4925](https://github.com/sequelize/sequelize/issues/4925)
+- [FIXED] Multiple custom unique validation messages being overwritten by the first-defined message, [#4920](https://github.com/sequelize/sequelize/issues/4920)
 
 # 3.19.0
 - [ADDED] Geography support for postgres

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -535,7 +535,7 @@ AbstractQuery.prototype.getUniqueConstraintErrorMessage = function(field) {
   if (self.model) {
     Object.keys(self.model.uniqueKeys).forEach(function(key) {
       if (self.model.uniqueKeys[key].fields.indexOf(field.replace(/"/g, '')) >= 0) {
-        if (self.model.uniqueKeys[key].hasOwnProperty('msg')) {
+        if (self.model.uniqueKeys[key].msg) {
           message = self.model.uniqueKeys[key].msg;
         }
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -840,26 +840,24 @@ Model.prototype.refreshAttributes = function() {
       self._defaultValues[name] = Utils._.partial(Utils.toDefaultValue, definition.defaultValue);
     }
 
-    if (definition.hasOwnProperty('unique')) {
+    if (definition.hasOwnProperty('unique') && definition.unique !== false) {
       var idxName;
-      if (definition.unique === true) {
-        idxName = self.tableName + '_' + name + '_unique';
-        self.options.uniqueKeys[idxName] = {
-          name: idxName,
-          fields: [definition.field],
-          singleField: true
-        };
-      } else if (definition.unique !== false) {
+      if (typeof definition.unique === 'object' && definition.unique.hasOwnProperty('name')) {
+        idxName = definition.unique.name;
+      } else if (typeof definition.unique === 'string') {
         idxName = definition.unique;
-        if (typeof definition.unique === 'object') {
-          idxName = definition.unique.name;
-        }
-
-        self.options.uniqueKeys[idxName] = self.options.uniqueKeys[idxName] || {fields: [], msg: null};
-        self.options.uniqueKeys[idxName].fields.push(definition.field);
-        self.options.uniqueKeys[idxName].msg = self.options.uniqueKeys[idxName].msg || definition.unique.msg || null;
-        self.options.uniqueKeys[idxName].name = idxName || false;
+      } else {
+        idxName = self.tableName + '_' + name + '_unique';
       }
+
+      var idx = self.options.uniqueKeys[idxName] || { fields: [] };
+      idx = idx || {fields: [], msg: null};
+      idx.fields.push(definition.field);
+      idx.msg = idx.msg || definition.unique.msg || null;
+      idx.name = idxName || false;
+      idx.column = name;
+
+      self.options.uniqueKeys[idxName] = idx;
     }
 
     if (definition.hasOwnProperty('validate')) {

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -131,6 +131,45 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
           expect(err.errors[0].message).to.equal('custom unique error message');
         });
     });
+
+    it('should handle multiple unique messages correctly', function() {
+      var Model = this.sequelize.define('model', {
+        uniqueName1: {
+          type: Sequelize.STRING,
+          unique: { msg: 'custom unique error message 1' }
+        },
+        uniqueName2: {
+          type: Sequelize.STRING,
+          unique: { msg: 'custom unique error message 2' }
+        },
+      });
+      var records = [
+        { uniqueName1: 'unique name one', uniqueName2: 'unique name one' },
+        { uniqueName1: 'unique name one', uniqueName2: 'this is ok' },
+        { uniqueName1: 'this is ok', uniqueName2: 'unique name one' },
+      ];
+      return Model.sync({ force: true })
+        .then(function() {
+          return Model.create(records[0]);
+        }).then(function(instance) {
+          expect(instance).to.be.ok;
+          return expect(Model.create(records[1])).to.be.rejected;
+        }).then(function(err) {
+          expect(err).to.be.an.instanceOf(Error);
+          console.log(err.errors);
+          expect(err.errors).to.have.length(1);
+          expect(err.errors[0].path).to.include('uniqueName1');
+          expect(err.errors[0].message).to.equal('custom unique error message 1');
+
+          return expect(Model.create(records[2])).to.be.rejected;
+        }).then(function(err) {
+          expect(err).to.be.an.instanceOf(Error);
+          console.log(err.errors);
+          expect(err.errors).to.have.length(1);
+          expect(err.errors[0].path).to.include('uniqueName2');
+          expect(err.errors[0].message).to.equal('custom unique error message 2');
+        });
+    });
   });
 
   describe('#create', function() {


### PR DESCRIPTION
This issue was not in the dialect as https://github.com/sequelize/sequelize/issues/4920 hints, but rather in the model definition. Sequelized looks/ed for unique index names when the `unique` property is given as an object, even if it only contains a `msg`. This resulted in, when many columns contained an object like `unique: { msg: '...' }`, it grouping them under the `undefined` key and subsequently ignoring further message definitions.

This PR modifies the building so that the name is pulled out only if defined in the unique property.