### PR TITLE
Fixing associations doc

### DIFF
--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -264,10 +264,9 @@ With Belongs-To-Many you can query based on **through** relation and select spec
 User.findAll({
   include: [{
     model: Project,
-      through: {
-        attributes: ['createdAt', 'startedAt', 'finishedAt']
-          where: {completed: true}
-      }
+    through: 'userProjects',
+    attributes: ['createdAt', 'startedAt', 'finishedAt'],
+    where: {completed: true}
   }]
 });
 ```

--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -264,9 +264,10 @@ With Belongs-To-Many you can query based on **through** relation and select spec
 User.findAll({
   include: [{
     model: Project,
-    through: 'userProjects',
-    attributes: ['createdAt', 'startedAt', 'finishedAt'],
-    where: {completed: true}
+    through: {
+      attributes: ['createdAt', 'startedAt', 'finishedAt'],
+      where: {completed: true}
+    }
   }]
 });
 ```


### PR DESCRIPTION
I'm not positive that this was what was intended originally, but as it currently is, this code snippet isn't valid javascript.  I was able to find no example of `through` taking anything other than a string, but it does seem like `attributes` and `where` can both go in `include`, so I assume that this is the right way.  This also makes sense given the context of the example.