### PR TITLE
Fix defaultValues getting overwritten on build

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Fix defaultValues getting overwritten on build
+
 # 3.21.0
 - [FIXED] Confirmed that values modified in validation hooks are preserved [#3534](https://github.com/sequelize/sequelize/issues/3534)
 - [FIXED] Support lower case type names in SQLite [#5482](https://github.com/sequelize/sequelize/issues/5482)

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -22,10 +22,9 @@ var initValues = function(values, options) {
     defaults = {};
 
     if (this.Model._hasDefaultValues) {
-      Utils._.each(this.Model._defaultValues, function(valueFn, key) {
-        if (defaults[key] === undefined) {
-          defaults[key] = valueFn();
-        }
+      defaults = _.mapValues(this.Model._defaultValues, function(valueFn) {
+        var value = valueFn();
+        return (value && value._isSequelizeMethod) ? value : _.cloneDeep(value);
       });
     }
 

--- a/test/unit/instance/build.test.js
+++ b/test/unit/instance/build.test.js
@@ -94,5 +94,21 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       expect(instance.get('number2')).not.to.be.undefined;
       expect(instance.get('number2')).to.equal(2);
     });
+
+    it('should clone the default values', function () {
+      var Model = current.define('Model', {
+        data: {
+          type: DataTypes.JSONB,
+          defaultValue: { foo: 'bar' }
+        }
+      })
+        , instance;
+
+      instance = Model.build();
+      instance.data.foo = 'biz';
+
+      expect(instance.get('data')).to.eql({ foo: 'biz' });
+      expect(Model.build().get('data')).to.eql({ foo: 'bar' });
+    });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Creating new model instances in sequelize has an odd behaviour whereby their default values aren't cloned and are therefore shared mutable state between all instances of a class. This means that if we change one if its attributes in one model instance, it gets changed to all other instances as well. Example:

```js
// For a `Model` model with the attribute `data` with `defaultValue` set to `{ foo: 'bar' }`:
var model1 = db.Model.build();
model1.data.foo; // 'bar'
model1.data.foo = 'biz';
model1.data.foo; // 'biz'

var model2 = db.Model.build();
model2.data.foo; // 'biz'
```

The proposed fix applies a deep clone to the objects that are defined as `defaultValue`. This also addresses the edge case of sequelize methods as default values which, due to their nature, aren't meant to be cloned.