### PR TITLE
Adding the ability to log warnings if they are present in MySQL.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - [FIXED] Trigger afterCreate hook after all nested includes (for hasMany or belongsToMany associations) have been created to be consistent with hasOne.
 - [REMOVED] Support for `pool:false`
 - [REMOVED] Default transaction isolation level [#5094](https://github.com/sequelize/sequelize/issues/5094)
+- [ADDED] Add logging for mysql warnings, observant of the `showWarnings` option. [#5900](https://github.com/sequelize/sequelize/issues/5900)
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -15,7 +15,8 @@ var Query = function(connection, sequelize, options) {
   this.options = Utils._.extend({
     logging: console.log,
     plain: false,
-    raw: false
+    raw: false,
+    showWarnings: false
   }, options || {});
 
   this.checkLoggingOption();
@@ -29,6 +30,7 @@ Query.prototype.run = function(sql, parameters) {
   
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
+  var showWarnings = this.sequelize.options.showWarnings || this.options.showWarnings;
 
   if (benchmark) {
     var queryBegin = Date.now();
@@ -43,19 +45,25 @@ Query.prototype.run = function(sql, parameters) {
         self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
       }
 
-      // Log warnings if we've got them.
-      if (results && results.warningCount > 0) {
-        self.logWarnings();
-      }
-
       if (err) {
         err.sql = sql;
 
         reject(self.formatError(err));
       } else {
-        resolve(self.formatResults(results));
+        resolve(results);
       }
     }).setMaxListeners(100);
+  })
+  // Log warnings if we've got them.
+  .then(function(results){
+    if (showWarnings && results && results.warningCount > 0) {
+      return self.logWarnings(results);
+    }
+    return results;
+  })
+  // Return formatted results...
+  .then(function(results){
+    return self.formatResults(results);
   });
 
   return promise;
@@ -123,19 +131,27 @@ Query.prototype.formatResults = function(data) {
   return result;
 };
 
-Query.prototype.logWarnings = function () {
+Query.prototype.logWarnings = function (results) {
   var self = this;
-  self.connection.query('SHOW WARNINGS', function(err, warningResults) {
-    self.sequelize.log('MySQL Warnings (' + self.connection.uuid + '):', self.options);
-    warningResults.forEach(function(_warningResult) {
-      if (_warningResult.hasOwnProperty('Message')) {
-        self.sequelize.log('\t'+_warningResult.Message, self.options);
-      } else {
-        _warningResult.keys().forEach( function(_objectKey) {
-          self.sequelize.log('\t'+[_objectKey, _warningResult[_objectKey]].join(': '), self.options);
-        });
-      }
+  return this.run('SHOW WARNINGS').then(function(warningResults) {
+    var warningMessage = 'MySQL Warnings (' + (self.connection.uuid||'default') + '): ';
+    var messages = [];
+
+    warningResults.forEach(function(_warningRow){
+      _warningRow.forEach(function(_warningResult) {
+        if (_warningResult.hasOwnProperty('Message')) {
+          messages.push(_warningResult.Message);
+        } else {
+          _warningResult.keys().forEach( function(_objectKey) {
+            messages.push([_objectKey, _warningResult[_objectKey]].join(': '));
+          });
+        }
+      });
     });
+    
+    self.sequelize.log(warningMessage + messages.join('; '), self.options);
+
+    return results;
   });
 };
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -27,10 +27,6 @@ Query.prototype.run = function(sql, parameters) {
   var self = this;
   this.sql = sql;
   
-  if (this.options.hasOwnProperty('horse')) {
-    console.dir(this.options.logging)
-  }
-
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -150,7 +150,7 @@ Query.prototype.logWarnings = function (results) {
     });
     
     self.sequelize.log(warningMessage + messages.join('; '), self.options);
-
+    
     return results;
   });
 };

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -144,10 +144,10 @@ Query.prototype.logWarnings = function (results) {
       } else {
         _warningResult.keys().forEach( function(_objectKey) {
             messages.push([_objectKey, _warningResult[_objectKey]].join(': '));
-          });
+        });
       }
-      });
     });
