### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,28 @@
+_Thanks for wanting to report an issue you've found in Sequelize. Please delete this text and fill in the template below. If unsure about something, just do as best as you're able._
+
+_Note that it will be much easier for us to fix the issue if a test case that reproduces the problem is provided. Ideally this test case should not have any external dependencies. We understand that it is not always possible to reduce your code to a small test case, but we would appreciate to have as much data as possible. Thank you!_
+
+_Github should only be used for feature requests and bugs - all questions belong on StackOverflow, Slack, or Google groups._
+
+_This template is for submitting issues - if you want to submit a feature request you may skip this template_
+
+
+## What you are doing?
+_Post a minimal code sample that reproduces the issue, including models and associations_
+
+```js
+// code here
+```
+
+## What do you expect to happen?
+_I wanted Foo!_
+
+## What is actually happening?
+_But the output was bar!_
+
+_Output, either JSON or SQL_
+
+
+__Dialect:__ mysql / postgres / sqlite / mssql / any
+__Database version:__ XXX
+__Sequelize version:__ XXX

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+_Thanks for wanting to fix something on Sequelize - we already love you long time! Please delete this text and fill in the template below. If unsure about something, just do as best as you're able._
+
+_If your PR only contains changes to documentation, you may skip the template below._
+
+### Pull Request check-list
+
+_Please make sure to review and check all of these items:_
+
+- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
+- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
+- [ ] Have you added new tests to prevent regressions?
+- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
+- [ ] Have you added an entry under `Future` in the changelog?
+
+_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._
+
+### Description of change
+
+_Please provide a description of the change here._


### PR DESCRIPTION
Personally I love the idea of an issue template. Some people over at https://github.com/rust-lang/rust/pull/31732 are less excited than me, but personally I don't mind turning a few users away if they can't take the time to write a proper description of the issue - changes are the issue wouldn't have been fixed anyway because it wasn't explained properly :)

https://github.com/blog/2111-issue-and-pull-request-templates