### PR TITLE
Added support for using password for sqlite encryption plugin like sq…

### DIFF
--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -64,6 +64,10 @@ ConnectionManager.prototype.getConnection = function(options) {
       }
     );
   }).tap(function (connection) {
+    if (self.sequelize.config.password) {
+      // Make it possible to define and use password for sqlite encryption plugin like sqlcipher
+      connection.run('PRAGMA key=' + self.sequelize.escape(self.sequelize.config.password));
+    }
     if (self.sequelize.options.foreignKeys !== false) {
       // Make it possible to define and use foreign key constraints unless
       // explicitly disallowed. It's still opt-in per relation


### PR DESCRIPTION

### Pull Request check-list


- [Y] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [N] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [N] Have you added new tests to prevent regressions?
- [N] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [N] Have you added an entry under `Future` in the changelog?


### Description of change

There are some sqlite encryption plugins like [sqlcipher](https://github.com/sqlcipher/sqlcipher), with which you can encrypt your sqlite database file. The SQL syntax:
```
PRAGMA key = 'passphrase';
```
According to the [project description](https://github.com/sqlcipher/sqlcipher#encrypting-a-database), PRAGMA key or sqlite3_key should be called as the **first** operation when a database is open.

And sqlcipher is well supported by [node-sqlite3](https://github.com/mapbox/node-sqlite3).

So, what I want to do is to support it in sequelize. Not complicate,  and I did run `npm run test-sqlite`.

Thanks!

