### PR TITLE
Added CHARACTER_MAXIMUM_LENGTH field from INFORMATION_SCHEMA.COLUMNS …

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -108,6 +108,7 @@ var QueryGenerator = {
       'SELECT',
         "c.COLUMN_NAME AS 'Name',",
         "c.DATA_TYPE AS 'Type',",
+        "c.CHARACTER_MAXIMUM_LENGTH AS 'Length',",
         "c.IS_NULLABLE as 'IsNull',",
         "COLUMN_DEFAULT AS 'Default',",
         "tc.CONSTRAINT_TYPE AS 'Constraint'",


### PR DESCRIPTION

Added CHARACTER_MAXIMUM_LENGTH field from INFORMATION_SCHEMA.COLUMNS table to the mssql dialect's describeTableQuery so that sequelize-auto and other apps can use this information.