### PR TITLE
Ryan/master/update schema method documentation

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1318,7 +1318,7 @@ Model.prototype.all = function(options) {
  * @param  {Boolean}                   [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param  {Object}                    [options.having]
  * @param  {String}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
- * @param  {Boolean|Error Instance}    [options.rejectOnEmpty=false] Throws an error when no records found
+ * @param  {Boolean|Error}    [options.rejectOnEmpty=false] Throws an error when no records found
  *
  * @see    {Sequelize#query}
  * @return {Promise<Array<Instance>>}

--- a/lib/model.js
+++ b/lib/model.js
@@ -1031,11 +1031,20 @@ Model.prototype.dropSchema = function(schema) {
  * Apply a schema to this model. For postgres, this will actually place the schema in front of the table name - `"schema"."tableName"`,
  * while the schema will be prepended to the table name for mysql and sqlite - `'schema.tablename'`.
  *
+ * This method is intended for use cases where the same model is needed in multiple schemas. In such a use case it is important
+ * to call `model.schema(schema, [options]).sync()` for each model to ensure the models are created in the correct schema.
+ *
+ * If a single default schema per model is needed, set the `options.schema='schema'` parameter during the `define()` call
+ * for the model.
+ *
  * @param {String} schema The name of the schema
  * @param {Object} [options]
  * @param {String} [options.schemaDelimiter='.'] The character(s) that separates the schema name from the table name
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
+ *
+ * @see {Sequelize#define} for more information about setting a default schema.
+ *
  * @return {this}
  */
 Model.prototype.schema = function(schema, options) { // testhint options:none


### PR DESCRIPTION
### Description of change

Updated the documentation for Model.schema(schema, [options]) to include a description of the intended use case and a mention of how to set a default schema for a model via the define params.
