### PR TITLE
Fixed bug defaultValue was not used when attribute was set in fields …

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - [CHANGED] Throw `bluebird.AggregateError` instead of array from `bulkCreate` when validation fails
 - [FIXED] `$notIn: []` is now converted to `NOT IN (NULL)`  [#4859](https://github.com/sequelize/sequelize/issues/4859)
 - [FIXED] Add `raw` support to `instance.get()` [#5815](https://github.com/sequelize/sequelize/issues/5815)
+- [FIXED] Use `defaultValue` for attribute in `Model.create()` when given attribute is specified but excluded in `fields` (similar to [#3458](https://github.com/sequelize/sequelize/issues/3458))
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -52,7 +52,7 @@ var initValues = function(values, options) {
 
     if (Object.keys(defaults).length) {
       for (key in defaults) {
-        if (values[key] === undefined) {
+        if (values[key] === undefined || (options.attributes && options.attributes.indexOf(key) < 0)) {
           this.set(key, Utils.toDefaultValue(defaults[key]), defaultsOptions);
           delete values[key];
         }

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -819,6 +819,27 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         });
       });
     });
+
+    describe('excluded attributes', function() {
+      it('should use default value if an attribute is excluded in attributes option', function() {
+        var Person = this.sequelize.define('Person', {
+          username: DataTypes.STRING,
+          taskCount: {
+            type: DataTypes.INTEGER,
+            defaultValue: 2
+          }
+        });
+
+        var person = Person.build({
+          username: 'John',
+          taskCount: 5
+        }, {
+          attributes: ['username']
+        });
+        expect(person.username).to.equal('John');
+        expect(person.taskCount).to.equal(2);
+      });
+    });
   });
 
   describe('complete', function() {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1203,27 +1203,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
-    it('should use default value if attribute is excluded in fields option', function() {
-      var User = this.sequelize.define('User', {
-        username: DataTypes.STRING,
-        taskCount: {
-          type: DataTypes.INTEGER,
-          defaultValue: 2
-        }
-      });
-
-      return User.sync().then(function() {
-        return User.create({
-          username: 'John',
-          taskCount: 5
-        }, {
-          fields: ['username']
-        }).then(function(savedUser) {
-          expect(savedUser.taskCount).to.equal(2);
-        });
-      });
-    });
-
     describe('enums', function() {
       it('correctly restores enum values', function() {
         var self = this

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1203,6 +1203,27 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    it('should use default value if attribute is excluded in fields option', function() {
+      var User = this.sequelize.define('User', {
+        username: DataTypes.STRING,
+        taskCount: {
+          type: DataTypes.INTEGER,
+          defaultValue: 2
+        }
+      });
+
+      return User.sync().then(function() {
+        return User.create({
+          username: 'John',
+          taskCount: 5
+        }, {
+          fields: ['username']
+        }).then(function(savedUser) {
+          expect(savedUser.taskCount).to.equal(2);
+        });
+      });
+    });
+
     describe('enums', function() {
       it('correctly restores enum values', function() {
         var self = this


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test-mariadb` pass with this change (including linting)?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?
### Description of change

Similar to issue [#3458](https://github.com/sequelize/sequelize/issues/3458) but when you specified the attribute even though it is not in fields array it was set to null.

```
var Media = sequelize.define('Media', {
        uuid: {
            type: DataTypes.UUID,
            defaultValue: DataTypes.UUIDV4,
            primaryKey: true,
            allowNull: false
        },
        someValue: DataTypes.STRING
});

Media.create({uuid: 'some value', someValue: 'some value'}, {
            fields: ['someValue']
});
```

Would result into a `notNull Violation: uuid cannot be null`
