### PR TITLE
Restore old behaviour when using SYSTEM timezone in MySQL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# NEXT
+
+ - [FIXED] dates being returned as `null` when using the `SYSTEM` timezone in MySQL [#5457](https://github.com/sequelize/sequelize/pull/5457)
+
 # 3.19.3
 - [FIXED] `updatedAt` and `createdAt` values are now set before validation [#5367](https://github.com/sequelize/sequelize/pull/5367)
 - [FIXED] `describeTable` maintains proper enum casing in mysql [#5321](https://github.com/sequelize/sequelize/pull/5321)

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -47,10 +47,15 @@ module.exports = function (BaseTypes) {
       return value;
     }
 
+    var zoned;
     if (moment.tz.zone(options.timezone)) {
-      value = moment.tz(value, options.timezone).toDate();
+      zoned = moment.tz(value, options.timezone).toDate();
     } else {
-      value = new Date(value + ' ' + options.timezone);
+      zoned = new Date(value + ' ' + options.timezone);
+    }
+
+    if (zoned && !isNaN(zoned.getTime())) {
+      value = zoned;
     }
 
     return value;

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -72,6 +72,24 @@ if (dialect !== 'sqlite') {
           expect(normalUser.createdAt.getTime() - timezonedUser.createdAt.getTime()).to.be.closeTo(60 * 60 * 4 * 1000 * -1, 60 * 60 * 1000);
         });
       });
+
+      it('handles SYSTEM timezone', function() {
+        var sequelizeWithSystemTimezone = Support.createSequelizeInstance({
+          timezone: 'SYSTEM'
+        });
+
+        var NormalUser = this.sequelize.define('user', {})
+          , TimezonedUser = sequelizeWithSystemTimezone.define('user', {});
+
+        return this.sequelize.sync({ force: true }).bind(this).then(function() {
+          return TimezonedUser.create({});
+        }).then(function(timezonedUser) {
+          return TimezonedUser.findById(timezonedUser.id);
+        }).then(function(timezonedUser) {
+          expect(timezonedUser.createdAt).not.to.be.null;
+          expect(timezonedUser.createdAt).to.be.a('string');
+        });
+      });
     }
   });
 }


### PR DESCRIPTION
As of 3.19.0, due to the changes in https://github.com/sequelize/sequelize/pull/5442, when using the SYSTEM timezone in MySQL all dates coming out of the database were set to `null`. This caused some considerable issues on our end!

This PR restores the previous behaviour of returning the date as a string when the SYSTEM timezone is set. Though it's not ideal -- all dates should preferably be parsed to Date objects -- it is behaviour that we've come to rely on in various parts of our platform (the format of the string is different than the format when JSON encoding Dates). It'd be great to have everything be Dates, but this will be a breaking change so should be held off until 4.0.0 :wink: 
