### PR TITLE
Fix #3965, before/after upsert hooks

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@
 - [CHANGED] `Sequelize.Promise` is now an independent copy of `bluebird` library [#5974](https://github.com/sequelize/sequelize/issues/5974)
 - [ADDED] before/after Save hook [#2702](https://github.com/sequelize/sequelize/issues/2702)
 - [ADDED] Remove hooks by reference [#6155](https://github.com/sequelize/sequelize/issues/6155)
+- [ADDED] before/after Upsert hook [#3965](https://github.com/sequelize/sequelize/issues/3965)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/docs/docs/hooks.md
+++ b/docs/docs/hooks.md
@@ -22,6 +22,7 @@ For a full list of hooks, see [Hooks API](/api/hooks).
   beforeDestroy(instance, options, fn)
   beforeUpdate(instance, options, fn)
   beforeSave(instance, options, fn)
+  beforeUpsert(values, options, fn)
 (-)
   create
   destroy
@@ -31,6 +32,7 @@ For a full list of hooks, see [Hooks API](/api/hooks).
   afterDestroy(instance, options, fn)
   afterUpdate(instance, options, fn)
   afterSave(instance, options, fn)
+  afterUpsert(created, options, fn)
 (6)
   afterBulkCreate(instances, options, fn)
   afterBulkDestroy(options, fn)

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -50,6 +50,8 @@ const hookTypes = {
   afterUpdate: {params: 2},
   beforeSave: {params: 2, proxies: ['beforeUpdate', 'beforeCreate']},
   afterSave: {params: 2, proxies: ['afterUpdate', 'afterCreate']},
+  beforeUpsert: {params: 2},
+  afterUpsert: {params: 2},
   beforeBulkCreate: {params: 2},
   afterBulkCreate: {params: 2},
   beforeBulkDestroy: {params: 1},
@@ -269,12 +271,26 @@ Hooks.hasHooks = Hooks.hasHook;
  * @name afterCreate
  */
 
- /**
-  * A hook that is run before creating or updating a single instance, It proxies `beforeCreate` and `beforeUpdate`
-  * @param {String}   name
-  * @param {Function} fn   A callback function that is called with attributes, options
-  * @name beforeSave
-  */
+/**
+ * A hook that is run before creating or updating a single instance, It proxies `beforeCreate` and `beforeUpdate`
+ * @param {String}   name
+ * @param {Function} fn   A callback function that is called with attributes, options
+ * @name beforeSave
+ */
+
+/**
+ * A hook that is run before upserting
+ * @param {String}   name
+ * @param {Function} fn   A callback function that is called with attributes, options
+ * @name beforeUpsert
+ */
+
+/**
+ * A hook that is run after upserting
+ * @param {String}   name
+ * @param {Function} fn   A callback function that is called with attributes, options
+ * @name afterUpsert
+ */
 
  /**
   * A hook that is run after creating or updating a single instance, It proxies `afterCreate` and `afterUpdate`

--- a/lib/model.js
+++ b/lib/model.js
@@ -1964,6 +1964,7 @@ class Model {
    * @param  {Object}       [options]
    * @param  {Boolean}      [options.validate=true] Run validations before the row is inserted
    * @param  {Array}        [options.fields=Object.keys(this.attributes)] The fields to insert / update. Defaults to all fields
+   * @param  {Boolean}      [options.hooks=true]  Run before / after upsert hooks?
    * @param  {Transaction}  [options.transaction] Transaction to run query under
    * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
@@ -1973,7 +1974,9 @@ class Model {
    * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated.
    */
   static upsert(values, options) {
-    options = Utils.cloneDeep(options) || {};
+    options = Utils._.extend({
+      hooks: true
+    }, Utils.cloneDeep(options || {}));
 
     if (!options.fields) {
       options.fields = Object.keys(this.attributes);
@@ -2006,7 +2009,17 @@ class Model {
         delete updateValues[this.primaryKeyField];
       }
 
-      return this.QueryInterface.upsert(this.getTableName(options), insertValues, updateValues, instance.where(), this, options);
+      return new Promise((resolve) => {
+        if (options.hooks) {
+          resolve(this.runHooks('beforeUpsert', values, options));
+        } else { resolve(); }
+      }).then(() => (
+        this.QueryInterface.upsert(this.getTableName(options), insertValues, updateValues, instance.where(), this, options)
+      )).tap(result => {
+        if (options.hooks) {
+          return this.runHooks('afterUpsert', result, options);
+        }
+      });
     });
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2009,10 +2009,10 @@ class Model {
         delete updateValues[this.primaryKeyField];
       }
 
-      return new Promise((resolve) => {
+      return Promise.try(() => {
         if (options.hooks) {
-          resolve(this.runHooks('beforeUpsert', values, options));
-        } else { resolve(); }
+          return this.runHooks('beforeUpsert', values, options);
+        }
       }).then(() => (
         this.QueryInterface.upsert(this.getTableName(options), insertValues, updateValues, instance.where(), this, options)
       )).tap(result => {

--- a/test/integration/hooks/upsert.test.js
+++ b/test/integration/hooks/upsert.test.js
@@ -2,92 +2,94 @@
 
 /* jshint -W030 */
 var chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , sinon = require('sinon');
+, expect = chai.expect
+, Support = require(__dirname + '/../support')
+, DataTypes = require(__dirname + '/../../../lib/data-types')
+, sinon = require('sinon');
 
-describe(Support.getTestDialectTeaser('Hooks'), function() {
-  beforeEach(function() {
-    this.User = this.sequelize.define('User', {
-      username: {
-        type: DataTypes.STRING,
-        allowNull: false
-      },
-      mood: {
-        type: DataTypes.ENUM,
-        values: ['happy', 'sad', 'neutral']
-      }
+if (Support.sequelize.dialect.supports.upserts) {
+  describe(Support.getTestDialectTeaser('Hooks'), function() {
+    beforeEach(function() {
+      this.User = this.sequelize.define('User', {
+        username: {
+          type: DataTypes.STRING,
+          allowNull: false
+        },
+        mood: {
+          type: DataTypes.ENUM,
+          values: ['happy', 'sad', 'neutral']
+        }
+      });
+      return this.sequelize.sync({ force: true });
     });
-    return this.sequelize.sync({ force: true });
+
+    describe('#upsert', function() {
+      describe('on success', function() {
+        it('should run hooks', function() {
+          var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+          this.User.beforeUpsert(beforeHook);
+          this.User.afterUpsert(afterHook);
+
+          return this.User.upsert({username: 'Toni', mood: 'happy'}).then(function() {
+            expect(beforeHook).to.have.been.calledOnce;
+            expect(afterHook).to.have.been.calledOnce;
+          });
+        });
+      });
+
+      describe('on error', function() {
+        it('should return an error from before', function() {
+          var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+          this.User.beforeUpsert(function(values, options) {
+            beforeHook();
+            throw new Error('Whoops!');
+          });
+          this.User.afterUpsert(afterHook);
+
+          return expect(this.User.upsert({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
+            expect(beforeHook).to.have.been.calledOnce;
+            expect(afterHook).not.to.have.been.called;
+          });
+        });
+
+        it('should return an error from after', function() {
+          var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+
+          this.User.beforeUpsert(beforeHook);
+          this.User.afterUpsert(function(user, options) {
+            afterHook();
+            throw new Error('Whoops!');
+          });
+
+          return expect(this.User.upsert({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
+            expect(beforeHook).to.have.been.calledOnce;
+            expect(afterHook).to.have.been.calledOnce;
+          });
+        });
+      });
+
+      describe('preserves changes to values', function() {
+        it('beforeUpsert', function(){
+          var hookCalled = 0;
+          var valuesOriginal = { mood: 'sad', username: 'leafninja' };
+
+          this.User.beforeUpsert(function(values, options) {
+            values.mood = 'happy';
+            hookCalled++;
+          });
+
+          return this.User.upsert(valuesOriginal).then(function() {
+            expect(valuesOriginal.mood).to.equal('happy');
+            expect(hookCalled).to.equal(1);
+          });
+        });
+      });
+    });
   });
-
-  describe('#upsert', function() {
-    describe('on success', function() {
-      it('should run hooks', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
-
-        this.User.beforeUpsert(beforeHook);
-        this.User.afterUpsert(afterHook);
-
-        return this.User.upsert({username: 'Toni', mood: 'happy'}).then(function() {
-          expect(beforeHook).to.have.been.calledOnce;
-          expect(afterHook).to.have.been.calledOnce;
-        });
-      });
-    });
-
-    describe('on error', function() {
-      it('should return an error from before', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
-
-        this.User.beforeUpsert(function(values, options) {
-          beforeHook();
-          throw new Error('Whoops!');
-        });
-        this.User.afterUpsert(afterHook);
-
-        return expect(this.User.upsert({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
-          expect(beforeHook).to.have.been.calledOnce;
-          expect(afterHook).not.to.have.been.called;
-        });
-      });
-
-      it('should return an error from after', function() {
-        var beforeHook = sinon.spy()
-          , afterHook = sinon.spy();
-
-
-        this.User.beforeUpsert(beforeHook);
-        this.User.afterUpsert(function(user, options) {
-          afterHook();
-          throw new Error('Whoops!');
-        });
-
-        return expect(this.User.upsert({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
-          expect(beforeHook).to.have.been.calledOnce;
-          expect(afterHook).to.have.been.calledOnce;
-        });
-      });
-    });
-
-    describe('preserves changes to values', function() {
-      it('beforeUpsert', function(){
-        var hookCalled = 0;
-        var valuesOriginal = { mood: 'sad', username: 'leafninja' };
-
-        this.User.beforeUpsert(function(values, options) {
-          values.mood = 'happy';
-          hookCalled++;
-        });
-
-        return this.User.upsert(valuesOriginal).then(function() {
-          expect(valuesOriginal.mood).to.equal('happy');
-          expect(hookCalled).to.equal(1);
-        });
-      });
-    });
-  });
-});
+}

--- a/test/integration/hooks/upsert.test.js
+++ b/test/integration/hooks/upsert.test.js
@@ -1,0 +1,93 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , DataTypes = require(__dirname + '/../../../lib/data-types')
+  , sinon = require('sinon');
+
+describe(Support.getTestDialectTeaser('Hooks'), function() {
+  beforeEach(function() {
+    this.User = this.sequelize.define('User', {
+      username: {
+        type: DataTypes.STRING,
+        allowNull: false
+      },
+      mood: {
+        type: DataTypes.ENUM,
+        values: ['happy', 'sad', 'neutral']
+      }
+    });
+    return this.sequelize.sync({ force: true });
+  });
+
+  describe('#upsert', function() {
+    describe('on success', function() {
+      it('should run hooks', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+        this.User.beforeUpsert(beforeHook);
+        this.User.afterUpsert(afterHook);
+
+        return this.User.upsert({username: 'Toni', mood: 'happy'}).then(function() {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe('on error', function() {
+      it('should return an error from before', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+        this.User.beforeUpsert(function(values, options) {
+          beforeHook();
+          throw new Error('Whoops!');
+        });
+        this.User.afterUpsert(afterHook);
+
+        return expect(this.User.upsert({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).not.to.have.been.called;
+        });
+      });
+
+      it('should return an error from after', function() {
+        var beforeHook = sinon.spy()
+          , afterHook = sinon.spy();
+
+
+        this.User.beforeUpsert(beforeHook);
+        this.User.afterUpsert(function(user, options) {
+          afterHook();
+          throw new Error('Whoops!');
+        });
+
+        return expect(this.User.upsert({username: 'Toni', mood: 'happy'})).to.be.rejected.then(function(err) {
+          expect(beforeHook).to.have.been.calledOnce;
+          expect(afterHook).to.have.been.calledOnce;
+        });
+      });
+    });
+
+    describe('preserves changes to values', function() {
+      it('beforeUpsert', function(){
+        var hookCalled = 0;
+        var valuesOriginal = { mood: 'sad', username: 'leafninja' };
+
+        this.User.beforeUpsert(function(values, options) {
+          values.mood = 'happy';
+          hookCalled++;
+        });
+
+        return this.User.upsert(valuesOriginal).then(function() {
+          expect(valuesOriginal.mood).to.equal('happy');
+          expect(hookCalled).to.equal(1);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #3965 

Added `before/after Upsert` hooks with tests and documentation update.

