### PR TITLE
empty array  in where should return no data

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2004,6 +2004,11 @@ var QueryGenerator = {
           return item && item.length;
         });
 
+        // $or: [] should return no data.
+        if (key === '$or' && value.length === 0) {
+          return '0 = 1';
+        }
+
         return value.length ? outerBinding + '('+value.join(binding)+')' : undefined;
       } else {
         value = self.whereItemsQuery(value, options, binding);

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2005,13 +2005,19 @@ var QueryGenerator = {
         });
 
         // $or: [] should return no data.
-        if (key === '$or' && value.length === 0) {
+        // $not of no restriction should also return no data
+        if ((key === '$or' || key === '$not') && value.length === 0) {
           return '0 = 1';
         }
 
         return value.length ? outerBinding + '('+value.join(binding)+')' : undefined;
       } else {
         value = self.whereItemsQuery(value, options, binding);
+
+        if ((key === '$or' || key === '$not') && !value) {
+          return '0 = 1';
+        }
+
         return value ? outerBinding + '('+value+')' : undefined;
       }
     }

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -253,6 +253,10 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           default: "0 = 1"
         });
 
+        testsql('$or', {}, {
+          default: "0 = 1"
+        });
+
         test("sequelize.or()", function () {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.or()), {
             default: "0 = 1"
@@ -322,6 +326,14 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           }
         }, {
           default: 'NOT ([shared] = 1 AND ([group_id] = 1 OR [user_id] = 2))'
+        });
+
+        testsql('$not', [], {
+          default: "0 = 1"
+        });
+
+        testsql('$not', {}, {
+          default: "0 = 1"
         });
       });
     });

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -248,6 +248,16 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
             mssql: "([group_id] = 1 OR ([user_id] = 2 AND [role] = N'admin'))"
           });
         });
+
+        testsql('$or', [], {
+          default: "0 = 1"
+        });
+
+        test("sequelize.or()", function () {
+          expectsql(sql.whereItemQuery(undefined, this.sequelize.or()), {
+            default: "0 = 1"
+          });
+        });
       });
 
       suite('$and', function () {


### PR DESCRIPTION
This is a pull request for a fix to issue #5453 

When a query contains { where: { $or: [] } }, it should return any empty set. Currently, however, the entire WHERE clause disappears. This fix adds WHERE 0 = 1 in the degenerate case so that no data is returned from the query.