### PR TITLE
Fixed #4893, DECIMAL precision for Postgres 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Postgres DECIMAL precision. (PostgreSQL) [#4893](https://github.com/sequelize/sequelize/issues/4893)
+
 # 3.23.0
 - [FIXED] Invalid query generated when using LIKE + ANY [#5736](https://github.com/sequelize/sequelize/issues/5736)
 - [FIXED] Method QueryInterface.bulkDelete no longer working when the model parameter is missing. (PostgreSQL) [#5615](https://github.com/sequelize/sequelize/issues/5615)

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -36,7 +36,7 @@ module.exports = function (BaseTypes) {
   var DECIMAL = BaseTypes.DECIMAL.inherits();
 
   DECIMAL.parse = function (value) {
-    return parseFloat(value);
+    return value;
   };
 
   // numeric

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -331,35 +331,37 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
     });
   }
 
-  it('should parse DECIMAL as string', function () {
-    var Model = this.sequelize.define('model', {
-      decimal: Sequelize.DECIMAL,
-      decimalPre: Sequelize.DECIMAL(10, 4),
-      decimalWithParser: Sequelize.DECIMAL(32, 15),
-      decimalWithIntParser: Sequelize.DECIMAL(10, 4),
-      decimalWithFloatParser: Sequelize.DECIMAL(10, 8)
-    });
+  if (dialect === 'postgres') {
+    it('should parse DECIMAL as string', function () {
+      var Model = this.sequelize.define('model', {
+        decimal: Sequelize.DECIMAL,
+        decimalPre: Sequelize.DECIMAL(10, 4),
+        decimalWithParser: Sequelize.DECIMAL(32, 15),
+        decimalWithIntParser: Sequelize.DECIMAL(10, 4),
+        decimalWithFloatParser: Sequelize.DECIMAL(10, 8)
+      });
 
-    var sampleData = {
-      id: 1,
-      decimal: 12345678.12345678,
-      decimalPre: 123456.1234,
-      decimalWithParser: '12345678123456781.123456781234567',
-      decimalWithIntParser: 1.234,
-      decimalWithFloatParser: 0.12345678
-    };
+      var sampleData = {
+        id: 1,
+        decimal: 12345678.12345678,
+        decimalPre: 123456.1234,
+        decimalWithParser: '12345678123456781.123456781234567',
+        decimalWithIntParser: 1.234,
+        decimalWithFloatParser: 0.12345678
+      };
 
-    return Model.sync({ force: true }).then(function () {
-      return Model.create(sampleData);
-    }).then(function () {
-      return Model.find({id: 1});
-    }).then(function (user) {
-      expect(user.get('decimal')).to.be.eql('12345678.12345678');
-      expect(user.get('decimalPre')).to.be.eql('123456.1234');
-      expect(user.get('decimalWithParser')).to.be.eql('12345678123456781.123456781234567');
-      expect(user.get('decimalWithIntParser')).to.be.eql('1.2340');
-      expect(user.get('decimalWithFloatParser')).to.be.eql('0.12345678');
+      return Model.sync({ force: true }).then(function () {
+        return Model.create(sampleData);
+      }).then(function () {
+        return Model.find({id: 1});
+      }).then(function (user) {
+        expect(user.get('decimal')).to.be.eql('12345678.12345678');
+        expect(user.get('decimalPre')).to.be.eql('123456.1234');
+        expect(user.get('decimalWithParser')).to.be.eql('12345678123456781.123456781234567');
+        expect(user.get('decimalWithIntParser')).to.be.eql('1.2340');
+        expect(user.get('decimalWithFloatParser')).to.be.eql('0.12345678');
+      });
     });
-  });
+  }
 
 });

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -307,7 +307,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
 
   if (dialect === 'postgres' || dialect === 'sqlite') {
     // postgres actively supports IEEE floating point literals, and sqlite doesn't care what we throw at it
-    it('should store and parse IEEE floating point literals (NaN and Infinity', function () {
+    it('should store and parse IEEE floating point literals (NaN and Infinity)', function () {
       var Model = this.sequelize.define('model', {
         float: Sequelize.FLOAT,
         double: Sequelize.DOUBLE,
@@ -330,4 +330,36 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
       });
     });
   }
+
+  it('should parse DECIMAL as string', function () {
+    var Model = this.sequelize.define('model', {
+      decimal: Sequelize.DECIMAL,
+      decimalPre: Sequelize.DECIMAL(10, 4),
+      decimalWithParser: Sequelize.DECIMAL(32, 15),
+      decimalWithIntParser: Sequelize.DECIMAL(10, 4),
+      decimalWithFloatParser: Sequelize.DECIMAL(10, 8)
+    });
+
+    var sampleData = {
+      id: 1,
+      decimal: 12345678.12345678,
+      decimalPre: 123456.1234,
+      decimalWithParser: '12345678123456781.123456781234567',
+      decimalWithIntParser: 1.234,
+      decimalWithFloatParser: 0.12345678
+    };
+
+    return Model.sync({ force: true }).then(function () {
+      return Model.create(sampleData);
+    }).then(function () {
+      return Model.find({id: 1});
+    }).then(function (user) {
+      expect(user.get('decimal')).to.be.eql('12345678.12345678');
+      expect(user.get('decimalPre')).to.be.eql('123456.1234');
+      expect(user.get('decimalWithParser')).to.be.eql('12345678123456781.123456781234567');
+      expect(user.get('decimalWithIntParser')).to.be.eql('1.2340');
+      expect(user.get('decimalWithFloatParser')).to.be.eql('0.12345678');
+    });
+  });
+
 });

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -645,8 +645,8 @@ if (dialect.match(/^postgres/)) {
           // Check to see if the default value for a range field works
 
           expect(newUser.acceptable_marks.length).to.equal(2);
-          expect(newUser.acceptable_marks[0]).to.equal(0.65); // lower bound
-          expect(newUser.acceptable_marks[1]).to.equal(1); // upper bound
+          expect(newUser.acceptable_marks[0]).to.equal('0.65'); // lower bound
+          expect(newUser.acceptable_marks[1]).to.equal('1'); // upper bound
           expect(newUser.acceptable_marks.inclusive).to.deep.equal([false, false]); // not inclusive
           expect(newUser.course_period[0] instanceof Date).to.be.ok; // lower bound
           expect(newUser.course_period[1] instanceof Date).to.be.ok; // upper bound
@@ -717,8 +717,8 @@ if (dialect.match(/^postgres/)) {
         return User.create({ username: 'user', email: ['foo@bar.com'], course_period: period }).then(function(newUser) {
           // Check to see if the default value for a range field works
           expect(newUser.acceptable_marks.length).to.equal(2);
-          expect(newUser.acceptable_marks[0]).to.equal(0.65); // lower bound
-          expect(newUser.acceptable_marks[1]).to.equal(1); // upper bound
+          expect(newUser.acceptable_marks[0]).to.equal('0.65'); // lower bound
+          expect(newUser.acceptable_marks[1]).to.equal('1'); // upper bound
           expect(newUser.acceptable_marks.inclusive).to.deep.equal([false, false]); // not inclusive
           expect(newUser.course_period[0] instanceof Date).to.be.ok;
           expect(newUser.course_period[1] instanceof Date).to.be.ok;


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #4893) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #4893 , returns good old string rather than parsing DECIMAL value to float.

@janmeier 

