### PR TITLE
Include as rewrite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985] (https://github.com/sequelize/sequelize/issues/5985) 
+
 # 3.23.3
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
+
 # 3.23.2
 - [FIXED] Type validation now works with non-strings due to updated validator@5.0.0 [#5861](https://github.com/sequelize/sequelize/pull/5861)
 - [FIXED] Improved offset and limit support for SQL server 2008 [#5616](https://github.com/sequelize/sequelize/pull/5616)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Future
+# 3.23.3
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
 
 # 3.23.2

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1571,8 +1571,20 @@ var QueryGenerator = {
           }
         }
 
+        var hadSubquery = false;
+
         if (subQuery && (Array.isArray(t) && !(t[0] instanceof Model) && !(t[0].model instanceof Model))) {
           subQueryOrder.push(this.quote(t, model));
+          hadSubquery = true;       
+        }
+
+        if (hadSubquery) {
+          for (var name in model.attributes) {
+            var attribute = model.attributes[name];
+            if (attribute.field && attribute.field === t[0]) {
+              t[0] = attribute.fieldName;
+            }
+          }
         }
 
         mainQueryOrder.push(this.quote(t, model));

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -65,12 +65,13 @@ ConnectionManager.prototype.connect = function(config) {
       });
     }
 
-    var connection = new self.lib.Connection(connectionConfig);
+    var connection = new self.lib.Connection(connectionConfig)
+      , connectionLock = new ResourceLock(connection);
     connection.lib = self.lib;
 
     connection.on('connect', function(err) {
       if (!err) {
-        resolve(new ResourceLock(connection));
+        resolve(connectionLock);
         return;
       }
 
@@ -115,7 +116,7 @@ ConnectionManager.prototype.connect = function(config) {
         switch (err.code) {
         case 'ESOCKET':
         case 'ECONNRESET':
-          self.pool.destroy(connection);
+          self.pool.destroy(connectionLock);
         }
       });
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -551,7 +551,9 @@ validateIncludedElement = function(include, tableNames, options) {
   }
 
   include.association = association;
-  include.as = association.as;
+  if (!include.as) {
+    include.as = association.as;
+  }
 
   // If through, we create a pseudo child include, to ease our parsing later on
   if (include.association.through && Object(include.association.through.model) === include.association.through.model) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS/io.js",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     {

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require('../../support')
+  , dialect = Support.getTestDialect();
+
+if (dialect.match(/^mssql/)) {
+  describe('[MSSQL Specific] Query Queue', function () {
+    it('should work with handleDisconnects', function() {
+      var sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, idle: 5000}})
+        , cm = sequelize.connectionManager
+        , conn;
+
+      return sequelize.sync()
+        .then(function() {
+          return cm.getConnection();
+        })
+        .then(function(connection) {
+          // Save current connection
+          conn = connection;
+
+          // simulate a unexpected end
+          connection.unwrap().emit('error', {code: 'ECONNRESET'});
+        })
+        .then(function() {
+          return cm.releaseConnection(conn);
+        })
+        .then(function() {
+          // Get next available connection
+          return cm.getConnection();
+        })
+        .then(function(connection) {
+          expect(conn).to.not.be.equal(connection);
+          expect(cm.validate(conn)).to.not.be.ok;
+
+          return cm.releaseConnection(connection);
+        });
+    });
+  });
+}

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -569,7 +569,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             });
           });
 
