### PR TITLE
Do not set limit if findOne() is run querying on a unique key

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1444,10 +1444,17 @@ class Model {
     options = Utils.cloneDeep(options);
 
     if (options.limit === undefined) {
-      const pkVal = options.where && options.where[this.primaryKeyAttribute];
 
-      // Don't add limit if querying directly on the pk
-      if (!options.where || !(Utils.isPrimitive(pkVal) || Buffer.isBuffer(pkVal))) {
+      var self = this;
+      // Don't add limit if querying directly on the pk or any other unique key
+      if (!options.where || !Object.keys(this.attributes).some(function (key) {
+        var attribute = self.rawAttributes[key];
+        if (attribute.unique === true || attribute.primaryKey === true) {
+          var value = options.where[attribute.fieldName];
+          return Utils.isPrimitive(value) || Buffer.isBuffer(value);
+        }
+        return false;
+      })) {
         options.limit = 1;
       }
     }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._
### Description of change

I noticed that when I am running a query using findOne() with an include and querying on a unique key, sequelize produces a MySQL query with a nested subquery. The nested subquery is not there when I change the query to use the primary key in the where clause instead of the unique key.

I extended the if clause in the findOne() method to treat both these cases equally as I believe the extra nested subquery is not needed in the former case.

I am not sure how to write a test for this as this change does not have implications on the outside - only the query is simpler internally. Please advise.
