### PR TITLE
Fix model.count with includes and specified column

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@
 - [FIXED] `Int4` range not properly parsed [#5747](https://github.com/sequelize/sequelize/issues/5747)
 - [FIXED] `upsert` does not fail anymore on not null validations [#5711](https://github.com/sequelize/sequelize/issues/5711)
 - [FIXED] Don't remove includes from count queries and unify findAndCount and count queries. [#6123](https://github.com/sequelize/sequelize/issues/6123)
+- [FIXED] `Model.count` with `options.col` and `options.include` works properly now
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1541,7 +1541,7 @@ class Model {
     }).then(() => {
       let col = options.col || '*';
       if (options.include) {
-        col = this.name + '.' + this.primaryKeyField;
+        col = this.name + '.' + (options.col || this.primaryKeyField);
       }
 
       Utils.mapOptionFieldNames(options, this);

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -150,5 +150,28 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    it('should be able to specify column for COUNT() with includes', function() {
+      return this.sequelize.sync({ force: true }).then(() =>
+        this.User.bulkCreate([
+          { username: 'ember' , age: 10},
+          { username: 'angular' , age: 20},
+          { username: 'mithril' , age: 10}
+        ])
+      ).then(() =>
+        this.User.count({
+          col: 'username',
+          distinct: true,
+          include: [this.Project]
+        })
+      ).then((count) => {
+        expect(parseInt(count)).to.be.eql(3);
+        return this.User.count({
+          col: 'age',
+          distinct: true,
+          include: [this.Project]
+        });
+      }).then((count) => expect(parseInt(count)).to.be.eql(2));
+    });
+
   });
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

This fixes a missed case for the new col option from #6114

[edit]
__Note__: Count is still not working with multiple fields e.g. a composite primary key. And is it really the best idea to add a new option instead of overloading the distinct option to also allow strings instead of a boolean?
[/edit]