### PR TITLE
Use model.primaryKeyField for HasMany.count column

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -342,7 +342,7 @@ HasMany.prototype.count = function(instance, options) {
 
   options = association.target.__optClone(options) || {};
   options.attributes = [
-    [sequelize.fn('COUNT', sequelize.col(model.primaryKeyAttribute)), 'count']
+    [sequelize.fn('COUNT', sequelize.col(model.primaryKeyField)), 'count']
   ];
   options.raw = true;
   options.plain = true;


### PR DESCRIPTION
In `HasMany.count()`, replaces SQL call `COUNT(model.primaryKeyName)` with `primaryKeyField` as is used in `Model.count()`. This fixes an error when doing a count() on an association with "id" primary key attribute mapped to a field name other than "id"