### PR TITLE
Removed support for pool:false

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 - [FIXED] Add `raw` support to `instance.get()` [#5815](https://github.com/sequelize/sequelize/issues/5815)
 - [ADDED] Compare `deletedAt` against current timestamp when using paranoid [#5880](https://github.com/sequelize/sequelize/pull/5880)
 - [FIXED] `BIGINT` gets truncated [#5176](https://github.com/sequelize/sequelize/issues/5176)
+- [REMOVED] Support for `pool:false`
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails
@@ -15,6 +16,7 @@
 - When `bulkCreate` is rejected because of validation failure it throws a `bluebird.AggregateError` instead of an array. This object is an array-like so length and index access will still work, but `instanceof` array will not
 - `$notIn: []` will now match all rows instead of none
 - (MySQL) `BIGINT` now gets converted to string when number is too big
+- Removed support for `pool:false`, if you still want to use single connection set `pool.max` to `1`
 
 # 3.23.2
 - [FIXED] Type validation now works with non-strings due to updated validator@5.0.0 [#5861](https://github.com/sequelize/sequelize/pull/5861)

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -62,9 +62,9 @@ var sequelize = new Sequelize('mysql://localhost:3306/database', {})
 | [options.native=false] | Boolean | A flag that defines if native library shall be used or not. Currently only has an effect for postgres |
 | [options.replication=false] | Boolean | Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database` |
 | [options.pool={}] | Object | Should sequelize use a connection pool. Default is true |
-| [options.pool.maxConnections] | Integer |  |
-| [options.pool.minConnections] | Integer |  |
-| [options.pool.maxIdleTime] | Integer | The maximum time, in milliseconds, that a connection can be idle before being released |
+| [options.pool.max] | Integer |  |
+| [options.pool.min] | Integer |  |
+| [options.pool.idle] | Integer | The maximum time, in milliseconds, that a connection can be idle before being released |
 | [options.pool.validateConnection] | Function | A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected |
 | [options.quoteIdentifiers=true] | Boolean | Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them. |
 | [options.transactionType='DEFERRED'] | String | Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only. |

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -106,7 +106,7 @@ var sequelize = new Sequelize('database', 'username', 'password', {
  
   // use pooling in order to reduce db connection overload and to increase speed
   // currently only for mysql and postgresql (since v1.5.0)
-  pool: { maxConnections: 5, maxIdleTime: 30},
+  pool: { max: 5, idle: 30},
  
   // language is used to determine how to translate words into singular or plural form based on the [lingo project](https://github.com/visionmedia/lingo)
   // options are: en [default], es
@@ -140,8 +140,8 @@ var sequelize = new Sequelize('database', null, null, {
     write: { host: 'localhost', username: 'root', password: null }
   },
   pool: { // If you want to override the options used for the read pool you can do so here
-    maxConnections: 20,
-    maxIdleTime: 30000
+    max: 20,
+    idle: 30000
   },
 })
 ```
@@ -152,9 +152,9 @@ Sequelize uses a pool to manage connections to your replicas. The default option
 
 ```js
 {
-  maxConnections: 10,
-  minConnections: 0,
-  maxIdleTime:    1000
+  max: 10,
+  min: 0,
+  idle: 1000
 }
 ```
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -21,27 +21,17 @@ ConnectionManager = function(dialect, sequelize) {
   this.versionPromise = null;
   this.dialectName = this.sequelize.options.dialect;
 
-  if (config.pool) {
-    config.pool = _.clone(config.pool); // Make sure we don't modify the existing config object (user might re-use it)
-    config.pool =_.defaults(config.pool, defaultPoolingConfig, {
+  if (config.pool !== false) {
+    config.pool =_.defaults(config.pool || {}, defaultPoolingConfig, {
       validate: this.$validate.bind(this)
     }) ;
   } else {
-    // If the user has turned off pooling we provide a 0/1 pool for backwards compat
-    config.pool = _.defaults({
-      max: 1,
-      min: 0
-    }, defaultPoolingConfig, {
-      validate: this.$validate.bind(this)
-    });
+    throw new Error('Support for pool:false was removed in v4.0');
   }
 
-  // Map old names
-  if (config.pool.maxIdleTime) config.pool.idle = config.pool.maxIdleTime;
-  if (config.pool.maxConnections) config.pool.max = config.pool.maxConnections;
-  if (config.pool.minConnections) config.pool.min = config.pool.minConnections;
+  // Save a reference to the bound version so we can remove it with removeListener
+  this.onProcessExit = this.onProcessExit.bind(this);
 
-  this.onProcessExit = this.onProcessExit.bind(this); // Save a reference to the bound version so we can remove it with removeListener
   process.on('exit', this.onProcessExit);
 };
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -80,9 +80,9 @@ var url = require('url')
  * @param {Boolean}  [options.native=false] A flag that defines if native library shall be used or not. Currently only has an effect for postgres
  * @param {Boolean}  [options.replication=false] Use read / write replication. To enable replication, pass an object, with two properties, read and write. Write should be an object (a single server for handling writes), and read an array of object (several servers to handle reads). Each read/write server can have the following properties: `host`, `port`, `username`, `password`, `database`
  * @param {Object}   [options.pool={}] Should sequelize use a connection pool. Default is true
- * @param {Integer}  [options.pool.maxConnections]
- * @param {Integer}  [options.pool.minConnections]
- * @param {Integer}  [options.pool.maxIdleTime] The maximum time, in milliseconds, that a connection can be idle before being released
+ * @param {Integer}  [options.pool.max] Maximum number of connection in pool. Default is 5
+ * @param {Integer}  [options.pool.min] Minimum number of connection in pool. Default is 0
+ * @param {Integer}  [options.pool.idle] The maximum time, in milliseconds, that a connection can be idle before being released
  * @param {Function} [options.pool.validateConnection] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
  * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.
  * @param {String}   [options.transactionType='DEFERRED'] Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.

--- a/test/config/config.js
+++ b/test/config/config.js
@@ -6,8 +6,8 @@ module.exports = {
   database: process.env.SEQ_DB   || 'sequelize_test',
   host:     process.env.SEQ_HOST || '127.0.0.1',
   pool:     {
-    maxConnections: process.env.SEQ_POOL_MAX  || 5,
-    maxIdleTime:    process.env.SEQ_POOL_IDLE || 30000
+    max: process.env.SEQ_POOL_MAX  || 5,
+    idle: process.env.SEQ_POOL_IDLE || 30000
   },
 
   rand: function() {
@@ -25,12 +25,12 @@ module.exports = {
     host:     process.env.SEQ_MSSQL_HOST || process.env.SEQ_HOST || 'mssql.sequelizejs.com',
     port:     process.env.SEQ_MSSQL_PORT || process.env.SEQ_PORT || 11433,
     pool:     {
-      maxConnections: process.env.SEQ_MSSQL_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
-      maxIdleTime:    process.env.SEQ_MSSQL_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
+      max: process.env.SEQ_MSSQL_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
+      idle: process.env.SEQ_MSSQL_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
     }
   },
 
-  //make maxIdleTime small so that tests exit promptly
+  //make idle time small so that tests exit promptly
   mysql: {
     database: process.env.SEQ_MYSQL_DB   || process.env.SEQ_DB   || 'sequelize_test',
     username: process.env.SEQ_MYSQL_USER || process.env.SEQ_USER || 'root',
@@ -38,8 +38,8 @@ module.exports = {
     host:     process.env.MYSQL_PORT_3306_TCP_ADDR || process.env.SEQ_MYSQL_HOST || process.env.SEQ_HOST || '127.0.0.1',
     port:     process.env.MYSQL_PORT_3306_TCP_PORT || process.env.SEQ_MYSQL_PORT || process.env.SEQ_PORT || 3306,
     pool:     {
-      maxConnections: process.env.SEQ_MYSQL_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
-      maxIdleTime:    process.env.SEQ_MYSQL_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
+      max: process.env.SEQ_MYSQL_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
+      idle: process.env.SEQ_MYSQL_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
     }
   },
 
@@ -53,8 +53,8 @@ module.exports = {
     host:     process.env.POSTGRES_PORT_5432_TCP_ADDR || process.env.SEQ_PG_HOST || process.env.SEQ_HOST  || '127.0.0.1',
     port:     process.env.POSTGRES_PORT_5432_TCP_PORT || process.env.SEQ_PG_PORT || process.env.SEQ_PORT  || 5432,
     pool:     {
-      maxConnections: process.env.SEQ_PG_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
-      maxIdleTime:    process.env.SEQ_PG_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
+      max: process.env.SEQ_PG_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
+      idle: process.env.SEQ_PG_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
     }
   },
 
@@ -65,8 +65,8 @@ module.exports = {
     host:     process.env.SEQ_MYSQL_HOST || process.env.SEQ_HOST || '127.0.0.1',
     port:     process.env.SEQ_MYSQL_PORT || process.env.SEQ_PORT || 3306,
     pool:     {
-      maxConnections: process.env.SEQ_MYSQL_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
-      maxIdleTime:    process.env.SEQ_MYSQL_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
+      max: process.env.SEQ_MYSQL_POOL_MAX  || process.env.SEQ_POOL_MAX  || 5,
+      idle: process.env.SEQ_MYSQL_POOL_IDLE || process.env.SEQ_POOL_IDLE || 3000
     }
   }
 };

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -34,8 +34,11 @@ if (Support.dialectIsMySQL()) {
     });
 
     it('accepts new queries after shutting down a connection', function() {
-      // Create a sequelize instance with pooling disabled
-      var sequelize = Support.createSequelizeInstance({ pool: false });
+      // Create a sequelize instance with fast disconnecting connection
+      var sequelize = Support.createSequelizeInstance({ pool: {
+        idle: 50,
+        max: 1
+      } });
       var User = sequelize.define('User', { username: DataTypes.STRING });
 
       return User.sync({force: true}).then(function() {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -32,13 +32,13 @@ var qq = function(str) {
 describe(Support.getTestDialectTeaser('Sequelize'), function() {
   describe('constructor', function() {
     if (dialect !== 'sqlite') {
-      it.skip('should work with minConnections', function() {
+      it.skip('should work with min connections', function() {
         var ConnectionManager = current.dialect.connectionManager
           , connectionSpy = ConnectionManager.connect = chai.spy(ConnectionManager.connect);
 
         Support.createSequelizeInstance({
           pool: {
-            minConnections: 2
+            min: 2
           }
         });
         expect(connectionSpy).to.have.been.called.twice;

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -24,6 +24,15 @@ describe('Sequelize', function() {
     });
   });
 
+  it('should throw error if pool:false', function() {
+    expect(function() {
+      new Sequelize('localhost', 'test', 'test', {
+        dialect: 'mysql',
+        pool: false
+      });
+    }).to.throw('Support for pool:false was removed in v4.0');
+  });
+
   describe('Instantiation with arguments', function() {
     it('should accept four parameters (database, username, password, options)', function() {
       var sequelize = new Sequelize('dbname', 'root', 'pass', {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #5686 

Removed support for `pool:false`. If config specifically set `pool:false` an error will be thrown. Otherwise default pool config will be used. Document updates are included as well.

Full change list

- [x] Remove support for `pool:false`
- [x] Remove old naming
- [x] Check & update pooling docs
- [x] Update tests and config which use old pool settings