### PR TITLE
Issue #6069 - Association HasOne - Add a test on setAssociation update that should not fail

### DIFF
--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -239,6 +239,33 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
       });
     });
 
+    it('supports updating with a primary key instead of an object', function() {
+      var User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING })
+        , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING });
+
+      User.hasOne(Task);
+
+      return this.sequelize.sync({ force: true }).then(function() {
+        return User.create({id: 1, username: 'foo'}).then(function(user) {
+          return Task.create({id: 20, title: 'bar'}).then(function(task) {
+            return user.setTaskXYZ(task.id).then(function() {
+              return user.getTaskXYZ().then(function(task) {
+                expect(task).not.to.be.null;
+
+                return Task.create({id: 2, title: 'bar2'}).then(function(task2) {
+                  return user.setTaskXYZ(task2.id).then(function() {
+                    return user.getTaskXYZ().then(function(_task) {
+                      expect(_task).not.to.be.null;
+                    });
+                  });
+                });
+              });
+            });
+          });
+        });
+      });
+    });
+
     it('supports setting same association twice', function () {
       var Home = this.sequelize.define('home', {})
         , User = this.sequelize.define('user');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes [#6069](https://github.com/sequelize/sequelize/issues/6069)) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

This tests seems valid to me, but it fails.
I don't have the fix, I just wanted to be sure that the issue ([issue #6069](https://github.com/sequelize/sequelize/issues/6069)) I have in my project in production is real.
Let me know if you need help.
