### PR TITLE
Ignore model-level validation when creating through table using string

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -161,7 +161,8 @@ var BelongsToMany = function(source, target, options) {
       this.through.model = this.sequelize.define(this.through.model, {}, _.extend(this.options, {
         tableName: this.through.model,
         indexes: {}, //we dont want indexes here (as referenced in #2416)
-        paranoid: false  // A paranoid join table does not make sense
+        paranoid: false,  // A paranoid join table does not make sense
+        validate: {} // Don't propagate model-level validations
       }));
     } else {
       this.through.model = this.sequelize.model(this.through.model);

--- a/test/unit/associations/belongs-to-many.test.js
+++ b/test/unit/associations/belongs-to-many.test.js
@@ -40,6 +40,24 @@ describe(Support.getTestDialectTeaser('belongsToMany'), function() {
     expect(AB.options.scopes).to.have.length(0);
   });
 
+  it('should not inherit validations from parent to join table', function () {
+    var A = current.define('a')
+      , B = current.define('b', {}, {
+        validate: {
+          validateModel: function () {
+            return true;
+          }
+        }
+      })
+      , AB;
+
+    B.belongsToMany(A, { through: 'AB' });
+
+    AB = current.model('AB');
+
+    expect(AB.options.validate).to.deep.equal({});
+  });
+
   describe('timestamps', function () {
     it('follows the global timestamps true option', function () {
       var User = current.define('User', {})


### PR DESCRIPTION
Sequelize 3.19.3, Ubuntu Linux (64-bit) 15.10, Node.js 4.3.2 (LTS).

When declaring a join table with the through option declared as a string, Sequelize creates the through model at runtime, and copies the model validation rules from the source table into the through model. More often than not, the model validation rules from the source table would be inappropriate/undesirable for the join table (since their data fields are different anyway).

It's also worth noting that if a through model is given, this behavior is not exhibited.

Through table as string:

```javascript
'use strict';
let Promise = require('bluebird');
let Sequelize = require('sequelize');
let sequelize = new Sequelize('database', 'username', 'password', {
  host: 'localhost',
  dialect: 'postgres'
});

let Job = sequelize.define('Job', {
  title: Sequelize.STRING
}, {
  validate: {
    validateModel: function () {
      console.log(this);
    }
  }
});

let Site = sequelize.define('Site', {
  name: Sequelize.STRING
});

Job.belongsToMany(Site, { through: 'SiteJobs' });
Site.belongsToMany(Job, { through: 'SiteJobs' });

sequelize.sync()
  .then(function () {
    return Promise.all([
      Job.build({ title: 'Test Job' }).save(),
      Site.build({ name: 'Test Site' }).save()
    ]);
  })
  .then(function (result) {
    return result[0].setSites([ result[1] ]);
  })
  .then(function () {
    console.log('Done');	
  });
```

The example above outputs the SiteJob instance, followed by 'Done'.

Through table as model:
```javascript
'use strict';
let Promise = require('bluebird');
let Sequelize = require('sequelize');
let sequelize = new Sequelize('database', 'username', 'password', {
  host: 'localhost',
  dialect: 'postgres'
});

let Job = sequelize.define('Job', {
  title: Sequelize.STRING
}, {
  validate: {
    validateModel: function () {
      console.log(this);
    }
  }
});

let Site = sequelize.define('Site', {
  name: Sequelize.STRING
});

let SiteJob = sequelize.define('SiteJob');

Job.belongsToMany(Site, { through: SiteJob });
Site.belongsToMany(Job, { through: SiteJob });

sequelize.sync()
  .then(function () {
    return Promise.all([
      Job.build({ title: 'Test Job' }).save(),
      Site.build({ name: 'Test Site' }).save()
    ]);
  })
  .then(function (result) {
    return result[0].setSites([ result[1] ]);
  })
  .then(function () {
    console.log('Done');	
  });
```

The example above outputs only 'Done'.

This PR fixes this issue by overriding the `validate` option by an empty object.