### PR TITLE
Fix #5788, passed sync options.logging to query directly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@
 - [FIXED] Don't remove includes from count queries and unify findAndCount and count queries. [#6123](https://github.com/sequelize/sequelize/issues/6123)
 - [FIXED] `Model.count` with `options.col` and `options.include` works properly now
 - [FIXED] `bulkCreate` don't map fields to attributes properly [#4476](https://github.com/sequelize/sequelize/issues/4476)[#3908](https://github.com/sequelize/sequelize/issues/3908)[#4103](https://github.com/sequelize/sequelize/issues/4103)[#3764](https://github.com/sequelize/sequelize/issues/3764)[#3789](https://github.com/sequelize/sequelize/issues/3789)[#4600](https://github.com/sequelize/sequelize/issues/4600)
+- [FIXED] `sync` don't handle global `options.logging` properly [#5788](https://github.com/sequelize/sequelize/issues/5788)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -762,7 +762,6 @@ class Sequelize {
 
     options = _.clone(options) || {};
     options.hooks = options.hooks === undefined ? true : !!options.hooks;
-    options.logging = options.logging === undefined ? false : options.logging;
     options = Utils._.defaults(options, this.options.sync, this.options);
 
     if (options.match) {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #5788, Passed `options.logging` directly to query so it can respect global `logging` options.

