### PR TITLE
Fixing MySQL error when inserting fractional datetimes on MySQL versi…

### DIFF
--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -31,12 +31,12 @@ module.exports = function (BaseTypes) {
   };
 
   DATE.prototype.$stringify = function (date, options) {
+    date = BaseTypes.DATE.prototype.$applyTimezone(date, options);
     // Fractional DATETIMEs only supported on MySQL 5.6.4+
     if (this._length) {
-      return BaseTypes.DATE.prototype.$stringify(date, options);
+      return date.format('YYYY-MM-DD HH:mm:ss.SSS');
     }
 
-    date = BaseTypes.DATE.prototype.$applyTimezone(date, options);
     return date.format('YYYY-MM-DD HH:mm:ss');
   };
 

--- a/test/unit/sql/insert.js
+++ b/test/unit/sql/insert.js
@@ -58,6 +58,28 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
           mysql: "INSERT INTO `users` (`date`) VALUES ('2015-01-20 01:00:00');"
         });
     });
+
+    it('formats date correctly when sub-second precision is explicitly specified', function () {
+      var timezoneSequelize = Support.createSequelizeInstance({
+        timezone: Support.getTestDialect() === 'sqlite' ? '+00:00' : 'CET'
+      });
+
+      var User = timezoneSequelize.define('user', {
+        date: {
+          type: DataTypes.DATE(3)
+        }
+      },{
+        timestamps:false
+      });
+
+      expectsql(timezoneSequelize.dialect.QueryGenerator.insertQuery(User.tableName, {date: new Date(Date.UTC(2015, 0, 20, 1, 2, 3, 89))}, User.rawAttributes, {}),
+        {
+          postgres: 'INSERT INTO "users" ("date") VALUES (\'2015-01-20 02:02:03.089 +01:00\');',
+          sqlite: 'INSERT INTO `users` (`date`) VALUES (\'2015-01-20 01:02:03.089 +00:00\');',
+          mssql: 'INSERT INTO [users] ([date]) VALUES (N\'2015-01-20 02:02:03.089\');',
+          mysql: "INSERT INTO `users` (`date`) VALUES ('2015-01-20 02:02:03.089');"
+        });
+    });
   });
 
   describe('bulkCreate', function () {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [y] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [y] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [y] Have you added new tests to prevent regressions?
- [n] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [n] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

The MySQL dialect no longer emits timezone when writing Fractional dates (sub-second precision) 