### PR TITLE
model/as check on $injectScope

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2707,11 +2707,13 @@ Model.prototype.$injectScope = function (options) {
     // This is used if several scopes specify the same include - the last scope should take precedence
     scope.include.reverse().forEach(function (scopeInclude) {
       if (scopeInclude.all || !options.include.some(function matchesModelAndAlias(item) {
-        var isSameModel = item.model && item.model.name === scopeInclude.model.name;
-        if (!isSameModel || !item.as) return isSameModel;
+        if(scopeInclude.model) {
+          var isSameModel = item.model && item.model.name === scopeInclude.model.name;
+          if (!isSameModel || !item.as) return isSameModel;
 
-        if (scopeInclude.as) {
-          return item.as === scopeInclude.as;
+          if (scopeInclude.as) {
+            return item.as === scopeInclude.as;
+          }
         } else {
           var association = scopeInclude.association || self.getAssociation(scopeInclude.model, scopeInclude.as);
           return association ? item.as === association.as : false;


### PR DESCRIPTION
- Ensure scope include uses model/as format instead of association before performing same-model test

https://github.com/sequelize/sequelize/issues/5639