### PR TITLE
Fixed #5675, beforeFind issue with options modification

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,7 @@
 - [ADDED] before/after Save hook [#2702](https://github.com/sequelize/sequelize/issues/2702)
 - [ADDED] Remove hooks by reference [#6155](https://github.com/sequelize/sequelize/issues/6155)
 - [ADDED] before/after Upsert hook [#3965](https://github.com/sequelize/sequelize/issues/3965)
+- [FIXED] Modifying `options` in `beforeFind` throws error [#5675](https://github.com/sequelize/sequelize/issues/5675)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1297,13 +1297,13 @@ class Model {
     }
 
     return Promise.try(() => {
-      this._conformOptions(options, this);
       this.$injectScope(options);
 
       if (options.hooks) {
         return this.runHooks('beforeFind', options);
       }
     }).then(() => {
+      this._conformOptions(options, this);
       this._expandIncludeAll(options);
 
       if (options.hooks) {

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -30,6 +30,15 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       ]);
     });
 
+    it('allow changing attributes via beforeFind #5675', function() {
+      this.User.beforeFind((options) => {
+        options.attributes = {
+          include: ['id']
+        }
+      });
+      return this.User.findAll({});
+    });
+
     describe('on success', function() {
       it('all hooks run', function() {
         var beforeHook = false

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -34,7 +34,7 @@ describe(Support.getTestDialectTeaser('Hooks'), function() {
       this.User.beforeFind((options) => {
         options.attributes = {
           include: ['id']
-        }
+        };
       });
       return this.User.findAll({});
     });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #5675

`options` now conformed after beforeFind hook so change in hook can be properly parsed as well.