-           it('allows mulitple assocations of the same model with different alias', function() {
+          it('allows mulitple assocations of the same model with different alias', function() {
             var self = this;
 
             this.Worker.hasOne(this.Task, { as: 'DoTo' });
@@ -578,6 +578,20 @@ describe(Support.getTestDialectTeaser('Model'), function() {
                 include: [
                   { model: self.Task, as: 'ToDo' },
                   { model: self.Task, as: 'DoTo' }
+                ]
+              });
+            });
+          });
+
+          it('allows mulitple assocations of the same association with different alias', function() {
+            var self = this;
+
+            var association = this.Worker.hasOne(this.Task, { as: 'DoTo' });
+            return this.init(function() {
+              return self.Worker.findOne({
+                include: [
+                  { association: association, as: 'ToDo' },
+                  { association: association, as: 'DoTo' }
                 ]
               });
             });
@@ -739,6 +753,20 @@ describe(Support.getTestDialectTeaser('Model'), function() {
                 include: [
                   { model: self.Task, as: 'ToDos' },
                   { model: self.Task, as: 'DoTos' }
+                ]
+              });
+            });
+          });
+
+          it('allows mulitple assocations of the same association with different alias', function() {
+            var self = this;
+
+            var association = this.Worker.hasMany(this.Task, { as: 'DoTos' });
+            return this.init(function() {
+              return self.Worker.findOne({
+                include: [
+                  { association: association, as: 'ToDos' },
+                  { association: association, as: 'DoTos' }
                 ]
               });
             });

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -10,6 +10,58 @@ var chai = require('chai')
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('findAll', function () {
     describe('order', function () {
+      it('should work on a model field whose name doesnt match the database, while offsetting and including a hasMany.', function() {
+        var Foo = current.define('foo', {
+          fooId: {
+            field: 'foo_id',
+            type: DataTypes.UUID,
+            primaryKey: true
+          },
+          baseNumber: {
+            field: 'base_number',
+            type: DataTypes.STRING(25)
+          }
+        }, {
+          timestamps: false
+        }),
+          Bar = current.define('bar', {
+            barId: {
+              field: 'bar_id',
+              type: DataTypes.UUID,
+              primaryKey: true
+            },
+            fooId: {
+              field: 'foo_id',
+              type: DataTypes.UUID,
+              allowNull: false
+            }
+          }, {
+            timestamps: false
+          });
+
+        Foo.hasMany(Bar, {foreignKey: 'foo_id', as: 'bars'});
+
+        return current.sync({force: true})
+          .then(function () {
+            var options = {
+              include: [
+                {
+                  model: Bar, as: 'bars'
+                }
+              ],
+              offset: 0,
+              limit: 50,
+              order: [['base_number', 'ASC']]
+            };
+
+            return Foo.findAll(options).then(function () {
+              console.log('success!');
+            }, function (err) {
+              throw err;
+            });
+          });        
+       });
+
       describe('Sequelize.literal()', function () {
         beforeEach(function () {
           this.User = this.sequelize.define('User', {

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -47,6 +47,35 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       this.Company.Owner = this.Company.belongsTo(this.User, {as: 'Owner', foreignKey: 'ownerId'});
     });
 
+    describe('alias', function () {
+      it('should inject the alias', function () {
+        var options = Sequelize.Model.$validateIncludedElements({
+          model: this.User,
+          include: [
+            {
+              association: this.User.Company
+            }
+          ]
+        });
+
+        expect(options.include[0].as).to.deep.equal('Company');
+      });
+
+      it('should not rewrite the alias when present with associations', function () {
+        var options = Sequelize.Model.$validateIncludedElements({
+          model: this.User,
+          include: [
+            {
+              as: 'foo',
+              association: this.User.Company
+            }
+          ]
+        });
+
+        expect(options.include[0].as).to.deep.equal('foo');
+      });
+    });
+
     describe('attributes', function () {
       it('should not inject the aliassed PK again, if its already there', function () {
         var options = Sequelize.Model.$validateIncludedElements({


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

Not necessary I think. Documentation already refers the `options.include[].as` and `options.include[].association`.

- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

It allows us to `include` the same association multiple times with a different `as`.
Example:
```js
user.findAll({
  include: [
    { association: User.Tasks, as: 'someTasks', where: { name: { $like: 'bar' } },
    { association: User.Tasks, as: 'otherTasks', where: { name: { $like: 'foo' } }
  ]
})
```

My user case: I use [graphql-sequelize](https://github.com/mickhansen/graphql-sequelize) and it generates `include` for nested object/properties. I had to apply a `where` clause on a relationship and I can't modify the options after the nested `include`.

Thanks for review.