### PR TITLE
Include with OR in outer WHERE

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1374,6 +1374,10 @@ var QueryGenerator = {
           joinQueries.mainQuery.push(joinQueryItem);
         }
 
+        if (include.joinInSubQuery && subQuery) {
+          joinQueries.subQuery.push(joinQueryItem);
+        }
+
         if (include.include) {
           include.include.filter(function (include) {
             return !include.separate;


### PR DESCRIPTION
Hi, 

I need to review this pull request with one of you @mickhansen or @janmeier before adding documention or tests. This allow things like that:

```js
Post.findAll({ 
 where: {
  $or: {
   title: 'hello',
   '$comments.text$': 'hello'
  }
 },
 include: [{
  Model: Comment,
  joinInSubQuery: true
}]
 limit: 10,
})
```

This include the join in the Post subQuery and allow to filter on the `title` *OR* on the `comments.text` filed.

```SQL
SELECT
  ...
FROM (SELECT
        ...
      FROM "posts" AS "post" LEFT OUTER JOIN "comments" AS "comments" ON "post"."id" = "comments"."postId"
      WHERE ("post"."title" = 'hello' OR "comments"."text" = 'hello')
      LIMIT '2') AS "task"
  LEFT OUTER JOIN "comments" AS "comments" ON "post"."id" = "comments"."postId";
```