### PR TITLE
belongs-to-many setters will respect through scope

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -542,7 +542,9 @@ class BelongsToMany extends Association {
       const targetKey = association.target.primaryKeyAttribute;
       const identifier = association.identifier;
       const foreignIdentifier = association.foreignIdentifier;
-      const where = {};
+      const sourceWhere = {};
+      let where;
+      let throughScopeWhere;
 
       if (newAssociatedObjects === null) {
         newAssociatedObjects = [];
@@ -550,7 +552,17 @@ class BelongsToMany extends Association {
         newAssociatedObjects = association.toInstanceArray(newAssociatedObjects);
       }
 
-      where[identifier] = this.get(sourceKey);
+      if (association.through.scope) {
+        throughScopeWhere = _.clone(association.through.scope);
+      }
+
+      sourceWhere[identifier] = this.get(sourceKey);
+      where = {
+        $and: [
+          throughScopeWhere,
+          sourceWhere
+        ]
+      };
       return association.through.model.findAll(_.defaults({where, raw: true}, options)).then(currentRows => {
         const obsoleteAssociations = [];
         const promises = [];


### PR DESCRIPTION
### Pull Request check-list

I'll go through this list if the basic functionality of this change is wanted.

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This change modifies the generated set<Assoications> functions for Belong-To-Many relations with a through scope. It adds the through scope to the first select query to avoid removing rows that are outside of the scope.

Without this fix, it's not possible to use setAssociations when having several Belongs-To-Many relationships that only differs in scope.

If this sounds like a good idea, I'll try to add the tests for it as well.

