### PR TITLE
Closes #5985 - Cannot query a custom-named field when offsetting, ordering and using hasMany simultaneously (v3 pull request)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future 
+- [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985] (https://github.com/sequelize/sequelize/issues/5985) 
+
 # 3.23.3
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Future 
+# Future
 - [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985] (https://github.com/sequelize/sequelize/issues/5985) 
 
 # 3.23.3

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1572,18 +1572,19 @@ var QueryGenerator = {
         }
 
         var hadSubquery = false;
-        if (subQuery && (Array.isArray(t) && !(t[0] instanceof Model) && !(t[0].model instanceof Model))) {
-          subQueryOrder.push(this.quote(t, model)); 
-          hadSubquery = true;
-         }
 
-        if (hadSubquery) { 
-          for (var name in model.attributes) { 
-            var attribute = model.attributes[name]; 
-            if (attribute.field && attribute.field === t[0]) { 
-              t[0] = attribute.fieldName; 
-            } 
-          } 
+        if (subQuery && (Array.isArray(t) && !(t[0] instanceof Model) && !(t[0].model instanceof Model))) {
+          subQueryOrder.push(this.quote(t, model));
+          hadSubquery = true;       
+        }
+
+        if (hadSubquery) {
+          for (var name in model.attributes) {
+            var attribute = model.attributes[name];
+            if (attribute.field && attribute.field === t[0]) {
+              t[0] = attribute.fieldName;
+            }
+          }
         }
 
         mainQueryOrder.push(this.quote(t, model));

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1571,8 +1571,19 @@ var QueryGenerator = {
           }
         }
 
+        var hadSubquery = false;
         if (subQuery && (Array.isArray(t) && !(t[0] instanceof Model) && !(t[0].model instanceof Model))) {
-          subQueryOrder.push(this.quote(t, model));
+          subQueryOrder.push(this.quote(t, model)); 
+          hadSubquery = true;
+         }
+
+        if (hadSubquery) { 
+          for (var name in model.attributes) { 
+            var attribute = model.attributes[name]; 
+            if (attribute.field && attribute.field === t[0]) { 
+              t[0] = attribute.fieldName; 
+            } 
+          } 
         }
 
         mainQueryOrder.push(this.quote(t, model));

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -10,56 +10,57 @@ var chai = require('chai')
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('findAll', function () {
     describe('order', function () {
-      it('should work on a model field whose name doesnt match the database, while offsetting and including a hasMany.', function() { 
-        var Foo = current.define('foo', { 
-          fooId: { 
-            field: 'foo_id', 
-            type: DataTypes.UUID, 
-            primaryKey: true 
-          }, 
-          baseNumber: { 
-            field: 'base_number', 
-            type: DataTypes.STRING(25) 
-          } 
-        }, { 
-          timestamps: false 
-        }), 
-          Bar = current.define('bar', { 
-            barId: { 
-              field: 'bar_id', 
-              type: DataTypes.UUID, 
-              primaryKey: true 
-            }, 
-            fooId: { 
-              field: 'foo_id', 
-              type: DataTypes.UUID, 
-              allowNull: false 
-            } 
-          }, { 
-            timestamps: false 
-          });  
-
-        Foo.hasMany(Bar, {foreignKey: 'foo_id', as: 'bars'});  
-
-        return current.sync({force: true}) 
-          .then(function () { 
-            var options = { 
-              include: [ 
-                { 
-                  model: Bar, as: 'bars' 
-                } 
-              ], 
-              offset: 0, 
-              limit: 50, 
-              order: [['base_number', 'ASC']] 
-            };  
-            return Foo.findAll(options).then(function () { 
-              console.log('success!'); 
-            }, function (err) { 
-              throw err; 
-            }); 
+      it('should work on a model field whose name doesnt match the database, while offsetting and including a hasMany.', function() {
+        var Foo = current.define('foo', {
+          fooId: {
+            field: 'foo_id',
+            type: DataTypes.UUID,
+            primaryKey: true
+          },
+          baseNumber: {
+            field: 'base_number',
+            type: DataTypes.STRING(25)
+          }
+        }, {
+          timestamps: false
+        }),
+          Bar = current.define('bar', {
+            barId: {
+              field: 'bar_id',
+              type: DataTypes.UUID,
+              primaryKey: true
+            },
+            fooId: {
+              field: 'foo_id',
+              type: DataTypes.UUID,
+              allowNull: false
+            }
+          }, {
+            timestamps: false
           });
-         });
+
+        Foo.hasMany(Bar, {foreignKey: 'foo_id', as: 'bars'});
+
+        return current.sync({force: true})
+          .then(function () {
+            var options = {
+              include: [
+                {
+                  model: Bar, as: 'bars'
+                }
+              ],
+              offset: 0,
+              limit: 50,
+              order: [['base_number', 'ASC']]
+            };
+
+            return Foo.findAll(options).then(function () {
+              console.log('success!');
+            }, function (err) {
+              throw err;
+            });
+          });        
+       });
 
       describe('Sequelize.literal()', function () {
         beforeEach(function () {

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -10,6 +10,57 @@ var chai = require('chai')
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('findAll', function () {
     describe('order', function () {
+      it('should work on a model field whose name doesnt match the database, while offsetting and including a hasMany.', function() { 
+        var Foo = current.define('foo', { 
+          fooId: { 
+            field: 'foo_id', 
+            type: DataTypes.UUID, 
+            primaryKey: true 
+          }, 
+          baseNumber: { 
+            field: 'base_number', 
+            type: DataTypes.STRING(25) 
+          } 
+        }, { 
+          timestamps: false 
+        }), 
+          Bar = current.define('bar', { 
+            barId: { 
+              field: 'bar_id', 
+              type: DataTypes.UUID, 
+              primaryKey: true 
+            }, 
+            fooId: { 
+              field: 'foo_id', 
+              type: DataTypes.UUID, 
+              allowNull: false 
+            } 
+          }, { 
+            timestamps: false 
+          });  
+
+        Foo.hasMany(Bar, {foreignKey: 'foo_id', as: 'bars'});  
+
+        return current.sync({force: true}) 
+          .then(function () { 
+            var options = { 
+              include: [ 
+                { 
+                  model: Bar, as: 'bars' 
+                } 
+              ], 
+              offset: 0, 
+              limit: 50, 
+              order: [['base_number', 'ASC']] 
+            };  
+            return Foo.findAll(options).then(function () { 
+              console.log('success!'); 
+            }, function (err) { 
+              throw err; 
+            }); 
+          });
+         });
+
       describe('Sequelize.literal()', function () {
         beforeEach(function () {
           this.User = this.sequelize.define('User', {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

[FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. #5985