### PR TITLE
Fix 3568, MySQL transaction are not set to AutoCommit now

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 - [FIXED] All associations now prefer aliases to construct foreign key [#5267](https://github.com/sequelize/sequelize/issues/5267)
 - [REMOVED] Default transaction auto commit [#5094](https://github.com/sequelize/sequelize/issues/5094)
 - [REMOVED] Callback support for hooks [#5228](https://github.com/sequelize/sequelize/issues/5228)
+- [FIXED] Broken transactions in `MySQL` [#3568](https://github.com/sequelize/sequelize/issues/3568)
 
 ## BC breaks:
 - `hookValidate` removed in favor of `validate` with `hooks: true | false`. `validate` returns a promise which is rejected if validation fails

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1692,6 +1692,11 @@ var QueryGenerator = {
       return;
     }
 
+    // no query when value is not explicitly set
+    if (typeof value === 'undefined' || value === null) {
+      return;
+    }
+
     return 'SET autocommit = ' + (!!value ? 1 : 0) + ';';
   },
 

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -35,10 +35,7 @@ MysqlDialect.prototype.supports = _.merge(_.cloneDeep(Abstract.prototype.support
   updateOnDuplicate: true,
   indexViaAlter: true,
   NUMERIC: true,
-  GEOMETRY: true,
-  transactionOptions: {
-    autocommit: true
-  }
+  GEOMETRY: true
 });
 
 ConnectionManager.prototype.defaultVersion = '5.6.0';

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -34,10 +34,6 @@ describe('Transaction', function() {
       all: [
         'START TRANSACTION;'
       ],
-      mysql: [
-        'START TRANSACTION;',
-        'SET autocommit = 1;'
-      ],
       sqlite: [
         'BEGIN DEFERRED TRANSACTION;'
       ],


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue or a description of the issue you are solving?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #3568

`MySQL` transactions were broken because of `AUTO COMMIT`. Setting it to `0` will not work because it will remain same for whole connection. It can be solved if we don't send any `AUTO COMMIT` option at all. `MySQL` automatically keep a transaction under `0` and reset setting to `1` beyond transaction.

