### PR TITLE
Added Sequelize.DATE(6) (MySQL) to docs

### DIFF
--- a/docs/docs/models-definition.md
+++ b/docs/docs/models-definition.md
@@ -107,6 +107,7 @@ Sequelize.DECIMAL                     // DECIMAL
 Sequelize.DECIMAL(10, 2)              // DECIMAL(10,2)
 
 Sequelize.DATE                        // DATETIME for mysql / sqlite, TIMESTAMP WITH TIME ZONE for postgres
+Sequelize.DATE(6)                     // DATETIME(6) for mysql 5.6.4+. Fractional seconds support with up to 6 digits of precision 
 Sequelize.DATEONLY                    // DATE without time.
 Sequelize.BOOLEAN                     // TINYINT(1)
 


### PR DESCRIPTION
Way late documentation update for MySQL fractional DATETIME support.