### PR TITLE
fixes msssql only error when no order by but has offset or limit present

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -685,6 +685,11 @@ var QueryGenerator = {
     if (options.limit || options.offset) {
       if (!options.order || (options.include && !orders.subQueryOrder.length)) {
         fragment += (options.order && !isSubQuery) ? ', ' : ' ORDER BY ';
+
+        if(model.name){
+          fragment += this.quoteIdentifier(model.name) + '.';
+        }
+
         fragment += this.quoteIdentifier(model.primaryKeyField);
       }
 

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -685,12 +685,7 @@ var QueryGenerator = {
     if (options.limit || options.offset) {
       if (!options.order || (options.include && !orders.subQueryOrder.length)) {
         fragment += (options.order && !isSubQuery) ? ', ' : ' ORDER BY ';
-
-        if(model.name){
-          fragment += this.quoteIdentifier(model.name) + '.';
-        }
-
-        fragment += this.quoteIdentifier(model.primaryKeyField);
+        fragment += this.quoteTable(model.name) + '.' + this.quoteIdentifier(model.primaryKeyField);
       }
 
       if (options.offset || options.limit) {

--- a/test/unit/sql/offset-limit.test.js
+++ b/test/unit/sql/offset-limit.test.js
@@ -26,6 +26,14 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
     };
 
     testsql({
+      limit: 10,//when no order by present, one is automagically prepended, test it's existence
+      model:{primaryKeyField:'id', name:'tableRef'}
+    }, {
+      default: ' LIMIT 10',
+      mssql: ' ORDER BY [tableRef].[id] OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY'
+    });
+
+    testsql({
       limit: 10,
       order: [
         ['email', 'DESC'] // for MSSQL


### PR DESCRIPTION
Quite the simple fix. Applies to MSSQL only.

To reproduce: Create two models and relate them. Then query one with an include of another and then ensure the query has NO order by BUT has an OFFSET or LIMIT. When the order by is automatigically prepend by mssql/query-generator.js, the table reference is not present.

I have tested in my environment but unsure how to make ya'll certain this is the right fix. It is though, I'm using it.

