### PR TITLE
Inflection

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 - [ADDED] Support for range operators [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [FIXED] Broken transactions in `MySQL` [#3568](https://github.com/sequelize/sequelize/issues/3568)
 - [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)
+- [INTERNALS] Updated `inflection` dependency and pinned version
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/changelog.md
+++ b/changelog.md
@@ -3,7 +3,7 @@
 - [ADDED] Support for range operators [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [FIXED] Broken transactions in `MySQL` [#3568](https://github.com/sequelize/sequelize/issues/3568)
 - [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)
-- [INTERNALS] Updated `inflection` dependency and pinned version
+- [INTERNALS] Updated `inflection` dependency and pinned version and expose all used `inflection` methods on `Utils`
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 - [FIXED] Broken transactions in `MySQL` [#3568](https://github.com/sequelize/sequelize/issues/3568)
 - [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)
 - [INTERNALS] Updated `inflection` dependency and pinned version and expose all used `inflection` methods on `Utils`
+- [ADDED] `Sequelize.useInflection` method
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -544,7 +544,7 @@ const QueryGenerator = {
     return Utils._.map(indexes, index => {
       if (!index.hasOwnProperty('name')) {
         const onlyAttributeNames = index.fields.map(field => (typeof field === 'string') ? field : (field.name || field.attribute));
-        index.name = Utils.inflection.underscore(rawTablename + '_' + onlyAttributeNames.join('_'));
+        index.name = Utils.underscore(rawTablename + '_' + onlyAttributeNames.join('_'));
       }
 
       return index;

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -345,7 +345,7 @@ var QueryGenerator = {
       , indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.inflection.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
     }
 
     var values = {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -192,7 +192,7 @@ const QueryGenerator = {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.inflection.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
     }
 
     return `DROP INDEX ${indexName} ON ${this.quoteTable(tableName)}`;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -363,7 +363,7 @@ const QueryGenerator = {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.inflection.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
     }
 
     return `DROP INDEX IF EXISTS ${this.quoteIdentifiers(indexName)}`;

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -229,7 +229,7 @@ const QueryGenerator = {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.inflection.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
     }
 
     return 'DROP INDEX IF EXISTS ' + indexName;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -360,8 +360,8 @@ class Sequelize {
    * @param {Boolean}                 [options.underscoredAll=false] Converts camelCased model names to underscored table names if true
    * @param {Boolean}                 [options.freezeTableName=false] If freezeTableName is true, sequelize will not try to alter the DAO name to get the table name. Otherwise, the model name will be pluralized
    * @param {Object}                  [options.name] An object with two attributes, `singular` and `plural`, which are used when this model is associated to others.
-   * @param {String}                  [options.name.singular=inflection.singularize(modelName)]
-   * @param {String}                  [options.name.plural=inflection.pluralize(modelName)]
+   * @param {String}                  [options.name.singular=Utils.singularize(modelName)]
+   * @param {String}                  [options.name.plural=Utils.pluralize(modelName)]
    * @param {Array<Object>}           [options.indexes]
    * @param {String}                  [options.indexes[].name] The name of the index. Defaults to model name + _ + fields concatenated
    * @param {String}                  [options.indexes[].type] Index type. Only used by mysql. One of `UNIQUE`, `FULLTEXT` and `SPATIAL`
@@ -398,8 +398,8 @@ class Sequelize {
 
     options = Utils.merge({
       name: {
-        plural: Utils.inflection.pluralize(modelName),
-        singular: Utils.inflection.singularize(modelName)
+        plural: Utils.pluralize(modelName),
+        singular: Utils.singularize(modelName)
       },
       indexes: [],
       omitNul: globalOptions.omitNull

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1254,6 +1254,12 @@ Sequelize.prototype.Deferrable = Sequelize.Deferrable = Deferrable;
 Sequelize.prototype.Association = Sequelize.Association = Association;
 
 /**
+ * Provide alternative version of `inflection` module to be used by `Utils.pluralize` etc.
+ * @param {Object} _inflection - `inflection` module
+ */
+Sequelize.useInflection = Utils.useInflection;
+
+/**
  * Allow hooks to be defined on Sequelize + on sequelize instance as universal hooks to run on all models
  * and on Sequelize/sequelize methods e.g. Sequelize(), Sequelize#define()
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -13,22 +13,22 @@ exports.Promise = Promise;
 exports._ = _;
 exports.inflection = inflection;
 
-function camelizeIf(string, condition) {
-  let result = string;
+function camelizeIf(str, condition) {
+  let result = str;
 
   if (condition) {
-    result = camelize(string);
+    result = camelize(str);
   }
 
   return result;
 }
 exports.camelizeIf = camelizeIf;
 
-function underscoredIf(string, condition) {
-  let result = string;
+function underscoredIf(str, condition) {
+  let result = str;
 
   if (condition) {
-    result = inflection.underscore(string);
+    result = underscore(str);
   }
 
   return result;
@@ -96,6 +96,11 @@ function camelize(str) {
   return str.trim().replace(/[-_\s]+(.)?/g, (match, c) => c.toUpperCase());
 }
 exports.camelize = camelize;
+
+function underscore(str) {
+  return inflection.underscore(str);
+}
+exports.underscore = underscore;
 
 function format(arr, dialect) {
   const timeZone = null;
@@ -296,13 +301,13 @@ function combineTableNames(tableName1, tableName2) {
 }
 exports.combineTableNames = combineTableNames;
 
-function singularize(s) {
-  return inflection.singularize(s);
+function singularize(str) {
+  return inflection.singularize(str);
 }
 exports.singularize = singularize;
 
-function pluralize(s) {
-  return inflection.pluralize(s);
+function pluralize(str) {
+  return inflection.pluralize(str);
 }
 exports.pluralize = pluralize;
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,14 +4,18 @@ const DataTypes = require('./data-types');
 const SqlString = require('./sql-string');
 const _ = require('lodash').runInContext(); // Prevent anyone messing with template settings by creating a fresh copy
 const parameterValidator = require('./utils/parameter-validator');
-const inflection = require('inflection');
 const uuid = require('node-uuid');
 const Promise = require('./promise');
 const primitives = ['string', 'number', 'boolean'];
+let inflection = require('inflection');
 
 exports.Promise = Promise;
 exports._ = _;
-exports.inflection = inflection;
+
+function useInflection(_inflection) {
+  inflection = _inflection;
+}
+exports.useInflection = useInflection;
 
 function camelizeIf(str, condition) {
   let result = str;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "depd": "^1.1.0",
     "dottie": "^1.0.0",
     "generic-pool": "2.4.2",
-    "inflection": "^1.6.0",
+    "inflection": "1.10.0",
     "lodash": "4.13.1",
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Have you added an entry under `Future` in the changelog?

### Description of change

As discussed in #6023.

This PR:

* Updates [inflection](https://www.npmjs.com/package/inflection) dependency to latest and pins the version
* Exports all used [inflection](https://www.npmjs.com/package/inflection) methods as methods of `Utils`
* Updates codebase to use e.g. `Utils.underscore()` rather than `inflection.underscore()`
* Allows a later version of [inflection](https://www.npmjs.com/package/inflection) to be set by user with `Sequelize.Utils.inflection = require('inflection')` and `Utils.pluralize()` etc will use this overriden version of [inflection](https://www.npmjs.com/package/inflection).

I will add to the [test shims](https://github.com/sequelize/sequelize/blob/master/test/supportShim.js) to check that `inflection` is not accessed directly once PR #5836 is merged.