+  });
 
     self.sequelize.log(warningMessage + messages.join('; '), self.options);
     

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -26,6 +26,10 @@ Query.formatBindParameters = AbstractQuery.formatBindParameters;
 Query.prototype.run = function(sql, parameters) {
   var self = this;
   this.sql = sql;
+  
+  if (this.options.hasOwnProperty('horse')) {
+    console.dir(this.options.logging)
+  }
 
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
@@ -124,20 +128,20 @@ Query.prototype.formatResults = function(data) {
 };
 
 Query.prototype.logWarnings = function () {
-  var self = this
+  var self = this;
   self.connection.query('SHOW WARNINGS', function(err, warningResults) {
-    self.sequelize.log( `MySQL Warnings (${self.connection.uuid}):` )
+    self.sequelize.log('MySQL Warnings (' + self.connection.uuid + '):', self.options);
     warningResults.forEach(function(_warningResult) {
       if (_warningResult.hasOwnProperty('Message')) {
-        self.sequelize.log("\t"+_warningResult.Message)
+        self.sequelize.log('\t'+_warningResult.Message, self.options);
       } else {
         _warningResult.keys().forEach( function(_objectKey) {
-          self.sequelize.log("\t"+[_objectKey, _warningResult[_objectKey]].join(': '))
-        })
+          self.sequelize.log('\t'+[_objectKey, _warningResult[_objectKey]].join(': '), self.options);
+        });
       }
-    })
-  })
-}
+    });
+  });
+};
 
 Query.prototype.formatError = function (err) {
   var match;

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -136,7 +136,7 @@ Query.prototype.logWarnings = function (results) {
   return this.run('SHOW WARNINGS').then(function(warningResults) {
     var warningMessage = 'MySQL Warnings (' + (self.connection.uuid||'default') + '): ';
     var messages = [];
-
+      
     warningResults.forEach(function(_warningRow){
       _warningRow.forEach(function(_warningResult) {
       if (_warningResult.hasOwnProperty('Message')) {

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -43,6 +43,11 @@ Query.prototype.run = function(sql, parameters) {
         self.sequelize.log('Executed (' + (self.connection.uuid || 'default') + '): ' + self.sql, (Date.now() - queryBegin), self.options);
       }
 
+      // Log warnings if we've got them.
+      if (results && results.warningCount > 0) {
+        self.logWarnings();
+      }
+
       if (err) {
         err.sql = sql;
 
@@ -118,6 +123,21 @@ Query.prototype.formatResults = function(data) {
   return result;
 };
 
+Query.prototype.logWarnings = function () {
+  var self = this
+  self.connection.query('SHOW WARNINGS', function(err, warningResults) {
+    self.sequelize.log( `MySQL Warnings (${self.connection.uuid}):` )
+    warningResults.forEach(function(_warningResult) {
+      if (_warningResult.hasOwnProperty('Message')) {
+        self.sequelize.log("\t"+_warningResult.Message)
+      } else {
+        _warningResult.keys().forEach( function(_objectKey) {
+          self.sequelize.log("\t"+[_objectKey, _warningResult[_objectKey]].join(': '))
+        })
+      }
+    })
+  })
+}
 
 Query.prototype.formatError = function (err) {
   var match;

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -139,16 +139,16 @@ Query.prototype.logWarnings = function (results) {
       
     warningResults.forEach(function(_warningRow){
       _warningRow.forEach(function(_warningResult) {
-      if (_warningResult.hasOwnProperty('Message')) {
+        if (_warningResult.hasOwnProperty('Message')) {
           messages.push(_warningResult.Message);
-      } else {
-        _warningResult.keys().forEach( function(_objectKey) {
+        } else {
+          _warningResult.keys().forEach( function(_objectKey) {
             messages.push([_objectKey, _warningResult[_objectKey]].join(': '));
-        });
-      }
+          });
+        }
     });
   });
-
+    
     self.sequelize.log(warningMessage + messages.join('; '), self.options);
     
     return results;

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -27,7 +27,7 @@ Query.formatBindParameters = AbstractQuery.formatBindParameters;
 Query.prototype.run = function(sql, parameters) {
   var self = this;
   this.sql = sql;
-  
+
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
   var showWarnings = this.sequelize.options.showWarnings || this.options.showWarnings;

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -27,7 +27,7 @@ Query.formatBindParameters = AbstractQuery.formatBindParameters;
 Query.prototype.run = function(sql, parameters) {
   var self = this;
   this.sql = sql;
-
+  
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
   var showWarnings = this.sequelize.options.showWarnings || this.options.showWarnings;
@@ -139,16 +139,16 @@ Query.prototype.logWarnings = function (results) {
 
     warningResults.forEach(function(_warningRow){
       _warningRow.forEach(function(_warningResult) {
-        if (_warningResult.hasOwnProperty('Message')) {
+      if (_warningResult.hasOwnProperty('Message')) {
           messages.push(_warningResult.Message);
-        } else {
-          _warningResult.keys().forEach( function(_objectKey) {
+      } else {
+        _warningResult.keys().forEach( function(_objectKey) {
             messages.push([_objectKey, _warningResult[_objectKey]].join(': '));
           });
-        }
+      }
       });
     });
-    
+
     self.sequelize.log(warningMessage + messages.join('; '), self.options);
     
     return results;

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -136,7 +136,7 @@ Query.prototype.logWarnings = function (results) {
   return this.run('SHOW WARNINGS').then(function(warningResults) {
     var warningMessage = 'MySQL Warnings (' + (self.connection.uuid||'default') + '): ';
     var messages = [];
-      
+        
     warningResults.forEach(function(_warningRow){
       _warningRow.forEach(function(_warningResult) {
         if (_warningResult.hasOwnProperty('Message')) {
@@ -146,7 +146,7 @@ Query.prototype.logWarnings = function (results) {
             messages.push([_objectKey, _warningResult[_objectKey]].join(': '));
           });
         }
-    });
+      });
   });
     
     self.sequelize.log(warningMessage + messages.join('; '), self.options);

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -27,7 +27,7 @@ Query.formatBindParameters = AbstractQuery.formatBindParameters;
 Query.prototype.run = function(sql, parameters) {
   var self = this;
   this.sql = sql;
-
+  
   //do we need benchmark for this query execution
   var benchmark = this.sequelize.options.benchmark || this.options.benchmark;
   var showWarnings = this.sequelize.options.showWarnings || this.options.showWarnings;

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -277,7 +277,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         bCol: { type: Sequelize.STRING, unique: 'a_and_b' }
       });
 
-      return User.sync({ force: true, logging: _.after(2, _.once(function(sql) {
+      return User.sync({ force: true, logging: _.after(3, _.once(function(sql) {
         if (dialect === 'mssql') {
           expect(sql).to.match(/CONSTRAINT\s*([`"\[]?user_and_email[`"\]]?)?\s*UNIQUE\s*\([`"\[]?username[`"\]]?, [`"\[]?email[`"\]]?\)/);
           expect(sql).to.match(/CONSTRAINT\s*([`"\[]?a_and_b[`"\]]?)?\s*UNIQUE\s*\([`"\[]?aCol[`"\]]?, [`"\[]?bCol[`"\]]?\)/);
@@ -2223,7 +2223,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
 
       var run = function() {
         return UserPub.sync({ force: true }).then(function() {
-          return ItemPub.sync({ force: true, logging: _.after(2, _.once(function(sql) {
+          return ItemPub.sync({ force: true, logging: _.after(3, _.once(function(sql) {
             if (dialect === 'postgres') {
               expect(sql).to.match(/REFERENCES\s+"prefix"\."UserPubs" \("id"\)/);
             } else if (dialect === 'mssql') {
@@ -2664,7 +2664,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         str: { type: Sequelize.STRING, unique: true }
       });
 
-      return uniqueTrue.sync({force: true, logging: _.after(2, _.once(function(s) {
+      return uniqueTrue.sync({force: true, logging: _.after(3, _.once(function(s) {
         expect(s).to.match(/UNIQUE/);
       }))});
     });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -277,7 +277,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         bCol: { type: Sequelize.STRING, unique: 'a_and_b' }
       });
 
-      return User.sync({ force: true, logging: _.after(3, _.once(function(sql) {
+      return User.sync({ force: true, logging: _.after(2, _.once(function(sql) {
         if (dialect === 'mssql') {
           expect(sql).to.match(/CONSTRAINT\s*([`"\[]?user_and_email[`"\]]?)?\s*UNIQUE\s*\([`"\[]?username[`"\]]?, [`"\[]?email[`"\]]?\)/);
           expect(sql).to.match(/CONSTRAINT\s*([`"\[]?a_and_b[`"\]]?)?\s*UNIQUE\s*\([`"\[]?aCol[`"\]]?, [`"\[]?bCol[`"\]]?\)/);
@@ -2223,7 +2223,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
 
       var run = function() {
         return UserPub.sync({ force: true }).then(function() {
-          return ItemPub.sync({ force: true, logging: _.after(3, _.once(function(sql) {
+          return ItemPub.sync({ force: true, logging: _.after(2, _.once(function(sql) {
             if (dialect === 'postgres') {
               expect(sql).to.match(/REFERENCES\s+"prefix"\."UserPubs" \("id"\)/);
             } else if (dialect === 'mssql') {
@@ -2664,7 +2664,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         str: { type: Sequelize.STRING, unique: true }
       });
 
-      return uniqueTrue.sync({force: true, logging: _.after(3, _.once(function(s) {
+      return uniqueTrue.sync({force: true, logging: _.after(2, _.once(function(s) {
         expect(s).to.match(/UNIQUE/);
       }))});
     });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -95,7 +95,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
       describe('with an invalid connection', function() {
         beforeEach(function() {
-          var options = _.extend({logging:true,showWarnings:true}, this.sequelize.options, { port: '99999' });
+          var options = _.extend({}, this.sequelize.options, { port: '99999' });
           this.sequelizeWithInvalidConnection = new Sequelize('wat', 'trololo', 'wow', options);
         });
 
@@ -281,7 +281,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
         return sequelize.query(insertWarningQuery)
         .then(function(results) {
           expect(logger.callCount).to.equal(3);
-          expect(logger.args[2][0]).to.be.match(/^MySQL Warnings \(default\): Data truncated for column 'createdAt'/m);
+          expect(logger.args[2][0]).to.be.match(/^MySQL Warnings \(default\):.*?'createdAt'/m);
         });
       });
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -267,23 +267,26 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
         });
       });
     
-      it('logs warnings when there are warnings', function() {
-        var logger = sinon.spy();
-        var sequelize = Support.createSequelizeInstance({
-          logging: logger,
-          benchmark: false,
-          showWarnings: true
-        });
-        var insertWarningQuery = 'INSERT INTO ' + qq(this.User.tableName) + ' (username, email_address, ' +
-          qq('createdAt') + ', ' + qq('updatedAt') +
-          ") VALUES ('john', 'john@gmail.com', 'HORSE', '2012-01-01 10:10:10')";
+      // We can only test MySQL warnings when using MySQL.
+      if (Support.dialectIsMySQL()) {
+        it('logs warnings when there are warnings', function() {
+          var logger = sinon.spy();
+          var sequelize = Support.createSequelizeInstance({
+            logging: logger,
+            benchmark: false,
+            showWarnings: true
+          });
+          var insertWarningQuery = 'INSERT INTO ' + qq(this.User.tableName) + ' (username, email_address, ' +
+            qq('createdAt') + ', ' + qq('updatedAt') +
+            ") VALUES ('john', 'john@gmail.com', 'HORSE', '2012-01-01 10:10:10')";
 
-        return sequelize.query(insertWarningQuery)
-        .then(function(results) {
-          expect(logger.callCount).to.equal(3);
-          expect(logger.args[2][0]).to.be.match(/^MySQL Warnings \(default\):.*?'createdAt'/m);
+          return sequelize.query(insertWarningQuery)
+          .then(function(results) {
+            expect(logger.callCount).to.equal(3);
+            expect(logger.args[2][0]).to.be.match(/^MySQL Warnings \(default\):.*?'createdAt'/m);
+          });
         });
-      });
+      }
 
       it('executes a query with global benchmarking option and custom logger', function() {
         var logger = sinon.spy();

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -95,7 +95,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
       describe('with an invalid connection', function() {
         beforeEach(function() {
-          var options = _.extend({}, this.sequelize.options, { port: '99999' });
+          var options = _.extend({logging:true,showWarnings:true}, this.sequelize.options, { port: '99999' });
           this.sequelizeWithInvalidConnection = new Sequelize('wat', 'trololo', 'wow', options);
         });
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -1197,6 +1197,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
       it('through Sequelize.sync()', function() {
         var self = this;
+        self.spy.reset();
         return this.sequelize.sync({ force: true, logging: false }).then(function() {
           expect(self.spy.notCalled).to.be.true;
         });
@@ -1204,6 +1205,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
 
       it('through DAOFactory.sync()', function() {
         var self = this;
+        self.spy.reset();
         return this.User.sync({ force: true, logging: false }).then(function() {
           expect(self.spy.notCalled).to.be.true;
         });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -252,6 +252,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       return this.sequelize.query(this.insertQuery);
     });
 
+
     describe('logging', function () {
       it('executes a query with global benchmarking option and default logger', function() {
         var logger = sinon.spy(console, 'log');
@@ -263,6 +264,24 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
         return sequelize.query('select 1;').then(function() {
           expect(logger.calledOnce).to.be.true;
           expect(logger.args[0][0]).to.be.match(/Executed \(default\): select 1; Elapsed time: \d+ms/);
+        });
+      });
+    
+      it('logs warnings when there are warnings', function() {
+        var logger = sinon.spy();
+        var sequelize = Support.createSequelizeInstance({
+          logging: logger,
+          benchmark: false,
+          showWarnings: true
+        });
+        var insertWarningQuery = 'INSERT INTO ' + qq(this.User.tableName) + ' (username, email_address, ' +
+          qq('createdAt') + ', ' + qq('updatedAt') +
+          ") VALUES ('john', 'john@gmail.com', 'HORSE', '2012-01-01 10:10:10')";
+
+        return sequelize.query(insertWarningQuery)
+        .then(function(results) {
+          expect(logger.callCount).to.equal(3);
+          expect(logger.args[2][0]).to.be.match(/^MySQL Warnings \(default\): Data truncated for column 'createdAt'/m);
         });
       });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
 + One caveat, tests are failing on `master`. My tests fail identically to those on `master`.
- [X] Does your issue contain a link to existing issue (Closes #5900) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [N/A] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This provides the ability for MySQL logs to be reported using the existing `sequelize.log()` functionality. This should help people find issues which MySQL doesn't consider errors, but does consider worthy of warning on.

