### PR TITLE
Fix #6069, HasOne throws erro when try to update using a primary key

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)
 - [INTERNALS] Updated `inflection` dependency and pinned version and expose all used `inflection` methods on `Utils`
 - [ADDED] `Sequelize.useInflection` method
+- [FIXED] `hasOne` throws error on update with a primary key [#6069](https://github.com/sequelize/sequelize/issues/6069)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -212,7 +212,7 @@ class HasOne extends Association {
       return this[association.accessors.get](options).then(oldInstance => {
         // TODO Use equals method once #5605 is resolved
         alreadyAssociated = oldInstance && associatedInstance && _.every(association.target.primaryKeyAttributes, attribute =>
-          oldInstance.get(attribute, {raw: true}) === associatedInstance.get(attribute, {raw: true})
+          oldInstance.get(attribute, {raw: true}) === (associatedInstance.get ? associatedInstance.get(attribute, {raw: true}) : associatedInstance)
         );
 
         if (oldInstance && !alreadyAssociated) {

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -239,6 +239,38 @@ describe(Support.getTestDialectTeaser('HasOne'), function() {
       });
     });
 
+    it('supports updating with a primary key instead of an object', function() {
+      var User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING })
+      , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING });
+
+      User.hasOne(Task);
+
+      return this.sequelize.sync({ force: true }).then(function() {
+        return Promise.all([
+          User.create({id: 1, username: 'foo'}),
+          Task.create({id: 20, title: 'bar'})
+        ]);
+      })
+      .spread(function(user, task) {
+        return user.setTaskXYZ(task.id)
+          .then(() => user.getTaskXYZ())
+          .then((task) => {
+            expect(task).not.to.be.null;
+            return Promise.all([
+              user,
+              Task.create({id: 2, title: 'bar2'})
+            ]);
+          });
+      })
+      .spread(function(user, task2) {
+        return user.setTaskXYZ(task2.id)
+          .then(() => user.getTaskXYZ())
+          .then((task) => {
+            expect(task).not.to.be.null;
+          });
+      });
+    });
+
     it('supports setting same association twice', function () {
       var Home = this.sequelize.define('home', {})
         , User = this.sequelize.define('user');


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Fixed #6069 
Closes #6075 

`injectSetter` was assuming we always pass the instance but we should be allowed to use primary keys as well.

Now update on `hasOne` relation will work with `primaryKey` as well.

Thanks @arnaudbesnier for submitting a test case :)
