### PR TITLE
rejectOnEmpty mode

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] rejectOnEmpty mode [#272](https://github.com/sequelize/sequelize/issues/272) [#5480](https://github.com/sequelize/sequelize/issues/5480)
 - [ADDED] `beforeCount` hook [#5209](https://github.com/sequelize/sequelize/pull/5209)
 - [ADDED] `validationFailed` hook [#1626](https://github.com/sequelize/sequelize/issues/1626)
 - [FIXED] Mark index as `unique: true` when `type: 'UNIQUE'`. Fixes [#5351](https://github.com/sequelize/sequelize/issues/5351)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -301,7 +301,7 @@ error.InstanceError = function (message) {
 util.inherits(error.InstanceError, error.BaseError);
 
 /**
- * Thrown when a record was not found, Usually used with kenophobic mode (see message for details)
+ * Thrown when a record was not found, Usually used with rejectOnEmpty mode (see message for details)
  * @extends BaseError
  * @constructor
  */

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -299,3 +299,15 @@ error.InstanceError = function (message) {
   this.message = message;
 };
 util.inherits(error.InstanceError, error.BaseError);
+
+/**
+ * Thrown when a record was not found, Usually used with kenophobic mode (see message for details)
+ * @extends BaseError
+ * @constructor
+ */
+error.EmptyResultError = function (message) {
+  error.BaseError.apply(this, arguments);
+  this.name = 'SequelizeEmptyResultError';
+  this.message = message;
+};
+util.inherits(error.EmptyResultError, error.BaseError);

--- a/lib/model.js
+++ b/lib/model.js
@@ -35,7 +35,7 @@ var Model = function(name, attributes, options) {
     underscored: false,
     underscoredAll: false,
     paranoid: false,
-    kenophobic: false,
+    rejectOnEmpty: false,
     whereCollection: null,
     schema: null,
     schemaDelimiter: '',
@@ -1335,7 +1335,7 @@ Model.prototype.all = function(options) {
  * @param  {Object}                    [options.having]
  * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  * @param  {Boolean}                   [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
- * @param  {Boolean|Error Instance}    [options.kenophobic=false] Throws error when no record is found
+ * @param  {Boolean|Error Instance}    [options.rejectOnEmpty=false] Throws an error when no records found
  *
  * @see    {Sequelize#query}
  * @return {Promise<Array<Instance>>}
@@ -1356,10 +1356,10 @@ Model.prototype.findAll = function(options) {
   tableNames[this.getTableName(options)] = true;
   options = optClone(options);
 
-  _.defaults(options, { hooks: true, kenophobic: false });
+  _.defaults(options, { hooks: true, rejectOnEmpty: this.options.rejectOnEmpty });
 
-  //set kenophobic option from model config
-  options.kenophobic = options.kenophobic || this.options.kenophobic;
+    //set rejectOnEmpty option from model config
+    options.rejectOnEmpty = options.rejectOnEmpty || this.options.rejectOnEmpty;
 
   return Promise.bind(this).then(function() {
     conformOptions(options, this);
@@ -1411,12 +1411,12 @@ Model.prototype.findAll = function(options) {
     }
   }).then(function (results) {
 
-    //kenophobic mode
-    if (_.isEmpty(results) && options.kenophobic) {
-      if (typeof options.kenophobic === 'function') {
-        throw new options.kenophobic();
-      } else if (typeof options.kenophobic === 'object') {
-        throw options.kenophobic;
+    //rejectOnEmpty mode
+    if (_.isEmpty(results) && options.rejectOnEmpty) {
+      if (typeof options.rejectOnEmpty === 'function') {
+        throw new options.rejectOnEmpty();
+      } else if (typeof options.rejectOnEmpty === 'object') {
+        throw options.rejectOnEmpty;
       } else {
         throw new sequelizeErrors.EmptyResultError();
       }
@@ -1535,7 +1535,7 @@ Model.prototype.findOne = function(options) {
   // Bypass a possible overloaded findAll.
   return Model.prototype.findAll.call(this, _.defaults(options, {
     plain: true,
-    kenophobic: false
+    rejectOnEmpty: false
   }));
 };
 Model.prototype.find = Model.prototype.findOne;

--- a/lib/model.js
+++ b/lib/model.js
@@ -12,6 +12,7 @@ var Utils = require('./utils')
   , Promise = require('./promise')
   , QueryTypes = require('./query-types')
   , Hooks = require('./hooks')
+  , sequelizeErrors = require('./errors')
   , _ = require('lodash')
   , associationsMixin = require('./associations/mixin');
 
@@ -34,6 +35,7 @@ var Model = function(name, attributes, options) {
     underscored: false,
     underscoredAll: false,
     paranoid: false,
+    kenophobic: false,
     whereCollection: null,
     schema: null,
     schemaDelimiter: '',
@@ -1333,6 +1335,7 @@ Model.prototype.all = function(options) {
  * @param  {Object}                    [options.having]
  * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  * @param  {Boolean}                   [options.benchmark=false] Print query execution time in milliseconds when logging SQL.
+ * @param  {Boolean|Error Instance}    [options.kenophobic=false] Throws error when no record is found
  *
  * @see    {Sequelize#query}
  * @return {Promise<Array<Instance>>}
@@ -1353,7 +1356,10 @@ Model.prototype.findAll = function(options) {
   tableNames[this.getTableName(options)] = true;
   options = optClone(options);
 
-  _.defaults(options, { hooks: true });
+  _.defaults(options, { hooks: true, kenophobic: false });
+
+  //set kenophobic option from model config
+  options.kenophobic = options.kenophobic || this.options.kenophobic;
 
   return Promise.bind(this).then(function() {
     conformOptions(options, this);
@@ -1404,6 +1410,18 @@ Model.prototype.findAll = function(options) {
       return this.runHooks('afterFind', results, options);
     }
   }).then(function (results) {
+
+    //kenophobic mode
+    if (_.isEmpty(results) && options.kenophobic) {
+      if (typeof options.kenophobic === 'function') {
+        throw new options.kenophobic();
+      } else if (typeof options.kenophobic === 'object') {
+        throw options.kenophobic;
+      } else {
+        throw new sequelizeErrors.EmptyResultError();
+      }
+    }
+
     return Model.$findSeparate(results, originalOptions);
   });
 };
@@ -1516,7 +1534,8 @@ Model.prototype.findOne = function(options) {
 
   // Bypass a possible overloaded findAll.
   return Model.prototype.findAll.call(this, _.defaults(options, {
-    plain: true
+    plain: true,
+    kenophobic: false
   }));
 };
 Model.prototype.find = Model.prototype.findOne;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -441,6 +441,13 @@ Sequelize.prototype.ConnectionTimedOutError = Sequelize.ConnectionTimedOutError 
 Sequelize.prototype.InstanceError = Sequelize.InstanceError =
   sequelizeErrors.InstanceError;
 
+/**
+  * Thrown when a record was not found, Usually used with kenophobic mode (see message for details)
+  * @see {Errors#RecordNotFoundError}
+  */
+Sequelize.prototype.EmptyResultError = Sequelize.EmptyResultError =
+  sequelizeErrors.EmptyResultError;
+
 
 Sequelize.prototype.refreshTypes = function () {
   this.connectionManager.refreshTypeParser(DataTypes);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -442,7 +442,7 @@ Sequelize.prototype.InstanceError = Sequelize.InstanceError =
   sequelizeErrors.InstanceError;
 
 /**
-  * Thrown when a record was not found, Usually used with kenophobic mode (see message for details)
+  * Thrown when a record was not found, Usually used with rejectOnEmpty mode (see message for details)
   * @see {Errors#RecordNotFoundError}
   */
 Sequelize.prototype.EmptyResultError = Sequelize.EmptyResultError =

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -936,19 +936,19 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
-    describe('kenophobic mode', function() {
+    describe('rejectOnEmpty mode', function() {
       it('throws error when record not found by findOne', function() {
         return expect(this.User.findOne({
           where: {
             username: 'ath-kantam-pradakshnami'
           },
-          kenophobic: true
+          rejectOnEmpty: true
         })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
 
       it('throws error when record not found by findById', function() {
         return expect(this.User.findById(4732322332323333232344334354234, {
-          kenophobic: true
+          rejectOnEmpty: true
         })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
 
@@ -957,7 +957,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           where: {
             username: 'some-username-that-is-not-used-anywhere'
           },
-          kenophobic: true
+          rejectOnEmpty: true
         })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
 
@@ -965,7 +965,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         var Model = current.define('Test', {
           username: Sequelize.STRING(100)
         },{
-          kenophobic: true
+          rejectOnEmpty: true
         });
 
         return Model.sync({ force: true })

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -944,13 +944,13 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           }
         }, {
           kenophobic: true
-        })).to.eventually.be.rejectedWith(Sequelize.RecordNotFoundError);
+        })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
 
       it('throws error when record not found by findById', function() {
         return expect(this.User.findById(4732322332323333232344334354234, {
           kenophobic: true
-        })).to.eventually.be.rejectedWith(Sequelize.RecordNotFoundError);
+        })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
 
       it('throws error when record not found by find', function() {
@@ -960,7 +960,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           }
         }, {
           kenophobic: true
-        })).to.eventually.be.rejectedWith(Sequelize.RecordNotFoundError);
+        })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
 
     });

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -935,5 +935,35 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         expect(spy.called).to.be.ok;
       });
     });
+
+    describe('kenophobic mode', function() {
+      it('throws error when record not found by findOne', function() {
+        return expect(this.User.findOne({
+          where: {
+            username: 'ath-kantam-pradakshnami'
+          }
+        }, {
+          kenophobic: true
+        })).to.eventually.be.rejectedWith(Sequelize.RecordNotFoundError);
+      });
+
+      it('throws error when record not found by findById', function() {
+        return expect(this.User.findById(4732322332323333232344334354234, {
+          kenophobic: true
+        })).to.eventually.be.rejectedWith(Sequelize.RecordNotFoundError);
+      });
+
+      it('throws error when record not found by find', function() {
+        return expect(this.User.find({
+          where: {
+            username: 'some-username-that-is-not-used-anywhere'
+          }
+        }, {
+          kenophobic: true
+        })).to.eventually.be.rejectedWith(Sequelize.RecordNotFoundError);
+      });
+
+    });
+
   });
 });

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -941,8 +941,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         return expect(this.User.findOne({
           where: {
             username: 'ath-kantam-pradakshnami'
-          }
-        }, {
+          },
           kenophobic: true
         })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
       });
@@ -957,10 +956,41 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         return expect(this.User.find({
           where: {
             username: 'some-username-that-is-not-used-anywhere'
-          }
-        }, {
+          },
           kenophobic: true
         })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+      });
+
+      it('works from model options', function() {
+        var Model = current.define('Test', {
+          username: Sequelize.STRING(100)
+        },{
+          kenophobic: true
+        });
+
+        return Model.sync({ force: true })
+          .then(function() {
+            return expect(Model.findOne({
+              where: {
+                username: 'some-username-that-is-not-used-anywhere'
+              }
+            })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+          });
+      });
+
+      it('resolve null when disabled', function() {
+        var Model = current.define('Test', {
+          username: Sequelize.STRING(100)
+        });
+
+        return Model.sync({ force: true })
+          .then(function() {
+            return expect(Model.findOne({
+              where: {
+                username: 'some-username-that-is-not-used-anywhere-for-sure-this-time'
+              }
+            })).to.eventually.be.equal(null);
+          });
       });
 
     });

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1390,12 +1390,12 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
   });
 
