### PR TITLE
use IS NULL if value is undefined

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2219,9 +2219,9 @@ var QueryGenerator = {
         }.bind(this));
       }
 
-      if (comparator === '=' && value === null) {
+      if (comparator === '=' && (value === null || value === undefined)) {
         comparator = 'IS';
-      } else if (comparator === '!=' && value === null) {
+      } else if (comparator === '!=' && (value === null || value === undefined)) {
         comparator = 'IS NOT';
       }
 

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -91,6 +91,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       mssql: '[deleted] IS NULL'
     });
 
+    testsql('deleted', undefined, {
+      default: '`deleted` IS NULL',
+      postgres: '"deleted" IS NULL',
+      mssql: '[deleted] IS NULL'
+    });
+
     suite('$in', function () {
       testsql('equipment', {
         $in: [1, 3]


### PR DESCRIPTION
This PR fixes the issue discussed in #4851

We were bitten by this bug when we are doing 

`
Person.findAll({
  where: {
    firstName: undefined
  }
})
`

The resulting query is 

`SELECT "id", "first_name" AS "firstName", "last_name" AS "lastName" FROM "person" AS "person" WHERE "person"."first_name" = NULL;`

which is wrong according to postgres, mysql and mssql docs:

http://www.postgresql.org/docs/9.1/static/functions-comparison.html
http://dev.mysql.com/doc/refman/5.7/en/working-with-null.html
https://msdn.microsoft.com/en-us/library/ms188795.aspx

Postgres:
`Do not write expression = NULL because NULL is not "equal to" NULL. (The null value represents an unknown value, and it is not known whether two unknown values are equal.) This behavior conforms to the SQL standard.`

MySQL:
`To test for NULL, use the IS NULL and IS NOT NULL operators, as shown here:`

This fix changes the query so that passing an `undefined` or `null` in the where clause would use the `IS/IS NOT` syntax

`SELECT "id", "first_name" AS "firstName", "last_name" AS "lastName" FROM "person" AS "person" WHERE "person"."first_name" IS NULL;`
