### PR TITLE
Fixed #5747, Properly parse Int4 range types

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@
 - [FIXED] Don't patch `validator` library globally [#6196](https://github.com/sequelize/sequelize/issues/6196)
 - [CHANGED] `ignore` for create was renamed to `ignoreDuplicates` [#6138](https://github.com/sequelize/sequelize/issues/6138)
 - [FIXED] Index names not quoted properly in `removeIndex` [#5888](https://github.com/sequelize/sequelize/issues/5888)
+- [FIXED] `Int4` range not properly parsed [#5747](https://github.com/sequelize/sequelize/issues/5747)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -386,7 +386,7 @@ module.exports = BaseTypes => {
   inherits(RANGE, BaseTypes.RANGE);
 
   RANGE.oid_map = {
-    3904: 1007, // int4
+    3904: 23, // int4
     3905: 1007,
     3906: 1700, // Numeric
     3907: 1700,

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -362,6 +362,24 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
         expect(user.get('decimalWithFloatParser')).to.be.eql('0.12345678');
       });
     });
+
+    it('should return Int4 range properly #5747', function() {
+      var Model = this.sequelize.define('M', {
+        interval: {
+            type: Sequelize.RANGE(Sequelize.INTEGER),
+            allowNull: false,
+            unique: true
+        }
+      });
+
+      return Model.sync({ force: true })
+              .then(() => Model.create({ interval: [1,4] }) )
+              .then(() => Model.findAll() )
+              .spread((m) => {
+                expect(m.interval[0]).to.be.eql(1);
+                expect(m.interval[1]).to.be.eql(4);
+              });
+    });
   }
 
   if (dialect === 'mysql') {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Fixes #5747 , Incorrect `OID` was used for `Int4` in `range` type.
