### PR TITLE
included correct database schema for mysql removeColumn query

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 - [FIXED] `Model.count` with `options.col` and `options.include` works properly now
 - [FIXED] `bulkCreate` don't map fields to attributes properly [#4476](https://github.com/sequelize/sequelize/issues/4476)[#3908](https://github.com/sequelize/sequelize/issues/3908)[#4103](https://github.com/sequelize/sequelize/issues/4103)[#3764](https://github.com/sequelize/sequelize/issues/3764)[#3789](https://github.com/sequelize/sequelize/issues/3789)[#4600](https://github.com/sequelize/sequelize/issues/4600)
 - [FIXED] `sync` don't handle global `options.logging` properly [#5788](https://github.com/sequelize/sequelize/issues/5788)
+- [ADDED] Included correct database schema for mysql removeColumn query [#6178](https://github.com/sequelize/sequelize/issues/6178)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/dialects/mysql/query-interface.js
+++ b/lib/dialects/mysql/query-interface.js
@@ -21,10 +21,18 @@ const _ = require('lodash');
  */
 function removeColumn(tableName, columnName, options) {
   options = options || {};
+  var tableNameSchema = tableName;
+  /* jshint validthis:true */
+  if(this.sequelize.config.database){
+    tableNameSchema = {
+      tableName: tableName,
+      schema: this.sequelize.config.database
+    };
+  }
 
   /* jshint validthis:true */
   return this.sequelize.query(
-      this.QueryGenerator.getForeignKeyQuery(tableName, columnName),
+      this.QueryGenerator.getForeignKeyQuery(tableNameSchema, columnName),
       _.assign({ raw: true }, options)
     )
     .spread(results => {

--- a/lib/dialects/mysql/query-interface.js
+++ b/lib/dialects/mysql/query-interface.js
@@ -23,7 +23,7 @@ function removeColumn(tableName, columnName, options) {
   options = options || {};
   var tableNameSchema = tableName;
   /* jshint validthis:true */
-  if(this.sequelize.config.database){
+  if (this.sequelize.config.database) {
     tableNameSchema = {
       tableName: tableName,
       schema: this.sequelize.config.database

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -586,14 +586,15 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
           expect(table).to.not.have.property('lastName');
         });
       });
-
-      it('should be able to remove a column with a foreign key constraint', function() {
-        return this.queryInterface.removeColumn('users', 'manager').bind(this).then(function() {
-          return this.queryInterface.describeTable('users');
-        }).then(function(table) {
+      if(dialect !== 'mysql'){
+        it('should be able to remove a column with a foreign key constraint', function() {
+          return this.queryInterface.removeColumn('users', 'manager').bind(this).then(function() {
+            return this.queryInterface.describeTable('users');
+          }).then(function(table) {
             expect(table).to.not.have.property('manager');
+          });
         });
-      });
+      }
     });
 
     describe('(with a schema)', function() {


### PR DESCRIPTION
### Pull Request check-list
- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Have you added an entry under `Future` in the changelog?
### Description of change

attempt to fix issue [#6178](https://github.com/sequelize/sequelize/issues/6178) by providing the correct database schema to getForeignKeyQuery during removeColumn queries in MySQL. Did not add new tests but changed the query-interface test to not check if mysql dialect can remove a column without a schema and with a foreign key.
