### PR TITLE
Fix #6148, Ignore the group on findAndCountAll

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
 - [ADDED] Intensive connection logging [#851](https://github.com/sequelize/sequelize/issues/851)
 - [FIXED] Only `belongsTo` uses `as` to construct foreign key - revert of [#5957](https://github.com/sequelize/sequelize/pull/5957) introduced in 4.0.0-0
 - [CHANGED] `Sequelize.Promise` is now an independent copy of `bluebird` library [#5974](https://github.com/sequelize/sequelize/issues/5974)
+- [FIXED] `findAndCountAll` dont ignore `group` [#6148](https://github.com/sequelize/sequelize/issues/6148)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1292,7 +1292,7 @@ class Model {
     // forgot to pass options.where ?
     if (!options.where) {
       let commonKeys =  _.intersection(_.keys(options), _.keys(this.rawAttributes));
-      // jshint -W030 
+      // jshint -W030
       commonKeys.length && Utils.warn(`Model attributes (${commonKeys.join(',')}) found in finder method options but options.where object is empty. Did you forget to use options.where?`);
     }
 
@@ -1619,8 +1619,8 @@ class Model {
       throw new Error('The argument passed to findAndCount must be an options object, use findById if you wish to pass a single primary key value');
     }
 
-    // no limit, offset, order, attributes for the options given to count()
-    const countOptions = _.omit(_.clone(options), ['offset', 'limit', 'order', 'attributes']);
+    // no limit, offset, order, attributes, group for the options given to count()
+    const countOptions = _.omit(_.clone(options), ['offset', 'limit', 'order', 'attributes', 'group']);
 
     this._conformOptions(countOptions, this);
 

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1265,6 +1265,14 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    it('handles group', function() {
+      return this.User.findAndCountAll({group: 'username', offset: 1}).then(function(info) {
+        expect(info.count).to.equal(3);
+        expect(Array.isArray(info.rows)).to.be.ok;
+        expect(info.rows.length).to.equal(2);
+      });
+    });
+
     it('handles limit', function() {
       return this.User.findAndCountAll({limit: 1}).then(function(info) {
         expect(info.count).to.equal(3);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #6148

`findAndCountAll` now ignores `group` for count

