### PR TITLE
ConnectionManager: Re-throw initialization errors

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -17,7 +17,10 @@ ConnectionManager = function(dialect, sequelize) {
   try {
     this.lib = require(sequelize.config.dialectModulePath || 'tedious');
   } catch (err) {
-    throw new Error('Please install tedious package manually');
+    if (err.code === 'MODULE_NOT_FOUND') {
+      throw new Error('Please install tedious package manually');
+    }
+    throw err;
   }
 };
 

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -20,7 +20,10 @@ ConnectionManager = function(dialect, sequelize) {
       this.lib = require('mysql');
     }
   } catch (err) {
-    throw new Error('Please install mysql package manually');
+    if (err.code === 'MODULE_NOT_FOUND') {
+      throw new Error('Please install mysql package manually');
+    }
+    throw err;
   }
 
   this.refreshTypeParser(dataTypes);

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -23,7 +23,10 @@ ConnectionManager = function(dialect, sequelize) {
     }
     this.lib = sequelize.config.native ? pgLib.native : pgLib;
   } catch (err) {
-    throw new Error('Please install \'' + (sequelize.config.dialectModulePath || 'pg') + '\' module manually');
+    if (err.code === 'MODULE_NOT_FOUND') {
+      throw new Error('Please install \'' + (sequelize.config.dialectModulePath || 'pg') + '\' module manually');
+    }
+    throw err;
   }
 
   this.refreshTypeParser(dataTypes.postgres);

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -21,7 +21,10 @@ ConnectionManager = function(dialect, sequelize) {
   try {
     this.lib = require(sequelize.config.dialectModulePath || 'sqlite3').verbose();
   } catch (err) {
-    throw new Error('Please install sqlite3 package manually');
+    if (err.code === 'MODULE_NOT_FOUND') {
+      throw new Error('Please install sqlite3 package manually');
+    }
+    throw err;
   }
 
   this.refreshTypeParser(dataTypes);


### PR DESCRIPTION
ConnectionManager: Re-throw initialization errors unless they are MODULE_NOT_FOUND. This prevents such errors from being misleadingly overridden.

As described in https://github.com/sequelize/sequelize/issues/3302#issuecomment-199238449