### PR TITLE
ES6 conversion for association / hooks

### DIFF
--- a/test/integration/associations/alias.test.js
+++ b/test/integration/associations/alias.test.js
@@ -1,104 +1,90 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , Sequelize = require('../../../index')
-  , Promise = Sequelize.Promise;
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const Sequelize = require('../../../index');
 
-describe(Support.getTestDialectTeaser('Alias'), function() {
+describe(Support.getTestDialectTeaser('Alias'), () => {
   it('should uppercase the first letter in alias getter, but not in eager loading', function() {
-    var User = this.sequelize.define('user', {})
-      , Task = this.sequelize.define('task', {});
+    const User = this.sequelize.define('user', {}), Task = this.sequelize.define('task', {});
 
     User.hasMany(Task, { as: 'assignments', foreignKey: 'userId' });
     Task.belongsTo(User, { as: 'owner', foreignKey: 'userId' });
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.create({ id: 1 });
-    }).then(function(user) {
+    return this.sequelize.sync({ force: true })
+    .then(() => User.create({ id: 1 }))
+    .then(user => {
       expect(user.getAssignments).to.be.ok;
 
       return Task.create({ id: 1, userId: 1 });
-    }).then(function(task) {
+    }).then(task => {
       expect(task.getOwner).to.be.ok;
 
-      return Promise.all([
+      return Sequelize.Promise.all([
         User.find({ where: { id: 1 }, include: [{model: Task, as: 'assignments'}] }),
         Task.find({ where: { id: 1 }, include: [{model: User, as: 'owner'}] })
       ]);
-    }).spread(function(user, task) {
+    }).spread((user, task) => {
       expect(user.assignments).to.be.ok;
       expect(task.owner).to.be.ok;
     });
   });
 
   it('shouldnt touch the passed alias', function() {
-    var User = this.sequelize.define('user', {})
-      , Task = this.sequelize.define('task', {});
+    const User = this.sequelize.define('user', {}), Task = this.sequelize.define('task', {});
 
     User.hasMany(Task, { as: 'ASSIGNMENTS', foreignKey: 'userId' });
     Task.belongsTo(User, { as: 'OWNER', foreignKey: 'userId' });
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.create({ id: 1 });
-    }).then(function(user) {
+    return this.sequelize.sync({ force: true }).then(() => User.create({ id: 1 })).then(user => {
       expect(user.getASSIGNMENTS).to.be.ok;
 
       return Task.create({ id: 1, userId: 1 });
-    }).then(function(task) {
+    }).then(task => {
       expect(task.getOWNER).to.be.ok;
 
-      return Promise.all([
+      return Sequelize.Promise.all([
         User.find({ where: { id: 1 }, include: [{model: Task, as: 'ASSIGNMENTS'}] }),
         Task.find({ where: { id: 1 }, include: [{model: User, as: 'OWNER'}] })
       ]);
-    }).spread(function(user, task) {
+    }).spread((user, task) => {
       expect(user.ASSIGNMENTS).to.be.ok;
       expect(task.OWNER).to.be.ok;
     });
   });
 
   it('should allow me to pass my own plural and singular forms to hasMany', function() {
-    var User = this.sequelize.define('user', {})
-      , Task = this.sequelize.define('task', {});
+    const User = this.sequelize.define('user', {}), Task = this.sequelize.define('task', {});
 
     User.hasMany(Task, { as: { singular: 'task', plural: 'taskz'} });
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.create({ id: 1 });
-    }).then(function(user) {
+    return this.sequelize.sync({ force: true }).then(() => User.create({ id: 1 })).then(user => {
       expect(user.getTaskz).to.be.ok;
       expect(user.addTask).to.be.ok;
       expect(user.addTaskz).to.be.ok;
-    }).then(function() {
-      return User.find({ where: { id: 1 }, include: [{model: Task, as: 'taskz'}] });
-    }).then(function(user) {
+    }).then(() => User.find({ where: { id: 1 }, include: [{model: Task, as: 'taskz'}] })).then(user => {
       expect(user.taskz).to.be.ok;
     });
   });
 
   it('should allow me to define plural and singular forms on the model', function() {
-    var User = this.sequelize.define('user', {})
-      , Task = this.sequelize.define('task', {}, {
-          name: {
-            singular: 'assignment',
-            plural: 'assignments'
-          }
-        });
+    const User = this.sequelize.define('user', {}),
+          Task = this.sequelize.define('task', {}, {
+                name: {
+                  singular: 'assignment',
+                  plural: 'assignments'
+                }
+              });
 
     User.hasMany(Task);
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.create({ id: 1 });
-    }).then(function(user) {
+    return this.sequelize.sync({ force: true }).then(() => User.create({ id: 1 })).then(user => {
       expect(user.getAssignments).to.be.ok;
       expect(user.addAssignment).to.be.ok;
       expect(user.addAssignments).to.be.ok;
-    }).then(function() {
-      return User.find({ where: { id: 1 }, include: [Task] });
-    }).then(function(user) {
+    }).then(() => User.find({ where: { id: 1 }, include: [Task] })).then(user => {
       expect(user.assignments).to.be.ok;
     });
   });

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -481,7 +481,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     it('should be able to set twice with custom primary keys', function() {
-      const User = this.sequelize.define('User', { uid: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true }, username: DataTypes.STRING }), Task = this.sequelize.define('Task', { tid: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true }, title: DataTypes.STRING });
+      const User = this.sequelize.define('User', { uid: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true }, username: DataTypes.STRING })
+          , Task = this.sequelize.define('Task', { tid: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true }, title: DataTypes.STRING });
 
       User.belongsToMany(Task, { through: 'UserTasks' });
       Task.belongsToMany(User, { through: 'UserTasks' });
@@ -1274,8 +1275,25 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     describe('without sync', () => {
       beforeEach(function() {
         const self = this;
-
-        return self.sequelize.queryInterface.createTable('users', { id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true } , username: DataTypes.STRING, createdAt: DataTypes.DATE, updatedAt: DataTypes.DATE }).then(() => self.sequelize.queryInterface.createTable('tasks', { id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true }, title: DataTypes.STRING, createdAt: DataTypes.DATE, updatedAt: DataTypes.DATE })).then(() => self.sequelize.queryInterface.createTable('users_tasks', { TaskId: DataTypes.INTEGER, UserId: DataTypes.INTEGER, createdAt: DataTypes.DATE, updatedAt: DataTypes.DATE }));
+        return self.sequelize.queryInterface
+          .createTable('users', {
+            id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+            username: DataTypes.STRING,
+            createdAt: DataTypes.DATE,
+            updatedAt: DataTypes.DATE
+          })
+          .then(() => self.sequelize.queryInterface.createTable('tasks', {
+            id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+            title: DataTypes.STRING,
+            createdAt: DataTypes.DATE,
+            updatedAt: DataTypes.DATE
+          }))
+          .then(() => self.sequelize.queryInterface.createTable('users_tasks',{
+            TaskId: DataTypes.INTEGER,
+            UserId: DataTypes.INTEGER,
+            createdAt: DataTypes.DATE,
+            updatedAt: DataTypes.DATE
+          }));
       });
 
       it('removes all associations', function() {
@@ -1289,7 +1307,10 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return Sequelize.Promise.all([
           this.User.create({username: 'foo'}),
           this.Task.create({title: 'foo'})
-        ]).spread((user, task) => user.addTask(task).return (user)).then(user => user.setTasks(null)).then(result => {
+        ])
+        .spread((user, task) => user.addTask(task).return (user))
+        .then(user => user.setTasks(null))
+        .then(result => {
           expect(result).to.be.ok;
         });
       });
@@ -1316,7 +1337,10 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return Sequelize.Promise.all([
           this.User.create(),
           this.Project.create()
-        ]).spread((user, project) => user.addProject(project, { status: 'active', data: 42 }).return (user)).then(user => user.getProjects()).then(projects => {
+        ])
+        .spread((user, project) => user.addProject(project, { status: 'active', data: 42 }).return (user))
+        .then(user => user.getProjects())
+        .then(projects => {
           const project = projects[0];
 
           expect(project.UserProjects).to.be.ok;
@@ -1330,7 +1354,10 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return Sequelize.Promise.all([
           this.User.create(),
           this.Project.create()
-        ]).spread((user, project) => user.addProject(project, { status: 'active', data: 42 }).return (user)).then(user => user.getProjects({ joinTableAttributes: ['status']})).then(projects => {
+        ])
+        .spread((user, project) => user.addProject(project, { status: 'active', data: 42 }).return (user))
+        .then(user => user.getProjects({ joinTableAttributes: ['status']}))
+        .then(projects => {
           const project = projects[0];
 
           expect(project.UserProjects).to.be.ok;
@@ -1377,7 +1404,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         });
 
         it('should be able to add twice (second call result in UPDATE call) without any attributes (and timestamps off) on the through model', function() {
-          const Worker = this.sequelize.define('Worker', {}, {timestamps: false}), Task = this.sequelize.define('Task', {}, {timestamps: false}), WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
+          const Worker = this.sequelize.define('Worker', {}, {timestamps: false})
+              , Task = this.sequelize.define('Task', {}, {timestamps: false})
+              , WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
 
           Worker.belongsToMany(Task, { through: WorkerTasks });
           Task.belongsToMany(Worker, { through: WorkerTasks });
@@ -1394,29 +1423,14 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
         it('should be able to add twice (second call result in UPDATE call) with custom primary keys and without any attributes (and timestamps off) on the through model', function() {
           const Worker = this.sequelize.define('Worker', {
-                    id: {
-                      type: DataTypes.INTEGER,
-                      allowNull: false,
-                      primaryKey: true,
-                      autoIncrement: true
-                    }
-                  }, {timestamps: false}),
-                Task = this.sequelize.define('Task', {
-                    id: {
-                      type: DataTypes.INTEGER,
-                      allowNull: false,
-                      primaryKey: true,
-                      autoIncrement: true
-                    }
-                  }, {timestamps: false}),
-                WorkerTasks = this.sequelize.define('WorkerTasks', {
-                    id: {
-                      type: DataTypes.INTEGER,
-                      allowNull: false,
-                      primaryKey: true,
-                      autoIncrement: true
-                    }
-                  }, {timestamps: false});
+                  id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true }
+                }, {timestamps: false});
+          const Task = this.sequelize.define('Task', {
+            id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true }
+          }, {timestamps: false});
+          const WorkerTasks = this.sequelize.define('WorkerTasks', {
+            id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true }
+          }, {timestamps: false});
 
           Worker.belongsToMany(Task, { through: WorkerTasks });
           Task.belongsToMany(Worker, { through: WorkerTasks });
@@ -1460,7 +1474,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         });
 
         it('should be able to set twice (second call result in UPDATE calls) without any attributes (and timestamps off) on the through model', function() {
-          const Worker = this.sequelize.define('Worker', {}, {timestamps: false}), Task = this.sequelize.define('Task', {}, {timestamps: false}), WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
+          const Worker = this.sequelize.define('Worker', {}, {timestamps: false})
+              , Task = this.sequelize.define('Task', {}, {timestamps: false})
+              , WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
 
           Worker.belongsToMany(Task, { through: WorkerTasks });
           Task.belongsToMany(Worker, { through: WorkerTasks });
@@ -1491,7 +1507,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
     describe('removing from the join table', () => {
       it('should remove a single entry without any attributes (and timestamps off) on the through model', function() {
-        const Worker = this.sequelize.define('Worker', {}, {timestamps: false}), Task = this.sequelize.define('Task', {}, {timestamps: false}), WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
+        const Worker = this.sequelize.define('Worker', {}, {timestamps: false})
+            , Task = this.sequelize.define('Task', {}, {timestamps: false})
+            , WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
 
         Worker.belongsToMany(Task, { through: WorkerTasks });
         Task.belongsToMany(Worker, { through: WorkerTasks });
@@ -1500,13 +1518,20 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return this.sequelize.sync({force: true}).then(() => Sequelize.Sequelize.Promise.all([
           Worker.create({}),
           Task.bulkCreate([{}, {}, {}]).then(() => Task.findAll())
-        ])).spread((worker, tasks) => worker.setTasks(tasks).then(() => worker.removeTask(tasks[0])).then(() => worker.removeTask(tasks[1].id)).then(() => worker.getTasks())).then(tasks => {
+        ]))
+        .spread((worker, tasks) => worker.setTasks(tasks)
+        .then(() => worker.removeTask(tasks[0]))
+        .then(() => worker.removeTask(tasks[1].id))
+        .then(() => worker.getTasks()))
+        .then(tasks => {
           expect(tasks.length).to.equal(1);
         });
       });
 
       it('should remove multiple entries without any attributes (and timestamps off) on the through model', function() {
-        const Worker = this.sequelize.define('Worker', {}, {timestamps: false}), Task = this.sequelize.define('Task', {}, {timestamps: false}), WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
+        const Worker = this.sequelize.define('Worker', {}, {timestamps: false})
+            , Task = this.sequelize.define('Task', {}, {timestamps: false})
+            , WorkerTasks = this.sequelize.define('WorkerTasks', {}, {timestamps: false});
 
         Worker.belongsToMany(Task, { through: WorkerTasks });
         Task.belongsToMany(Worker, { through: WorkerTasks });
@@ -1515,7 +1540,12 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return this.sequelize.sync({force: true}).then(() => Sequelize.Sequelize.Promise.all([
           Worker.create({}),
           Task.bulkCreate([{}, {}, {}, {}, {}]).then(() => Task.findAll())
-        ])).spread((worker, tasks) => worker.setTasks(tasks).then(() => worker.removeTasks([tasks[0], tasks[1]])).then(() => worker.removeTasks([tasks[2].id, tasks[3].id])).then(() => worker.getTasks())).then(tasks => {
+        ]))
+        .spread((worker, tasks) => worker.setTasks(tasks)
+        .then(() => worker.removeTasks([tasks[0], tasks[1]]))
+        .then(() => worker.removeTasks([tasks[2].id, tasks[3].id]))
+        .then(() => worker.getTasks()))
+        .then(tasks => {
           expect(tasks.length).to.equal(1);
         });
       });
@@ -1596,7 +1626,10 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     it('creates the join table when through is a model', function() {
-      const self = this, User = this.sequelize.define('User', {}), Group = this.sequelize.define('Group', {}), UserGroup = this.sequelize.define('GroupUser', {}, {tableName: 'user_groups'});
+      const self = this
+          , User = this.sequelize.define('User', {})
+          , Group = this.sequelize.define('Group', {})
+          , UserGroup = this.sequelize.define('GroupUser', {}, {tableName: 'user_groups'});
 
       User.belongsToMany(Group, { as: 'MyGroups', through: UserGroup});
       Group.belongsToMany(User, { as: 'MyUsers', through: UserGroup});

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -1,20 +1,18 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , sinon = require('sinon')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , Sequelize = require('../../../index')
-  , Promise = Sequelize.Promise
-  , current = Support.sequelize;
+const chai = require('chai');
+const sinon = require('sinon');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const Sequelize = require('../../../index');
+const current = Support.sequelize;
 
-describe(Support.getTestDialectTeaser('BelongsTo'), function() {
-  describe('Model.associations', function() {
+describe(Support.getTestDialectTeaser('BelongsTo'), () => {
+  describe('Model.associations', () => {
     it('should store all assocations when associting to the same table multiple times', function() {
-      var User = this.sequelize.define('User', {})
-        , Group = this.sequelize.define('Group', {});
+      const User = this.sequelize.define('User', {}), Group = this.sequelize.define('Group', {});
 
       Group.belongsTo(User);
       Group.belongsTo(User, { foreignKey: 'primaryGroupId', as: 'primaryUsers' });
@@ -24,330 +22,218 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
     });
   });
 
-  describe('get', function () {
-    describe('multiple', function () {
+  describe('get', () => {
+    describe('multiple', () => {
       it('should fetch associations for multiple instances', function () {
-        var User = this.sequelize.define('User', {})
-          , Task = this.sequelize.define('Task', {});
+        const User = this.sequelize.define('User', {}), Task = this.sequelize.define('Task', {});
 
         Task.User = Task.belongsTo(User, {as: 'user'});
 
-        return this.sequelize.sync({force: true}).then(function () {
-          return Promise.join(
-            Task.create({
-              id: 1,
-              user: {id: 1}
-            }, {
-              include: [Task.User]
-            }),
-            Task.create({
-              id: 2,
-              user: {id: 2}
-            }, {
-              include: [Task.User]
-            }),
-            Task.create({
-              id: 3
-            })
-          );
-        }).then(function (tasks) {
-          return Task.User.get(tasks).then(function (result) {
-            expect(result[tasks[0].id].id).to.equal(tasks[0].user.id);
-            expect(result[tasks[1].id].id).to.equal(tasks[1].user.id);
-            expect(result[tasks[2].id]).to.be.undefined;
-          });
-        });
+        return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+          Task.create({
+            id: 1,
+            user: {id: 1}
+          }, {
+            include: [Task.User]
+          }),
+          Task.create({
+            id: 2,
+            user: {id: 2}
+          }, {
+            include: [Task.User]
+          }),
+          Task.create({
+            id: 3
+          })
+        )).then(tasks => Task.User.get(tasks).then(result => {
+          expect(result[tasks[0].id].id).to.equal(tasks[0].user.id);
+          expect(result[tasks[1].id].id).to.equal(tasks[1].user.id);
+          expect(result[tasks[2].id]).to.be.undefined;
+        }));
       });
     });
   });
 
-  describe('getAssociation', function() {
+  describe('getAssociation', () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then(function (sequelize) {
-          var User = sequelize.define('User', { username: Support.Sequelize.STRING })
-            , Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
+          const User = sequelize.define('User', { username: Support.Sequelize.STRING }), Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.belongsTo(User);
 
-          return sequelize.sync({ force: true }).then(function() {
-            return User.create({ username: 'foo' }).then(function(user) {
-              return Group.create({ name: 'bar' }).then(function(group) {
-                return sequelize.transaction().then(function(t) {
-                  return group.setUser(user, { transaction: t }).then(function() {
-                    return Group.all().then(function(groups) {
-                      return groups[0].getUser().then(function(associatedUser) {
-                        expect(associatedUser).to.be.null;
-                        return Group.all({ transaction: t }).then(function(groups) {
-                          return groups[0].getUser({ transaction: t }).then(function(associatedUser) {
-                            expect(associatedUser).to.be.not.null;
-                            return t.rollback();
-                          });
-                        });
-                      });
-                    });
-                  });
-                });
-              });
-            });
-          });
+          return sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.setUser(user, { transaction: t }).then(() => Group.all().then(groups => groups[0].getUser().then(associatedUser => {
+            expect(associatedUser).to.be.null;
+            return Group.all({ transaction: t }).then(groups => groups[0].getUser({ transaction: t }).then(associatedUser => {
+              expect(associatedUser).to.be.not.null;
+              return t.rollback();
+            }));
+          })))))));
         });
       });
     }
 
     it('should be able to handle a where object that\'s a first class citizen.', function() {
-      var User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING })
-        , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING });
+      const User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING }), Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING });
 
       Task.belongsTo(User);
 
-      return User.sync({ force: true }).then(function() {
-        // Can't use Promise.all cause of foreign key references
-        return Task.sync({ force: true });
-      }).then(function() {
-        return Promise.all([
-          User.create({ username: 'foo', gender: 'male' }),
-          User.create({ username: 'bar', gender: 'female' }),
-          Task.create({ title: 'task', status: 'inactive' })
-        ]);
-      }).spread(function(userA, userB, task) {
-        return task.setUserXYZ(userA).then(function() {
-          return task.getUserXYZ({where: ['gender = ?', 'female']});
-        });
-      }).then(function(user) {
+      return User.sync({ force: true }).then(() => Task.sync({ force: true })).then(() => Sequelize.Promise.all([
+        User.create({ username: 'foo', gender: 'male' }),
+        User.create({ username: 'bar', gender: 'female' }),
+        Task.create({ title: 'task', status: 'inactive' })
+      ])).spread((userA, userB, task) => task.setUserXYZ(userA).then(() => task.getUserXYZ({where: ['gender = ?', 'female']}))).then(user => {
         expect(user).to.be.null;
       });
     });
 
     it('supports schemas', function() {
-      var User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING }).schema('archive')
-        , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING }).schema('archive')
-        , self = this;
+      const User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING }).schema('archive'), Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING }).schema('archive'), self = this;
 
       Task.belongsTo(User);
 
-      return self.sequelize.dropAllSchemas().then(function() {
-        return self.sequelize.createSchema('archive');
-      }).then(function() {
-        return User.sync({force: true });
-      }).then(function() {
-        return Task.sync({force: true });
-      }).then(function() {
-        return Promise.all([
-          User.create({ username: 'foo', gender: 'male' }),
-          Task.create({ title: 'task', status: 'inactive' })
-        ]);
-      }).spread(function(user, task) {
-        return task.setUserXYZ(user).then(function() {
-          return task.getUserXYZ();
-        });
-      }).then(function(user) {
+      return self.sequelize.dropAllSchemas().then(() => self.sequelize.createSchema('archive')).then(() => User.sync({force: true })).then(() => Task.sync({force: true })).then(() => Sequelize.Promise.all([
+        User.create({ username: 'foo', gender: 'male' }),
+        Task.create({ title: 'task', status: 'inactive' })
+      ])).spread((user, task) => task.setUserXYZ(user).then(() => task.getUserXYZ())).then(user => {
         expect(user).to.be.ok;
       });
     });
   });
 
-  describe('setAssociation', function() {
+  describe('setAssociation', () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then(function (sequelize) {
-          var User = sequelize.define('User', { username: Support.Sequelize.STRING })
-            , Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
+          const User = sequelize.define('User', { username: Support.Sequelize.STRING }), Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.belongsTo(User);
 
-          return sequelize.sync({ force: true }).then(function() {
-            return User.create({ username: 'foo' }).then(function(user) {
-              return Group.create({ name: 'bar' }).then(function(group) {
-                return sequelize.transaction().then(function(t) {
-                  return group.setUser(user, { transaction: t }).then(function() {
-                    return Group.all().then(function(groups) {
-                      return groups[0].getUser().then(function(associatedUser) {
-                        expect(associatedUser).to.be.null;
-                        return t.rollback();
-                      });
-                    });
-                  });
-                });
-              });
-            });
-          });
+          return sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.setUser(user, { transaction: t }).then(() => Group.all().then(groups => groups[0].getUser().then(associatedUser => {
+            expect(associatedUser).to.be.null;
+            return t.rollback();
+          })))))));
         });
       });
     }
 
     it('can set the association with declared primary keys...', function() {
-      var User = this.sequelize.define('UserXYZ', { user_id: {type: DataTypes.INTEGER, primaryKey: true }, username: DataTypes.STRING })
-        , Task = this.sequelize.define('TaskXYZ', { task_id: {type: DataTypes.INTEGER, primaryKey: true }, title: DataTypes.STRING });
+      const User = this.sequelize.define('UserXYZ', { user_id: {type: DataTypes.INTEGER, primaryKey: true }, username: DataTypes.STRING }), Task = this.sequelize.define('TaskXYZ', { task_id: {type: DataTypes.INTEGER, primaryKey: true }, title: DataTypes.STRING });
 
       Task.belongsTo(User, { foreignKey: 'user_id' });
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ user_id: 1, username: 'foo' }).then(function(user) {
-          return Task.create({ task_id: 1, title: 'task' }).then(function(task) {
-            return task.setUserXYZ(user).then(function() {
-              return task.getUserXYZ().then(function(user) {
-                expect(user).not.to.be.null;
+      return this.sequelize.sync({ force: true }).then(() => User.create({ user_id: 1, username: 'foo' }).then(user => Task.create({ task_id: 1, title: 'task' }).then(task => task.setUserXYZ(user).then(() => task.getUserXYZ().then(user => {
+        expect(user).not.to.be.null;
 
-                return task.setUserXYZ(null).then(function() {
-                  return task.getUserXYZ().then(function(user) {
-                    expect(user).to.be.null;
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
+        return task.setUserXYZ(null).then(() => task.getUserXYZ().then(user => {
+          expect(user).to.be.null;
+        }));
+      })))));
     });
 
     it('clears the association if null is passed', function() {
-      var User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
-        , Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING });
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING });
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'foo' }).then(function(user) {
-          return Task.create({ title: 'task' }).then(function(task) {
-            return task.setUserXYZ(user).then(function() {
-              return task.getUserXYZ().then(function(user) {
-                expect(user).not.to.be.null;
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUserXYZ(user).then(() => task.getUserXYZ().then(user => {
+        expect(user).not.to.be.null;
 
-                return task.setUserXYZ(null).then(function() {
-                  return task.getUserXYZ().then(function(user) {
-                    expect(user).to.be.null;
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
+        return task.setUserXYZ(null).then(() => task.getUserXYZ().then(user => {
+          expect(user).to.be.null;
+        }));
+      })))));
     });
 
     it('should throw a ForeignKeyConstraintError if the associated record does not exist', function() {
-      var User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
-        , Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING });
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING });
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(function () {
-          return Task.create({ title: 'task' }).then(function(task) {
-            return expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.create({ title: 'task' }).then(task => expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError))));
     });
 
     it('supports passing the primary key instead of an object', function() {
-      var User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
-        , Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING });
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING });
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ id: 15, username: 'jansemand' }).then(function(user) {
-          return Task.create({}).then(function(task) {
-            return task.setUserXYZ(user.id).then(function() {
-              return task.getUserXYZ().then(function(user) {
-                expect(user.username).to.equal('jansemand');
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ id: 15, username: 'jansemand' }).then(user => Task.create({}).then(task => task.setUserXYZ(user.id).then(() => task.getUserXYZ().then(user => {
+        expect(user.username).to.equal('jansemand');
+      })))));
     });
 
     it('should support logging', function() {
-      var User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
-        , Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING })
-        , spy = sinon.spy();
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING }), spy = sinon.spy();
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create().then(function(user) {
-          return Task.create({}).then(function(task) {
-            return task.setUserXYZ(user, {logging: spy}).then(function() {
-              expect(spy.called).to.be.ok;
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create().then(user => Task.create({}).then(task => task.setUserXYZ(user, {logging: spy}).then(() => {
+        expect(spy.called).to.be.ok;
+      }))));
     });
 
     it('should not clobber atributes', function() {
-      var Comment = this.sequelize.define('comment', {
+      const Comment = this.sequelize.define('comment', {
         text: DataTypes.STRING
       });
 
-      var Post = this.sequelize.define('post', {
+      const Post = this.sequelize.define('post', {
         title: DataTypes.STRING
       });
 
       Post.hasOne(Comment);
       Comment.belongsTo(Post);
 
-      return this.sequelize.sync().then(function() {
-        return Post.create({
-          title: 'Post title'
-        }).then(function(post) {
-          return Comment.create({
-            text: 'OLD VALUE'
-          }).then(function(comment) {
-            comment.text = 'UPDATED VALUE';
-            return comment.setPost(post).then(function() {
-              expect(comment.text).to.equal('UPDATED VALUE');
-            });
-          });
+      return this.sequelize.sync().then(() => Post.create({
+        title: 'Post title'
+      }).then(post => Comment.create({
+        text: 'OLD VALUE'
+      }).then(comment => {
+        comment.text = 'UPDATED VALUE';
+        return comment.setPost(post).then(() => {
+          expect(comment.text).to.equal('UPDATED VALUE');
         });
-      });
+      })));
     });
 
     it('should set the foreign key value without saving when using save: false', function () {
-      var Comment = this.sequelize.define('comment', {
+      const Comment = this.sequelize.define('comment', {
         text: DataTypes.STRING
       });
 
-      var Post = this.sequelize.define('post', {
+      const Post = this.sequelize.define('post', {
         title: DataTypes.STRING
       });
 
       Post.hasMany(Comment, {foreignKey: 'post_id'});
       Comment.belongsTo(Post, {foreignKey: 'post_id'});
 
-      return this.sequelize.sync({force: true}).then(function () {
-        return Promise.join(
-          Post.create(),
-          Comment.create()
-        ).spread(function (post, comment) {
-          expect(comment.get('post_id')).not.to.be.ok;
+      return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+        Post.create(),
+        Comment.create()
+      ).spread((post, comment) => {
+        expect(comment.get('post_id')).not.to.be.ok;
 
-          var setter = comment.setPost(post, {save: false});
+        const setter = comment.setPost(post, {save: false});
 
-          expect(setter).to.be.undefined;
-          expect(comment.get('post_id')).to.equal(post.get('id'));
-          expect(comment.changed('post_id')).to.be.true;
-        });
-      });
+        expect(setter).to.be.undefined;
+        expect(comment.get('post_id')).to.equal(post.get('id'));
+        expect(comment.changed('post_id')).to.be.true;
+      }));
     });
 
     it('supports setting same association twice', function () {
-      var Home = this.sequelize.define('home', {})
-        , User = this.sequelize.define('user');
+      const Home = this.sequelize.define('home', {}), User = this.sequelize.define('user');
 
       Home.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).bind({}).then(function () {
-        return Promise.all([
-          Home.create(),
-          User.create()
-        ]);
-      }).spread(function (home, user) {
+      return this.sequelize.sync({ force: true }).bind({}).then(() => Sequelize.Promise.all([
+        Home.create(),
+        User.create()
+      ])).spread(function (home, user) {
         this.home = home;
         this.user = user;
         return home.setUser(user);
@@ -359,59 +245,42 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
     });
   });
 
-  describe('createAssociation', function() {
+  describe('createAssociation', () => {
     it('creates an associated model instance', function() {
-      var User = this.sequelize.define('User', { username: DataTypes.STRING })
-        , Task = this.sequelize.define('Task', { title: DataTypes.STRING });
+      const User = this.sequelize.define('User', { username: DataTypes.STRING }), Task = this.sequelize.define('Task', { title: DataTypes.STRING });
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return Task.create({ title: 'task' }).then(function(task) {
-          return task.createUser({ username: 'bob' }).then(function() {
-            return task.getUser().then(function(user) {
-              expect(user).not.to.be.null;
-              expect(user.username).to.equal('bob');
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => Task.create({ title: 'task' }).then(task => task.createUser({ username: 'bob' }).then(() => task.getUser().then(user => {
+        expect(user).not.to.be.null;
+        expect(user.username).to.equal('bob');
+      }))));
     });
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then(function (sequelize) {
-          var User = sequelize.define('User', { username: Support.Sequelize.STRING })
-            , Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
+          const User = sequelize.define('User', { username: Support.Sequelize.STRING }), Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.belongsTo(User);
 
-          return sequelize.sync({ force: true }).then(function() {
-            return Group.create({ name: 'bar' }).then(function(group) {
-              return sequelize.transaction().then(function(t) {
-                return group.createUser({ username: 'foo' }, { transaction: t }).then(function() {
-                  return group.getUser().then(function(user) {
-                    expect(user).to.be.null;
+          return sequelize.sync({ force: true }).then(() => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.createUser({ username: 'foo' }, { transaction: t }).then(() => group.getUser().then(user => {
+            expect(user).to.be.null;
 
-                    return group.getUser({ transaction: t }).then(function(user) {
-                      expect(user).not.to.be.null;
+            return group.getUser({ transaction: t }).then(user => {
+              expect(user).not.to.be.null;
 
-                      return t.rollback();
-                    });
-                  });
-                });
-              });
+              return t.rollback();
             });
-          });
+          })))));
         });
       });
     }
   });
 
-  describe('foreign key', function() {
+  describe('foreign key', () => {
     it('should lowercase foreign keys when using underscored', function() {
-      var User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: true })
-        , Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: true });
+      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: true }), Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: true });
 
       User.belongsTo(Account);
 
@@ -419,8 +288,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
     });
 
     it('should use model name when using camelcase', function() {
-      var User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false })
-        , Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: false });
+      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false }), Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: false });
 
       User.belongsTo(Account);
 
@@ -428,8 +296,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
     });
 
     it('should support specifying the field of a foreign key', function() {
-       var User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false })
-         , Account = this.sequelize.define('Account', { title: Sequelize.STRING }, { underscored: false });
+       const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false }), Account = this.sequelize.define('Account', { title: Sequelize.STRING }, { underscored: false });
 
       User.belongsTo(Account, {
         foreignKey: {
@@ -441,164 +308,92 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
       expect(User.rawAttributes.AccountId).to.exist;
       expect(User.rawAttributes.AccountId.field).to.equal('account_id');
 
-      return Account.sync({ force: true }).then(function() {
-        // Can't use Promise.all cause of foreign key references
-        return User.sync({ force: true });
-      }).then(function() {
-        return Promise.all([
-          User.create({ username: 'foo' }),
-          Account.create({ title: 'pepsico' })
-        ]);
-      }).spread(function(user, account) {
-        return user.setAccount(account).then(function() {
-          return user.getAccount();
-        });
-      }).then(function(user) {
+      return Account.sync({ force: true }).then(() => User.sync({ force: true })).then(() => Sequelize.Promise.all([
+        User.create({ username: 'foo' }),
+        Account.create({ title: 'pepsico' })
+      ])).spread((user, account) => user.setAccount(account).then(() => user.getAccount())).then(user => {
         // the sql query should correctly look at task_id instead of taskId
         expect(user).to.not.be.null;
         return User.findOne({
           where: {username: 'foo'},
           include: [Account]
         });
-      }).then(function(task) {
+      }).then(task => {
         expect(task.Account).to.exist;
       });
     });
   });
 
-  describe('foreign key constraints', function() {
+  describe('foreign key constraints', () => {
     it('are enabled by default', function() {
-      var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-        , User = this.sequelize.define('User', { username: DataTypes.STRING });
+      const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
       Task.belongsTo(User); // defaults to SET NULL
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'foo' }).then(function(user) {
-          return Task.create({ title: 'task' }).then(function(task) {
-            return task.setUser(user).then(function() {
-              return user.destroy().then(function() {
-                return task.reload().then(function() {
-                  expect(task.UserId).to.equal(null);
-                });
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => user.destroy().then(() => task.reload().then(() => {
+        expect(task.UserId).to.equal(null);
+      }))))));
     });
 
     it('sets to NO ACTION if allowNull: false', function() {
-      var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-        , User = this.sequelize.define('User', { username: DataTypes.STRING });
+      const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
       Task.belongsTo(User, { foreignKey: { allowNull: false }}); // defaults to NO ACTION
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'foo' }).then(function(user) {
-          return Task.create({ title: 'task', UserId: user.id }).then(function(task) {
-            return expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(function () {
-              return Task.findAll().then(function(tasks) {
-                expect(tasks).to.have.length(1);
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task', UserId: user.id }).then(task => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.findAll().then(tasks => {
+        expect(tasks).to.have.length(1);
+      })))));
     });
 
     it('should be possible to disable them', function() {
-      var Task = this.sequelize.define('Task', { title: Sequelize.STRING })
-        , User = this.sequelize.define('User', { username: Sequelize.STRING });
+      const Task = this.sequelize.define('Task', { title: Sequelize.STRING }), User = this.sequelize.define('User', { username: Sequelize.STRING });
 
       Task.belongsTo(User, { constraints: false });
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'foo' }).then(function(user) {
-          return Task.create({ title: 'task' }).then(function(task) {
-            return task.setUser(user).then(function() {
-              return user.destroy().then(function() {
-                return task.reload().then(function() {
-                  expect(task.UserId).to.equal(user.id);
-                });
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => user.destroy().then(() => task.reload().then(() => {
+        expect(task.UserId).to.equal(user.id);
+      }))))));
     });
 
     it('can cascade deletes', function() {
-      var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-        , User = this.sequelize.define('User', { username: DataTypes.STRING });
+      const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
       Task.belongsTo(User, {onDelete: 'cascade'});
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'foo' }).then(function(user) {
-          return Task.create({ title: 'task' }).then(function(task) {
-            return task.setUser(user).then(function() {
-              return user.destroy().then(function() {
-                return Task.findAll().then(function(tasks) {
-                  expect(tasks).to.have.length(0);
-                });
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => user.destroy().then(() => Task.findAll().then(tasks => {
+        expect(tasks).to.have.length(0);
+      }))))));
     });
 
     if (current.dialect.supports.constraints.restrict) {
       it('can restrict deletes', function() {
-        var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-          , User = this.sequelize.define('User', { username: DataTypes.STRING });
+        const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
         Task.belongsTo(User, {onDelete: 'restrict'});
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return User.create({ username: 'foo' }).then(function(user) {
-            return Task.create({ title: 'task' }).then(function(task) {
-              return task.setUser(user).then(function() {
-                return expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(function () {
-                  return Task.findAll().then(function(tasks) {
-                    expect(tasks).to.have.length(1);
-                  });
-                });
-              });
-            });
-          });
-        });
+        return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.findAll().then(tasks => {
+          expect(tasks).to.have.length(1);
+        }))))));
       });
 
       it('can restrict updates', function() {
-        var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-          , User = this.sequelize.define('User', { username: DataTypes.STRING });
+        const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
         Task.belongsTo(User, {onUpdate: 'restrict'});
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return User.create({ username: 'foo' }).then(function(user) {
-            return Task.create({ title: 'task' }).then(function(task) {
-              return task.setUser(user).then(function() {
+        return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => {
 
-                // Changing the id of a DAO requires a little dance since
-                // the `UPDATE` query generated by `save()` uses `id` in the
-                // `WHERE` clause
+          // Changing the id of a DAO requires a little dance since
+          // the `UPDATE` query generated by `save()` uses `id` in the
+          // `WHERE` clause
 
-                var tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
-                return expect(
-                  user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
-                ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(function () {
-                  // Should fail due to FK restriction
-                  return Task.findAll().then(function(tasks) {
-                    expect(tasks).to.have.length(1);
-                  });
-                });
-              });
-            });
-          });
-        });
+          const tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
+          return expect(
+            user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
+          ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.findAll().then(tasks => {
+            expect(tasks).to.have.length(1);
+          }));
+        }))));
       });
 
     }
@@ -606,47 +401,38 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
     // NOTE: mssql does not support changing an autoincrement primary key
     if (Support.getTestDialect() !== 'mssql') {
       it('can cascade updates', function() {
-        var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-          , User = this.sequelize.define('User', { username: DataTypes.STRING });
+        const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
         Task.belongsTo(User, {onUpdate: 'cascade'});
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return User.create({ username: 'foo' }).then(function(user) {
-            return Task.create({ title: 'task' }).then(function(task) {
-              return task.setUser(user).then(function() {
+        return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => {
 
-                // Changing the id of a DAO requires a little dance since
-                // the `UPDATE` query generated by `save()` uses `id` in the
-                // `WHERE` clause
+          // Changing the id of a DAO requires a little dance since
+          // the `UPDATE` query generated by `save()` uses `id` in the
+          // `WHERE` clause
 
-                var tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
-                return user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
-                .then(function() {
-                  return Task.findAll().then(function(tasks) {
-                    expect(tasks).to.have.length(1);
-                    expect(tasks[0].UserId).to.equal(999);
-                  });
-                });
-              });
-            });
-          });
-        });
+          const tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
+          return user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
+          .then(() => Task.findAll().then(tasks => {
+            expect(tasks).to.have.length(1);
+            expect(tasks[0].UserId).to.equal(999);
+          }));
+        }))));
       });
     }
 
   });
 
