### PR TITLE
Parse connection options from URI query strings.

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -103,27 +103,33 @@ var Sequelize = function(database, username, password, options) {
 
   if (arguments.length === 1 || (arguments.length === 2 && typeof username === 'object')) {
     options = username || {};
-    urlParts = url.parse(arguments[0]);
-    // reset username and password to null so we don't pass the options as the username
-    username = null;
-    password = null;
+    // Parse given URI with query string.
+    urlParts = url.parse(arguments[0], true);
 
-    // SQLite don't have DB in connection url
-    if (urlParts.pathname) {
-      database = urlParts.pathname.replace(/^\//, '');
-    }
+    // Make sure to get arguments from given URI.
+    database = (urlParts.pathname || '').replace(/^\//, '') ||
+               urlParts.query.dbname ||
+               null;
+    username = (urlParts.auth || '').split(':')[0] ||
+               urlParts.query.user ||
+               null;
+    password = (urlParts.auth || '').split(':')[0] ||
+               urlParts.query.password ||
+               null;
 
-    options.dialect = urlParts.protocol.replace(/:$/, '');
-    options.host = urlParts.hostname;
-
-    if (urlParts.port) {
-      options.port = urlParts.port;
-    }
-
-    if (urlParts.auth) {
-      username = urlParts.auth.split(':')[0];
-      password = urlParts.auth.split(':')[1];
-    }
+    // Get options from given URI.
+    options.dialect = (urlParts.protocol || '').replace(/:$/, '') ||
+                      options.dialect ||
+                      null;
+    options.host    = urlParts.hostname ||
+                      urlParts.query.hostaddr ||
+                      urlParts.query.host ||
+                      options.host ||
+                      null;
+    options.port    = urlParts.port ||
+                      urlParts.query.port ||
+                      options.port ||
+                      null;
   }
 
   var config = {database: database, username: username, password: password};


### PR DESCRIPTION
Though passing parameters via URI query string is a common feature with database connection string, sequelize doesn't supports this. I have briefly implemented this feature, which will help to put all options in a single URI, like `postgres:///dbname?host=/var/run/postgresql` or `sqlite:///?host=/path/to/file.sqlite`.

FYI:
PostgreSQL: [31.1.1.2. Connection URIs](http://www.postgresql.org/docs/9.4/static/libpq-connect.html)
Mysql: [5.1 Driver/Datasource Class Names, URL Syntax and Configuration Properties for Connector/J](https://dev.mysql.com/doc/connector-j/en/connector-j-reference-configuration-properties.html)
SQLite: [Uniform Resource Identifiers](https://www.sqlite.org/uri.html)