-  describe('kenophobic mode', function() {
+  describe('rejectOnEmpty mode', function() {
     it('works from model options', function() {
       var Model = current.define('Test', {
         username: Sequelize.STRING(100)
       },{
-        kenophobic: true
+        rejectOnEmpty: true
       });
 
       return Model.sync({ force: true })
@@ -1413,7 +1413,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       var Model = current.define('Test', {
         username: Sequelize.STRING(100)
       },{
-        kenophobic: new Sequelize.ConnectionError('Some Error') //using custom error instance
+        rejectOnEmpty: new Sequelize.ConnectionError('Some Error') //using custom error instance
       });
 
       return Model.sync({ force: true })
@@ -1431,7 +1431,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       var Model = current.define('Test', {
         username: Sequelize.STRING(100)
       },{
-        kenophobic: Sequelize.ConnectionError //using custom error instance
+        rejectOnEmpty: Sequelize.ConnectionError //using custom error instance
       });
 
       return Model.sync({ force: true })
@@ -1443,7 +1443,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           })).to.eventually.be.rejectedWith(Sequelize.ConnectionError);
         });
     });
-    
+
   });
 
 });

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1389,4 +1389,61 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       expect(spy.called).to.be.ok;
     });
   });
+
+  describe('kenophobic mode', function() {
+    it('works from model options', function() {
+      var Model = current.define('Test', {
+        username: Sequelize.STRING(100)
+      },{
+        kenophobic: true
+      });
+
+      return Model.sync({ force: true })
+        .then(function() {
+          return expect(Model.findAll({
+            where: {
+              username: 'some-username-that-is-not-used-anywhere'
+            }
+          })).to.eventually.be.rejectedWith(Sequelize.EmptyResultError);
+        });
+    });
+
+    it('throws custom error with initialized', function() {
+
+      var Model = current.define('Test', {
+        username: Sequelize.STRING(100)
+      },{
+        kenophobic: new Sequelize.ConnectionError('Some Error') //using custom error instance
+      });
+
+      return Model.sync({ force: true })
+        .then(function() {
+          return expect(Model.findAll({
+            where: {
+              username: 'some-username-that-is-not-used-anywhere-for-sure-this-time'
+            }
+          })).to.eventually.be.rejectedWith(Sequelize.ConnectionError);
+        });
+    });
+
+    it('throws custom error with instance', function() {
+
+      var Model = current.define('Test', {
+        username: Sequelize.STRING(100)
+      },{
+        kenophobic: Sequelize.ConnectionError //using custom error instance
+      });
+
+      return Model.sync({ force: true })
+        .then(function() {
+          return expect(Model.findAll({
+            where: {
+              username: 'some-username-that-is-not-used-anywhere-for-sure-this-time'
+            }
+          })).to.eventually.be.rejectedWith(Sequelize.ConnectionError);
+        });
+    });
+    
+  });
+
 });


### PR DESCRIPTION
Allow finder methods to throw `RecordNotFound` error when query returns null set and `kenophobic` mode is `true`. This option can be set per method basis or with model options.

Closes #5480 
Closes #272

> Kenophobic means a person with fear of emptiness or void, You can suggest any other name if want to :)