### PR TITLE
Bugfix for postgres adapter when nested transactions are used with quoteIdentifiers disabled

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1697,7 +1697,8 @@ var QueryGenerator = {
    */
   startTransactionQuery: function(transaction) {
     if (transaction.parent) {
-      return 'SAVEPOINT ' + this.quoteIdentifier(transaction.name) + ';';
+      // force quoting of savepoint identifiers for postgres
+      return 'SAVEPOINT ' + this.quoteIdentifier(transaction.name, true) + ';';
     }
 
     return 'START TRANSACTION;';
@@ -1739,7 +1740,8 @@ var QueryGenerator = {
    */
   rollbackTransactionQuery: function(transaction) {
     if (transaction.parent) {
-      return 'ROLLBACK TO SAVEPOINT ' + this.quoteIdentifier(transaction.name) + ';';
+      // force quoting of savepoint identifiers for postgres
+      return 'ROLLBACK TO SAVEPOINT ' + this.quoteIdentifier(transaction.name, true) + ';';
     }
 
     return 'ROLLBACK;';

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -884,7 +884,6 @@ var QueryGenerator = {
 
     return AbstractQueryGenerator.setAutocommitQuery.call(this, value, options);
   }
-
 };
 
 module.exports = Utils._.extend(Utils._.clone(AbstractQueryGenerator), QueryGenerator);

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -883,7 +883,26 @@ var QueryGenerator = {
     }
 
     return AbstractQueryGenerator.setAutocommitQuery.call(this, value, options);
+  },
+
+  startTransactionQuery: function(transaction) {
+    if (transaction.parent) {
+      // force quoting of savepoint identifiers for postgres
+      return 'SAVEPOINT ' + this.quoteIdentifier(transaction.name, true) + ';';
+    }
+
+    return 'START TRANSACTION;';
+  },
+
+  rollbackTransactionQuery: function(transaction) {
+    if (transaction.parent) {
+      // force quoting of savepoint identifiers for postgres
+      return 'ROLLBACK TO SAVEPOINT ' + this.quoteIdentifier(transaction.name, true) + ';';
+    }
+
+    return 'ROLLBACK;';
   }
+
 };
 
 module.exports = Utils._.extend(Utils._.clone(AbstractQueryGenerator), QueryGenerator);

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -883,24 +883,6 @@ var QueryGenerator = {
     }
 
     return AbstractQueryGenerator.setAutocommitQuery.call(this, value, options);
-  },
-
-  startTransactionQuery: function(transaction) {
-    if (transaction.parent) {
-      // force quoting of savepoint identifiers for postgres
-      return 'SAVEPOINT ' + this.quoteIdentifier(transaction.name, true) + ';';
-    }
-
-    return 'START TRANSACTION;';
-  },
-
-  rollbackTransactionQuery: function(transaction) {
-    if (transaction.parent) {
-      // force quoting of savepoint identifiers for postgres
-      return 'ROLLBACK TO SAVEPOINT ' + this.quoteIdentifier(transaction.name, true) + ';';
-    }
-
-    return 'ROLLBACK;';
   }
 
 };

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -852,6 +852,42 @@ if (dialect.match(/^postgres/)) {
           expectation: 'DROP INDEX IF EXISTS mySchema.user_foo_bar',
           context: {options: {quoteIdentifiers: false}}
         }
+      ],
+
+      startTransactionQuery: [
+        {
+          arguments: [{}],
+          expectation: 'START TRANSACTION;',
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{parent: 'MockTransaction', name: 'transaction-uid'}],
+          expectation: 'SAVEPOINT \"transaction-uid\";',
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{parent: 'MockTransaction', name: 'transaction-uid'}],
+          expectation: 'SAVEPOINT \"transaction-uid\";',
+          context: {options: {quoteIdentifiers: true}}
+        }
+      ],
+
+      rollbackTransactionQuery: [
+        {
+          arguments: [{}],
+          expectation: 'ROLLBACK;',
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{parent: 'MockTransaction', name: 'transaction-uid'}],
+          expectation: 'ROLLBACK TO SAVEPOINT \"transaction-uid\";',
+          context: {options: {quoteIdentifiers: false}}
+        },
+        {
+          arguments: [{parent: 'MockTransaction', name: 'transaction-uid'}],
+          expectation: 'ROLLBACK TO SAVEPOINT \"transaction-uid\";',
+          context: {options: {quoteIdentifiers: true}}
+        }
       ]
     };
 


### PR DESCRIPTION
There is a bug in the postgres adapter when nested transactions are used in conjunction with the 'quoteIdentifiers' option set to false. The savepoint identifiers generated by sequelize contain special characters which require the identifier to be always quoted. However, if the 'quoteIdentifiers' option is set to false all identifiers in postgres are unquoted.
I added a bug fix that forces the quoting of savepoint identifiers while all other identifiers are still quoted/unquoted according to the configuration.

