### PR TITLE
refactor(testing): Re-enable support shim, and extend to test options…

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -424,7 +424,7 @@ BelongsToMany.prototype.injectGetter = function(obj) {
   var association = this;
 
   obj[this.accessors.get] = function(options) {
-    options = association.target.__optClone(options) || {};
+    options = Utils.cloneDeep(options) || {};
 
     var instance = this
       , through = association.through
@@ -486,7 +486,7 @@ BelongsToMany.prototype.injectGetter = function(obj) {
     var model = association.target
       , sequelize = model.sequelize;
 
-    options = association.target.__optClone(options) || {};
+    options = Utils.cloneDeep(options);
     options.attributes = [
       [sequelize.fn('COUNT', sequelize.col([association.target.name, model.primaryKeyAttribute].join('.'))), 'count']
     ];
@@ -506,10 +506,8 @@ BelongsToMany.prototype.injectGetter = function(obj) {
       instances = [instances];
     }
 
-    options = options || {};
-    options.scope = false;
-
-    _.defaults(options, {
+    options = _.assign({}, options, {
+      scope: false,
       raw: true
     });
 
@@ -640,7 +638,7 @@ BelongsToMany.prototype.injectSetter = function(obj) {
     // If newInstances is null or undefined, no-op
     if (!newInstances) return Utils.Promise.resolve();
 
-    additionalAttributes = additionalAttributes || {};
+    additionalAttributes = _.clone(additionalAttributes) || {};
 
     var instance = this
       , defaultAttributes = _.omit(additionalAttributes, ['transaction', 'hooks', 'individualHooks', 'ignoreDuplicates', 'validate', 'fields', 'logging'])

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -140,7 +140,7 @@ BelongsTo.prototype.injectGetter = function(instancePrototype) {
     var where = {};
     where[association.targetKey] = this.get(association.foreignKey);
 
-    options = association.target.$optClone(options) || {};
+    options = Utils.cloneDeep(options);
 
     options.where = {
       $and: [

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -272,7 +272,7 @@ HasMany.prototype.get = function(instances, options) {
     instances = undefined;
   }
 
-  options = association.target.$optClone(options) || {};
+  options = Utils.cloneDeep(options) || {};
 
   if (association.scope) {
     _.assign(where, association.scope);
@@ -340,7 +340,7 @@ HasMany.prototype.count = function(instance, options) {
     , model = association.target
     , sequelize = model.sequelize;
 
-  options = association.target.__optClone(options) || {};
+  options = Utils.cloneDeep(options);
   options.attributes = [
     [sequelize.fn('COUNT', sequelize.col(model.primaryKeyField)), 'count']
   ];
@@ -360,9 +360,10 @@ HasMany.prototype.has = function(sourceInstance, targetInstances, options) {
     targetInstances = [targetInstances];
   }
 
-  options = options || {};
-  options.scope = false;
-  options.raw = true;
+  options = _.assign({}, options, {
+    scope: false,
+    raw: true
+  });
 
   where.$or = targetInstances.map(function (instance) {
     if (instance instanceof association.target.Instance) {

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -139,7 +139,7 @@ HasOne.prototype.injectGetter = function(instancePrototype) {
       _.assign(where, association.scope);
     }
 
-    options = association.target.__optClone(options) || {};
+    options = Utils.cloneDeep(options);
 
     options.where = {
       $and: [
@@ -176,8 +176,9 @@ HasOne.prototype.injectSetter = function(instancePrototype) {
     var instance = this,
       alreadyAssociated;
 
-    options = options || {};
-    options.scope = false;
+    options = _.assign({}, options, {
+      scope: false
+    });
     return instance[association.accessors.get](options).then(function(oldInstance) {
       // TODO Use equals method once #5605 is resolved
       alreadyAssociated = oldInstance && associatedInstance && _.every(association.target.primaryKeyAttributes, function(attribute) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -44,8 +44,8 @@ var QueryGenerator = {
     var databaseVersion = Utils._.get(self, 'sequelize.options.databaseVersion', 0);
     //Postgres 9.0 does not support CREATE TABLE IF NOT EXISTS, 9.1 and above do
     var query = 'CREATE TABLE ' +
-                ( (databaseVersion === 0 || semver.gte(databaseVersion, '9.1.0')) ? 'IF NOT EXISTS ' : '') +
-                '<%= table %> (<%= attributes%>)<%= comments %>'
+      ( (databaseVersion === 0 || semver.gte(databaseVersion, '9.1.0')) ? 'IF NOT EXISTS ' : '') +
+      '<%= table %> (<%= attributes%>)<%= comments %>'
       , comments = ''
       , attrStr = []
       , i;
@@ -163,7 +163,7 @@ var QueryGenerator = {
           // Also support json dot notation
           var path = smth.path.split('.');
           str = util.format("%s#>>'{%s}'",
-              _.first(path),
+            _.first(path),
             _.tail(path).join(','));
         }
 
@@ -422,7 +422,7 @@ var QueryGenerator = {
       fragment += ' LIMIT ' + this.escape(options.limit);
     }
     if (options.offset != null) {
-       fragment += ' OFFSET ' + this.escape(options.offset);
+      fragment += ' OFFSET ' + this.escape(options.offset);
     }
 
     return fragment;
@@ -443,8 +443,8 @@ var QueryGenerator = {
 
       if (Array.isArray(attribute.values) && (attribute.values.length > 0)) {
         replacements.type = 'ENUM(' + Utils._.map(attribute.values, function(value) {
-          return this.escape(value);
-        }.bind(this)).join(', ') + ')';
+            return this.escape(value);
+          }.bind(this)).join(', ') + ')';
       } else {
         throw new Error("Values for ENUM haven't been defined.");
       }
@@ -558,12 +558,12 @@ var QueryGenerator = {
 
   createTrigger: function(tableName, triggerName, eventType, fireOnSpec, functionName, functionParams, optionsArray) {
     var sql = [
-        'CREATE <%= constraintVal %>TRIGGER <%= triggerName %>'
-        , '<%= eventType %> <%= eventSpec %>'
-        , 'ON <%= tableName %>'
-        , '<%= optionsSpec %>'
-        , 'EXECUTE PROCEDURE <%= functionName %>(<%= paramList %>);'
-      ].join('\n\t');
+      'CREATE <%= constraintVal %>TRIGGER <%= triggerName %>'
+      , '<%= eventType %> <%= eventSpec %>'
+      , 'ON <%= tableName %>'
+      , '<%= optionsSpec %>'
+      , 'EXECUTE PROCEDURE <%= functionName %>(<%= paramList %>);'
+    ].join('\n\t');
 
     return Utils._.template(sql)({
       constraintVal: this.triggerEventTypeIsConstraint(eventType),
@@ -596,11 +596,11 @@ var QueryGenerator = {
 
   createFunction: function(functionName, params, returnType, language, body, options) {
     var sql = ['CREATE FUNCTION <%= functionName %>(<%= paramList %>)'
-        , 'RETURNS <%= returnType %> AS $func$'
-        , 'BEGIN'
-        , '\t<%= body %>'
-        , 'END;'
-        , "$func$ language '<%= language %>'<%= options %>;"
+      , 'RETURNS <%= returnType %> AS $func$'
+      , 'BEGIN'
+      , '\t<%= body %>'
+      , 'END;'
+      , "$func$ language '<%= language %>'<%= options %>;"
     ].join('\n');
 
     return Utils._.template(sql)({
@@ -670,7 +670,7 @@ var QueryGenerator = {
 
   expandOptions: function expandOptions(options) {
     return Utils._.isUndefined(options) || Utils._.isEmpty(options) ?
-        '' : '\n\t' + options.join('\n\t');
+      '' : '\n\t' + options.join('\n\t');
   },
 
   decodeTriggerEventType: function decodeTriggerEventType(eventSpecifier) {
@@ -846,7 +846,7 @@ var QueryGenerator = {
   },
 
   /*
-  /**
+   /**
    * Generates an SQL query that returns all foreign keys of a table.
    *
    * @param  {String} tableName  The name of the table.

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -495,7 +495,7 @@ Instance.prototype.save = function(options) {
     throw new Error('The second argument was removed in favor of the options object.');
   }
 
-  options = this.$Model.$optClone(options || {});
+  options = Utils.cloneDeep(options);
   options = _.defaults(options, {
     hooks: true,
     validate: true
@@ -802,8 +802,8 @@ Instance.prototype.update = function(values, options) {
   options = options || {};
   if (Array.isArray(options)) options = {fields: options};
 
-  options = this.$Model.$optClone(options);
-  setOptions = this.$Model.$optClone(options);
+  options = Utils.cloneDeep(options);
+  setOptions = Utils.cloneDeep(options);
   setOptions.attributes = options.fields;
   this.set(values, setOptions);
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -8,7 +8,6 @@ var Utils = require('./utils')
   , HasMany = require('./associations/has-many')
   , DataTypes = require('./data-types')
   , Util = require('util')
-  , Transaction = require('./transaction')
   , Promise = require('./promise')
   , QueryTypes = require('./query-types')
   , Hooks = require('./hooks')
@@ -307,27 +306,6 @@ function conformInclude(include, self) {
 
 Model.$conformInclude = conformInclude;
 
-var optClone = Model.prototype.__optClone = Model.prototype.$optClone = function(options) {
-  options = options || {};
-  return Utils.cloneDeep(options, function(elem) {
-    // The InstanceFactories used for include are pass by ref, so don't clone them.
-    if (elem && typeof elem === 'object' &&
-      (
-        elem._isSequelizeMethod ||
-        elem instanceof Model ||
-        elem instanceof Instance ||
-        elem instanceof Transaction ||
-        elem instanceof Association
-      )
-    ) {
-      return elem;
-    }
-
-    // Otherwise return undefined, meaning, 'handle this lodash'
-    return undefined;
-  });
-};
-
 var expandIncludeAllElement = function(includes, include) {
   // check 'all' attribute provided is valid
   var all = include.all;
@@ -413,7 +391,7 @@ var expandIncludeAllElement = function(includes, include) {
       used.push(parent);
 
       // include this model
-      var thisInclude = optClone(include);
+      var thisInclude = Utils.cloneDeep(include);
       thisInclude.model = model;
       if (as) {
         thisInclude.as = as;
@@ -990,9 +968,8 @@ Model.prototype.removeAttribute = function(attribute) {
  * @return {Promise<this>}
  */
 Model.prototype.sync = function(options) {
-  options = options || {};
+  options = _.extend({}, this.options, options);
   options.hooks = options.hooks === undefined ? true : !!options.hooks;
-  options = Utils._.extend({}, this.options, options);
 
   var self = this
     , attributes = this.tableAttributes;
@@ -1360,7 +1337,7 @@ Model.prototype.findAll = function(options) {
     , originalOptions;
 
   tableNames[this.getTableName(options)] = true;
-  options = optClone(options);
+  options = Utils.cloneDeep(options);
 
   _.defaults(options, { hooks: true, rejectOnEmpty: this.options.rejectOnEmpty });
 
@@ -1408,7 +1385,7 @@ Model.prototype.findAll = function(options) {
       return this.runHooks('beforeFindAfterOptions', options);
     }
   }).then(function() {
-    originalOptions = optClone(options);
+    originalOptions = Utils.cloneDeep(options);
     options.tableNames = Object.keys(tableNames);
     return this.QueryInterface.select(this, this.getTableName(options), options);
   }).tap(function(results) {
@@ -1498,7 +1475,7 @@ Model.prototype.findById = function(param, options) {
     return Promise.resolve(null);
   }
 
-  options = optClone(options) || {};
+  options = Utils.cloneDeep(options) || {};
 
   if (typeof param === 'number' || typeof param === 'string' || Buffer.isBuffer(param)) {
     options.where = {};
@@ -1527,7 +1504,7 @@ Model.prototype.findOne = function(options) {
   if (options !== undefined && !_.isPlainObject(options)) {
     throw new Error('The argument passed to findOne must be an options object, use findById if you wish to pass a single primary key value');
   }
-  options = optClone(options);
+  options = Utils.cloneDeep(options);
 
   if (options.limit === undefined) {
     var pkVal = options.where && options.where[this.primaryKeyAttribute];
@@ -1563,7 +1540,8 @@ Model.prototype.find = Model.prototype.findOne;
  * @return {Promise<options.dataType|object>}                Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in which case the complete data result is returned.
  */
 Model.prototype.aggregate = function(attribute, aggregateFunction, options) {
-  options = Utils._.extend({ attributes: [] }, options || {});
+  options = Utils.cloneDeep(options);
+  options = _.defaults(options, { attributes: [] });
   conformOptions(options, this);
   this.$injectScope(options);
 
@@ -1617,9 +1595,8 @@ Model.prototype.aggregate = function(attribute, aggregateFunction, options) {
  * @return {Promise<Integer>}
  */
 Model.prototype.count = function(options) {
-  options = Utils._.clone(options || {});
-
-  _.defaults(options, { hooks: true });
+  options = Utils.cloneDeep(options);
+  options.hooks = true;
 
   var col = '*';
 
@@ -1862,7 +1839,7 @@ Model.prototype.bulkBuild = function(valueSets, options) { // testhint options:n
  * @return {Promise<Instance>}
  */
 Model.prototype.create = function(values, options) {
-  options = optClone(options || {});
+  options = Utils.cloneDeep(options || {});
 
   return this.build(values, {
     isNewRecord: true,
@@ -1936,6 +1913,8 @@ Model.prototype.findOrCreate = function(options) {
       'Please note that the API has changed, and is now options only (an object with where, defaults keys, transaction etc.)'
     );
   }
+
+  options = _.assign({}, options);
 
   if (options.transaction === undefined && this.sequelize.constructor.cls) {
     var t = this.sequelize.constructor.cls.get('transaction');
@@ -2065,7 +2044,7 @@ Model.prototype.findCreateFind = function(options) {
  * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated.
  */
 Model.prototype.upsert = function (values, options) {
-  options = optClone(options) || {};
+  options = Utils.cloneDeep(options) || {};
 
   if (!options.fields) {
     options.fields = Object.keys(this.attributes);
@@ -2281,7 +2260,7 @@ Model.prototype.bulkCreate = function(records, options) {
  * @see {Model#destroy} for more information
  */
 Model.prototype.truncate = function(options) {
-  options = optClone(options) || {};
+  options = Utils.cloneDeep(options) || {};
   options.truncate = true;
   return this.destroy(options);
 };
@@ -2314,12 +2293,13 @@ Model.prototype.destroy = function(options) {
     throw new Error('Expected plain object, array or sequelize method in the options.where parameter of model.destroy.');
   }
 
-  options = Utils._.extend({
+  options = Utils.cloneDeep(options);
+  options = _.defaults(options, {
     hooks: true,
     individualHooks: false,
     force: false,
     cascade: false
-  }, options || {});
+  });
 
   options.type = QueryTypes.BULKDELETE;
   this.$injectScope(options);
@@ -2479,14 +2459,15 @@ Model.prototype.update = function(values, options) {
     throw new Error('Expected plain object, array or sequelize method in the options.where parameter of model.update.');
   }
 
-  options = Utils._.extend({
+  options = Utils.cloneDeep(options);
+  options = _.defaults(options, {
     validate: true,
     hooks: true,
     individualHooks: false,
     returning: false,
     force: false,
     sideEffects: true
-  }, options || {});
+  });
 
   options.type = QueryTypes.BULKUPDATE;
 
@@ -2699,7 +2680,7 @@ Model.prototype.$expandAttributes = function (options) {
 // Inject $scope into options. Includes should have been conformed (conformOptions) before calling this
 Model.prototype.$injectScope = function (options) {
   var self = this;
-  var scope = optClone(this.$scope);
+  var scope = Utils.cloneDeep(this.$scope);
 
   var filteredScope = _.omit(scope, 'include'); // Includes need special treatment
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -49,8 +49,7 @@ QueryInterface.prototype.showAllSchemas = function(options) {
 
   options = _.assign({}, options, {
     raw: true,
-    type: this.sequelize.QueryTypes.SELECT,
-    logging: false
+    type: this.sequelize.QueryTypes.SELECT
   });
 
   var showSchemasSql = self.QueryGenerator.showSchemasQuery();
@@ -179,7 +178,7 @@ QueryInterface.prototype.createTable = function(tableName, attributes, options, 
 
 QueryInterface.prototype.dropTable = function(tableName, options) {
   // if we're forcing we should be cascading unless explicitly stated otherwise
-  options = options || {};
+  options = _.clone(options) || {};
   options.cascade = options.cascade || options.force || false;
 
   var sql = this.QueryGenerator.dropTableQuery(tableName, options)
@@ -278,7 +277,7 @@ QueryInterface.prototype.dropAllEnums = function(options) {
 
   var self = this;
 
-  return this.pgListEnums(options).map(function(result) {
+  return this.pgListEnums(null, options).map(function(result) {
     return self.sequelize.query(
       self.QueryGenerator.pgEnumDrop(null, null, self.QueryGenerator.pgEscapeAndQuote(result.enum_name)),
       _.assign({}, options, { raw: true })
@@ -443,7 +442,7 @@ QueryInterface.prototype.addIndex = function(tableName, attributes, options, raw
     rawTablename = tableName;
   }
 
-  options = options || {};
+  options = Utils.cloneDeep(options);
   options.fields = attributes;
   var sql = this.QueryGenerator.addIndexQuery(tableName, options, rawTablename);
   return this.sequelize.query(sql, _.assign({}, options, { supportsSearchPath: false }));
@@ -492,7 +491,7 @@ QueryInterface.prototype.removeIndex = function(tableName, indexNameOrAttributes
 };
 
 QueryInterface.prototype.insert = function(instance, tableName, values, options) {
-  options = options || {};
+  options = Utils.cloneDeep(options);
   options.hasTrigger = instance && instance.Model.options.hasTrigger;
   var sql = this.QueryGenerator.insertQuery(tableName, values, instance && instance.Model.rawAttributes, options);
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -739,7 +739,7 @@ Sequelize.prototype.query = function(sql, options) {
 
   var self = this;
 
-  options = options || {};
+  options = _.assign({}, this.options.query, options);
 
   if (options.instance && !options.model) {
     options.model = options.instance.Model;
@@ -750,7 +750,7 @@ Sequelize.prototype.query = function(sql, options) {
     options.fieldMap =  options.model.fieldAttributeMap;
   }
 
-  if (Utils._.isPlainObject(sql)) {
+  if (_.isPlainObject(sql)) {
     if (sql.values !== undefined) {
       if (options.replacements !== undefined) {
         throw new Error('Both `sql.values` and `options.replacements` cannot be set at the same time');
@@ -796,8 +796,7 @@ Sequelize.prototype.query = function(sql, options) {
     bindParameters = bindSql[1];
   }
 
-  options = Utils._.extend(Utils._.clone(this.options.query), options);
-  options = Utils._.defaults(options, {
+  options = _.defaults(options, {
     logging: this.options.hasOwnProperty('logging') ? this.options.logging : console.log,
     searchPath: this.options.hasOwnProperty('searchPath') ? this.options.searchPath : 'DEFAULT',
   });
@@ -973,7 +972,7 @@ Sequelize.prototype.dropAllSchemas = function(options) {
 Sequelize.prototype.sync = function(options) {
   var self = this;
 
-  options = options || {};
+  options = _.clone(options) || {};
   options.hooks = options.hooks === undefined ? true : !!options.hooks;
   options.logging = options.logging === undefined ? false : options.logging;
   options = Utils._.defaults(options, this.options.sync, this.options);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -87,20 +87,23 @@ var Utils = module.exports = {
     var timeZone = null;
     return SqlString.formatNamedParameters(sql, parameters, timeZone, dialect);
   },
-  cloneDeep: function(obj, fn) {
+  cloneDeep: function(obj) {
+    obj = obj || {};
     return _.cloneDeepWith(obj, function (elem) {
-      // Do not try to customize cloning of plain objects and strings
+      // Do not try to customize cloning of arrays or POJOs
       if (Array.isArray(elem) || _.isPlainObject(elem)) {
         return undefined;
       }
+
+      // Don't clone stuff that's an object, but not a plain one - fx example sequelize models and instances
+      if (typeof elem === 'object' && !_.isPlainObject(elem)) {
+        return elem;
+      }
+
       // Preserve special data-types like `fn` across clones. _.get() is used for checking up the prototype chain
       if (elem && typeof elem.clone === 'function') {
         return elem.clone();
       }
-      // Unfortunately, lodash.cloneDeep doesn't preserve Buffer.isBuffer, which we have to rely on for binary data
-      if (Buffer.isBuffer(elem)) { return elem; }
-
-      return fn ? fn(elem) : undefined;
     });
   },
 

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -36,16 +36,6 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
       });
     });
 
-    it('does not modify the passed arguments', function() {
-      return this.User.create({}).bind(this).then(function(user) {
-        this.options = {};
-
-        return user.getTasks(this.options);
-      }).then(function() {
-        expect(this.options).to.deep.equal({});
-      });
-    });
-
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
         return Support.prepareTransactionTest(this.sequelize).bind({}).then(function(sequelize) {

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -59,23 +59,6 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
       });
     }
 
-    it('does not modify the passed arguments', function() {
-      var User = this.sequelize.define('user', {})
-        , Project = this.sequelize.define('project', {});
-
-      User.belongsTo(Project);
-
-      return this.sequelize.sync({ force: true }).bind(this).then(function() {
-        return User.create({});
-      }).then(function(user) {
-        this.options = {};
-
-        return user.getProject(this.options);
-      }).then(function() {
-        expect(this.options).to.deep.equal({});
-      });
-    });
-
     it('should be able to handle a where object that\'s a first class citizen.', function() {
       var User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING })
         , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING });

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -835,16 +835,6 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
         });
       });
 
-      it('does not modify the passed arguments', function() {
-        return this.User.create({}).bind(this).then(function(user) {
-          this.options = {};
-
-          return user.getTasks(this.options);
-        }).then(function() {
-          expect(this.options).to.deep.equal({});
-        });
-      });
-
       it('should treat the where object of associations as a first class citizen', function() {
         var self = this;
         this.Article = this.sequelize.define('Article', {

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -60,23 +60,6 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
       });
     }
 
-    it('does not modify the passed arguments', function() {
-      var User = this.sequelize.define('user', {})
-        , Project = this.sequelize.define('project', {});
-
-      User.hasOne(Project);
-
-      return this.sequelize.sync({ force: true }).bind(this).then(function() {
-        return User.create({});
-      }).then(function(user) {
-        this.options = {};
-
-        return user.getProject(this.options);
-      }).then(function() {
-        expect(this.options).to.deep.equal({});
-      });
-    });
-
     it('should be able to handle a where object that\'s a first class citizen.', function() {
       var User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING })
         , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1715,14 +1715,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
-    it('does not modify the passed arguments', function() {
-      var options = { where: ['username = ?', 'user1']};
-
-      return this.User.count(options).then(function() {
-        expect(options).to.deep.equal({ where: ['username = ?', 'user1']});
-      });
-    });
-
     describe("options sent to aggregate", function () {
       var options, aggregateSpy;
 

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -107,14 +107,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       }
 
-      it('does not modify the passed arguments', function() {
-        var options = { where: ['specialkey = ?', 'awesome']};
-
-        return this.UserPrimary.findOne(options).then(function() {
-          expect(options).to.deep.equal({ where: ['specialkey = ?', 'awesome']});
-        });
-      });
-
       it('treats questionmarks in an array', function() {
         var test = false;
         return this.UserPrimary.findOne({

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1110,13 +1110,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
 
-      it('does not modify the passed arguments', function() {
-        var options = { where: ['username = ?', 'awesome']};
-        return this.User.findAll(options).then(function() {
-          expect(options).to.deep.equal({ where: ['username = ?', 'awesome']});
-        });
-      });
-
       it('can also handle array notation', function() {
         var self = this;
         return this.User.findAll({where: ['id = ?', this.users[1].id]}).then(function(users) {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -251,54 +251,65 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       return this.sequelize.query(this.insertQuery);
     });
 
-    it('executes a query with global benchmarking option and default logger', function() {
-      var logger = sinon.spy(console, 'log');
-      var sequelize = Support.createSequelizeInstance({
-        logging: logger,
-        benchmark: true
+    describe('logging', function () {
+      before(function () {
+        // Shimming interferes with the global logging function 
+        Sequelize.dontShim = true;
       });
 
-      return sequelize.query('select 1;').then(function() {
-        expect(logger.calledOnce).to.be.true;
-        expect(logger.args[0][0]).to.be.match(/Executed \(default\): select 1; Elapsed time: \d+ms/);
-      });
-    });
-
-    it('executes a query with global benchmarking option and custom logger', function() {
-      var logger = sinon.spy();
-      var sequelize = Support.createSequelizeInstance({
-        logging: logger,
-        benchmark: true
+      after(function () {
+        Sequelize.dontShim = true;
       });
 
-      return sequelize.query('select 1;').then(function() {
-        expect(logger.calledOnce).to.be.true;
-        expect(logger.args[0][0]).to.be.equal('Executed (default): select 1;');
-        expect(typeof logger.args[0][1] === 'number').to.be.true;
+      it('executes a query with global benchmarking option and default logger', function() {
+        var logger = sinon.spy(console, 'log');
+        var sequelize = Support.createSequelizeInstance({
+          logging: logger,
+          benchmark: true
+        });
+
+        return sequelize.query('select 1;').then(function() {
+          expect(logger.calledOnce).to.be.true;
+          expect(logger.args[0][0]).to.be.match(/Executed \(default\): select 1; Elapsed time: \d+ms/);
+        });
       });
-    });
 
-    it('executes a query with benchmarking option and default logger', function() {
-      var logger = sinon.spy(console, 'log');
-      return this.sequelize.query('select 1;', {
-        logging: logger,
-        benchmark: true
-      }).then(function() {
-        expect(logger.calledOnce).to.be.true;
-        expect(logger.args[0][0]).to.be.match(/Executed \(default\): select 1; Elapsed time: \d+ms/);
+      it('executes a query with global benchmarking option and custom logger', function() {
+        var logger = sinon.spy();
+        var sequelize = Support.createSequelizeInstance({
+          logging: logger,
+          benchmark: true
+        });
+
+        return sequelize.query('select 1;').then(function() {
+          expect(logger.calledOnce).to.be.true;
+          expect(logger.args[0][0]).to.be.equal('Executed (default): select 1;');
+          expect(typeof logger.args[0][1] === 'number').to.be.true;
+        });
       });
-    });
 
-    it('executes a query with benchmarking option and custom logger', function() {
-      var logger = sinon.spy();
+      it('executes a query with benchmarking option and default logger', function() {
+        var logger = sinon.spy(console, 'log');
+        return this.sequelize.query('select 1;', {
+          logging: logger,
+          benchmark: true
+        }).then(function() {
+          expect(logger.calledOnce).to.be.true;
+          expect(logger.args[0][0]).to.be.match(/Executed \(default\): select 1; Elapsed time: \d+ms/);
+        });
+      });
 
-      return this.sequelize.query('select 1;', {
-        logging: logger,
-        benchmark: true
-      }).then(function() {
-        expect(logger.calledOnce).to.be.true;
-        expect(logger.args[0][0]).to.be.equal('Executed (default): select 1;');
-        expect(typeof logger.args[0][1] === 'number').to.be.true;
+      it('executes a query with benchmarking option and custom logger', function() {
+        var logger = sinon.spy();
+
+        return this.sequelize.query('select 1;', {
+          logging: logger,
+          benchmark: true
+        }).then(function() {
+          expect(logger.calledOnce).to.be.true;
+          expect(logger.args[0][0]).to.be.equal('Executed (default): select 1;');
+          expect(typeof logger.args[0][1] === 'number').to.be.true;
+        });
       });
     });
 

--- a/test/support.js
+++ b/test/support.js
@@ -29,7 +29,7 @@ Sequelize.Promise.onPossiblyUnhandledRejection(function(e, promise) {
 Sequelize.Promise.longStackTraces();
 
 // shim all Sequelize methods for testing for correct `options.logging` passing
-if (!process.env.COVERAGE && false) supportShim(Sequelize);
+if (!process.env.COVERAGE) supportShim(Sequelize);
 
 var Support = {
   Sequelize: Sequelize,

--- a/test/unit/instance/decrement.test.js
+++ b/test/unit/instance/decrement.test.js
@@ -39,13 +39,6 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           instance.decrement(['id']);
         }).to.not.throw();
       });
-
-      it('should not modify options when it given to decrement', function () {
-        instance = Model.build({id: 3}, {isNewRecord: false});
-        var options = { by: 2 };
-        instance.decrement(['id'], options);
-        expect(options).to.deep.equal({ by: 2 });
-      });
     });
   });
 });

--- a/test/unit/instance/destroy.test.js
+++ b/test/unit/instance/destroy.test.js
@@ -39,13 +39,6 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           instance.destroy();
         }).to.not.throw();
       });
-
-      it('should not modify options when it given to destroy', function () {
-        instance = Model.build({id: 1}, {isNewRecord: false});
-        var options = { transaction: null };
-        instance.destroy(options);
-        expect(options).to.deep.equal({ transaction: null });
-      });
     });
   });
 });

--- a/test/unit/instance/increment.test.js
+++ b/test/unit/instance/increment.test.js
@@ -39,13 +39,6 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           instance.increment(['id']);
         }).to.not.throw();
       });
-
-      it('should not modify options when it given to increment', function () {
-        instance = Model.build({id: 1}, {isNewRecord: false});
-        var options = { by: 2 };
-        instance.increment(['id'], options);
-        expect(options).to.deep.equal({ by: 2 });
-      });
     });
   });
 });

--- a/test/unit/instance/reload.test.js
+++ b/test/unit/instance/reload.test.js
@@ -44,14 +44,6 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           instance.reload();
         }).to.not.throw();
       });
-
-      it('should not modify options when it given to reload', function () {
-        instance = Model.build({id: 1}, {isNewRecord: false});
-        var options = { transaction: null };
-        instance.reload(options);
-        expect(options).to.deep.equal({ transaction: null });
-      });
-
     });
   });
 });

--- a/test/unit/instance/restore.test.js
+++ b/test/unit/instance/restore.test.js
@@ -44,14 +44,6 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           instance.restore();
         }).to.not.throw();
       });
-
-      it('should not modify options when it given to restore', function () {
-        instance = Model.build({id: 1}, {isNewRecord: false});
-        var options = { transaction: null };
-        instance.restore(options);
-        expect(options).to.deep.equal({ transaction: null });
-      });
     });
   });
-
 });

--- a/test/unit/instance/save.test.js
+++ b/test/unit/instance/save.test.js
@@ -52,13 +52,6 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           instance.save();
         }).to.not.throw();
       });
-
-      it('should not modify options when it given to save', function () {
-        instance = Model.build({});
-        var options = { transaction: null };
-        instance.save(options);
-        expect(options).to.deep.equal({ transaction: null });
-      });
     });
   });
 });


### PR DESCRIPTION
This build on https://github.com/sequelize/sequelize/pull/4541 by re-enabling support shim, and also checking that options are not modified. In order to check that we clone the options object before each call, which unfortunately seems to up the time it takes to run tests a bit :( But on the bright side I did find a couple of places where options were being modified / not passed down correctly.

I've also replaced `optclone` with a method that avoids cloning anything of type object thats not a plain object. This handles all types of sequelize objects (models, instances etc.) and also `Buffer`, which we had a special case for previously

Ping @overlookmotel 