### PR TITLE
Task 5248, Refactor methods which use fields and options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - [REMOVED] MariaDB dialect
 - [FIXED] `hasOne` now prefer aliases to construct foreign key [#5247](https://github.com/sequelize/sequelize/issues/5247)
 - [CHANGED] `instance.equals` now only checks primary keys, instead of all attributes.
+- [CHANGED] Refactor methods to use options only [#5248](https://github.com/sequelize/sequelize/issues/5248)
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails
@@ -27,6 +28,7 @@
 - Removed MariaDB dialect - this was just a thin wrapper around MySQL, so using `dialect: 'mysql'` instead should work with no further changes
 - `hasOne` now prefer `as` option to generate foreign key name, otherwise it defaults to source model name
 - `instance.equals` now provides reference equality (do two instances refer to the same row, i.e. are their primary key(s) equal). Use `instance.get()` to get and compare all values.
+- Changed signature for `increment`/`decrement` to only use `options`. Use `options.fields` to pass the `fields`
 
 # 3.23.2
 - [FIXED] Type validation now works with non-strings due to updated validator@5.0.0 [#5861](https://github.com/sequelize/sequelize/pull/5861)

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -827,7 +827,7 @@ Instance.prototype.updateAttributes = Instance.prototype.update;
  * @param {Boolean}     [options.force=false] If set to true, paranoid models will actually be deleted
  * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
- * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {String}      [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<undefined>}
  */
@@ -915,23 +915,29 @@ Instance.prototype.restore = function(options) {
  * query. To get the correct value after an increment into the Instance you should do a reload.
  *
  *```js
- * instance.increment('number') // increment number by 1
- * instance.increment(['number', 'count'], { by: 2 }) // increment number and count by 2
- * instance.increment({ answer: 42, tries: 1}, { by: 2 }) // increment answer by 42, and tries by 1.
+ * instance.increment({ fields: 'number' }) // increment number by 1
+ * instance.increment({ fields: ['number', 'count'], by: 2 }) // increment number and count by 2
+ * instance.increment({ fields: { answer: 42, tries: 1 }, by: 2 }) // increment answer by 42, and tries by 1.
  *                                                        // `by` is ignored, since each column has its own value
  * ```
  *
  * @see {Instance#reload}
- * @param {String|Array|Object} fields If a string is provided, that column is incremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is incremented by the value given.
- * @param {Object} [options]
- * @param {Integer} [options.by=1] The number to increment by
- * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
- * @param {Transaction} [options.transaction]
- * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param
+ * @param {Object}              [options]
+ * @param {String|Array|Object} [options.fields] If a string is provided, that column is incremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is incremented by the value given.
+ * @param {Integer}             [options.by=1] The number to increment by
+ * @param {Function}            [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Transaction}         [options.transaction]
+ * @param {String}              [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise<this>}
  */
-Instance.prototype.increment = function(fields, options) {
+Instance.prototype.increment = function(options) {
+
+  if (arguments.length > 1 || !options.fields) {
+      throw new Error('Increment was refactored to use options only. Pass fields via `options.fields` option.');
+  }
+
   var identifier = this.where()
     , updatedAtAttr = this.Model._timestampAttributes.updatedAt
     , values = {}
@@ -945,14 +951,14 @@ Instance.prototype.increment = function(fields, options) {
 
   where = _.extend({}, options.where, identifier);
 
-  if (Utils._.isString(fields)) {
-    values[fields] = options.by;
-  } else if (Utils._.isArray(fields)) {
-    Utils._.each(fields, function(field) {
+  if (Utils._.isString(options.fields)) {
+    values[options.fields] = options.by;
+  } else if (Utils._.isArray(options.fields)) {
+    Utils._.each(options.fields, function(field) {
       values[field] = options.by;
     });
   } else { // Assume fields is key-value pairs
-    values = fields;
+    values = options.fields;
   }
 
   if (updatedAtAttr && !values[updatedAtAttr]) {
@@ -978,36 +984,41 @@ Instance.prototype.increment = function(fields, options) {
  * query. To get the correct value after an decrement into the Instance you should do a reload.
  *
  * ```js
- * instance.decrement('number') // decrement number by 1
- * instance.decrement(['number', 'count'], { by: 2 }) // decrement number and count by 2
- * instance.decrement({ answer: 42, tries: 1}, { by: 2 }) // decrement answer by 42, and tries by 1.
+ * instance.decrement({ fields: 'number' }) // decrement number by 1
+ * instance.decrement({ fields: ['number', 'count'], by: 2 }) // decrement number and count by 2
+ * instance.decrement({ fields: { answer: 42, tries: 1 }, by: 2 }) // decrement answer by 42, and tries by 1.
  *                                                        // `by` is ignored, since each column has its own value
  * ```
  *
  * @see {Instance#reload}
- * @param {String|Array|Object} fields If a string is provided, that column is decremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is decremented by the value given
- * @param {Object} [options]
- * @param {Integer} [options.by=1] The number to decrement by
- * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
- * @param {Transaction} [options.transaction]
- * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param {Object}              [options]
+ * @param {String|Array|Object} [options.fields] If a string is provided, that column is decremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is decremented by the value given
+ * @param {Integer}             [options.by=1] The number to decrement by
+ * @param {Function}            [options.logging=false] A function that gets executed while running the query to log the sql.
+ * @param {Transaction}         [options.transaction]
+ * @param {String}              [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
  *
  * @return {Promise}
  */
-Instance.prototype.decrement = function(fields, options) {
+Instance.prototype.decrement = function(options) {
+
+  if (arguments.length > 1 || !options.fields) {
+      throw new Error('Decrement was refactored to use options only. Pass fields via `options.fields` option.');
+  }
+
   options = _.defaults({}, options, {
     by: 1
   });
 
-  if (!Utils._.isString(fields) && !Utils._.isArray(fields)) { // Assume fields is key-value pairs
-    Utils._.each(fields, function(value, field) {
-      fields[field] = -value;
+  if (!Utils._.isString(options.fields) && !Utils._.isArray(options.fields)) { // Assume fields is key-value pairs
+    Utils._.each(options.fields, function(value, field) {
+      options.fields[field] = -value;
     });
   }
 
   options.by = 0 - options.by;
 
-  return this.increment(fields, options);
+  return this.increment(options);
 };
 
 /**

--- a/lib/plugins/counter-cache.js
+++ b/lib/plugins/counter-cache.js
@@ -82,14 +82,14 @@ CounterCache.prototype.injectHooks = function() {
       var query = CounterUtil._sourceQuery(targetId);
 
       return association.source.find({ where: query, logging: options && options.logging }).then(function (instance) {
-        return instance.increment(counterCacheInstance.columnName, { by: 1, logging: options && options.logging });
+        return instance.increment({ fields: counterCacheInstance.columnName, by: 1, logging: options && options.logging });
       });
     },
     decrement: function (targetId, options) {
       var query = CounterUtil._sourceQuery(targetId);
 
       return association.source.find({ where: query, logging: options && options.logging }).then(function (instance) {
-        return instance.decrement(counterCacheInstance.columnName, { by: 1, logging: options && options.logging });
+        return instance.decrement({ fields: counterCacheInstance.columnName, by: 1, logging: options && options.logging });
       });
     },
     // helpers

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -132,7 +132,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           return User.sync({ force: true }).then(function() {
             return User.create({ number: 1 }).then(function(user) {
               return sequelize.transaction().then(function(t) {
-                return user.increment('number', { by: 2, transaction: t }).then(function() {
+                return user.increment({ fields: 'number', by: 2, transaction: t }).then(function() {
                   return User.findAll().then(function(users1) {
                     return User.findAll({ transaction: t }).then(function(users2) {
                       expect(users1[0].number).to.equal(1);
@@ -151,7 +151,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     if (current.dialect.supports.returnValues.returning) {
       it('supports returning', function() {
         return this.User.findById(1).then(function(user1) {
-          return user1.increment('aNumber', { by: 2 }).then(function() {
+          return user1.increment({ fields: 'aNumber', by: 2 }).then(function() {
             expect(user1.aNumber).to.be.equal(2);
           });
         });
@@ -161,7 +161,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('supports where conditions', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.increment(['aNumber'], { by: 2, where: { bNumber: 1 } }).then(function() {
+        return user1.increment({ fields: ['aNumber'], by: 2, where: { bNumber: 1 } }).then(function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(0);
           });
@@ -172,7 +172,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with array', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.increment(['aNumber'], { by: 2 }).then(function() {
+        return user1.increment({ fields: ['aNumber'], by: 2 }).then(function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(2);
           });
@@ -183,7 +183,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with single field', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.increment('aNumber', { by: 2 }).then(function() {
+        return user1.increment({fields: 'aNumber', by: 2 }).then(function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(2);
           });
@@ -194,7 +194,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with single field and no value', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.increment('aNumber').then(function() {
+        return user1.increment({ fields: 'aNumber' }).then(function() {
           return self.User.findById(1).then(function(user2) {
             expect(user2.aNumber).to.be.equal(1);
           });
@@ -210,7 +210,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           return user2.updateAttributes({
             aNumber: user2.aNumber + 1
           }).then(function() {
-            return user1.increment(['aNumber'], { by: 2 }).then(function() {
+            return user1.increment({ fields: ['aNumber'], by: 2 }).then(function() {
               return self.User.findById(1).then(function(user5) {
                 expect(user5.aNumber).to.be.equal(3);
               });
@@ -224,9 +224,9 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
         return this.sequelize.Promise.all([
-          user1.increment(['aNumber'], { by: 2 }),
-          user1.increment(['aNumber'], { by: 2 }),
-          user1.increment(['aNumber'], { by: 2 })
+          user1.increment({ fields: ['aNumber'], by: 2 }),
+          user1.increment({ fields: ['aNumber'], by: 2 }),
+          user1.increment({ fields: ['aNumber'], by: 2 })
         ]).then(function() {
           return self.User.findById(1).then(function(user2) {
             expect(user2.aNumber).to.equal(6);
@@ -238,7 +238,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with key value pair', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.increment({ 'aNumber': 1, 'bNumber': 2 }).then(function() {
+        return user1.increment({ fields: { 'aNumber': 1, 'bNumber': 2 } }).then(function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(1);
             expect(user3.bNumber).to.be.equal(2);
@@ -259,7 +259,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         oldDate = user.updatedAt;
 
         this.clock.tick(1000);
-        return user.increment('aNumber', {by: 1});
+        return user.increment({ fields: 'aNumber', by: 1});
       }).then(function() {
         return expect(User.findById(1)).to.eventually.have.property('updatedAt').afterTime(oldDate);
       });
@@ -279,7 +279,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           return User.sync({ force: true }).then(function() {
             return User.create({ number: 3 }).then(function(user) {
               return sequelize.transaction().then(function(t) {
-                return user.decrement('number', { by: 2, transaction: t }).then(function() {
+                return user.decrement({ fields: 'number', by: 2, transaction: t }).then(function() {
                   return User.findAll().then(function(users1) {
                     return User.findAll({ transaction: t }).then(function(users2) {
                       expect(users1[0].number).to.equal(3);
@@ -298,7 +298,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with array', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.decrement(['aNumber'], { by: 2 }).then(function() {
+        return user1.decrement({ fields: ['aNumber'], by: 2 }).then(function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(-2);
           });
@@ -309,7 +309,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with single field', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.decrement('aNumber', { by: 2 }).then(function() {
+        return user1.decrement({ fields: 'aNumber', by: 2 }).then(function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(-2);
           });
@@ -320,7 +320,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with single field and no value', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.decrement('aNumber').then(function() {
+        return user1.decrement({ fields: 'aNumber' }).then(function() {
           return self.User.findById(1).then(function(user2) {
             expect(user2.aNumber).to.be.equal(-1);
           });
@@ -336,7 +336,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           return user2.updateAttributes({
             aNumber: user2.aNumber + 1
           }).then(function() {
-            return user1.decrement(['aNumber'], { by: 2 }).then(function() {
+            return user1.decrement({ fields: ['aNumber'], by: 2 }).then(function() {
               return self.User.findById(1).then(function(user5) {
                 expect(user5.aNumber).to.be.equal(-1);
               });
@@ -350,9 +350,9 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
         return this.sequelize.Promise.all([
-          user1.decrement(['aNumber'], { by: 2 }),
-          user1.decrement(['aNumber'], { by: 2 }),
-          user1.decrement(['aNumber'], { by: 2 })
+          user1.decrement({ fields: ['aNumber'], by: 2 }),
+          user1.decrement({ fields: ['aNumber'], by: 2 }),
+          user1.decrement({ fields: ['aNumber'], by: 2 })
         ]).then(function() {
           return self.User.findById(1).then(function(user2) {
             expect(user2.aNumber).to.equal(-6);
@@ -364,7 +364,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
     it('with key value pair', function() {
       var self = this;
       return this.User.findById(1).then(function(user1) {
-        return user1.decrement({ 'aNumber': 1, 'bNumber': 2}).then(function() {
+        return user1.decrement({ fields: { 'aNumber': 1, 'bNumber': 2} }).then(function() {
           return self.User.findById(1).then(function(user3) {
             expect(user3.aNumber).to.be.equal(-1);
             expect(user3.bNumber).to.be.equal(-2);
@@ -384,7 +384,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       }).then(function(user) {
         oldDate = user.updatedAt;
         this.clock.tick(1000);
-        return user.decrement('aNumber', {by: 1});
+        return user.decrement({ fields: 'aNumber', by: 1});
       }).then(function() {
         return expect(User.findById(1)).to.eventually.have.property('updatedAt').afterTime(oldDate);
       });

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -376,7 +376,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
 
       it('should work with increment', function () {
         return this.User.create().then(function (user) {
-          return user.increment('taskCount');
+          return user.increment({ fields: 'taskCount' });
         });
       });
 

--- a/test/integration/schema.test.js
+++ b/test/integration/schema.test.js
@@ -27,7 +27,7 @@ describe(Support.getTestDialectTeaser('Schema'), function() {
 
   it('supports increment', function() {
     return this.User.create({ aNumber: 1 }).then(function(user) {
-      return user.increment('aNumber', { by: 3 });
+      return user.increment({ fields: 'aNumber', by: 3 });
     }).then(function(result) {
       return result.reload();
     }).then(function(user) {
@@ -38,7 +38,7 @@ describe(Support.getTestDialectTeaser('Schema'), function() {
 
   it('supports decrement', function() {
     return this.User.create({ aNumber: 10 }).then(function(user) {
-      return user.decrement('aNumber', { by: 3 });
+      return user.decrement({ fields: 'aNumber', by: 3 });
     }).then(function(result) {
       return result.reload();
     }).then(function(user) {

--- a/test/unit/instance/decrement.test.js
+++ b/test/unit/instance/decrement.test.js
@@ -33,11 +33,11 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         stub.restore();
       });
 
-      it('should allow decrements even if options are not given', function () {
+      it('should throw error if options.fields are missing', function () {
         instance = Model.build({id: 3}, {isNewRecord: false});
         expect(function () {
           instance.decrement(['id']);
-        }).to.not.throw();
+        }).to.throw('Decrement was refactored to use options only. Pass fields via `options.fields` option.');
       });
     });
   });

--- a/test/unit/instance/increment.test.js
+++ b/test/unit/instance/increment.test.js
@@ -33,11 +33,11 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         stub.restore();
       });
 
-      it('should allow increments even if options are not given', function () {
+      it('should throw error if options.fields are missing', function () {
         instance = Model.build({id: 1}, {isNewRecord: false});
         expect(function () {
           instance.increment(['id']);
-        }).to.not.throw();
+        }).to.throw('Increment was refactored to use options only. Pass fields via `options.fields` option.');
       });
     });
   });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included ?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #5248

It appears most of methods are already using the `options` only approach. This PR refactors these methods

- [x] `increment`, `(fields, options)` to `(options)`
- [x] `decrement`, `(fields, options)` to `(options)`

Although `aggregate` methods like `max`, `min` etc also follow the signature like `(field, options)` but I have decided to not change their syntax, because its fairly common to use `User.max('id')` or `User.min('age')`. Same argument can be applied to `increment` and `decrement` as well, but for `aggregate` its more common I think.

Let me know if we need to refactor `aggregate` methods as well.

cc @janmeier 
