### PR TITLE
Fix #5888, properly quote index when removing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@
 - [CHANGED] `Sequelize.Validator` is now an independent copy of `validator` library
 - [FIXED] Don't patch `validator` library globally [#6196](https://github.com/sequelize/sequelize/issues/6196)
 - [CHANGED] `ignore` for create was renamed to `ignoreDuplicates` [#6138](https://github.com/sequelize/sequelize/issues/6138)
+- [FIXED] Index names not quoted properly in `removeIndex` [#5888](https://github.com/sequelize/sequelize/issues/5888)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -350,7 +350,7 @@ var QueryGenerator = {
 
     var values = {
       tableName: this.quoteIdentifiers(tableName),
-      indexName: indexName
+      indexName: this.quoteIdentifiers(indexName)
     };
 
     return Utils._.template(sql)(values);

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -195,7 +195,7 @@ const QueryGenerator = {
       indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
     }
 
-    return `DROP INDEX ${indexName} ON ${this.quoteTable(tableName)}`;
+    return `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteTable(tableName)}`;
   },
 
   attributeToSQL(attribute, options) {

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -232,7 +232,7 @@ const QueryGenerator = {
       indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
     }
 
-    return 'DROP INDEX IF EXISTS ' + indexName;
+    return `DROP INDEX IF EXISTS ${this.quoteIdentifier(indexName)}`;
   },
 
   describeTableQuery(tableName, schema, schemaDelimiter) {

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -521,10 +521,10 @@ if (dialect === 'mysql') {
       removeIndexQuery: [
         {
           arguments: ['User', 'user_foo_bar'],
-          expectation: 'DROP INDEX user_foo_bar ON `User`'
+          expectation: 'DROP INDEX `user_foo_bar` ON `User`'
         }, {
           arguments: ['User', ['foo', 'bar']],
-          expectation: 'DROP INDEX user_foo_bar ON `User`'
+          expectation: 'DROP INDEX `user_foo_bar` ON `User`'
         }
       ]
     };

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -147,4 +147,14 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
     }
   });
+
+  suite('removeIndex', function () {
+    test('naming', function () {
+      expectsql(sql.removeIndexQuery('table', ['column1', 'column2'], {}, 'table'), {
+        mysql: 'DROP INDEX `table_column1_column2` ON `table`',
+        mssql: 'DROP INDEX table_column1_column2 ON [table]',
+        default: 'DROP INDEX IF EXISTS [table_column1_column2]'
+      });
+    });
+  });
 });

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -152,7 +152,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
     test('naming', function () {
       expectsql(sql.removeIndexQuery('table', ['column1', 'column2'], {}, 'table'), {
         mysql: 'DROP INDEX `table_column1_column2` ON `table`',
-        mssql: 'DROP INDEX table_column1_column2 ON [table]',
+        mssql: 'DROP INDEX [table_column1_column2] ON [table]',
         default: 'DROP INDEX IF EXISTS [table_column1_column2]'
       });
     });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Fixes #5888 , `MySQL` and `SQLite` were not properly quoting index names when removing. 
