### PR TITLE
defaultScope can be used with complex function.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 - [FIXED] Fix defaultValues getting overwritten on build
 - [FIXED] Queue queries against tedious connections
 - [ADDED] Enable type validation for all queries
+- [ADDED] `defaultScope` can be a complex function
 
 # 3.21.0
 - [FIXED] Confirmed that values modified in validation hooks are preserved [#3534](https://github.com/sequelize/sequelize/issues/3534)

--- a/lib/model.js
+++ b/lib/model.js
@@ -719,7 +719,8 @@ Model.prototype.init = function(modelManager) {
 
   findAutoIncrementField.call(this);
 
-  this.$scope = this.options.defaultScope;
+  this.$scope = _.isFunction(this.options.defaultScope) ? this.options.defaultScope() : this.options.defaultScope;
+  this.options.scopes.defaultScope = this.options.defaultScope;
 
   if (_.isPlainObject(this.$scope)) {
     conformOptions(this.$scope, this);
@@ -1121,17 +1122,21 @@ Model.prototype.addScope = function (name, scope, options) {
     override: false
   }, options);
 
-  if ((name === 'defaultScope' || name in this.options.scopes) && options.override === false) {
+  if ((name in this.options.scopes) && options.override === false) {
     throw new Error('The scope ' + name + ' already exists. Pass { override: true } as options to silence this error');
   }
 
-  conformOptions(scope, this);
+  if (_.isPlainObject(scope)) {
+    conformOptions(scope, this);
+  }
 
   if (name === 'defaultScope') {
-    this.options.defaultScope = this.$scope = scope;
-  } else {
-    this.options.scopes[name] = scope;
+    this.options.defaultScope = scope;
+    this.$scope = _.isFunction(this.options.defaultScope) ? this.options.defaultScope() : this.options.defaultScope;
+    conformOptions(this.$scope, this);
   }
+
+  this.options.scopes[name] = scope;
 };
 
 /**
@@ -1208,20 +1213,19 @@ Model.prototype.scope = function(option) {
           scopeName = option.method;
           scope = self.options.scopes[scopeName].apply(self);
         }
+
+        conformOptions(scope, self);
       } else {
         scope = option;
       }
     } else {
-      if (option === 'defaultScope' && _.isPlainObject(self.options.defaultScope)) {
-        scope = self.options.defaultScope;
-      } else {
-        scopeName = option;
-        scope = self.options.scopes[scopeName];
+      // option should be a string.
+      scopeName = option;
+      scope = self.options.scopes[scopeName];
 
-        if (_.isFunction(scope)) {
-          scope = scope();
-          conformOptions(scope, self);
-        }
+      if (_.isFunction(scope)) {
+        scope = scope();
+        conformOptions(scope, self);
       }
     }
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [Y] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [N] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [Y] Have you added new tests to prevent regressions?
- [Not needed] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [Y] Have you added an entry under `Future` in the changelog?

### Description of change

Before this PR defaultScope can be used with plain object only, while scopes can be used with complex function. If complex function parameter is optional, defaultScope as function will give comfort.