### PR TITLE
Enable type validation for all queries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Future
 - [FIXED] Fix defaultValues getting overwritten on build
 - [FIXED] Queue queries against tedious connections
+- [ADDED] Enable type validation for all queries
 
 # 3.21.0
 - [FIXED] Confirmed that values modified in validation hooks are preserved [#3534](https://github.com/sequelize/sequelize/issues/3534)

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -669,8 +669,8 @@ RANGE.prototype.validate = function(value) {
 var UUID = ABSTRACT.inherits();
 
 UUID.prototype.key = UUID.key = 'UUID';
-UUID.prototype.validate = function(value) {
-  if (!Validator.isUUID(value)) {
+UUID.prototype.validate = function(value, options) {
+  if (!Validator.isUUID(value) && (!options || !options.acceptStrings || typeof value !== 'string')) {
     throw new sequelizeErrors.ValidationError(util.format('%j is not a valid uuid', value));
   }
 
@@ -689,8 +689,8 @@ var UUIDV1 = function() {
 util.inherits(UUIDV1, ABSTRACT);
 
 UUIDV1.prototype.key = UUIDV1.key = 'UUIDV1';
-UUIDV1.prototype.validate = function(value) {
-  if (!Validator.isUUID(value)) {
+UUIDV1.prototype.validate = function(value, options) {
+  if (!Validator.isUUID(value) && (!options || !options.acceptStrings || typeof value !== 'string')) {
     throw new sequelizeErrors.ValidationError(util.format('%j is not a valid uuid', value));
   }
 
@@ -709,8 +709,8 @@ var UUIDV4 = function() {
 util.inherits(UUIDV4, ABSTRACT);
 
 UUIDV4.prototype.key = UUIDV4.key = 'UUIDV4';
-UUIDV4.prototype.validate = function(value) {
-  if (!Validator.isUUID(value, 4)) {
+UUIDV4.prototype.validate = function(value, options) {
+  if (!Validator.isUUID(value, 4) && (!options || !options.acceptStrings || typeof value !== 'string')) {
     throw new sequelizeErrors.ValidationError(util.format('%j is not a valid uuidv4', value));
   }
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -952,10 +952,10 @@ var QueryGenerator = {
           if (['INSERT', 'UPDATE'].indexOf(options.context) !== -1 && this.typeValidation && field.type.validate && value) {
             if (options.isList && Array.isArray(value)) {
               _.forEach(value, function(item) {
-                field.type.validate(item);
+                field.type.validate(item, options);
               });
             } else {
-              field.type.validate(value);
+              field.type.validate(value, options);
             }
           }
 
@@ -2235,6 +2235,8 @@ var QueryGenerator = {
       } else if (comparator === '!=' && value === null) {
         comparator = 'IS NOT';
       }
+
+      escapeOptions.acceptStrings = comparator.indexOf('LIKE') !== -1;
 
       if (escapeValue) {
         value = this.escape(value, field, escapeOptions);

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -949,7 +949,7 @@ var QueryGenerator = {
         return this.handleSequelizeMethod(value);
       } else {
         if (field && field.type) {
-          if (['INSERT', 'UPDATE'].indexOf(options.context) !== -1 && this.typeValidation && field.type.validate && value) {
+          if (this.typeValidation && field.type.validate && value) {
             if (options.isList && Array.isArray(value)) {
               _.forEach(value, function(item) {
                 field.type.validate(item, options);

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -950,7 +950,13 @@ var QueryGenerator = {
       } else {
         if (field && field.type) {
           if (['INSERT', 'UPDATE'].indexOf(options.context) !== -1 && this.typeValidation && field.type.validate && value) {
-            field.type.validate(value);
+            if (options.isList && Array.isArray(value)) {
+              _.forEach(value, function(item) {
+                field.type.validate(item);
+              });
+            } else {
+              field.type.validate(value);
+            }
           }
 
           if (field.type.stringify) {
@@ -2200,6 +2206,7 @@ var QueryGenerator = {
       value = value.map(this.quoteIdentifier.bind(this)).join('.');
     } else {
       var escapeValue = true;
+      var escapeOptions = {};
 
       if (_.isPlainObject(value)) {
         _.forOwn(value, function (item, key) {
@@ -2209,9 +2216,11 @@ var QueryGenerator = {
 
             if (_.isPlainObject(value) && value.$any) {
               comparator += ' ANY';
+              escapeOptions.isList = true;
               value = value.$any;
             } else if (_.isPlainObject(value) && value.$all) {
               comparator += ' ALL';
+              escapeOptions.isList = true;
               value = value.$all;
             } else if (value && value.$col) {
               escapeValue = false;
@@ -2228,7 +2237,7 @@ var QueryGenerator = {
       }
 
       if (escapeValue) {
-        value = this.escape(value, field);
+        value = this.escape(value, field, escapeOptions);
       }
     }
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -949,10 +949,8 @@ var QueryGenerator = {
         return this.handleSequelizeMethod(value);
       } else {
         if (field && field.type) {
-          if (['INSERT', 'UPDATE'].indexOf(options.context) !== -1 && this.typeValidation && field && field.type && value) {
-            if (field.type.validate) {
-              field.type.validate(value);
-            }
+          if (['INSERT', 'UPDATE'].indexOf(options.context) !== -1 && this.typeValidation && field.type.validate && value) {
+            field.type.validate(value);
           }
 
           if (field.type.stringify) {

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -240,6 +240,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
 
           expect(type.validate(uuid.v4())).to.equal(true);
         });
+
+        test('should return `true` if `value` is a string and we accept strings', function() {
+          var type = DataTypes.UUID();
+
+          expect(type.validate('foobar', { acceptStrings: true })).to.equal(true);
+        });
       });
     });
 
@@ -261,6 +267,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           var type = DataTypes.UUIDV1();
 
           expect(type.validate(uuid.v1())).to.equal(true);
+        });
+
+        test('should return `true` if `value` is a string and we accept strings', function() {
+          var type = DataTypes.UUIDV1();
+
+          expect(type.validate('foobar', { acceptStrings: true })).to.equal(true);
         });
       });
     });
@@ -284,6 +296,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           var type = DataTypes.UUIDV4();
 
           expect(type.validate(uuid.v4())).to.equal(true);
+        });
+
+        test('should return `true` if `value` is a string and we accept strings', function() {
+          var type = DataTypes.UUIDV4();
+
+          expect(type.validate('foobar', { acceptStrings: true })).to.equal(true);
         });
       });
     });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

When the validation on datatypes got reverted and put behind a flag, a new rule was added to allow them only on `INSERT` and `UPDATE` queries. However, these validations are useful for the remaining queries, as well, like `SELECT`.

This PR proposes enabling these validations for all queries. This would still only be applicable to anyone who has enabled the datatypes validation flag, which is disabled by default.

This PR also removes some redundant checks on the affected conditional (`field` and `field.type` have already been checked in an outer conditional) and reduces the level of nesting used to validate the datatype.