### PR TITLE
ES6 conversion of dialect tests

### DIFF
--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -1,99 +1,99 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , sinon = require('sinon')
-  , Config = require(__dirname + '/../../../config/config')
-  , ConnectionManager = require(__dirname + '/../../../../lib/dialects/abstract/connection-manager')
-  , Pooling = require('generic-pool')
-  , _ = require('lodash')
-  , Promise = require(__dirname + '/../../../../lib/promise');
+const chai = require('chai');
+const sinon = require('sinon');
+const _ = require('lodash');
+const Pooling = require('generic-pool');
+const expect = chai.expect;
+const Support = require('./../../support');
+const Config = require('./../../../config/config');
+const ConnectionManager = require('./../../../../lib/dialects/abstract/connection-manager');
+const Sequelize = require('./../../../../index');
+const baseConf = Config[Support.getTestDialect()];
 
-var baseConf = Config[Support.getTestDialect()];
-var poolEntry = {
+const poolEntry = {
   host: baseConf.host,
   port: baseConf.port,
   pool: {}
 };
 
-describe('Connction Manager', function() {
+describe('Connction Manager', () => {
 
-  var sandbox;
+  let sandbox;
 
-  beforeEach(function(){
+  beforeEach(() => {
     sandbox = sinon.sandbox.create();
   });
 
-  afterEach(function(){
+  afterEach(() => {
     sandbox.restore();
   });
 
-  it('should initialize a single pool without replication', function() {
-    var options = {
+  it('should initialize a single pool without replication', () => {
+    const options = {
       replication: null
     };
-    var sequelize = Support.createSequelizeInstance(options);
-    var connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const sequelize = Support.createSequelizeInstance(options);
+    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
 
-    var poolSpy = sandbox.spy(Pooling, 'Pool');
+    const poolSpy = sandbox.spy(Pooling, 'Pool');
     connectionManager.initPools();
     expect(poolSpy.calledOnce).to.be.true;
   });
 
-  it('should initialize a multiple pools with replication', function() {
-    var options = {
+  it('should initialize a multiple pools with replication', () => {
+    const options = {
       replication: {
         write: _.clone(poolEntry),
         read: [_.clone(poolEntry), _.clone(poolEntry)]
       }
     };
-    var sequelize = Support.createSequelizeInstance(options);
-    var connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const sequelize = Support.createSequelizeInstance(options);
+    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
 
-    var poolSpy = sandbox.spy(Pooling, 'Pool');
+    const poolSpy = sandbox.spy(Pooling, 'Pool');
     connectionManager.initPools();
     expect(poolSpy.calledTwice).to.be.true;
   });
 
-  it('should round robin calls to the read pool', function() {
+  it('should round robin calls to the read pool', () => {
     if (Support.getTestDialect() === 'sqlite') {
       return;
     }
 
-    var slave1 = _.clone(poolEntry);
-    var slave2 = _.clone(poolEntry);
+    const slave1 = _.clone(poolEntry);
+    const slave2 = _.clone(poolEntry);
     slave1.host = 'slave1';
     slave2.host = 'slave2';
 
-    var options = {
+    const options = {
       replication: {
         write: _.clone(poolEntry),
         read: [slave1, slave2]
       }
     };
-    var sequelize = Support.createSequelizeInstance(options);
-    var connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const sequelize = Support.createSequelizeInstance(options);
+    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
 
-    var resolvedPromise = new Promise(function(resolve) {
+    const resolvedPromise = new Sequelize.Promise(resolve => {
       resolve({
         queryType: 'read'
       });
     });
 
-    var connectStub = sandbox.stub(connectionManager, '$connect').returns(resolvedPromise);
+    const connectStub = sandbox.stub(connectionManager, '$connect').returns(resolvedPromise);
     sandbox.stub(connectionManager, '$disconnect').returns(resolvedPromise);
     sandbox.stub(sequelize, 'databaseVersion').returns(resolvedPromise);
     connectionManager.initPools();
 
-    var queryOptions = {
+    const queryOptions = {
       priority: 0,
       type: 'SELECT',
       useMaster: false
     };
 
-    var _getConnection = _.bind(connectionManager.getConnection, connectionManager, queryOptions);
+    const _getConnection = _.bind(connectionManager.getConnection, connectionManager, queryOptions);
 
     return _getConnection()
       .then(_getConnection)
@@ -102,38 +102,38 @@ describe('Connction Manager', function() {
         chai.expect(connectStub.callCount).to.equal(4);
 
         // First call is the get connection for DB versions - ignore
-        var calls = connectStub.getCalls();
+        const calls = connectStub.getCalls();
         chai.expect(calls[1].args[0].host).to.eql('slave1');
         chai.expect(calls[2].args[0].host).to.eql('slave2');
         chai.expect(calls[3].args[0].host).to.eql('slave1');
       });
   });
 
-  it('should allow forced reads from the write pool', function() {
-    var master = _.clone(poolEntry);
+  it('should allow forced reads from the write pool', () => {
+    const master = _.clone(poolEntry);
     master.host = 'the-boss';
 
-    var options = {
+    const options = {
       replication: {
         write: master,
         read: [_.clone(poolEntry)]
       }
     };
-    var sequelize = Support.createSequelizeInstance(options);
-    var connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const sequelize = Support.createSequelizeInstance(options);
+    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
 
-    var resolvedPromise = new Promise(function(resolve) {
+    const resolvedPromise = new Sequelize.Promise(resolve => {
       resolve({
         queryType: 'read'
       });
     });
 
-    var connectStub = sandbox.stub(connectionManager, '$connect').returns(resolvedPromise);
+    const connectStub = sandbox.stub(connectionManager, '$connect').returns(resolvedPromise);
     sandbox.stub(connectionManager, '$disconnect').returns(resolvedPromise);
     sandbox.stub(sequelize, 'databaseVersion').returns(resolvedPromise);
     connectionManager.initPools();
 
-    var queryOptions = {
+    const queryOptions = {
       priority: 0,
       type: 'SELECT',
       useMaster: true
@@ -142,7 +142,7 @@ describe('Connction Manager', function() {
     return connectionManager.getConnection(queryOptions)
       .then(function checkPoolHosts() {
         chai.expect(connectStub).to.have.been.calledTwice; // Once to get DB version, and once to actually get the connection.
-        var calls = connectStub.getCalls();
+        const calls = connectStub.getCalls();
         chai.expect(calls[1].args[0].host).to.eql('the-boss');
       });
   });

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -1,37 +1,30 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require('../../support')
-  , dialect = Support.getTestDialect();
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('../../support');
+const dialect = Support.getTestDialect();
 
 if (dialect.match(/^mssql/)) {
-  describe('[MSSQL Specific] Query Queue', function () {
-    it('should work with handleDisconnects', function() {
-      var sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, idle: 5000}})
-        , cm = sequelize.connectionManager
-        , conn;
+  describe('[MSSQL Specific] Query Queue', () => {
+    it('should work with handleDisconnects', () => {
+      const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, idle: 5000}});
+      const cm = sequelize.connectionManager;
+      let conn;
 
       return sequelize.sync()
-        .then(function() {
-          return cm.getConnection();
-        })
-        .then(function(connection) {
+        .then(() => cm.getConnection())
+        .then(connection => {
           // Save current connection
           conn = connection;
 
           // simulate a unexpected end
           connection.unwrap().emit('error', {code: 'ECONNRESET'});
         })
-        .then(function() {
-          return cm.releaseConnection(conn);
-        })
-        .then(function() {
-          // Get next available connection
-          return cm.getConnection();
-        })
-        .then(function(connection) {
+        .then(() => cm.releaseConnection(conn))
+        .then(() => cm.getConnection())
+        .then(connection => {
           expect(conn).to.not.be.equal(connection);
           expect(cm.validate(conn)).to.not.be.ok;
 

--- a/test/integration/dialects/mssql/query-queue.test.js
+++ b/test/integration/dialects/mssql/query-queue.test.js
@@ -1,37 +1,33 @@
 'use strict';
 
-var chai = require('chai')
-  , expect = chai.expect
-  , Promise = require('../../../../lib/promise')
-  , DataTypes = require('../../../../lib/data-types')
-  , Support = require('../../support')
-  , dialect = Support.getTestDialect();
+const chai = require('chai');
+const expect = chai.expect;
+const Sequelize = require('./../../../../index');
+const DataTypes = require('../../../../lib/data-types');
+const Support = require('../../support');
+const dialect = Support.getTestDialect();
 
 if (dialect.match(/^mssql/)) {
-  describe('[MSSQL Specific] Query Queue', function () {
+  describe('[MSSQL Specific] Query Queue', () => {
     beforeEach(function () {
-      var User = this.User = this.sequelize.define('User', {
+      const User = this.User = this.sequelize.define('User', {
         username: DataTypes.STRING
       });
 
-      return this.sequelize.sync({ force: true }).then(function () {
-        return User.create({ username: 'John'});
-      });
+      return this.sequelize.sync({ force: true }).then(() => User.create({ username: 'John'}));
     });
 
     it('should queue concurrent requests to a connection', function() {
-      var User = this.User;
+      const User = this.User;
 
-      return expect(this.sequelize.transaction(function (t) {
-        return Promise.all([
-          User.findOne({
-            transaction: t
-          }),
-          User.findOne({
-            transaction: t
-          })
-        ]);
-      })).not.to.be.rejected;
+      return expect(this.sequelize.transaction(t => Sequelize.Promise.all([
+        User.findOne({
+          transaction: t
+        }),
+        User.findOne({
+          transaction: t
+        })
+      ]))).not.to.be.rejected;
     });
   });
 }

--- a/test/integration/dialects/mysql/associations.test.js
+++ b/test/integration/dialects/mysql/associations.test.js
@@ -1,41 +1,34 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , DataTypes = require(__dirname + '/../../../../lib/data-types');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require('./../../../../lib/data-types');
 
 if (dialect === 'mysql') {
-  describe('[MYSQL Specific] Associations', function() {
-    describe('many-to-many', function() {
-      describe('where tables have the same prefix', function() {
+  describe('[MYSQL Specific] Associations', () => {
+    describe('many-to-many', () => {
+      describe('where tables have the same prefix', () => {
         it('should create a table wp_table1wp_table2s', function() {
-          var Table2 = this.sequelize.define('wp_table2', {foo: DataTypes.STRING})
-            , Table1 = this.sequelize.define('wp_table1', {foo: DataTypes.STRING})
-            , self = this;
+          const Table2 = this.sequelize.define('wp_table2', {foo: DataTypes.STRING}), Table1 = this.sequelize.define('wp_table1', {foo: DataTypes.STRING}), self = this;
 
           Table1.belongsToMany(Table2, { through: 'wp_table1swp_table2s' });
           Table2.belongsToMany(Table1, { through: 'wp_table1swp_table2s' });
-          return Table1.sync({ force: true }).then(function() {
-            return Table2.sync({ force: true }).then(function() {
-              expect(self.sequelize.modelManager.getModel('wp_table1swp_table2s')).to.exist;
-            });
-          });
+          return Table1.sync({ force: true }).then(() => Table2.sync({ force: true }).then(() => {
+            expect(self.sequelize.modelManager.getModel('wp_table1swp_table2s')).to.exist;
+          }));
         });
       });
 
-      describe('when join table name is specified', function() {
+      describe('when join table name is specified', () => {
         beforeEach(function() {
-          var Table2 = this.sequelize.define('ms_table1', {foo: DataTypes.STRING})
-            , Table1 = this.sequelize.define('ms_table2', {foo: DataTypes.STRING});
+          const Table2 = this.sequelize.define('ms_table1', {foo: DataTypes.STRING}), Table1 = this.sequelize.define('ms_table2', {foo: DataTypes.STRING});
 
           Table1.belongsToMany(Table2, {through: 'table1_to_table2'});
           Table2.belongsToMany(Table1, {through: 'table1_to_table2'});
-          return Table1.sync({ force: true }).then(function() {
-            return Table2.sync({ force: true });
-          });
+          return Table1.sync({ force: true }).then(() => Table2.sync({ force: true }));
         });
 
         it('should not use only a specified name', function() {
@@ -45,100 +38,82 @@ if (dialect === 'mysql') {
       });
     });
 
-    describe('HasMany', function() {
+    describe('HasMany', () => {
       beforeEach(function() {
         //prevent periods from occurring in the table name since they are used to delimit (table.column)
-        this.User = this.sequelize.define('User' + Math.ceil(Math.random() * 10000000), { name: DataTypes.STRING });
-        this.Task = this.sequelize.define('Task' + Math.ceil(Math.random() * 10000000), { name: DataTypes.STRING });
+        this.User = this.sequelize.define(`User${Math.ceil(Math.random() * 10000000)}`, { name: DataTypes.STRING });
+        this.Task = this.sequelize.define(`Task${Math.ceil(Math.random() * 10000000)}`, { name: DataTypes.STRING });
         this.users = null;
         this.tasks = null;
 
         this.User.belongsToMany(this.Task, {as: 'Tasks', through: 'UserTasks'});
         this.Task.belongsToMany(this.User, {as: 'Users', through: 'UserTasks'});
 
-        var self = this
-          , users = []
-          , tasks = [];
+        const self = this, users = [], tasks = [];
 
-        for (var i = 0; i < 5; ++i) {
-          users[users.length] = {name: 'User' + Math.random()};
+        for (let i = 0; i < 5; ++i) {
+          users[users.length] = {name: `User${Math.random()}`};
         }
 
-        for (var x = 0; x < 5; ++x) {
-          tasks[tasks.length] = {name: 'Task' + Math.random()};
+        for (let x = 0; x < 5; ++x) {
+          tasks[tasks.length] = {name: `Task${Math.random()}`};
         }
 
-        return this.sequelize.sync({ force: true }).then(function() {
-          return self.User.bulkCreate(users).then(function() {
-            return self.Task.bulkCreate(tasks);
-          });
-        });
+        return this.sequelize.sync({ force: true }).then(() => self.User.bulkCreate(users).then(() => self.Task.bulkCreate(tasks)));
       });
 
-      describe('addDAO / getModel', function() {
+      describe('addDAO / getModel', () => {
         beforeEach(function() {
-          var self = this;
+          const self = this;
 
           self.user = null;
           self.task = null;
 
-          return self.User.findAll().then(function(_users) {
-            return self.Task.findAll().then(function(_tasks) {
-              self.user = _users[0];
-              self.task = _tasks[0];
-            });
-          });
+          return self.User.findAll().then(_users => self.Task.findAll().then(_tasks => {
+            self.user = _users[0];
+            self.task = _tasks[0];
+          }));
         });
 
         it('should correctly add an association to the dao', function() {
-          var self = this;
+          const self = this;
 
-          return self.user.getTasks().then(function(_tasks) {
+          return self.user.getTasks().then(_tasks => {
             expect(_tasks.length).to.equal(0);
-            return self.user.addTask(self.task).then(function() {
-              return self.user.getTasks().then(function(_tasks) {
-                expect(_tasks.length).to.equal(1);
-              });
-            });
+            return self.user.addTask(self.task).then(() => self.user.getTasks().then(_tasks => {
+              expect(_tasks.length).to.equal(1);
+            }));
           });
         });
       });
 
-      describe('removeDAO', function() {
+      describe('removeDAO', () => {
         beforeEach(function() {
-          var self = this;
+          const self = this;
 
           self.user = null;
           self.tasks = null;
 
-          return self.User.findAll().then(function(_users) {
-            return self.Task.findAll().then(function(_tasks) {
-              self.user = _users[0];
-              self.tasks = _tasks;
-            });
-          });
+          return self.User.findAll().then(_users => self.Task.findAll().then(_tasks => {
+            self.user = _users[0];
+            self.tasks = _tasks;
+          }));
         });
 
         it('should correctly remove associated objects', function() {
-          var self = this;
+          const self = this;
 
-          return self.user.getTasks().then(function(__tasks) {
+          return self.user.getTasks().then(__tasks => {
             expect(__tasks.length).to.equal(0);
-            return self.user.setTasks(self.tasks).then(function() {
-              return self.user.getTasks().then(function(_tasks) {
-                expect(_tasks.length).to.equal(self.tasks.length);
-                return self.user.removeTask(self.tasks[0]).then(function() {
-                  return self.user.getTasks().then(function(_tasks) {
-                    expect(_tasks.length).to.equal(self.tasks.length - 1);
-                    return self.user.removeTasks([self.tasks[1], self.tasks[2]]).then(function() {
-                      return self.user.getTasks().then(function(_tasks) {
-                        expect(_tasks).to.have.length(self.tasks.length - 3);
-                      });
-                    });
-                  });
-                });
-              });
-            });
+            return self.user.setTasks(self.tasks).then(() => self.user.getTasks().then(_tasks => {
+              expect(_tasks.length).to.equal(self.tasks.length);
+              return self.user.removeTask(self.tasks[0]).then(() => self.user.getTasks().then(_tasks => {
+                expect(_tasks.length).to.equal(self.tasks.length - 1);
+                return self.user.removeTasks([self.tasks[1], self.tasks[2]]).then(() => self.user.getTasks().then(_tasks => {
+                  expect(_tasks).to.have.length(self.tasks.length - 3);
+                }));
+              }));
+            }));
           });
         });
       });

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -1,83 +1,60 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , sinon = require('sinon')
-  , DataTypes = require(__dirname + '/../../../../lib/data-types');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../../support');
+const dialect = Support.getTestDialect();
+const sinon = require('sinon');
+const DataTypes = require('./../../../../lib/data-types');
 
 if (dialect === 'mysql') {
-  describe('[MYSQL Specific] Connector Manager', function() {
+  describe('[MYSQL Specific] Connector Manager', () => {
     it('works correctly after being idle', function() {
-      var User = this.sequelize.define('User', { username: DataTypes.STRING })
-        , spy = sinon.spy()
-        , self = this;
+      const User = this.sequelize.define('User', { username: DataTypes.STRING }), spy = sinon.spy(), self = this;
 
-      return User.sync({force: true}).then(function() {
-        return User.create({username: 'user1'}).then(function() {
-          return User.count().then(function(count) {
-            expect(count).to.equal(1);
-            spy();
-            return self.sequelize.Promise.delay(1000).then(function() {
-              return User.count().then(function(count) {
-                expect(count).to.equal(1);
-                spy();
-                if (!spy.calledTwice) {
-                  throw new Error('Spy was not called twice');
-                }
-              });
-            });
-          });
-        });
-      });
+      return User.sync({force: true}).then(() => User.create({username: 'user1'}).then(() => User.count().then(count => {
+        expect(count).to.equal(1);
+        spy();
+        return self.sequelize.Promise.delay(1000).then(() => User.count().then(count => {
+          expect(count).to.equal(1);
+          spy();
+          if (!spy.calledTwice) {
+            throw new Error('Spy was not called twice');
+          }
+        }));
+      })));
     });
 
-    it('accepts new queries after shutting down a connection', function() {
+    it('accepts new queries after shutting down a connection', () => {
       // Create a sequelize instance with fast disconnecting connection
-      var sequelize = Support.createSequelizeInstance({ pool: {
+      const sequelize = Support.createSequelizeInstance({ pool: {
         idle: 50,
         max: 1
       } });
-      var User = sequelize.define('User', { username: DataTypes.STRING });
+      const User = sequelize.define('User', { username: DataTypes.STRING });
 
-      return User.sync({force: true}).then(function() {
-        return User.create({username: 'user1'});
-      }).then(function() {
-        // After 100 ms the DB connection will be disconnected for inactivity
-        return sequelize.Promise.delay(100);
-      }).then(function () {
-        // This query will be queued just after the `client.end` is executed and before its callback is called
-        return sequelize.query('SELECT COUNT(*) AS count FROM Users', { type: sequelize.QueryTypes.SELECT });
-      }).then(function(count) {
+      return User.sync({force: true}).then(() => User.create({username: 'user1'})).then(() => sequelize.Promise.delay(100)).then(() => sequelize.query('SELECT COUNT(*) AS count FROM Users', { type: sequelize.QueryTypes.SELECT })).then(count => {
         expect(count[0].count).to.equal(1);
       });
     });
 
     // This should run only on direct mysql
     if (dialect === 'mysql') {
-      it('should maintain connection', function() {
-        var sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}})
-          , cm = sequelize.connectionManager
-          , conn;
+      it('should maintain connection', () => {
+        const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
+        const cm = sequelize.connectionManager;
+        let conn;
 
         return sequelize.sync()
-          .then(function() {
-            return cm.getConnection();
-          })
-          .then(function(connection) {
+          .then(() => cm.getConnection())
+          .then(connection => {
             // Save current connection
             conn = connection;
           })
-          .then(function() {
-            return cm.releaseConnection(conn);
-          })
-          .then(function() {
-            // Get next available connection
-            return cm.getConnection();
-          })
-          .then(function(connection) {
+          .then(() => cm.releaseConnection(conn))
+          .then(() => cm.getConnection())
+          .then(connection => {
             // Old threadId should be different from current new one
             expect(conn.threadId).to.be.equal(connection.threadId);
             expect(cm.validate(conn)).to.be.ok;
@@ -86,30 +63,23 @@ if (dialect === 'mysql') {
           });
       });
 
-      it('should work with handleDisconnects', function() {
-        var sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}})
-          , cm = sequelize.connectionManager
-          , conn;
+      it('should work with handleDisconnects', () => {
+        const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
+        const cm = sequelize.connectionManager;
+        let conn;
 
         return sequelize.sync()
-          .then(function() {
-            return cm.getConnection();
-          })
-          .then(function(connection) {
+          .then(() => cm.getConnection())
+          .then(connection => {
             // Save current connection
             conn = connection;
 
             // simulate a unexpected end
             connection._protocol.end();
           })
-          .then(function() {
-            return cm.releaseConnection(conn);
-          })
-          .then(function() {
-            // Get next available connection
-            return cm.getConnection();
-          })
-          .then(function(connection) {
+          .then(() => cm.releaseConnection(conn))
+          .then(() => cm.getConnection())
+          .then(connection => {
             // Old threadId should be different from current new one
             expect(conn.threadId).to.not.be.equal(connection.threadId);
             expect(cm.validate(conn)).to.not.be.ok;

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -1,18 +1,18 @@
 'use strict';
 
 /* jshint -W110 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , config = require(__dirname + '/../../../config/config');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('./../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require('./../../../../lib/data-types');
+const config = require('./../../../config/config');
 
 if (dialect === 'mysql') {
-  describe('[MYSQL Specific] DAOFactory', function() {
-    describe('constructor', function() {
+  describe('[MYSQL Specific] DAOFactory', () => {
+    describe('constructor', () => {
       it('handles extended attributes (unique)', function() {
-        var User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: { type: DataTypes.STRING, unique: true }
         }, { timestamps: false });
 
@@ -20,58 +20,58 @@ if (dialect === 'mysql') {
       });
 
       it('handles extended attributes (default)', function() {
-        var User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: {type: DataTypes.STRING, defaultValue: 'foo'}
         }, { timestamps: false });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.attributes)).to.deep.equal({username: "VARCHAR(255) DEFAULT 'foo'", id: 'INTEGER NOT NULL auto_increment PRIMARY KEY'});
       });
 
       it('handles extended attributes (null)', function() {
-        var User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: {type: DataTypes.STRING, allowNull: false}
         }, { timestamps: false });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.attributes)).to.deep.equal({username: 'VARCHAR(255) NOT NULL', id: 'INTEGER NOT NULL auto_increment PRIMARY KEY'});
       });
 
       it('handles extended attributes (primaryKey)', function() {
-        var User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: {type: DataTypes.STRING, primaryKey: true}
         }, { timestamps: false });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.attributes)).to.deep.equal({username: 'VARCHAR(255) PRIMARY KEY'});
       });
 
       it('adds timestamps', function() {
-        var User1 = this.sequelize.define('User' + config.rand(), {});
-        var User2 = this.sequelize.define('User' + config.rand(), {}, { timestamps: true });
+        const User1 = this.sequelize.define(`User${config.rand()}`, {});
+        const User2 = this.sequelize.define(`User${config.rand()}`, {}, { timestamps: true });
 
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User1.attributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', updatedAt: 'DATETIME NOT NULL', createdAt: 'DATETIME NOT NULL'});
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User2.attributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', updatedAt: 'DATETIME NOT NULL', createdAt: 'DATETIME NOT NULL'});
       });
 
       it('adds deletedAt if paranoid', function() {
-        var User = this.sequelize.define('User' + config.rand(), {}, { paranoid: true });
+        const User = this.sequelize.define(`User${config.rand()}`, {}, { paranoid: true });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.attributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', deletedAt: 'DATETIME', updatedAt: 'DATETIME NOT NULL', createdAt: 'DATETIME NOT NULL'});
       });
 
       it('underscores timestamps if underscored', function() {
-        var User = this.sequelize.define('User' + config.rand(), {}, { paranoid: true, underscored: true });
+        const User = this.sequelize.define(`User${config.rand()}`, {}, { paranoid: true, underscored: true });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.attributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', deleted_at: 'DATETIME', updated_at: 'DATETIME NOT NULL', created_at: 'DATETIME NOT NULL'});
       });
 
       it('omits text fields with defaultValues', function() {
-        var User = this.sequelize.define('User' + config.rand(), {name: {type: DataTypes.TEXT, defaultValue: 'helloworld'}});
+        const User = this.sequelize.define(`User${config.rand()}`, {name: {type: DataTypes.TEXT, defaultValue: 'helloworld'}});
         expect(User.attributes.name.type.toString()).to.equal('TEXT');
       });
 
       it('omits blobs fields with defaultValues', function() {
-        var User = this.sequelize.define('User' + config.rand(), {name: {type: DataTypes.STRING.BINARY, defaultValue: 'helloworld'}});
+        const User = this.sequelize.define(`User${config.rand()}`, {name: {type: DataTypes.STRING.BINARY, defaultValue: 'helloworld'}});
         expect(User.attributes.name.type.toString()).to.equal('VARCHAR(255) BINARY');
       });
     });
 
-    describe('primaryKeys', function() {
+    describe('primaryKeys', () => {
       it('determines the correct primaryKeys', function() {
-        var User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           foo: {type: DataTypes.STRING, primaryKey: true},
           bar: DataTypes.STRING
         });

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -1,20 +1,19 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , config = require(__dirname + '/../../../config/config')
-  , DataTypes = require(__dirname + '/../../../../lib/data-types');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
+const config = require(__dirname + '/../../../config/config');
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
 
 if (dialect.match(/^postgres/)) {
-  describe('[POSTGRES Specific] associations', function() {
-    describe('many-to-many', function() {
-      describe('where tables have the same prefix', function() {
+  describe('[POSTGRES Specific] associations', () => {
+    describe('many-to-many', () => {
+      describe('where tables have the same prefix', () => {
         it('should create a table wp_table1wp_table2s', function() {
-          var Table2 = this.sequelize.define('wp_table2', {foo: DataTypes.STRING})
-            , Table1 = this.sequelize.define('wp_table1', {foo: DataTypes.STRING});
+          const Table2 = this.sequelize.define('wp_table2', {foo: DataTypes.STRING}), Table1 = this.sequelize.define('wp_table1', {foo: DataTypes.STRING});
 
           Table1.belongsToMany(Table2, { through: 'wp_table1swp_table2s' });
           Table2.belongsToMany(Table1, { through: 'wp_table1swp_table2s' });
@@ -23,10 +22,9 @@ if (dialect.match(/^postgres/)) {
         });
       });
 
-      describe('when join table name is specified', function() {
+      describe('when join table name is specified', () => {
         beforeEach(function() {
-          var Table2 = this.sequelize.define('ms_table1', {foo: DataTypes.STRING})
-            , Table1 = this.sequelize.define('ms_table2', {foo: DataTypes.STRING});
+          const Table2 = this.sequelize.define('ms_table1', {foo: DataTypes.STRING}), Table1 = this.sequelize.define('ms_table2', {foo: DataTypes.STRING});
 
           Table1.belongsToMany(Table2, {through: 'table1_to_table2'});
           Table2.belongsToMany(Table1, {through: 'table1_to_table2'});
@@ -42,10 +40,10 @@ if (dialect.match(/^postgres/)) {
       });
     });
 
-    describe('HasMany', function() {
-      describe('addDAO / getModel', function() {
+    describe('HasMany', () => {
+      describe('addDAO / getModel', () => {
         beforeEach(function() {
-          var self = this;
+          const self = this;
 
           //prevent periods from occurring in the table name since they are used to delimit (table.column)
           this.User = this.sequelize.define('User' + config.rand(), { name: DataTypes.STRING });
@@ -56,50 +54,37 @@ if (dialect.match(/^postgres/)) {
           this.User.belongsToMany(this.Task, {as: 'Tasks', through: 'usertasks'});
           this.Task.belongsToMany(this.User, {as: 'Users', through: 'usertasks'});
 
-          var users = []
-            , tasks = [];
+          const users = [], tasks = [];
 
-          for (var i = 0; i < 5; ++i) {
+          for (let i = 0; i < 5; ++i) {
             users[users.length] = {name: 'User' + Math.random()};
           }
 
-          for (var x = 0; x < 5; ++x) {
+          for (let x = 0; x < 5; ++x) {
             tasks[tasks.length] = {name: 'Task' + Math.random()};
           }
 
-          return this.sequelize.sync({ force: true }).then(function() {
-            return self.User.bulkCreate(users).then(function() {
-              return self.Task.bulkCreate(tasks).then(function() {
-                return self.User.findAll().then(function(_users) {
-                  return self.Task.findAll().then(function(_tasks) {
-                    self.user = _users[0];
-                    self.task = _tasks[0];
-                  });
-                });
-              });
-            });
-          });
+          return this.sequelize.sync({ force: true }).then(() => self.User.bulkCreate(users).then(() => self.Task.bulkCreate(tasks).then(() => self.User.findAll().then(_users => self.Task.findAll().then(_tasks => {
+            self.user = _users[0];
+            self.task = _tasks[0];
+          })))));
         });
 
         it('should correctly add an association to the dao', function() {
-          var self = this;
+          const self = this;
 
-          return self.user.getTasks().then(function(_tasks) {
+          return self.user.getTasks().then(_tasks => {
             expect(_tasks).to.have.length(0);
-            return self.user.addTask(self.task).then(function() {
-              return self.user.getTasks().then(function(_tasks) {
-                expect(_tasks).to.have.length(1);
-              });
-            });
+            return self.user.addTask(self.task).then(() => self.user.getTasks().then(_tasks => {
+              expect(_tasks).to.have.length(1);
+            }));
           });
         });
       });
 
-      describe('removeDAO', function() {
+      describe('removeDAO', () => {
         it('should correctly remove associated objects', function() {
-          var self = this
-            , users = []
-            , tasks = [];
+          const self = this, users = [], tasks = [];
 
           //prevent periods from occurring in the table name since they are used to delimit (table.column)
           this.User = this.sequelize.define('User' + config.rand(), { name: DataTypes.STRING });
@@ -110,47 +95,33 @@ if (dialect.match(/^postgres/)) {
           this.User.belongsToMany(this.Task, {as: 'Tasks', through: 'usertasks'});
           this.Task.belongsToMany(this.User, {as: 'Users', through: 'usertasks'});
 
-          for (var i = 0; i < 5; ++i) {
+          for (let i = 0; i < 5; ++i) {
             users[users.length] = {id: i + 1, name: 'User' + Math.random()};
           }
 
-          for (var x = 0; x < 5; ++x) {
+          for (let x = 0; x < 5; ++x) {
             tasks[tasks.length] = {id: x + 1, name: 'Task' + Math.random()};
           }
 
-          return this.sequelize.sync({ force: true }).then(function() {
-            return self.User.bulkCreate(users).then(function() {
-              return self.Task.bulkCreate(tasks).then(function() {
-                return self.User.findAll().then(function(_users) {
-                  return self.Task.findAll().then(function(_tasks) {
-                    self.user = _users[0];
-                    self.task = _tasks[0];
-                    self.users = _users;
-                    self.tasks = _tasks;
+          return this.sequelize.sync({ force: true }).then(() => self.User.bulkCreate(users).then(() => self.Task.bulkCreate(tasks).then(() => self.User.findAll().then(_users => self.Task.findAll().then(_tasks => {
+            self.user = _users[0];
+            self.task = _tasks[0];
+            self.users = _users;
+            self.tasks = _tasks;
 
-                    return self.user.getTasks().then(function(__tasks) {
-                      expect(__tasks).to.have.length(0);
-                      return self.user.setTasks(self.tasks).then(function() {
-                        return self.user.getTasks().then(function(_tasks) {
-                          expect(_tasks).to.have.length(self.tasks.length);
-                          return self.user.removeTask(self.tasks[0]).then(function() {
-                            return self.user.getTasks().then(function(_tasks) {
-                              expect(_tasks).to.have.length(self.tasks.length - 1);
-                              return self.user.removeTasks([self.tasks[1], self.tasks[2]]).then(function() {
-                                return self.user.getTasks().then(function(_tasks) {
-                                  expect(_tasks).to.have.length(self.tasks.length - 3);
-                                });
-                              });
-                            });
-                          });
-                        });
-                      });
-                    });
-                  });
-                });
-              });
+            return self.user.getTasks().then(__tasks => {
+              expect(__tasks).to.have.length(0);
+              return self.user.setTasks(self.tasks).then(() => self.user.getTasks().then(_tasks => {
+                expect(_tasks).to.have.length(self.tasks.length);
+                return self.user.removeTask(self.tasks[0]).then(() => self.user.getTasks().then(_tasks => {
+                  expect(_tasks).to.have.length(self.tasks.length - 1);
+                  return self.user.removeTasks([self.tasks[1], self.tasks[2]]).then(() => self.user.getTasks().then(_tasks => {
+                    expect(_tasks).to.have.length(self.tasks.length - 3);
+                  }));
+                }));
+              }));
             });
-          });
+          })))));
         });
       });
     });

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -1,25 +1,23 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , _ = require('lodash');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const _ = require('lodash');
 
 if (dialect.match(/^postgres/)) {
-  describe('[POSTGRES] Sequelize', function() {
+  describe('[POSTGRES] Sequelize', () => {
     function checkTimezoneParsing(baseOptions) {
-      var options = _.extend({}, baseOptions, { timezone: 'Asia/Kolkata', timestamps: true });
-      var sequelize = Support.createSequelizeInstance(options);
+      const options = _.extend({}, baseOptions, { timezone: 'Asia/Kolkata', timestamps: true });
+      const sequelize = Support.createSequelizeInstance(options);
 
-      var tzTable = sequelize.define('tz_table', { foo: DataTypes.STRING });
-      return tzTable.sync({force: true}).then(function() {
-        return tzTable.create({foo: 'test'}).then(function(row) {
-          expect(row).to.be.not.null;
-        });
-      });
+      const tzTable = sequelize.define('tz_table', { foo: DataTypes.STRING });
+      return tzTable.sync({force: true}).then(() => tzTable.create({foo: 'test'}).then(row => {
+        expect(row).to.be.not.null;
+      }));
     }
 
     it('should correctly parse the moment based timezone', function() {

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -2,15 +2,15 @@
 
 /* jshint -W030 */
 /* jshint -W110 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , sequelize = require(__dirname + '/../../../../lib/sequelize');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const sequelize = require(__dirname + '/../../../../lib/sequelize');
 
 if (dialect.match(/^postgres/)) {
-  describe('[POSTGRES Specific] DAO', function() {
+  describe('[POSTGRES Specific] DAO', () => {
     beforeEach(function() {
       this.sequelize.options.quoteIdentifiers = true;
       this.User = this.sequelize.define('User', {
@@ -47,7 +47,7 @@ if (dialect.match(/^postgres/)) {
           email: ['hello', 'world']
         },
         attributes: ['id','username','email','settings','document','phones','emergency_contact','friends'],
-        logging: function (sql) {
+        logging(sql) {
           expect(sql).to.equal('Executing (default): SELECT "id", "username", "email", "settings", "document", "phones", "emergency_contact", "friends" FROM "Users" AS "User" WHERE "User"."email" = ARRAY[\'hello\',\'world\']::TEXT[];');
         }
       });
@@ -60,7 +60,7 @@ if (dialect.match(/^postgres/)) {
         friends: [{
           name: 'John Smith'
         }]
-      }).then(function(userInstance){
+      }).then(userInstance => {
         expect(userInstance.friends).to.have.length(1);
         expect(userInstance.friends[0].name).to.equal('John Smith');
 
@@ -71,30 +71,28 @@ if (dialect.match(/^postgres/)) {
         });
       })
       .get('friends')
-      .tap(function(friends){
+      .tap(friends => {
         expect(friends).to.have.length(1);
         expect(friends[0].name).to.equal('John Smythe');
       });
     });
 
     it('should be able to find a record while searching in an array', function() {
-      var self = this;
+      const self = this;
       return this.User.bulkCreate([
         {username: 'bob', email: ['myemail@email.com']},
         {username: 'tony', email: ['wrongemail@email.com']}
-      ]).then(function() {
-        return self.User.findAll({where: {email: ['myemail@email.com']}}).then(function(user) {
-          expect(user).to.be.instanceof(Array);
-          expect(user).to.have.length(1);
-          expect(user[0].username).to.equal('bob');
-        });
-      });
+      ]).then(() => self.User.findAll({where: {email: ['myemail@email.com']}}).then(user => {
+        expect(user).to.be.instanceof(Array);
+        expect(user).to.have.length(1);
+        expect(user[0].username).to.equal('bob');
+      }));
     });
 
-    describe('json', function() {
+    describe('json', () => {
       it('should tell me that a column is json', function() {
         return this.sequelize.queryInterface.describeTable('Users')
-          .then(function(table) {
+          .then(table => {
             expect(table.emergency_contact.type).to.equal('JSON');
           });
       });
@@ -105,195 +103,175 @@ if (dialect.match(/^postgres/)) {
           emergency_contact: { name: 'joe', phones: [1337, 42] }
         }, {
           fields: ['id', 'username', 'document', 'emergency_contact'],
-          logging: function(sql) {
-            var expected = '\'{"name":"joe","phones":[1337,42]}\'';
+          logging(sql) {
+            const expected = '\'{"name":"joe","phones":[1337,42]}\'';
             expect(sql.indexOf(expected)).not.to.equal(-1);
           }
         });
       });
 
       it('should insert json using a custom field name', function() {
-        var self = this;
+        const self = this;
 
         this.UserFields = this.sequelize.define('UserFields', {
           emergencyContact: { type: DataTypes.JSON, field: 'emergy_contact' }
         });
-        return this.UserFields.sync({ force: true }).then(function() {
-          return self.UserFields.create({
-            emergencyContact: { name: 'joe', phones: [1337, 42] }
-          }).then(function(user) {
-            expect(user.emergencyContact.name).to.equal('joe');
-          });
-        });
+        return this.UserFields.sync({ force: true }).then(() => self.UserFields.create({
+          emergencyContact: { name: 'joe', phones: [1337, 42] }
+        }).then(user => {
+          expect(user.emergencyContact.name).to.equal('joe');
+        }));
       });
 
       it('should update json using a custom field name', function() {
-        var self = this;
+        const self = this;
 
         this.UserFields = this.sequelize.define('UserFields', {
           emergencyContact: { type: DataTypes.JSON, field: 'emergy_contact' }
         });
-        return this.UserFields.sync({ force: true }).then(function() {
-          return self.UserFields.create({
-            emergencyContact: { name: 'joe', phones: [1337, 42] }
-          }).then(function(user) {
-            user.emergencyContact = { name: 'larry' };
-            return user.save();
-          }).then(function(user) {
-            expect(user.emergencyContact.name).to.equal('larry');
-          });
-        });
+        return this.UserFields.sync({ force: true }).then(() => self.UserFields.create({
+          emergencyContact: { name: 'joe', phones: [1337, 42] }
+        }).then(user => {
+          user.emergencyContact = { name: 'larry' };
+          return user.save();
+        }).then(user => {
+          expect(user.emergencyContact.name).to.equal('larry');
+        }));
       });
 
       it('should be able retrieve json value as object', function() {
-        var self = this;
-        var emergencyContact = { name: 'kate', phone: 1337 };
+        const self = this;
+        const emergencyContact = { name: 'kate', phone: 1337 };
 
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
-          .then(function(user) {
+          .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact); // .eql does deep value comparison instead of
                                                                      // strict equal comparison
             return self.User.find({ where: { username: 'swen' }, attributes: ['emergency_contact'] });
           })
-          .then(function(user) {
+          .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
           });
       });
 
       it('should be able to retrieve element of array by index', function() {
-        var self = this;
-        var emergencyContact = { name: 'kate', phones: [1337, 42] };
+        const self = this;
+        const emergencyContact = { name: 'kate', phones: [1337, 42] };
 
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
-          .then(function(user) {
+          .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
             return self.User.find({ where: { username: 'swen' }, attributes: [[sequelize.json('emergency_contact.phones.1'), 'firstEmergencyNumber']] });
           })
-          .then(function(user) {
+          .then(user => {
             expect(parseInt(user.getDataValue('firstEmergencyNumber'))).to.equal(42);
           });
       });
 
       it('should be able to retrieve root level value of an object by key', function() {
-        var self = this;
-        var emergencyContact = { kate: 1337 };
+        const self = this;
+        const emergencyContact = { kate: 1337 };
 
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
-          .then(function(user) {
+          .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
             return self.User.find({ where: { username: 'swen' }, attributes: [[sequelize.json('emergency_contact.kate'), 'katesNumber']] });
           })
-          .then(function(user) {
+          .then(user => {
             expect(parseInt(user.getDataValue('katesNumber'))).to.equal(1337);
           });
       });
 
       it('should be able to retrieve nested value of an object by path', function() {
-        var self = this;
-        var emergencyContact = { kate: { email: 'kate@kate.com', phones: [1337, 42] } };
+        const self = this;
+        const emergencyContact = { kate: { email: 'kate@kate.com', phones: [1337, 42] } };
 
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
-          .then(function(user) {
+          .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
             return self.User.find({ where: { username: 'swen' }, attributes: [[sequelize.json('emergency_contact.kate.email'), 'katesEmail']] });
           })
-          .then(function(user) {
+          .then(user => {
             expect(user.getDataValue('katesEmail')).to.equal('kate@kate.com');
           })
-          .then(function() {
-            return self.User.find({ where: { username: 'swen' }, attributes: [[sequelize.json('emergency_contact.kate.phones.1'), 'katesFirstPhone']] });
-          })
-          .then(function(user) {
+          .then(() => self.User.find({ where: { username: 'swen' }, attributes: [[sequelize.json('emergency_contact.kate.phones.1'), 'katesFirstPhone']] }))
+          .then(user => {
             expect(parseInt(user.getDataValue('katesFirstPhone'))).to.equal(42);
           });
       });
 
       it('should be able to retrieve a row based on the values of the json document', function() {
-        var self = this;
+        const self = this;
 
         return this.sequelize.Promise.all([
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })])
-          .then(function() {
-            return self.User.find({ where: sequelize.json("emergency_contact->>'name'", 'kate'), attributes: ['username', 'emergency_contact'] });
-          })
-          .then(function(user) {
+          .then(() => self.User.find({ where: sequelize.json("emergency_contact->>'name'", 'kate'), attributes: ['username', 'emergency_contact'] }))
+          .then(user => {
             expect(user.emergency_contact.name).to.equal('kate');
           });
       });
 
       it('should be able to query using the nested query language', function() {
-        var self = this;
+        const self = this;
 
         return this.sequelize.Promise.all([
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })])
-          .then(function() {
-            return self.User.find({
-              where: sequelize.json({ emergency_contact: { name: 'kate' } })
-            });
-          })
-          .then(function(user) {
+          .then(() => self.User.find({
+          where: sequelize.json({ emergency_contact: { name: 'kate' } })
+        }))
+          .then(user => {
             expect(user.emergency_contact.name).to.equal('kate');
           });
       });
 
       it('should be able to query using dot syntax', function() {
-        var self = this;
+        const self = this;
 
         return this.sequelize.Promise.all([
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })])
-          .then(function() {
-            return self.User.find({ where: sequelize.json('emergency_contact.name', 'joe') });
-          })
-          .then(function(user) {
+          .then(() => self.User.find({ where: sequelize.json('emergency_contact.name', 'joe') }))
+          .then(user => {
             expect(user.emergency_contact.name).to.equal('joe');
           });
       });
 
       it('should be able to store values that require JSON escaping', function() {
-        var self = this;
-        var text = "Multi-line '$string' needing \"escaping\" for $$ and $1 type values";
+        const self = this;
+        const text = "Multi-line '$string' needing \"escaping\" for $$ and $1 type values";
 
         return this.User.create({ username: 'swen', emergency_contact: { value: text } })
-          .then(function(user) {
+          .then(user => {
             expect(user.isNewRecord).to.equal(false);
           })
-          .then(function() {
-            return self.User.find({ where: { username: 'swen' } });
-          })
-          .then(function() {
-            return self.User.find({ where: sequelize.json('emergency_contact.value', text) });
-          })
-          .then(function(user) {
+          .then(() => self.User.find({ where: { username: 'swen' } }))
+          .then(() => self.User.find({ where: sequelize.json('emergency_contact.value', text) }))
+          .then(user => {
             expect(user.username).to.equal('swen');
           });
       });
 
       it('should be able to findOrCreate with values that require JSON escaping', function() {
-        var self = this;
-        var text = "Multi-line '$string' needing \"escaping\" for $$ and $1 type values";
+        const self = this;
+        const text = "Multi-line '$string' needing \"escaping\" for $$ and $1 type values";
 
         return this.User.findOrCreate({ where: { username: 'swen' }, defaults: { emergency_contact: { value: text } } })
-          .then(function(user) {
+          .then(user => {
             expect(!user.isNewRecord).to.equal(true);
           })
-          .then(function() {
-            return self.User.find({ where: { username: 'swen' } });
-          })
-          .then(function() {
-            return self.User.find({ where: sequelize.json('emergency_contact.value', text) });
-          })
-          .then(function(user) {
+          .then(() => self.User.find({ where: { username: 'swen' } }))
+          .then(() => self.User.find({ where: sequelize.json('emergency_contact.value', text) }))
+          .then(user => {
             expect(user.username).to.equal('swen');
           });
       });
     });
 
-    describe('hstore', function() {
+    describe('hstore', () => {
       it('should tell me that a column is hstore and not USER-DEFINED', function() {
-        return this.sequelize.queryInterface.describeTable('Users').then(function(table) {
+        return this.sequelize.queryInterface.describeTable('Users').then(table => {
           expect(table.settings.type).to.equal('HSTORE');
           expect(table.document.type).to.equal('HSTORE');
         });
@@ -305,8 +283,8 @@ if (dialect.match(/^postgres/)) {
           email: ['myemail@email.com'],
           settings: {mailing: false, push: 'facebook', frequency: 3}
         }, {
-          logging: function (sql) {
-            var expected = '\'"mailing"=>"false","push"=>"facebook","frequency"=>"3"\',\'"default"=>"\'\'value\'\'"\'';
+          logging(sql) {
+            const expected = '\'"mailing"=>"false","push"=>"facebook","frequency"=>"3"\',\'"default"=>"\'\'value\'\'"\'';
             expect(sql.indexOf(expected)).not.to.equal(-1);
           }
         });
@@ -314,9 +292,9 @@ if (dialect.match(/^postgres/)) {
 
     });
 
-    describe('range', function() {
+    describe('range', () => {
       it('should tell me that a column is range and not USER-DEFINED', function() {
-        return this.sequelize.queryInterface.describeTable('Users').then(function(table) {
+        return this.sequelize.queryInterface.describeTable('Users').then(table => {
           expect(table.course_period.type).to.equal('TSTZRANGE');
           expect(table.available_amount.type).to.equal('INT4RANGE');
         });
@@ -324,29 +302,25 @@ if (dialect.match(/^postgres/)) {
 
     });
 
-    describe('enums', function() {
+    describe('enums', () => {
       it('should be able to ignore enum types that already exist', function() {
-        var User = this.sequelize.define('UserEnums', {
+        const User = this.sequelize.define('UserEnums', {
           mood: DataTypes.ENUM('happy', 'sad', 'meh')
         });
 
-        return User.sync({ force: true }).then(function() {
-          return User.sync();
-        });
+        return User.sync({ force: true }).then(() => User.sync());
       });
 
       it('should be able to create/drop enums multiple times', function() {
-        var User = this.sequelize.define('UserEnums', {
+        const User = this.sequelize.define('UserEnums', {
           mood: DataTypes.ENUM('happy', 'sad', 'meh')
         });
 
-        return User.sync({ force: true }).then(function() {
-          return User.sync({ force: true });
-        });
+        return User.sync({ force: true }).then(() => User.sync({ force: true }));
       });
 
       it('should be able to create/drop multiple enums multiple times', function() {
-        var DummyModel = this.sequelize.define('Dummy-pg', {
+        const DummyModel = this.sequelize.define('Dummy-pg', {
           username: DataTypes.STRING,
           theEnumOne: {
             type: DataTypes.ENUM,
@@ -366,17 +340,11 @@ if (dialect.match(/^postgres/)) {
           }
         });
 
-        return DummyModel.sync({ force: true }).then(function() {
-          // now sync one more time:
-          return DummyModel.sync({force: true}).then(function() {
-            // sync without dropping
-            return DummyModel.sync();
-          });
-        });
+        return DummyModel.sync({ force: true }).then(() => DummyModel.sync({force: true}).then(() => DummyModel.sync()));
       });
 
       it('should be able to add values to enum types', function() {
-        var User = this.sequelize.define('UserEnums', {
+        let User = this.sequelize.define('UserEnums', {
             mood: DataTypes.ENUM('happy', 'sad', 'meh')
           });
 
@@ -388,15 +356,15 @@ if (dialect.match(/^postgres/)) {
           return User.sync();
         }).then(function() {
           return this.sequelize.getQueryInterface().pgListEnums(User.getTableName());
-        }).then(function (enums) {
+        }).then(enums => {
           expect(enums).to.have.length(1);
           expect(enums[0].enum_value).to.equal("{neutral,happy,sad,ecstatic,meh,joyful}");
         });
       });
     });
 
-    describe('integers', function() {
-      describe('integer', function() {
+    describe('integers', () => {
+      describe('integer', () => {
         beforeEach(function() {
           this.User = this.sequelize.define('User', {
             aNumber: DataTypes.INTEGER
@@ -406,29 +374,29 @@ if (dialect.match(/^postgres/)) {
         });
 
         it('positive', function() {
-          var User = this.User;
+          const User = this.User;
 
-          return User.create({aNumber: 2147483647}).then(function(user) {
+          return User.create({aNumber: 2147483647}).then(user => {
             expect(user.aNumber).to.equal(2147483647);
-            return User.find({where: {aNumber: 2147483647}}).then(function(_user) {
+            return User.find({where: {aNumber: 2147483647}}).then(_user => {
               expect(_user.aNumber).to.equal(2147483647);
             });
           });
         });
 
         it('negative', function() {
-          var User = this.User;
+          const User = this.User;
 
-          return User.create({aNumber: -2147483647}).then(function(user) {
+          return User.create({aNumber: -2147483647}).then(user => {
             expect(user.aNumber).to.equal(-2147483647);
-            return User.find({where: {aNumber: -2147483647}}).then(function(_user) {
+            return User.find({where: {aNumber: -2147483647}}).then(_user => {
               expect(_user.aNumber).to.equal(-2147483647);
             });
           });
         });
       });
 
-      describe('bigint', function() {
+      describe('bigint', () => {
         beforeEach(function() {
           this.User = this.sequelize.define('User', {
             aNumber: DataTypes.BIGINT
@@ -438,22 +406,22 @@ if (dialect.match(/^postgres/)) {
         });
 
         it('positive', function() {
-          var User = this.User;
+          const User = this.User;
 
-          return User.create({aNumber: '9223372036854775807'}).then(function(user) {
+          return User.create({aNumber: '9223372036854775807'}).then(user => {
             expect(user.aNumber).to.equal('9223372036854775807');
-            return User.find({where: {aNumber: '9223372036854775807'}}).then(function(_user) {
+            return User.find({where: {aNumber: '9223372036854775807'}}).then(_user => {
               expect(_user.aNumber).to.equal('9223372036854775807');
             });
           });
         });
 
         it('negative', function() {
-          var User = this.User;
+          const User = this.User;
 
-          return User.create({aNumber: '-9223372036854775807'}).then(function(user) {
+          return User.create({aNumber: '-9223372036854775807'}).then(user => {
             expect(user.aNumber).to.equal('-9223372036854775807');
-            return User.find({where: {aNumber: '-9223372036854775807'}}).then(function(_user) {
+            return User.find({where: {aNumber: '-9223372036854775807'}}).then(_user => {
               expect(_user.aNumber).to.equal('-9223372036854775807');
             });
           });
@@ -461,7 +429,7 @@ if (dialect.match(/^postgres/)) {
       });
     });
 
-    describe('timestamps', function() {
+    describe('timestamps', () => {
       beforeEach(function() {
         this.User = this.sequelize.define('User', {
           dates: DataTypes.ARRAY(DataTypes.DATE)
@@ -473,30 +441,30 @@ if (dialect.match(/^postgres/)) {
         return this.User.create({
           dates: []
         }, {
-          logging: function(sql) {
+          logging(sql) {
             expect(sql.indexOf('TIMESTAMP WITH TIME ZONE')).to.be.greaterThan(0);
           }
         });
       });
     });
 
-    describe('model', function() {
+    describe('model', () => {
       it('create handles array correctly', function() {
         return this.User
           .create({ username: 'user', email: ['foo@bar.com', 'bar@baz.com'] })
-          .then(function(oldUser) {
+          .then(oldUser => {
             expect(oldUser.email).to.contain.members(['foo@bar.com', 'bar@baz.com']);
           });
       });
 
       it('should save hstore correctly', function() {
-        return this.User.create({ username: 'user', email: ['foo@bar.com'], settings: { created: '"value"' }}).then(function(newUser) {
+        return this.User.create({ username: 'user', email: ['foo@bar.com'], settings: { created: '"value"' }}).then(newUser => {
           // Check to see if the default value for an hstore field works
           expect(newUser.document).to.deep.equal({ default: "'value'" });
           expect(newUser.settings).to.deep.equal({ created: '"value"' });
 
           // Check to see if updating an hstore field works
-          return newUser.updateAttributes({settings: {should: 'update', to: 'this', first: 'place'}}).then(function(oldUser) {
+          return newUser.updateAttributes({settings: {should: 'update', to: 'this', first: 'place'}}).then(oldUser => {
             // Postgres always returns keys in alphabetical order (ascending)
             expect(oldUser.settings).to.deep.equal({first: 'place', should: 'update', to: 'this'});
           });
@@ -504,135 +472,108 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should save hstore array correctly', function() {
-        var User = this.User;
+        const User = this.User;
 
         return this.User.create({
           username: 'bob',
           email: ['myemail@email.com'],
           phones: [{ number: '123456789', type: 'mobile' }, { number: '987654321', type: 'landline' }, { number: '8675309', type: "Jenny's"}, {number: '5555554321', type: '"home\n"' }]
-        }).then(function() {
-          return User.findById(1).then(function(user) {
-            expect(user.phones.length).to.equal(4);
-            expect(user.phones[1].number).to.equal('987654321');
-            expect(user.phones[2].type).to.equal("Jenny's");
-            expect(user.phones[3].type).to.equal('"home\n"');
-          });
-        });
+        }).then(() => User.findById(1).then(user => {
+          expect(user.phones.length).to.equal(4);
+          expect(user.phones[1].number).to.equal('987654321');
+          expect(user.phones[2].type).to.equal("Jenny's");
+          expect(user.phones[3].type).to.equal('"home\n"');
+        }));
       });
 
       it('should bulkCreate with hstore property', function() {
-        var User = this.User;
+        const User = this.User;
 
         return this.User.bulkCreate([{
           username: 'bob',
           email: ['myemail@email.com'],
           settings: {mailing: true, push: 'facebook', frequency: 3}
-        }]).then(function() {
-          return User.findById(1).then(function(user) {
-            expect(user.settings.mailing).to.equal('true');
-          });
-        });
+        }]).then(() => User.findById(1).then(user => {
+          expect(user.settings.mailing).to.equal('true');
+        }));
       });
 
       it('should update hstore correctly', function() {
-        var self = this;
+        const self = this;
 
-        return this.User.create({ username: 'user', email: ['foo@bar.com'], settings: { test: '"value"' }}).then(function(newUser) {
+        return this.User.create({ username: 'user', email: ['foo@bar.com'], settings: { test: '"value"' }}).then(newUser => {
             // Check to see if the default value for an hstore field works
             expect(newUser.document).to.deep.equal({ default: "'value'" });
             expect(newUser.settings).to.deep.equal({ test: '"value"' });
 
             // Check to see if updating an hstore field works
-            return self.User.update({ settings: { should: 'update', to: 'this', first: 'place' }}, { where: newUser.where() }).then(function() {
-              return newUser.reload().then(function() {
-                // Postgres always returns keys in alphabetical order (ascending)
-                expect(newUser.settings).to.deep.equal({ first: 'place', should: 'update', to: 'this' });
-              });
-            });
+            return self.User.update({ settings: { should: 'update', to: 'this', first: 'place' }}, { where: newUser.where() }).then(() => newUser.reload().then(() => {
+              // Postgres always returns keys in alphabetical order (ascending)
+              expect(newUser.settings).to.deep.equal({ first: 'place', should: 'update', to: 'this' });
+            }));
           });
       });
 
       it('should update hstore correctly and return the affected rows', function() {
-        var self = this;
+        const self = this;
 
-        return this.User.create({ username: 'user', email: ['foo@bar.com'], settings: { test: '"value"' }}).then(function(oldUser) {
-            // Update the user and check that the returned object's fields have been parsed by the hstore library
-            return self.User.update({ settings: { should: 'update', to: 'this', first: 'place' }}, { where: oldUser.where(), returning: true }).spread(function(count, users) {
-              expect(count).to.equal(1);
-              expect(users[0].settings).to.deep.equal({ should: 'update', to: 'this', first: 'place' });
-            });
-          });
+        return this.User.create({ username: 'user', email: ['foo@bar.com'], settings: { test: '"value"' }}).then(oldUser => self.User.update({ settings: { should: 'update', to: 'this', first: 'place' }}, { where: oldUser.where(), returning: true }).spread((count, users) => {
+          expect(count).to.equal(1);
+          expect(users[0].settings).to.deep.equal({ should: 'update', to: 'this', first: 'place' });
+        }));
       });
 
       it('should read hstore correctly', function() {
-        var self = this;
-        var data = { username: 'user', email: ['foo@bar.com'], settings: { test: '"value"' }};
+        const self = this;
+        const data = { username: 'user', email: ['foo@bar.com'], settings: { test: '"value"' }};
 
         return this.User.create(data)
-          .then(function() {
-            return self.User.find({ where: { username: 'user' }});
-          })
-          .then(function(user) {
+          .then(() => self.User.find({ where: { username: 'user' }}))
+          .then(user => {
             // Check that the hstore fields are the same when retrieving the user
             expect(user.settings).to.deep.equal(data.settings);
           });
       });
 
       it('should read an hstore array correctly', function() {
-        var self = this;
-        var data = { username: 'user', email: ['foo@bar.com'], phones: [{ number: '123456789', type: 'mobile' }, { number: '987654321', type: 'landline' }] };
+        const self = this;
+        const data = { username: 'user', email: ['foo@bar.com'], phones: [{ number: '123456789', type: 'mobile' }, { number: '987654321', type: 'landline' }] };
 
         return this.User.create(data)
-          .then(function() {
-            // Check that the hstore fields are the same when retrieving the user
-            return self.User.find({ where: { username: 'user' }});
-          }).then(function(user) {
+          .then(() => self.User.find({ where: { username: 'user' }})).then(user => {
             expect(user.phones).to.deep.equal(data.phones);
           });
       });
 
       it('should read hstore correctly from multiple rows', function() {
-        var self = this;
+        const self = this;
 
         return self.User
           .create({ username: 'user1', email: ['foo@bar.com'], settings: { test: '"value"' }})
-          .then(function() {
-            return self.User.create({ username: 'user2', email: ['foo2@bar.com'], settings: { another: '"example"' }});
-          })
-          .then(function() {
-            // Check that the hstore fields are the same when retrieving the user
-            return self.User.findAll({ order: 'username' });
-          })
-          .then(function(users) {
+          .then(() => self.User.create({ username: 'user2', email: ['foo2@bar.com'], settings: { another: '"example"' }}))
+          .then(() => self.User.findAll({ order: 'username' }))
+          .then(users => {
             expect(users[0].settings).to.deep.equal({ test: '"value"' });
             expect(users[1].settings).to.deep.equal({ another: '"example"' });
           });
       });
 
       it('should read hstore correctly from included models as well', function() {
-        var self = this,
-          HstoreSubmodel = self.sequelize.define('hstoreSubmodel', {
-            someValue: DataTypes.HSTORE
-          }),
-          submodelValue = { testing: '"hstore"' };
+        const self = this,
+              HstoreSubmodel = self.sequelize.define('hstoreSubmodel', {
+                someValue: DataTypes.HSTORE
+              }),
+              submodelValue = { testing: '"hstore"' };
 
         self.User.hasMany(HstoreSubmodel);
 
         return self.sequelize
           .sync({ force: true })
-          .then(function() {
-            return self.User.create({ username: 'user1' })
-              .then(function (user) {
-                return HstoreSubmodel.create({ someValue: submodelValue})
-                  .then(function (submodel) {
-                    return user.setHstoreSubmodels([submodel]);
-                  });
-              });
-          })
-          .then(function() {
-            return self.User.find({ where: { username: 'user1' }, include: [HstoreSubmodel]});
-          })
-          .then(function(user) {
+          .then(() => self.User.create({ username: 'user1' })
+          .then(user => HstoreSubmodel.create({ someValue: submodelValue})
+          .then(submodel => user.setHstoreSubmodels([submodel]))))
+          .then(() => self.User.find({ where: { username: 'user1' }, include: [HstoreSubmodel]}))
+          .then(user => {
             expect(user.hasOwnProperty('hstoreSubmodels')).to.be.ok;
             expect(user.hstoreSubmodels.length).to.equal(1);
             expect(user.hstoreSubmodels[0].someValue).to.deep.equal(submodelValue);
@@ -640,8 +581,8 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should save range correctly', function() {
-        var period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
-        return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: period}).then(function(newUser) {
+        const period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
+        return this.User.create({ username: 'user', email: ['foo@bar.com'], course_period: period}).then(newUser => {
           // Check to see if the default value for a range field works
 
           expect(newUser.acceptable_marks.length).to.equal(2);
@@ -655,7 +596,7 @@ if (dialect.match(/^postgres/)) {
           expect(newUser.course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
 
           // Check to see if updating a range field works
-          return newUser.updateAttributes({acceptable_marks: [0.8, 0.9]}).then(function() {
+          return newUser.updateAttributes({acceptable_marks: [0.8, 0.9]}).then(() => {
             expect(newUser.acceptable_marks.length).to.equal(2);
             expect(newUser.acceptable_marks[0]).to.equal(0.8); // lower bound
             expect(newUser.acceptable_marks[1]).to.equal(0.9); // upper bound
@@ -664,57 +605,52 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should save range array correctly', function() {
-        var User = this.User,
-          holidays = [
-            [new Date(2015, 3, 1), new Date(2015, 3, 15)],
-            [new Date(2015, 8, 1), new Date(2015, 9, 15)]
-          ];
+        const User = this.User,
+              holidays = [
+                [new Date(2015, 3, 1), new Date(2015, 3, 15)],
+                [new Date(2015, 8, 1), new Date(2015, 9, 15)]
+              ];
 
         return User.create({
           username: 'bob',
           email: ['myemail@email.com'],
-          holidays: holidays
-        }).then(function() {
-          return User.findById(1).then(function(user) {
-            expect(user.holidays.length).to.equal(2);
-            expect(user.holidays[0].length).to.equal(2);
-            expect(user.holidays[0][0] instanceof Date).to.be.ok;
-            expect(user.holidays[0][1] instanceof Date).to.be.ok;
-            expect(user.holidays[0][0]).to.equalTime(holidays[0][0]);
-            expect(user.holidays[0][1]).to.equalTime(holidays[0][1]);
-            expect(user.holidays[1].length).to.equal(2);
-            expect(user.holidays[1][0] instanceof Date).to.be.ok;
-            expect(user.holidays[1][1] instanceof Date).to.be.ok;
-            expect(user.holidays[1][0]).to.equalTime(holidays[1][0]);
-            expect(user.holidays[1][1]).to.equalTime(holidays[1][1]);
-          });
-        });
+          holidays
+        }).then(() => User.findById(1).then(user => {
+          expect(user.holidays.length).to.equal(2);
+          expect(user.holidays[0].length).to.equal(2);
+          expect(user.holidays[0][0] instanceof Date).to.be.ok;
+          expect(user.holidays[0][1] instanceof Date).to.be.ok;
+          expect(user.holidays[0][0]).to.equalTime(holidays[0][0]);
+          expect(user.holidays[0][1]).to.equalTime(holidays[0][1]);
+          expect(user.holidays[1].length).to.equal(2);
+          expect(user.holidays[1][0] instanceof Date).to.be.ok;
+          expect(user.holidays[1][1] instanceof Date).to.be.ok;
+          expect(user.holidays[1][0]).to.equalTime(holidays[1][0]);
+          expect(user.holidays[1][1]).to.equalTime(holidays[1][1]);
+        }));
       });
 
       it('should bulkCreate with range property', function() {
-        var User = this.User,
-            period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
+        const User = this.User, period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
 
         return User.bulkCreate([{
           username: 'bob',
           email: ['myemail@email.com'],
           course_period: period
-        }]).then(function() {
-          return User.findById(1).then(function(user) {
-            expect(user.course_period[0] instanceof Date).to.be.ok;
-            expect(user.course_period[1] instanceof Date).to.be.ok;
-            expect(user.course_period[0]).to.equalTime(period[0]); // lower bound
-            expect(user.course_period[1]).to.equalTime(period[1]); // upper bound
-            expect(user.course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
-          });
-        });
+        }]).then(() => User.findById(1).then(user => {
+          expect(user.course_period[0] instanceof Date).to.be.ok;
+          expect(user.course_period[1] instanceof Date).to.be.ok;
+          expect(user.course_period[0]).to.equalTime(period[0]); // lower bound
+          expect(user.course_period[1]).to.equalTime(period[1]); // upper bound
+          expect(user.course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
+        }));
       });
 
       it('should update range correctly', function() {
-        var User = this.User
-          , period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
+        const User = this.User;
+        let period = [new Date(2015, 0, 1), new Date(2015, 11, 31)];
 
-        return User.create({ username: 'user', email: ['foo@bar.com'], course_period: period }).then(function(newUser) {
+        return User.create({ username: 'user', email: ['foo@bar.com'], course_period: period }).then(newUser => {
           // Check to see if the default value for a range field works
           expect(newUser.acceptable_marks.length).to.equal(2);
           expect(newUser.acceptable_marks[0]).to.equal('0.65'); // lower bound
@@ -729,96 +665,80 @@ if (dialect.match(/^postgres/)) {
           period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
 
           // Check to see if updating a range field works
-          return User.update({course_period: period}, {where: newUser.where()}).then(function() {
-            return newUser.reload().then(function() {
-              expect(newUser.course_period[0] instanceof Date).to.be.ok;
-              expect(newUser.course_period[1] instanceof Date).to.be.ok;
-              expect(newUser.course_period[0]).to.equalTime(period[0]); // lower bound
-              expect(newUser.course_period[1]).to.equalTime(period[1]); // upper bound
-              expect(newUser.course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
-            });
-          });
+          return User.update({course_period: period}, {where: newUser.where()}).then(() => newUser.reload().then(() => {
+            expect(newUser.course_period[0] instanceof Date).to.be.ok;
+            expect(newUser.course_period[1] instanceof Date).to.be.ok;
+            expect(newUser.course_period[0]).to.equalTime(period[0]); // lower bound
+            expect(newUser.course_period[1]).to.equalTime(period[1]); // upper bound
+            expect(newUser.course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
+          }));
         });
       });
 
       it('should update range correctly and return the affected rows', function () {
-        var User = this.User
-          , period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
+        const User = this.User, period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
 
         return User.create({
           username:      'user',
           email:         ['foo@bar.com'],
           course_period: [new Date(2015, 0, 1), new Date(2015, 11, 31)]
-        }).then(function (oldUser) {
-            // Update the user and check that the returned object's fields have been parsed by the range parser
-            return User.update({ course_period: period }, { where: oldUser.where(), returning: true })
-              .spread(function (count, users) {
-                expect(count).to.equal(1);
-                expect(users[0].course_period[0] instanceof Date).to.be.ok;
-                expect(users[0].course_period[1] instanceof Date).to.be.ok;
-                expect(users[0].course_period[0]).to.equalTime(period[0]); // lower bound
-                expect(users[0].course_period[1]).to.equalTime(period[1]); // upper bound
-                expect(users[0].course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
-              });
-          });
+        }).then(oldUser => User.update({ course_period: period }, { where: oldUser.where(), returning: true })
+          .spread((count, users) => {
+            expect(count).to.equal(1);
+            expect(users[0].course_period[0] instanceof Date).to.be.ok;
+            expect(users[0].course_period[1] instanceof Date).to.be.ok;
+            expect(users[0].course_period[0]).to.equalTime(period[0]); // lower bound
+            expect(users[0].course_period[1]).to.equalTime(period[1]); // upper bound
+            expect(users[0].course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
+          }));
       });
 
       it('should read range correctly', function() {
-        var User = this.User;
+        const User = this.User;
 
-        var course_period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
+        const course_period = [new Date(2015, 1, 1), new Date(2015, 10, 30)];
         course_period.inclusive = [false, false];
 
-        var data = { username: 'user', email: ['foo@bar.com'], course_period: course_period};
+        const data = { username: 'user', email: ['foo@bar.com'], course_period};
 
         return User.create(data)
-          .then(function() {
-            return User.find({ where: { username: 'user' }});
-          })
-          .then(function(user) {
+          .then(() => User.find({ where: { username: 'user' }}))
+          .then(user => {
             // Check that the range fields are the same when retrieving the user
             expect(user.course_period).to.deep.equal(data.course_period);
           });
       });
 
       it('should read range array correctly', function() {
-        var User = this.User,
-            holidays = [
-              [new Date(2015, 3, 1, 10), new Date(2015, 3, 15)],
-              [new Date(2015, 8, 1), new Date(2015, 9, 15)]
-            ];
+        const User = this.User,
+              holidays = [
+                [new Date(2015, 3, 1, 10), new Date(2015, 3, 15)],
+                [new Date(2015, 8, 1), new Date(2015, 9, 15)]
+              ];
 
         holidays[0].inclusive = [true, true];
         holidays[1].inclusive = [true, true];
 
-        var data = { username: 'user', email: ['foo@bar.com'], holidays: holidays };
+        const data = { username: 'user', email: ['foo@bar.com'], holidays };
 
         return User.create(data)
-          .then(function() {
-            // Check that the range fields are the same when retrieving the user
-            return User.find({ where: { username: 'user' }});
-          }).then(function(user) {
+          .then(() => User.find({ where: { username: 'user' }})).then(user => {
             expect(user.holidays).to.deep.equal(data.holidays);
           });
       });
 
       it('should read range correctly from multiple rows', function() {
-        var User = this.User,
-            periods = [
-              [new Date(2015, 0, 1), new Date(2015, 11, 31)],
-              [new Date(2016, 0, 1), new Date(2016, 11, 31)]
-            ];
+        const User = this.User,
+              periods = [
+                [new Date(2015, 0, 1), new Date(2015, 11, 31)],
+                [new Date(2016, 0, 1), new Date(2016, 11, 31)]
+              ];
 
         return User
           .create({ username: 'user1', email: ['foo@bar.com'], course_period: periods[0]})
-          .then(function() {
-            return User.create({ username: 'user2', email: ['foo2@bar.com'], course_period: periods[1]});
-          })
-          .then(function() {
-            // Check that the range fields are the same when retrieving the user
-            return User.findAll({ order: 'username' });
-          })
-          .then(function(users) {
+          .then(() => User.create({ username: 'user2', email: ['foo2@bar.com'], course_period: periods[1]}))
+          .then(() => User.findAll({ order: 'username' }))
+          .then(users => {
             expect(users[0].course_period[0]).to.equalTime(periods[0][0]); // lower bound
             expect(users[0].course_period[1]).to.equalTime(periods[0][1]); // upper bound
             expect(users[0].course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
@@ -829,30 +749,22 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('should read range correctly from included models as well', function () {
-        var self = this
-          , period = [new Date(2016, 0, 1), new Date(2016, 11, 31)]
-          , HolidayDate = this.sequelize.define('holidayDate', {
-              period: DataTypes.RANGE(DataTypes.DATE)
-            });
+        const self = this,
+              period = [new Date(2016, 0, 1), new Date(2016, 11, 31)],
+              HolidayDate = this.sequelize.define('holidayDate', {
+                    period: DataTypes.RANGE(DataTypes.DATE)
+                  });
 
         self.User.hasMany(HolidayDate);
 
         return self.sequelize
           .sync({ force: true })
-          .then(function () {
-            return self.User
-              .create({ username: 'user', email: ['foo@bar.com'] })
-              .then(function (user) {
-                return HolidayDate.create({ period: period })
-                  .then(function (holidayDate) {
-                    return user.setHolidayDates([holidayDate]);
-                  });
-              });
-          })
-          .then(function () {
-            return self.User.find({ where: { username: 'user' }, include: [HolidayDate] });
-          })
-          .then(function (user) {
+          .then(() => self.User
+          .create({ username: 'user', email: ['foo@bar.com'] })
+          .then(user => HolidayDate.create({ period })
+          .then(holidayDate => user.setHolidayDates([holidayDate]))))
+          .then(() => self.User.find({ where: { username: 'user' }, include: [HolidayDate] }))
+          .then(user => {
             expect(user.hasOwnProperty('holidayDates')).to.be.ok;
             expect(user.holidayDates.length).to.equal(1);
             expect(user.holidayDates[0].period.length).to.equal(2);
@@ -863,37 +775,32 @@ if (dialect.match(/^postgres/)) {
     });
 
     it('should save geometry correctly', function() {
-      var point = { type: 'Point', coordinates: [39.807222,-76.984722] };
-      return this.User.create({ username: 'user', email: ['foo@bar.com'], location: point}).then(function(newUser) {
+      const point = { type: 'Point', coordinates: [39.807222,-76.984722] };
+      return this.User.create({ username: 'user', email: ['foo@bar.com'], location: point}).then(newUser => {
         expect(newUser.location).to.deep.eql(point);
       });
     });
 
     it('should update geometry correctly', function() {
-      var User = this.User;
-      var point1 = { type: 'Point', coordinates: [39.807222,-76.984722] }
-        , point2 = { type: 'Point', coordinates: [39.828333,-77.232222] };
-      return User.create({ username: 'user', email: ['foo@bar.com'], location: point1}).then(function(oldUser) {
-        return User.update({ location: point2 }, { where: { username: oldUser.username }, returning: true }).spread(function(count, updatedUsers) {
-          expect(updatedUsers[0].location).to.deep.eql(point2);
-        });
-      });
+      const User = this.User;
+      const point1 = { type: 'Point', coordinates: [39.807222,-76.984722] }, point2 = { type: 'Point', coordinates: [39.828333,-77.232222] };
+      return User.create({ username: 'user', email: ['foo@bar.com'], location: point1}).then(oldUser => User.update({ location: point2 }, { where: { username: oldUser.username }, returning: true }).spread((count, updatedUsers) => {
+        expect(updatedUsers[0].location).to.deep.eql(point2);
+      }));
     });
 
     it('should read geometry correctly', function() {
-      var User = this.User;
-      var point = { type: 'Point', coordinates: [39.807222,-76.984722] };
+      const User = this.User;
+      const point = { type: 'Point', coordinates: [39.807222,-76.984722] };
 
-      return User.create({ username: 'user', email: ['foo@bar.com'], location: point}).then(function(user) {
-          return User.find({ where: { username: user.username }});
-      }).then(function(user) {
+      return User.create({ username: 'user', email: ['foo@bar.com'], location: point}).then(user => User.find({ where: { username: user.username }})).then(user => {
           expect(user.location).to.deep.eql(point);
       });
     });
 
-    describe('[POSTGRES] Unquoted identifiers', function() {
+    describe('[POSTGRES] Unquoted identifiers', () => {
       it('can insert and select', function() {
-        var self = this;
+        const self = this;
         this.sequelize.options.quoteIdentifiers = false;
         this.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = false;
 
@@ -904,40 +811,38 @@ if (dialect.match(/^postgres/)) {
           quoteIdentifiers: false
         });
 
-        return this.User.sync({ force: true }).then(function() {
-          return self.User
-            .create({ username: 'user', fullName: 'John Smith' })
-            .then(function(user) {
-              // We can insert into a table with non-quoted identifiers
-              expect(user.id).to.exist;
-              expect(user.id).not.to.be.null;
-              expect(user.username).to.equal('user');
-              expect(user.fullName).to.equal('John Smith');
+        return this.User.sync({ force: true }).then(() => self.User
+          .create({ username: 'user', fullName: 'John Smith' })
+          .then(user => {
+            // We can insert into a table with non-quoted identifiers
+            expect(user.id).to.exist;
+            expect(user.id).not.to.be.null;
+            expect(user.username).to.equal('user');
+            expect(user.fullName).to.equal('John Smith');
 
-              // We can query by non-quoted identifiers
-              return self.User.find({
-                where: {fullName: 'John Smith'}
-              })
-              .then(function(user2) {
-                // We can map values back to non-quoted identifiers
-                expect(user2.id).to.equal(user.id);
-                expect(user2.username).to.equal('user');
-                expect(user2.fullName).to.equal('John Smith');
+            // We can query by non-quoted identifiers
+            return self.User.find({
+              where: {fullName: 'John Smith'}
+            })
+            .then(user2 => {
+              // We can map values back to non-quoted identifiers
+              expect(user2.id).to.equal(user.id);
+              expect(user2.username).to.equal('user');
+              expect(user2.fullName).to.equal('John Smith');
 
-                // We can query and aggregate by non-quoted identifiers
-                return self.User
-                  .count({
-                    where: {fullName: 'John Smith'}
-                  })
-                  .then(function(count) {
-                    self.sequelize.options.quoteIndentifiers = true;
-                    self.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = true;
-                    self.sequelize.options.logging = false;
-                    expect(count).to.equal(1);
-                  });
-              });
+              // We can query and aggregate by non-quoted identifiers
+              return self.User
+                .count({
+                  where: {fullName: 'John Smith'}
+                })
+                .then(count => {
+                  self.sequelize.options.quoteIndentifiers = true;
+                  self.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = true;
+                  self.sequelize.options.logging = false;
+                  expect(count).to.equal(1);
+                });
             });
-        });
+          }));
       });
     });
   });

--- a/test/integration/dialects/postgres/error.test.js
+++ b/test/integration/dialects/postgres/error.test.js
@@ -1,48 +1,46 @@
 'use strict';
 
-var chai      = require('chai')
-  , expect    = chai.expect
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , Support   = require(__dirname + '/../../support')
-  , Sequelize = Support.Sequelize
-  , dialect   = Support.getTestDialect()
-  , _ = require('lodash');
+const chai = require('chai');
+const expect = chai.expect;
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const Support   = require(__dirname + '/../../support');
+const Sequelize = Support.Sequelize;
+const dialect   = Support.getTestDialect();
+const _ = require('lodash');
 
 if (dialect.match(/^postgres/)) {
-  var constraintName = 'overlap_period';
+  const constraintName = 'overlap_period';
   beforeEach(function () {
-    var self = this;
+    const self = this;
     this.Booking = self.sequelize.define('Booking', {
       roomNo: DataTypes.INTEGER,
       period: DataTypes.RANGE(DataTypes.DATE)
     });
     return self.Booking
       .sync({ force: true })
-      .then(function () {
-        return self.sequelize.query('ALTER TABLE "' + self.Booking.tableName + '" ADD CONSTRAINT ' + constraintName +
-                                    ' EXCLUDE USING gist ("roomNo" WITH =, period WITH &&)');
-      });
+      .then(() => self.sequelize.query('ALTER TABLE "' + self.Booking.tableName + '" ADD CONSTRAINT ' + constraintName +
+                                ' EXCLUDE USING gist ("roomNo" WITH =, period WITH &&)'));
   });
 
-  describe('[POSTGRES Specific] ExclusionConstraintError', function () {
+  describe('[POSTGRES Specific] ExclusionConstraintError', () => {
 
-    it('should contain error specific properties', function () {
-      var errDetails = {
+    it('should contain error specific properties', () => {
+      const errDetails = {
         message:    'Exclusion constraint error',
         constraint: 'constraint_name',
         fields:     { 'field1': 1, 'field2': [123, 321] },
         table:      'table_name',
         parent:     new Error('Test error')
       };
-      var err = new Sequelize.ExclusionConstraintError(errDetails);
+      const err = new Sequelize.ExclusionConstraintError(errDetails);
 
-      _.each(errDetails, function (value, key) {
+      _.each(errDetails, (value, key) => {
         expect(value).to.be.deep.equal(err[key]);
       });
     });
 
     it('should throw ExclusionConstraintError when "period" value overlaps existing', function () {
-      var Booking = this.Booking;
+      const Booking = this.Booking;
 
       return Booking
         .create({
@@ -50,14 +48,12 @@ if (dialect.match(/^postgres/)) {
           guestName: 'Incognito Visitor',
           period:    [new Date(2015, 0, 1), new Date(2015, 0, 3)]
         })
-        .then(function () {
-          return expect(Booking
-            .create({
-              roomNo:    1,
-              guestName: 'Frequent Visitor',
-              period:    [new Date(2015, 0, 2), new Date(2015, 0, 5)]
-            })).to.eventually.be.rejectedWith(Sequelize.ExclusionConstraintError);
-        });
+        .then(() => expect(Booking
+        .create({
+          roomNo:    1,
+          guestName: 'Frequent Visitor',
+          period:    [new Date(2015, 0, 2), new Date(2015, 0, 5)]
+        })).to.eventually.be.rejectedWith(Sequelize.ExclusionConstraintError));
     });
 
   });

--- a/test/integration/dialects/postgres/hstore.test.js
+++ b/test/integration/dialects/postgres/hstore.test.js
@@ -1,82 +1,82 @@
 'use strict';
 
 /* jshint -W110 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , hstore = require('../../../../lib/dialects/postgres/hstore');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
+const hstore = require('../../../../lib/dialects/postgres/hstore');
 
 if (dialect.match(/^postgres/)) {
-  describe('[POSTGRES Specific] hstore', function() {
-    describe('stringify', function() {
-      it('should handle empty objects correctly', function() {
+  describe('[POSTGRES Specific] hstore', () => {
+    describe('stringify', () => {
+      it('should handle empty objects correctly', () => {
         expect(hstore.stringify({ })).to.equal('');
       });
 
-      it('should handle null values correctly', function() {
+      it('should handle null values correctly', () => {
         expect(hstore.stringify({ null: null })).to.equal('"null"=>NULL');
       });
 
-      it('should handle null values correctly', function() {
+      it('should handle null values correctly', () => {
         expect(hstore.stringify({ foo: null })).to.equal('"foo"=>NULL');
       });
 
-      it('should handle empty string correctly', function() {
+      it('should handle empty string correctly', () => {
         expect(hstore.stringify({foo: ''})).to.equal('"foo"=>\"\"');
       });
 
-      it('should handle a string with backslashes correctly', function() {
+      it('should handle a string with backslashes correctly', () => {
         expect(hstore.stringify({foo: '\\'})).to.equal('"foo"=>"\\\\"');
       });
 
-      it('should handle a string with double quotes correctly', function() {
+      it('should handle a string with double quotes correctly', () => {
         expect(hstore.stringify({foo: '""a"'})).to.equal('"foo"=>"\\"\\"a\\""');
       });
 
-      it('should handle a string with single quotes correctly', function() {
+      it('should handle a string with single quotes correctly', () => {
         expect(hstore.stringify({foo: "''a'"})).to.equal('"foo"=>"\'\'\'\'a\'\'"');
       });
 
-      it('should handle simple objects correctly', function() {
+      it('should handle simple objects correctly', () => {
         expect(hstore.stringify({ test: 'value' })).to.equal('"test"=>"value"');
       });
 
     });
 
-    describe('parse', function() {
-      it('should handle a null object correctly', function() {
+    describe('parse', () => {
+      it('should handle a null object correctly', () => {
         expect(hstore.parse(null)).to.deep.equal(null);
       });
 
-      it('should handle empty string correctly', function() {
+      it('should handle empty string correctly', () => {
         expect(hstore.parse('"foo"=>\"\"')).to.deep.equal({foo: ''});
       });
 
-      it('should handle a string with double quotes correctly', function() {
+      it('should handle a string with double quotes correctly', () => {
         expect(hstore.parse('"foo"=>"\\\"\\\"a\\\""')).to.deep.equal({foo: '\"\"a\"'});
       });
 
-      it('should handle a string with single quotes correctly', function() {
+      it('should handle a string with single quotes correctly', () => {
         expect(hstore.parse('"foo"=>"\'\'\'\'a\'\'"')).to.deep.equal({foo: "''a'"});
       });
 
-      it('should handle a string with backslashes correctly', function() {
+      it('should handle a string with backslashes correctly', () => {
         expect(hstore.parse('"foo"=>"\\\\"')).to.deep.equal({foo: '\\'});
       });
 
-      it('should handle empty objects correctly', function() {
+      it('should handle empty objects correctly', () => {
         expect(hstore.parse('')).to.deep.equal({ });
       });
 
-      it('should handle simple objects correctly', function() {
+      it('should handle simple objects correctly', () => {
         expect(hstore.parse('"test"=>"value"')).to.deep.equal({ test: 'value' });
       });
 
     });
-    describe('stringify and parse', function() {
-      it('should stringify then parse back the same structure', function() {
-        var testObj = {foo: 'bar', count: '1', emptyString: '', quotyString: '""', extraQuotyString: '"""a"""""', backslashes: '\\f023', moreBackslashes: '\\f\\0\\2\\1', backslashesAndQuotes: '\\"\\"uhoh"\\"', nully: null};
+    describe('stringify and parse', () => {
+      it('should stringify then parse back the same structure', () => {
+        const testObj = {foo: 'bar', count: '1', emptyString: '', quotyString: '""', extraQuotyString: '"""a"""""', backslashes: '\\f023', moreBackslashes: '\\f\\0\\2\\1', backslashesAndQuotes: '\\"\\"uhoh"\\"', nully: null};
         expect(hstore.parse(hstore.stringify(testObj))).to.deep.equal(testObj);
         expect(hstore.parse(hstore.stringify(hstore.parse(hstore.stringify(testObj))))).to.deep.equal(testObj);
       });

--- a/test/integration/dialects/postgres/query-interface.test.js
+++ b/test/integration/dialects/postgres/query-interface.test.js
@@ -1,52 +1,42 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , dialect = Support.getTestDialect()
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , _ = require('lodash');
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const _ = require('lodash');
 
 if (dialect.match(/^postgres/)) {
-  describe('[POSTGRES Specific] QueryInterface', function () {
+  describe('[POSTGRES Specific] QueryInterface', () => {
     beforeEach(function () {
       this.sequelize.options.quoteIdenifiers = true;
       this.queryInterface = this.sequelize.getQueryInterface();
     });
 
-    describe('indexes', function () {
+    describe('indexes', () => {
       beforeEach(function () {
-        var self = this;
-        return this.queryInterface.dropTable('Group').then(function () {
-          return self.queryInterface.createTable('Group', {
-            username: DataTypes.STRING,
-            isAdmin: DataTypes.BOOLEAN,
-            from: DataTypes.STRING
-          });
-        });
+        const self = this;
+        return this.queryInterface.dropTable('Group').then(() => self.queryInterface.createTable('Group', {
+          username: DataTypes.STRING,
+          isAdmin: DataTypes.BOOLEAN,
+          from: DataTypes.STRING
+        }));
       });
 
       it('adds, reads and removes a named functional index to the table', function () {
-        var self = this;
+        const self = this;
         return this.queryInterface.addIndex('Group', [this.sequelize.fn('lower', this.sequelize.col('username'))], {
           name: 'group_username_lower'
-        }).then(function () {
-          return self.queryInterface.showIndex('Group').then(function (indexes) {
-            var indexColumns = _.uniq(indexes.map(function (index) {
-              return index.name;
-            }));
-            expect(indexColumns).to.include('group_username_lower');
-            return self.queryInterface.removeIndex('Group', 'group_username_lower').then(function () {
-              return self.queryInterface.showIndex('Group').then(function (indexes) {
-                indexColumns = _.uniq(indexes.map(function (index) {
-                  return index.name;
-                }));
-                expect(indexColumns).to.be.empty;
-              });
-            });
-          });
-        });
+        }).then(() => self.queryInterface.showIndex('Group').then(indexes => {
+          let indexColumns = _.uniq(indexes.map(index => index.name));
+          expect(indexColumns).to.include('group_username_lower');
+          return self.queryInterface.removeIndex('Group', 'group_username_lower').then(() => self.queryInterface.showIndex('Group').then(indexes => {
+            indexColumns = _.uniq(indexes.map(index => index.name));
+            expect(indexColumns).to.be.empty;
+          }));
+        }));
       });
     });
   });

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -1,30 +1,30 @@
 'use strict';
 
-var chai    = require('chai')
-  , expect  = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , dialect = Support.getTestDialect()
-  , range   = require('../../../../lib/dialects/postgres/range')
-  , _       = require('lodash');
+const chai = require('chai');
+const expect  = chai.expect;
+const Support = require(__dirname + '/../../support');
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const dialect = Support.getTestDialect();
+const range = require('../../../../lib/dialects/postgres/range');
+const _ = require('lodash');
 
 if (dialect.match(/^postgres/)) {
   // Don't try to load pg until we know we're running on postgres.
-  var pg = require('pg');
+  const pg = require('pg');
 
-  describe('[POSTGRES Specific] range datatype', function () {
-    describe('stringify', function () {
-      it('should handle empty objects correctly', function () {
+  describe('[POSTGRES Specific] range datatype', () => {
+    describe('stringify', () => {
+      it('should handle empty objects correctly', () => {
         expect(range.stringify([])).to.equal('empty');
       });
 
-      it('should handle null as empty bound', function () {
+      it('should handle null as empty bound', () => {
         expect(range.stringify([null, 1])).to.equal('[,1)');
         expect(range.stringify([1, null])).to.equal('[1,)');
         expect(range.stringify([null, null])).to.equal('[,)');
       });
 
-      it('should handle Infinity/-Infinity as infinity/-infinity bounds', function () {
+      it('should handle Infinity/-Infinity as infinity/-infinity bounds', () => {
         expect(range.stringify([Infinity, 1])).to.equal('[infinity,1)');
         expect(range.stringify([1, Infinity])).to.equal('[1,infinity)');
         expect(range.stringify([-Infinity, 1])).to.equal('[-infinity,1)');
@@ -32,26 +32,26 @@ if (dialect.match(/^postgres/)) {
         expect(range.stringify([-Infinity, Infinity])).to.equal('[-infinity,infinity)');
       });
 
-      it('should throw error when array length is no 0 or 2', function () {
-        expect(function () { range.stringify([1]); }).to.throw();
-        expect(function () { range.stringify([1, 2, 3]); }).to.throw();
+      it('should throw error when array length is no 0 or 2', () => {
+        expect(() => { range.stringify([1]); }).to.throw();
+        expect(() => { range.stringify([1, 2, 3]); }).to.throw();
       });
 
-      it('should throw error when non-array parameter is passed', function () {
-        expect(function () { range.stringify({}); }).to.throw();
-        expect(function () { range.stringify('test'); }).to.throw();
-        expect(function () { range.stringify(undefined); }).to.throw();
+      it('should throw error when non-array parameter is passed', () => {
+        expect(() => { range.stringify({}); }).to.throw();
+        expect(() => { range.stringify('test'); }).to.throw();
+        expect(() => { range.stringify(undefined); }).to.throw();
       });
 
-      it('should handle array of objects with `inclusive` and `value` properties', function () {
+      it('should handle array of objects with `inclusive` and `value` properties', () => {
         expect(range.stringify([{ inclusive: true, value: 0 }, { value: 1 }])).to.equal('[0,1)');
         expect(range.stringify([{ inclusive: true, value: 0 }, { inclusive: true, value: 1 }])).to.equal('[0,1]');
         expect(range.stringify([{ inclusive: false, value: 0 }, 1])).to.equal('(0,1)');
         expect(range.stringify([0, { inclusive: true, value: 1 }])).to.equal('[0,1]');
       });
 
-      it('should handle inclusive property of input array properly', function () {
-        var testRange = [1, 2];
+      it('should handle inclusive property of input array properly', () => {
+        const testRange = [1, 2];
 
         testRange.inclusive = [true, false];
         expect(range.stringify(testRange)).to.equal('[1,2)');
@@ -69,58 +69,58 @@ if (dialect.match(/^postgres/)) {
         expect(range.stringify(testRange)).to.equal('(1,2)');
       });
 
-      it('should handle date values', function () {
-        var Range = new DataTypes.postgres.RANGE(DataTypes.DATE);
+      it('should handle date values', () => {
+        const Range = new DataTypes.postgres.RANGE(DataTypes.DATE);
         expect(Range.stringify([new Date(Date.UTC(2000, 1, 1)),
                                 new Date(Date.UTC(2000, 1, 2))], { timezone: '+02:00' })).to.equal('\'["2000-02-01 02:00:00.000 +02:00","2000-02-02 02:00:00.000 +02:00")\'');
       });
     });
 
-    describe('stringify value', function () {
+    describe('stringify value', () => {
 
-      it('should stringify integer values with appropriate casting', function () {
-        var Range = new DataTypes.postgres.RANGE(DataTypes.INTEGER);
+      it('should stringify integer values with appropriate casting', () => {
+        const Range = new DataTypes.postgres.RANGE(DataTypes.INTEGER);
         expect(Range.stringify(1)).to.equal('\'1\'::integer');
       });
 
-      it('should stringify bigint values with appropriate casting', function () {
-        var Range = new DataTypes.postgres.RANGE(DataTypes.BIGINT);
+      it('should stringify bigint values with appropriate casting', () => {
+        const Range = new DataTypes.postgres.RANGE(DataTypes.BIGINT);
         expect(Range.stringify(1)).to.equal('\'1\'::bigint');
       });
 
-      it('should stringify numeric values with appropriate casting', function () {
-        var Range = new DataTypes.postgres.RANGE(DataTypes.DECIMAL);
+      it('should stringify numeric values with appropriate casting', () => {
+        const Range = new DataTypes.postgres.RANGE(DataTypes.DECIMAL);
         expect(Range.stringify(1.1)).to.equal('\'1.1\'::numeric');
       });
 
-      it('should stringify dateonly values with appropriate casting', function () {
-        var Range = new DataTypes.postgres.RANGE(DataTypes.DATEONLY);
+      it('should stringify dateonly values with appropriate casting', () => {
+        const Range = new DataTypes.postgres.RANGE(DataTypes.DATEONLY);
         expect(Range.stringify(new Date(Date.UTC(2000, 1, 1))).indexOf('::date')).not.to.equal(-1);
       });
 
-      it('should stringify date values with appropriate casting', function () {
-        var Range = new DataTypes.postgres.RANGE(DataTypes.DATE);
+      it('should stringify date values with appropriate casting', () => {
+        const Range = new DataTypes.postgres.RANGE(DataTypes.DATE);
         expect(Range.stringify(new Date(Date.UTC(2000, 1, 1)), { timezone: '+02:00' })).to.equal('\'2000-02-01 02:00:00.000 +02:00\'::timestamptz');
       });
 
     });
 
-    describe('parse', function () {
-      it('should handle a null object correctly', function () {
+    describe('parse', () => {
+      it('should handle a null object correctly', () => {
         expect(range.parse(null)).to.equal(null);
       });
 
-      it('should handle empty range string correctly', function () {
+      it('should handle empty range string correctly', () => {
         expect(range.parse('empty')).to.deep.equal(_.extend([], { inclusive: [] }));
       });
 
-      it('should handle empty bounds correctly', function () {
+      it('should handle empty bounds correctly', () => {
         expect(range.parse('(1,)', DataTypes.postgres.INTEGER.parse)).to.deep.equal(_.extend([1, null], { inclusive: [false, false] }));
         expect(range.parse('(,1)', DataTypes.postgres.INTEGER.parse)).to.deep.equal(_.extend([null, 1], { inclusive: [false, false] }));
         expect(range.parse('(,)', DataTypes.postgres.INTEGER.parse)).to.deep.equal(_.extend([null, null], { inclusive: [false, false] }));
       });
 
-      it('should handle infinity/-infinity bounds correctly', function () {
+      it('should handle infinity/-infinity bounds correctly', () => {
         expect(range.parse('(infinity,1)', DataTypes.postgres.INTEGER.parse)).to.deep.equal(_.extend([Infinity, 1], { inclusive: [false, false] }));
         expect(range.parse('(1,infinity)',  DataTypes.postgres.INTEGER.parse)).to.deep.equal(_.extend([1, Infinity], { inclusive: [false, false] }));
         expect(range.parse('(-infinity,1)',  DataTypes.postgres.INTEGER.parse)).to.deep.equal(_.extend([-Infinity, 1], { inclusive: [false, false] }));
@@ -128,28 +128,27 @@ if (dialect.match(/^postgres/)) {
         expect(range.parse('(-infinity,infinity)',  DataTypes.postgres.INTEGER.parse)).to.deep.equal(_.extend([-Infinity, Infinity], { inclusive: [false, false] }));
       });
 
-      it('should return raw value if not range is returned', function () {
+      it('should return raw value if not range is returned', () => {
         expect(range.parse('some_non_array')).to.deep.equal('some_non_array');
       });
 
-      it('should handle native postgres timestamp format', function () {
-        var tsOid = DataTypes.postgres.DATE.types.postgres.oids[0],
-            parser = pg.types.getTypeParser(tsOid);
+      it('should handle native postgres timestamp format', () => {
+        const tsOid = DataTypes.postgres.DATE.types.postgres.oids[0], parser = pg.types.getTypeParser(tsOid);
         expect(range.parse('(2016-01-01 08:00:00-04,)', parser)[0].toISOString()).to.equal('2016-01-01T12:00:00.000Z');
       });
 
     });
-    describe('stringify and parse', function () {
-      it('should stringify then parse back the same structure', function () {
-        var testRange = [5,10];
+    describe('stringify and parse', () => {
+      it('should stringify then parse back the same structure', () => {
+        const testRange = [5,10];
         testRange.inclusive = [true, true];
 
-        var Range = new DataTypes.postgres.RANGE(DataTypes.INTEGER);
+        const Range = new DataTypes.postgres.RANGE(DataTypes.INTEGER);
 
-        var stringified = Range.stringify(testRange, {});
+        let stringified = Range.stringify(testRange, {});
         stringified = stringified.substr(1, stringified.length - 2); // Remove the escaping ticks
 
-        expect(DataTypes.postgres.RANGE.parse(stringified, 3904, function () { return DataTypes.postgres.INTEGER.parse; })).to.deep.equal(testRange);
+        expect(DataTypes.postgres.RANGE.parse(stringified, 3904, () => DataTypes.postgres.INTEGER.parse)).to.deep.equal(testRange);
       });
     });
   });

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -1,16 +1,16 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , dialect = Support.getTestDialect()
-  , dbFile = __dirname + '/test.sqlite'
-  , storages = [dbFile];
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const dialect = Support.getTestDialect();
+const dbFile = __dirname + '/test.sqlite';
+const storages = [dbFile];
 
 if (dialect === 'sqlite') {
-  describe('[SQLITE Specific] DAOFactory', function() {
+  describe('[SQLITE Specific] DAOFactory', () => {
     after(function() {
       this.sequelize.options.storage = ':memory:';
     });
@@ -25,101 +25,95 @@ if (dialect === 'sqlite') {
       return this.User.sync({ force: true });
     });
 
-    storages.forEach(function(storage) {
-      describe('with storage "' + storage + '"', function() {
-        after(function() {
+    storages.forEach(storage => {
+      describe('with storage "' + storage + '"', () => {
+        after(() => {
           if (storage === dbFile) {
             require('fs').writeFileSync(dbFile, '');
           }
         });
 
-        describe('create', function() {
+        describe('create', () => {
           it('creates a table entry', function() {
-            var self = this;
-            return this.User.create({ age: 21, name: 'John Wayne', bio: 'noot noot' }).then(function(user) {
+            const self = this;
+            return this.User.create({ age: 21, name: 'John Wayne', bio: 'noot noot' }).then(user => {
               expect(user.age).to.equal(21);
               expect(user.name).to.equal('John Wayne');
               expect(user.bio).to.equal('noot noot');
 
-              return self.User.findAll().then(function(users) {
-                var usernames = users.map(function(user) {
-                  return user.name;
-                });
+              return self.User.findAll().then(users => {
+                const usernames = users.map(user => user.name);
                 expect(usernames).to.contain('John Wayne');
               });
             });
           });
 
           it('should allow the creation of an object with options as attribute', function() {
-            var Person = this.sequelize.define('Person', {
+            const Person = this.sequelize.define('Person', {
               name: DataTypes.STRING,
               options: DataTypes.TEXT
             });
 
-            return Person.sync({ force: true }).then(function() {
-              var options = JSON.stringify({ foo: 'bar', bar: 'foo' });
+            return Person.sync({ force: true }).then(() => {
+              const options = JSON.stringify({ foo: 'bar', bar: 'foo' });
 
               return Person.create({
                 name: 'John Doe',
-                options: options
-              }).then(function(people) {
+                options
+              }).then(people => {
                 expect(people.options).to.deep.equal(options);
               });
             });
           });
 
           it('should allow the creation of an object with a boolean (true) as attribute', function() {
-            var Person = this.sequelize.define('Person', {
+            const Person = this.sequelize.define('Person', {
               name: DataTypes.STRING,
               has_swag: DataTypes.BOOLEAN
             });
 
-            return Person.sync({ force: true }).then(function() {
-              return Person.create({
-                name: 'John Doe',
-                has_swag: true
-              }).then(function(people) {
-                expect(people.has_swag).to.be.ok;
-              });
-            });
+            return Person.sync({ force: true }).then(() => Person.create({
+              name: 'John Doe',
+              has_swag: true
+            }).then(people => {
+              expect(people.has_swag).to.be.ok;
+            }));
           });
 
           it('should allow the creation of an object with a boolean (false) as attribute', function() {
-            var Person = this.sequelize.define('Person', {
+            const Person = this.sequelize.define('Person', {
               name: DataTypes.STRING,
               has_swag: DataTypes.BOOLEAN
             });
 
-            return Person.sync({ force: true }).then(function() {
-              return Person.create({
-                name: 'John Doe',
-                has_swag: false
-              }).then(function(people) {
-                expect(people.has_swag).to.not.be.ok;
-              });
-            });
+            return Person.sync({ force: true }).then(() => Person.create({
+              name: 'John Doe',
+              has_swag: false
+            }).then(people => {
+              expect(people.has_swag).to.not.be.ok;
+            }));
           });
         });
 
-        describe('.find', function() {
+        describe('.find', () => {
           beforeEach(function() {
             return this.User.create({name: 'user', bio: 'footbar'});
           });
 
           it('finds normal lookups', function() {
-            return this.User.find({ where: { name: 'user' } }).then(function(user) {
+            return this.User.find({ where: { name: 'user' } }).then(user => {
               expect(user.name).to.equal('user');
             });
           });
 
           it.skip('should make aliased attributes available', function() {
-            return this.User.find({ where: { name: 'user' }, attributes: ['id', ['name', 'username']] }).then(function(user) {
+            return this.User.find({ where: { name: 'user' }, attributes: ['id', ['name', 'username']] }).then(user => {
               expect(user.username).to.equal('user');
             });
           });
         });
 
-        describe('.all', function() {
+        describe('.all', () => {
           beforeEach(function() {
             return this.User.bulkCreate([
               {name: 'user', bio: 'foobar'},
@@ -128,43 +122,37 @@ if (dialect === 'sqlite') {
           });
 
           it('should return all users', function() {
-            return this.User.findAll().then(function(users) {
+            return this.User.findAll().then(users => {
               expect(users).to.have.length(2);
             });
           });
         });
 
-        describe('.min', function() {
+        describe('.min', () => {
           it('should return the min value', function() {
-            var self = this
-              , users = [];
+            const self = this, users = [];
 
-            for (var i = 2; i < 5; i++) {
+            for (let i = 2; i < 5; i++) {
               users[users.length] = {age: i};
             }
 
-            return this.User.bulkCreate(users).then(function() {
-              return self.User.min('age').then(function(min) {
-                expect(min).to.equal(2);
-              });
-            });
+            return this.User.bulkCreate(users).then(() => self.User.min('age').then(min => {
+              expect(min).to.equal(2);
+            }));
           });
         });
 
-        describe('.max', function() {
+        describe('.max', () => {
           it('should return the max value', function() {
-            var self = this
-              , users = [];
+            const self = this, users = [];
 
-            for (var i = 2; i <= 5; i++) {
+            for (let i = 2; i <= 5; i++) {
               users[users.length] = {age: i};
             }
 
-            return this.User.bulkCreate(users).then(function() {
-              return self.User.max('age').then(function(min) {
-                expect(min).to.equal(5);
-              });
-            });
+            return this.User.bulkCreate(users).then(() => self.User.max('age').then(min => {
+              expect(min).to.equal(5);
+            }));
           });
         });
       });

--- a/test/integration/dialects/sqlite/dao.test.js
+++ b/test/integration/dialects/sqlite/dao.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../../support')
-  , DataTypes = require(__dirname + '/../../../../lib/data-types')
-  , dialect = Support.getTestDialect();
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const dialect = Support.getTestDialect();
 
 if (dialect === 'sqlite') {
-  describe('[SQLITE Specific] DAO', function() {
+  describe('[SQLITE Specific] DAO', () => {
     beforeEach(function() {
       this.User = this.sequelize.define('User', {
         username: DataTypes.STRING,
@@ -27,22 +27,17 @@ if (dialect === 'sqlite') {
       return this.sequelize.sync({ force: true });
     });
 
-    describe('findAll', function() {
+    describe('findAll', () => {
       it('handles dates correctly', function() {
-        var self = this
-          , user = this.User.build({ username: 'user' });
+        const self = this, user = this.User.build({ username: 'user' });
 
         user.dataValues.createdAt = new Date(2011, 4, 4);
 
-        return user.save().then(function() {
-          return self.User.create({ username: 'new user' }).then(function() {
-            return self.User.findAll({
-              where: { createdAt: { $gt:  new Date(2012, 1, 1) }}
-            }).then(function(users) {
-              expect(users).to.have.length(1);
-            });
-          });
-        });
+        return user.save().then(() => self.User.create({ username: 'new user' }).then(() => self.User.findAll({
+          where: { createdAt: { $gt:  new Date(2012, 1, 1) }}
+        }).then(users => {
+          expect(users).to.have.length(1);
+        })));
       });
 
       it('handles dates with aliasses correctly #3611', function() {
@@ -50,7 +45,7 @@ if (dialect === 'sqlite') {
           dateField: new Date(2010, 10, 10)
         }).bind(this).then(function () {
           return this.User.findAll().get(0);
-        }).then(function (user) {
+        }).then(user => {
           expect(user.get('dateField')).to.be.an.instanceof(Date);
           expect(user.get('dateField')).to.equalTime(new Date(2010, 10, 10));
         });
@@ -65,21 +60,19 @@ if (dialect === 'sqlite') {
           return this.User.findAll({
             include: [this.Project]
           }).get(0);
-        }).then(function (user) {
+        }).then(user => {
           expect(user.projects[0].get('dateField')).to.be.an.instanceof(Date);
           expect(user.projects[0].get('dateField')).to.equalTime(new Date(1990, 5, 5));
         });
       });
     });
 
-    describe('regression tests', function() {
+    describe('regression tests', () => {
 
       it('do not crash while parsing unique constraint errors', function() {
-        var Payments = this.sequelize.define('payments', {});
+        const Payments = this.sequelize.define('payments', {});
 
-        return Payments.sync({force: true}).then(function () {
-          return (expect(Payments.bulkCreate([{id: 1}, {id: 1}], { ignoreDuplicates: false })).to.eventually.be.rejected);
-        });
+        return Payments.sync({force: true}).then(() => expect(Payments.bulkCreate([{id: 1}, {id: 1}], { ignoreDuplicates: false })).to.eventually.be.rejected);
 
       });
     });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?

### Description of change

`integration/dialect` these test are grouped properly but many tests are still scattered in some other big tests. I haven't touched them yet. This PR only convert these tests to ES6.

In next PRs I would move more dialect specific tests to these sections.

