### PR TITLE
Execute promises sequentially rather than parallel

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1009,9 +1009,15 @@ Sequelize.prototype.truncate = function(options) {
     }
   }, { reverse: false });
 
-  return Promise.map(models, function(model) {
+  var truncateModel = function(model) {
     return model.truncate(options);
-  });
+  };
+
+  if (options && options.cascade) {
+    return Promise.each(models, truncateModel);
+  } else {
+    return Promise.map(models, truncateModel);
+  }
 };
 
 /**


### PR DESCRIPTION
Promise.map allows promises to execute in parallel, which can cause
deadlocks when cascading truncates. Promise.each executes promises
sequentially, which should ensure that we don't have two or more
TRUNCATE operations getting in each others' way.