### PR TITLE
BIGINT converted to strings when required (mysql)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,7 +5,8 @@
 - [CHANGED] Throw `bluebird.AggregateError` instead of array from `bulkCreate` when validation fails
 - [FIXED] `$notIn: []` is now converted to `NOT IN (NULL)`  [#4859](https://github.com/sequelize/sequelize/issues/4859)
 - [FIXED] Add `raw` support to `instance.get()` [#5815](https://github.com/sequelize/sequelize/issues/5815)
-- [ADDED] Compare deletedAt against current timestamp when using paranoid [#5880](https://github.com/sequelize/sequelize/pull/5880)
+- [ADDED] Compare `deletedAt` against current timestamp when using paranoid [#5880](https://github.com/sequelize/sequelize/pull/5880)
+- [FIXED] `BIGINT` gets truncated [#5176](https://github.com/sequelize/sequelize/issues/5176)
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails
@@ -13,6 +14,7 @@
 - Remove default dialect
 - When `bulkCreate` is rejected because of validation failure it throws a `bluebird.AggregateError` instead of an array. This object is an array-like so length and index access will still work, but `instanceof` array will not
 - `$notIn: []` will now match all rows instead of none
+- (MySQL) `BIGINT` now gets converted to string when number is too big
 
 # 3.23.2
 - [FIXED] Type validation now works with non-strings due to updated validator@5.0.0 [#5861](https://github.com/sequelize/sequelize/pull/5861)

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -60,7 +60,9 @@ ConnectionManager.prototype.connect = function(config) {
       password: config.password,
       database: config.database,
       timezone: self.sequelize.options.timezone,
-      typeCast: ConnectionManager.$typecast.bind(self)
+      typeCast: ConnectionManager.$typecast.bind(self),
+      bigNumberStrings: false,
+      supportBigNumbers: true
     };
 
     if (config.dialectOptions) {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -364,4 +364,26 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
     });
   }
 
+  if (dialect === 'mysql') {
+    it('should parse BIGINT as string', function () {
+      var Model = this.sequelize.define('model', {
+        jewelPurity: Sequelize.BIGINT
+      });
+
+      var sampleData = {
+        id: 1,
+        jewelPurity: '9223372036854775807',
+      };
+
+      return Model.sync({ force: true }).then(function () {
+        return Model.create(sampleData);
+      }).then(function () {
+        return Model.find({id: 1});
+      }).then(function (user) {
+        expect(user.get('jewelPurity')).to.be.eql(sampleData.jewelPurity);
+        expect(user.get('jewelPurity')).to.be.string;
+      });
+    });
+  }
+
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Fixes #5176 

By using the API of `node-mysql` now `mysql` dialect can represent `BIGINT` in string form. In Addition to that this conversion will only happen when number is too big for JS to handle.

So this change will not effect small numbers. If a number gets big enough to get truncated we will convert it to `string` to save valid number.

cc @janmeier @mickhansen 
