### PR TITLE
My tests failed with docker before I did not include mocha and jshint installations globaly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:5
 
 RUN apt-get install libpq-dev
+RUN npm install jshint -g
+RUN npm install mocha -g
 
 COPY package.json /
 RUN npm install


### PR DESCRIPTION
### Description of change

My tests failed with docker before I did not include mocha and jshint installations globaly.
