### PR TITLE
feat(promise): add promise extension point

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -17,8 +17,8 @@ function shimCLS(object, functionName, fnArgs){
           }
         }
       }
-      if(global.Sequelize && global.Sequelize.shimmerWap){
-          global.Sequelize.shimmerWap(object, functionName, fnArgs, arguments);
+      if (global.Sequelize && global.Sequelize.shimmerWap) {
+        global.Sequelize.shimmerWap(object, functionName, fnArgs, arguments);
       }
       return fn.apply(this, arguments);
     };

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -17,7 +17,9 @@ function shimCLS(object, functionName, fnArgs){
           }
         }
       }
-
+      if(global.Sequelize && global.Sequelize.shim){
+          global.Sequelize.shim(object, functionName, fnArgs, arguments);
+      }
       return fn.apply(this, arguments);
     };
   });

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -17,8 +17,8 @@ function shimCLS(object, functionName, fnArgs){
           }
         }
       }
-      if(global.Sequelize && global.Sequelize.shim){
-          global.Sequelize.shim(object, functionName, fnArgs, arguments);
+      if(global.Sequelize && global.Sequelize.shimmerWap){
+          global.Sequelize.shimmerWap(object, functionName, fnArgs, arguments);
       }
       return fn.apply(this, arguments);
     };


### PR DESCRIPTION
I'm trying to use sequelize with zone.js to develop trace log feature. But because sequelize uses bluebird's Promise, zone.js doesn't work. 

so I add promise extension point . 

This sample is that I add zone name to sequelize log , using promise extension point.

----
### sample code
```typescript
/// <reference path="typings/sequelize/sequelize" />
/// <reference path="typings/zone.js/zone.js.d.ts" />
/// <reference path="typings/node/node" />

require('zone.js');
import * as sequelize from 'sequelize';

let zoneEnable = true;
if (zoneEnable) {
    global['Sequelize'] = {
        shimmerWap: function(object: any, functionName: string, fnArgs: number[], args: any[]) {
            for (let x = 0; x < fnArgs.length; x++) {
                let argIndex = fnArgs[x] < 0 ? args.length + fnArgs[x] : fnArgs[x];
                if (argIndex < args.length && typeof args[argIndex] === 'function') {
                    args[argIndex] = Zone.current.wrap(args[argIndex], functionName);
                }
            }
        }
    };
}

function zone_log(messages: string) {
    console.log(`[${Zone.current.name}]`, messages);
}

let db = new sequelize('sample', 'username', 'password', {
    dialect: 'sqlite',
    storage: 'database.sqlite',
    logging: function(message: string) {
        zone_log(message);
    }
});

let User = db.define('User', {
    name: sequelize.STRING
});

execute();
async function execute() {
    await Zone.current.fork({
        name: 'zone-init'
    }).run(async () => {
        zone_log('init');
        await db.transaction(async (t) => {
            zone_log('sync');
            await User.sync({ force: true });
        });
    });

    await Zone.current.fork({
        name: 'zone-invoke'
    }).run(async () => {
        zone_log('invoke');
        await db.transaction(async (t) => {
            await User.create({ name: 'kodo' });
            let users = await User.findAll();
            zone_log('users' + JSON.stringify(users));

        });
    });

}
```

### log
```
[zone-init] init
[zone-init] Executing (5c03a1e6-ff93-4ffb-a45d-ea1ff38d8f87): BEGIN DEFERRED TRANSACTION;
[zone-init] Executing (5c03a1e6-ff93-4ffb-a45d-ea1ff38d8f87): -- SQLite is not able to choose the isolation level REPEATABLE READ.
[zone-init] Executing (5c03a1e6-ff93-4ffb-a45d-ea1ff38d8f87): -- SQLite does not support SET autocommit.
[zone-init] sync
[zone-init] Executing (default): DROP TABLE IF EXISTS `Users`;
[zone-init] Executing (default): CREATE TABLE IF NOT EXISTS `Users` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255), `createdAt` DATETIME NOT NULL, `updatedAt` DATETIME NOT NULL);
[zone-init] Executing (default): PRAGMA INDEX_LIST(`Users`)
[zone-init] Executing (5c03a1e6-ff93-4ffb-a45d-ea1ff38d8f87): COMMIT;
[zone-invoke] invoke
[zone-invoke] Executing (a025148f-7a50-40f9-813a-da507cbf3193): BEGIN DEFERRED TRANSACTION;
[zone-invoke] Executing (a025148f-7a50-40f9-813a-da507cbf3193): -- SQLite is not able to choose the isolation level REPEATABLE READ.
[zone-invoke] Executing (a025148f-7a50-40f9-813a-da507cbf3193): -- SQLite does not support SET autocommit.
[zone-invoke] Executing (default): INSERT INTO `Users` (`id`,`name`,`createdAt`,`updatedAt`) VALUES (NULL,'kodo','2016-03-06 08:21:02.493 +00:00','2016-03-06 08:21:02.493 +00:00');
[zone-invoke] Executing (default): SELECT `id`, `name`, `createdAt`, `updatedAt` FROM `Users` AS `User`;
[zone-invoke] users[{"id":1,"name":"kodo","createdAt":"2016-03-06T08:21:02.493Z","updatedAt":"2016-03-06T08:21:02.493Z"}]
[zone-invoke] Executing (a025148f-7a50-40f9-813a-da507cbf3193): COMMIT;

```
