### PR TITLE
only check model keys for delete with limit

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Method QueryInterface.bulkDelete no longer working when the model parameter is missing. (PostgreSQL) [#5615](https://github.com/sequelize/sequelize/issues/5615)
+
 # 3.22.0
 - [FIXED] Fix defaultValues getting overwritten on build
 - [FIXED] Queue queries against tedious connections

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -357,23 +357,28 @@ var QueryGenerator = {
       options.limit = 1;
     }
 
+    var replacements = {
+      table: tableName,
+      where: this.getWhereConditions(where, null, model, options),
+      limit: !!options.limit ? ' LIMIT ' + this.escape(options.limit) : ''
+    };
+
     if (options.limit) {
+      if (!model) {
+        throw new Error('Cannot LIMIT delete without a model.');
+      }
+
+      var pks = _.map(_.values(model.primaryKeys), function (pk) {
+        return this.quoteIdentifier((pk.field));
+      }.bind(this)).join(',');
+
+      replacements.primaryKeys = model.primaryKeyAttributes.length > 1 ? '(' + pks + ')' : pks;
+      replacements.primaryKeysSelection = pks;
+
       query = 'DELETE FROM <%= table %> WHERE <%= primaryKeys %> IN (SELECT <%= primaryKeysSelection %> FROM <%= table %><%= where %><%= limit %>)';
     } else {
       query = 'DELETE FROM <%= table %><%= where %>';
     }
-
-    var pks = _.map(_.values(model.primaryKeys), function (pk) {
-      return this.quoteIdentifier((pk.field));
-    }.bind(this)).join(',');
-
-    var replacements = {
-      table: tableName,
-      where: this.getWhereConditions(where, null, model, options),
-      limit: !!options.limit ? ' LIMIT ' + this.escape(options.limit) : '',
-      primaryKeys: model.primaryKeyAttributes.length > 1 ? '(' + pks + ')' : pks,
-      primaryKeysSelection: pks
-    };
 
     if (replacements.where) {
       replacements.where = ' WHERE ' + replacements.where;

--- a/test/support.js
+++ b/test/support.js
@@ -221,7 +221,11 @@ var Support = {
                     .replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT);
     }
 
-    expect(query).to.equal(expectation);
+    if (_.isError(query)) {
+      expect(query.message).to.equal(expectation.message);
+    } else {
+      expect(query).to.equal(expectation);
+    }
   }
 };
 

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -34,10 +34,10 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
             options,
             User
           ), {
-            postgres:  'TRUNCATE "public"."test_users" CASCADE',
-            mssql:  "TRUNCATE TABLE [public].[test_users]",
-            mysql: 'TRUNCATE `public.test_users`',
-            sqlite: 'DELETE FROM `public.test_users`'
+            postgres: 'TRUNCATE "public"."test_users" CASCADE',
+            mssql:    "TRUNCATE TABLE [public].[test_users]",
+            mysql:    'TRUNCATE `public.test_users`',
+            sqlite:   'DELETE FROM `public.test_users`'
           }
         );
       });
@@ -58,7 +58,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
             options,
             User
           ), {
-            default: "DELETE FROM [public.test_users] WHERE `name` = 'foo'",
+            default:  "DELETE FROM [public.test_users] WHERE `name` = 'foo'",
             postgres: 'DELETE FROM "public"."test_users" WHERE "name" = \'foo\'',
             mssql:    "DELETE FROM [public].[test_users] WHERE [name] = N'foo'; SELECT @@ROWCOUNT AS AFFECTEDROWS;"
           }
@@ -82,6 +82,37 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
             User
           ), {
             postgres: 'DELETE FROM "public"."test_users" WHERE "id" IN (SELECT "id" FROM "public"."test_users" WHERE "name" = \'foo\'\';DROP TABLE mySchema.myTable;\' LIMIT 10)',
+            sqlite:   "DELETE FROM `public.test_users` WHERE `name` = 'foo'';DROP TABLE mySchema.myTable;'",
+            mssql:    "DELETE TOP(10) FROM [public].[test_users] WHERE [name] = N'foo'';DROP TABLE mySchema.myTable;'; SELECT @@ROWCOUNT AS AFFECTEDROWS;",
+            default:  "DELETE FROM [public.test_users] WHERE `name` = 'foo\\';DROP TABLE mySchema.myTable;' LIMIT 10"
+          }
+        );
+      });
+    });
+
+    suite('delete with limit and without model', function () {
+      var options = {
+        table: User.getTableName(),
+        where: {name: "foo';DROP TABLE mySchema.myTable;"},
+        limit: 10
+      };
+
+      test(util.inspect(options, {depth: 2}), function () {
+        var query;
+        try {
+          query = sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            null
+          );
+        } catch(err) {
+          query = err;
+        }
+
+        return expectsql(
+          query, {
+            postgres: new Error("Cannot LIMIT delete without a model."),
             sqlite:   "DELETE FROM `public.test_users` WHERE `name` = 'foo'';DROP TABLE mySchema.myTable;'",
             mssql:    "DELETE TOP(10) FROM [public].[test_users] WHERE [name] = N'foo'';DROP TABLE mySchema.myTable;'; SELECT @@ROWCOUNT AS AFFECTEDROWS;",
             default:  "DELETE FROM [public.test_users] WHERE `name` = 'foo\\';DROP TABLE mySchema.myTable;' LIMIT 10"


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

deleteQuery assumes a model exist and tries to extract primary keys from it, even when this is an unnecessary step. This change prevents model.primaryKeys from being accessed unless options.limit is provided.

It also throws a more friendly error if model is not defined.

Fixes #5615 

