### PR TITLE
Added the ability to catch invalid scopes

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -51,7 +51,7 @@ exports.SequelizeScopeError = SequelizeScopeError;
  * @constructor
  */
 class ValidationError extends BaseError {
-  constructor(message) {
+  constructor(message, errors) {
     super(message);
     this.name = 'SequelizeValidationError';
     this.message = 'Validation Error';

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -25,6 +25,22 @@ class BaseError extends Error {
 exports.BaseError = BaseError;
 
 /**
+ * Scope Error. Thrown when the sequelize cannot query the specified scope.
+ *
+ * @param {string} message Error message
+ *
+ * @extends BaseError
+ * @constructor
+ */
+class SequelizeScopeError extends BaseError {
+  constructor(parent) {
+    super(parent);
+    this.name = 'SequelizeScopeError';
+  }
+}
+exports.SequelizeScopeError = SequelizeScopeError;
+
+/**
  * Validation Error. Thrown when the sequelize validation has failed. The error contains an `errors` property,
  * which is an array with 1 or more ValidationErrorItems, one for each validation that failed.
  *
@@ -35,7 +51,7 @@ exports.BaseError = BaseError;
  * @constructor
  */
 class ValidationError extends BaseError {
-  constructor(message, errors) {
+  constructor(message) {
     super(message);
     this.name = 'SequelizeValidationError';
     this.message = 'Validation Error';

--- a/lib/model.js
+++ b/lib/model.js
@@ -1161,7 +1161,7 @@ class Model {
           return objectValue ? objectValue : sourceValue;
         });
       } else {
-        throw new Error('Invalid scope ' + scopeName + ' called.');
+        throw new sequelizeErrors.SequelizeScopeError('Invalid scope ' + scopeName + ' called.');
       }
     }
 


### PR DESCRIPTION
I literally just added the ability to catch invalid scope errors. My api allows user's to input scopes, and I need a way of catching those input errors. Adding this to the sequelize package seemed like the perfect work around for me, and it doesn't hurt to be there ;)

