### PR TITLE
added support for hasMany counter cache relations where association c…

### DIFF
--- a/lib/plugins/counter-cache.js
+++ b/lib/plugins/counter-cache.js
@@ -3,7 +3,8 @@
 var Utils = require('./../utils')
   , Helpers = require('../associations/helpers')
   , DataTypes = require('../data-types')
-  , Promise = require('bluebird');
+  , Promise = require('bluebird')
+  , _ = require('lodash');
 
 var CounterCache = function(association, options) {
   this.association = association;
@@ -66,8 +67,9 @@ CounterCache.prototype.injectHooks = function() {
 
   CounterUtil = {
     update: function (targetId, options) {
-      var query = CounterUtil._targetQuery(targetId);
-
+      var query = CounterUtil._targetQuery(targetId, {
+        scope: association.scope
+      });
       return association.target.count({ where: query, logging: options && options.logging }).then(function (count) {
         var newValues = {};
 
@@ -93,10 +95,14 @@ CounterCache.prototype.injectHooks = function() {
       });
     },
     // helpers
-    _targetQuery: function (id) {
+    _targetQuery: function (id, options) {
       var query = {};
 
       query[association.foreignKey] = id;
+
+      if (options && options.hasOwnProperty('scope')) {
+        _.extend(query, options.scope);
+      }
 
       return query;
     },


### PR DESCRIPTION
(this pull request was also made on master and tested on both branches) https://github.com/sequelize/sequelize/pull/5939

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

The counterCache plugin was not adhering to scoped associations for non-atomic counter operations. This update adds any scope properties defined on the association into the counter query run on non-atomic counterCache updates.