### PR TITLE
feat(model): put model in options for hook access

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2148,6 +2148,8 @@ Model.prototype.bulkCreate = function(records, options) {
     }
     options.updateOnDuplicate = updatableFields;
   }
+  
+  options.model = this;
 
   var self = this
     , createdAtAttr = this._timestampAttributes.createdAt
@@ -2226,8 +2228,6 @@ Model.prototype.bulkCreate = function(records, options) {
         }
       }
 
-      // Insert all records at once
-      options.model = self;
       return self.QueryInterface.bulkInsert(self.getTableName(options), records, options, attributes).then(function (results) {
         if (Array.isArray(results)) {
           results.forEach(function (result, i) {
@@ -2382,7 +2382,8 @@ Model.prototype.restore = function(options) {
   }, options || {});
 
   options.type = QueryTypes.RAW;
-
+  options.model = this;
+  
   var self = this
     , instances;
 
@@ -2498,6 +2499,8 @@ Model.prototype.update = function(values, options) {
   if (this._timestampAttributes.updatedAt && !options.silent) {
     values[this._timestampAttributes.updatedAt] = this.$getDefaultTimestamp(this._timestampAttributes.updatedAt) || Utils.now(this.sequelize.options.dialect);
   }
+  
+  options.model = this;
 
   var instances
     , valuesUse;


### PR DESCRIPTION
### Description of change

Use case for this is generic cache invalidation using the options.model.name and options.where.id or obj.id