### PR TITLE
Use transaction when creating index

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1020,7 +1020,12 @@ Model.prototype.sync = function(options) {
     });
 
     return Promise.map(indexes, function (index) {
-      return self.QueryInterface.addIndex(self.getTableName(options), _.assign({logging: options.logging, benchmark: options.benchmark}, index), self.tableName);
+      return self.QueryInterface.addIndex(
+                self.getTableName(options),
+                _.assign({logging: options.logging,
+                          benchmark: options.benchmark,
+                          transaction: options.transaction}, index),
+                self.tableName);
     });
   }).then(function () {
     if (options.hooks) {


### PR DESCRIPTION
Creating a table under a transaction fails if the table has indexes on it. This is because the index is created outside of the transaction, and the table is invisible outside the transaction.