### PR TITLE
Check previous date value is not null before setting

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -346,7 +346,7 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
             if (!(value instanceof Date)) {
               value = new Date(value);
             }
-            if (!(originalValue instanceof Date)) {
+            if (!(originalValue instanceof Date) && originalValue !== null) {
               originalValue = new Date(originalValue);
             }
             if (originalValue && value.getTime() === originalValue.getTime()) {


### PR DESCRIPTION
### Pull Request check-list
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Closes #5719
- [ ] Have you added an entry under `Future` in the changelog?
### Description of change

Prevent setting dates in previous data values to `new Date(null)` when they should be `null`.
