### PR TITLE
added update support for primary keys that are not autoincrement

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -331,8 +331,9 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
             return this;
           }
 
-          // If attempting to set primary key and primary key is already defined, return
-          if (this.Model._hasPrimaryKeys && originalValue && this.Model._isPrimaryKey(key)) {
+          // If attempting to set primary key and primary key is already defined
+          // and its autoIncrement, return
+          if (this.Model._hasPrimaryKeys && originalValue && this.Model._isPrimaryKey(key) && this.Model.rawAttributes[key].autoIncrement) {
             return this;
           }
 

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -28,7 +28,7 @@ describe(Support.getTestDialectTeaser('DAO'), function() {
         expect(user.get('name')).to.equal('Jan');
       });
 
-      it('doesn\'t overwrite defined primary keys', function() {
+      it('overwrites defined primary keys', function() {
         var User = this.sequelize.define('User', {
           identifier: {type: DataTypes.STRING, primaryKey: true}
         });
@@ -37,7 +37,7 @@ describe(Support.getTestDialectTeaser('DAO'), function() {
 
         expect(user.get('identifier')).to.equal('identifier');
         user.set('identifier', 'another identifier');
-        expect(user.get('identifier')).to.equal('identifier');
+        expect(user.get('identifier')).to.equal('another identifier');
       });
 
       it('doesn\'t set timestamps', function() {


### PR DESCRIPTION
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

I modified the primary key setter check to allow pks that aren't autoincrement to proceed with the set
I reviewed the test cases that were failing with the changes and updated the test cases.
THANK YOU for npm run test (it helped me validate the changes)

I believe this should update should be non-breaking.  I had originally allowed any pk to change, but that caused other problems.  After researching and by restricting autoincrement pks from being updated, the tests now pass.   

Not sure if this should be labeled enhancement or bug fix

NOTE: I have not modified the changelog yet...
