### PR TITLE
sequelize.close return a promise

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -64,21 +64,26 @@ ConnectionManager.prototype.refreshTypeParser = function(dataTypes) {
 
 ConnectionManager.prototype.onProcessExit = function() {
   var self = this;
-
-  if (this.pool) {
-    this.pool.drain(function() {
-      self.pool.destroyAllNow();
-    });
-  }
+  return new Promise(function (resolve, reject) {
+    if (self.pool) {
+      self.pool.drain(function() {
+        self.pool.destroyAllNow(function () {
+          resolve();
+        });
+      });
+    } else {
+      resolve();
+    }
+  });
 };
 
 ConnectionManager.prototype.close = function () {
-  this.onProcessExit();
   process.removeListener('exit', this.onProcessExit); // Remove the listener, so all references to this instance can be garbage collected.
 
   this.getConnection = function () {
     return Promise.reject(new Error('ConnectionManager.getConnection was called after the connection manager was closed!'));
   };
+  return this.onProcessExit();
 };
 
 // This cannot happen in the constructor because the user can specify a min. number of connections to have in the pool
@@ -95,8 +100,8 @@ ConnectionManager.prototype.initPools = function () {
           callback(err, connection); // For some reason this is needed, else generic-pool things err is a connection or some shit
         });
       },
-      destroy: function(connection) {
-        self.$disconnect(connection);
+      destroy: function(connection, cb) {
+        self.$disconnect(connection, cb);
         return null;
       },
       max: config.pool.max,
@@ -138,12 +143,21 @@ ConnectionManager.prototype.initPools = function () {
         self.pool.write.acquire(callback, priority);
       }
     },
-    destroy: function(connection) {
-      return self.pool[connection.queryType].destroy(connection);
+    destroy: function(connection, cb) {
+      return self.pool[connection.queryType].destroy(connection, cb);
     },
-    destroyAllNow: function() {
-      self.pool.read.destroyAllNow();
-      self.pool.write.destroyAllNow();
+    destroyAllNow: function(cb) {
+      var todo = 2;
+      var done = 0;
+      function check_cb() {
+        ++done;
+        if (todo === done && cb) {
+          cb();
+        }
+      }
+
+      self.pool.read.destroyAllNow(check_cb);
+      self.pool.write.destroyAllNow(check_cb);
     },
     drain: function(cb) {
       self.pool.write.drain(function() {
@@ -161,8 +175,8 @@ ConnectionManager.prototype.initPools = function () {
           callback(err, connection); // For some reason this is needed, else generic-pool things err is a connection or some shit
         });
       },
-      destroy: function(connection) {
-        self.$disconnect(connection);
+      destroy: function(connection, cb) {
+        self.$disconnect(connection, cb);
         return null;
       },
       validate: config.pool.validate,
@@ -179,8 +193,8 @@ ConnectionManager.prototype.initPools = function () {
           callback(err, connection); // For some reason this is needed, else generic-pool things err is a connection or some shit
         });
       },
-      destroy: function(connection) {
-        self.$disconnect(connection);
+      destroy: function(connection, cb) {
+        self.$disconnect(connection, cb);
         return null;
       },
       validate: config.pool.validate,
@@ -249,8 +263,8 @@ ConnectionManager.prototype.$connect = function(config) {
     });
   });
 };
-ConnectionManager.prototype.$disconnect = function(connection) {
-  return this.dialect.connectionManager.disconnect(connection);
+ConnectionManager.prototype.$disconnect = function(connection, cb) {
+  return this.dialect.connectionManager.disconnect(connection).then(cb);
 };
 
 ConnectionManager.prototype.$validate = function(connection) {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -174,8 +174,8 @@ ConnectionManager.prototype.connect = function(config) {
 };
 ConnectionManager.prototype.disconnect = function(connection) {
   return new Promise(function (resolve, reject) {
+    connection.on('end', resolve);
     connection.end();
-    resolve();
   });
 };
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1345,9 +1345,10 @@ Sequelize.prototype.log = function() {
  *
  * Normally this is done on process exit, so you only need to call this method if you are creating multiple instances, and want
  * to garbage collect some of them.
+ * @return {Promise}
  */
 Sequelize.prototype.close = function () {
-  this.connectionManager.close();
+  return this.connectionManager.close();
 };
 
 Sequelize.prototype.normalizeDataType = function(Type) {


### PR DESCRIPTION
sequelize.close return undefined. That's... not useful.

This PR aims to add a Promise to close and not just a bad promise, like ConnectionManager.close.
Also fix pgsql disconnect promise that was sync.

This PR cannot land ATM!
This must land first https://github.com/coopernurse/node-pool/pull/141 (because there is another bug there that block this fix)

After that I will update package.json

I can't find a way to do a test for this in the current tests folder. So I just attached here.

``` js
// sudo -u postgres psql -c "drop database sequelize_test;"
// sudo -u postgres psql -c "create database sequelize_test;"

var Sequelize = require('./index.js');
var sequelize = new Sequelize('sequelize_test', 'postgres', 'postgres', {
  host: 'localhost',
  //port: 9092, // vagrant port
  dialect: 'postgres',
});
// just something to sync
var datadef = sequelize.define('just_create_table', {
  created_date: Sequelize.DATE
});

sequelize.sync().then(function() {
  console.log("handles before:", process._getActiveHandles().length);
  return sequelize.close().then(function() {
    console.log("handles after:", process._getActiveHandles().length);
  })
})
.then(function() {
  console.log("handles after:", process._getActiveHandles().length);
});
```

Before this patch I see: 4 4 4
After: 4 2 2

Related issues:
https://github.com/sequelize/sequelize/issues/4711 @tdzl2003
