### PR TITLE
Performance improvement for #3414

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -311,7 +311,7 @@ var optClone = Model.prototype.__optClone = Model.prototype.$optClone = function
   options = options || {};
   return Utils.cloneDeep(options, function(elem) {
     // The InstanceFactories used for include are pass by ref, so don't clone them.
-    if (elem &&
+    if (elem && typeof elem === 'object' &&
       (
         elem._isSequelizeMethod ||
         elem instanceof Model ||


### PR DESCRIPTION
After studying #3414 and its performance test suite I tracked back the performance degradation causes. It appears to be these reasons

* Generic performance hit due to Promises (we cant do much about it ?)
* `optClone` method (consumes `300+ ms` for 1501 array elements in `findAll`)
* Hitting the database (450 - 550 ms)
* Other JS execution

I was able to improve the performance by adding a small fix to `optClone` method. These are the results

| Elements / Exec. Count | Fix Applied  | Total Time (ms) | Node | Sequelize |
|---|---|---|---|---|
| 1501 / 5000 | No | 11557 | 0.12 | 1.7.0 |
| 1501 / 5000 | No | 11403 | 0.12 | 1.7.0 |
| 1501 / 5000 | No | 13173 | 0.12 | 2.0.0 |
| 1501 / 5000 | No | 13210 | 0.12 | 2.0.0 |
| 1501 / 5000 | **No** | **16447** | 0.12 | 3.20 |
| 1501 / 5000 | **No** | **17447** | 0.12 | 3.20 |
| 1501 / 5000 | **Yes** | **15707** | 0.12 | 3.20 |
| 1501 / 5000 | **Yes** | **16024** | 0.12 | 3.20 |

It improves the performance a bit. Its certainly not in line with `1.7.0` which is fastest of all these but considering Promise overhead and other new feature may be we can now close #3414