### PR TITLE
(clean up) Closes #6196, Don't global patch validator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,12 +17,15 @@
 - [ADDED] before/after Upsert hook [#3965](https://github.com/sequelize/sequelize/issues/3965)
 - [FIXED] Modifying `options` in `beforeFind` throws error [#5675](https://github.com/sequelize/sequelize/issues/5675)
 - [REMOVED] `classMethods` and `instanceMethods` [#5869](https://github.com/sequelize/sequelize/issues/5869#issuecomment-221773485)
+- [CHANGED] `Sequelize.Validator` is now an independent copy of `validator` library
+- [FIXED] Don't patch `validator` library globally [#6196](https://github.com/sequelize/sequelize/issues/6196)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)
 - Only `belongsTo` uses `as` to construct foreign key - revert of [#5957](https://github.com/sequelize/sequelize/pull/5957) introduced in 4.0.0-0
 - Sequelize uses an independent copy of `bluebird` library. This means (1) promises returned from Sequelize methods are instances of `Sequelize.Promise` but not global `Bluebird` and (2) the CLS patch does not affect global `Bluebird`.
 - Dropped support for `classMethods` and `instanceMethods`. As Models are now ES6 classes `classMethods` can be directly assigned and `instanceMethods` should be added to `Model.prototype`
+- `Sequelize.Validator` is now a cloned version of `validator`, It will not pollute global library methods.
 
 # 4.0.0-0
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -7,7 +7,7 @@ const _ = require('lodash');
 const Wkt = require('terraformer-wkt-parser');
 const sequelizeErrors = require('./errors');
 const warnings = {};
-const Validator = require('validator');
+const Validator = require('./utils/validator-extras').validator;
 const momentTz = require('moment-timezone');
 const moment = require('moment');
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -15,6 +15,7 @@ const sequelizeErrors = require('./errors');
 const Promise = require('./promise');
 const Hooks = require('./hooks');
 const Association = require('./associations/index');
+const Validator = require('./utils/validator-extras').validator;
 const _ = require('lodash');
 
 /**
@@ -1219,7 +1220,7 @@ Sequelize.prototype.QueryTypes = Sequelize.QueryTypes = QueryTypes;
  * @property Validator
  * @see https://github.com/chriso/validator.js
  */
-Sequelize.prototype.Validator = Sequelize.Validator = require('validator');
+Sequelize.prototype.Validator = Sequelize.Validator = Validator;
 
 Sequelize.prototype.Model = Sequelize.Model = Model;
 

--- a/lib/utils/validator-extras.js
+++ b/lib/utils/validator-extras.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const validator = require('validator');
 const _ = require('lodash');
+const validator = _.cloneDeep(require('validator'));
 
 const extensions = {
   extend(name, fn) {
@@ -38,7 +38,7 @@ const extensions = {
     return !this.regex(str, pattern, modifiers);
   },
   isDecimal(str) {
-    return str !== '' && str.match(/^(?:-?(?:[0-9]+))?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/);
+    return str !== '' && !!str.match(/^(?:-?(?:[0-9]+))?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/);    
   },
   min(str, val) {
     const number = parseFloat(str);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #6196 , Sequelize patching to validator will not modify the global instance.

Also fixed case where `isDecimal` method will return an `Array` instead of `Boolean`.

