### PR TITLE
Make new Model() identical to Model.build()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1701,36 +1701,19 @@ class Model {
   }
 
   /**
-   * Builds a new model instance. Values is an object of key value pairs, must be defined but can be empty.
-
-   * @param {Object}  values
+   * Builds a new model instance.
+   *
+   * @param {Object}  [(values|values[])={}] An object of key value pairs or an array of such. If an array, the function will return an array of instances.
    * @param {Object}  [options]
    * @param {Boolean} [options.raw=false] If set to true, values will ignore field and virtual setters.
    * @param {Boolean} [options.isNewRecord=true]
    * @param {Array}   [options.include] an array of include options - Used to build prefetched/included model instances. See `set`
    *
-   * @return {Instance}
+   * @return {(Model|Model[])}
    */
   static build(values, options) { // testhint options:none
     if (Array.isArray(values)) {
       return this.bulkBuild(values, options);
-    }
-    options = _.extend({
-      isNewRecord: true,
-      $schema: this.$schema,
-      $schemaDelimiter: this.$schemaDelimiter
-    }, options || {});
-
-    if (options.attributes) {
-      options.attributes = options.attributes.map(attribute => Array.isArray(attribute) ? attribute[1] : attribute);
-    }
-
-    if (!options.includeValidated) {
-      this._conformOptions(options, this);
-      if (options.include) {
-        this._expandIncludeAll(options);
-        this._validateIncludedElements(options);
-      }
     }
 
     return new this(values, options);
@@ -2623,7 +2606,34 @@ class Model {
     return this.name;
   }
 
+  /**
+   * Builds a new model instance.
+   * @param {Object}  [values={}] an object of key value pairs
+   * @param {Object}  [options]
+   * @param {Boolean} [options.raw=false] If set to true, values will ignore field and virtual setters.
+   * @param {Boolean} [options.isNewRecord=true]
+   * @param {Array}   [options.include] an array of include options - Used to build prefetched/included model instances. See `set`
+   */
   constructor(values, options) {
+    values = values || {};
+    options = _.extend({
+      isNewRecord: true,
+      $schema: this.constructor.$schema,
+      $schemaDelimiter: this.constructor.$schemaDelimiter
+    }, options || {});
+
+    if (options.attributes) {
+      options.attributes = options.attributes.map(attribute => Array.isArray(attribute) ? attribute[1] : attribute);
+    }
+
+    if (!options.includeValidated) {
+      this.constructor._conformOptions(options, this.constructor);
+      if (options.include) {
+        this.constructor._expandIncludeAll(options);
+        this.constructor._validateIncludedElements(options);
+      }
+    }
+
     this.dataValues = {};
     this._previousDataValues = {};
     this._changed = {};


### PR DESCRIPTION
This moves all logic from `Model.build()` to the constructor, so they accept the exact same parameters. The only difference is `build()` can also take an array of values. Also makes `values` optional.