### PR TITLE
Fix #5880, deletedAt compare against NOW

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - [CHANGED] Throw `bluebird.AggregateError` instead of array from `bulkCreate` when validation fails
 - [FIXED] `$notIn: []` is now converted to `NOT IN (NULL)`  [#4859](https://github.com/sequelize/sequelize/issues/4859)
 - [FIXED] Add `raw` support to `instance.get()` [#5815](https://github.com/sequelize/sequelize/issues/5815)
+- [ADDED] Compare deletedAt against current timestamp when using paranoid [#5880](https://github.com/sequelize/sequelize/pull/5880)
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails

--- a/lib/model.js
+++ b/lib/model.js
@@ -139,7 +139,7 @@ var paranoidClause = function(model, options) {
     , deletedAtObject = {}
     , deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-  deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gte: model.sequelize.fn('NOW'), $eq: null } };
+  deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gte: model.sequelize.literal('CURRENT_TIMESTAMP'), $eq: null } };
 
   deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -139,6 +139,8 @@ var paranoidClause = function(model, options) {
     , deletedAtObject = {}
     , deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
+  deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gte: model.sequelize.fn('NOW'), $eq: null } };
+
   deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 
   if (Utils._.isEmpty(options.where)) {

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -2,6 +2,7 @@
 
 var chai = require('chai')
   , expect = chai.expect
+  , sinon = require('sinon')
   , Support = require(__dirname + '/../support')
   , DataTypes = require(__dirname + '/../../../lib/data-types');
 
@@ -29,6 +30,14 @@ describe(Support.getTestDialectTeaser('Paranoid'), function() {
     D.belongsToMany(A, {through: 'a_d'});
 
     return S.sync({ force: true });
+  });
+
+  before(function () {
+    this.clock = sinon.useFakeTimers();
+  });
+
+  after(function () {
+    this.clock.restore();
   });
 
   it('paranoid with timestamps: false should be ignored / not crash', function() {
@@ -108,6 +117,9 @@ describe(Support.getTestDialectTeaser('Paranoid'), function() {
     }).then(function () {
       return this.y.destroy();
     }).then(function () {
+      //prevent CURRENT_TIMESTAMP to be same
+      this.clock.tick(1000);
+
       return X.findAll({
         include: [Y]
       }).get(0);

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -7,6 +7,7 @@ var chai = require('chai')
   , Sequelize = require('../../../index')
   , Promise = Sequelize.Promise
   , expect = chai.expect
+  , moment = require('moment')
   , Support = require(__dirname + '/../support')
   , DataTypes = require(__dirname + '/../../../lib/data-types')
   , config = require(__dirname + '/../../config/config')
@@ -985,6 +986,29 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           });
       });
 
+    });
+
+    it('should find records where deletedAt set to future', function() {
+      var User = this.sequelize.define('paranoiduser', {
+        username: Sequelize.STRING
+      }, { paranoid: true });
+
+      return User.sync({ force: true }).then(function() {
+        return User.bulkCreate([
+          {username: 'Bob'},
+          {username: 'Tobi', deletedAt: moment().add(30, 'minutes').format()},
+          {username: 'Max', deletedAt: moment().add(30, 'days').format()},
+          {username: 'Tony', deletedAt: moment().subtract(30, 'days').format()}
+        ]);
+      }).then(function() {
+        return User.find({ where: {username: 'Tobi'} });
+      }).then(function(tobi) {
+        expect(tobi).not.to.be.null;
+      }).then(function() {
+        return User.findAll();
+      }).then(function(users) {
+        expect(users.length).to.be.eql(3);
+      });
     });
 
   });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #5880 , `deletedAt` field is compared against `CURRENT_TIMESTAMP` rather than `IS NULL`. It also check for `IS NULL` in case `deletedAt` is not set at all.
