### PR TITLE
Fix #2852, Added DEBUG support and intensive connection logging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@
 - [FIXED] `hasOne` throws error on update with a primary key [#6069](https://github.com/sequelize/sequelize/issues/6069)
 - [FIXED] `Model.count` gives SQL syntax error when using `distinct` [#4840](https://github.com/sequelize/sequelize/issues/4840)
 - [ADDED] `Model.count` now allow specifying column to count on, use `options.col` [#4442](https://github.com/sequelize/sequelize/issues/4442)
+- [ADDED] `DEBUG` support [#2852](https://github.com/sequelize/sequelize/issues/2852)
+- [ADDED] Intensive connection logging [#851](https://github.com/sequelize/sequelize/issues/851)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 /**
-  The entry point.
-  @module Sequelize
-**/
+  * The entry point.
+  *
+  * @module Sequelize
+  */
 module.exports = require('./lib/sequelize');

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -215,7 +215,7 @@ class ConnectionManager {
     return promise.then(() => new Promise((resolve, reject) => {
       this.pool.acquire((err, connection) => {
         if (err) return reject(err);
-        debug(`connection acquire`);
+        debug(`connection acquired`);
         resolve(connection);
       }, options.priority, options.type, options.useMaster);
     }));
@@ -224,7 +224,7 @@ class ConnectionManager {
   releaseConnection(connection) {
     return new Promise((resolve, reject) => {
       this.pool.release(connection);
-      debug(`connection release`);
+      debug(`connection released`);
       resolve();
     });
   }

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -3,6 +3,7 @@
 const Pooling = require('generic-pool');
 const Promise = require('../../promise');
 const _ = require('lodash');
+const Utils = require('../../utils');
 const semver = require('semver');
 const defaultPoolingConfig = {
   max: 5,
@@ -51,6 +52,7 @@ class ConnectionManager {
   onProcessExit() {
     if (this.pool) {
       this.pool.drain(() => {
+        Utils.getLogger().debug(`connection drain via pool due to process exit`);
         this.pool.destroyAllNow();
       });
     }
@@ -75,10 +77,12 @@ class ConnectionManager {
         name: 'sequelize-connection',
         create: (callback) => {
           this.$connect(config).nodeify((err, connection) => {
+            Utils.getLogger().debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
             callback(err, connection); // For some reason this is needed, else generic-pool things err is a connection or some shit
           });
         },
         destroy: (connection) => {
+          Utils.getLogger().debug(`connection destroy via pool`);
           this.$disconnect(connection);
           return null;
         },
@@ -122,9 +126,11 @@ class ConnectionManager {
         }
       },
       destroy: (connection) => {
+        Utils.getLogger().debug(`connection destroy via pool`);
         return this.pool[connection.queryType].destroy(connection);
       },
       destroyAllNow: () => {
+        Utils.getLogger().debug(`all connection destroy via pool`);
         this.pool.read.destroyAllNow();
         this.pool.write.destroyAllNow();
       },
@@ -208,6 +214,7 @@ class ConnectionManager {
     return promise.then(() => new Promise((resolve, reject) => {
       this.pool.acquire((err, connection) => {
         if (err) return reject(err);
+        Utils.getLogger().debug(`connection acquire via pool`);
         resolve(connection);
       }, options.priority, options.type, options.useMaster);
     }));
@@ -216,6 +223,7 @@ class ConnectionManager {
   releaseConnection(connection) {
     return new Promise((resolve, reject) => {
       this.pool.release(connection);
+      Utils.getLogger().debug(`connection release via pool`);
       resolve();
     });
   }

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -52,7 +52,7 @@ class ConnectionManager {
   onProcessExit() {
     if (this.pool) {
       this.pool.drain(() => {
-        Utils.getLogger().debug(`connection drain via pool due to process exit`);
+        Utils.debug(`connection drain via pool due to process exit`);
         this.pool.destroyAllNow();
       });
     }
@@ -77,12 +77,12 @@ class ConnectionManager {
         name: 'sequelize-connection',
         create: (callback) => {
           this.$connect(config).nodeify((err, connection) => {
-            Utils.getLogger().debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
+            Utils.debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
             callback(err, connection); // For some reason this is needed, else generic-pool things err is a connection or some shit
           });
         },
         destroy: (connection) => {
-          Utils.getLogger().debug(`connection destroy via pool`);
+          Utils.debug(`connection destroy via pool`);
           this.$disconnect(connection);
           return null;
         },
@@ -126,11 +126,11 @@ class ConnectionManager {
         }
       },
       destroy: (connection) => {
-        Utils.getLogger().debug(`connection destroy via pool`);
+        Utils.debug(`connection destroy via pool`);
         return this.pool[connection.queryType].destroy(connection);
       },
       destroyAllNow: () => {
-        Utils.getLogger().debug(`all connection destroy via pool`);
+        Utils.debug(`all connection destroy via pool`);
         this.pool.read.destroyAllNow();
         this.pool.write.destroyAllNow();
       },
@@ -214,7 +214,7 @@ class ConnectionManager {
     return promise.then(() => new Promise((resolve, reject) => {
       this.pool.acquire((err, connection) => {
         if (err) return reject(err);
-        Utils.getLogger().debug(`connection acquire via pool`);
+        Utils.debug(`connection acquire via pool`);
         resolve(connection);
       }, options.priority, options.type, options.useMaster);
     }));
@@ -223,7 +223,7 @@ class ConnectionManager {
   releaseConnection(connection) {
     return new Promise((resolve, reject) => {
       this.pool.release(connection);
-      Utils.getLogger().debug(`connection release via pool`);
+      Utils.debug(`connection release via pool`);
       resolve();
     });
   }

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -4,6 +4,7 @@ const Pooling = require('generic-pool');
 const Promise = require('../../promise');
 const _ = require('lodash');
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('pool');
 const semver = require('semver');
 const defaultPoolingConfig = {
   max: 5,
@@ -52,7 +53,7 @@ class ConnectionManager {
   onProcessExit() {
     if (this.pool) {
       this.pool.drain(() => {
-        Utils.debug(`connection drain via pool due to process exit`);
+        debug(`connection drain due to process exit`);
         this.pool.destroyAllNow();
       });
     }
@@ -77,12 +78,12 @@ class ConnectionManager {
         name: 'sequelize-connection',
         create: (callback) => {
           this.$connect(config).nodeify((err, connection) => {
-            Utils.debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
+            debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
             callback(err, connection); // For some reason this is needed, else generic-pool things err is a connection or some shit
           });
         },
         destroy: (connection) => {
-          Utils.debug(`connection destroy via pool`);
+          debug(`connection destroy`);
           this.$disconnect(connection);
           return null;
         },
@@ -126,11 +127,11 @@ class ConnectionManager {
         }
       },
       destroy: (connection) => {
-        Utils.debug(`connection destroy via pool`);
+        debug(`connection destroy`);
         return this.pool[connection.queryType].destroy(connection);
       },
       destroyAllNow: () => {
-        Utils.debug(`all connection destroy via pool`);
+        debug(`all connection destroy`);
         this.pool.read.destroyAllNow();
         this.pool.write.destroyAllNow();
       },
@@ -214,7 +215,7 @@ class ConnectionManager {
     return promise.then(() => new Promise((resolve, reject) => {
       this.pool.acquire((err, connection) => {
         if (err) return reject(err);
-        Utils.debug(`connection acquire via pool`);
+        debug(`connection acquire`);
         resolve(connection);
       }, options.priority, options.type, options.useMaster);
     }));
@@ -223,7 +224,7 @@ class ConnectionManager {
   releaseConnection(connection) {
     return new Promise((resolve, reject) => {
       this.pool.release(connection);
-      Utils.debug(`connection release via pool`);
+      debug(`connection release`);
       resolve();
     });
   }

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -3,6 +3,7 @@
 const AbstractConnectionManager = require('../abstract/connection-manager');
 const ResourceLock = require('./resource-lock');
 const Promise = require('../../promise');
+const Utils = require('../../utils');
 const sequelizeErrors = require('../../errors');
 const parserStore = require('../parserStore')('mssql');
 const _ = require('lodash');
@@ -66,6 +67,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       connection.on('connect', err => {
         if (!err) {
+          Utils.getLogger().debug(`connection acquire`);
           resolve(connectionLock);
           return;
         }
@@ -130,6 +132,7 @@ class ConnectionManager extends AbstractConnectionManager {
     return new Promise(resolve => {
       connection.on('end', resolve);
       connection.close();
+      Utils.getLogger().debug(`connection disconnect`);
     });
   }
 

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -133,7 +133,7 @@ class ConnectionManager extends AbstractConnectionManager {
     return new Promise(resolve => {
       connection.on('end', resolve);
       connection.close();
-      debug(`connection disconnect`);
+      debug(`connection closed`);
     });
   }
 

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -67,7 +67,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       connection.on('connect', err => {
         if (!err) {
-          Utils.getLogger().debug(`connection acquire`);
+          Utils.debug(`connection acquire`);
           resolve(connectionLock);
           return;
         }
@@ -132,7 +132,7 @@ class ConnectionManager extends AbstractConnectionManager {
     return new Promise(resolve => {
       connection.on('end', resolve);
       connection.close();
-      Utils.getLogger().debug(`connection disconnect`);
+      Utils.debug(`connection disconnect`);
     });
   }
 

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -4,6 +4,7 @@ const AbstractConnectionManager = require('../abstract/connection-manager');
 const ResourceLock = require('./resource-lock');
 const Promise = require('../../promise');
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('connection:mssql');
 const sequelizeErrors = require('../../errors');
 const parserStore = require('../parserStore')('mssql');
 const _ = require('lodash');
@@ -67,7 +68,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       connection.on('connect', err => {
         if (!err) {
-          Utils.debug(`connection acquire`);
+          debug(`connection acquire`);
           resolve(connectionLock);
           return;
         }
@@ -132,7 +133,7 @@ class ConnectionManager extends AbstractConnectionManager {
     return new Promise(resolve => {
       connection.on('end', resolve);
       connection.close();
-      Utils.debug(`connection disconnect`);
+      debug(`connection disconnect`);
     });
   }
 

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -68,7 +68,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       connection.on('connect', err => {
         if (!err) {
-          debug(`connection acquire`);
+          debug(`connection acquired`);
           resolve(connectionLock);
           return;
         }

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -39,7 +39,7 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (connection.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.getLogger().debug(`executing(${connection.uuid || 'default'}) : ${this.sql}`);
+    Utils.debug(`executing(${connection.uuid || 'default'}) : ${this.sql}`);
 
     return new Promise((resolve, reject) => {
         // TRANSACTION SUPPORT
@@ -73,8 +73,8 @@ class Query extends AbstractQuery {
 
           const request = new connection.lib.Request(this.sql, err => {
 
-            Utils.getLogger().debug(`executed(${connection.uuid || 'default'}) : ${this.sql}`);
-            
+            Utils.debug(`executed(${connection.uuid || 'default'}) : ${this.sql}`);
+
             if (benchmark) {
               this.sequelize.log('Executed (' + (connection.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);
             }

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('sql:mssql');
 const Promise = require('../../promise');
 const AbstractQuery = require('../abstract/query');
 const sequelizeErrors = require('../../errors.js');
@@ -39,7 +40,7 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (connection.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.debug(`executing(${connection.uuid || 'default'}) : ${this.sql}`);
+    debug(`executing(${connection.uuid || 'default'}) : ${this.sql}`);
 
     return new Promise((resolve, reject) => {
         // TRANSACTION SUPPORT
@@ -73,7 +74,7 @@ class Query extends AbstractQuery {
 
           const request = new connection.lib.Request(this.sql, err => {
 
-            Utils.debug(`executed(${connection.uuid || 'default'}) : ${this.sql}`);
+            debug(`executed(${connection.uuid || 'default'}) : ${this.sql}`);
 
             if (benchmark) {
               this.sequelize.log('Executed (' + (connection.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -39,6 +39,8 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (connection.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
+    Utils.getLogger().debug(`executing(${connection.uuid || 'default'}) : ${this.sql}`);
+
     return new Promise((resolve, reject) => {
         // TRANSACTION SUPPORT
         if (_.includes(this.sql, 'BEGIN TRANSACTION')) {
@@ -71,6 +73,8 @@ class Query extends AbstractQuery {
 
           const request = new connection.lib.Request(this.sql, err => {
 
+            Utils.getLogger().debug(`executed(${connection.uuid || 'default'}) : ${this.sql}`);
+            
             if (benchmark) {
               this.sequelize.log('Executed (' + (connection.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);
             }

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -112,10 +112,10 @@ class ConnectionManager extends AbstractConnectionManager {
               // Remove it from read/write pool
               this.pool.destroy(connection);
             }
-            Utils.getLogger().debug(`connection error ${err.code}`);
+            Utils.debug(`connection error ${err.code}`);
           });
         }
-        Utils.getLogger().debug(`connection acquire`);
+        Utils.debug(`connection acquire`);
         resolve(connection);
       });
 
@@ -129,14 +129,14 @@ class ConnectionManager extends AbstractConnectionManager {
     // Dont disconnect connections with an ended protocol
     // That wil trigger a connection error
     if (connection._protocol._ended) {
-      Utils.getLogger().debug(`connection tried to disconnect but was already at ENDED state`);
+      Utils.debug(`connection tried to disconnect but was already at ENDED state`);
       return Promise.resolve();
     }
 
     return new Promise((resolve, reject) => {
       connection.end(err => {
         if (err) return reject(new sequelizeErrors.ConnectionError(err));
-        Utils.getLogger().debug(`connection disconnected`);
+        Utils.debug(`connection disconnected`);
         resolve();
       });
     });

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -2,6 +2,7 @@
 
 const AbstractConnectionManager = require('../abstract/connection-manager');
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('connection:mysql');
 const Promise = require('../../promise');
 const sequelizeErrors = require('../../errors');
 const dataTypes = require('../../data-types').mysql;
@@ -112,10 +113,10 @@ class ConnectionManager extends AbstractConnectionManager {
               // Remove it from read/write pool
               this.pool.destroy(connection);
             }
-            Utils.debug(`connection error ${err.code}`);
+            debug(`connection error ${err.code}`);
           });
         }
-        Utils.debug(`connection acquire`);
+        debug(`connection acquire`);
         resolve(connection);
       });
 
@@ -129,14 +130,14 @@ class ConnectionManager extends AbstractConnectionManager {
     // Dont disconnect connections with an ended protocol
     // That wil trigger a connection error
     if (connection._protocol._ended) {
-      Utils.debug(`connection tried to disconnect but was already at ENDED state`);
+      debug(`connection tried to disconnect but was already at ENDED state`);
       return Promise.resolve();
     }
 
     return new Promise((resolve, reject) => {
       connection.end(err => {
         if (err) return reject(new sequelizeErrors.ConnectionError(err));
-        Utils.debug(`connection disconnected`);
+        debug(`connection disconnected`);
         resolve();
       });
     });

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -112,8 +112,10 @@ class ConnectionManager extends AbstractConnectionManager {
               // Remove it from read/write pool
               this.pool.destroy(connection);
             }
+            Utils.getLogger().debug(`connection error ${err.code}`);
           });
         }
+        Utils.getLogger().debug(`connection acquire`);
         resolve(connection);
       });
 
@@ -127,12 +129,14 @@ class ConnectionManager extends AbstractConnectionManager {
     // Dont disconnect connections with an ended protocol
     // That wil trigger a connection error
     if (connection._protocol._ended) {
+      Utils.getLogger().debug(`connection tried to disconnect but was already at ENDED state`);
       return Promise.resolve();
     }
 
     return new Promise((resolve, reject) => {
       connection.end(err => {
         if (err) return reject(new sequelizeErrors.ConnectionError(err));
+        Utils.getLogger().debug(`connection disconnected`);
         resolve();
       });
     });

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -116,7 +116,7 @@ class ConnectionManager extends AbstractConnectionManager {
             debug(`connection error ${err.code}`);
           });
         }
-        debug(`connection acquire`);
+        debug(`connection acquired`);
         resolve(connection);
       });
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -38,12 +38,12 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.getLogger().debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
+    Utils.debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
     return new Utils.Promise((resolve, reject) => {
       this.connection.query(this.sql, (err, results) => {
 
-        Utils.getLogger().debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
+        Utils.debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
           this.sequelize.log('Executed (' + (this.connection.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -38,8 +38,12 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
+    Utils.getLogger().debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
+
     return new Utils.Promise((resolve, reject) => {
       this.connection.query(this.sql, (err, results) => {
+
+        Utils.getLogger().debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
           this.sequelize.log('Executed (' + (this.connection.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('sql:mysql');
 const AbstractQuery = require('../abstract/query');
 const uuid = require('node-uuid');
 const sequelizeErrors = require('../../errors.js');
@@ -38,12 +39,12 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
+    debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
     return new Utils.Promise((resolve, reject) => {
       this.connection.query(this.sql, (err, results) => {
 
-        Utils.debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
+        debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
           this.sequelize.log('Executed (' + (this.connection.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -110,7 +110,7 @@ class ConnectionManager extends AbstractConnectionManager {
           return;
         }
         responded = true;
-        debug(`connection acquire`);
+        debug(`connection acquired`);
         resolve(connection);
       });
 

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -2,6 +2,7 @@
 
 const AbstractConnectionManager = require('../abstract/connection-manager');
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('connection:pg');
 const Promise = require('../../promise');
 const sequelizeErrors = require('../../errors');
 const semver = require('semver');
@@ -109,13 +110,13 @@ class ConnectionManager extends AbstractConnectionManager {
           return;
         }
         responded = true;
-        Utils.debug(`connection acquire`);
+        debug(`connection acquire`);
         resolve(connection);
       });
 
       // If we didn't ever hear from the client.connect() callback the connection timeout, node-postgres does not treat this as an error since no active query was ever emitted
       connection.on('end', () => {
-        Utils.debug(`connection disconnect`);
+        debug(`connection disconnect`);
         if (!responded) {
           reject(new sequelizeErrors.ConnectionTimedOutError(new Error('Connection timed out')));
         }
@@ -123,7 +124,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       // Don't let a Postgres restart (or error) to take down the whole app
       connection.on('error', (err) => {
-        Utils.debug(`connection error ${err.code}`);
+        debug(`connection error ${err.code}`);
         connection._invalid = true;
       });
     }).tap(connection => {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -116,7 +116,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       // If we didn't ever hear from the client.connect() callback the connection timeout, node-postgres does not treat this as an error since no active query was ever emitted
       connection.on('end', () => {
-        debug(`connection disconnect`);
+        debug(`connection timeout`);
         if (!responded) {
           reject(new sequelizeErrors.ConnectionTimedOutError(new Error('Connection timed out')));
         }

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -109,13 +109,13 @@ class ConnectionManager extends AbstractConnectionManager {
           return;
         }
         responded = true;
-        Utils.getLogger().debug(`connection acquire`);
+        Utils.debug(`connection acquire`);
         resolve(connection);
       });
 
       // If we didn't ever hear from the client.connect() callback the connection timeout, node-postgres does not treat this as an error since no active query was ever emitted
       connection.on('end', () => {
-        Utils.getLogger().debug(`connection disconnect`);
+        Utils.debug(`connection disconnect`);
         if (!responded) {
           reject(new sequelizeErrors.ConnectionTimedOutError(new Error('Connection timed out')));
         }
@@ -123,7 +123,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       // Don't let a Postgres restart (or error) to take down the whole app
       connection.on('error', (err) => {
-        Utils.getLogger().debug(`connection error ${err.code}`);
+        Utils.debug(`connection error ${err.code}`);
         connection._invalid = true;
       });
     }).tap(connection => {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -109,18 +109,21 @@ class ConnectionManager extends AbstractConnectionManager {
           return;
         }
         responded = true;
+        Utils.getLogger().debug(`connection acquire`);
         resolve(connection);
       });
 
       // If we didn't ever hear from the client.connect() callback the connection timeout, node-postgres does not treat this as an error since no active query was ever emitted
       connection.on('end', () => {
+        Utils.getLogger().debug(`connection disconnect`);
         if (!responded) {
           reject(new sequelizeErrors.ConnectionTimedOutError(new Error('Connection timed out')));
         }
       });
 
       // Don't let a Postgres restart (or error) to take down the whole app
-      connection.on('error', () => {
+      connection.on('error', (err) => {
+        Utils.getLogger().debug(`connection error ${err.code}`);
         connection._invalid = true;
       });
     }).tap(connection => {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('sql:pg');
 const AbstractQuery = require('../abstract/query');
 const QueryTypes = require('../../query-types');
 const Promise = require('../../promise');
@@ -72,7 +73,7 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.debug(`executing(${this.client.uuid || 'default'}) : ${this.sql}`);
+    debug(`executing(${this.client.uuid || 'default'}) : ${this.sql}`);
 
     return new Promise((resolve, reject) => {
       query.on('row', row => {
@@ -93,7 +94,7 @@ class Query extends AbstractQuery {
 
       query.on('end', result => {
 
-        Utils.debug(`executed(${this.client.uuid || 'default'}) : ${this.sql}`);
+        debug(`executed(${this.client.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
           this.sequelize.log('Executed (' + (this.client.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -72,7 +72,7 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.getLogger().debug(`executing(${this.client.uuid || 'default'}) : ${this.sql}`);
+    Utils.debug(`executing(${this.client.uuid || 'default'}) : ${this.sql}`);
 
     return new Promise((resolve, reject) => {
       query.on('row', row => {
@@ -93,7 +93,7 @@ class Query extends AbstractQuery {
 
       query.on('end', result => {
 
-        Utils.getLogger().debug(`executed(${this.client.uuid || 'default'}) : ${this.sql}`);
+        Utils.debug(`executed(${this.client.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
           this.sequelize.log('Executed (' + (this.client.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -72,6 +72,8 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
+    Utils.getLogger().debug(`executing(${this.client.uuid || 'default'}) : ${this.sql}`);
+
     return new Promise((resolve, reject) => {
       query.on('row', row => {
         rows.push(row);
@@ -90,6 +92,8 @@ class Query extends AbstractQuery {
       });
 
       query.on('end', result => {
+
+        Utils.getLogger().debug(`executed(${this.client.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
           this.sequelize.log('Executed (' + (this.client.uuid || 'default') + '): ' + this.sql, (Date.now() - queryBegin), this.options);

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -61,7 +61,7 @@ class ConnectionManager extends AbstractConnectionManager {
             if (err.code === 'SQLITE_CANTOPEN') return reject(new sequelizeErrors.ConnectionError(err));
             return reject(new sequelizeErrors.ConnectionError(err));
           }
-          Utils.getLogger().debug(`connection acquire ${options.uuid}`);
+          Utils.debug(`connection acquire ${options.uuid}`);
           resolve(this.connections[options.inMemory || options.uuid]);
         }
       );
@@ -79,7 +79,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
     if (connection.uuid) {
       connection.close();
-      Utils.getLogger().debug(`connection released ${connection.uuid}`);
+      Utils.debug(`connection released ${connection.uuid}`);
       delete this.connections[connection.uuid];
     }
   }

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -3,6 +3,7 @@
 const AbstractConnectionManager = require('../abstract/connection-manager');
 const Promise = require('../../promise');
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('connection:sqlite');
 const dataTypes = require('../../data-types').sqlite;
 const sequelizeErrors = require('../../errors');
 const parserStore = require('../parserStore')('sqlite');
@@ -61,7 +62,7 @@ class ConnectionManager extends AbstractConnectionManager {
             if (err.code === 'SQLITE_CANTOPEN') return reject(new sequelizeErrors.ConnectionError(err));
             return reject(new sequelizeErrors.ConnectionError(err));
           }
-          Utils.debug(`connection acquire ${options.uuid}`);
+          debug(`connection acquire ${options.uuid}`);
           resolve(this.connections[options.inMemory || options.uuid]);
         }
       );
@@ -79,7 +80,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
     if (connection.uuid) {
       connection.close();
-      Utils.debug(`connection released ${connection.uuid}`);
+      debug(`connection released ${connection.uuid}`);
       delete this.connections[connection.uuid];
     }
   }

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -2,6 +2,7 @@
 
 const AbstractConnectionManager = require('../abstract/connection-manager');
 const Promise = require('../../promise');
+const Utils = require('../../utils');
 const dataTypes = require('../../data-types').sqlite;
 const sequelizeErrors = require('../../errors');
 const parserStore = require('../parserStore')('sqlite');
@@ -60,6 +61,7 @@ class ConnectionManager extends AbstractConnectionManager {
             if (err.code === 'SQLITE_CANTOPEN') return reject(new sequelizeErrors.ConnectionError(err));
             return reject(new sequelizeErrors.ConnectionError(err));
           }
+          Utils.getLogger().debug(`connection acquire ${options.uuid}`);
           resolve(this.connections[options.inMemory || options.uuid]);
         }
       );
@@ -77,6 +79,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
     if (connection.uuid) {
       connection.close();
+      Utils.getLogger().debug(`connection released ${connection.uuid}`);
       delete this.connections[connection.uuid];
     }
   }

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -62,7 +62,7 @@ class ConnectionManager extends AbstractConnectionManager {
             if (err.code === 'SQLITE_CANTOPEN') return reject(new sequelizeErrors.ConnectionError(err));
             return reject(new sequelizeErrors.ConnectionError(err));
           }
-          debug(`connection acquire ${options.uuid}`);
+          debug(`connection acquired ${options.uuid}`);
           resolve(this.connections[options.inMemory || options.uuid]);
         }
       );

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Utils = require('../../utils');
+const debug = Utils.getLogger().debugContext('sql:sqlite');
 const Promise = require('../../promise');
 const AbstractQuery = require('../abstract/query');
 const QueryTypes = require('../../query-types');
@@ -93,7 +94,7 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.debug(`executing(${this.database.uuid || 'default'}) : ${this.sql}`);
+    debug(`executing(${this.database.uuid || 'default'}) : ${this.sql}`);
 
     return new Promise(resolve => {
       const columnTypes = {};
@@ -108,7 +109,7 @@ class Query extends AbstractQuery {
               function afterExecute(err, results) {
                 /* jshint validthis:true */
 
-                Utils.debug(`executed(${query.database.uuid || 'default'}) : ${query.sql}`);
+                debug(`executed(${query.database.uuid || 'default'}) : ${query.sql}`);
 
                 if (benchmark) {
                   query.sequelize.log('Executed (' + (query.database.uuid || 'default') + '): ' + query.sql, (Date.now() - queryBegin), query.options);

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -93,7 +93,7 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
-    Utils.getLogger().debug(`executing(${this.database.uuid || 'default'}) : ${this.sql}`);
+    Utils.debug(`executing(${this.database.uuid || 'default'}) : ${this.sql}`);
 
     return new Promise(resolve => {
       const columnTypes = {};
@@ -108,7 +108,7 @@ class Query extends AbstractQuery {
               function afterExecute(err, results) {
                 /* jshint validthis:true */
 
-                Utils.getLogger().debug(`executed(${query.database.uuid || 'default'}) : ${query.sql}`);
+                Utils.debug(`executed(${query.database.uuid || 'default'}) : ${query.sql}`);
 
                 if (benchmark) {
                   query.sequelize.log('Executed (' + (query.database.uuid || 'default') + '): ' + query.sql, (Date.now() - queryBegin), query.options);

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const Utils = require('../../utils');
 const Promise = require('../../promise');
 const AbstractQuery = require('../abstract/query');
 const QueryTypes = require('../../query-types');
@@ -92,6 +93,8 @@ class Query extends AbstractQuery {
       this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
     }
 
+    Utils.getLogger().debug(`executing(${this.database.uuid || 'default'}) : ${this.sql}`);
+
     return new Promise(resolve => {
       const columnTypes = {};
       this.database.serialize(() => {
@@ -104,6 +107,9 @@ class Query extends AbstractQuery {
               // cannot use arrow function here because the function is bound to the statement
               function afterExecute(err, results) {
                 /* jshint validthis:true */
+
+                Utils.getLogger().debug(`executed(${query.database.uuid || 'default'}) : ${query.sql}`);
+
                 if (benchmark) {
                   query.sequelize.log('Executed (' + (query.database.uuid || 'default') + '): ' + query.sql, (Date.now() - queryBegin), query.options);
                 }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -80,6 +80,8 @@ var hookAliases = {
   beforeConnection: 'beforeConnect'
 };
 
+var debug = Utils.getLogger().debug;
+
 var Hooks = {
   replaceHookAliases: function(hooks) {
     var realHookName;
@@ -118,6 +120,7 @@ var Hooks = {
     if (hookTypes[hookType] && hookTypes[hookType].sync) {
       hooks.forEach(function(hook) {
         if (typeof hook === 'object') hook = hook.fn;
+        debug(`running hook ${hookType}`); // log sync hooks
         return hook.apply(self, fnArgs);
       });
       return;
@@ -132,7 +135,7 @@ var Hooks = {
       if (hookType && hook.length > hookTypes[hookType].params) {
         hook = Promise.promisify(hook, self);
       }
-
+      debug(`running hook ${hookType}`); // log async hook
       return hook.apply(self, fnArgs);
     }).return();
 
@@ -158,6 +161,7 @@ var Hooks = {
       name = null;
     }
 
+    debug(`adding hook ${hookType}`);
     hookType = hookAliases[hookType] || hookType;
 
     this.options.hooks[hookType] = this.options.hooks[hookType] || [];
@@ -178,6 +182,7 @@ var Hooks = {
       return this;
     }
 
+    debug(`removing hook ${hookType}`);
     this.options.hooks[hookType] = this.options.hooks[hookType].filter(function (hook) {
       // don't remove unnamed hooks
       if (typeof hook === 'function') {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -1,7 +1,8 @@
 'use strict';
 
-var Utils = require('./utils')
-  , Promise = require('./promise');
+const Utils = require('./utils')
+  , Promise = require('./promise')
+  , debug = Utils.getLogger().debugContext('hooks');
 
 /**
  * Hooks are function that are called before and after  (bulk-) creation/updating/deletion and validation. Hooks can be added to you models in three ways:
@@ -118,7 +119,7 @@ var Hooks = {
     if (hookTypes[hookType] && hookTypes[hookType].sync) {
       hooks.forEach(function(hook) {
         if (typeof hook === 'object') hook = hook.fn;
-        Utils.debug(`running hook ${hookType}`); // log sync hooks
+        debug(`running hook ${hookType}`); // log sync hooks
         return hook.apply(self, fnArgs);
       });
       return;
@@ -133,7 +134,7 @@ var Hooks = {
       if (hookType && hook.length > hookTypes[hookType].params) {
         hook = Promise.promisify(hook, self);
       }
-      Utils.debug(`running hook ${hookType}`); // log async hook
+      debug(`running hook ${hookType}`); // log async hook
       return hook.apply(self, fnArgs);
     }).return();
 
@@ -159,7 +160,7 @@ var Hooks = {
       name = null;
     }
 
-    Utils.debug(`adding hook ${hookType}`);
+    debug(`adding hook ${hookType}`);
     hookType = hookAliases[hookType] || hookType;
 
     this.options.hooks[hookType] = this.options.hooks[hookType] || [];

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -80,8 +80,6 @@ var hookAliases = {
   beforeConnection: 'beforeConnect'
 };
 
-var debug = Utils.getLogger().debug;
-
 var Hooks = {
   replaceHookAliases: function(hooks) {
     var realHookName;
@@ -120,7 +118,7 @@ var Hooks = {
     if (hookTypes[hookType] && hookTypes[hookType].sync) {
       hooks.forEach(function(hook) {
         if (typeof hook === 'object') hook = hook.fn;
-        debug(`running hook ${hookType}`); // log sync hooks
+        Utils.debug(`running hook ${hookType}`); // log sync hooks
         return hook.apply(self, fnArgs);
       });
       return;
@@ -135,7 +133,7 @@ var Hooks = {
       if (hookType && hook.length > hookTypes[hookType].params) {
         hook = Promise.promisify(hook, self);
       }
-      debug(`running hook ${hookType}`); // log async hook
+      Utils.debug(`running hook ${hookType}`); // log async hook
       return hook.apply(self, fnArgs);
     }).return();
 
@@ -161,7 +159,7 @@ var Hooks = {
       name = null;
     }
 
-    debug(`adding hook ${hookType}`);
+    Utils.debug(`adding hook ${hookType}`);
     hookType = hookAliases[hookType] || hookType;
 
     this.options.hooks[hookType] = this.options.hooks[hookType] || [];
@@ -182,7 +180,7 @@ var Hooks = {
       return this;
     }
 
-    debug(`removing hook ${hookType}`);
+    Utils.debug(`removing hook ${hookType}`);
     this.options.hooks[hookType] = this.options.hooks[hookType].filter(function (hook) {
       // don't remove unnamed hooks
       if (typeof hook === 'function') {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -187,7 +187,7 @@ class Sequelize {
     }
 
     if (this.options.logging === true) {
-      console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
+      Utils.getLogger().deprecate('The logging-option should be either a function or false. Default: console.log');
       this.options.logging = console.log;
     }
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -187,7 +187,7 @@ class Sequelize {
     }
 
     if (this.options.logging === true) {
-      Utils.getLogger().deprecate('The logging-option should be either a function or false. Default: console.log');
+      Utils.deprecate('The logging-option should be either a function or false. Default: console.log');
       this.options.logging = console.log;
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,11 +14,8 @@ let logger = new Logger();
 
 exports.Promise = Promise;
 exports._ = _;
-
-function getLogger() {
-  return logger;
-}
-exports.getLogger = getLogger;
+exports.debug = logger.debug.bind(logger);
+exports.deprecate = logger.deprecate.bind(logger);
 
 function useInflection(_inflection) {
   inflection = _inflection;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,13 +4,21 @@ const DataTypes = require('./data-types');
 const SqlString = require('./sql-string');
 const _ = require('lodash').runInContext(); // Prevent anyone messing with template settings by creating a fresh copy
 const parameterValidator = require('./utils/parameter-validator');
+const Logger = require('./utils/logger');
 const uuid = require('node-uuid');
 const Promise = require('./promise');
 const primitives = ['string', 'number', 'boolean'];
+
 let inflection = require('inflection');
+let logger = new Logger();
 
 exports.Promise = Promise;
 exports._ = _;
+
+function getLogger() {
+  return logger;
+}
+exports.getLogger = getLogger;
 
 function useInflection(_inflection) {
   inflection = _inflection;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -16,6 +16,7 @@ exports.Promise = Promise;
 exports._ = _;
 exports.debug = logger.debug.bind(logger);
 exports.deprecate = logger.deprecate.bind(logger);
+exports.getLogger = () => ( logger );
 
 function useInflection(_inflection) {
   inflection = _inflection;

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,3 +1,5 @@
+'use strict';
+
 /**
  * Sequelize module for debug and deprecation messages.
  * It require a `context` for which messages will be printed.

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -31,6 +31,13 @@ class Logger {
   debug(message) {
     this.config.debug && this.debug(message);
   }
+
+  debugContext(childContext) {
+    if (!context) {
+      throw new Error('No context supplied to debug');
+    }
+    return debug([this.config.context, childContext].join(':'));
+  }
 }
 
 module.exports = Logger;

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -33,7 +33,7 @@ class Logger {
   }
 
   debugContext(childContext) {
-    if (!context) {
+    if (!childContext) {
       throw new Error('No context supplied to debug');
     }
     return debug([this.config.context, childContext].join(':'));

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -1,0 +1,34 @@
+/**
+ * Sequelize module for debug and deprecation messages.
+ * It require a `context` for which messages will be printed.
+ *
+ * @module logging
+ */
+
+/* jshint -W030 */
+const depd = require('depd')
+    , debug = require('debug')
+    , _ = require('lodash');
+
+class Logger {
+  constructor(config) {
+
+    this.config = _.extend({
+      context: 'sequelize',
+      debug: true
+    }, config || {});
+
+    this.depd = depd(this.config.context);
+    this.debug = debug(this.config.context);
+  }
+
+  deprecate(message) {
+    this.depd(message);
+  }
+
+  debug(message) {
+    this.config.debug && this.debug(message);
+  }
+}
+
+module.exports = Logger;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.0",
+    "debug": "^2.2.0",
     "depd": "^1.1.0",
     "dottie": "^1.0.0",
     "generic-pool": "2.4.2",


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #2852
Closes #851 

Added support for logging via DEBUG module.
Also used `depd` module to show deprecation warning. Setup a module for handling all logging tasks.

- [x] Query pre / post execution
- [x] Hooks removal / addition / running
- [x] Connection connection / disconnect / error ( all dialects)
- [x] Pool init / drain / release
 