### PR TITLE
Closes #5964 -- Fix MSSQL disconnect handling

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future (4.0.0-pre1)
+- [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
 - [CHANGED] Remove `hookValidate` in favor of `validate` with `hooks: true | false`.
 - [REMOVED] Support for `referencesKey`
 - [CHANGED] Throw if `dialect` is not provided to the constructor

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -65,12 +65,13 @@ ConnectionManager.prototype.connect = function(config) {
       });
     }
 
-    var connection = new self.lib.Connection(connectionConfig);
+    var connection = new self.lib.Connection(connectionConfig)
+      , connectionLock = new ResourceLock(connection);
     connection.lib = self.lib;
 
     connection.on('connect', function(err) {
       if (!err) {
-        resolve(new ResourceLock(connection));
+        resolve(connectionLock);
         return;
       }
 
@@ -115,7 +116,7 @@ ConnectionManager.prototype.connect = function(config) {
         switch (err.code) {
         case 'ESOCKET':
         case 'ECONNRESET':
-          self.pool.destroy(connection);
+          self.pool.destroy(connectionLock);
         }
       });
     }

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require('../../support')
+  , dialect = Support.getTestDialect();
+
+if (dialect.match(/^mssql/)) {
+  describe('[MSSQL Specific] Query Queue', function () {
+    it('should work with handleDisconnects', function() {
+      var sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, idle: 5000}})
+        , cm = sequelize.connectionManager
+        , conn;
+
+      return sequelize.sync()
+        .then(function() {
+          return cm.getConnection();
+        })
+        .then(function(connection) {
+          // Save current connection
+          conn = connection;
+
+          // simulate a unexpected end
+          connection.unwrap().emit('error', {code: 'ECONNRESET'});
+        })
+        .then(function() {
+          return cm.releaseConnection(conn);
+        })
+        .then(function() {
+          // Get next available connection
+          return cm.getConnection();
+        })
+        .then(function(connection) {
+          expect(conn).to.not.be.equal(connection);
+          expect(cm.validate(conn)).to.not.be.ok;
+
+          return cm.releaseConnection(connection);
+        });
+    });
+  });
+}


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

When handling disconnects, the MSSQL connection manager was passing a raw connection to the pool destroy method instead of a mutex as expected.

Closes https://github.com/sequelize/sequelize/issues/5964

