### PR TITLE
Add query queueing to MSSQL connections

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Future
 - [FIXED] Fix defaultValues getting overwritten on build
+- [FIXED] Queue queries against tedious connections
 
 # 3.21.0
 - [FIXED] Confirmed that values modified in validation hooks are preserved [#3534](https://github.com/sequelize/sequelize/issues/3534)

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -2,6 +2,7 @@
 
 var AbstractConnectionManager = require('../abstract/connection-manager')
   , ConnectionManager
+  , ResourceLock = require('./resource-lock')
   , Utils = require('../../utils')
   , Promise = require('../../promise')
   , sequelizeErrors = require('../../errors')
@@ -66,7 +67,7 @@ ConnectionManager.prototype.connect = function(config) {
 
     connection.on('connect', function(err) {
       if (!err) {
-        resolve(connection);
+        resolve(new ResourceLock(connection));
         return;
       }
 
@@ -119,7 +120,9 @@ ConnectionManager.prototype.connect = function(config) {
   });
 };
 
-ConnectionManager.prototype.disconnect = function(connection) {
+ConnectionManager.prototype.disconnect = function(connectionLock) {
+  var connection = connectionLock.unwrap();
+
   // Dont disconnect a connection that is already disconnected
   if (!!connection.closed) {
     return Promise.resolve();
@@ -131,7 +134,9 @@ ConnectionManager.prototype.disconnect = function(connection) {
   });
 };
 
-ConnectionManager.prototype.validate = function(connection) {
+ConnectionManager.prototype.validate = function(connectionLock) {
+  var connection = connectionLock.unwrap();
+
   return connection && connection.loggedIn;
 };
 

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Utils = require('../../utils')
+  , Promise = require('../../promise')
   , AbstractQuery = require('../abstract/query')
   , sequelizeErrors = require('../../errors.js')
   , parserStore = require('../parserStore')('mssql'),
@@ -27,7 +28,7 @@ Query.prototype.getInsertIdField = function() {
 };
 
 Query.formatBindParameters = AbstractQuery.formatBindParameters;
-Query.prototype.run = function(sql, parameters) {
+Query.prototype._run = function(connection, sql, parameters) {
   var self = this;
   this.sql = sql;
 
@@ -37,13 +38,13 @@ Query.prototype.run = function(sql, parameters) {
   if (benchmark) {
     var queryBegin = Date.now();
   } else {
-    this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
+    this.sequelize.log('Executing (' + (connection.uuid || 'default') + '): ' + this.sql, this.options);
   }
 
   var promise = new Utils.Promise(function(resolve, reject) {
       // TRANSACTION SUPPORT
       if (_.includes(self.sql, 'BEGIN TRANSACTION')) {
-        self.connection.beginTransaction(function(err) {
+        connection.beginTransaction(function(err) {
           if (!!err) {
             reject(self.formatError(err));
           } else {
@@ -51,7 +52,7 @@ Query.prototype.run = function(sql, parameters) {
           }
         } /* name, isolation_level */);
       } else if (_.includes(self.sql, 'COMMIT TRANSACTION')) {
-        self.connection.commitTransaction(function(err) {
+        connection.commitTransaction(function(err) {
           if (!!err) {
             reject(self.formatError(err));
           } else {
@@ -59,7 +60,7 @@ Query.prototype.run = function(sql, parameters) {
           }
         });
       } else if (_.includes(self.sql, 'ROLLBACK TRANSACTION')) {
-        self.connection.rollbackTransaction(function(err) {
+        connection.rollbackTransaction(function(err) {
           if (!!err) {
             reject(self.formatError(err));
           } else {
@@ -70,10 +71,10 @@ Query.prototype.run = function(sql, parameters) {
         // QUERY SUPPORT
         var results = [];
 
-        var request = new self.connection.lib.Request(self.sql, function(err) {
+        var request = new connection.lib.Request(self.sql, function(err) {
 
           if (benchmark) {
-            self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
+            self.sequelize.log('Executed (' + (connection.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
           }
 
           if (err) {
@@ -100,11 +101,19 @@ Query.prototype.run = function(sql, parameters) {
           results.push(row);
         });
 
-        self.connection.execSql(request);
+        connection.execSql(request);
       }
   });
 
   return promise;
+};
+
+Query.prototype.run = function(sql, parameters) {
+  var self = this;
+
+  return Promise.using(this.connection.lock(), function (connection) {
+    return self._run(connection, sql, parameters);
+  });
 };
 
 /**

--- a/lib/dialects/mssql/resource-lock.js
+++ b/lib/dialects/mssql/resource-lock.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var Promise = require('../../promise');
+
+function ResourceLock(resource) {
+  this.resource = resource;
+  this.previous = Promise.resolve(resource);
+}
+
+ResourceLock.prototype.unwrap = function () {
+  return this.resource;
+};
+
+ResourceLock.prototype.lock = function () {
+  var lock = this.previous;
+  var resolve;
+
+  this.previous = new Promise(function (r) {
+    resolve = r;
+  });
+
+  return lock.disposer(resolve);
+};
+
+module.exports = ResourceLock;

--- a/test/integration/dialects/mssql/query-queue.test.js
+++ b/test/integration/dialects/mssql/query-queue.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var chai = require('chai')
+  , expect = chai.expect
+  , Promise = require('../../../../lib/promise')
+  , DataTypes = require('../../../../lib/data-types')
+  , Support = require('../../support')
+  , dialect = Support.getTestDialect();
+
+if (dialect.match(/^mssql/)) {
+  describe('[MSSQL Specific] Query Queue', function () {
+    beforeEach(function () {
+      var User = this.User = this.sequelize.define('User', {
+        username: DataTypes.STRING
+      });
+
+      return this.sequelize.sync({ force: true }).then(function () {
+        return User.create({ username: 'John'});
+      });
+    });
+
+    it('should queue concurrent requests to a connection', function() {
+      var User = this.User;
+
+      return expect(this.sequelize.transaction(function (t) {
+        return Promise.all([
+          User.findOne({
+            transaction: t
+          }),
+          User.findOne({
+            transaction: t
+          })
+        ]);
+      })).not.to.be.rejected;
+    });
+  });
+}

--- a/test/unit/dialects/mssql/resource-lock.test.js
+++ b/test/unit/dialects/mssql/resource-lock.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+var ResourceLock = require('../../../../lib/dialects/mssql/resource-lock')
+  , Promise = require('../../../../lib/promise')
+  , assert = require('assert');
+
+describe('[MSSQL Specific] ResourceLock', function () {
+  it('should process requests serially', function () {
+    var expected = {};
+    var lock = new ResourceLock(expected);
+    var last = 0;
+
+    function validateResource(actual) {
+      assert.equal(actual, expected);
+    }
+
+    return Promise.all([
+      Promise.using(lock.lock(), function (resource) {
+        validateResource(resource);
+        assert.equal(last, 0);
+        last = 1;
+
+        return Promise.delay(15);
+      }),
+      Promise.using(lock.lock(), function (resource) {
+        validateResource(resource);
+        assert.equal(last, 1);
+        last = 2;
+      }),
+      Promise.using(lock.lock(), function (resource) {
+        validateResource(resource);
+        assert.equal(last, 2);
+        last = 3;
+
+        return Promise.delay(5);
+      })
+    ]);
+  });
+
+  it('should still return resource after failure', function () {
+    var expected = {};
+    var lock = new ResourceLock(expected);
+
+    function validateResource(actual) {
+      assert.equal(actual, expected);
+    }
+
+    return Promise.all([
+      Promise.using(lock.lock(), function (resource) {
+        validateResource(resource);
+
+        throw new Error('unexpected error');
+      }).catch(function () {}),
+      Promise.using(lock.lock(), validateResource)
+    ]);
+  });
+
+  it('should be able to.lock resource without waiting on lock', function () {
+    var expected = {};
+    var lock = new ResourceLock(expected);
+
+    assert.equal(lock.unwrap(), expected);
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Resolves https://github.com/sequelize/sequelize/issues/4105. Adds a simple queuing mechanism to tedious connections via a resource lock. This will add a small amount of overhead to all requests but will prevent the possibility of interleaving requests on a single connection, especially within a transaction.

Currently broken:

```js
sequelize.transaction(transaction => {
  return Promise.all([1, 2, 3].map(id => Model.findById(id, { transaction })));
});
```

Even though these will still *not* happen concurrently, it will no longer result in error.

### Operation

The queue leverages Bluebird promises to effectively created a linked list queue with each request containing a reference to resolve the next dependent promise. Bluebird `disposer` will ensure that the next operation will begin only *after* the current promise chain has been fulfilled.