### PR TITLE
Don't override toString() in Model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -46,10 +46,6 @@ class Model {
     return this.QueryInterface.QueryGenerator;
   }
 
-  static toString() {
-    return '[object SequelizeModel:'+this.name+']';
-  }
-
   // validateIncludedElements should have been called before this method
   static _paranoidClause(model, options) {
     options = options || {};


### PR DESCRIPTION
`toString()` should not return `[object SequelizeModel:name]`, as a model is not an object anymore, but a class (function). The default behaviour for a class/function is to return the class source, like `class MyModel extends Sequelize.Model {...` which also gives you the information that it is a Sequelize model and the model name.