### PR TITLE
Docs: Update links to Bluebird API docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ We're glad to get pull request if any functionality is missing or something is b
 * Explain the issue that your PR is solving - or link to an existing issue
 * Make sure that all existing tests pass
 * Add some tests for your new functionality or a test exhibiting the bug you are solving. Ideally all new tests should not pass _without_ your changes.
-  - Use [promise style](https://github.com/petkaantonov/bluebird#what-are-promises-and-why-should-i-use-them) in all new tests. Specifically this means:
+  - Use [promise style](http://bluebirdjs.com/docs/why-promises.html) in all new tests. Specifically this means:
     - don't use `EventEmitter`, `QueryChainer` or the `success`, `done` and `error` events
-    - don't use nested callbacks (use [Promise.bind](https://github.com/petkaantonov/bluebird/blob/master/API.md#binddynamic-thisarg---promise) to maintain context in promise chains)
+    - don't use nested callbacks (use [Promise.bind](http://bluebirdjs.com/docs/api/promise.bind.html) to maintain context in promise chains)
     - don't use a done callback in your test, just return the promise chain.
   - Small bugfixes and direct backports to the 1.7 branch are accepted without tests.
 * If you are adding to / changing the public API, remember to add API docs, in the form of [JSDoc style](http://usejsdoc.org/about-getting-started.html) comments. See [section 4a](#4a-check-the-documentation  ) for the specifics.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -83,7 +83,7 @@ var Post = sequelize.define('post', {}, {
 ```
 
 ## Promises
-Sequelize uses promises to control async control-flow. If you are unfamiliar with how promises work, now might be a good time to brush up on them, [here](https://github.com/wbinnssmith/awesome-promises) and [here](https://github.com/petkaantonov/bluebird#what-are-promises-and-why-should-i-use-them)
+Sequelize uses promises to control async control-flow. If you are unfamiliar with how promises work, now might be a good time to brush up on them, [here](https://github.com/wbinnssmith/awesome-promises) and [here](http://bluebirdjs.com/docs/why-promises.html)
 
 Basically a promise represents a value which will be present at some point - "I promise you I will give you a result or an error at some point". This means that
 
@@ -102,4 +102,4 @@ User.findOne().then(function (user) {
 });
 ```
 
-Once you've got the hang of what promises are and how they work, use the [bluebird API reference](https://github.com/petkaantonov/bluebird/blob/master/API.md) as your go to tool. In particular, you'll probably be using [`.all`](https://github.com/petkaantonov/bluebird/blob/master/API.md#all---promise) a lot.  
+Once you've got the hang of what promises are and how they work, use the [bluebird API reference](http://bluebirdjs.com/docs/api-reference.html) as your go to tool. In particular, you'll probably be using [`.all`](http://bluebirdjs.com/docs/api/promise.all.html) a lot.  

--- a/docs/docs/models-definition.md
+++ b/docs/docs/models-definition.md
@@ -664,4 +664,4 @@ sequelize.define('user', {}, {
 [0]: #configuration
 [3]: https://github.com/chriso/validator.js
 [5]: /docs/latest/misc#asynchronicity
-[6]: https://github.com/petkaantonov/bluebird/blob/master/API.md#spreadfunction-fulfilledhandler--function-rejectedhandler----promise
+[6]: http://bluebirdjs.com/docs/api/spread.html


### PR DESCRIPTION
In October 2015 Bluebird moved their documentation to its own domain (see commit https://github.com/petkaantonov/bluebird/commit/94fd4fe67f4a60d0fbf102c7a5c8ed8fdb230310#diff-88333ba11114e014e87198d04680144d)

These changes update the Bluebird links in the Sequelize docs to point to their new locations.