### PR TITLE
Add DATEONLY attributes to _dateAttributes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -819,7 +819,7 @@ Model.prototype.refreshAttributes = function() {
 
     if (definition.type instanceof DataTypes.BOOLEAN) {
       self._booleanAttributes.push(name);
-    } else if (definition.type instanceof DataTypes.DATE) {
+    } else if (definition.type instanceof DataTypes.DATE || definition.type instanceof DataTypes.DATEONLY) {
       self._dateAttributes.push(name);
     } else if (definition.type instanceof DataTypes.HSTORE || DataTypes.ARRAY.is(definition.type, DataTypes.HSTORE)) {
       self._hstoreAttributes.push(name);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This PR ensure that an attribute of type `DATEONLY` is considered as a date attribute. It's now parse as date when set to the model.