-  describe('Association column', function() {
+  describe('Association column', () => {
     it('has correct type and name for non-id primary keys with non-integer type', function() {
-      var User = this.sequelize.define('UserPKBT', {
-        username: {
-          type: DataTypes.STRING
-        }
-      })
-        , self = this;
+      const User = this.sequelize.define('UserPKBT', {
+              username: {
+                type: DataTypes.STRING
+              }
+            }),
+            self = this;
 
-      var Group = this.sequelize.define('GroupPKBT', {
+      const Group = this.sequelize.define('GroupPKBT', {
         name: {
           type: DataTypes.STRING,
           primaryKey: true
@@ -655,115 +441,80 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
 
       User.belongsTo(Group);
 
-      return self.sequelize.sync({ force: true }).then(function() {
+      return self.sequelize.sync({ force: true }).then(() => {
         expect(User.rawAttributes.GroupPKBTName.type).to.an.instanceof(DataTypes.STRING);
       });
     });
 
     it('should support a non-primary key as the association column on a target without a primary key', function() {
-      var User = this.sequelize.define('User', { username: DataTypes.STRING })
-        , Task = this.sequelize.define('Task', { title: DataTypes.STRING });
+      const User = this.sequelize.define('User', { username: DataTypes.STRING }), Task = this.sequelize.define('Task', { title: DataTypes.STRING });
 
       User.removeAttribute('id');
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'bob' }).then(function(newUser) {
-          return Task.create({ title: 'some task' }).then(function(newTask) {
-            return newTask.setUser(newUser).then(function() {
-              return Task.findOne({title: 'some task'}).then(function (foundTask) {
-                return foundTask.getUser().then(function (foundUser) {
-                  expect(foundUser.username).to.equal('bob');
-                });
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(newUser => Task.create({ title: 'some task' }).then(newTask => newTask.setUser(newUser).then(() => Task.findOne({title: 'some task'}).then(foundTask => foundTask.getUser().then(foundUser => {
+        expect(foundUser.username).to.equal('bob');
+      }))))));
     });
 
     it('should support a non-primary unique key as the association column', function() {
-      var User = this.sequelize.define('User', {
-            username: {
-              type: DataTypes.STRING,
-              field: 'user_name',
-              unique: true
-            }
-          })
-        , Task = this.sequelize.define('Task', {
-            title: DataTypes.STRING
-          });
+      const User = this.sequelize.define('User', {
+                  username: {
+                    type: DataTypes.STRING,
+                    field: 'user_name',
+                    unique: true
+                  }
+                }),
+            Task = this.sequelize.define('Task', {
+                  title: DataTypes.STRING
+                });
 
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'bob' }).then(function(newUser) {
-          return Task.create({ title: 'some task' }).then(function(newTask) {
-            return newTask.setUser(newUser).then(function() {
-              return Task.findOne({title: 'some task'}).then(function (foundTask) {
-                return foundTask.getUser().then(function (foundUser) {
-                  expect(foundUser.username).to.equal('bob');
-                });
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(newUser => Task.create({ title: 'some task' }).then(newTask => newTask.setUser(newUser).then(() => Task.findOne({title: 'some task'}).then(foundTask => foundTask.getUser().then(foundUser => {
+        expect(foundUser.username).to.equal('bob');
+      }))))));
     });
 
     it('should support a non-primary key as the association column with a field option', function() {
-      var User = this.sequelize.define('User', {
-          username: {
-            type:  DataTypes.STRING,
-            field: 'the_user_name_field'
-          }
-        })
-        , Task = this.sequelize.define('Task', { title: DataTypes.STRING });
+      const User = this.sequelize.define('User', {
+                username: {
+                  type:  DataTypes.STRING,
+                  field: 'the_user_name_field'
+                }
+              }),
+            Task = this.sequelize.define('Task', { title: DataTypes.STRING });
 
       User.removeAttribute('id');
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'bob' }).then(function(newUser) {
-          return Task.create({ title: 'some task' }).then(function(newTask) {
-            return newTask.setUser(newUser).then(function() {
-              return Task.findOne({title: 'some task'}).then(function (foundTask) {
-                return foundTask.getUser().then(function (foundUser) {
-                  expect(foundUser.username).to.equal('bob');
-                });
-              });
-            });
-          });
-        });
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(newUser => Task.create({ title: 'some task' }).then(newTask => newTask.setUser(newUser).then(() => Task.findOne({title: 'some task'}).then(foundTask => foundTask.getUser().then(foundUser => {
+        expect(foundUser.username).to.equal('bob');
+      }))))));
     });
   });
 
-  describe('Association options', function() {
+  describe('Association options', () => {
     it('can specify data type for autogenerated relational keys', function() {
-      var User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
-        , dataTypes = [DataTypes.INTEGER, DataTypes.BIGINT, DataTypes.STRING]
-        , self = this
-        , Tasks = {};
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), dataTypes = [DataTypes.INTEGER, DataTypes.BIGINT, DataTypes.STRING], self = this, Tasks = {};
 
-      dataTypes.forEach(function(dataType) {
-        var tableName = 'TaskXYZ_' + dataType.key;
+      dataTypes.forEach(dataType => {
+        const tableName = `TaskXYZ_${dataType.key}`;
         Tasks[dataType] = self.sequelize.define(tableName, { title: DataTypes.STRING });
 
         Tasks[dataType].belongsTo(User, { foreignKey: 'userId', keyType: dataType, constraints: false });
       });
 
-      return self.sequelize.sync({ force: true }).then(function() {
-        dataTypes.forEach(function(dataType) {
+      return self.sequelize.sync({ force: true }).then(() => {
+        dataTypes.forEach(dataType => {
           expect(Tasks[dataType].rawAttributes.userId.type).to.be.an.instanceof(dataType);
         });
       });
     });
 
-    describe('allows the user to provide an attribute definition object as foreignKey', function() {
+    describe('allows the user to provide an attribute definition object as foreignKey', () => {
       it('works with a column that hasnt been defined before', function() {
-        var Task = this.sequelize.define('task', {})
-          , User = this.sequelize.define('user', {});
+        const Task = this.sequelize.define('task', {}), User = this.sequelize.define('user', {});
 
         Task.belongsTo(User, {
           foreignKey: {
@@ -779,18 +530,18 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
       });
 
       it('works when taking a column directly from the object', function() {
-        var User = this.sequelize.define('user', {
-            uid: {
-              type: Sequelize.INTEGER,
-              primaryKey: true
-            }
-          })
-          , Profile = this.sequelize.define('project', {
-            user_id: {
-              type: Sequelize.INTEGER,
-              allowNull: false
-            }
-          });
+        const User = this.sequelize.define('user', {
+                  uid: {
+                    type: Sequelize.INTEGER,
+                    primaryKey: true
+                  }
+                }),
+              Profile = this.sequelize.define('project', {
+                  user_id: {
+                    type: Sequelize.INTEGER,
+                    allowNull: false
+                  }
+                });
 
         Profile.belongsTo(User, { foreignKey: Profile.rawAttributes.user_id});
 
@@ -801,13 +552,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
       });
 
       it('works when merging with an existing definition', function() {
-        var Task = this.sequelize.define('task', {
-            projectId: {
-              defaultValue: 42,
-              type: Sequelize.INTEGER
-            }
-          })
-          , Project = this.sequelize.define('project', {});
+        const Task = this.sequelize.define('task', {
+                  projectId: {
+                    defaultValue: 42,
+                    type: Sequelize.INTEGER
+                  }
+                }),
+              Project = this.sequelize.define('project', {});
 
         Task.belongsTo(Project, { foreignKey: { allowNull: true }});
 
@@ -818,18 +569,17 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
     });
 
     it('should throw an error if foreignKey and as result in a name clash', function() {
-      var Person = this.sequelize.define('person', {})
-        , Car = this.sequelize.define('car', {});
+      const Person = this.sequelize.define('person', {}), Car = this.sequelize.define('car', {});
 
       expect(Car.belongsTo.bind(Car, Person, {foreignKey: 'person'})).to
         .throw ('Naming collision between attribute \'person\' and association \'person\' on model car. To remedy this, change either foreignKey or as in your association definition');
     });
 
     it('should throw an error if an association clashes with the name of an already define attribute', function() {
-       var Person = this.sequelize.define('person', {})
-        , Car = this.sequelize.define('car', {
-            person: Sequelize.INTEGER
-          });
+       const Person = this.sequelize.define('person', {}),
+             Car = this.sequelize.define('car', {
+                  person: Sequelize.INTEGER
+                });
 
         expect(Car.belongsTo.bind(Car, Person, {as: 'person'})).to
         .throw ('Naming collision between attribute \'person\' and association \'person\' on model car. To remedy this, change either foreignKey or as in your association definition');

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -63,9 +63,18 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
           Group.belongsTo(User);
 
-          return sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.setUser(user, { transaction: t }).then(() => Group.all().then(groups => groups[0].getUser().then(associatedUser => {
+          return sequelize.sync({ force: true })
+          .then(() => User.create({ username: 'foo' })
+          .then(user => Group.create({ name: 'bar' })
+          .then(group => sequelize.transaction()
+          .then(t => group.setUser(user, { transaction: t })
+          .then(() => Group.all()
+          .then(groups => groups[0].getUser()
+          .then(associatedUser => {
             expect(associatedUser).to.be.null;
-            return Group.all({ transaction: t }).then(groups => groups[0].getUser({ transaction: t }).then(associatedUser => {
+            return Group.all({ transaction: t })
+            .then(groups => groups[0].getUser({ transaction: t })
+            .then(associatedUser => {
               expect(associatedUser).to.be.not.null;
               return t.rollback();
             }));
@@ -75,28 +84,43 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     }
 
     it('should be able to handle a where object that\'s a first class citizen.', function() {
-      const User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING }), Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING });
+      const User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING })
+          , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING });
 
       Task.belongsTo(User);
 
-      return User.sync({ force: true }).then(() => Task.sync({ force: true })).then(() => Sequelize.Promise.all([
+      return User.sync({ force: true })
+      .then(() => Task.sync({ force: true }))
+      .then(() => Sequelize.Promise.all([
         User.create({ username: 'foo', gender: 'male' }),
         User.create({ username: 'bar', gender: 'female' }),
         Task.create({ title: 'task', status: 'inactive' })
-      ])).spread((userA, userB, task) => task.setUserXYZ(userA).then(() => task.getUserXYZ({where: ['gender = ?', 'female']}))).then(user => {
+      ]))
+      .spread((userA, userB, task) => task.setUserXYZ(userA)
+      .then(() => task.getUserXYZ({where: ['gender = ?', 'female']})))
+      .then(user => {
         expect(user).to.be.null;
       });
     });
 
     it('supports schemas', function() {
-      const User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING }).schema('archive'), Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING }).schema('archive'), self = this;
+      const User = this.sequelize.define('UserXYZ', { username: Sequelize.STRING, gender: Sequelize.STRING }).schema('archive')
+          , Task = this.sequelize.define('TaskXYZ', { title: Sequelize.STRING, status: Sequelize.STRING }).schema('archive')
+          , self = this;
 
       Task.belongsTo(User);
 
-      return self.sequelize.dropAllSchemas().then(() => self.sequelize.createSchema('archive')).then(() => User.sync({force: true })).then(() => Task.sync({force: true })).then(() => Sequelize.Promise.all([
+      return self.sequelize.dropAllSchemas()
+      .then(() => self.sequelize.createSchema('archive'))
+      .then(() => User.sync({force: true }))
+      .then(() => Task.sync({force: true }))
+      .then(() => Sequelize.Promise.all([
         User.create({ username: 'foo', gender: 'male' }),
         Task.create({ title: 'task', status: 'inactive' })
-      ])).spread((user, task) => task.setUserXYZ(user).then(() => task.getUserXYZ())).then(user => {
+      ]))
+      .spread((user, task) => task.setUserXYZ(user)
+      .then(() => task.getUserXYZ()))
+      .then(user => {
         expect(user).to.be.ok;
       });
     });
@@ -111,7 +135,14 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
           Group.belongsTo(User);
 
-          return sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.setUser(user, { transaction: t }).then(() => Group.all().then(groups => groups[0].getUser().then(associatedUser => {
+          return sequelize.sync({ force: true })
+          .then(() => User.create({ username: 'foo' })
+          .then(user => Group.create({ name: 'bar' })
+          .then(group => sequelize.transaction()
+          .then(t => group.setUser(user, { transaction: t })
+          .then(() => Group.all()
+          .then(groups => groups[0].getUser()
+          .then(associatedUser => {
             expect(associatedUser).to.be.null;
             return t.rollback();
           })))))));
@@ -120,11 +151,17 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     }
 
     it('can set the association with declared primary keys...', function() {
-      const User = this.sequelize.define('UserXYZ', { user_id: {type: DataTypes.INTEGER, primaryKey: true }, username: DataTypes.STRING }), Task = this.sequelize.define('TaskXYZ', { task_id: {type: DataTypes.INTEGER, primaryKey: true }, title: DataTypes.STRING });
+      const User = this.sequelize.define('UserXYZ', { user_id: {type: DataTypes.INTEGER, primaryKey: true }, username: DataTypes.STRING })
+          , Task = this.sequelize.define('TaskXYZ', { task_id: {type: DataTypes.INTEGER, primaryKey: true }, title: DataTypes.STRING });
 
       Task.belongsTo(User, { foreignKey: 'user_id' });
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ user_id: 1, username: 'foo' }).then(user => Task.create({ task_id: 1, title: 'task' }).then(task => task.setUserXYZ(user).then(() => task.getUserXYZ().then(user => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ user_id: 1, username: 'foo' })
+      .then(user => Task.create({ task_id: 1, title: 'task' })
+      .then(task => task.setUserXYZ(user)
+      .then(() => task.getUserXYZ()
+      .then(user => {
         expect(user).not.to.be.null;
 
         return task.setUserXYZ(null).then(() => task.getUserXYZ().then(user => {
@@ -138,9 +175,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUserXYZ(user).then(() => task.getUserXYZ().then(user => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task' })
+      .then(task => task.setUserXYZ(user)
+      .then(() => task.getUserXYZ()
+      .then(user => {
         expect(user).not.to.be.null;
-
         return task.setUserXYZ(null).then(() => task.getUserXYZ().then(user => {
           expect(user).to.be.null;
         }));
@@ -152,7 +193,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(() => expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.create({ title: 'task' }).then(task => expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError))));
+      return this.sequelize.sync({ force: true })
+      .then(() => expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError)
+      .then(() => Task.create({ title: 'task' })
+      .then(task => expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError))));
     });
 
     it('supports passing the primary key instead of an object', function() {
@@ -160,17 +204,27 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ id: 15, username: 'jansemand' }).then(user => Task.create({}).then(task => task.setUserXYZ(user.id).then(() => task.getUserXYZ().then(user => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ id: 15, username: 'jansemand' })
+      .then(user => Task.create({})
+      .then(task => task.setUserXYZ(user.id)
+      .then(() => task.getUserXYZ().then(user => {
         expect(user.username).to.equal('jansemand');
       })))));
     });
 
     it('should support logging', function() {
-      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING }), spy = sinon.spy();
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
+          , Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING })
+          , spy = sinon.spy();
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(() => User.create().then(user => Task.create({}).then(task => task.setUserXYZ(user, {logging: spy}).then(() => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create()
+      .then(user => Task.create({})
+      .then(task => task.setUserXYZ(user, {logging: spy})
+      .then(() => {
         expect(spy.called).to.be.ok;
       }))));
     });
@@ -251,7 +305,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User);
 
-      return this.sequelize.sync({ force: true }).then(() => Task.create({ title: 'task' }).then(task => task.createUser({ username: 'bob' }).then(() => task.getUser().then(user => {
+      return this.sequelize.sync({ force: true })
+      .then(() => Task.create({ title: 'task' })
+      .then(task => task.createUser({ username: 'bob' })
+      .then(() => task.getUser()
+      .then(user => {
         expect(user).not.to.be.null;
         expect(user.username).to.equal('bob');
       }))));
@@ -264,12 +322,15 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
           Group.belongsTo(User);
 
-          return sequelize.sync({ force: true }).then(() => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.createUser({ username: 'foo' }, { transaction: t }).then(() => group.getUser().then(user => {
+          return sequelize.sync({ force: true })
+          .then(() => Group.create({ name: 'bar' })
+          .then(group => sequelize.transaction()
+          .then(t => group.createUser({ username: 'foo' }, { transaction: t })
+          .then(() => group.getUser()
+          .then(user => {
             expect(user).to.be.null;
-
             return group.getUser({ transaction: t }).then(user => {
               expect(user).not.to.be.null;
-
               return t.rollback();
             });
           })))));
@@ -280,7 +341,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
   describe('foreign key', () => {
     it('should lowercase foreign keys when using underscored', function() {
-      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: true }), Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: true });
+      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: true })
+          , Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: true });
 
       User.belongsTo(Account);
 
@@ -288,7 +350,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     });
 
     it('should use model name when using camelcase', function() {
-      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false }), Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: false });
+      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false })
+          , Account = this.sequelize.define('Account', { name: Sequelize.STRING }, { underscored: false });
 
       User.belongsTo(Account);
 
@@ -296,7 +359,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     });
 
     it('should support specifying the field of a foreign key', function() {
-       const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false }), Account = this.sequelize.define('Account', { title: Sequelize.STRING }, { underscored: false });
+      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { underscored: false })
+          , Account = this.sequelize.define('Account', { title: Sequelize.STRING }, { underscored: false });
 
       User.belongsTo(Account, {
         foreignKey: {
@@ -330,7 +394,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User); // defaults to SET NULL
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => user.destroy().then(() => task.reload().then(() => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task' })
+      .then(task => task.setUser(user)
+      .then(() => user.destroy()
+      .then(() => task.reload()
+      .then(() => {
         expect(task.UserId).to.equal(null);
       }))))));
     });
@@ -340,7 +410,12 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User, { foreignKey: { allowNull: false }}); // defaults to NO ACTION
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task', UserId: user.id }).then(task => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.findAll().then(tasks => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task', UserId: user.id })
+      .then(task => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError)
+      .then(() => Task.findAll()
+      .then(tasks => {
         expect(tasks).to.have.length(1);
       })))));
     });
@@ -350,7 +425,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User, { constraints: false });
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => user.destroy().then(() => task.reload().then(() => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task' })
+      .then(task => task.setUser(user)
+      .then(() => user.destroy()
+      .then(() => task.reload()
+      .then(() => {
         expect(task.UserId).to.equal(user.id);
       }))))));
     });
@@ -360,7 +441,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User, {onDelete: 'cascade'});
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => user.destroy().then(() => Task.findAll().then(tasks => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task' })
+      .then(task => task.setUser(user)
+      .then(() => user.destroy()
+      .then(() => Task.findAll()
+      .then(tasks => {
         expect(tasks).to.have.length(0);
       }))))));
     });
@@ -371,7 +458,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
         Task.belongsTo(User, {onDelete: 'restrict'});
 
-        return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.findAll().then(tasks => {
+        return this.sequelize.sync({ force: true })
+        .then(() => User.create({ username: 'foo' })
+        .then(user => Task.create({ title: 'task' })
+        .then(task => task.setUser(user)
+        .then(() => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError)
+        .then(() => Task.findAll()
+        .then(tasks => {
           expect(tasks).to.have.length(1);
         }))))));
       });
@@ -405,7 +498,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
         Task.belongsTo(User, {onUpdate: 'cascade'});
 
-        return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => task.setUser(user).then(() => {
+        return this.sequelize.sync({ force: true })
+        .then(() => User.create({ username: 'foo' })
+        .then(user => Task.create({ title: 'task' })
+        .then(task => task.setUser(user)
+        .then(() => {
 
           // Changing the id of a DAO requires a little dance since
           // the `UPDATE` query generated by `save()` uses `id` in the
@@ -426,11 +523,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
   describe('Association column', () => {
     it('has correct type and name for non-id primary keys with non-integer type', function() {
       const User = this.sequelize.define('UserPKBT', {
-              username: {
-                type: DataTypes.STRING
-              }
-            }),
-            self = this;
+        username: {
+          type: DataTypes.STRING
+        }
+      }),
+      self = this;
 
       const Group = this.sequelize.define('GroupPKBT', {
         name: {
@@ -452,43 +549,61 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       User.removeAttribute('id');
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(newUser => Task.create({ title: 'some task' }).then(newTask => newTask.setUser(newUser).then(() => Task.findOne({title: 'some task'}).then(foundTask => foundTask.getUser().then(foundUser => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'bob' })
+      .then(newUser => Task.create({ title: 'some task' })
+      .then(newTask => newTask.setUser(newUser)
+      .then(() => Task.findOne({title: 'some task'})
+      .then(foundTask => foundTask.getUser()
+      .then(foundUser => {
         expect(foundUser.username).to.equal('bob');
       }))))));
     });
 
     it('should support a non-primary unique key as the association column', function() {
       const User = this.sequelize.define('User', {
-                  username: {
-                    type: DataTypes.STRING,
-                    field: 'user_name',
-                    unique: true
-                  }
-                }),
-            Task = this.sequelize.define('Task', {
-                  title: DataTypes.STRING
-                });
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name',
+          unique: true
+        }
+      }),
+      Task = this.sequelize.define('Task', {
+        title: DataTypes.STRING
+      });
 
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(newUser => Task.create({ title: 'some task' }).then(newTask => newTask.setUser(newUser).then(() => Task.findOne({title: 'some task'}).then(foundTask => foundTask.getUser().then(foundUser => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'bob' })
+      .then(newUser => Task.create({ title: 'some task' })
+      .then(newTask => newTask.setUser(newUser)
+      .then(() => Task.findOne({title: 'some task'})
+      .then(foundTask => foundTask.getUser()
+      .then(foundUser => {
         expect(foundUser.username).to.equal('bob');
       }))))));
     });
 
     it('should support a non-primary key as the association column with a field option', function() {
       const User = this.sequelize.define('User', {
-                username: {
-                  type:  DataTypes.STRING,
-                  field: 'the_user_name_field'
-                }
-              }),
-            Task = this.sequelize.define('Task', { title: DataTypes.STRING });
+        username: {
+          type:  DataTypes.STRING,
+          field: 'the_user_name_field'
+        }
+      }),
+      Task = this.sequelize.define('Task', { title: DataTypes.STRING });
 
       User.removeAttribute('id');
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(newUser => Task.create({ title: 'some task' }).then(newTask => newTask.setUser(newUser).then(() => Task.findOne({title: 'some task'}).then(foundTask => foundTask.getUser().then(foundUser => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'bob' })
+      .then(newUser => Task.create({ title: 'some task' })
+      .then(newTask => newTask.setUser(newUser)
+      .then(() => Task.findOne({title: 'some task'})
+      .then(foundTask => foundTask.getUser()
+      .then(foundUser => {
         expect(foundUser.username).to.equal('bob');
       }))))));
     });
@@ -496,7 +611,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
   describe('Association options', () => {
     it('can specify data type for autogenerated relational keys', function() {
-      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), dataTypes = [DataTypes.INTEGER, DataTypes.BIGINT, DataTypes.STRING], self = this, Tasks = {};
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
+          , dataTypes = [DataTypes.INTEGER, DataTypes.BIGINT, DataTypes.STRING]
+          , self = this
+          , Tasks = {};
 
       dataTypes.forEach(dataType => {
         const tableName = `TaskXYZ_${dataType.key}`;
@@ -531,17 +649,17 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       it('works when taking a column directly from the object', function() {
         const User = this.sequelize.define('user', {
-                  uid: {
-                    type: Sequelize.INTEGER,
-                    primaryKey: true
-                  }
-                }),
-              Profile = this.sequelize.define('project', {
-                  user_id: {
-                    type: Sequelize.INTEGER,
-                    allowNull: false
-                  }
-                });
+          uid: {
+            type: Sequelize.INTEGER,
+            primaryKey: true
+          }
+        }),
+        Profile = this.sequelize.define('project', {
+          user_id: {
+            type: Sequelize.INTEGER,
+            allowNull: false
+          }
+        });
 
         Profile.belongsTo(User, { foreignKey: Profile.rawAttributes.user_id});
 
@@ -553,12 +671,12 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       it('works when merging with an existing definition', function() {
         const Task = this.sequelize.define('task', {
-                  projectId: {
-                    defaultValue: 42,
-                    type: Sequelize.INTEGER
-                  }
-                }),
-              Project = this.sequelize.define('project', {});
+          projectId: {
+            defaultValue: 42,
+            type: Sequelize.INTEGER
+          }
+        }),
+        Project = this.sequelize.define('project', {});
 
         Task.belongsTo(Project, { foreignKey: { allowNull: true }});
 
@@ -572,17 +690,17 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       const Person = this.sequelize.define('person', {}), Car = this.sequelize.define('car', {});
 
       expect(Car.belongsTo.bind(Car, Person, {foreignKey: 'person'})).to
-        .throw ('Naming collision between attribute \'person\' and association \'person\' on model car. To remedy this, change either foreignKey or as in your association definition');
+      .throw ('Naming collision between attribute \'person\' and association \'person\' on model car. To remedy this, change either foreignKey or as in your association definition');
     });
 
     it('should throw an error if an association clashes with the name of an already define attribute', function() {
-       const Person = this.sequelize.define('person', {}),
-             Car = this.sequelize.define('car', {
-                  person: Sequelize.INTEGER
-                });
+      const Person = this.sequelize.define('person', {}),
+      Car = this.sequelize.define('car', {
+        person: Sequelize.INTEGER
+      });
 
-        expect(Car.belongsTo.bind(Car, Person, {as: 'person'})).to
-        .throw ('Naming collision between attribute \'person\' and association \'person\' on model car. To remedy this, change either foreignKey or as in your association definition');
+      expect(Car.belongsTo.bind(Car, Person, {as: 'person'})).to
+      .throw ('Naming collision between attribute \'person\' and association \'person\' on model car. To remedy this, change either foreignKey or as in your association definition');
     });
   });
 });

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -649,7 +649,11 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
 
         Article.hasMany(Label);
 
-        return this.sequelize.sync({ force: true }).then(() => Article.create({ title: 'foo' })).then(article => article.createLabel({ text: 'bar' }).return (article)).then(article => Label.findAll({ where: { ArticleId: article.id }})).then(labels => {
+        return this.sequelize.sync({ force: true })
+        .then(() => Article.create({ title: 'foo' }))
+        .then(article => article.createLabel({ text: 'bar' }).return (article))
+        .then(article => Label.findAll({ where: { ArticleId: article.id }}))
+        .then(labels => {
           expect(labels.length).to.equal(1);
         });
       });
@@ -863,7 +867,12 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
 
         User.hasMany(Task, { foreignKey: { allowNull: false }}); // defaults to CASCADE
 
-        return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task', UserId: user.id }).then(() => user.destroy().then(() => Task.findAll()))).then(tasks => {
+        return this.sequelize.sync({ force: true })
+        .then(() => User.create({ username: 'foo' })
+        .then(user => Task.create({ title: 'task', UserId: user.id })
+        .then(() => user.destroy()
+        .then(() => Task.findAll())))
+        .then(tasks => {
           expect(tasks).to.be.empty;
         }));
       });

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -1,22 +1,20 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , Sequelize = require('../../../index')
-  , moment = require('moment')
-  , sinon = require('sinon')
-  , Promise = Sequelize.Promise
-  , current = Support.sequelize
-  , dialect = Support.getTestDialect();
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const Sequelize = require('../../../index');
+const moment = require('moment');
+const sinon = require('sinon');
+const current = Support.sequelize;
+const dialect = Support.getTestDialect();
 
-describe(Support.getTestDialectTeaser('HasMany'), function() {
-  describe('Model.associations', function() {
+describe(Support.getTestDialectTeaser('HasMany'), () => {
+  describe('Model.associations', () => {
     it('should store all assocations when associting to the same table multiple times', function() {
-      var User = this.sequelize.define('User', {})
-        , Group = this.sequelize.define('Group', {});
+      const User = this.sequelize.define('User', {}), Group = this.sequelize.define('Group', {});
 
       Group.hasMany(User);
       Group.hasMany(User, { foreignKey: 'primaryGroupId', as: 'primaryUsers' });
@@ -26,266 +24,249 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
     });
   });
 
-  describe('get', function () {
+  describe('get', () => {
     if (current.dialect.supports.groupedLimit) {
-      describe('multiple', function () {
+      describe('multiple', () => {
         it('should fetch associations for multiple instances', function () {
-          var User = this.sequelize.define('User', {})
-            , Task = this.sequelize.define('Task', {});
+          const User = this.sequelize.define('User', {}), Task = this.sequelize.define('Task', {});
 
           User.Tasks = User.hasMany(Task, {as: 'tasks'});
 
-          return this.sequelize.sync({force: true}).then(function () {
-            return Promise.join(
-              User.create({
-                id: 1,
-                tasks: [
-                  {},
-                  {},
-                  {}
-                ]
-              }, {
-                include: [User.Tasks]
-              }),
-              User.create({
-                id: 2,
-                tasks: [
-                  {}
-                ]
-              }, {
-                include: [User.Tasks]
-              }),
-              User.create({
-                id: 3
-              })
-            );
-          }).then(function (users) {
-            return User.Tasks.get(users).then(function (result) {
-              expect(result[users[0].id].length).to.equal(3);
-              expect(result[users[1].id].length).to.equal(1);
-              expect(result[users[2].id].length).to.equal(0);
-            });
-          });
+          return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+            User.create({
+              id: 1,
+              tasks: [
+                {},
+                {},
+                {}
+              ]
+            }, {
+              include: [User.Tasks]
+            }),
+            User.create({
+              id: 2,
+              tasks: [
+                {}
+              ]
+            }, {
+              include: [User.Tasks]
+            }),
+            User.create({
+              id: 3
+            })
+          )).then(users => User.Tasks.get(users).then(result => {
+            expect(result[users[0].id].length).to.equal(3);
+            expect(result[users[1].id].length).to.equal(1);
+            expect(result[users[2].id].length).to.equal(0);
+          }));
         });
 
         it('should fetch associations for multiple instances with limit and order', function () {
-          var User = this.sequelize.define('User', {})
-            , Task = this.sequelize.define('Task', {
-                title: DataTypes.STRING
-              });
+          const User = this.sequelize.define('User', {}),
+                Task = this.sequelize.define('Task', {
+                      title: DataTypes.STRING
+                    });
 
           User.Tasks = User.hasMany(Task, {as: 'tasks'});
 
-          return this.sequelize.sync({force: true}).then(function () {
-            return Promise.join(
-              User.create({
-                tasks: [
-                  {title: 'b'},
-                  {title: 'd'},
-                  {title: 'c'},
-                  {title: 'a'}
-                ]
-              }, {
-                include: [User.Tasks]
-              }),
-              User.create({
-                tasks: [
-                  {title: 'a'},
-                  {title: 'c'},
-                  {title: 'b'}
-                ]
-              }, {
-                include: [User.Tasks]
-              })
-            );
-          }).then(function (users) {
-            return User.Tasks.get(users, {
-              limit: 2,
-              order: [
-                ['title', 'ASC']
+          return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+            User.create({
+              tasks: [
+                {title: 'b'},
+                {title: 'd'},
+                {title: 'c'},
+                {title: 'a'}
               ]
-            }).then(function (result) {
-              expect(result[users[0].id].length).to.equal(2);
-              expect(result[users[0].id][0].title).to.equal('a');
-              expect(result[users[0].id][1].title).to.equal('b');
+            }, {
+              include: [User.Tasks]
+            }),
+            User.create({
+              tasks: [
+                {title: 'a'},
+                {title: 'c'},
+                {title: 'b'}
+              ]
+            }, {
+              include: [User.Tasks]
+            })
+          )).then(users => User.Tasks.get(users, {
+            limit: 2,
+            order: [
+              ['title', 'ASC']
+            ]
+          }).then(result => {
+            expect(result[users[0].id].length).to.equal(2);
+            expect(result[users[0].id][0].title).to.equal('a');
+            expect(result[users[0].id][1].title).to.equal('b');
 
-              expect(result[users[1].id].length).to.equal(2);
-              expect(result[users[1].id][0].title).to.equal('a');
-              expect(result[users[1].id][1].title).to.equal('b');
-            });
-          });
+            expect(result[users[1].id].length).to.equal(2);
+            expect(result[users[1].id][0].title).to.equal('a');
+            expect(result[users[1].id][1].title).to.equal('b');
+          }));
         });
 
         it('should fetch multiple layers of associations with limit and order with separate=true', function () {
-          var User = this.sequelize.define('User', {})
-            , Task = this.sequelize.define('Task', {
-                title: DataTypes.STRING
-              })
-            , SubTask = this.sequelize.define('SubTask', {
-                title: DataTypes.STRING
-              });
+          const User = this.sequelize.define('User', {}),
+                Task = this.sequelize.define('Task', {
+                      title: DataTypes.STRING
+                    }),
+                SubTask = this.sequelize.define('SubTask', {
+                      title: DataTypes.STRING
+                    });
 
           User.Tasks = User.hasMany(Task, {as: 'tasks'});
           Task.SubTasks = Task.hasMany(SubTask, {as: 'subtasks'});
 
-          return this.sequelize.sync({force: true}).then(function() {
-            return Promise.join(
-              User.create({
-                id: 1,
-                tasks: [
-                  {title: 'b', subtasks: [
-                    {title:'c'},
-                    {title:'a'}
-                  ]},
-                  {title: 'd'},
-                  {title: 'c', subtasks: [
-                    {title:'b'},
-                    {title:'a'},
-                    {title:'c'}
-                  ]},
-                  {title: 'a', subtasks: [
-                    {title:'c'},
-                    {title:'a'},
-                    {title:'b'}
-                  ]}
-                ]
-              }, {
-                include: [{association: User.Tasks, include: [Task.SubTasks]}]
-              }),
-              User.create({
-                id: 2,
-                tasks: [
-                  {title: 'a', subtasks: [
-                    {title:'b'},
-                    {title:'a'},
-                    {title:'c'}
-                  ]},
-                  {title: 'c', subtasks: [
-                    {title:'a'}
-                  ]},
-                  {title: 'b', subtasks: [
-                    {title:'a'},
-                    {title:'b'}
-                  ]}
-                ]
-              }, {
-                include: [{association: User.Tasks, include: [Task.SubTasks]}]
-              })
-            );
-          }).then(function(users) {
-            return User.findAll({
-              include: [{
-                association: User.Tasks,
-                limit: 2,
-                order: [['title', 'ASC']],
-                separate: true,
-                as: 'tasks',
-                include: [
-                  {
-                    association: Task.SubTasks,
-                    order: [['title', 'DESC']],
-                    separate: true,
-                    as: 'subtasks'
-                  }
-                ]
-              }],
-              order: [
-                ['id', 'ASC']
+          return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+            User.create({
+              id: 1,
+              tasks: [
+                {title: 'b', subtasks: [
+                  {title:'c'},
+                  {title:'a'}
+                ]},
+                {title: 'd'},
+                {title: 'c', subtasks: [
+                  {title:'b'},
+                  {title:'a'},
+                  {title:'c'}
+                ]},
+                {title: 'a', subtasks: [
+                  {title:'c'},
+                  {title:'a'},
+                  {title:'b'}
+                ]}
               ]
-            }).then(function(users) {
-              expect(users[0].tasks.length).to.equal(2);
+            }, {
+              include: [{association: User.Tasks, include: [Task.SubTasks]}]
+            }),
+            User.create({
+              id: 2,
+              tasks: [
+                {title: 'a', subtasks: [
+                  {title:'b'},
+                  {title:'a'},
+                  {title:'c'}
+                ]},
+                {title: 'c', subtasks: [
+                  {title:'a'}
+                ]},
+                {title: 'b', subtasks: [
+                  {title:'a'},
+                  {title:'b'}
+                ]}
+              ]
+            }, {
+              include: [{association: User.Tasks, include: [Task.SubTasks]}]
+            })
+          )).then(users => User.findAll({
+            include: [{
+              association: User.Tasks,
+              limit: 2,
+              order: [['title', 'ASC']],
+              separate: true,
+              as: 'tasks',
+              include: [
+                {
+                  association: Task.SubTasks,
+                  order: [['title', 'DESC']],
+                  separate: true,
+                  as: 'subtasks'
+                }
+              ]
+            }],
+            order: [
+              ['id', 'ASC']
+            ]
+          }).then(users => {
+            expect(users[0].tasks.length).to.equal(2);
 
-              expect(users[0].tasks[0].title).to.equal('a');
-              expect(users[0].tasks[0].subtasks.length).to.equal(3);
-              expect(users[0].tasks[0].subtasks[0].title).to.equal('c');
-              expect(users[0].tasks[0].subtasks[1].title).to.equal('b');
-              expect(users[0].tasks[0].subtasks[2].title).to.equal('a');
+            expect(users[0].tasks[0].title).to.equal('a');
+            expect(users[0].tasks[0].subtasks.length).to.equal(3);
+            expect(users[0].tasks[0].subtasks[0].title).to.equal('c');
+            expect(users[0].tasks[0].subtasks[1].title).to.equal('b');
+            expect(users[0].tasks[0].subtasks[2].title).to.equal('a');
 
-              expect(users[0].tasks[1].title).to.equal('b');
-              expect(users[0].tasks[1].subtasks.length).to.equal(2);
-              expect(users[0].tasks[1].subtasks[0].title).to.equal('c');
-              expect(users[0].tasks[1].subtasks[1].title).to.equal('a');
+            expect(users[0].tasks[1].title).to.equal('b');
+            expect(users[0].tasks[1].subtasks.length).to.equal(2);
+            expect(users[0].tasks[1].subtasks[0].title).to.equal('c');
+            expect(users[0].tasks[1].subtasks[1].title).to.equal('a');
 
-              expect(users[1].tasks.length).to.equal(2);
-              expect(users[1].tasks[0].title).to.equal('a');
-              expect(users[1].tasks[0].subtasks.length).to.equal(3);
-              expect(users[1].tasks[0].subtasks[0].title).to.equal('c');
-              expect(users[1].tasks[0].subtasks[1].title).to.equal('b');
-              expect(users[1].tasks[0].subtasks[2].title).to.equal('a');
+            expect(users[1].tasks.length).to.equal(2);
+            expect(users[1].tasks[0].title).to.equal('a');
+            expect(users[1].tasks[0].subtasks.length).to.equal(3);
+            expect(users[1].tasks[0].subtasks[0].title).to.equal('c');
+            expect(users[1].tasks[0].subtasks[1].title).to.equal('b');
+            expect(users[1].tasks[0].subtasks[2].title).to.equal('a');
 
-              expect(users[1].tasks[1].title).to.equal('b');
-              expect(users[1].tasks[1].subtasks.length).to.equal(2);
-              expect(users[1].tasks[1].subtasks[0].title).to.equal('b');
-              expect(users[1].tasks[1].subtasks[1].title).to.equal('a');
-            });
-          });
+            expect(users[1].tasks[1].title).to.equal('b');
+            expect(users[1].tasks[1].subtasks.length).to.equal(2);
+            expect(users[1].tasks[1].subtasks[0].title).to.equal('b');
+            expect(users[1].tasks[1].subtasks[1].title).to.equal('a');
+          }));
         });
 
         it('should fetch associations for multiple instances with limit and order and a belongsTo relation', function () {
-          var User = this.sequelize.define('User', {})
-            , Task = this.sequelize.define('Task', {
-                title: DataTypes.STRING,
-                categoryId: {
-                  type: DataTypes.INTEGER,
-                  field: 'category_id'
-                }
-              })
-            , Category = this.sequelize.define('Category', {});
+          const User = this.sequelize.define('User', {}),
+                Task = this.sequelize.define('Task', {
+                      title: DataTypes.STRING,
+                      categoryId: {
+                        type: DataTypes.INTEGER,
+                        field: 'category_id'
+                      }
+                    }),
+                Category = this.sequelize.define('Category', {});
 
           User.Tasks = User.hasMany(Task, {as: 'tasks'});
           Task.Category = Task.belongsTo(Category, {as: 'category', foreignKey: 'categoryId'});
 
-          return this.sequelize.sync({force: true}).then(function () {
-            return Promise.join(
-              User.create({
-                tasks: [
-                  {title: 'b', category: {}},
-                  {title: 'd', category: {}},
-                  {title: 'c', category: {}},
-                  {title: 'a', category: {}}
-                ]
-              }, {
-                include: [{association: User.Tasks, include: [Task.Category]}]
-              }),
-              User.create({
-                tasks: [
-                  {title: 'a', category: {}},
-                  {title: 'c', category: {}},
-                  {title: 'b', category: {}}
-                ]
-              }, {
-                include: [{association: User.Tasks, include: [Task.Category]}]
-              })
-            );
-          }).then(function (users) {
-            return User.Tasks.get(users, {
-              limit: 2,
-              order: [
-                ['title', 'ASC']
-              ],
-              include: [Task.Category],
-            }).then(function (result) {
-              expect(result[users[0].id].length).to.equal(2);
-              expect(result[users[0].id][0].title).to.equal('a');
-              expect(result[users[0].id][0].category).to.be.ok;
-              expect(result[users[0].id][1].title).to.equal('b');
-              expect(result[users[0].id][1].category).to.be.ok;
+          return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+            User.create({
+              tasks: [
+                {title: 'b', category: {}},
+                {title: 'd', category: {}},
+                {title: 'c', category: {}},
+                {title: 'a', category: {}}
+              ]
+            }, {
+              include: [{association: User.Tasks, include: [Task.Category]}]
+            }),
+            User.create({
+              tasks: [
+                {title: 'a', category: {}},
+                {title: 'c', category: {}},
+                {title: 'b', category: {}}
+              ]
+            }, {
+              include: [{association: User.Tasks, include: [Task.Category]}]
+            })
+          )).then(users => User.Tasks.get(users, {
+            limit: 2,
+            order: [
+              ['title', 'ASC']
+            ],
+            include: [Task.Category],
+          }).then(result => {
+            expect(result[users[0].id].length).to.equal(2);
+            expect(result[users[0].id][0].title).to.equal('a');
+            expect(result[users[0].id][0].category).to.be.ok;
+            expect(result[users[0].id][1].title).to.equal('b');
+            expect(result[users[0].id][1].category).to.be.ok;
 
-              expect(result[users[1].id].length).to.equal(2);
-              expect(result[users[1].id][0].title).to.equal('a');
-              expect(result[users[1].id][0].category).to.be.ok;
-              expect(result[users[1].id][1].title).to.equal('b');
-              expect(result[users[1].id][1].category).to.be.ok;
-            });
-          });
+            expect(result[users[1].id].length).to.equal(2);
+            expect(result[users[1].id][0].title).to.equal('a');
+            expect(result[users[1].id][0].category).to.be.ok;
+            expect(result[users[1].id][1].title).to.equal('b');
+            expect(result[users[1].id][1].category).to.be.ok;
+          }));
         });
       });
     }
   });
 
-  describe('(1:N)', function() {
+  describe('(1:N)', () => {
 
-    describe('hasSingle', function() {
+    describe('hasSingle', () => {
       beforeEach(function() {
         this.Article = this.sequelize.define('Article', { 'title': DataTypes.STRING });
         this.Label = this.sequelize.define('Label', { 'text': DataTypes.STRING });
@@ -308,8 +289,8 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
 
       if (current.dialect.supports.transactions) {
         it('supports transactions', function() {
-          var Article, Label, sequelize, article, label, t;
-          return Support.prepareTransactionTest(this.sequelize).then(function(_sequelize) {
+          let Article, Label, sequelize, article, label, t;
+          return Support.prepareTransactionTest(this.sequelize).then(_sequelize => {
             sequelize = _sequelize;
             Article = sequelize.define('Article', { 'title': DataTypes.STRING });
             Label = sequelize.define('Label', { 'text': DataTypes.STRING });
@@ -317,89 +298,69 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
             Article.hasMany(Label);
 
             return sequelize.sync({ force: true });
-          }).then(function() {
-            return Promise.all([
-              Article.create({ title: 'foo' }),
-              Label.create({ text: 'bar' })
-            ]);
-          }).spread(function(_article, _label) {
+          }).then(() => Sequelize.Promise.all([
+            Article.create({ title: 'foo' }),
+            Label.create({ text: 'bar' })
+          ])).spread((_article, _label) => {
             article = _article;
             label = _label;
             return sequelize.transaction();
-          }).then(function(_t) {
+          }).then(_t => {
             t = _t;
             return article.setLabels([label], { transaction: t });
-          }).then(function() {
-            return Article.all({ transaction: t });
-          }).then(function(articles) {
-            return articles[0].hasLabel(label).then(function(hasLabel) {
-              expect(hasLabel).to.be.false;
-            });
-          }).then(function() {
-            return Article.all({ transaction: t });
-          }).then(function(articles) {
-            return articles[0].hasLabel(label, { transaction: t }).then(function(hasLabel) {
-              expect(hasLabel).to.be.true;
-              return t.rollback();
-            });
-          });
+          }).then(() => Article.all({ transaction: t })).then(articles => articles[0].hasLabel(label).then(hasLabel => {
+            expect(hasLabel).to.be.false;
+          })).then(() => Article.all({ transaction: t })).then(articles => articles[0].hasLabel(label, { transaction: t }).then(hasLabel => {
+            expect(hasLabel).to.be.true;
+            return t.rollback();
+          }));
         });
       }
 
       it('does not have any labels assigned to it initially', function() {
-        return Promise.all([
+        return Sequelize.Promise.all([
           this.Article.create({ title: 'Article' }),
           this.Label.create({ text: 'Awesomeness' }),
           this.Label.create({ text: 'Epicness' })
-        ]).spread(function(article, label1, label2) {
-          return Promise.all([
-            article.hasLabel(label1),
-            article.hasLabel(label2)
-          ]);
-        }).spread(function(hasLabel1, hasLabel2) {
+        ]).spread((article, label1, label2) => Sequelize.Promise.all([
+          article.hasLabel(label1),
+          article.hasLabel(label2)
+        ])).spread((hasLabel1, hasLabel2) => {
           expect(hasLabel1).to.be.false;
           expect(hasLabel2).to.be.false;
         });
       });
 
       it('answers true if the label has been assigned', function() {
-        return Promise.all([
+        return Sequelize.Promise.all([
           this.Article.create({ title: 'Article' }),
           this.Label.create({ text: 'Awesomeness' }),
           this.Label.create({ text: 'Epicness' })
-        ]).spread(function(article, label1, label2) {
-          return article.addLabel(label1).then(function() {
-            return Promise.all([
-              article.hasLabel(label1),
-              article.hasLabel(label2)
-            ]);
-          });
-        }).spread(function(hasLabel1, hasLabel2) {
+        ]).spread((article, label1, label2) => article.addLabel(label1).then(() => Sequelize.Promise.all([
+          article.hasLabel(label1),
+          article.hasLabel(label2)
+        ]))).spread((hasLabel1, hasLabel2) => {
           expect(hasLabel1).to.be.true;
           expect(hasLabel2).to.be.false;
         });
       });
 
       it('answers correctly if the label has been assigned when passing a primary key instead of an object', function() {
-        return Promise.all([
+        return Sequelize.Promise.all([
           this.Article.create({ title: 'Article' }),
           this.Label.create({ text: 'Awesomeness' }),
           this.Label.create({ text: 'Epicness' })
-        ]).spread(function(article, label1, label2) {
-          return article.addLabel(label1).then(function() {
-            return Promise.all([
-              article.hasLabel(label1.id),
-              article.hasLabel(label2.id)
-            ]);
-          });
-        }).spread(function(hasLabel1, hasLabel2) {
+        ]).spread((article, label1, label2) => article.addLabel(label1).then(() => Sequelize.Promise.all([
+          article.hasLabel(label1.id),
+          article.hasLabel(label2.id)
+        ]))).spread((hasLabel1, hasLabel2) => {
           expect(hasLabel1).to.be.true;
           expect(hasLabel2).to.be.false;
         });
       });
     });
 
-    describe('hasAll', function() {
+    describe('hasAll', () => {
       beforeEach(function() {
         this.Article = this.sequelize.define('Article', {
           'title': DataTypes.STRING
@@ -424,7 +385,7 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
 
             return this.sequelize.sync({ force: true });
           }).then(function() {
-            return Promise.all([
+            return Sequelize.Promise.all([
               this.Article.create({ title: 'foo' }),
               this.Label.create({ text: 'bar' })
             ]);
@@ -438,7 +399,7 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
           }).then(function() {
             return this.Article.all({ transaction: this.t });
           }).then(function(articles) {
-            return Promise.all([
+            return Sequelize.Promise.all([
               articles[0].hasLabels([this.label]),
               articles[0].hasLabels([this.label], { transaction: this.t })
             ]);
@@ -452,63 +413,47 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       }
 
       it('answers false if only some labels have been assigned', function() {
-        return Promise.all([
+        return Sequelize.Promise.all([
           this.Article.create({ title: 'Article' }),
           this.Label.create({ text: 'Awesomeness' }),
           this.Label.create({ text: 'Epicness' })
-        ]).spread(function(article, label1, label2) {
-          return article.addLabel(label1).then(function() {
-            return article.hasLabels([label1, label2]);
-          });
-        }).then(function(result) {
+        ]).spread((article, label1, label2) => article.addLabel(label1).then(() => article.hasLabels([label1, label2]))).then(result => {
           expect(result).to.be.false;
         });
       });
 
       it('answers false if only some labels have been assigned when passing a primary key instead of an object', function() {
-        return Promise.all([
+        return Sequelize.Promise.all([
           this.Article.create({ title: 'Article' }),
           this.Label.create({ text: 'Awesomeness' }),
           this.Label.create({ text: 'Epicness' })
-        ]).spread(function(article, label1, label2) {
-          return article.addLabel(label1).then(function() {
-            return article.hasLabels([label1.id, label2.id]).then(function(result) {
-              expect(result).to.be.false;
-            });
-          });
-        });
+        ]).spread((article, label1, label2) => article.addLabel(label1).then(() => article.hasLabels([label1.id, label2.id]).then(result => {
+          expect(result).to.be.false;
+        })));
       });
 
       it('answers true if all label have been assigned', function() {
-        return Promise.all([
+        return Sequelize.Promise.all([
           this.Article.create({ title: 'Article' }),
           this.Label.create({ text: 'Awesomeness' }),
           this.Label.create({ text: 'Epicness' })
-        ]).spread(function(article, label1, label2) {
-          return article.setLabels([label1, label2]).then(function() {
-            return article.hasLabels([label1, label2]).then(function(result) {
-              expect(result).to.be.true;
-            });
-          });
-        });
+        ]).spread((article, label1, label2) => article.setLabels([label1, label2]).then(() => article.hasLabels([label1, label2]).then(result => {
+          expect(result).to.be.true;
+        })));
       });
 
       it('answers true if all label have been assigned when passing a primary key instead of an object', function() {
-        return Promise.all([
+        return Sequelize.Promise.all([
           this.Article.create({ title: 'Article' }),
           this.Label.create({ text: 'Awesomeness' }),
           this.Label.create({ text: 'Epicness' })
-        ]).spread(function(article, label1, label2) {
-          return article.setLabels([label1, label2]).then(function() {
-            return article.hasLabels([label1.id, label2.id]).then(function(result) {
-              expect(result).to.be.true;
-            });
-          });
-        });
+        ]).spread((article, label1, label2) => article.setLabels([label1, label2]).then(() => article.hasLabels([label1.id, label2.id]).then(result => {
+          expect(result).to.be.true;
+        })));
       });
     });
 
-    describe('setAssociations', function() {
+    describe('setAssociations', () => {
 
       if (current.dialect.supports.transactions) {
         it('supports transactions', function() {
@@ -521,7 +466,7 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
             this.sequelize = sequelize;
             return sequelize.sync({ force: true });
           }).then(function() {
-            return Promise.all([
+            return Sequelize.Promise.all([
               this.Article.create({ title: 'foo' }),
               this.Label.create({ text: 'bar' }),
               this.sequelize.transaction()
@@ -544,17 +489,14 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       }
 
       it('clears associations when passing null to the set-method', function() {
-        var User = this.sequelize.define('User', { username: DataTypes.STRING })
-          , Task = this.sequelize.define('Task', { title: DataTypes.STRING });
+        const User = this.sequelize.define('User', { username: DataTypes.STRING }), Task = this.sequelize.define('Task', { title: DataTypes.STRING });
 
         Task.hasMany(User);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Promise.all([
-            User.create({ username: 'foo' }),
-            Task.create({ title: 'task' })
-          ]);
-        }).bind({}).spread(function(user, task) {
+        return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+          User.create({ username: 'foo' }),
+          Task.create({ title: 'task' })
+        ])).bind({}).spread(function(user, task) {
           this.task = task;
           return task.setUsers([user]);
         }).then(function() {
@@ -565,24 +507,21 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
           return this.task.setUsers(null);
         }).then(function() {
           return this.task.getUsers();
-        }).then(function(users) {
+        }).then(users => {
           expect(users).to.have.length(0);
         });
       });
 
       it('supports passing the primary key instead of an object', function() {
-        var Article = this.sequelize.define('Article', { title: DataTypes.STRING })
-          , Label = this.sequelize.define('Label', { text: DataTypes.STRING });
+        const Article = this.sequelize.define('Article', { title: DataTypes.STRING }), Label = this.sequelize.define('Label', { text: DataTypes.STRING });
 
         Article.hasMany(Label);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Promise.all([
-            Article.create({}),
-            Label.create({ text: 'label one' }),
-            Label.create({ text: 'label two' })
-          ]);
-        }).bind({}).spread(function(article, label1, label2) {
+        return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+          Article.create({}),
+          Label.create({ text: 'label one' }),
+          Label.create({ text: 'label two' })
+        ])).bind({}).spread(function(article, label1, label2) {
           this.article = article;
           this.label1 = label1;
           this.label2 = label2;
@@ -591,14 +530,14 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
           return this.article.setLabels([this.label2.id]);
         }).then(function() {
           return this.article.getLabels();
-        }).then(function(labels) {
+        }).then(labels => {
           expect(labels).to.have.length(1);
           expect(labels[0].text).to.equal('label two');
         });
       });
     });
 
-    describe('addAssociations', function() {
+    describe('addAssociations', () => {
       if (current.dialect.supports.transactions) {
         it('supports transactions', function() {
           return Support.prepareTransactionTest(this.sequelize).bind({}).then(function(sequelize) {
@@ -609,7 +548,7 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
             this.sequelize = sequelize;
             return sequelize.sync({ force: true });
           }).then(function() {
-            return Promise.all([
+            return Sequelize.Promise.all([
               this.Article.create({ title: 'foo' }),
               this.Label.create({ text: 'bar' })
             ]);
@@ -634,43 +573,35 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       }
 
       it('supports passing the primary key instead of an object', function() {
-        var Article = this.sequelize.define('Article', { 'title': DataTypes.STRING })
-          , Label = this.sequelize.define('Label', { 'text': DataTypes.STRING });
+        const Article = this.sequelize.define('Article', { 'title': DataTypes.STRING }), Label = this.sequelize.define('Label', { 'text': DataTypes.STRING });
 
         Article.hasMany(Label);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Promise.all([
-            Article.create({}),
-            Label.create({ text: 'label one' })
-          ]);
-        }).bind({}).spread(function(article, label) {
+        return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+          Article.create({}),
+          Label.create({ text: 'label one' })
+        ])).bind({}).spread(function(article, label) {
           this.article = article;
           return article.addLabel(label.id);
         }).then(function() {
           return this.article.getLabels();
-        }).then(function(labels) {
+        }).then(labels => {
           expect(labels[0].text).to.equal('label one'); // Make sure that we didn't modify one of the other attributes while building / saving a new instance
         });
       });
     });
 
-    describe('addMultipleAssociations', function() {
+    describe('addMultipleAssociations', () => {
       it('adds associations without removing the current ones', function() {
-        var User = this.sequelize.define('User', { username: DataTypes.STRING })
-          , Task = this.sequelize.define('Task', { title: DataTypes.STRING });
+        const User = this.sequelize.define('User', { username: DataTypes.STRING }), Task = this.sequelize.define('Task', { title: DataTypes.STRING });
 
         Task.hasMany(User);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return User.bulkCreate([
-            { username: 'foo '},
-            { username: 'bar '},
-            { username: 'baz '}
-          ]);
-        }).bind({}).then(function() {
-          return Task.create({ title: 'task' });
-        }).then(function(task) {
+        return this.sequelize.sync({ force: true }).then(() => User.bulkCreate([
+          { username: 'foo '},
+          { username: 'bar '},
+          { username: 'baz '}
+        ])).bind({}).then(() => Task.create({ title: 'task' })).then(function(task) {
           this.task = task;
           return User.findAll();
         }).then(function(users) {
@@ -680,7 +611,7 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
           return this.task.addUsers([this.users[1], this.users[2]]);
         }).then(function() {
           return this.task.getUsers();
-        }).then(function(users) {
+        }).then(users => {
           expect(users).to.have.length(3);
         });
       });
@@ -689,14 +620,11 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
     it('clears associations when passing null to the set-method with omitNull set to true', function() {
       this.sequelize.options.omitNull = true;
 
-      var User = this.sequelize.define('User', { username: DataTypes.STRING })
-        , Task = this.sequelize.define('Task', { title: DataTypes.STRING });
+      const User = this.sequelize.define('User', { username: DataTypes.STRING }), Task = this.sequelize.define('Task', { title: DataTypes.STRING });
 
       Task.hasMany(User);
 
-      return this.sequelize.sync({ force: true }).then(function() {
-        return User.create({ username: 'foo' });
-      }).bind({}).then(function(user) {
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' })).bind({}).then(function(user) {
         this.user = user;
         return Task.create({ title: 'task' });
       }).then(function(task) {
@@ -710,44 +638,36 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
         return this.task.setUsers(null);
       }).then(function() {
         return this.task.getUsers();
-      }).then(function(_users) {
+      }).then(_users => {
         expect(_users).to.have.length(0);
       });
     });
 
-    describe('createAssociations', function() {
+    describe('createAssociations', () => {
       it('creates a new associated object', function() {
-        var Article = this.sequelize.define('Article', { 'title': DataTypes.STRING })
-          , Label = this.sequelize.define('Label', { 'text': DataTypes.STRING });
+        const Article = this.sequelize.define('Article', { 'title': DataTypes.STRING }), Label = this.sequelize.define('Label', { 'text': DataTypes.STRING });
 
         Article.hasMany(Label);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Article.create({ title: 'foo' });
-        }).then(function(article) {
-          return article.createLabel({ text: 'bar' }).return (article);
-        }).then(function(article) {
-          return Label.findAll({ where: { ArticleId: article.id }});
-        }).then(function(labels) {
+        return this.sequelize.sync({ force: true }).then(() => Article.create({ title: 'foo' })).then(article => article.createLabel({ text: 'bar' }).return (article)).then(article => Label.findAll({ where: { ArticleId: article.id }})).then(labels => {
           expect(labels.length).to.equal(1);
         });
       });
 
       it('creates the object with the association directly', function() {
-        var spy = sinon.spy();
+        const spy = sinon.spy();
 
-        var Article = this.sequelize.define('Article', {
-          'title': DataTypes.STRING
+        const Article = this.sequelize.define('Article', {
+                'title': DataTypes.STRING
 
-        }), Label = this.sequelize.define('Label', {
-          'text': DataTypes.STRING
-        });
+              }),
+              Label = this.sequelize.define('Label', {
+                'text': DataTypes.STRING
+              });
 
         Article.hasMany(Label);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Article.create({ title: 'foo' });
-        }).bind({}).then(function(article) {
+        return this.sequelize.sync({ force: true }).then(() => Article.create({ title: 'foo' })).bind({}).then(function(article) {
           this.article = article;
           return article.createLabel({ text: 'bar' }, {logging: spy});
         }).then(function(label) {
@@ -790,53 +710,43 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       }
 
       it('supports passing the field option', function() {
-        var Article = this.sequelize.define('Article', {
-              'title': DataTypes.STRING
-            })
-          , Label = this.sequelize.define('Label', {
-              'text': DataTypes.STRING
-            });
+        const Article = this.sequelize.define('Article', {
+                    'title': DataTypes.STRING
+                  }),
+              Label = this.sequelize.define('Label', {
+                    'text': DataTypes.STRING
+                  });
 
         Article.hasMany(Label);
 
-        return this.sequelize.sync({force: true}).then(function() {
-          return Article.create();
-        }).then(function(article) {
-          return article.createLabel({
-            text: 'yolo'
-          }, {
-            fields: ['text']
-          }).return (article);
-        }).then(function(article) {
-          return article.getLabels();
-        }).then(function(labels) {
+        return this.sequelize.sync({force: true}).then(() => Article.create()).then(article => article.createLabel({
+          text: 'yolo'
+        }, {
+          fields: ['text']
+        }).return (article)).then(article => article.getLabels()).then(labels => {
           expect(labels.length).to.be.ok;
         });
       });
     });
 
-    describe('getting assocations with options', function() {
+    describe('getting assocations with options', () => {
       beforeEach(function() {
-        var self = this;
+        const self = this;
 
         this.User = this.sequelize.define('User', { username: DataTypes.STRING });
         this.Task = this.sequelize.define('Task', { title: DataTypes.STRING, active: DataTypes.BOOLEAN });
 
         this.User.hasMany(self.Task);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Promise.all([
-            self.User.create({ username: 'John'}),
-            self.Task.create({ title: 'Get rich', active: true}),
-            self.Task.create({ title: 'Die trying', active: false})
-          ]);
-        }).spread(function(john, task1, task2) {
-          return john.setTasks([task1, task2]);
-        });
+        return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+          self.User.create({ username: 'John'}),
+          self.Task.create({ title: 'Get rich', active: true}),
+          self.Task.create({ title: 'Die trying', active: false})
+        ])).spread((john, task1, task2) => john.setTasks([task1, task2]));
       });
 
       it('should treat the where object of associations as a first class citizen', function() {
-        var self = this;
+        const self = this;
         this.Article = this.sequelize.define('Article', {
           'title': DataTypes.STRING
         });
@@ -847,18 +757,16 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
 
         this.Article.hasMany(this.Label);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Promise.all([
-            self.Article.create({ title: 'Article' }),
-            self.Label.create({ text: 'Awesomeness', until: '2014-01-01 01:00:00' }),
-            self.Label.create({ text: 'Epicness', until: '2014-01-03 01:00:00' })
-          ]);
-        }).bind({}).spread(function(article, label1, label2) {
+        return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+          self.Article.create({ title: 'Article' }),
+          self.Label.create({ text: 'Awesomeness', until: '2014-01-01 01:00:00' }),
+          self.Label.create({ text: 'Epicness', until: '2014-01-03 01:00:00' })
+        ])).bind({}).spread(function(article, label1, label2) {
           this.article = article;
           return article.setLabels([label1, label2]);
         }).then(function() {
           return this.article.getLabels({where: ['until > ?', moment('2014-01-02').toDate()]});
-        }).then(function(labels) {
+        }).then(labels => {
           expect(labels).to.be.instanceof(Array);
           expect(labels).to.have.length(1);
           expect(labels[0].text).to.equal('Epicness');
@@ -866,25 +774,21 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       });
 
       it('gets all associated objects when no options are passed', function() {
-        return this.User.find({where: {username: 'John'}}).then(function(john) {
-          return john.getTasks();
-        }).then(function(tasks) {
+        return this.User.find({where: {username: 'John'}}).then(john => john.getTasks()).then(tasks => {
           expect(tasks).to.have.length(2);
         });
       });
 
       it('only get objects that fulfill the options', function() {
-        return this.User.find({ where: { username: 'John' } }).then(function(john) {
-          return john.getTasks({ where: { active: true }, limit: 10, order: 'id DESC' });
-        }).then(function(tasks) {
+        return this.User.find({ where: { username: 'John' } }).then(john => john.getTasks({ where: { active: true }, limit: 10, order: 'id DESC' })).then(tasks => {
           expect(tasks).to.have.length(1);
         });
       });
     });
 
-    describe('countAssociations', function () {
+    describe('countAssociations', () => {
       beforeEach(function() {
-        var self = this;
+        const self = this;
 
         this.User = this.sequelize.define('User', { username: DataTypes.STRING });
         this.Task = this.sequelize.define('Task', { title: DataTypes.STRING, active: DataTypes.BOOLEAN });
@@ -893,13 +797,11 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
           foreignKey: 'userId'
         });
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Promise.all([
-            self.User.create({ username: 'John'}),
-            self.Task.create({ title: 'Get rich', active: true}),
-            self.Task.create({ title: 'Die trying', active: false})
-          ]);
-        }).spread(function(john, task1, task2) {
+        return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+          self.User.create({ username: 'John'}),
+          self.Task.create({ title: 'Get rich', active: true}),
+          self.Task.create({ title: 'Die trying', active: false})
+        ])).spread((john, task1, task2) => {
           self.user = john;
           return john.setTasks([task1, task2]);
         });
@@ -930,9 +832,9 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       });
     });
 
-    describe('selfAssociations', function() {
+    describe('selfAssociations', () => {
       it('should work with alias', function() {
-        var Person = this.sequelize.define('Group', {});
+        const Person = this.sequelize.define('Group', {});
 
         Person.hasMany(Person, { as: 'Children'});
 
@@ -941,61 +843,40 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
     });
   });
 
-  describe('Foreign key constraints', function() {
-    describe('1:m', function() {
+  describe('Foreign key constraints', () => {
+    describe('1:m', () => {
       it('sets null by default', function() {
-        var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-          , User = this.sequelize.define('User', { username: DataTypes.STRING });
+        const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
         User.hasMany(Task);
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return Promise.all([
-            User.create({ username: 'foo' }),
-            Task.create({ title: 'task' })
-          ]);
-        }).spread(function(user, task) {
-          return user.setTasks([task]).then(function() {
-            return user.destroy().then(function() {
-              return task.reload();
-            });
-          });
-        }).then(function(task) {
+        return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+          User.create({ username: 'foo' }),
+          Task.create({ title: 'task' })
+        ])).spread((user, task) => user.setTasks([task]).then(() => user.destroy().then(() => task.reload()))).then(task => {
           expect(task.UserId).to.equal(null);
         });
       });
 
       it('sets to CASCADE if allowNull: false', function() {
-        var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-          , User = this.sequelize.define('User', { username: DataTypes.STRING });
+        const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
         User.hasMany(Task, { foreignKey: { allowNull: false }}); // defaults to CASCADE
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return User.create({ username: 'foo' }).then(function(user) {
-            return Task.create({ title: 'task', UserId: user.id }).then(function() {
-              return user.destroy().then(function() {
-                return Task.findAll();
-              });
-            });
-          }).then(function(tasks) {
-            expect(tasks).to.be.empty;
-          });
-        });
+        return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task', UserId: user.id }).then(() => user.destroy().then(() => Task.findAll()))).then(tasks => {
+          expect(tasks).to.be.empty;
+        }));
       });
 
       it('should be possible to remove all constraints', function() {
-        var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-          , User = this.sequelize.define('User', { username: DataTypes.STRING });
+        const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
         User.hasMany(Task, { constraints: false });
 
-        return this.sequelize.sync({ force: true }).bind({}).then(function() {
-          return Promise.all([
-            User.create({ username: 'foo' }),
-            Task.create({ title: 'task' })
-          ]);
-        }).spread(function(user, task) {
+        return this.sequelize.sync({ force: true }).bind({}).then(() => Sequelize.Promise.all([
+          User.create({ username: 'foo' }),
+          Task.create({ title: 'task' })
+        ])).spread(function(user, task) {
           this.user = user;
           this.task = task;
           return user.setTasks([task]);
@@ -1009,25 +890,20 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       });
 
       it('can cascade deletes', function() {
-        var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-          , User = this.sequelize.define('User', { username: DataTypes.STRING });
+        const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
         User.hasMany(Task, {onDelete: 'cascade'});
 
-        return this.sequelize.sync({ force: true }).bind({}).then(function() {
-          return Promise.all([
-            User.create({ username: 'foo' }),
-            Task.create({ title: 'task' })
-          ]);
-        }).spread(function(user, task) {
+        return this.sequelize.sync({ force: true }).bind({}).then(() => Sequelize.Promise.all([
+          User.create({ username: 'foo' }),
+          Task.create({ title: 'task' })
+        ])).spread(function(user, task) {
           this.user = user;
           this.task = task;
           return user.setTasks([task]);
         }).then(function() {
           return this.user.destroy();
-        }).then(function() {
-          return Task.findAll();
-        }).then(function(tasks) {
+        }).then(() => Task.findAll()).then(tasks => {
           expect(tasks).to.have.length(0);
         });
       });
@@ -1035,28 +911,21 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       // NOTE: mssql does not support changing an autoincrement primary key
       if (dialect !== 'mssql') {
         it('can cascade updates', function() {
-          var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-            , User = this.sequelize.define('User', { username: DataTypes.STRING });
+          const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
           User.hasMany(Task, {onUpdate: 'cascade'});
 
-          return this.sequelize.sync({ force: true }).then(function() {
-            return Promise.all([
-              User.create({ username: 'foo' }),
-              Task.create({ title: 'task' })
-            ]);
-          }).spread(function(user, task) {
-            return user.setTasks([task]).return (user);
-          }).then(function(user) {
+          return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+            User.create({ username: 'foo' }),
+            Task.create({ title: 'task' })
+          ])).spread((user, task) => user.setTasks([task]).return (user)).then(user => {
             // Changing the id of a DAO requires a little dance since
             // the `UPDATE` query generated by `save()` uses `id` in the
             // `WHERE` clause
 
-            var tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
+            const tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
             return user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id});
-          }).then(function() {
-            return Task.findAll();
-          }).then(function(tasks) {
+          }).then(() => Task.findAll()).then(tasks => {
             expect(tasks).to.have.length(1);
             expect(tasks[0].UserId).to.equal(999);
           });
@@ -1065,57 +934,43 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
 
       if (current.dialect.supports.constraints.restrict) {
         it('can restrict deletes', function() {
-          var self = this;
-          var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-            , User = this.sequelize.define('User', { username: DataTypes.STRING });
+          const self = this;
+          const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
           User.hasMany(Task, {onDelete: 'restrict'});
 
-          return this.sequelize.sync({ force: true }).bind({}).then(function() {
-            return Promise.all([
-              User.create({ username: 'foo' }),
-              Task.create({ title: 'task' })
-            ]);
-          }).spread(function(user, task) {
+          return this.sequelize.sync({ force: true }).bind({}).then(() => Sequelize.Promise.all([
+            User.create({ username: 'foo' }),
+            Task.create({ title: 'task' })
+          ])).spread(function(user, task) {
             this.user = user;
             this.task = task;
             return user.setTasks([task]);
           }).then(function() {
-            return this.user.destroy().catch (self.sequelize.ForeignKeyConstraintError, function() {
-              // Should fail due to FK violation
-              return Task.findAll();
-            });
-          }).then(function(tasks) {
+            return this.user.destroy().catch (self.sequelize.ForeignKeyConstraintError, () => Task.findAll());
+          }).then(tasks => {
             expect(tasks).to.have.length(1);
           });
         });
 
         it('can restrict updates', function() {
-          var self = this;
-          var Task = this.sequelize.define('Task', { title: DataTypes.STRING })
-            , User = this.sequelize.define('User', { username: DataTypes.STRING });
+          const self = this;
+          const Task = this.sequelize.define('Task', { title: DataTypes.STRING }), User = this.sequelize.define('User', { username: DataTypes.STRING });
 
           User.hasMany(Task, {onUpdate: 'restrict'});
 
-          return this.sequelize.sync({ force: true }).then(function() {
-            return Promise.all([
-              User.create({ username: 'foo' }),
-              Task.create({ title: 'task' })
-            ]);
-          }).spread(function(user, task) {
-            return user.setTasks([task]).return (user);
-          }).then(function(user) {
+          return this.sequelize.sync({ force: true }).then(() => Sequelize.Promise.all([
+            User.create({ username: 'foo' }),
+            Task.create({ title: 'task' })
+          ])).spread((user, task) => user.setTasks([task]).return (user)).then(user => {
             // Changing the id of a DAO requires a little dance since
             // the `UPDATE` query generated by `save()` uses `id` in the
             // `WHERE` clause
 
-            var tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
+            const tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
             return user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
-            .catch (self.sequelize.ForeignKeyConstraintError, function() {
-              // Should fail due to FK violation
-              return Task.findAll();
-            });
-          }).then(function(tasks) {
+            .catch (self.sequelize.ForeignKeyConstraintError, () => Task.findAll());
+          }).then(tasks => {
             expect(tasks).to.have.length(1);
           });
         });
@@ -1125,45 +980,41 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
     });
   });
 
-  describe('Association options', function() {
+  describe('Association options', () => {
     it('can specify data type for autogenerated relational keys', function() {
-      var User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING })
-        , dataTypes = [Sequelize.INTEGER, Sequelize.BIGINT, Sequelize.STRING]
-        , self = this
-        , Tasks = {};
+      const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING }), dataTypes = [Sequelize.INTEGER, Sequelize.BIGINT, Sequelize.STRING], self = this, Tasks = {};
 
-      return Promise.each(dataTypes, function(dataType) {
-        var tableName = 'TaskXYZ_' + dataType.key;
+      return Sequelize.Promise.each(dataTypes, dataType => {
+        const tableName = `TaskXYZ_${dataType.key}`;
         Tasks[dataType] = self.sequelize.define(tableName, { title: DataTypes.STRING });
 
         User.hasMany(Tasks[dataType], { foreignKey: 'userId', keyType: dataType, constraints: false });
 
-        return Tasks[dataType].sync({ force: true }).then(function() {
+        return Tasks[dataType].sync({ force: true }).then(() => {
           expect(Tasks[dataType].rawAttributes.userId.type).to.be.an.instanceof(dataType);
         });
       });
     });
 
     it('infers the keyType if none provided', function() {
-      var User = this.sequelize.define('User', {
-        id: { type: DataTypes.STRING, primaryKey: true },
-        username: DataTypes.STRING
-      })
-      , Task = this.sequelize.define('Task', {
-        title: DataTypes.STRING
-      });
+      const User = this.sequelize.define('User', {
+              id: { type: DataTypes.STRING, primaryKey: true },
+              username: DataTypes.STRING
+            }),
+            Task = this.sequelize.define('Task', {
+              title: DataTypes.STRING
+            });
 
       User.hasMany(Task);
 
-      return this.sequelize.sync({ force: true }).then(function() {
+      return this.sequelize.sync({ force: true }).then(() => {
         expect(Task.rawAttributes.UserId.type instanceof DataTypes.STRING).to.be.ok;
       });
     });
 
-    describe('allows the user to provide an attribute definition object as foreignKey', function() {
+    describe('allows the user to provide an attribute definition object as foreignKey', () => {
       it('works with a column that hasnt been defined before', function() {
-        var Task = this.sequelize.define('task', {})
-          , User = this.sequelize.define('user', {});
+        const Task = this.sequelize.define('task', {}), User = this.sequelize.define('user', {});
 
         User.hasMany(Task, {
           foreignKey: {
@@ -1179,18 +1030,18 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       });
 
       it('works when taking a column directly from the object', function() {
-        var Project = this.sequelize.define('project', {
-            user_id: {
-              type: Sequelize.INTEGER,
-              defaultValue: 42
-            }
-          })
-        , User = this.sequelize.define('user', {
-            uid: {
-              type: Sequelize.INTEGER,
-              primaryKey: true
-            }
-          });
+        const Project = this.sequelize.define('project', {
+                  user_id: {
+                    type: Sequelize.INTEGER,
+                    defaultValue: 42
+                  }
+                }),
+              User = this.sequelize.define('user', {
+                  uid: {
+                    type: Sequelize.INTEGER,
+                    primaryKey: true
+                  }
+                });
 
         User.hasMany(Project, { foreignKey: Project.rawAttributes.user_id});
 
@@ -1201,13 +1052,13 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
       });
 
       it('works when merging with an existing definition', function() {
-        var Task = this.sequelize.define('task', {
-            userId: {
-              defaultValue: 42,
-              type: Sequelize.INTEGER
-            }
-          })
-        , User = this.sequelize.define('user', {});
+        const Task = this.sequelize.define('task', {
+                  userId: {
+                    defaultValue: 42,
+                    type: Sequelize.INTEGER
+                  }
+                }),
+              User = this.sequelize.define('user', {});
 
         User.hasMany(Task, { foreignKey: { allowNull: true }});
 
@@ -1218,7 +1069,7 @@ describe(Support.getTestDialectTeaser('HasMany'), function() {
     });
 
     it('should throw an error if foreignKey and as result in a name clash', function() {
-      var User = this.sequelize.define('user', {
+      const User = this.sequelize.define('user', {
             user: Sequelize.INTEGER
           });
 

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -61,9 +61,19 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
           Group.hasOne(User);
 
-          return sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(fakeUser => User.create({ username: 'foo' }).then(user => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.setUser(user, { transaction: t }).then(() => Group.all().then(groups => groups[0].getUser().then(associatedUser => {
+          return sequelize.sync({ force: true })
+          .then(() => User.create({ username: 'foo' })
+          .then(fakeUser => User.create({ username: 'foo' })
+          .then(user => Group.create({ name: 'bar' })
+          .then(group => sequelize.transaction()
+          .then(t => group.setUser(user, { transaction: t })
+          .then(() => Group.all()
+          .then(groups => groups[0].getUser()
+          .then(associatedUser => {
             expect(associatedUser).to.be.null;
-            return Group.all({ transaction: t }).then(groups => groups[0].getUser({ transaction: t }).then(associatedUser => {
+            return Group.all({ transaction: t })
+            .then(groups => groups[0].getUser({ transaction: t })
+            .then(associatedUser => {
               expect(associatedUser).not.to.be.null;
               expect(associatedUser.id).to.equal(user.id);
               expect(associatedUser.id).not.to.equal(fakeUser.id);
@@ -79,7 +89,13 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       User.hasOne(Task);
 
-      return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task', status: 'inactive' }).then(task => user.setTaskXYZ(task).then(() => user.getTaskXYZ({where: ['status = ?', 'active']}).then(task => {
+      return User.sync({ force: true })
+      .then(() => Task.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task', status: 'inactive' })
+      .then(task => user.setTaskXYZ(task)
+      .then(() => user.getTaskXYZ({where: ['status = ?', 'active']})
+      .then(task => {
         expect(task).to.be.null;
       }))))));
     });
@@ -89,11 +105,19 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
         return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
-          const User = sequelize.define('User', { username: Support.Sequelize.STRING }), Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+          const User = sequelize.define('User', { username: Support.Sequelize.STRING })
+              , Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.hasOne(User);
 
-          return sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Group.create({ name: 'bar' }).then(group => sequelize.transaction().then(t => group.setUser(user, { transaction: t }).then(() => Group.all().then(groups => groups[0].getUser().then(associatedUser => {
+          return sequelize.sync({ force: true })
+          .then(() => User.create({ username: 'foo' })
+          .then(user => Group.create({ name: 'bar' })
+          .then(group => sequelize.transaction()
+          .then(t => group.setUser(user, { transaction: t })
+          .then(() => Group.all()
+          .then(groups => groups[0].getUser()
+          .then(associatedUser => {
             expect(associatedUser).to.be.null;
             return t.rollback();
           })))))));
@@ -102,11 +126,17 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
     }
 
     it('can set an association with predefined primary keys', function() {
-      const User = this.sequelize.define('UserXYZZ', { userCoolIdTag: { type: Sequelize.INTEGER, primaryKey: true }, username: Sequelize.STRING }), Task = this.sequelize.define('TaskXYZZ', { taskOrSomething: { type: Sequelize.INTEGER, primaryKey: true }, title: Sequelize.STRING });
+      const User = this.sequelize.define('UserXYZZ', { userCoolIdTag: { type: Sequelize.INTEGER, primaryKey: true }, username: Sequelize.STRING })
+          , Task = this.sequelize.define('TaskXYZZ', { taskOrSomething: { type: Sequelize.INTEGER, primaryKey: true }, title: Sequelize.STRING });
 
       User.hasOne(Task, {foreignKey: 'userCoolIdTag'});
 
-      return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => User.create({userCoolIdTag: 1, username: 'foo'}).then(user => Task.create({taskOrSomething: 1, title: 'bar'}).then(task => user.setTaskXYZZ(task).then(() => user.getTaskXYZZ().then(task => {
+      return User.sync({ force: true })
+      .then(() => Task.sync({ force: true })
+      .then(() => User.create({userCoolIdTag: 1, username: 'foo'})
+      .then(user => Task.create({taskOrSomething: 1, title: 'bar'})
+      .then(task => user.setTaskXYZZ(task)
+      .then(() => user.getTaskXYZZ().then(task => {
         expect(task).not.to.be.null;
 
         return user.setTaskXYZZ(null).then(() => user.getTaskXYZZ().then(_task => {
@@ -134,7 +164,11 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       User.hasOne(Task);
 
-      return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.create({ title: 'task' }).then(task => expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError)))));
+      return User.sync({ force: true })
+      .then(() => Task.sync({ force: true })
+      .then(() => expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError)
+      .then(() => Task.create({ title: 'task' })
+      .then(task => expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError)))));
     });
 
     it('supports passing the primary key instead of an object', function() {
@@ -211,7 +245,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
           User.hasOne(Group);
 
-          return sequelize.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(user => sequelize.transaction().then(t => user.createGroup({ name: 'testgroup' }, { transaction: t }).then(() => User.all().then(users => users[0].getGroup().then(group => {
+          return sequelize
+          .sync({ force: true })
+          .then(() => User.create({ username: 'bob' })
+          .then(user => sequelize.transaction()
+          .then(t => user.createGroup({ name: 'testgroup' }, { transaction: t })
+          .then(() => User.all()
+          .then(users => users[0].getGroup()
+          .then(group => {
             expect(group).to.be.null;
             return User.all({ transaction: t }).then(users => users[0].getGroup({ transaction: t }).then(group => {
               expect(group).to.be.not.null;
@@ -275,7 +316,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       User.hasOne(Task); // defaults to set NULL
 
-      return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => user.setTask(task).then(() => user.destroy().then(() => task.reload().then(() => {
+      return User.sync({ force: true })
+      .then(() => Task.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task' })
+      .then(task => user.setTask(task)
+      .then(() => user.destroy()
+      .then(() => task.reload()
+      .then(() => {
         expect(task.UserId).to.equal(null);
       })))))));
     });
@@ -285,7 +333,12 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       User.hasOne(Task, { foreignKey: { allowNull: false }}); // defaults to CASCADE
 
-      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task', UserId: user.id }).then(() => user.destroy().then(() => Task.findAll()))).then(tasks => {
+      return this.sequelize.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task', UserId: user.id })
+      .then(() => user.destroy()
+      .then(() => Task.findAll())))
+      .then(tasks => {
         expect(tasks).to.be.empty;
       }));
     });
@@ -295,7 +348,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       User.hasOne(Task, { constraints: false });
 
-      return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => user.setTask(task).then(() => user.destroy().then(() => task.reload().then(() => {
+      return User.sync({ force: true })
+      .then(() => Task.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task' })
+      .then(task => user.setTask(task)
+      .then(() => user.destroy()
+      .then(() => task.reload()
+      .then(() => {
         expect(task.UserId).to.equal(user.id);
       })))))));
     });
@@ -305,7 +365,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       User.hasOne(Task, {onDelete: 'cascade'});
 
-      return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => user.setTask(task).then(() => user.destroy().then(() => Task.findAll().then(tasks => {
+      return User.sync({ force: true })
+      .then(() => Task.sync({ force: true })
+      .then(() => User.create({ username: 'foo' })
+      .then(user => Task.create({ title: 'task' })
+      .then(task => user.setTask(task)
+      .then(() => user.destroy()
+      .then(() => Task.findAll()
+      .then(tasks => {
         expect(tasks).to.have.length(0);
       })))))));
     });
@@ -347,7 +414,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
         User.hasOne(Task, {onDelete: 'restrict'});
 
-        return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => user.setTask(task).then(() => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => Task.findAll().then(tasks => {
+        return User.sync({ force: true })
+        .then(() => Task.sync({ force: true })
+        .then(() => User.create({ username: 'foo' })
+        .then(user => Task.create({ title: 'task' })
+        .then(task => user.setTask(task)
+        .then(() => expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError)
+        .then(() => Task.findAll()
+        .then(tasks => {
           expect(tasks).to.have.length(1);
         })))))));
       });
@@ -357,7 +431,12 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
         User.hasOne(Task, {onUpdate: 'restrict'});
 
-        return User.sync({ force: true }).then(() => Task.sync({ force: true }).then(() => User.create({ username: 'foo' }).then(user => Task.create({ title: 'task' }).then(task => user.setTask(task).then(() => {
+        return User.sync({ force: true })
+        .then(() => Task.sync({ force: true })
+        .then(() => User.create({ username: 'foo' })
+        .then(user => Task.create({ title: 'task' })
+        .then(task => user.setTask(task)
+        .then(() => {
 
           // Changing the id of a DAO requires a little dance since
           // the `UPDATE` query generated by `save()` uses `id` in the

--- a/test/integration/associations/multiple-level-filters.test.js
+++ b/test/integration/associations/multiple-level-filters.test.js
@@ -1,15 +1,14 @@
 'use strict';
 
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types');
+/* jshint -W030 */
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
 
-describe(Support.getTestDialectTeaser('Multiple Level Filters'), function() {
+describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
   it('can filter through belongsTo', function() {
-    var User = this.sequelize.define('User', {username: DataTypes.STRING })
-      , Task = this.sequelize.define('Task', {title: DataTypes.STRING })
-      , Project = this.sequelize.define('Project', { title: DataTypes.STRING });
+    const User = this.sequelize.define('User', {username: DataTypes.STRING }), Task = this.sequelize.define('Task', {title: DataTypes.STRING }), Project = this.sequelize.define('Project', { title: DataTypes.STRING });
 
     Project.belongsTo(User);
     User.hasMany(Project);
@@ -17,53 +16,43 @@ describe(Support.getTestDialectTeaser('Multiple Level Filters'), function() {
     Task.belongsTo(Project);
     Project.hasMany(Task);
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.bulkCreate([{
-        username: 'leia'
-      }, {
-        username: 'vader'
-      }]).then(function() {
-        return Project.bulkCreate([{
-          UserId: 1,
-          title: 'republic'
-        },{
-          UserId: 2,
-          title: 'empire'
-        }]).then(function() {
-          return Task.bulkCreate([{
-            ProjectId: 1,
-            title: 'fight empire'
-          },{
-            ProjectId: 1,
-            title: 'stablish republic'
-          },{
-            ProjectId: 2,
-            title: 'destroy rebel alliance'
-          },{
-            ProjectId: 2,
-            title: 'rule everything'
-          }]).then(function() {
-            return Task.findAll({
-              include: [
-                {model: Project, include: [
-                  {model: User, where: {username: 'leia'}}
-                ]}
-              ]
-            }).then(function(tasks) {
-              expect(tasks.length).to.be.equal(2);
-              expect(tasks[0].title).to.be.equal('fight empire');
-              expect(tasks[1].title).to.be.equal('stablish republic');
-            });
-          });
-        });
-      });
-    });
+    return this.sequelize.sync({ force: true }).then(() => User.bulkCreate([{
+      username: 'leia'
+    }, {
+      username: 'vader'
+    }]).then(() => Project.bulkCreate([{
+      UserId: 1,
+      title: 'republic'
+    },{
+      UserId: 2,
+      title: 'empire'
+    }]).then(() => Task.bulkCreate([{
+      ProjectId: 1,
+      title: 'fight empire'
+    },{
+      ProjectId: 1,
+      title: 'stablish republic'
+    },{
+      ProjectId: 2,
+      title: 'destroy rebel alliance'
+    },{
+      ProjectId: 2,
+      title: 'rule everything'
+    }]).then(() => Task.findAll({
+      include: [
+        {model: Project, include: [
+          {model: User, where: {username: 'leia'}}
+        ]}
+      ]
+    }).then(tasks => {
+      expect(tasks.length).to.be.equal(2);
+      expect(tasks[0].title).to.be.equal('fight empire');
+      expect(tasks[1].title).to.be.equal('stablish republic');
+    })))));
   });
 
   it('avoids duplicated tables in query', function() {
-    var User = this.sequelize.define('User', {username: DataTypes.STRING })
-      , Task = this.sequelize.define('Task', {title: DataTypes.STRING })
-      , Project = this.sequelize.define('Project', { title: DataTypes.STRING });
+    const User = this.sequelize.define('User', {username: DataTypes.STRING }), Task = this.sequelize.define('Task', {title: DataTypes.STRING }), Project = this.sequelize.define('Project', { title: DataTypes.STRING });
 
     Project.belongsTo(User);
     User.hasMany(Project);
@@ -71,56 +60,46 @@ describe(Support.getTestDialectTeaser('Multiple Level Filters'), function() {
     Task.belongsTo(Project);
     Project.hasMany(Task);
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.bulkCreate([{
-        username: 'leia'
-      }, {
-        username: 'vader'
-      }]).then(function() {
-        return Project.bulkCreate([{
-          UserId: 1,
-          title: 'republic'
-        },{
-          UserId: 2,
-          title: 'empire'
-        }]).then(function() {
-          return Task.bulkCreate([{
-            ProjectId: 1,
-            title: 'fight empire'
-          },{
-            ProjectId: 1,
-            title: 'stablish republic'
-          },{
-            ProjectId: 2,
-            title: 'destroy rebel alliance'
-          },{
-            ProjectId: 2,
-            title: 'rule everything'
-          }]).then(function() {
-            return Task.findAll({
-              include: [
-                {model: Project, include: [
-                  {model: User, where: {
-                    username: 'leia',
-                    id: 1
-                  }}
-                ]}
-              ]
-            }).then(function(tasks) {
-              expect(tasks.length).to.be.equal(2);
-              expect(tasks[0].title).to.be.equal('fight empire');
-              expect(tasks[1].title).to.be.equal('stablish republic');
-            });
-          });
-        });
-      });
-    });
+    return this.sequelize.sync({ force: true }).then(() => User.bulkCreate([{
+      username: 'leia'
+    }, {
+      username: 'vader'
+    }]).then(() => Project.bulkCreate([{
+      UserId: 1,
+      title: 'republic'
+    },{
+      UserId: 2,
+      title: 'empire'
+    }]).then(() => Task.bulkCreate([{
+      ProjectId: 1,
+      title: 'fight empire'
+    },{
+      ProjectId: 1,
+      title: 'stablish republic'
+    },{
+      ProjectId: 2,
+      title: 'destroy rebel alliance'
+    },{
+      ProjectId: 2,
+      title: 'rule everything'
+    }]).then(() => Task.findAll({
+      include: [
+        {model: Project, include: [
+          {model: User, where: {
+            username: 'leia',
+            id: 1
+          }}
+        ]}
+      ]
+    }).then(tasks => {
+      expect(tasks.length).to.be.equal(2);
+      expect(tasks[0].title).to.be.equal('fight empire');
+      expect(tasks[1].title).to.be.equal('stablish republic');
+    })))));
   });
 
   it('can filter through hasMany', function() {
-    var User = this.sequelize.define('User', {username: DataTypes.STRING })
-      , Task = this.sequelize.define('Task', {title: DataTypes.STRING })
-      , Project = this.sequelize.define('Project', { title: DataTypes.STRING });
+    const User = this.sequelize.define('User', {username: DataTypes.STRING }), Task = this.sequelize.define('Task', {title: DataTypes.STRING }), Project = this.sequelize.define('Project', { title: DataTypes.STRING });
 
     Project.belongsTo(User);
     User.hasMany(Project);
@@ -128,88 +107,61 @@ describe(Support.getTestDialectTeaser('Multiple Level Filters'), function() {
     Task.belongsTo(Project);
     Project.hasMany(Task);
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.bulkCreate([{
-        username: 'leia'
-      }, {
-        username: 'vader'
-      }]).then(function() {
-        return Project.bulkCreate([{
-          UserId: 1,
-          title: 'republic'
-        },{
-          UserId: 2,
-          title: 'empire'
-        }]).then(function() {
-          return Task.bulkCreate([{
-            ProjectId: 1,
-            title: 'fight empire'
-          },{
-            ProjectId: 1,
-            title: 'stablish republic'
-          },{
-            ProjectId: 2,
-            title: 'destroy rebel alliance'
-          },{
-            ProjectId: 2,
-            title: 'rule everything'
-          }]).then(function() {
-            return User.findAll({
-              include: [
-                {model: Project, include: [
-                  {model: Task, where: {title: 'fight empire'}}
-                ]}
-              ]
-            }).then(function(users) {
-              expect(users.length).to.be.equal(1);
-              expect(users[0].username).to.be.equal('leia');
-            });
-          });
-        });
-      });
-    });
+    return this.sequelize.sync({ force: true }).then(() => User.bulkCreate([{
+      username: 'leia'
+    }, {
+      username: 'vader'
+    }]).then(() => Project.bulkCreate([{
+      UserId: 1,
+      title: 'republic'
+    },{
+      UserId: 2,
+      title: 'empire'
+    }]).then(() => Task.bulkCreate([{
+      ProjectId: 1,
+      title: 'fight empire'
+    },{
+      ProjectId: 1,
+      title: 'stablish republic'
+    },{
+      ProjectId: 2,
+      title: 'destroy rebel alliance'
+    },{
+      ProjectId: 2,
+      title: 'rule everything'
+    }]).then(() => User.findAll({
+      include: [
+        {model: Project, include: [
+          {model: Task, where: {title: 'fight empire'}}
+        ]}
+      ]
+    }).then(users => {
+      expect(users.length).to.be.equal(1);
+      expect(users[0].username).to.be.equal('leia');
+    })))));
   });
 
   it('can filter through hasMany connector', function() {
-    var User = this.sequelize.define('User', {username: DataTypes.STRING })
-      , Project = this.sequelize.define('Project', { title: DataTypes.STRING });
+    const User = this.sequelize.define('User', {username: DataTypes.STRING }), Project = this.sequelize.define('Project', { title: DataTypes.STRING });
 
     Project.belongsToMany(User, {through: 'user_project'});
     User.belongsToMany(Project, {through: 'user_project'});
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return User.bulkCreate([{
-        username: 'leia'
-      }, {
-        username: 'vader'
-      }]).then(function() {
-        return Project.bulkCreate([{
-          title: 'republic'
-        },{
-          title: 'empire'
-        }]).then(function() {
-          return User.findById(1).then(function(user) {
-            return Project.findById(1).then(function(project) {
-              return user.setProjects([project]).then(function() {
-                return User.findById(2).then(function(user) {
-                  return Project.findById(2).then(function(project) {
-                    return user.setProjects([project]).then(function() {
-                      return User.findAll({
-                        include: [
-                          {model: Project, where: {title: 'republic'}}
-                        ]
-                      }).then(function(users) {
-                        expect(users.length).to.be.equal(1);
-                        expect(users[0].username).to.be.equal('leia');
-                      });
-                    });
-                  });
-                });
-              });
-            });
-          });
-        });
-      });
-    });
+    return this.sequelize.sync({ force: true }).then(() => User.bulkCreate([{
+      username: 'leia'
+    }, {
+      username: 'vader'
+    }]).then(() => Project.bulkCreate([{
+      title: 'republic'
+    },{
+      title: 'empire'
+    }]).then(() => User.findById(1).then(user => Project.findById(1).then(project => user.setProjects([project]).then(() => User.findById(2).then(user => Project.findById(2).then(project => user.setProjects([project]).then(() => User.findAll({
+      include: [
+        {model: Project, where: {title: 'republic'}}
+      ]
+    }).then(users => {
+      expect(users.length).to.be.equal(1);
+      expect(users[0].username).to.be.equal('leia');
+    }))))))))));
   });
 });

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -1,15 +1,14 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , Sequelize = require('../../../index')
-  , Promise = Sequelize.Promise;
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const Sequelize = require('../../../index');
 
-describe(Support.getTestDialectTeaser('associations'), function() {
-  describe('scope', function() {
+describe(Support.getTestDialectTeaser('associations'), () => {
+  describe('scope', () => {
     beforeEach(function() {
       this.Post = this.sequelize.define('post', {});
       this.Image = this.sequelize.define('image', {});
@@ -24,8 +23,8 @@ describe(Support.getTestDialectTeaser('associations'), function() {
         }
       }, {
         instanceMethods: {
-          getItem: function() {
-            return this['get' + this.get('commentable').substr(0, 1).toUpperCase() + this.get('commentable').substr(1)]();
+          getItem() {
+            return this[`get${this.get('commentable').substr(0, 1).toUpperCase()}${this.get('commentable').substr(1)}`]();
           }
         }
       });
@@ -88,21 +87,19 @@ describe(Support.getTestDialectTeaser('associations'), function() {
       });
     });
 
-    describe('1:1', function() {
+    describe('1:1', () => {
       it('should create, find and include associations with scope values', function() {
-        var self = this;
-        return this.sequelize.sync({force: true}).then(function() {
-          return Promise.join(
-            self.Post.create(),
-            self.Comment.create({
-              title: 'I am a comment'
-            }),
-            self.Comment.create({
-              title: 'I am a main comment',
-              isMain: true
-            })
-          );
-        }).bind(this).spread(function(post) {
+        const self = this;
+        return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+          self.Post.create(),
+          self.Comment.create({
+            title: 'I am a comment'
+          }),
+          self.Comment.create({
+            title: 'I am a main comment',
+            isMain: true
+          })
+        )).bind(this).spread(function(post) {
           this.post = post;
           return post.createComment({
             title: 'I am a post comment'
@@ -111,7 +108,7 @@ describe(Support.getTestDialectTeaser('associations'), function() {
           expect(comment.get('commentable')).to.equal('post');
           expect(comment.get('isMain')).to.be.false;
           return this.Post.scope('withMainComment').findById(this.post.get('id'));
-        }).then(function(post) {
+        }).then(post => {
           expect(post.mainComment).to.be.null;
           return post.createMainComment({
               title: 'I am a main post comment'
@@ -134,7 +131,7 @@ describe(Support.getTestDialectTeaser('associations'), function() {
           return this.post.setMainComment(comment);
         }).then( function () {
           return this.post.getMainComment();
-        }).then(function (mainComment) {
+        }).then(mainComment => {
           expect(mainComment.get('commentable')).to.equal('post');
           expect(mainComment.get('isMain')).to.be.true;
           expect(mainComment.get('title')).to.equal('I am a future main comment');
@@ -142,48 +139,42 @@ describe(Support.getTestDialectTeaser('associations'), function() {
       });
     });
 
-    describe('1:M', function() {
+    describe('1:M', () => {
       it('should create, find and include associations with scope values', function() {
-        var self = this;
-        return this.sequelize.sync({force: true}).then(function() {
-          return Promise.join(
-            self.Post.create(),
-            self.Image.create(),
-            self.Question.create(),
-            self.Comment.create({
-              title: 'I am a image comment'
-            }),
-            self.Comment.create({
-              title: 'I am a question comment'
-            })
-          );
-        }).bind(this).spread(function(post, image, question, commentA, commentB) {
+        const self = this;
+        return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.join(
+          self.Post.create(),
+          self.Image.create(),
+          self.Question.create(),
+          self.Comment.create({
+            title: 'I am a image comment'
+          }),
+          self.Comment.create({
+            title: 'I am a question comment'
+          })
+        )).bind(this).spread(function(post, image, question, commentA, commentB) {
           this.post = post;
           this.image = image;
           this.question = question;
-          return Promise.join(
+          return Sequelize.Promise.join(
             post.createComment({
               title: 'I am a post comment'
             }),
             image.addComment(commentA),
             question.setComments([commentB])
           );
-        }).then(function() {
-          return self.Comment.findAll();
-        }).then(function(comments) {
-          comments.forEach(function(comment) {
+        }).then(() => self.Comment.findAll()).then(comments => {
+          comments.forEach(comment => {
             expect(comment.get('commentable')).to.be.ok;
           });
-          expect(comments.map(function(comment) {
-            return comment.get('commentable');
-          }).sort()).to.deep.equal(['image', 'post', 'question']);
+          expect(comments.map(comment => comment.get('commentable')).sort()).to.deep.equal(['image', 'post', 'question']);
         }).then(function() {
-          return Promise.join(
+          return Sequelize.Promise.join(
             this.post.getComments(),
             this.image.getComments(),
             this.question.getComments()
           );
-        }).spread(function(postComments, imageComments, questionComments) {
+        }).spread((postComments, imageComments, questionComments) => {
           expect(postComments.length).to.equal(1);
           expect(postComments[0].get('title')).to.equal('I am a post comment');
           expect(imageComments.length).to.equal(1);
@@ -192,29 +183,25 @@ describe(Support.getTestDialectTeaser('associations'), function() {
           expect(questionComments[0].get('title')).to.equal('I am a question comment');
 
           return [postComments[0], imageComments[0], questionComments[0]];
-        }).spread(function(postComment, imageComment, questionComment) {
-          return Promise.join(
-            postComment.getItem(),
-            imageComment.getItem(),
-            questionComment.getItem()
-          );
-        }).spread(function(post, image, question) {
+        }).spread((postComment, imageComment, questionComment) => Sequelize.Promise.join(
+          postComment.getItem(),
+          imageComment.getItem(),
+          questionComment.getItem()
+        )).spread((post, image, question) => {
           expect(post).to.be.instanceof(self.Post);
           expect(image).to.be.instanceof(self.Image);
           expect(question).to.be.instanceof(self.Question);
-        }).then(function() {
-          return Promise.join(
-            self.Post.find({
-              include: [self.Comment]
-            }),
-            self.Image.findOne({
-              include: [self.Comment]
-            }),
-            self.Question.findOne({
-              include: [self.Comment]
-            })
-          );
-        }).spread(function(post, image, question) {
+        }).then(() => Sequelize.Promise.join(
+          self.Post.find({
+            include: [self.Comment]
+          }),
+          self.Image.findOne({
+            include: [self.Comment]
+          }),
+          self.Question.findOne({
+            include: [self.Comment]
+          })
+        )).spread((post, image, question) => {
           expect(post.comments.length).to.equal(1);
           expect(post.comments[0].get('title')).to.equal('I am a post comment');
           expect(image.comments.length).to.equal(1);
@@ -224,35 +211,27 @@ describe(Support.getTestDialectTeaser('associations'), function() {
         });
       });
       it('should make the same query if called multiple time (#4470)', function () {
-        var self = this;
-        var logs = [];
-        var logging = function (log) {
+        const self = this;
+        const logs = [];
+        const logging = log => {
           logs.push(log);
         };
 
-        return this.sequelize.sync({force: true}).then(function () {
-          return self.Post.create();
-        }).then(function (post) {
-          return post.createComment({
-            title: 'I am a post comment'
-          });
-        }).then(function() {
-          return self.Post.scope('withComments').findAll({
-            logging: logging
-          });
-        }).then(function () {
-          return self.Post.scope('withComments').findAll({
-            logging: logging
-          });
-        }).then(function () {
+        return this.sequelize.sync({force: true}).then(() => self.Post.create()).then(post => post.createComment({
+          title: 'I am a post comment'
+        })).then(() => self.Post.scope('withComments').findAll({
+          logging
+        })).then(() => self.Post.scope('withComments').findAll({
+          logging
+        })).then(() => {
           expect(logs[0]).to.equal(logs[1]);
         });
       });
     });
 
     if (Support.getTestDialect() !== 'sqlite') {
-      describe('N:M', function() {
-        describe('on the target', function() {
+      describe('N:M', () => {
+        describe('on the target', () => {
           beforeEach(function() {
             this.Post = this.sequelize.define('post', {});
             this.Tag = this.sequelize.define('tag', {
@@ -266,28 +245,24 @@ describe(Support.getTestDialectTeaser('associations'), function() {
           });
 
           it('should create, find and include associations with scope values', function() {
-            var self = this;
-            return Promise.join(
+            const self = this;
+            return Sequelize.Promise.join(
               self.Post.sync({force: true}),
               self.Tag.sync({force: true})
-            ).bind(this).then(function() {
-              return self.PostTag.sync({force: true});
-            }).then(function() {
-              return Promise.join(
-                self.Post.create(),
-                self.Post.create(),
-                self.Post.create(),
-                self.Tag.create({type: 'category'}),
-                self.Tag.create({type: 'category'}),
-                self.Tag.create({type: 'tag'}),
-                self.Tag.create({type: 'tag'})
-              );
-            }).spread(function(postA, postB, postC, categoryA, categoryB, tagA, tagB) {
+            ).bind(this).then(() => self.PostTag.sync({force: true})).then(() => Sequelize.Promise.join(
+              self.Post.create(),
+              self.Post.create(),
+              self.Post.create(),
+              self.Tag.create({type: 'category'}),
+              self.Tag.create({type: 'category'}),
+              self.Tag.create({type: 'tag'}),
+              self.Tag.create({type: 'tag'})
+            )).spread(function(postA, postB, postC, categoryA, categoryB, tagA, tagB) {
               this.postA = postA;
               this.postB = postB;
               this.postC = postC;
 
-              return Promise.join(
+              return Sequelize.Promise.join(
                 postA.addCategory(categoryA),
                 postB.setCategories([categoryB]),
                 postC.createCategory(),
@@ -296,7 +271,7 @@ describe(Support.getTestDialectTeaser('associations'), function() {
                 postC.setTags([tagB])
               );
             }).then(function() {
-              return Promise.join(
+              return Sequelize.Promise.join(
                 this.postA.getCategories(),
                 this.postA.getTags(),
                 this.postB.getCategories(),
@@ -304,7 +279,13 @@ describe(Support.getTestDialectTeaser('associations'), function() {
                 this.postC.getCategories(),
                 this.postC.getTags()
               );
-            }).spread(function(postACategories, postATags, postBCategories, postBTags, postCCategories, postCTags) {
+            }).spread((
+              postACategories,
+              postATags,
+              postBCategories,
+              postBTags,
+              postCCategories,
+              postCTags) => {
               expect(postACategories.length).to.equal(1);
               expect(postATags.length).to.equal(1);
               expect(postBCategories.length).to.equal(1);
@@ -318,37 +299,35 @@ describe(Support.getTestDialectTeaser('associations'), function() {
               expect(postBTags[0].get('type')).to.equal('tag');
               expect(postCCategories[0].get('type')).to.equal('category');
               expect(postCTags[0].get('type')).to.equal('tag');
-            }).then(function() {
-              return Promise.join(
-                self.Post.findOne({
-                  where: {
-                    id: self.postA.get('id')
-                  },
-                  include: [
-                    {model: self.Tag, as: 'tags'},
-                    {model: self.Tag, as: 'categories'}
-                  ]
-                }),
-                self.Post.findOne({
-                  where: {
-                    id: self.postB.get('id')
-                  },
-                  include: [
-                    {model: self.Tag, as: 'tags'},
-                    {model: self.Tag, as: 'categories'}
-                  ]
-                }),
-                self.Post.findOne({
-                  where: {
-                    id: self.postC.get('id')
-                  },
-                  include: [
-                    {model: self.Tag, as: 'tags'},
-                    {model: self.Tag, as: 'categories'}
-                  ]
-                })
-              );
-            }).spread(function(postA, postB, postC) {
+            }).then(() => Sequelize.Promise.join(
+              self.Post.findOne({
+                where: {
+                  id: self.postA.get('id')
+                },
+                include: [
+                  {model: self.Tag, as: 'tags'},
+                  {model: self.Tag, as: 'categories'}
+                ]
+              }),
+              self.Post.findOne({
+                where: {
+                  id: self.postB.get('id')
+                },
+                include: [
+                  {model: self.Tag, as: 'tags'},
+                  {model: self.Tag, as: 'categories'}
+                ]
+              }),
+              self.Post.findOne({
+                where: {
+                  id: self.postC.get('id')
+                },
+                include: [
+                  {model: self.Tag, as: 'tags'},
+                  {model: self.Tag, as: 'categories'}
+                ]
+              })
+            )).spread((postA, postB, postC) => {
               expect(postA.get('categories').length).to.equal(1);
               expect(postA.get('tags').length).to.equal(1);
               expect(postB.get('categories').length).to.equal(1);
@@ -366,7 +345,7 @@ describe(Support.getTestDialectTeaser('associations'), function() {
           });
         });
 
-        describe('on the through model', function() {
+        describe('on the through model', () => {
           beforeEach(function() {
             this.Post = this.sequelize.define('post', {});
             this.Image = this.sequelize.define('image', {});
@@ -455,8 +434,8 @@ describe(Support.getTestDialectTeaser('associations'), function() {
           });
 
           it('should create, find and include associations with scope values', function() {
-            var self = this;
-            return Promise.join(
+            const self = this;
+            return Sequelize.Promise.join(
               this.Post.sync({force: true}),
               this.Image.sync({force: true}),
               this.Question.sync({force: true}),
@@ -464,7 +443,7 @@ describe(Support.getTestDialectTeaser('associations'), function() {
             ).bind(this).then(function() {
               return this.ItemTag.sync({force: true});
             }).then(function() {
-              return Promise.join(
+              return Sequelize.Promise.join(
                 this.Post.create(),
                 this.Image.create(),
                 this.Question.create(),
@@ -476,79 +455,59 @@ describe(Support.getTestDialectTeaser('associations'), function() {
               this.post = post;
               this.image = image;
               this.question = question;
-              return Promise.join(
-                post.setTags([tagA]).then(function() {
-                  return Promise.join(
-                    post.createTag({name: 'postTag'}),
-                    post.addTag(tagB)
-                  );
-                }),
-                image.setTags([tagB]).then(function() {
-                  return Promise.join(
-                    image.createTag({name: 'imageTag'}),
-                    image.addTag(tagC)
-                  );
-                }),
-                question.setTags([tagC]).then(function() {
-                  return Promise.join(
-                    question.createTag({name: 'questionTag'}),
-                    question.addTag(tagA)
-                  );
-                })
+              return Sequelize.Promise.join(
+                post.setTags([tagA]).then(() => Sequelize.Promise.join(
+                  post.createTag({name: 'postTag'}),
+                  post.addTag(tagB)
+                )),
+                image.setTags([tagB]).then(() => Sequelize.Promise.join(
+                  image.createTag({name: 'imageTag'}),
+                  image.addTag(tagC)
+                )),
+                question.setTags([tagC]).then(() => Sequelize.Promise.join(
+                  question.createTag({name: 'questionTag'}),
+                  question.addTag(tagA)
+                ))
               );
             }).then(function() {
-              return Promise.join(
+              return Sequelize.Promise.join(
                 this.post.getTags(),
                 this.image.getTags(),
                 this.question.getTags()
-              ).spread(function(postTags, imageTags, questionTags) {
+              ).spread((postTags, imageTags, questionTags) => {
                 expect(postTags.length).to.equal(3);
                 expect(imageTags.length).to.equal(3);
                 expect(questionTags.length).to.equal(3);
 
-                expect(postTags.map(function(tag) {
-                  return tag.name;
-                }).sort()).to.deep.equal(['postTag', 'tagA', 'tagB']);
+                expect(postTags.map(tag => tag.name).sort()).to.deep.equal(['postTag', 'tagA', 'tagB']);
 
-                expect(imageTags.map(function(tag) {
-                  return tag.name;
-                }).sort()).to.deep.equal(['imageTag', 'tagB', 'tagC']);
+                expect(imageTags.map(tag => tag.name).sort()).to.deep.equal(['imageTag', 'tagB', 'tagC']);
 
-                expect(questionTags.map(function(tag) {
-                  return tag.name;
-                }).sort()).to.deep.equal(['questionTag', 'tagA', 'tagC']);
-              }).then(function () {
-                return Promise.join(
-                  self.Post.findOne({
-                    where: {},
-                    include: [self.Tag]
-                  }),
-                  self.Image.findOne({
-                    where: {},
-                    include: [self.Tag]
-                  }),
-                  self.Question.findOne({
-                    where: {},
-                    include: [self.Tag]
-                  })
-                ).spread(function (post, image, question) {
-                  expect(post.tags.length).to.equal(3);
-                  expect(image.tags.length).to.equal(3);
-                  expect(question.tags.length).to.equal(3);
+                expect(questionTags.map(tag => tag.name).sort()).to.deep.equal(['questionTag', 'tagA', 'tagC']);
+              }).then(() => Sequelize.Promise.join(
+                self.Post.findOne({
+                  where: {},
+                  include: [self.Tag]
+                }),
+                self.Image.findOne({
+                  where: {},
+                  include: [self.Tag]
+                }),
+                self.Question.findOne({
+                  where: {},
+                  include: [self.Tag]
+                })
+              ).spread((post, image, question) => {
+                expect(post.tags.length).to.equal(3);
+                expect(image.tags.length).to.equal(3);
+                expect(question.tags.length).to.equal(3);
 
-                  expect(post.tags.map(function(tag) {
-                    return tag.name;
-                  }).sort()).to.deep.equal(['postTag', 'tagA', 'tagB']);
+                expect(post.tags.map(tag => tag.name).sort()).to.deep.equal(['postTag', 'tagA', 'tagB']);
 
-                  expect(image.tags.map(function(tag) {
-                    return tag.name;
-                  }).sort()).to.deep.equal(['imageTag', 'tagB', 'tagC']);
+                expect(image.tags.map(tag => tag.name).sort()).to.deep.equal(['imageTag', 'tagB', 'tagC']);
 
-                  expect(question.tags.map(function(tag) {
-                    return tag.name;
-                  }).sort()).to.deep.equal(['questionTag', 'tagA', 'tagC']);
-                });
-              });
+                expect(question.tags.map(tag => tag.name).sort()).to.deep.equal(['questionTag', 'tagA', 'tagC']);
+              }));
             });
           });
         });

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -1,17 +1,16 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , Sequelize = require(__dirname + '/../../../index')
-  , Promise = Sequelize.Promise
-  , _ = require('lodash');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const Sequelize = require('./../../../index');
+const _ = require('lodash');
 
-describe(Support.getTestDialectTeaser('Self'), function() {
+describe(Support.getTestDialectTeaser('Self'), () => {
   it('supports freezeTableName', function() {
-    var Group = this.sequelize.define('Group', {}, {
+    const Group = this.sequelize.define('Group', {}, {
       tableName: 'user_group',
       timestamps: false,
       underscored: true,
@@ -19,44 +18,38 @@ describe(Support.getTestDialectTeaser('Self'), function() {
     });
 
     Group.belongsTo(Group, { as: 'Parent', foreignKey: 'parent_id' });
-    return Group.sync({force: true}).then(function() {
-      return Group.findAll({
-        include: [{
-          model: Group,
-          as: 'Parent'
-        }]
-      });
-    });
+    return Group.sync({force: true}).then(() => Group.findAll({
+      include: [{
+        model: Group,
+        as: 'Parent'
+      }]
+    }));
   });
 
   it('can handle 1:m associations', function() {
-    var Person = this.sequelize.define('Person', { name: DataTypes.STRING });
+    const Person = this.sequelize.define('Person', { name: DataTypes.STRING });
 
     Person.hasMany(Person, { as: 'Children', foreignKey: 'parent_id'});
 
     expect(Person.rawAttributes.parent_id).to.be.ok;
 
-    return this.sequelize.sync({force: true}).then(function() {
-      return Promise.all([
-        Person.create({ name: 'Mary' }),
-        Person.create({ name: 'John' }),
-        Person.create({ name: 'Chris' })
-      ]);
-    }).spread(function(mary, john, chris) {
-      return mary.setChildren([john, chris]);
-    });
+    return this.sequelize.sync({force: true}).then(() => Sequelize.Promise.all([
+      Person.create({ name: 'Mary' }),
+      Person.create({ name: 'John' }),
+      Person.create({ name: 'Chris' })
+    ])).spread((mary, john, chris) => mary.setChildren([john, chris]));
   });
 
   it('can handle n:m associations', function() {
-    var self = this;
+    const self = this;
 
-    var Person = this.sequelize.define('Person', { name: DataTypes.STRING });
+    const Person = this.sequelize.define('Person', { name: DataTypes.STRING });
 
     Person.belongsToMany(Person, { as: 'Parents', through: 'Family', foreignKey: 'ChildId', otherKey: 'PersonId' });
     Person.belongsToMany(Person, { as: 'Childs', through: 'Family', foreignKey: 'PersonId', otherKey: 'ChildId' });
 
-    var foreignIdentifiers = _.map(_.values(Person.associations), 'foreignIdentifier');
-    var rawAttributes = _.keys(this.sequelize.models.Family.rawAttributes);
+    const foreignIdentifiers = _.map(_.values(Person.associations), 'foreignIdentifier');
+    const rawAttributes = _.keys(this.sequelize.models.Family.rawAttributes);
 
     expect(foreignIdentifiers.length).to.equal(2);
     expect(rawAttributes.length).to.equal(4);
@@ -64,26 +57,18 @@ describe(Support.getTestDialectTeaser('Self'), function() {
     expect(foreignIdentifiers).to.have.members(['PersonId', 'ChildId']);
     expect(rawAttributes).to.have.members(['createdAt', 'updatedAt', 'PersonId', 'ChildId']);
 
-    return this.sequelize.sync({ force: true }).then(function() {
-      return self.sequelize.Promise.all([
-        Person.create({ name: 'Mary' }),
-        Person.create({ name: 'John' }),
-        Person.create({ name: 'Chris' })
-      ]).spread(function(mary, john, chris) {
-        return mary.setParents([john]).then(function() {
-          return chris.addParent(john);
-        }).then(function() {
-          return john.getChilds();
-        }).then(function(children) {
-          expect(_.map(children, 'id')).to.have.members([mary.id, chris.id]);
-        });
-      });
-    });
+    return this.sequelize.sync({ force: true }).then(() => self.sequelize.Sequelize.Promise.all([
+      Person.create({ name: 'Mary' }),
+      Person.create({ name: 'John' }),
+      Person.create({ name: 'Chris' })
+    ]).spread((mary, john, chris) => mary.setParents([john]).then(() => chris.addParent(john)).then(() => john.getChilds()).then(children => {
+      expect(_.map(children, 'id')).to.have.members([mary.id, chris.id]);
+    })));
   });
 
   it('can handle n:m associations with pre-defined through table', function() {
-    var Person = this.sequelize.define('Person', { name: DataTypes.STRING });
-    var Family = this.sequelize.define('Family', {
+    const Person = this.sequelize.define('Person', { name: DataTypes.STRING });
+    const Family = this.sequelize.define('Family', {
       preexisting_child: {
         type: DataTypes.INTEGER,
         primaryKey: true
@@ -97,8 +82,8 @@ describe(Support.getTestDialectTeaser('Self'), function() {
     Person.belongsToMany(Person, { as: 'Parents', through: Family, foreignKey: 'preexisting_child', otherKey: 'preexisting_parent' });
     Person.belongsToMany(Person, { as: 'Children', through: Family, foreignKey: 'preexisting_parent', otherKey: 'preexisting_child' });
 
-    var foreignIdentifiers = _.map(_.values(Person.associations), 'foreignIdentifier');
-    var rawAttributes = _.keys(Family.rawAttributes);
+    const foreignIdentifiers = _.map(_.values(Person.associations), 'foreignIdentifier');
+    const rawAttributes = _.keys(Family.rawAttributes);
 
     expect(foreignIdentifiers.length).to.equal(2);
     expect(rawAttributes.length).to.equal(2);
@@ -106,19 +91,17 @@ describe(Support.getTestDialectTeaser('Self'), function() {
     expect(foreignIdentifiers).to.have.members(['preexisting_parent', 'preexisting_child']);
     expect(rawAttributes).to.have.members(['preexisting_parent', 'preexisting_child']);
 
-    var count = 0;
-    return this.sequelize.sync({ force: true }).bind(this).then(function() {
-      return Promise.all([
-        Person.create({ name: 'Mary' }),
-        Person.create({ name: 'John' }),
-        Person.create({ name: 'Chris' })
-      ]);
-    }).spread(function(mary, john, chris) {
+    let count = 0;
+    return this.sequelize.sync({ force: true }).bind(this).then(() => Sequelize.Promise.all([
+      Person.create({ name: 'Mary' }),
+      Person.create({ name: 'John' }),
+      Person.create({ name: 'Chris' })
+    ])).spread(function(mary, john, chris) {
       this.mary = mary;
       this.chris = chris;
       this.john = john;
       return mary.setParents([john], {
-        logging: function(sql) {
+        logging(sql) {
           if (sql.match(/INSERT/)) {
             count++;
             expect(sql).to.have.string('preexisting_child');
@@ -128,7 +111,7 @@ describe(Support.getTestDialectTeaser('Self'), function() {
       });
     }).then(function() {
       return this.mary.addParent(this.chris, {
-        logging: function(sql) {
+        logging(sql) {
           if (sql.match(/INSERT/)) {
               count++;
               expect(sql).to.have.string('preexisting_child');
@@ -138,9 +121,9 @@ describe(Support.getTestDialectTeaser('Self'), function() {
       });
     }).then(function() {
       return this.john.getChildren({
-        logging: function(sql) {
+        logging(sql) {
           count++;
-          var whereClause = sql.split('FROM')[1]; // look only in the whereClause
+          const whereClause = sql.split('FROM')[1]; // look only in the whereClause
           expect(whereClause).to.have.string('preexisting_child');
           expect(whereClause).to.have.string('preexisting_parent');
         }

--- a/test/integration/hooks/associations.test.js
+++ b/test/integration/hooks/associations.test.js
@@ -1,14 +1,14 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , sinon = require('sinon')
-  , dialect = Support.getTestDialect();
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const sinon = require('sinon');
+const dialect = Support.getTestDialect();
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -35,11 +35,11 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
   });
 
 
-  describe('associations', function() {
-    describe('1:1', function() {
-      describe('cascade onUpdate', function() {
+  describe('associations', () => {
+    describe('1:1', () => {
+      describe('cascade onUpdate', () => {
         beforeEach(function() {
-          var self = this;
+          const self = this;
 
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
@@ -52,56 +52,44 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           this.Projects.hasOne(this.Tasks, {onUpdate: 'cascade', hooks: true});
           this.Tasks.belongsTo(this.Projects);
 
-          return this.Projects.sync({ force: true }).then(function() {
-            return self.Tasks.sync({ force: true });
-          });
+          return this.Projects.sync({ force: true }).then(() => self.Tasks.sync({ force: true }));
         });
 
         it('on success', function() {
-          var self = this
-          , beforeHook = false
-          , afterHook = false;
+          const self = this;
+          let beforeHook = false;
+          let afterHook = false;
 
-          this.Tasks.beforeUpdate(function(task, options, fn) {
+          this.Tasks.beforeUpdate((task, options, fn) => {
             beforeHook = true;
             fn();
           });
 
-          this.Tasks.afterUpdate(function(task, options, fn) {
+          this.Tasks.afterUpdate((task, options, fn) => {
             afterHook = true;
             fn();
           });
 
-          return this.Projects.create({title: 'New Project'}).then(function(project) {
-            return self.Tasks.create({title: 'New Task'}).then(function(task) {
-              return project.setTask(task).then(function() {
-                return project.updateAttributes({id: 2}).then(function() {
-                  expect(beforeHook).to.be.true;
-                  expect(afterHook).to.be.true;
-                });
-              });
-            });
-          });
+          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => project.updateAttributes({id: 2}).then(() => {
+            expect(beforeHook).to.be.true;
+            expect(afterHook).to.be.true;
+          }))));
         });
 
         it('on error', function() {
-          var self = this;
+          const self = this;
 
-          this.Tasks.afterUpdate(function(task, options, fn) {
+          this.Tasks.afterUpdate((task, options, fn) => {
             fn(new Error('Whoops!'));
           });
 
-          return this.Projects.create({title: 'New Project'}).then(function(project) {
-            return self.Tasks.create({title: 'New Task'}).then(function(task) {
-              return project.setTask(task).catch(function(err) {
-                expect(err).to.be.instanceOf(Error);
-              });
-            });
-          });
+          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).catch(err => {
+            expect(err).to.be.instanceOf(Error);
+          })));
         });
       });
 
-      describe('cascade onDelete', function() {
+      describe('cascade onDelete', () => {
         beforeEach(function() {
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
@@ -117,80 +105,64 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           return this.sequelize.sync({ force: true });
         });
 
-        describe('#remove', function() {
+        describe('#remove', () => {
           it('with no errors', function() {
-            var self = this
-            , beforeProject = sinon.spy()
-            , afterProject = sinon.spy()
-            , beforeTask = sinon.spy()
-            , afterTask = sinon.spy();
+            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.setTask(task).then(function() {
-                  return project.destroy().then(function() {
-                    expect(beforeProject).to.have.been.calledOnce;
-                    expect(afterProject).to.have.been.calledOnce;
-                    expect(beforeTask).to.have.been.calledOnce;
-                    expect(afterTask).to.have.been.calledOnce;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => project.destroy().then(() => {
+              expect(beforeProject).to.have.been.calledOnce;
+              expect(afterProject).to.have.been.calledOnce;
+              expect(beforeTask).to.have.been.calledOnce;
+              expect(afterTask).to.have.been.calledOnce;
+            }))));
           });
 
           it('with errors', function() {
-            var self = this
-            , beforeProject = false
-            , afterProject = false
-            , beforeTask = false
-            , afterTask = false
-            , CustomErrorText = 'Whoops!';
+            const self = this;
+            let beforeProject = false;
+            let afterProject = false;
+            let beforeTask = false;
+            let afterTask = false;
+            const CustomErrorText = 'Whoops!';
 
-            this.Projects.beforeCreate(function(project, options, fn) {
+            this.Projects.beforeCreate((project, options, fn) => {
               beforeProject = true;
               fn();
             });
 
-            this.Projects.afterCreate(function(project, options, fn) {
+            this.Projects.afterCreate((project, options, fn) => {
               afterProject = true;
               fn();
             });
 
-            this.Tasks.beforeDestroy(function(task, options, fn) {
+            this.Tasks.beforeDestroy((task, options, fn) => {
               beforeTask = true;
               fn(new Error(CustomErrorText));
             });
 
-            this.Tasks.afterDestroy(function(task, options, fn) {
+            this.Tasks.afterDestroy((task, options, fn) => {
               afterTask = true;
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.setTask(task).then(function() {
-                  return expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText).then(function () {
-                    expect(beforeProject).to.be.true;
-                    expect(afterProject).to.be.true;
-                    expect(beforeTask).to.be.true;
-                    expect(afterTask).to.be.false;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText).then(() => {
+              expect(beforeProject).to.be.true;
+              expect(afterProject).to.be.true;
+              expect(beforeTask).to.be.true;
+              expect(afterTask).to.be.false;
+            }))));
           });
         });
       });
 
-      describe('no cascade update', function() {
+      describe('no cascade update', () => {
         beforeEach(function() {
-          var self = this;
+          const self = this;
 
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
@@ -203,49 +175,35 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           this.Projects.hasOne(this.Tasks);
           this.Tasks.belongsTo(this.Projects);
 
-          return this.Projects.sync({ force: true }).then(function() {
-            return self.Tasks.sync({ force: true });
-          });
+          return this.Projects.sync({ force: true }).then(() => self.Tasks.sync({ force: true }));
         });
 
         it('on success', function() {
-          var self = this
-          , beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+          const self = this, beforeHook = sinon.spy(), afterHook = sinon.spy();
 
           this.Tasks.beforeUpdate(beforeHook);
           this.Tasks.afterUpdate(afterHook);
 
-          return this.Projects.create({title: 'New Project'}).then(function(project) {
-            return self.Tasks.create({title: 'New Task'}).then(function(task) {
-              return project.setTask(task).then(function() {
-                return project.updateAttributes({id: 2}).then(function() {
-                  expect(beforeHook).to.have.been.calledOnce;
-                  expect(afterHook).to.have.been.calledOnce;
-                });
-              });
-            });
-          });
+          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => project.updateAttributes({id: 2}).then(() => {
+            expect(beforeHook).to.have.been.calledOnce;
+            expect(afterHook).to.have.been.calledOnce;
+          }))));
         });
 
         it('on error', function() {
-          var self = this;
+          const self = this;
 
-          this.Tasks.afterUpdate(function(task, options) {
+          this.Tasks.afterUpdate((task, options) => {
             throw new Error('Whoops!');
           });
 
-          return this.Projects.create({title: 'New Project'}).then(function(project) {
-            return self.Tasks.create({title: 'New Task'}).then(function(task) {
-              return expect(project.setTask(task)).to.be.rejected;
-            });
-          });
+          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => expect(project.setTask(task)).to.be.rejected));
         });
       });
 
-      describe('no cascade delete', function() {
+      describe('no cascade delete', () => {
         beforeEach(function() {
-          var self = this;
+          const self = this;
 
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
@@ -258,73 +216,53 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           this.Projects.hasMany(this.Tasks);
           this.Tasks.belongsTo(this.Projects);
 
-          return this.Projects.sync({ force: true }).then(function() {
-            return self.Tasks.sync({ force: true });
-          });
+          return this.Projects.sync({ force: true }).then(() => self.Tasks.sync({ force: true }));
         });
 
-        describe('#remove', function() {
+        describe('#remove', () => {
           it('with no errors', function() {
-            var self = this
-            , beforeProject = sinon.spy()
-            , afterProject = sinon.spy()
-            , beforeTask = sinon.spy()
-            , afterTask = sinon.spy();
+            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  return project.removeTask(task).then(function() {
-                    expect(beforeProject).to.have.been.called;
-                    expect(afterProject).to.have.been.called;
-                    expect(beforeTask).not.to.have.been.called;
-                    expect(afterTask).not.to.have.been.called;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.removeTask(task).then(() => {
+              expect(beforeProject).to.have.been.called;
+              expect(afterProject).to.have.been.called;
+              expect(beforeTask).not.to.have.been.called;
+              expect(afterTask).not.to.have.been.called;
+            }))));
           });
 
           it('with errors', function() {
-            var self = this
-            , beforeProject = sinon.spy()
-            , afterProject = sinon.spy()
-            , beforeTask = sinon.spy()
-            , afterTask = sinon.spy();
+            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
-            this.Tasks.beforeUpdate(function(task, options) {
+            this.Tasks.beforeUpdate((task, options) => {
               beforeTask();
               throw new Error('Whoops!');
             });
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).catch(function(err) {
-                  expect(err).to.be.instanceOf(Error);
-                  expect(beforeProject).to.have.been.calledOnce;
-                  expect(afterProject).to.have.been.calledOnce;
-                  expect(beforeTask).to.have.been.calledOnce;
-                  expect(afterTask).not.to.have.been.called;
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).catch(err => {
+              expect(err).to.be.instanceOf(Error);
+              expect(beforeProject).to.have.been.calledOnce;
+              expect(afterProject).to.have.been.calledOnce;
+              expect(beforeTask).to.have.been.calledOnce;
+              expect(afterTask).not.to.have.been.called;
+            })));
           });
         });
       });
     });
 
-    describe('1:M', function() {
-      describe('cascade', function() {
+    describe('1:M', () => {
+      describe('cascade', () => {
         beforeEach(function() {
-          var self = this;
+          const self = this;
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
           });
@@ -336,83 +274,65 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           this.Projects.hasMany(this.Tasks, {onDelete: 'cascade', hooks: true});
           this.Tasks.belongsTo(this.Projects, {hooks: true});
 
-          return this.Projects.sync({ force: true }).then(function() {
-            return self.Tasks.sync({ force: true });
-          });
+          return this.Projects.sync({ force: true }).then(() => self.Tasks.sync({ force: true }));
         });
 
-        describe('#remove', function() {
+        describe('#remove', () => {
           it('with no errors', function() {
-            var self = this
-            , beforeProject = sinon.spy()
-            , afterProject = sinon.spy()
-            , beforeTask = sinon.spy()
-            , afterTask = sinon.spy();
+            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  return project.destroy().then(function() {
-                    expect(beforeProject).to.have.been.calledOnce;
-                    expect(afterProject).to.have.been.calledOnce;
-                    expect(beforeTask).to.have.been.calledOnce;
-                    expect(afterTask).to.have.been.calledOnce;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().then(() => {
+              expect(beforeProject).to.have.been.calledOnce;
+              expect(afterProject).to.have.been.calledOnce;
+              expect(beforeTask).to.have.been.calledOnce;
+              expect(afterTask).to.have.been.calledOnce;
+            }))));
           });
 
           it('with errors', function() {
-            var self = this
-            , beforeProject = false
-            , afterProject = false
-            , beforeTask = false
-            , afterTask = false;
+            const self = this;
+            let beforeProject = false;
+            let afterProject = false;
+            let beforeTask = false;
+            let afterTask = false;
 
-            this.Projects.beforeCreate(function(project, options, fn) {
+            this.Projects.beforeCreate((project, options, fn) => {
               beforeProject = true;
               fn();
             });
 
-            this.Projects.afterCreate(function(project, options, fn) {
+            this.Projects.afterCreate((project, options, fn) => {
               afterProject = true;
               fn();
             });
 
-            this.Tasks.beforeDestroy(function(task, options, fn) {
+            this.Tasks.beforeDestroy((task, options, fn) => {
               beforeTask = true;
               fn(new Error('Whoops!'));
             });
 
-            this.Tasks.afterDestroy(function(task, options, fn) {
+            this.Tasks.afterDestroy((task, options, fn) => {
               afterTask = true;
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  return project.destroy().catch(function(err) {
-                    expect(err).to.be.instanceOf(Error);
-                    expect(beforeProject).to.be.true;
-                    expect(afterProject).to.be.true;
-                    expect(beforeTask).to.be.true;
-                    expect(afterTask).to.be.false;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().catch(err => {
+              expect(err).to.be.instanceOf(Error);
+              expect(beforeProject).to.be.true;
+              expect(afterProject).to.be.true;
+              expect(beforeTask).to.be.true;
+              expect(afterTask).to.be.false;
+            }))));
           });
         });
       });
 
-      describe('no cascade', function() {
+      describe('no cascade', () => {
         beforeEach(function() {
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
@@ -428,78 +348,64 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           return this.sequelize.sync({ force: true });
         });
 
-        describe('#remove', function() {
+        describe('#remove', () => {
           it('with no errors', function() {
-            var self = this
-            , beforeProject = sinon.spy()
-            , afterProject = sinon.spy()
-            , beforeTask = sinon.spy()
-            , afterTask = sinon.spy();
+            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  return project.removeTask(task).then(function() {
-                    expect(beforeProject).to.have.been.called;
-                    expect(afterProject).to.have.been.called;
-                    expect(beforeTask).not.to.have.been.called;
-                    expect(afterTask).not.to.have.been.called;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.removeTask(task).then(() => {
+              expect(beforeProject).to.have.been.called;
+              expect(afterProject).to.have.been.called;
+              expect(beforeTask).not.to.have.been.called;
+              expect(afterTask).not.to.have.been.called;
+            }))));
           });
 
           it('with errors', function() {
-            var self = this
-            , beforeProject = false
-            , afterProject = false
-            , beforeTask = false
-            , afterTask = false;
+            const self = this;
+            let beforeProject = false;
+            let afterProject = false;
+            let beforeTask = false;
+            let afterTask = false;
 
-            this.Projects.beforeCreate(function(project, options, fn) {
+            this.Projects.beforeCreate((project, options, fn) => {
               beforeProject = true;
               fn();
             });
 
-            this.Projects.afterCreate(function(project, options, fn) {
+            this.Projects.afterCreate((project, options, fn) => {
               afterProject = true;
               fn();
             });
 
-            this.Tasks.beforeUpdate(function(task, options, fn) {
+            this.Tasks.beforeUpdate((task, options, fn) => {
               beforeTask = true;
               fn(new Error('Whoops!'));
             });
 
-            this.Tasks.afterUpdate(function(task, options, fn) {
+            this.Tasks.afterUpdate((task, options, fn) => {
               afterTask = true;
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).catch(function(err) {
-                  expect(err).to.be.instanceOf(Error);
-                  expect(beforeProject).to.be.true;
-                  expect(afterProject).to.be.true;
-                  expect(beforeTask).to.be.true;
-                  expect(afterTask).to.be.false;
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).catch(err => {
+              expect(err).to.be.instanceOf(Error);
+              expect(beforeProject).to.be.true;
+              expect(afterProject).to.be.true;
+              expect(beforeTask).to.be.true;
+              expect(afterTask).to.be.false;
+            })));
           });
         });
       });
     });
 
-    describe('M:M', function() {
-      describe('cascade', function() {
+    describe('M:M', () => {
+      describe('cascade', () => {
         beforeEach(function() {
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
@@ -515,78 +421,62 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           return this.sequelize.sync({ force: true });
         });
 
-        describe('#remove', function() {
+        describe('#remove', () => {
           it('with no errors', function() {
-            var self = this
-            , beforeProject = sinon.spy()
-            , afterProject = sinon.spy()
-            , beforeTask = sinon.spy()
-            , afterTask = sinon.spy();
+            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  return project.destroy().then(function() {
-                    expect(beforeProject).to.have.been.calledOnce;
-                    expect(afterProject).to.have.been.calledOnce;
-                    // Since Sequelize does not cascade M:M, these should be false
-                    expect(beforeTask).not.to.have.been.called;
-                    expect(afterTask).not.to.have.been.called;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().then(() => {
+              expect(beforeProject).to.have.been.calledOnce;
+              expect(afterProject).to.have.been.calledOnce;
+              // Since Sequelize does not cascade M:M, these should be false
+              expect(beforeTask).not.to.have.been.called;
+              expect(afterTask).not.to.have.been.called;
+            }))));
           });
 
           it('with errors', function() {
-            var self = this
-            , beforeProject = false
-            , afterProject = false
-            , beforeTask = false
-            , afterTask = false;
+            const self = this;
+            let beforeProject = false;
+            let afterProject = false;
+            let beforeTask = false;
+            let afterTask = false;
 
-            this.Projects.beforeCreate(function(project, options, fn) {
+            this.Projects.beforeCreate((project, options, fn) => {
               beforeProject = true;
               fn();
             });
 
-            this.Projects.afterCreate(function(project, options, fn) {
+            this.Projects.afterCreate((project, options, fn) => {
               afterProject = true;
               fn();
             });
 
-            this.Tasks.beforeDestroy(function(task, options, fn) {
+            this.Tasks.beforeDestroy((task, options, fn) => {
               beforeTask = true;
               fn(new Error('Whoops!'));
             });
 
-            this.Tasks.afterDestroy(function(task, options, fn) {
+            this.Tasks.afterDestroy((task, options, fn) => {
               afterTask = true;
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  return project.destroy().then(function() {
-                    expect(beforeProject).to.be.true;
-                    expect(afterProject).to.be.true;
-                    expect(beforeTask).to.be.false;
-                    expect(afterTask).to.be.false;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().then(() => {
+              expect(beforeProject).to.be.true;
+              expect(afterProject).to.be.true;
+              expect(beforeTask).to.be.false;
+              expect(afterTask).to.be.false;
+            }))));
           });
         });
       });
 
-      describe('no cascade', function() {
+      describe('no cascade', () => {
         beforeEach(function() {
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING
@@ -602,70 +492,56 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           return this.sequelize.sync({ force: true });
         });
 
-        describe('#remove', function() {
+        describe('#remove', () => {
           it('with no errors', function() {
-            var self = this
-            , beforeProject = sinon.spy()
-            , afterProject = sinon.spy()
-            , beforeTask = sinon.spy()
-            , afterTask = sinon.spy();
+            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  return project.removeTask(task).then(function() {
-                    expect(beforeProject).to.have.been.calledOnce;
-                    expect(afterProject).to.have.been.calledOnce;
-                    expect(beforeTask).not.to.have.been.called;
-                    expect(afterTask).not.to.have.been.called;
-                  });
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.removeTask(task).then(() => {
+              expect(beforeProject).to.have.been.calledOnce;
+              expect(afterProject).to.have.been.calledOnce;
+              expect(beforeTask).not.to.have.been.called;
+              expect(afterTask).not.to.have.been.called;
+            }))));
           });
 
           it('with errors', function() {
-            var self = this
-            , beforeProject = false
-            , afterProject = false
-            , beforeTask = false
-            , afterTask = false;
+            const self = this;
+            let beforeProject = false;
+            let afterProject = false;
+            let beforeTask = false;
+            let afterTask = false;
 
-            this.Projects.beforeCreate(function(project, options, fn) {
+            this.Projects.beforeCreate((project, options, fn) => {
               beforeProject = true;
               fn();
             });
 
-            this.Projects.afterCreate(function(project, options, fn) {
+            this.Projects.afterCreate((project, options, fn) => {
               afterProject = true;
               fn();
             });
 
-            this.Tasks.beforeUpdate(function(task, options, fn) {
+            this.Tasks.beforeUpdate((task, options, fn) => {
               beforeTask = true;
               fn(new Error('Whoops!'));
             });
 
-            this.Tasks.afterUpdate(function(task, options, fn) {
+            this.Tasks.afterUpdate((task, options, fn) => {
               afterTask = true;
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(function(project) {
-              return self.Tasks.create({title: 'New Task'}).then(function(task) {
-                return project.addTask(task).then(function() {
-                  expect(beforeProject).to.be.true;
-                  expect(afterProject).to.be.true;
-                  expect(beforeTask).to.be.false;
-                  expect(afterTask).to.be.false;
-                });
-              });
-            });
+            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => {
+              expect(beforeProject).to.be.true;
+              expect(afterProject).to.be.true;
+              expect(beforeTask).to.be.false;
+              expect(afterTask).to.be.false;
+            })));
           });
         });
       });
@@ -673,9 +549,9 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
 
     // NOTE: Reenable when FK constraints create table query is fixed when using hooks
     if (dialect !== 'mssql') {
-      describe('multiple 1:M', function () {
+      describe('multiple 1:M', () => {
 
-        describe('cascade', function() {
+        describe('cascade', () => {
           beforeEach(function() {
             this.Projects = this.sequelize.define('Project', {
               title: DataTypes.STRING
@@ -701,41 +577,36 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
             return this.sequelize.sync({force: true});
           });
 
-          describe('#remove', function() {
+          describe('#remove', () => {
             it('with no errors', function() {
-              var beforeProject = false
-              , afterProject = false
-              , beforeTask = false
-              , afterTask = false
-              , beforeMiniTask = false
-              , afterMiniTask = false;
+              let beforeProject = false, afterProject = false, beforeTask = false, afterTask = false, beforeMiniTask = false, afterMiniTask = false;
 
-              this.Projects.beforeCreate(function(project, options, fn) {
+              this.Projects.beforeCreate((project, options, fn) => {
                 beforeProject = true;
                 fn();
               });
 
-              this.Projects.afterCreate(function(project, options, fn) {
+              this.Projects.afterCreate((project, options, fn) => {
                 afterProject = true;
                 fn();
               });
 
-              this.Tasks.beforeDestroy(function(task, options, fn) {
+              this.Tasks.beforeDestroy((task, options, fn) => {
                 beforeTask = true;
                 fn();
               });
 
-              this.Tasks.afterDestroy(function(task, options, fn) {
+              this.Tasks.afterDestroy((task, options, fn) => {
                 afterTask = true;
                 fn();
               });
 
-              this.MiniTasks.beforeDestroy(function(minitask, options, fn) {
+              this.MiniTasks.beforeDestroy((minitask, options, fn) => {
                 beforeMiniTask = true;
                 fn();
               });
 
-              this.MiniTasks.afterDestroy(function(minitask, options, fn) {
+              this.MiniTasks.afterDestroy((minitask, options, fn) => {
                 afterMiniTask = true;
                 fn();
               });
@@ -743,11 +614,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
               return this.sequelize.Promise.all([
                 this.Projects.create({title: 'New Project'}),
                 this.MiniTasks.create({mini_title: 'New MiniTask'})
-              ]).bind(this).spread(function(project, minitask) {
-                return project.addMiniTask(minitask);
-              }).then(function(project) {
-                return project.destroy();
-              }).then(function() {
+              ]).bind(this).spread((project, minitask) => project.addMiniTask(minitask)).then(project => project.destroy()).then(() => {
                 expect(beforeProject).to.be.true;
                 expect(afterProject).to.be.true;
                 expect(beforeTask).to.be.false;
@@ -759,39 +626,34 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
             });
 
             it('with errors', function() {
-              var beforeProject = false
-              , afterProject = false
-              , beforeTask = false
-              , afterTask = false
-              , beforeMiniTask = false
-              , afterMiniTask = false;
+              let beforeProject = false, afterProject = false, beforeTask = false, afterTask = false, beforeMiniTask = false, afterMiniTask = false;
 
-              this.Projects.beforeCreate(function(project, options, fn) {
+              this.Projects.beforeCreate((project, options, fn) => {
                 beforeProject = true;
                 fn();
               });
 
-              this.Projects.afterCreate(function(project, options, fn) {
+              this.Projects.afterCreate((project, options, fn) => {
                 afterProject = true;
                 fn();
               });
 
-              this.Tasks.beforeDestroy(function(task, options, fn) {
+              this.Tasks.beforeDestroy((task, options, fn) => {
                 beforeTask = true;
                 fn();
               });
 
-              this.Tasks.afterDestroy(function(task, options, fn) {
+              this.Tasks.afterDestroy((task, options, fn) => {
                 afterTask = true;
                 fn();
               });
 
-              this.MiniTasks.beforeDestroy(function(minitask, options, fn) {
+              this.MiniTasks.beforeDestroy((minitask, options, fn) => {
                 beforeMiniTask = true;
                 fn(new Error('Whoops!'));
               });
 
-              this.MiniTasks.afterDestroy(function(minitask, options, fn) {
+              this.MiniTasks.afterDestroy((minitask, options, fn) => {
                 afterMiniTask = true;
                 fn();
               });
@@ -799,11 +661,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
               return this.sequelize.Promise.all([
                 this.Projects.create({title: 'New Project'}),
                 this.MiniTasks.create({mini_title: 'New MiniTask'})
-              ]).bind(this).spread(function(project, minitask) {
-                return project.addMiniTask(minitask);
-              }).then(function(project) {
-                return project.destroy();
-              }).catch(function() {
+              ]).bind(this).spread((project, minitask) => project.addMiniTask(minitask)).then(project => project.destroy()).catch(() => {
                 expect(beforeProject).to.be.true;
                 expect(afterProject).to.be.true;
                 expect(beforeTask).to.be.false;
@@ -816,8 +674,8 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
         });
       });
 
-      describe('multiple 1:M sequential hooks', function () {
-        describe('cascade', function() {
+      describe('multiple 1:M sequential hooks', () => {
+        describe('cascade', () => {
           beforeEach(function() {
             this.Projects = this.sequelize.define('Project', {
               title: DataTypes.STRING
@@ -843,41 +701,36 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
             return this.sequelize.sync({force: true});
           });
 
-          describe('#remove', function() {
+          describe('#remove', () => {
             it('with no errors', function() {
-              var beforeProject = false
-              , afterProject = false
-              , beforeTask = false
-              , afterTask = false
-              , beforeMiniTask = false
-              , afterMiniTask = false;
+              let beforeProject = false, afterProject = false, beforeTask = false, afterTask = false, beforeMiniTask = false, afterMiniTask = false;
 
-              this.Projects.beforeCreate(function(project, options, fn) {
+              this.Projects.beforeCreate((project, options, fn) => {
                 beforeProject = true;
                 fn();
               });
 
-              this.Projects.afterCreate(function(project, options, fn) {
+              this.Projects.afterCreate((project, options, fn) => {
                 afterProject = true;
                 fn();
               });
 
-              this.Tasks.beforeDestroy(function(task, options, fn) {
+              this.Tasks.beforeDestroy((task, options, fn) => {
                 beforeTask = true;
                 fn();
               });
 
-              this.Tasks.afterDestroy(function(task, options, fn) {
+              this.Tasks.afterDestroy((task, options, fn) => {
                 afterTask = true;
                 fn();
               });
 
-              this.MiniTasks.beforeDestroy(function(minitask, options, fn) {
+              this.MiniTasks.beforeDestroy((minitask, options, fn) => {
                 beforeMiniTask = true;
                 fn();
               });
 
-              this.MiniTasks.afterDestroy(function(minitask, options, fn) {
+              this.MiniTasks.afterDestroy((minitask, options, fn) => {
                 afterMiniTask = true;
                 fn();
               });
@@ -891,9 +744,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
                   task.addMiniTask(minitask),
                   project.addTask(task)
                 ]).return(project);
-              }).then(function(project) {
-                return project.destroy();
-              }).then(function() {
+              }).then(project => project.destroy()).then(() => {
                 expect(beforeProject).to.be.true;
                 expect(afterProject).to.be.true;
                 expect(beforeTask).to.be.true;
@@ -904,36 +755,36 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
             });
 
             it('with errors', function() {
-              var beforeProject = false
-              , afterProject = false
-              , beforeTask = false
-              , afterTask = false
-              , beforeMiniTask = false
-              , afterMiniTask = false
-              , CustomErrorText = 'Whoops!';
+              let beforeProject = false;
+              let afterProject = false;
+              let beforeTask = false;
+              let afterTask = false;
+              let beforeMiniTask = false;
+              let afterMiniTask = false;
+              const CustomErrorText = 'Whoops!';
 
-              this.Projects.beforeCreate(function() {
+              this.Projects.beforeCreate(() => {
                 beforeProject = true;
               });
 
-              this.Projects.afterCreate(function() {
+              this.Projects.afterCreate(() => {
                 afterProject = true;
               });
 
-              this.Tasks.beforeDestroy(function() {
+              this.Tasks.beforeDestroy(() => {
                 beforeTask = true;
                 throw new Error(CustomErrorText);
               });
 
-              this.Tasks.afterDestroy(function() {
+              this.Tasks.afterDestroy(() => {
                 afterTask = true;
               });
 
-              this.MiniTasks.beforeDestroy(function() {
+              this.MiniTasks.beforeDestroy(() => {
                 beforeMiniTask = true;
               });
 
-              this.MiniTasks.afterDestroy(function() {
+              this.MiniTasks.afterDestroy(() => {
                 afterMiniTask = true;
               });
 
@@ -946,16 +797,14 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
                   task.addMiniTask(minitask),
                   project.addTask(task)
                 ]).return(project);
-              }).then(function(project) {
-                return expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText).then(function () {
-                  expect(beforeProject).to.be.true;
-                  expect(afterProject).to.be.true;
-                  expect(beforeTask).to.be.true;
-                  expect(afterTask).to.be.false;
-                  expect(beforeMiniTask).to.be.false;
-                  expect(afterMiniTask).to.be.false;
-                });
-              });
+              }).then(project => expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText).then(() => {
+                expect(beforeProject).to.be.true;
+                expect(afterProject).to.be.true;
+                expect(beforeTask).to.be.true;
+                expect(afterTask).to.be.false;
+                expect(beforeMiniTask).to.be.false;
+                expect(afterMiniTask).to.be.false;
+              }));
             });
           });
         });

--- a/test/integration/hooks/associations.test.js
+++ b/test/integration/hooks/associations.test.js
@@ -52,7 +52,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           this.Projects.hasOne(this.Tasks, {onUpdate: 'cascade', hooks: true});
           this.Tasks.belongsTo(this.Projects);
 
-          return this.Projects.sync({ force: true }).then(() => self.Tasks.sync({ force: true }));
+          return this.Projects.sync({ force: true })
+          .then(() => self.Tasks.sync({ force: true }));
         });
 
         it('on success', function() {
@@ -70,7 +71,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             fn();
           });
 
-          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => project.updateAttributes({id: 2}).then(() => {
+          return this.Projects.create({title: 'New Project'})
+          .then(project => self.Tasks.create({title: 'New Task'})
+          .then(task => project.setTask(task)
+          .then(() => project.updateAttributes({id: 2})
+          .then(() => {
             expect(beforeHook).to.be.true;
             expect(afterHook).to.be.true;
           }))));
@@ -83,7 +88,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             fn(new Error('Whoops!'));
           });
 
-          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).catch(err => {
+          return this.Projects.create({title: 'New Project'})
+          .then(project => self.Tasks.create({title: 'New Task'})
+          .then(task => project.setTask(task)
+          .catch(err => {
             expect(err).to.be.instanceOf(Error);
           })));
         });
@@ -114,7 +122,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => project.destroy().then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.setTask(task)
+            .then(() => project.destroy()
+            .then(() => {
               expect(beforeProject).to.have.been.calledOnce;
               expect(afterProject).to.have.been.calledOnce;
               expect(beforeTask).to.have.been.calledOnce;
@@ -150,7 +162,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText).then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.setTask(task)
+            .then(() => expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText)
+            .then(() => {
               expect(beforeProject).to.be.true;
               expect(afterProject).to.be.true;
               expect(beforeTask).to.be.true;
@@ -184,7 +200,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           this.Tasks.beforeUpdate(beforeHook);
           this.Tasks.afterUpdate(afterHook);
 
-          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.setTask(task).then(() => project.updateAttributes({id: 2}).then(() => {
+          return this.Projects.create({title: 'New Project'})
+          .then(project => self.Tasks.create({title: 'New Task'})
+          .then(task => project.setTask(task)
+          .then(() => project.updateAttributes({id: 2})
+          .then(() => {
             expect(beforeHook).to.have.been.calledOnce;
             expect(afterHook).to.have.been.calledOnce;
           }))));
@@ -197,7 +217,9 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             throw new Error('Whoops!');
           });
 
-          return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => expect(project.setTask(task)).to.be.rejected));
+          return this.Projects.create({title: 'New Project'})
+          .then(project => self.Tasks.create({title: 'New Task'})
+          .then(task => expect(project.setTask(task)).to.be.rejected));
         });
       });
 
@@ -221,14 +243,22 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         describe('#remove', () => {
           it('with no errors', function() {
-            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
+            const self = this
+                , beforeProject = sinon.spy()
+                , afterProject = sinon.spy()
+                , beforeTask = sinon.spy()
+                , afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.removeTask(task).then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => project.removeTask(task)
+            .then(() => {
               expect(beforeProject).to.have.been.called;
               expect(afterProject).to.have.been.called;
               expect(beforeTask).not.to.have.been.called;
@@ -237,7 +267,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           });
 
           it('with errors', function() {
-            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
+            const self = this
+                , beforeProject = sinon.spy()
+                , afterProject = sinon.spy()
+                , beforeTask = sinon.spy()
+                , afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
@@ -247,7 +281,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             });
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).catch(err => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .catch(err => {
               expect(err).to.be.instanceOf(Error);
               expect(beforeProject).to.have.been.calledOnce;
               expect(afterProject).to.have.been.calledOnce;
@@ -279,14 +316,22 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         describe('#remove', () => {
           it('with no errors', function() {
-            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
+            const self = this
+                , beforeProject = sinon.spy()
+                , afterProject = sinon.spy()
+                , beforeTask = sinon.spy()
+                , afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => project.destroy()
+            .then(() => {
               expect(beforeProject).to.have.been.calledOnce;
               expect(afterProject).to.have.been.calledOnce;
               expect(beforeTask).to.have.been.calledOnce;
@@ -321,7 +366,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().catch(err => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => project.destroy()
+            .catch(err => {
               expect(err).to.be.instanceOf(Error);
               expect(beforeProject).to.be.true;
               expect(afterProject).to.be.true;
@@ -350,14 +399,22 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         describe('#remove', () => {
           it('with no errors', function() {
-            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
+            const self = this
+                , beforeProject = sinon.spy()
+                , afterProject = sinon.spy()
+                , beforeTask = sinon.spy()
+                , afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.removeTask(task).then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => project.removeTask(task)
+            .then(() => {
               expect(beforeProject).to.have.been.called;
               expect(afterProject).to.have.been.called;
               expect(beforeTask).not.to.have.been.called;
@@ -392,7 +449,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).catch(err => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .catch(err => {
               expect(err).to.be.instanceOf(Error);
               expect(beforeProject).to.be.true;
               expect(afterProject).to.be.true;
@@ -423,14 +483,22 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         describe('#remove', () => {
           it('with no errors', function() {
-            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
+            const self = this
+                , beforeProject = sinon.spy()
+                , afterProject = sinon.spy()
+                , beforeTask = sinon.spy()
+                , afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => project.destroy()
+            .then(() => {
               expect(beforeProject).to.have.been.calledOnce;
               expect(afterProject).to.have.been.calledOnce;
               // Since Sequelize does not cascade M:M, these should be false
@@ -466,7 +534,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.destroy().then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => project.destroy()
+            .then(() => {
               expect(beforeProject).to.be.true;
               expect(afterProject).to.be.true;
               expect(beforeTask).to.be.false;
@@ -494,14 +566,22 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         describe('#remove', () => {
           it('with no errors', function() {
-            const self = this, beforeProject = sinon.spy(), afterProject = sinon.spy(), beforeTask = sinon.spy(), afterTask = sinon.spy();
+            const self = this
+                , beforeProject = sinon.spy()
+                , afterProject = sinon.spy()
+                , beforeTask = sinon.spy()
+                , afterTask = sinon.spy();
 
             this.Projects.beforeCreate(beforeProject);
             this.Projects.afterCreate(afterProject);
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => project.removeTask(task).then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => project.removeTask(task)
+            .then(() => {
               expect(beforeProject).to.have.been.calledOnce;
               expect(afterProject).to.have.been.calledOnce;
               expect(beforeTask).not.to.have.been.called;
@@ -536,7 +616,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               fn();
             });
 
-            return this.Projects.create({title: 'New Project'}).then(project => self.Tasks.create({title: 'New Task'}).then(task => project.addTask(task).then(() => {
+            return this.Projects.create({title: 'New Project'})
+            .then(project => self.Tasks.create({title: 'New Task'})
+            .then(task => project.addTask(task)
+            .then(() => {
               expect(beforeProject).to.be.true;
               expect(afterProject).to.be.true;
               expect(beforeTask).to.be.false;
@@ -579,7 +662,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
           describe('#remove', () => {
             it('with no errors', function() {
-              let beforeProject = false, afterProject = false, beforeTask = false, afterTask = false, beforeMiniTask = false, afterMiniTask = false;
+              let beforeProject = false
+                , afterProject = false
+                , beforeTask = false
+                , afterTask = false
+                , beforeMiniTask = false
+                , afterMiniTask = false;
 
               this.Projects.beforeCreate((project, options, fn) => {
                 beforeProject = true;
@@ -626,7 +714,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             });
 
             it('with errors', function() {
-              let beforeProject = false, afterProject = false, beforeTask = false, afterTask = false, beforeMiniTask = false, afterMiniTask = false;
+              let beforeProject = false
+                , afterProject = false
+                , beforeTask = false
+                , afterTask = false
+                , beforeMiniTask = false
+                , afterMiniTask = false;
 
               this.Projects.beforeCreate((project, options, fn) => {
                 beforeProject = true;

--- a/test/integration/hooks/bulkOperation.test.js
+++ b/test/integration/hooks/bulkOperation.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -33,11 +33,10 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#bulkCreate', function() {
-    describe('on success', function() {
+  describe('#bulkCreate', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy();
+        const beforeBulk = sinon.spy(), afterBulk = sinon.spy();
 
         this.User.beforeBulkCreate(beforeBulk);
 
@@ -46,16 +45,16 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
         return this.User.bulkCreate([
           {username: 'Cheech', mood: 'sad'},
           {username: 'Chong', mood: 'sad'}
-        ]).then(function() {
+        ]).then(() => {
           expect(beforeBulk).to.have.been.calledOnce;
           expect(afterBulk).to.have.been.calledOnce;
         });
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        this.User.beforeBulkCreate(function(daos, options) {
+        this.User.beforeBulkCreate((daos, options) => {
           throw new Error('Whoops!');
         });
 
@@ -66,7 +65,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should return an error from after', function() {
-        this.User.afterBulkCreate(function(daos, options) {
+        this.User.afterBulkCreate((daos, options) => {
           throw new Error('Whoops!');
         });
 
@@ -77,7 +76,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
     });
 
-    describe('with the {individualHooks: true} option', function() {
+    describe('with the {individualHooks: true} option', () => {
       beforeEach(function() {
         this.User = this.sequelize.define('User', {
           username: {
@@ -98,32 +97,31 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should run the afterCreate/beforeCreate functions for each item created successfully', function() {
-        var beforeBulkCreate = false
-          , afterBulkCreate = false;
+        let beforeBulkCreate = false, afterBulkCreate = false;
 
-        this.User.beforeBulkCreate(function(daos, options, fn) {
+        this.User.beforeBulkCreate((daos, options, fn) => {
           beforeBulkCreate = true;
           fn();
         });
 
-        this.User.afterBulkCreate(function(daos, options, fn) {
+        this.User.afterBulkCreate((daos, options, fn) => {
           afterBulkCreate = true;
           fn();
         });
 
-        this.User.beforeCreate(function(user, options, fn) {
+        this.User.beforeCreate((user, options, fn) => {
           user.beforeHookTest = true;
           fn();
         });
 
-        this.User.afterCreate(function(user, options, fn) {
-          user.username = 'User' + user.id;
+        this.User.afterCreate((user, options, fn) => {
+          user.username = `User${user.id}`;
           fn();
         });
 
-        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).then(function(records) {
-          records.forEach(function(record) {
-            expect(record.username).to.equal('User' + record.id);
+        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).then(records => {
+          records.forEach(record => {
+            expect(record.username).to.equal(`User${record.id}`);
             expect(record.beforeHookTest).to.be.true;
           });
           expect(beforeBulkCreate).to.be.true;
@@ -132,29 +130,28 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should run the afterCreate/beforeCreate functions for each item created with an error', function() {
-        var beforeBulkCreate = false
-          , afterBulkCreate = false;
+        let beforeBulkCreate = false, afterBulkCreate = false;
 
-        this.User.beforeBulkCreate(function(daos, options, fn) {
+        this.User.beforeBulkCreate((daos, options, fn) => {
           beforeBulkCreate = true;
           fn();
         });
 
-        this.User.afterBulkCreate(function(daos, options, fn) {
+        this.User.afterBulkCreate((daos, options, fn) => {
           afterBulkCreate = true;
           fn();
         });
 
-        this.User.beforeCreate(function(user, options, fn) {
+        this.User.beforeCreate((user, options, fn) => {
           fn(new Error('You shall not pass!'));
         });
 
-        this.User.afterCreate(function(user, options, fn) {
-          user.username = 'User' + user.id;
+        this.User.afterCreate((user, options, fn) => {
+          user.username = `User${user.id}`;
           fn();
         });
 
-        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).catch(function(err) {
+        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).catch(err => {
           expect(err).to.be.instanceOf(Error);
           expect(beforeBulkCreate).to.be.true;
           expect(afterBulkCreate).to.be.false;
@@ -163,12 +160,10 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     });
   });
 
-  describe('#bulkUpdate', function() {
-    describe('on success', function() {
+  describe('#bulkUpdate', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var self = this
-          , beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy();
+        const self = this, beforeBulk = sinon.spy(), afterBulk = sinon.spy();
 
         this.User.beforeBulkUpdate(beforeBulk);
         this.User.afterBulkUpdate(afterBulk);
@@ -176,48 +171,42 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
         return this.User.bulkCreate([
           {username: 'Cheech', mood: 'sad'},
           {username: 'Chong', mood: 'sad'}
-        ]).then(function() {
-          return self.User.update({mood: 'happy'}, {where: {mood: 'sad'}}).then(function() {
-            expect(beforeBulk).to.have.been.calledOnce;
-            expect(afterBulk).to.have.been.calledOnce;
-          });
-        });
+        ]).then(() => self.User.update({mood: 'happy'}, {where: {mood: 'sad'}}).then(() => {
+          expect(beforeBulk).to.have.been.calledOnce;
+          expect(afterBulk).to.have.been.calledOnce;
+        }));
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        var self = this;
+        const self = this;
 
-        this.User.beforeBulkUpdate(function(options) {
+        this.User.beforeBulkUpdate(options => {
           throw new Error('Whoops!');
         });
 
         return this.User.bulkCreate([
           {username: 'Cheech', mood: 'sad'},
           {username: 'Chong', mood: 'sad'}
-        ]).then(function() {
-          return expect(self.User.update({mood: 'happy'}, {where: {mood: 'sad'}})).to.be.rejected;
-        });
+        ]).then(() => expect(self.User.update({mood: 'happy'}, {where: {mood: 'sad'}})).to.be.rejected);
       });
 
       it('should return an error from after', function() {
-        var self = this;
+        const self = this;
 
-        this.User.afterBulkUpdate(function(options) {
+        this.User.afterBulkUpdate(options => {
           throw new Error('Whoops!');
         });
 
         return this.User.bulkCreate([
           {username: 'Cheech', mood: 'sad'},
           {username: 'Chong', mood: 'sad'}
-        ]).then(function() {
-          return expect(self.User.update({mood: 'happy'}, {where: {mood: 'sad'}})).to.be.rejected;
-        });
+        ]).then(() => expect(self.User.update({mood: 'happy'}, {where: {mood: 'sad'}})).to.be.rejected);
       });
     });
 
-    describe('with the {individualHooks: true} option', function() {
+    describe('with the {individualHooks: true} option', () => {
       beforeEach(function() {
         this.User = this.sequelize.define('User', {
           username: {
@@ -238,41 +227,37 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should run the after/before functions for each item created successfully', function() {
-        var self = this
-          , beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy();
+        const self = this, beforeBulk = sinon.spy(), afterBulk = sinon.spy();
 
         this.User.beforeBulkUpdate(beforeBulk);
 
         this.User.afterBulkUpdate(afterBulk);
 
-        this.User.beforeUpdate(function(user, options) {
+        this.User.beforeUpdate((user, options) => {
           expect(user.changed()).to.not.be.empty;
           user.beforeHookTest = true;
         });
 
-        this.User.afterUpdate(function(user, options) {
-          user.username = 'User' + user.id;
+        this.User.afterUpdate((user, options) => {
+          user.username = `User${user.id}`;
         });
 
         return this.User.bulkCreate([
           {aNumber: 1}, {aNumber: 1}, {aNumber: 1}
-        ]).then(function() {
-          return self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).spread(function(affectedRows, records) {
-            records.forEach(function(record) {
-              expect(record.username).to.equal('User' + record.id);
-              expect(record.beforeHookTest).to.be.true;
-            });
-            expect(beforeBulk).to.have.been.calledOnce;
-            expect(afterBulk).to.have.been.calledOnce;
+        ]).then(() => self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).spread((affectedRows, records) => {
+          records.forEach(record => {
+            expect(record.username).to.equal(`User${record.id}`);
+            expect(record.beforeHookTest).to.be.true;
           });
-        });
+          expect(beforeBulk).to.have.been.calledOnce;
+          expect(afterBulk).to.have.been.calledOnce;
+        }));
       });
 
       it('should run the after/before functions for each item created successfully changing some data before updating', function() {
-        var self = this;
+        const self = this;
 
-        this.User.beforeUpdate(function(user, options) {
+        this.User.beforeUpdate((user, options) => {
           expect(user.changed()).to.not.be.empty;
           if (user.get('id') === 1) {
             user.set('aNumber', user.get('aNumber') + 3);
@@ -281,63 +266,56 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
 
         return this.User.bulkCreate([
           {aNumber: 1}, {aNumber: 1}, {aNumber: 1}
-        ]).then(function() {
-          return self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).spread(function(affectedRows, records) {
-            records.forEach(function(record, i) {
-              expect(record.aNumber).to.equal(10 + (record.id === 1 ? 3 : 0));
-            });
+        ]).then(() => self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).spread((affectedRows, records) => {
+          records.forEach((record, i) => {
+            expect(record.aNumber).to.equal(10 + (record.id === 1 ? 3 : 0));
           });
-        });
+        }));
       });
 
       it('should run the after/before functions for each item created with an error', function() {
-        var self = this
-          , beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy();
+        const self = this, beforeBulk = sinon.spy(), afterBulk = sinon.spy();
 
         this.User.beforeBulkUpdate(beforeBulk);
 
         this.User.afterBulkUpdate(afterBulk);
 
-        this.User.beforeUpdate(function(user, options) {
+        this.User.beforeUpdate((user, options) => {
           throw new Error('You shall not pass!');
         });
 
-        this.User.afterUpdate(function(user, options) {
-          user.username = 'User' + user.id;
+        this.User.afterUpdate((user, options) => {
+          user.username = `User${user.id}`;
         });
 
-        return this.User.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(function() {
-          return self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).catch(function(err) {
-            expect(err).to.be.instanceOf(Error);
-            expect(err.message).to.be.equal('You shall not pass!');
-            expect(beforeBulk).to.have.been.calledOnce;
-            expect(afterBulk).not.to.have.been.called;
-          });
-        });
+        return this.User.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(() => self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).catch(err => {
+          expect(err).to.be.instanceOf(Error);
+          expect(err.message).to.be.equal('You shall not pass!');
+          expect(beforeBulk).to.have.been.calledOnce;
+          expect(afterBulk).not.to.have.been.called;
+        }));
       });
     });
   });
 
-  describe('#bulkDestroy', function() {
-    describe('on success', function() {
+  describe('#bulkDestroy', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy();
+        const beforeBulk = sinon.spy(), afterBulk = sinon.spy();
 
         this.User.beforeBulkDestroy(beforeBulk);
         this.User.afterBulkDestroy(afterBulk);
 
-        return this.User.destroy({where: {username: 'Cheech', mood: 'sad'}}).then(function() {
+        return this.User.destroy({where: {username: 'Cheech', mood: 'sad'}}).then(() => {
           expect(beforeBulk).to.have.been.calledOnce;
           expect(afterBulk).to.have.been.calledOnce;
         });
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        this.User.beforeBulkDestroy(function(options) {
+        this.User.beforeBulkDestroy(options => {
           throw new Error('Whoops!');
         });
 
@@ -345,7 +323,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should return an error from after', function() {
-        this.User.afterBulkDestroy(function(options) {
+        this.User.afterBulkDestroy(options => {
           throw new Error('Whoops!');
         });
 
@@ -353,7 +331,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
     });
 
-    describe('with the {individualHooks: true} option', function() {
+    describe('with the {individualHooks: true} option', () => {
       beforeEach(function() {
         this.User = this.sequelize.define('User', {
           username: {
@@ -374,85 +352,81 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should run the after/before functions for each item created successfully', function() {
-        var self = this
-          , beforeBulk = false
-          , afterBulk = false
-          , beforeHook = false
-          , afterHook = false;
+        const self = this;
+        let beforeBulk = false;
+        let afterBulk = false;
+        let beforeHook = false;
+        let afterHook = false;
 
-        this.User.beforeBulkDestroy(function(options, fn) {
+        this.User.beforeBulkDestroy((options, fn) => {
           beforeBulk = true;
           fn();
         });
 
-        this.User.afterBulkDestroy(function(options, fn) {
+        this.User.afterBulkDestroy((options, fn) => {
           afterBulk = true;
           fn();
         });
 
-        this.User.beforeDestroy(function(user, options, fn) {
+        this.User.beforeDestroy((user, options, fn) => {
           beforeHook = true;
           fn();
         });
 
-        this.User.afterDestroy(function(user, options, fn) {
+        this.User.afterDestroy((user, options, fn) => {
           afterHook = true;
           fn();
         });
 
         return this.User.bulkCreate([
           {aNumber: 1}, {aNumber: 1}, {aNumber: 1}
-        ]).then(function() {
-          return self.User.destroy({where: {aNumber: 1}, individualHooks: true}).then(function() {
-            expect(beforeBulk).to.be.true;
-            expect(afterBulk).to.be.true;
-            expect(beforeHook).to.be.true;
-            expect(afterHook).to.be.true;
-          });
-        });
+        ]).then(() => self.User.destroy({where: {aNumber: 1}, individualHooks: true}).then(() => {
+          expect(beforeBulk).to.be.true;
+          expect(afterBulk).to.be.true;
+          expect(beforeHook).to.be.true;
+          expect(afterHook).to.be.true;
+        }));
       });
 
       it('should run the after/before functions for each item created with an error', function() {
-        var self = this
-          , beforeBulk = false
-          , afterBulk = false
-          , beforeHook = false
-          , afterHook = false;
+        const self = this;
+        let beforeBulk = false;
+        let afterBulk = false;
+        let beforeHook = false;
+        let afterHook = false;
 
-        this.User.beforeBulkDestroy(function(options, fn) {
+        this.User.beforeBulkDestroy((options, fn) => {
           beforeBulk = true;
           fn();
         });
 
-        this.User.afterBulkDestroy(function(options, fn) {
+        this.User.afterBulkDestroy((options, fn) => {
           afterBulk = true;
           fn();
         });
 
-        this.User.beforeDestroy(function(user, options, fn) {
+        this.User.beforeDestroy((user, options, fn) => {
           beforeHook = true;
           fn(new Error('You shall not pass!'));
         });
 
-        this.User.afterDestroy(function(user, options, fn) {
+        this.User.afterDestroy((user, options, fn) => {
           afterHook = true;
           fn();
         });
 
-        return this.User.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(function() {
-          return self.User.destroy({where: {aNumber: 1}, individualHooks: true}).catch(function(err) {
-            expect(err).to.be.instanceOf(Error);
-            expect(beforeBulk).to.be.true;
-            expect(beforeHook).to.be.true;
-            expect(afterBulk).to.be.false;
-            expect(afterHook).to.be.false;
-          });
-        });
+        return this.User.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(() => self.User.destroy({where: {aNumber: 1}, individualHooks: true}).catch(err => {
+          expect(err).to.be.instanceOf(Error);
+          expect(beforeBulk).to.be.true;
+          expect(beforeHook).to.be.true;
+          expect(afterBulk).to.be.false;
+          expect(afterHook).to.be.false;
+        }));
       });
     });
   });
 
-  describe('#bulkRestore', function() {
+  describe('#bulkRestore', () => {
     beforeEach(function() {
       return this.ParanoidUser.bulkCreate([
         {username: 'adam', mood: 'happy'},
@@ -462,24 +436,23 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
     });
 
-    describe('on success', function() {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy();
+        const beforeBulk = sinon.spy(), afterBulk = sinon.spy();
 
         this.ParanoidUser.beforeBulkRestore(beforeBulk);
         this.ParanoidUser.afterBulkRestore(afterBulk);
 
-        return this.ParanoidUser.restore({where: {username: 'adam', mood: 'happy'}}).then(function() {
+        return this.ParanoidUser.restore({where: {username: 'adam', mood: 'happy'}}).then(() => {
           expect(beforeBulk).to.have.been.calledOnce;
           expect(afterBulk).to.have.been.calledOnce;
         });
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        this.ParanoidUser.beforeBulkRestore(function(options) {
+        this.ParanoidUser.beforeBulkRestore(options => {
           throw new Error('Whoops!');
         });
 
@@ -487,7 +460,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should return an error from after', function() {
-        this.ParanoidUser.afterBulkRestore(function(options) {
+        this.ParanoidUser.afterBulkRestore(options => {
           throw new Error('Whoops!');
         });
 
@@ -495,7 +468,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
     });
 
-    describe('with the {individualHooks: true} option', function() {
+    describe('with the {individualHooks: true} option', () => {
       beforeEach(function() {
         this.ParanoidUser = this.sequelize.define('ParanoidUser', {
           aNumber: {
@@ -510,11 +483,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should run the after/before functions for each item restored successfully', function() {
-        var self = this
-          , beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy()
-          , beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const self = this, beforeBulk = sinon.spy(), afterBulk = sinon.spy(), beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.ParanoidUser.beforeBulkRestore(beforeBulk);
         this.ParanoidUser.afterBulkRestore(afterBulk);
@@ -523,11 +492,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
 
         return this.ParanoidUser.bulkCreate([
           {aNumber: 1}, {aNumber: 1}, {aNumber: 1}
-        ]).then(function() {
-          return self.ParanoidUser.destroy({where: {aNumber: 1}});
-        }).then(function() {
-          return self.ParanoidUser.restore({where: {aNumber: 1}, individualHooks: true});
-        }).then(function() {
+        ]).then(() => self.ParanoidUser.destroy({where: {aNumber: 1}})).then(() => self.ParanoidUser.restore({where: {aNumber: 1}, individualHooks: true})).then(() => {
           expect(beforeBulk).to.have.been.calledOnce;
           expect(afterBulk).to.have.been.calledOnce;
           expect(beforeHook).to.have.been.calledThrice;
@@ -536,26 +501,18 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should run the after/before functions for each item restored with an error', function() {
-        var self = this
-          , beforeBulk = sinon.spy()
-          , afterBulk = sinon.spy()
-          , beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const self = this, beforeBulk = sinon.spy(), afterBulk = sinon.spy(), beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.ParanoidUser.beforeBulkRestore(beforeBulk);
         this.ParanoidUser.afterBulkRestore(afterBulk);
-        this.ParanoidUser.beforeRestore(function(user, options, fn) {
+        this.ParanoidUser.beforeRestore((user, options, fn) => {
           beforeHook();
           fn(new Error('You shall not pass!'));
         });
 
         this.ParanoidUser.afterRestore(afterHook);
 
-        return this.ParanoidUser.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(function() {
-          return self.ParanoidUser.destroy({where: {aNumber: 1}});
-        }).then(function() {
-          return self.ParanoidUser.restore({where: {aNumber: 1}, individualHooks: true});
-        }).catch(function(err) {
+        return this.ParanoidUser.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(() => self.ParanoidUser.destroy({where: {aNumber: 1}})).then(() => self.ParanoidUser.restore({where: {aNumber: 1}, individualHooks: true})).catch(err => {
           expect(err).to.be.instanceOf(Error);
           expect(beforeBulk).to.have.been.calledOnce;
           expect(beforeHook).to.have.been.calledThrice;

--- a/test/integration/hooks/count.test.js
+++ b/test/integration/hooks/count.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-, expect = chai.expect
-, Support = require(__dirname + '/../support')
-, DataTypes = require(__dirname + '/../../../lib/data-types');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -21,7 +21,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#count', function() {
+  describe('#count', () => {
     beforeEach(function() {
       return this.User.bulkCreate([
         {username: 'adam', mood: 'happy'},
@@ -30,22 +30,22 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       ]);
     });
 
-    describe('on success', function() {
+    describe('on success', () => {
       it('hook runs', function() {
-        var beforeHook = false;
+        let beforeHook = false;
 
-        this.User.beforeCount(function() {
+        this.User.beforeCount(() => {
           beforeHook = true;
         });
 
-        return this.User.count().then(function(count) {
+        return this.User.count().then(count => {
           expect(count).to.equal(3);
           expect(beforeHook).to.be.true;
         });
       });
 
       it('beforeCount hook can change options', function() {
-        this.User.beforeCount(function(options) {
+        this.User.beforeCount(options => {
           options.where.username = 'adam';
         });
 
@@ -53,9 +53,9 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('in beforeCount hook returns error', function() {
-        this.User.beforeCount(function() {
+        this.User.beforeCount(() => {
           throw new Error('Oops!');
         });
 

--- a/test/integration/hooks/create.test.js
+++ b/test/integration/hooks/create.test.js
@@ -1,14 +1,14 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , Sequelize = Support.Sequelize
-  , sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const Sequelize = Support.Sequelize;
+const sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -23,50 +23,47 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#create', function() {
-    describe('on success', function() {
+  describe('#create', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeCreate(beforeHook);
         this.User.afterCreate(afterHook);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then(function() {
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(() => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).to.have.been.calledOnce;
         });
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
-        this.User.beforeCreate(function(user, options) {
+        this.User.beforeCreate((user, options) => {
           beforeHook();
           throw new Error('Whoops!');
         });
         this.User.afterCreate(afterHook);
 
-        return expect(this.User.create({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
+        return expect(this.User.create({username: 'Toni', mood: 'happy'})).to.be.rejected.then(err => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).not.to.have.been.called;
         });
       });
 
       it('should return an error from after', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeCreate(beforeHook);
-        this.User.afterCreate(function(user, options) {
+        this.User.afterCreate((user, options) => {
           afterHook();
           throw new Error('Whoops!');
         });
 
-        return expect(this.User.create({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
+        return expect(this.User.create({username: 'Toni', mood: 'happy'})).to.be.rejected.then(err => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).to.have.been.calledOnce;
         });
@@ -74,16 +71,16 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     });
 
     it('should not trigger hooks on parent when using N:M association setters', function() {
-      var A = this.sequelize.define('A', {
+      const A = this.sequelize.define('A', {
         name: Sequelize.STRING
       });
-      var B = this.sequelize.define('B', {
+      const B = this.sequelize.define('B', {
         name: Sequelize.STRING
       });
 
-      var hookCalled = 0;
+      let hookCalled = 0;
 
-      A.addHook('afterCreate', function(instance, options, next) {
+      A.addHook('afterCreate', (instance, options, next) => {
         hookCalled++;
         next();
       });
@@ -95,24 +92,22 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
         return this.sequelize.Promise.all([
           A.create({name: 'a'}),
           B.create({name: 'b'})
-        ]).spread(function(a, b) {
-          return a.addB(b).then(function() {
-            expect(hookCalled).to.equal(1);
-          });
-        });
+        ]).spread((a, b) => a.addB(b).then(() => {
+          expect(hookCalled).to.equal(1);
+        }));
       });
     });
 
-    describe('preserves changes to instance', function() {
+    describe('preserves changes to instance', () => {
       it('beforeValidate', function(){
-        var hookCalled = 0;
+        let hookCalled = 0;
 
-        this.User.beforeValidate(function(user, options) {
+        this.User.beforeValidate((user, options) => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({mood: 'sad', username: 'leafninja'}).then(function(user) {
+        return this.User.create({mood: 'sad', username: 'leafninja'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('leafninja');
           expect(hookCalled).to.equal(1);
@@ -120,14 +115,14 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('afterValidate', function() {
-        var hookCalled = 0;
+        let hookCalled = 0;
 
-        this.User.afterValidate(function(user, options) {
+        this.User.afterValidate((user, options) => {
           user.mood = 'neutral';
           hookCalled++;
         });
 
-        return this.User.create({mood: 'sad', username: 'fireninja'}).then(function(user) {
+        return this.User.create({mood: 'sad', username: 'fireninja'}).then(user => {
           expect(user.mood).to.equal('neutral');
           expect(user.username).to.equal('fireninja');
           expect(hookCalled).to.equal(1);
@@ -135,14 +130,14 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('beforeCreate', function(){
-        var hookCalled = 0;
+        let hookCalled = 0;
 
-        this.User.beforeCreate(function(user, options) {
+        this.User.beforeCreate((user, options) => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({username: 'akira'}).then(function(user) {
+        return this.User.create({username: 'akira'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('akira');
           expect(hookCalled).to.equal(1);

--- a/test/integration/hooks/destroy.test.js
+++ b/test/integration/hooks/destroy.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -22,59 +22,50 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#destroy', function() {
-    describe('on success', function() {
+  describe('#destroy', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeDestroy(beforeHook);
         this.User.afterDestroy(afterHook);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return user.destroy().then(function() {
-            expect(beforeHook).to.have.been.calledOnce;
-            expect(afterHook).to.have.been.calledOnce;
-          });
-        });
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => user.destroy().then(() => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        }));
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
-        this.User.beforeDestroy(function(user, options) {
+        this.User.beforeDestroy((user, options) => {
           beforeHook();
           throw new Error('Whoops!');
         });
         this.User.afterDestroy(afterHook);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return expect(user.destroy()).to.be.rejected.then(function() {
-            expect(beforeHook).to.have.been.calledOnce;
-            expect(afterHook).not.to.have.been.called;
-          });
-        });
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => expect(user.destroy()).to.be.rejected.then(() => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).not.to.have.been.called;
+        }));
       });
 
       it('should return an error from after', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeDestroy(beforeHook);
-        this.User.afterDestroy(function(user, options) {
+        this.User.afterDestroy((user, options) => {
           afterHook();
           throw new Error('Whoops!');
         });
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return expect(user.destroy()).to.be.rejected.then(function() {
-            expect(beforeHook).to.have.been.calledOnce;
-            expect(afterHook).to.have.been.calledOnce;
-          });
-        });
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => expect(user.destroy()).to.be.rejected.then(() => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        }));
       });
     });
   });

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -1,12 +1,12 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -22,7 +22,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#find', function() {
+  describe('#find', () => {
     beforeEach(function() {
       return this.User.bulkCreate([
         {username: 'adam', mood: 'happy'},
@@ -30,30 +30,27 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       ]);
     });
 
-    describe('on success', function() {
+    describe('on success', () => {
       it('all hooks run', function() {
-        var beforeHook = false
-          , beforeHook2 = false
-          , beforeHook3 = false
-          , afterHook = false;
+        let beforeHook = false, beforeHook2 = false, beforeHook3 = false, afterHook = false;
 
-        this.User.beforeFind(function() {
+        this.User.beforeFind(() => {
           beforeHook = true;
         });
 
-        this.User.beforeFindAfterExpandIncludeAll(function() {
+        this.User.beforeFindAfterExpandIncludeAll(() => {
           beforeHook2 = true;
         });
 
-        this.User.beforeFindAfterOptions(function() {
+        this.User.beforeFindAfterOptions(() => {
           beforeHook3 = true;
         });
 
-        this.User.afterFind(function() {
+        this.User.afterFind(() => {
           afterHook = true;
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(function(user) {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(beforeHook).to.be.true;
           expect(beforeHook2).to.be.true;
@@ -63,83 +60,83 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('beforeFind hook can change options', function() {
-        this.User.beforeFind(function(options) {
+        this.User.beforeFind(options => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(function(user) {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
 
       it('beforeFindAfterExpandIncludeAll hook can change options', function() {
-        this.User.beforeFindAfterExpandIncludeAll(function(options) {
+        this.User.beforeFindAfterExpandIncludeAll(options => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(function(user) {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
 
       it('beforeFindAfterOptions hook can change options', function() {
-        this.User.beforeFindAfterOptions(function(options) {
+        this.User.beforeFindAfterOptions(options => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(function(user) {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
 
       it('afterFind hook can change results', function() {
-        this.User.afterFind(function(user) {
+        this.User.afterFind(user => {
           user.mood = 'sad';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(function(user) {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('in beforeFind hook returns error', function() {
-        this.User.beforeFind(function() {
+        this.User.beforeFind(() => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
 
       it('in beforeFindAfterExpandIncludeAll hook returns error', function() {
-        this.User.beforeFindAfterExpandIncludeAll(function() {
+        this.User.beforeFindAfterExpandIncludeAll(() => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
 
       it('in beforeFindAfterOptions hook returns error', function() {
-        this.User.beforeFindAfterOptions(function() {
+        this.User.beforeFindAfterOptions(() => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
 
       it('in afterFind hook returns error', function() {
-        this.User.afterFind(function() {
+        this.User.afterFind(() => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (function(err) {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -1,15 +1,15 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , Sequelize = Support.Sequelize
-  , dialect = Support.getTestDialect()
-  , sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const Sequelize = Support.Sequelize;
+const dialect = Support.getTestDialect();
+const sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -35,15 +35,15 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#define', function() {
+  describe('#define', () => {
     before(function() {
-      this.sequelize.addHook('beforeDefine', function(attributes, options) {
+      this.sequelize.addHook('beforeDefine', (attributes, options) => {
         options.modelName = 'bar';
         options.name.plural = 'barrs';
         attributes.type = DataTypes.STRING;
       });
 
-      this.sequelize.addHook('afterDefine', function(factory) {
+      this.sequelize.addHook('afterDefine', factory => {
         factory.options.name.singular = 'barr';
       });
 
@@ -72,18 +72,18 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     });
   });
 
-  describe('#init', function() {
+  describe('#init', () => {
     before(function() {
-      Sequelize.addHook('beforeInit', function(config, options) {
+      Sequelize.addHook('beforeInit', (config, options) => {
         config.database = 'db2';
         options.host = 'server9';
       });
 
-      Sequelize.addHook('afterInit', function(sequelize) {
+      Sequelize.addHook('afterInit', sequelize => {
         sequelize.options.protocol = 'udp';
       });
 
-      this.seq = new Sequelize('db', 'user', 'pass', { dialect : dialect });
+      this.seq = new Sequelize('db', 'user', 'pass', { dialect });
     });
 
     it('beforeInit hook can alter config', function() {
@@ -98,26 +98,26 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       expect(this.seq.options.protocol).to.equal('udp');
     });
 
-    after(function() {
+    after(() => {
       Sequelize.options.hooks = {};
     });
   });
 
-  describe('passing DAO instances', function() {
-    describe('beforeValidate / afterValidate', function() {
+  describe('passing DAO instances', () => {
+    describe('beforeValidate / afterValidate', () => {
       it('should pass a DAO instance to the hook', function() {
-        var beforeHooked = false;
-        var afterHooked = false;
-        var User = this.sequelize.define('User', {
+        let beforeHooked = false;
+        let afterHooked = false;
+        const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
           hooks: {
-            beforeValidate: function(user, options, fn) {
+            beforeValidate(user, options, fn) {
               expect(user).to.be.instanceof(User);
               beforeHooked = true;
               fn();
             },
-            afterValidate: function(user, options, fn) {
+            afterValidate(user, options, fn) {
               expect(user).to.be.instanceof(User);
               afterHooked = true;
               fn();
@@ -125,166 +125,150 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           }
         });
 
-        return User.sync({ force: true }).then(function() {
-          return User.create({ username: 'bob' }).then(function() {
+        return User.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(() => {
+          expect(beforeHooked).to.be.true;
+          expect(afterHooked).to.be.true;
+        }));
+      });
+    });
+
+    describe('beforeCreate / afterCreate', () => {
+      it('should pass a DAO instance to the hook', function() {
+        let beforeHooked = false;
+        let afterHooked = false;
+        const User = this.sequelize.define('User', {
+          username: DataTypes.STRING
+        }, {
+          hooks: {
+            beforeCreate(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              fn();
+            },
+            afterCreate(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              fn();
+            }
+          }
+        });
+
+        return User.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(() => {
+          expect(beforeHooked).to.be.true;
+          expect(afterHooked).to.be.true;
+        }));
+      });
+    });
+
+    describe('beforeDestroy / afterDestroy', () => {
+      it('should pass a DAO instance to the hook', function() {
+        let beforeHooked = false;
+        let afterHooked = false;
+        const User = this.sequelize.define('User', {
+          username: DataTypes.STRING
+        }, {
+          hooks: {
+            beforeDestroy(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              fn();
+            },
+            afterDestroy(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              fn();
+            }
+          }
+        });
+
+        return User.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(user => user.destroy().then(() => {
+          expect(beforeHooked).to.be.true;
+          expect(afterHooked).to.be.true;
+        })));
+      });
+    });
+
+    describe('beforeDelete / afterDelete', () => {
+      it('should pass a DAO instance to the hook', function() {
+        let beforeHooked = false;
+        let afterHooked = false;
+        const User = this.sequelize.define('User', {
+          username: DataTypes.STRING
+        }, {
+          hooks: {
+            beforeDelete(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              fn();
+            },
+            afterDelete(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              fn();
+            }
+          }
+        });
+
+        return User.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(user => user.destroy().then(() => {
+          expect(beforeHooked).to.be.true;
+          expect(afterHooked).to.be.true;
+        })));
+      });
+    });
+
+    describe('beforeUpdate / afterUpdate', () => {
+      it('should pass a DAO instance to the hook', function() {
+        let beforeHooked = false;
+        let afterHooked = false;
+        const User = this.sequelize.define('User', {
+          username: DataTypes.STRING
+        }, {
+          hooks: {
+            beforeUpdate(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              fn();
+            },
+            afterUpdate(user, options, fn) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              fn();
+            }
+          }
+        });
+
+        return User.sync({ force: true }).then(() => User.create({ username: 'bob' }).then(user => {
+          user.username = 'bawb';
+          return user.save({ fields: ['username'] }).then(() => {
             expect(beforeHooked).to.be.true;
             expect(afterHooked).to.be.true;
           });
-        });
-      });
-    });
-
-    describe('beforeCreate / afterCreate', function() {
-      it('should pass a DAO instance to the hook', function() {
-        var beforeHooked = false;
-        var afterHooked = false;
-        var User = this.sequelize.define('User', {
-          username: DataTypes.STRING
-        }, {
-          hooks: {
-            beforeCreate: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              fn();
-            },
-            afterCreate: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              fn();
-            }
-          }
-        });
-
-        return User.sync({ force: true }).then(function() {
-          return User.create({ username: 'bob' }).then(function() {
-            expect(beforeHooked).to.be.true;
-            expect(afterHooked).to.be.true;
-          });
-        });
-      });
-    });
-
-    describe('beforeDestroy / afterDestroy', function() {
-      it('should pass a DAO instance to the hook', function() {
-        var beforeHooked = false;
-        var afterHooked = false;
-        var User = this.sequelize.define('User', {
-          username: DataTypes.STRING
-        }, {
-          hooks: {
-            beforeDestroy: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              fn();
-            },
-            afterDestroy: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              fn();
-            }
-          }
-        });
-
-        return User.sync({ force: true }).then(function() {
-          return User.create({ username: 'bob' }).then(function(user) {
-            return user.destroy().then(function() {
-              expect(beforeHooked).to.be.true;
-              expect(afterHooked).to.be.true;
-            });
-          });
-        });
-      });
-    });
-
-    describe('beforeDelete / afterDelete', function() {
-      it('should pass a DAO instance to the hook', function() {
-        var beforeHooked = false;
-        var afterHooked = false;
-        var User = this.sequelize.define('User', {
-          username: DataTypes.STRING
-        }, {
-          hooks: {
-            beforeDelete: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              fn();
-            },
-            afterDelete: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              fn();
-            }
-          }
-        });
-
-        return User.sync({ force: true }).then(function() {
-          return User.create({ username: 'bob' }).then(function(user) {
-            return user.destroy().then(function() {
-              expect(beforeHooked).to.be.true;
-              expect(afterHooked).to.be.true;
-            });
-          });
-        });
-      });
-    });
-
-    describe('beforeUpdate / afterUpdate', function() {
-      it('should pass a DAO instance to the hook', function() {
-        var beforeHooked = false;
-        var afterHooked = false;
-        var User = this.sequelize.define('User', {
-          username: DataTypes.STRING
-        }, {
-          hooks: {
-            beforeUpdate: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              fn();
-            },
-            afterUpdate: function(user, options, fn) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              fn();
-            }
-          }
-        });
-
-        return User.sync({ force: true }).then(function() {
-          return User.create({ username: 'bob' }).then(function(user) {
-            user.username = 'bawb';
-            return user.save({ fields: ['username'] }).then(function() {
-              expect(beforeHooked).to.be.true;
-              expect(afterHooked).to.be.true;
-            });
-          });
-        });
+        }));
       });
     });
   });
 
-  describe('Model#sync', function() {
-    describe('on success', function() {
+  describe('Model#sync', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeSync(beforeHook);
         this.User.afterSync(afterHook);
 
-        return this.User.sync().then(function() {
+        return this.User.sync().then(() => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).to.have.been.calledOnce;
         });
       });
 
       it('should not run hooks when "hooks = false" option passed', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeSync(beforeHook);
         this.User.afterSync(afterHook);
 
-        return this.User.sync({ hooks: false }).then(function() {
+        return this.User.sync({ hooks: false }).then(() => {
           expect(beforeHook).to.not.have.been.called;
           expect(afterHook).to.not.have.been.called;
         });
@@ -292,34 +276,32 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
 
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
-        this.User.beforeSync(function(options) {
+        this.User.beforeSync(options => {
           beforeHook();
           throw new Error('Whoops!');
         });
         this.User.afterSync(afterHook);
 
-        return expect(this.User.sync()).to.be.rejected.then(function(err) {
+        return expect(this.User.sync()).to.be.rejected.then(err => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).not.to.have.been.called;
         });
       });
 
       it('should return an error from after', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeSync(beforeHook);
-        this.User.afterSync(function(options) {
+        this.User.afterSync(options => {
           afterHook();
           throw new Error('Whoops!');
         });
 
-        return expect(this.User.sync()).to.be.rejected.then(function(err) {
+        return expect(this.User.sync()).to.be.rejected.then(err => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).to.have.been.calledOnce;
         });
@@ -327,20 +309,17 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     });
   });
 
-  describe('sequelize#sync', function() {
-    describe('on success', function() {
+  describe('sequelize#sync', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy()
-          , modelBeforeHook = sinon.spy()
-          , modelAfterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy(), modelBeforeHook = sinon.spy(), modelAfterHook = sinon.spy();
 
         this.sequelize.beforeBulkSync(beforeHook);
         this.User.beforeSync(modelBeforeHook);
         this.User.afterSync(modelAfterHook);
         this.sequelize.afterBulkSync(afterHook);
 
-        return this.sequelize.sync().then(function() {
+        return this.sequelize.sync().then(() => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(modelBeforeHook).to.have.been.calledOnce;
           expect(modelAfterHook).to.have.been.calledOnce;
@@ -349,17 +328,14 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should not run hooks if "hooks = false" option passed', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy()
-          , modelBeforeHook = sinon.spy()
-          , modelAfterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy(), modelBeforeHook = sinon.spy(), modelAfterHook = sinon.spy();
 
         this.sequelize.beforeBulkSync(beforeHook);
         this.User.beforeSync(modelBeforeHook);
         this.User.afterSync(modelAfterHook);
         this.sequelize.afterBulkSync(afterHook);
 
-        return this.sequelize.sync({ hooks: false }).then(function() {
+        return this.sequelize.sync({ hooks: false }).then(() => {
           expect(beforeHook).to.not.have.been.called;
           expect(modelBeforeHook).to.not.have.been.called;
           expect(modelAfterHook).to.not.have.been.called;
@@ -373,34 +349,32 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
 
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
 
       it('should return an error from before', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
-        this.sequelize.beforeBulkSync(function(options) {
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
+        this.sequelize.beforeBulkSync(options => {
           beforeHook();
           throw new Error('Whoops!');
         });
         this.sequelize.afterBulkSync(afterHook);
 
-        return expect(this.sequelize.sync()).to.be.rejected.then(function(err) {
+        return expect(this.sequelize.sync()).to.be.rejected.then(err => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).not.to.have.been.called;
         });
       });
 
       it('should return an error from after', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.sequelize.beforeBulkSync(beforeHook);
-        this.sequelize.afterBulkSync(function(options) {
+        this.sequelize.afterBulkSync(options => {
           afterHook();
           throw new Error('Whoops!');
         });
 
-        return expect(this.sequelize.sync()).to.be.rejected.then(function(err) {
+        return expect(this.sequelize.sync()).to.be.rejected.then(err => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).to.have.been.calledOnce;
         });

--- a/test/integration/hooks/restore.test.js
+++ b/test/integration/hooks/restore.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -33,65 +33,50 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#restore', function() {
-    describe('on success', function() {
+  describe('#restore', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.ParanoidUser.beforeRestore(beforeHook);
         this.ParanoidUser.afterRestore(afterHook);
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return user.destroy().then(function() {
-            return user.restore().then(function(user) {
-              expect(beforeHook).to.have.been.calledOnce;
-              expect(afterHook).to.have.been.calledOnce;
-            });
-          });
-        });
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => user.destroy().then(() => user.restore().then(user => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        })));
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
-        this.ParanoidUser.beforeRestore(function(user, options) {
+        this.ParanoidUser.beforeRestore((user, options) => {
           beforeHook();
           throw new Error('Whoops!');
         });
         this.ParanoidUser.afterRestore(afterHook);
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return user.destroy().then(function() {
-            return expect(user.restore()).to.be.rejected.then(function() {
-              expect(beforeHook).to.have.been.calledOnce;
-              expect(afterHook).not.to.have.been.called;
-            });
-          });
-        });
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => user.destroy().then(() => expect(user.restore()).to.be.rejected.then(() => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).not.to.have.been.called;
+        })));
       });
 
       it('should return an error from after', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.ParanoidUser.beforeRestore(beforeHook);
-        this.ParanoidUser.afterRestore(function(user, options) {
+        this.ParanoidUser.afterRestore((user, options) => {
           afterHook();
           throw new Error('Whoops!');
         });
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return user.destroy().then(function() {
-            return expect(user.restore()).to.be.rejected.then(function() {
-              expect(beforeHook).to.have.been.calledOnce;
-              expect(afterHook).to.have.been.calledOnce;
-            });
-          });
-        });
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => user.destroy().then(() => expect(user.restore()).to.be.rejected.then(() => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        })));
       });
     });
   });

--- a/test/integration/hooks/restore.test.js
+++ b/test/integration/hooks/restore.test.js
@@ -41,7 +41,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.ParanoidUser.beforeRestore(beforeHook);
         this.ParanoidUser.afterRestore(afterHook);
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => user.destroy().then(() => user.restore().then(user => {
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'})
+        .then(user => user.destroy()
+        .then(() => user.restore()
+        .then(user => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).to.have.been.calledOnce;
         })));
@@ -58,7 +61,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
         this.ParanoidUser.afterRestore(afterHook);
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => user.destroy().then(() => expect(user.restore()).to.be.rejected.then(() => {
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'})
+        .then(user => user.destroy()
+        .then(() => expect(user.restore()).to.be.rejected
+        .then(() => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).not.to.have.been.called;
         })));
@@ -73,7 +79,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Whoops!');
         });
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => user.destroy().then(() => expect(user.restore()).to.be.rejected.then(() => {
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'})
+        .then(user => user.destroy()
+        .then(() => expect(user.restore()).to.be.rejected
+        .then(() => {
           expect(beforeHook).to.have.been.calledOnce;
           expect(afterHook).to.have.been.calledOnce;
         })));

--- a/test/integration/hooks/updateAttributes.test.js
+++ b/test/integration/hooks/updateAttributes.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -22,73 +22,62 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#updateAttributes', function() {
-    describe('on success', function() {
+  describe('#updateAttributes', () => {
+    describe('on success', () => {
       it('should run hooks', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeUpdate(beforeHook);
         this.User.afterUpdate(afterHook);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return user.updateAttributes({username: 'Chong'}).then(function(user) {
-            expect(beforeHook).to.have.been.calledOnce;
-            expect(afterHook).to.have.been.calledOnce;
-            expect(user.username).to.equal('Chong');
-          });
-        });
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => user.updateAttributes({username: 'Chong'}).then(user => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+          expect(user.username).to.equal('Chong');
+        }));
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should return an error from before', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
-        this.User.beforeUpdate(function(user, options) {
+        this.User.beforeUpdate((user, options) => {
           beforeHook();
           throw new Error('Whoops!');
         });
         this.User.afterUpdate(afterHook);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return expect(user.updateAttributes({username: 'Chong'})).to.be.rejected.then(function() {
-            expect(beforeHook).to.have.been.calledOnce;
-            expect(afterHook).not.to.have.been.called;
-          });
-        });
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => expect(user.updateAttributes({username: 'Chong'})).to.be.rejected.then(() => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).not.to.have.been.called;
+        }));
       });
 
       it('should return an error from after', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
+        const beforeHook = sinon.spy(), afterHook = sinon.spy();
 
         this.User.beforeUpdate(beforeHook);
-        this.User.afterUpdate(function(user, options) {
+        this.User.afterUpdate((user, options) => {
           afterHook();
           throw new Error('Whoops!');
         });
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then(function(user) {
-          return expect(user.updateAttributes({username: 'Chong'})).to.be.rejected.then(function() {
-            expect(beforeHook).to.have.been.calledOnce;
-            expect(afterHook).to.have.been.calledOnce;
-          });
-        });
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => expect(user.updateAttributes({username: 'Chong'})).to.be.rejected.then(() => {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        }));
       });
     });
 
-    describe('preserves changes to instance', function() {
+    describe('preserves changes to instance', () => {
       it('beforeValidate', function(){
 
-        this.User.beforeValidate(function(user, options) {
+        this.User.beforeValidate((user, options) => {
           user.mood = 'happy';
         });
 
-        return this.User.create({username: 'fireninja', mood: 'invalid'}).then(function(user) {
-          return user.updateAttributes({username: 'hero'});
-        }).then(function(user) {
+        return this.User.create({username: 'fireninja', mood: 'invalid'}).then(user => user.updateAttributes({username: 'hero'})).then(user => {
           expect(user.username).to.equal('hero');
           expect(user.mood).to.equal('happy');
         });
@@ -96,13 +85,11 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
 
       it('afterValidate', function() {
 
-        this.User.afterValidate(function(user, options) {
+        this.User.afterValidate((user, options) => {
           user.mood = 'sad';
         });
 
-        return this.User.create({username: 'fireninja', mood: 'nuetral'}).then(function(user) {
-          return user.updateAttributes({username: 'spider'});
-        }).then(function(user) {
+        return this.User.create({username: 'fireninja', mood: 'nuetral'}).then(user => user.updateAttributes({username: 'spider'})).then(user => {
           expect(user.username).to.equal('spider');
           expect(user.mood).to.equal('sad');
         });

--- a/test/integration/hooks/validate.test.js
+++ b/test/integration/hooks/validate.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , sinon = require('sinon');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../support');
+const DataTypes = require('./../../../lib/data-types');
+const sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
+describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
@@ -22,30 +22,30 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
     return this.sequelize.sync({ force: true });
   });
 
-  describe('#validate', function() {
-    describe('#create', function() {
+  describe('#validate', () => {
+    describe('#create', () => {
       it('should return the user', function() {
-        this.User.beforeValidate(function(user, options) {
+        this.User.beforeValidate((user, options) => {
           user.username = 'Bob';
           user.mood = 'happy';
         });
 
-        this.User.afterValidate(function(user, options) {
+        this.User.afterValidate((user, options) => {
           user.username = 'Toni';
         });
 
-        return this.User.create({mood: 'ecstatic'}).then(function(user) {
+        return this.User.create({mood: 'ecstatic'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('Toni');
         });
       });
     });
 
-    describe('#3534, hooks modifications', function() {
+    describe('#3534, hooks modifications', () => {
       it('fields modified in hooks are saved', function() {
-        var self = this;
+        const self = this;
 
-        this.User.afterValidate(function(user, options) {
+        this.User.afterValidate((user, options) => {
           //if username is defined and has more than 5 char
           user.username = user.username
                           ? (user.username.length < 5 ? null : user.username)
@@ -54,12 +54,12 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
 
         });
 
-        this.User.beforeValidate(function(user, options) {
+        this.User.beforeValidate((user, options) => {
           user.mood = user.mood || 'neutral';
         });
 
 
-        return this.User.create({username: 'T', mood: 'neutral'}).then(function(user) {
+        return this.User.create({username: 'T', mood: 'neutral'}).then(user => {
           expect(user.mood).to.equal('neutral');
           expect(user.username).to.equal('Samorost 3');
 
@@ -68,7 +68,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           user.username = 'Samorost Good One';
 
           return user.save();
-        }).then(function(uSaved) {
+        }).then(uSaved => {
           expect(uSaved.mood).to.equal('sad');
           expect(uSaved.username).to.equal('Samorost Good One');
 
@@ -76,12 +76,12 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           uSaved.username = 'One';
 
           return uSaved.save();
-        }).then(function(uSaved) {
+        }).then(uSaved => {
           //attributes were replaced by hooks ?
           expect(uSaved.mood).to.equal('sad');
           expect(uSaved.username).to.equal('Samorost 3');
           return self.User.findById(uSaved.id);
-        }).then(function(uFetched) {
+        }).then(uFetched => {
           expect(uFetched.mood).to.equal('sad');
           expect(uFetched.username).to.equal('Samorost 3');
 
@@ -89,12 +89,12 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           uFetched.username = 'New Game is Needed';
 
           return uFetched.save();
-        }).then(function(uFetchedSaved) {
+        }).then(uFetchedSaved => {
           expect(uFetchedSaved.mood).to.equal('neutral');
           expect(uFetchedSaved.username).to.equal('New Game is Needed');
 
           return self.User.findById(uFetchedSaved.id);
-        }).then(function(uFetched) {
+        }).then(uFetched => {
           expect(uFetched.mood).to.equal('neutral');
           expect(uFetched.username).to.equal('New Game is Needed');
 
@@ -102,16 +102,16 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
           uFetched.username = 'New';
           uFetched.mood = 'happy';
           return uFetched.save();
-        }).then(function(uFetchedSaved) {
+        }).then(uFetchedSaved => {
           expect(uFetchedSaved.mood).to.equal('happy');
           expect(uFetchedSaved.username).to.equal('Samorost 3');
         });
       });
     });
 
-    describe('on error', function() {
+    describe('on error', () => {
       it('should emit an error from after hook', function() {
-        this.User.afterValidate(function(user, options) {
+        this.User.afterValidate((user, options) => {
           user.mood = 'ecstatic';
           throw new Error('Whoops! Changed user.mood!');
         });
@@ -120,31 +120,31 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       });
 
       it('should call validationFailed hook', function() {
-        var validationFailedHook = sinon.spy();
+        const validationFailedHook = sinon.spy();
 
         this.User.validationFailed(validationFailedHook);
 
-        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(function(err) {
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(err => {
           expect(validationFailedHook).to.have.been.calledOnce;
         });
       });
 
       it('should not replace the validation error in validationFailed hook by default', function() {
-        var validationFailedHook = sinon.stub();
+        const validationFailedHook = sinon.stub();
 
         this.User.validationFailed(validationFailedHook);
 
-        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(function(err) {
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(err => {
           expect(err.name).to.equal('SequelizeValidationError');
         });
       });
 
       it('should replace the validation error if validationFailed hook creates a new error', function() {
-        var validationFailedHook = sinon.stub().throws(new Error('Whoops!'));
+        const validationFailedHook = sinon.stub().throws(new Error('Whoops!'));
 
         this.User.validationFailed(validationFailedHook);
 
-        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(function(err) {
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(err => {
           expect(err.message).to.equal('Whoops!');
         });
       });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?

### Description of change

Convert `integration/association`  and `integration/hooks` to ES6. Only these two section are properly grouped so can be directly converted to ES6.

Other section would need regrouping then conversion.

