### PR TITLE
Add field name mapping for options.attributes in Instance.increment

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3537,6 +3537,14 @@ class Model {
       options.attributes[updatedAtAttr] = this.constructor.$getDefaultTimestamp(updatedAtAttr) || Utils.now(this.sequelize.options.dialect);
     }
 
+    for (const attr of Object.keys(options.attributes)) {
+      // Field name mapping for attributes
+      if (this.constructor.rawAttributes[attr] && this.constructor.rawAttributes[attr].field && this.constructor.rawAttributes[attr].field !== attr) {
+        options.attributes[this.constructor.rawAttributes[attr].field] = options.attributes[attr];
+        delete options.attributes[attr];
+      }
+    }
+
     for (const attr of Object.keys(values)) {
       // Field name mapping
       if (this.constructor.rawAttributes[attr] && this.constructor.rawAttributes[attr].field && this.constructor.rawAttributes[attr].field !== attr) {

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -264,6 +264,29 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         return expect(User.findById(1)).to.eventually.have.property('updatedAt').afterTime(oldDate);
       });
     });
+
+    it('with timestamps set to true and custom field names', function() {
+      var User = this.sequelize.define('IncrementUser', {
+        aNumber: DataTypes.INTEGER,
+        updatedAt: {
+          field: 'updated_at',
+          type: DataTypes.DATE,
+          allowNull: true
+        }
+      }, { timestamps: true, updatedAt: 'updatedAt' })
+        , oldDate;
+
+      return User.sync({ force: true }).bind(this).then(function() {
+        return User.create({aNumber: 1});
+      }).then(function(user) {
+        oldDate = user.updatedAt;
+
+        this.clock.tick(1000);
+        return user.increment('aNumber', {by: 1});
+      }).then(function() {
+        return expect(User.findById(1)).to.eventually.have.property('updatedAt').afterTime(oldDate);
+      });
+    });
   });
 
   describe('decrement', function() {

--- a/test/unit/instance/increment.test.js
+++ b/test/unit/instance/increment.test.js
@@ -79,7 +79,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           instance.increment(['id'], {attributes: {incrementedAt: new Date()}});
         }).to.not.throw();
 
-        expect(stub.calledOnce).to.be.true;
+        expect(stub.calledOnce).to.be.equal(true);
 
         var options = stub.getCall(0).args[1];
         expect(options).to.be.an('object').with.property('attributes');
@@ -91,6 +91,6 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         expect(attributes).to.not.have.property('incrementedAt');
         expect(attributes).to.not.have.property('updatedAt');
       });
-    })
+    });
   });
 });

--- a/test/unit/instance/increment.test.js
+++ b/test/unit/instance/increment.test.js
@@ -40,5 +40,57 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         }).to.not.throw();
       });
     });
+
+    describe('attributes mapping tests', function() {
+      var stub
+        , Model = current.define('User', {
+        id: {
+          type:          Sequelize.BIGINT,
+          primaryKey:    true,
+          autoIncrement: true,
+        },
+        incrementedAt: {
+          field: 'incremented_at',
+          type: Sequelize.DATE,
+        },
+        updatedAt: {
+          field: 'updated_at',
+          type: Sequelize.DATE,
+        }
+      })
+        , instance;
+
+      before(function() {
+        stub = sinon.stub(current, 'query').returns(
+          Sequelize.Promise.resolve({
+            _previousDataValues: {id: 1},
+            dataValues: {id: 3}
+          })
+        );
+      });
+
+      after(function() {
+        stub.restore();
+      });
+
+      it('should map updated_at and other attributes names', function() {
+        instance = Model.build({id: 1}, {isNewRecord: false});
+        expect(function() {
+          instance.increment(['id'], {attributes: {incrementedAt: new Date()}});
+        }).to.not.throw();
+
+        expect(stub.calledOnce).to.be.true;
+
+        var options = stub.getCall(0).args[1];
+        expect(options).to.be.an('object').with.property('attributes');
+
+        var attributes = options.attributes;
+        expect(attributes).to.be.an('object');
+        expect(attributes).to.have.property('incremented_at');
+        expect(attributes).to.have.property('updated_at');
+        expect(attributes).to.not.have.property('incrementedAt');
+        expect(attributes).to.not.have.property('updatedAt');
+      });
+    })
   });
 });


### PR DESCRIPTION
Got same issue as https://github.com/sequelize/sequelize/issues/4389, with model like: 

```
const Article = sequelize.define(
    'articles',
    {
      id: {
        field: 'id',
        type: DataTypes.BIGINT,
        primaryKey: true,
        autoIncrement: true,
      },
      createdAt: {
        field: 'created_at',
        type: DataTypes.DATE,
        index: true,
        allowNull: false,
        defaultValue: DataTypes.NOW,
      },
      commentsCount: {
        field: 'comments_count',
        type: DataTypes.BIGINT,
        allowNull: false,
        defaultValue: 0,
      },
      updatedAt: {
        field: 'updated_at',
        type: DataTypes.DATE,
        allowNull: true,
      },
    }, {
      underscored: true,
      createdAt: 'createdAt',
      updatedAt: 'updatedAt',
    });
```

while trying to increment a field:

```
Article.increment('commentsCount')
```

Looks like fields mapping is missing for options.attributes in Instance.increment method.
