### PR TITLE
fix setter for instances with raw option

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -582,7 +582,7 @@ BelongsToMany.prototype.injectSetter = function(obj) {
         if (!newObj) {
           obsoleteAssociations.push(currentRow);
         } else {
-          var throughAttributes = newObj[association.through.model.name];
+          var throughAttributes = newObj.get(association.through.model.name);
           // Quick-fix for subtle bug when using existing objects that might have the through model attached (not as an attribute object)
           if (throughAttributes instanceof association.through.model.Instance) {
             throughAttributes = {};
@@ -621,7 +621,7 @@ BelongsToMany.prototype.injectSetter = function(obj) {
           attributes[identifier] = instance.get(sourceKey);
           attributes[foreignIdentifier] = unassociatedObject.get(targetKey);
 
-          attributes = _.defaults(attributes, unassociatedObject[association.through.model.name], defaultAttributes);
+          attributes = _.defaults(attributes, unassociatedObject.get(association.through.model.name), defaultAttributes);
 
           _.assign(attributes, association.through.scope);
 
@@ -672,7 +672,7 @@ BelongsToMany.prototype.injectSetter = function(obj) {
         if (!existingAssociation) {
           unassociatedObjects.push(obj);
         } else {
-          var throughAttributes = obj[association.through.model.name]
+          var throughAttributes = obj.get(association.through.model.name)
             , attributes = _.defaults({}, throughAttributes, defaultAttributes);
 
           if (_.some(Object.keys(attributes), function (attribute) {
@@ -685,7 +685,7 @@ BelongsToMany.prototype.injectSetter = function(obj) {
 
       if (unassociatedObjects.length > 0) {
         var bulk = unassociatedObjects.map(function(unassociatedObject) {
-          var throughAttributes = unassociatedObject[association.through.model.name]
+          var throughAttributes = unassociatedObject.get(association.through.model.name)
             , attributes = _.defaults({}, throughAttributes, defaultAttributes);
 
           attributes[identifier] = instance.get(sourceKey);
@@ -700,7 +700,7 @@ BelongsToMany.prototype.injectSetter = function(obj) {
       }
 
       changedAssociations.forEach(function(assoc) {
-        var throughAttributes = assoc[association.through.model.name]
+        var throughAttributes = assoc.get(association.through.model.name)
           , attributes = _.defaults({}, throughAttributes, defaultAttributes)
           , where = {};
         // Quick-fix for subtle bug when using existing objects that might have the through model attached (not as an attribute object)


### PR DESCRIPTION
This fix allows you to send constructed instance from raw data in setAccociation () method. This avoids the silly, unnecessary models relations.

Example:

```js
var Products = db.define('Products', {
 name: {type: DataTypes.STRING, allowNull: false},
 description: {type: DataTypes.TEXT, allowNull: true}
});

var ProductFeatures = db.define('ProductFeatures', {
 name: {type: DataTypes.STRING, allowNull: false},
 type: {type: DataTypes.STRING, allowNull: false}
});

var ProductsToFeatures = db.define('ProductsToFeatures', {
 featureId: {type: DataTypes.INTEGER, allowNull: false},
 productId: {type: DataTypes.INTEGER, allowNull: false},
 value: {type: DataTypes.STRING, allowNull: false}
});

Products.BelongsToMany(ProductFeatures, {through: ProductsToFeatures, foreignKey: 'productId', otherKey: 'featureId'});

Products.findById(1).then(function (product) {
 var features = [];
 features.push(ProductFeatures.build({
   id: 3,
   ProductsToFeatures: {
      value: 112
   }
 }, {raw: true, isNewRecord: false }));

 // Set features from raw data with additional fields
 product.setFeatures(features).then(function (features) {
 
 });
});
```