### PR TITLE
Fix intermittently failing test on MSSQL

### DIFF
--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -36,13 +36,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
           return Promise.join(
             Task.create({
               id: 1,
-              user: {}
+              user: {id: 1}
             }, {
               include: [Task.User]
             }),
             Task.create({
               id: 2,
-              user: {}
+              user: {id: 2}
             }, {
               include: [Task.User]
             }),


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Have you added an entry under `Future` in the changelog?

### Description of change

This PR fixes a test which intermittently fails on MSSQL on Travis. e.g.: https://travis-ci.org/sequelize/sequelize/jobs/136937830

The issue is that the order in which the `User` instances is created in this test isn't necessarily the same as the order in the code. Most of the time it is, but sometimes not and so sometime the `id`s of the Users are in an unexpected order. When this happens the test fails. Hence failure which is only intermittent.

There doesn't appear to be anything wrong with the actual behavior that the test is testing for.