### PR TITLE
ENUM allow spaces in their definition

### DIFF
--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -386,4 +386,17 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
     });
   }
 
+  it('should allow spaces in ENUM', function () {
+    var Model = this.sequelize.define('user', {
+      name: Sequelize.STRING,
+      type: Sequelize.ENUM(['action', 'mecha', 'canon', 'class s'])
+    });
+
+    return Model.sync({ force: true}).then(function () {
+      return Model.create({ name: 'sakura', type: 'class s' });
+    }).then(function (record) {
+      expect(record.type).to.be.eql('class s');
+    });
+  });
+
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?

### Description of change

Closes #4770 , I confirmed with a test that creating `ENUM` with spaces is indeed possible

