### PR TITLE
Model.destroy: add model to options

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2320,6 +2320,7 @@ Model.prototype.destroy = function(options) {
   this.$injectScope(options);
 
   Utils.mapOptionFieldNames(options, this);
+  options.model = self;
 
   return Promise.try(function() {
     // Run before hook


### PR DESCRIPTION
This gets added in BulkCreate but not destroy. I need to figure out the model when using a global BulkDelete hook.