### PR TITLE
Cast value as string to pass new Validator.js string requirement

### DIFF
--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -254,12 +254,14 @@ InstanceValidator.prototype._invokeCustomValidator = Promise.method(function(val
  */
 InstanceValidator.prototype._invokeBuiltinValidator = Promise.method(function(value, test, validatorType, field) {
   var self = this;
+  // Cast value as string to pass new Validator.js string requirement
+  var valueString = String(value);
   // check if Validator knows that kind of validation test
   if (typeof validator[validatorType] !== 'function') {
     throw new Error('Invalid validator function: ' + validatorType);
   }
   var validatorArgs = self._extractValidatorArgs(test, validatorType, field);
-  if (!validator[validatorType].apply(validator, [value].concat(validatorArgs))) {
+  if (!validator[validatorType].apply(validator, [valueString].concat(validatorArgs))) {
   // extract the error msg
     throw new Error(test.msg || 'Validation ' + validatorType + ' failed');
   }


### PR DESCRIPTION
Long time user, first time PR-er :)

Trying to see if #5356 can be fixed by casting all values as `String()` in instance-validator before running validator function on them. My use cases for Sequelize are sort of limited so I'm not sure how well this will work, but let's let CI tell us!