### PR TITLE
Better validation of attribute definitions

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1037,7 +1037,10 @@ const QueryGenerator = {
         return this.handleSequelizeMethod(attr);
       }
 
-      if (Array.isArray(attr) && attr.length === 2) {
+      if (Array.isArray(attr)) {
+        if (attr.length !== 2) {
+          throw new Error(JSON.stringify(attr) + ' is not a valid attribute definition. Please use the following format: [\'attribute definition\', \'alias\']');
+        }
         attr = attr.slice();
 
         if (attr[0]._isSequelizeMethod) {

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -155,6 +155,13 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
 
+      it('should fail with meaningful error message on invalid attributes definition', function() {
+        expect(this.User.findOne({
+          where: { id: 1 },
+          attributes: ['id', ['username']]
+        })).to.be.rejectedWith('["username"] is not a valid attribute definition. Please use the following format: [\'attribute definition\', \'alias\']');
+      });
+
       it('should not try to convert boolean values if they are not selected', function() {
         var UserWithBoolean = this.sequelize.define('UserBoolean', {
           active: Sequelize.BOOLEAN


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

When writing more involved attribute definitions with functions (e.g. `attributes: [[sequelize.fn('COUNT', sequelize.fn('DISTINCT', sequelize.literal('CASE WHEN `rulez.acks`.`id` IS NULL AND...)` it happened to me couple of times already that I forgot to specify the actual alias for that attribute. In other words, the attribute was mistakenly defined as `['definition']` instead of `['definition', 'alias']`. In such cases, Sequelize fails with the following error:

```
Unhandled rejection TypeError: s.replace is not a function
    at removeTicks (/opt/insights/sequelize/lib/utils.js:445:12)
    at Object.addTicks (/opt/insights/sequelize/lib/utils.js:439:21)
    at Object.quoteIdentifier (/opt/insights/sequelize/lib/dialects/mysql/query-generator.js:293:18)
    at Object.quoteIdentifiers (/opt/insights/sequelize/lib/dialects/abstract/query-generator.js:909:19)
    at /opt/insights/sequelize/lib/dialects/abstract/query-generator.js:1052:82
```

This error message does not help at all. 

With this PR Sequelize detects when the alias param is missing a throws appropriate error.
