### PR TITLE
Model#truncate - Fixing documentation formatting

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -698,7 +698,7 @@ Truncate all instances of the model. This is a convenient method for Model.destr
 | ---- | ---- | ----------- |
 | [options] | object | The options passed to Model.destroy in addition to truncate |
 | [options.transaction] | Boolean &#124; function | Transaction to run query under |
-| [options.cascade | Boolean &#124; function | = false] Only used in conjunction with TRUNCATE. Truncates all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE. |
+| [options.cascade=false] | Boolean &#124; function | Only used in conjunction with TRUNCATE. Truncates all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE. |
 | [options.transaction] | Transaction | Transaction to run query under |
 | [options.logging] | Boolean &#124; function | A function that logs sql queries, or false for no logging |
 | [options.searchPath=DEFAULT] | String | An optional parameter to specify the schema search_path (Postgres only) |

--- a/lib/model.js
+++ b/lib/model.js
@@ -2253,7 +2253,7 @@ Model.prototype.bulkCreate = function(records, options) {
  *
  * @param {object} [options] The options passed to Model.destroy in addition to truncate
  * @param {Boolean|function} [options.transaction] Transaction to run query under
- * @param {Boolean|function} [options.cascade = false] Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
+ * @param {Boolean|function} [options.cascade=false] Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
  * @param {Transaction}      [options.transaction] Transaction to run query under
  * @param {Boolean|function} [options.logging] A function that logs sql queries, or false for no logging
  * @param {Boolean}          [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).


### PR DESCRIPTION
The options.cascade row of the table in Model#truncate seemed to be formatted incorrectly