### PR TITLE
model: only rewrite `include.as` if necessary

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -551,7 +551,9 @@ validateIncludedElement = function(include, tableNames, options) {
   }
 
   include.association = association;
-  include.as = association.as;
+  if (!include.as) {
+    include.as = association.as;
+  }
 
   // If through, we create a pseudo child include, to ease our parsing later on
   if (include.association.through && Object(include.association.through.model) === include.association.through.model) {

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -569,7 +569,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             });
           });
 
-           it('allows mulitple assocations of the same model with different alias', function() {
+          it('allows mulitple assocations of the same model with different alias', function() {
             var self = this;
 
             this.Worker.hasOne(this.Task, { as: 'DoTo' });
@@ -578,6 +578,20 @@ describe(Support.getTestDialectTeaser('Model'), function() {
                 include: [
                   { model: self.Task, as: 'ToDo' },
                   { model: self.Task, as: 'DoTo' }
+                ]
+              });
+            });
+          });
+
+          it('allows mulitple assocations of the same association with different alias', function() {
+            var self = this;
+
+            var association = this.Worker.hasOne(this.Task, { as: 'DoTo' });
+            return this.init(function() {
+              return self.Worker.findOne({
+                include: [
+                  { association: association, as: 'ToDo' },
+                  { association: association, as: 'DoTo' }
                 ]
               });
             });
@@ -739,6 +753,20 @@ describe(Support.getTestDialectTeaser('Model'), function() {
                 include: [
                   { model: self.Task, as: 'ToDos' },
                   { model: self.Task, as: 'DoTos' }
+                ]
+              });
+            });
+          });
+
+          it('allows mulitple assocations of the same association with different alias', function() {
+            var self = this;
+
+            var association = this.Worker.hasMany(this.Task, { as: 'DoTos' });
+            return this.init(function() {
+              return self.Worker.findOne({
+                include: [
+                  { association: association, as: 'ToDos' },
+                  { association: association, as: 'DoTos' }
                 ]
               });
             });

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -47,6 +47,35 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       this.Company.Owner = this.Company.belongsTo(this.User, {as: 'Owner', foreignKey: 'ownerId'});
     });
 
+    describe('alias', function () {
+      it('should inject the alias', function () {
+        var options = Sequelize.Model.$validateIncludedElements({
+          model: this.User,
+          include: [
+            {
+              association: this.User.Company
+            }
+          ]
+        });
+
+        expect(options.include[0].as).to.deep.equal('Company');
+      });
+
+      it('should not rewrite the alias when present with associations', function () {
+        var options = Sequelize.Model.$validateIncludedElements({
+          model: this.User,
+          include: [
+            {
+              as: 'foo',
+              association: this.User.Company
+            }
+          ]
+        });
+
+        expect(options.include[0].as).to.deep.equal('foo');
+      });
+    });
+
     describe('attributes', function () {
       it('should not inject the aliassed PK again, if its already there', function () {
         var options = Sequelize.Model.$validateIncludedElements({


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

Not necessary I think. Documentation already refers the `options.include[].as` and `options.include[].association`.
- [ ] Have you added an entry under `Future` in the changelog?
### Description of change

It allows us to `include` the same association multiple times with a different `as`.
Example:

``` js
user.findAll({
  include: [
    { association: User.Tasks, as: 'someTasks', where: { name: { $like: 'bar' } },
    { association: User.Tasks, as: 'otherTasks', where: { name: { $like: 'foo' } }
  ]
})
```

My user case: I use [graphql-sequelize](https://github.com/mickhansen/graphql-sequelize) and it generates `include` for nested object/properties. I had to apply a `where` clause on a relationship and I can't modify the options after the nested `include`.
### Note

PR also applies for v4 but I am waiting review before submitting another PR.

Thanks for review.
