### PR TITLE
Use independent copy of bluebird (closes #5974)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,10 +11,12 @@
 - [ADDED] `DEBUG` support [#2852](https://github.com/sequelize/sequelize/issues/2852)
 - [ADDED] Intensive connection logging [#851](https://github.com/sequelize/sequelize/issues/851)
 - [FIXED] Only `belongsTo` uses `as` to construct foreign key - revert of [#5957](https://github.com/sequelize/sequelize/pull/5957) introduced in 4.0.0-0
+- [CHANGED] `Sequelize.Promise` is now an independent copy of `bluebird` library [#5974](https://github.com/sequelize/sequelize/issues/5974)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)
 - Only `belongsTo` uses `as` to construct foreign key - revert of [#5957](https://github.com/sequelize/sequelize/pull/5957) introduced in 4.0.0-0
+- Sequelize uses an independent copy of `bluebird` library. This means (1) promises returned from Sequelize methods are instances of `Sequelize.Promise` but not global `Bluebird` and (2) the CLS patch does not affect global `Bluebird`.
 
 # 4.0.0-0
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const Promise = require('bluebird');
+const Promise = require('bluebird').getNewLibraryCopy();
 const shimmer = require('shimmer');
 
 // functionName: The Promise function that should be shimmed

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "https://github.com/sequelize/sequelize/issues"
   },
   "dependencies": {
-    "bluebird": "^3.4.0",
+    "bluebird": "^3.4.1",
     "debug": "^2.2.0",
     "depd": "^1.1.0",
     "dottie": "^1.0.0",

--- a/test/unit/promise.test.js
+++ b/test/unit/promise.test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+, expect = chai.expect
+, Support = require(__dirname + '/support')
+, Sequelize = Support.Sequelize
+, Promise = Sequelize.Promise
+, Bluebird = require('bluebird');
+
+describe('Promise', function() {
+  it('should be an independent copy of bluebird library', function() {
+    expect(Promise.prototype.then).to.be.a('function');
+    expect(Promise).to.not.equal(Bluebird);
+    expect(Promise.prototype).to.not.equal(Bluebird.prototype);
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Have you added an entry under `Future` in the changelog?

### Description of change

As discussed in #5974, this PR makes `Sequelize.Promise` an independent copy of the [bluebird](https://www.npmjs.com/package/bluebird) promise library.

The implications of this are:

* The shims applied to `Sequelize.Promise` for CLS support no longer affect the global instance of bluebird (returned from `require('bluebird')`)
* `Promise` used internally in Sequelize will not be affected by any patches / global options applied by another module to global `Bluebird`
* Promises returned from all Sequelize async methods are `instanceof Sequelize.Promise` but will not be `instanceof require('bluebird')`

It also opens the door for us to use `Promise.coroutine.addYieldHandler()` to allow yielding arrays of promises within coroutines ([co](https://www.npmjs.com/package/co)-style), but without causing malfunction in other code outside of Sequelize which also uses bluebird coroutines.