### PR TITLE
Fix #5057, Count no longer include attributes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 - [CHANGED] Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive) [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [ADDED] Support for range operators [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [FIXED] Broken transactions in `MySQL` [#3568](https://github.com/sequelize/sequelize/issues/3568)
+- [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1549,6 +1549,7 @@ class Model {
     _.defaults(options, { hooks: true });
 
     let col = '*';
+    let attributes = options.attributes;
 
     return Promise.try(() => {
       this._conformOptions(options, this);
@@ -1572,7 +1573,7 @@ class Model {
       options.limit = null;
       options.offset = null;
       options.order = null;
-      options.attributes = [];
+      options.attributes = attributes || [];
 
       return this.aggregate(col, 'count', options);
     });

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -51,5 +51,30 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }]
       })).to.eventually.equal(1);
     });
+
+    it('should return attributes', function () {
+      return this.User.create({
+        username: 'valak',
+        createdAt: (new Date()).setFullYear(2015)
+      })
+      .then(() =>
+        this.User.count({
+          attributes: ['createdAt'],
+          group: ['createdAt']
+        })
+      )
+      .then((users) => {
+        expect(users.length).to.be.eql(2);
+
+        // correct count
+        expect(users[0].count).to.be.eql('1');
+        expect(users[1].count).to.be.eql('2');
+
+        // have attributes
+        expect(users[0].createdAt).to.exist;
+        expect(users[1].createdAt).to.exist;
+      });
+    });
+
   });
 });

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -67,8 +67,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         expect(users.length).to.be.eql(2);
 
         // correct count
-        expect(users[0].count).to.be.eql('1');
-        expect(users[1].count).to.be.eql('2');
+        expect(users[0].count).to.be.equal(1);
+        expect(users[1].count).to.be.equal(2);
 
         // have attributes
         expect(users[0].createdAt).to.exist;

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -65,11 +65,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       )
       .then((users) => {
         expect(users.length).to.be.eql(2);
-
-        // correct count
-        expect(users[0].count).to.be.equal(1);
-        expect(users[1].count).to.be.equal(2);
-
+        
         // have attributes
         expect(users[0].createdAt).to.exist;
         expect(users[1].createdAt).to.exist;


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Fixes #5057 , A regression issue in which `attributes` are not included in count any more.
