### PR TITLE
Fix #5736, Invalid query generated when using LIKE with ANY

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] Invalid query generated when using LIKE + ANY [#5736](https://github.com/sequelize/sequelize/issues/5736)
 - [FIXED] Method QueryInterface.bulkDelete no longer working when the model parameter is missing. (PostgreSQL) [#5615](https://github.com/sequelize/sequelize/issues/5615)
 
 # 3.22.0

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2240,6 +2240,11 @@ var QueryGenerator = {
 
       if (escapeValue) {
         value = this.escape(value, field, escapeOptions);
+
+        //if ANY is used with like, add parentheses to generate correct query
+        if (escapeOptions.acceptStrings && (comparator.indexOf('ANY') > comparator.indexOf('LIKE'))) {
+         value = '(' + value + ')';
+        }
       }
     }
 

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -572,7 +572,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
               $any: ['foo', 'bar', 'baz']
             }
           }, {
-            postgres: "\"userId\" LIKE ANY ARRAY['foo','bar','baz']"
+            postgres: "\"userId\" LIKE ANY (ARRAY['foo','bar','baz'])"
           });
 
           testsql('userId', {
@@ -580,7 +580,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
               $any: ['foo', 'bar', 'baz']
             }
           }, {
-            postgres: "\"userId\" ILIKE ANY ARRAY['foo','bar','baz']"
+            postgres: "\"userId\" ILIKE ANY (ARRAY['foo','bar','baz'])"
           });
 
           testsql('userId', {
@@ -588,7 +588,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
               $any: ['foo', 'bar', 'baz']
             }
           }, {
-            postgres: "\"userId\" NOT LIKE ANY ARRAY['foo','bar','baz']"
+            postgres: "\"userId\" NOT LIKE ANY (ARRAY['foo','bar','baz'])"
           });
 
           testsql('userId', {
@@ -596,7 +596,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
               $any: ['foo', 'bar', 'baz']
             }
           }, {
-            postgres: "\"userId\" NOT ILIKE ANY ARRAY['foo','bar','baz']"
+            postgres: "\"userId\" NOT ILIKE ANY (ARRAY['foo','bar','baz'])"
           });
 
           testsql('userId', {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?


### Description of change

Closes #5736 
Closes #4064

I have detected the presence of `LIKE` and `ANY`, fixed the query if they are used in specific order.

cc @mickhansen @janmeier 