### PR TITLE
utcOffset fix

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -7,7 +7,8 @@ var util = require('util')
   , sequelizeErrors = require('./errors')
   , warnings = {}
   , Validator = require('validator')
-  , moment = require('moment-timezone');
+  , momentTz = require('moment-timezone')
+  , moment = require('moment');
 
 /**
  * A convenience class holding commonly used data types. The datatypes are used when defining a new model using `Sequelize.define`, like this:
@@ -463,14 +464,14 @@ DATE.prototype.validate = function(value) {
 };
 
 DATE.prototype.$applyTimezone = function (date, options) {
-  date = moment(date);
-
   if (options.timezone) {
-    if (moment.tz.zone(options.timezone)) {
-      date = date.tz(options.timezone);
+    if (momentTz.tz.zone(options.timezone)) {
+      date = momentTz(date).tz(options.timezone);
     } else {
-      date = date.utcOffset(options.timezone);
+      date = moment(date).utcOffset(options.timezone);
     }
+  } else {
+    date = momentTz(date);
   }
 
   return date;


### PR DESCRIPTION
Fix for #5547. The package `moment-timezone` doesn't have a `utcOffset` method while the package `moment` does. It was probably just assumed that `moment-timezone` would have the `utcOffset` method. 