### PR TITLE
Fix limit=0 

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1754,10 +1754,13 @@ var QueryGenerator = {
    */
   addLimitAndOffset: function(options, model) {
     var fragment = '';
-    if (options.offset && !options.limit) {
+    var limitExist = typeof options.limit !== "undefined" && options.limit !== null;
+    var offsetExit = typeof options.offset !== "undefined" && options.offset !== null;
+
+    if (offsetExit && !limitExist) {
       fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + 10000000000000;
-    } else if (options.limit) {
-      if (options.offset) {
+    } else if (limitExist) {
+      if (offsetExit) {
         fragment += ' LIMIT ' + this.escape(options.offset) + ', ' + this.escape(options.limit);
       } else {
         fragment += ' LIMIT ' + this.escape(options.limit);

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -417,8 +417,13 @@ var QueryGenerator = {
 
   addLimitAndOffset: function(options) {
     var fragment = '';
-    if (options.limit) fragment += ' LIMIT ' + this.escape(options.limit);
-    if (options.offset) fragment += ' OFFSET ' + this.escape(options.offset);
+
+    if (typeof options.limit !== "undefined" && options.limit !== null) {
+      fragment += ' LIMIT ' + this.escape(options.limit);
+    }
+    if ( typeof options.limit !== "undefined" && options.limit !== null) {
+       fragment += ' OFFSET ' + this.escape(options.offset);
+    }
 
     return fragment;
   },

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -340,9 +340,9 @@ if (Support.dialectIsMySQL()) {
           expectation: 'SELECT * FROM `myTable` LIMIT 0;',
           context: QueryGenerator
         }, {
-         title: "uses limit '0'",
+         title: 'uses limit \'0\'',
          arguments: ['myTable', {limit: '0'}],
-         expectation: "SELECT * FROM `myTable` LIMIT '0';",
+         expectation: 'SELECT * FROM `myTable` LIMIT \'0\';',
          context: QueryGenerator
        },{
          title: 'uses offset 0',
@@ -350,9 +350,9 @@ if (Support.dialectIsMySQL()) {
          expectation: 'SELECT * FROM `myTable` LIMIT 0, 10000000000000;',
          context: QueryGenerator
        }, {
-        title: "uses offset '0'",
+        title: 'uses offset \'0\'',
         arguments: ['myTable', {offset: '0'}],
-        expectation: "SELECT * FROM `myTable` LIMIT '0', 10000000000000;",
+        expectation: 'SELECT * FROM `myTable` LIMIT \'0\', 10000000000000;',
         context: QueryGenerator
       }, {
           title: 'multiple where arguments',

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -335,6 +335,26 @@ if (Support.dialectIsMySQL()) {
           expectation: 'SELECT * FROM `myTable` LIMIT 2, 10000000000000;',
           context: QueryGenerator
         }, {
+          title: 'uses limit 0',
+          arguments: ['myTable', {limit: 0}],
+          expectation: 'SELECT * FROM `myTable` LIMIT 0;',
+          context: QueryGenerator
+        }, {
+         title: "uses limit '0'",
+         arguments: ['myTable', {limit: '0'}],
+         expectation: "SELECT * FROM `myTable` LIMIT '0';",
+         context: QueryGenerator
+       },{
+         title: 'uses offset 0',
+         arguments: ['myTable', {offset: 0}],
+         expectation: 'SELECT * FROM `myTable` LIMIT 0, 10000000000000;',
+         context: QueryGenerator
+       }, {
+        title: "uses offset '0'",
+        arguments: ['myTable', {offset: '0'}],
+        expectation: "SELECT * FROM `myTable` LIMIT '0', 10000000000000;",
+        context: QueryGenerator
+      }, {
           title: 'multiple where arguments',
           arguments: ['myTable', {where: {boat: 'canoe', weather: 'cold'}}],
           expectation: "SELECT * FROM `myTable` WHERE `myTable`.`boat` = 'canoe' AND `myTable`.`weather` = 'cold';",

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -291,7 +291,27 @@ if (dialect.match(/^postgres/)) {
           expectation: 'SELECT * FROM "myTable" AS "myTable" ORDER BY "myTable"."id" DESC;',
           context: QueryGenerator,
           needsSequelize: true
+        },{
+          title: 'uses limit 0',
+          arguments: ['myTable', {limit: 0}],
+          expectation: 'SELECT * FROM `myTable` LIMIT 0;',
+          context: QueryGenerator
         }, {
+         title: "uses limit '0'",
+         arguments: ['myTable', {limit: '0'}],
+         expectation: "SELECT * FROM `myTable` LIMIT '0';",
+         context: QueryGenerator
+       },{
+         title: 'uses offset 0',
+         arguments: ['myTable', {offset: 0}],
+         expectation: 'SELECT * FROM `myTable` LIMIT 0, 10000000000000;',
+         context: QueryGenerator
+       }, {
+        title: "uses offset '0'",
+        arguments: ['myTable', {offset: '0'}],
+        expectation: "SELECT * FROM `myTable` LIMIT '0', 10000000000000;",
+        context: QueryGenerator
+      },{
          title: 'raw arguments are neither quoted nor escaped',
           arguments: ['myTable', {order: [[{raw: 'f1(f2(id))'},'DESC']]}],
           expectation: 'SELECT * FROM "myTable" ORDER BY f1(f2(id)) DESC;',

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -297,9 +297,9 @@ if (dialect.match(/^postgres/)) {
           expectation: 'SELECT * FROM `myTable` LIMIT 0;',
           context: QueryGenerator
         }, {
-         title: "uses limit '0'",
+         title: 'uses limit \'0\'',
          arguments: ['myTable', {limit: '0'}],
-         expectation: "SELECT * FROM `myTable` LIMIT '0';",
+         expectation: 'SELECT * FROM `myTable` LIMIT \'0\';',
          context: QueryGenerator
        },{
          title: 'uses offset 0',
@@ -307,9 +307,9 @@ if (dialect.match(/^postgres/)) {
          expectation: 'SELECT * FROM `myTable` LIMIT 0, 10000000000000;',
          context: QueryGenerator
        }, {
-        title: "uses offset '0'",
+        title: 'uses offset \'0\'',
         arguments: ['myTable', {offset: '0'}],
-        expectation: "SELECT * FROM `myTable` LIMIT '0', 10000000000000;",
+        expectation: 'SELECT * FROM `myTable` LIMIT \'0\', 10000000000000;',
         context: QueryGenerator
       },{
          title: 'raw arguments are neither quoted nor escaped',


### PR DESCRIPTION
This PR should fix the issue https://github.com/sequelize/sequelize/issues/3914.
When `option.limit` was set to `0` it was considered as limit isn't  set at all. This PR changes those checks to check for the existence of the limit option.  