### PR TITLE
hasOne now prefer for options.as foreign key name

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,7 +12,7 @@
 - [REMOVED] Default transaction isolation level [#5094](https://github.com/sequelize/sequelize/issues/5094)
 - [ADDED] Add logging for mysql warnings, observant of the `showWarnings` option. [#5900](https://github.com/sequelize/sequelize/issues/5900)
 - [REMOVED] MariaDB dialect
-- [CHANGED] `hasOne` now prefer aliases to construct foreign key [#5247](https://github.com/sequelize/sequelize/issues/5247)
+- [FIXED] `hasOne` now prefer aliases to construct foreign key [#5247](https://github.com/sequelize/sequelize/issues/5247)
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 - [REMOVED] Default transaction isolation level [#5094](https://github.com/sequelize/sequelize/issues/5094)
 - [ADDED] Add logging for mysql warnings, observant of the `showWarnings` option. [#5900](https://github.com/sequelize/sequelize/issues/5900)
 - [REMOVED] MariaDB dialect
+- [CHANGED] `hasOne` now prefer aliases to construct foreign key [#5247](https://github.com/sequelize/sequelize/issues/5247)
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails
@@ -23,6 +24,7 @@
 - Removed support for `pool:false`, if you still want to use single connection set `pool.max` to `1`
 - Removed default `REPEATABLE_READ` transaction isolation, use config option to explicitly set it
 - Removed MariaDB dialect - this was just a thin wrapper around MySQL, so using `dialect: 'mysql'` instead should work with no further changes
+- `hasOne` now prefer `as` option to generate foreign key name, otherwise it defaults to source model name
 
 # 3.23.2
 - [FIXED] Type validation now works with non-strings due to updated validator@5.0.0 [#5861](https://github.com/sequelize/sequelize/pull/5861)

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -47,7 +47,7 @@ var HasOne = function(srcModel, targetModel, options) {
   if (!this.foreignKey) {
     this.foreignKey = Utils.camelizeIf(
       [
-        Utils.underscoredIf(Utils.singularize(this.source.name), this.target.options.underscored),
+        Utils.underscoredIf(Utils.singularize(this.options.as || this.source.name), this.target.options.underscored),
         this.source.primaryKeyAttribute
       ].join('_'),
       !this.source.options.underscored

--- a/test/unit/associations/has-one.test.js
+++ b/test/unit/associations/has-one.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support   = require(__dirname + '/../support')
+  , DataTypes = require(__dirname + '/../../../lib/data-types')
+  , current   = Support.sequelize;
+
+describe(Support.getTestDialectTeaser('hasOne'), function() {
+  it('properly use the `as` key to generate foreign key name', function(){
+    var User = current.define('User', { username: DataTypes.STRING })
+      , Task = current.define('Task', { title: DataTypes.STRING });
+
+    User.hasOne(Task);
+    expect(Task.attributes.UserId).not.to.be.empty;
+
+    User.hasOne(Task, {as : 'Shabda'});
+    expect(Task.attributes.ShabdaId).not.to.be.empty;
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue or a description of the issue you are solving?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #5247

`hasOne` was not using the `options.as` alias for generating foreign key names. Now it does :)

cc @janmeier 

