### PR TITLE
associations: has-many: fix possible ambiguous field in count()

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -342,7 +342,7 @@ HasMany.prototype.count = function(instance, options) {
 
   options = Utils.cloneDeep(options);
   options.attributes = [
-    [sequelize.fn('COUNT', sequelize.col(model.primaryKeyField)), 'count']
+    [sequelize.fn('COUNT', sequelize.col([model.name, model.primaryKeyAttribute].join('.'))), 'count']
   ];
   options.raw = true;
   options.plain = true;


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?
### Description of change

`has-many` `count()` method does not alias the field. In complex query, it is possible to get a `Query error with ambiguous column name in SQL` error.
Notice that `belongs-to-many` use already an alias, see https://github.com/sequelize/sequelize/blob/v3/lib/associations/belongs-to-many.js#L499
