### PR TITLE
[doc] Adds list of options available on sequelize.QueryTypes object.

### DIFF
--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -143,7 +143,25 @@ A handy reference to the bluebird Promise class
 ## `QueryTypes`
 [View code](https://github.com/sequelize/sequelize/blob/3e5b8772ef75169685fc96024366bca9958fee63/lib/sequelize.js#L272)
 
-Available query types for use with `sequelize.query`
+A convenience object with query types for use with `sequelize.query`. Available options include:
+
+- SELECT
+- INSERT
+- UPDATE
+- BULKUPDATE
+- BULKDELETE
+- DELETE
+- UPSERT
+- VERSION
+- SHOWTABLES
+- SHOWINDEXES
+- DESCRIBE
+- RAW
+- FOREIGNKEYS
+
+**See:**
+
+* [Sequelize#query](sequelize#querysql-options-promise)
 
 ***
 
@@ -626,6 +644,7 @@ sequelize.query('SELECT...', { type: sequelize.QueryTypes.SELECT }).then(functio
 **See:**
 
 * [Model#build](model#build)
+* [Sequelize#QueryTypes](sequelize#querytypes)
 
 
 **Params:**


### PR DESCRIPTION
DOC CHANGE ONLY

### Currently
The current documentation for [Sequelize#QueryTypes](http://sequelize.readthedocs.io/en/latest/api/sequelize/#querytypes) is redundant and doesn't provide context for how to use it. 

![screen shot 2016-06-09 at 12 00 50 pm](https://cloud.githubusercontent.com/assets/8163408/15944096/c4e15972-2e40-11e6-944c-c96d43112319.png)

### Description of change
**Sequelize#QueryTypes**
- Added list of available QueryTypes to Sequelize#QueryTypes.
- Added "See" reference to Sequelize#query where there is a usage example.
- Image:
![screen shot 2016-06-09 at 12 44 54 pm](https://cloud.githubusercontent.com/assets/8163408/15944082/b3ebd836-2e40-11e6-8933-f0059fdf3811.png)

**Sequelize#query**
- Added "See" reference to Sequelize#QueryTypes so users can see their available options.
- Image:
![screen shot 2016-06-09 at 12 30 40 pm](https://cloud.githubusercontent.com/assets/8163408/15944281/bb86f552-2e41-11e6-8b31-b6c1ec07c073.png)





