### PR TITLE
Only add ORDER BY because of the OFFSET NEXT clause when no "order" i…

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -685,9 +685,8 @@ var QueryGenerator = {
     }
 
     if (options.limit || options.offset) {
-      if (!options.order || (options.include && !orders.subQueryOrder.length)) {
-        fragment += (options.order && !isSubQuery) ? ', ' : ' ORDER BY ';
-        fragment += this.quoteIdentifier(model.primaryKeyField);
+      if (!options.order || (isSubQuery && !orders.subQueryOrder.length)) {
+        fragment += ' ORDER BY ' + this.quoteIdentifier(model.primaryKeyField);
       }
 
       if (options.offset || options.limit) {


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? NOT TESTED
- [X] Does your issue contain a link to existing issue (Closes #6162) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions? 
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? No API modification
- [ ] Have you added an entry under `Future` in the changelog? 

### Description of change

This modification is needed to only include the extra ORDER BY when no other sorting is defined. Before could collide when sorting by the primary Key and it gives duplicated column error.