### PR TITLE
Fixes #4840, Model.count allow passing col to count on

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@
 - [INTERNALS] Updated `inflection` dependency and pinned version and expose all used `inflection` methods on `Utils`
 - [ADDED] `Sequelize.useInflection` method
 - [FIXED] `hasOne` throws error on update with a primary key [#6069](https://github.com/sequelize/sequelize/issues/6069)
+- [FIXED] `Model.count` gives SQL syntax error when using `distinct` [#4840](https://github.com/sequelize/sequelize/issues/4840)
+- [ADDED] `Model.count` now allow specifying column to count on, use `options.col` [#4442](https://github.com/sequelize/sequelize/issues/4442)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1530,7 +1530,9 @@ class Model {
    * @param {Object}        [options]
    * @param {Object}        [options.where] A hash of search attributes.
    * @param {Object}        [options.include] Include options. See `find` for details
-   * @param {boolean}       [options.distinct] Apply COUNT(DISTINCT(col)) on primary key, `Model.aggregate` should be used for other columns
+   * @param {Boolean}       [options.paranoid=true] Set `true` to count only non-deleted records. Can be used on models with `paranoid` enabled
+   * @param {Boolean}       [options.distinct] Apply COUNT(DISTINCT(col)) on primary key, `Model.aggregate` should be used for other columns
+   * @param {String}        [options.col] Column on which COUNT() should be applied
    * @param {Object}        [options.attributes] Used in conjunction with `group`
    * @param {Object}        [options.group] For creating complex counts. Will return multiple rows as needed.
    * @param {Transaction}   [options.transaction] Transaction to run query under
@@ -1544,7 +1546,7 @@ class Model {
     options = Utils.cloneDeep(options);
     _.defaults(options, { hooks: true });
 
-    let col = '*';
+    let col = options.col || '*';
     let attributes = options.attributes;
 
     return Promise.try(() => {

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -107,5 +107,31 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    it('should be able to specify column for COUNT()', function() {
+      return this.sequelize.sync({ force: true })
+      .then(() =>
+        this.User.bulkCreate([
+          { username: 'ember' , age: 10},
+          { username: 'angular' , age: 20},
+          { username: 'mithril' , age: 10}
+        ])
+      )
+      .then(() =>
+        this.User.count({
+          col: 'username'
+        })
+      )
+      .then((count) => {
+        expect(parseInt(count)).to.be.eql(3);
+        return this.User.count({
+          col: 'age',
+          distinct: true
+        });
+      })
+      .then((count) => {
+        expect(parseInt(count)).to.be.eql(2);
+      });
+    });
+
   });
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #4442 
Fixes #4840 
Closes #3740

`distinct` option with `Model.count` was broken because it generates a SQL query like 

`COUNT( DISTINCT(*) )` which is incorrect.

As noted in issues mentioned above, we should allow an option to pass the `col` so `distinct` can work as expected.

PR #3740 can be closed because #3019 is closed and missing `Model.count` `paranoid` documentation is added in this PR  

