### PR TITLE
fixed limit <= 0 (zero) issue: dialects / PostgreSQL

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -372,10 +372,10 @@ const QueryGenerator = {
   addLimitAndOffset(options) {
     let fragment = '';
     /*jshint eqeqeq:false*/
-    if (options.limit != null) {
+    if (!!options.limit && options.limit > 0) {
       fragment += ' LIMIT ' + this.escape(options.limit);
     }
-    if (options.offset != null) {
+    if (!!options.offset) {
       fragment += ' OFFSET ' + this.escape(options.offset);
     }
 


### PR DESCRIPTION
postgres doesn't queries data when its [LIMIT 0]