### PR TITLE
Bugfix/order clause in subquery 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Future
-- [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985] (https://github.com/sequelize/sequelize/issues/5985) 
+- [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985](https://github.com/sequelize/sequelize/issues/5985)
+- [FIXED] Don't remove includes from count queries and unify findAndCount and count queries. [#6123](https://github.com/sequelize/sequelize/issues/6123)
+- [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)
 
 # 3.23.3
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 # Future
+- [FIXED] - ORDER clause was not included in subquery if `order` option value was provided as plain string (not as an array value)
+
+# 3.23.4
 - [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985](https://github.com/sequelize/sequelize/issues/5985)
 - [FIXED] Don't remove includes from count queries and unify findAndCount and count queries. [#6123](https://github.com/sequelize/sequelize/issues/6123)
 - [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985] (https://github.com/sequelize/sequelize/issues/5985) 
+
 # 3.23.3
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
+
 # 3.23.2
 - [FIXED] Type validation now works with non-strings due to updated validator@5.0.0 [#5861](https://github.com/sequelize/sequelize/pull/5861)
 - [FIXED] Improved offset and limit support for SQL server 2008 [#5616](https://github.com/sequelize/sequelize/pull/5616)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# Future
+# 3.23.3
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling
 
 # 3.23.2

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1571,8 +1571,20 @@ var QueryGenerator = {
           }
         }
 
+        var hadSubquery = false;
+
         if (subQuery && (Array.isArray(t) && !(t[0] instanceof Model) && !(t[0].model instanceof Model))) {
           subQueryOrder.push(this.quote(t, model));
+          hadSubquery = true;       
+        }
+
+        if (hadSubquery) {
+          for (var name in model.attributes) {
+            var attribute = model.attributes[name];
+            if (attribute.field && attribute.field === t[0]) {
+              t[0] = attribute.fieldName;
+            }
+          }
         }
 
         mainQueryOrder.push(this.quote(t, model));

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1590,7 +1590,11 @@ var QueryGenerator = {
         mainQueryOrder.push(this.quote(t, model));
       }.bind(this));
     } else {
-      mainQueryOrder.push(this.quote(typeof options.order === 'string' ? new Utils.literal(options.order) : options.order, model));
+      var sql = this.quote(typeof options.order === 'string' ? new Utils.literal(options.order) : options.order, model);
+      if (subQuery) {
+        subQueryOrder.push(sql);
+      }
+      mainQueryOrder.push(sql);
     }
 
     return {

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -65,12 +65,13 @@ ConnectionManager.prototype.connect = function(config) {
       });
     }
 
-    var connection = new self.lib.Connection(connectionConfig);
+    var connection = new self.lib.Connection(connectionConfig)
+      , connectionLock = new ResourceLock(connection);
     connection.lib = self.lib;
 
     connection.on('connect', function(err) {
       if (!err) {
-        resolve(new ResourceLock(connection));
+        resolve(connectionLock);
         return;
       }
 
@@ -115,7 +116,7 @@ ConnectionManager.prototype.connect = function(config) {
         switch (err.code) {
         case 'ESOCKET':
         case 'ECONNRESET':
-          self.pool.destroy(connection);
+          self.pool.destroy(connectionLock);
         }
       });
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1595,34 +1595,23 @@ Model.prototype.aggregate = function(attribute, aggregateFunction, options) {
  * @return {Promise<Integer>}
  */
 Model.prototype.count = function(options) {
-  options = Utils.cloneDeep(options);
-  _.defaults(options, { hooks: true });
-
-  var col = '*';
-
   return Promise.bind(this).then(function() {
-    conformOptions(options, this);
-    this.$injectScope(options);
-
+    options = _.defaults(Utils.cloneDeep(options), { hooks: true });
     if (options.hooks) {
       return this.runHooks('beforeCount', options);
     }
   }).then(function() {
-    if (options.include) {
-      col = this.name + '.' + this.primaryKeyField;
-      expandIncludeAll.call(this, options);
-      validateIncludedElements.call(this, options);
-    }
+    var col = options.include ? this.name + '.' + this.primaryKeyField : '*';
 
-    Utils.mapOptionFieldNames(options, this);
-
-    options.plain = options.group ? false : true;
+    options.plain = !options.group;
     options.dataType = new DataTypes.INTEGER();
     options.includeIgnoreAttributes = false;
+
+    // No limit, offset, order or attributes for the options max be given to count()
+    // Set them to null to prevent scopes setting those values
     options.limit = null;
     options.offset = null;
     options.order = null;
-    options.attributes = [];
 
     return this.aggregate(col, 'count', options);
   });
@@ -1650,6 +1639,7 @@ Model.prototype.count = function(options) {
  *   include: [
  *      { model: Profile, required: true}
  *   ],
+ *   distinct: true,
  *   limit 3
  * });
  * ```
@@ -1666,38 +1656,11 @@ Model.prototype.findAndCount = function(options) {
     throw new Error('The argument passed to findAndCount must be an options object, use findById if you wish to pass a single primary key value');
   }
 
-  var self = this
-    // no limit, offset, order, attributes for the options given to count()
-    , countOptions = _.omit(_.clone(options), ['offset', 'limit', 'order', 'attributes']);
-
-  conformOptions(countOptions, this);
-
-  if (countOptions.include) {
-    countOptions.include = _.cloneDeepWith(countOptions.include, function (element) {
-      if (element instanceof Model) return element;
-      if (element instanceof Association) return element;
-      return undefined;
-    });
-
-    expandIncludeAll.call(this, countOptions);
-
-    validateIncludedElements.call(this, countOptions);
-
-    var keepNeeded = function(includes) {
-      return includes.filter(function (include) {
-        if (include.include) include.include = keepNeeded(include.include);
-
-        return include.required || include.hasIncludeRequired;
-      });
-    };
-    countOptions.include = keepNeeded(countOptions.include);
-
-    if (countOptions.include.length) {
-      // Use distinct to count the number of parent rows, instead of the number of matched includes
-      countOptions.distinct = true;
-    }
+  var self = this;
+  var countOptions = Utils.cloneDeep(options);
+  if (countOptions.attributes) {
+    countOptions.attributes = undefined;
   }
-
   return self.count(countOptions).then(function(count) {
     if (count === 0) {
       return {
@@ -1708,7 +1671,7 @@ Model.prototype.findAndCount = function(options) {
     return self.findAll(options).then(function(results) {
       return {
         count: count || 0,
-        rows: (results && Array.isArray(results) ? results : [])
+        rows: results
       };
     });
   });

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS/io.js",
-  "version": "3.23.3",
+  "version": "3.23.4",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS/io.js",
-  "version": "3.23.2",
+  "version": "3.23.3",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     {

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -36,13 +36,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
           return Promise.join(
             Task.create({
               id: 1,
-              user: {}
+              user: {id: 1}
             }, {
               include: [Task.User]
             }),
             Task.create({
               id: 2,
-              user: {}
+              user: {id: 2}
             }, {
               include: [Task.User]
             }),

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -1,0 +1,42 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require('../../support')
+  , dialect = Support.getTestDialect();
+
+if (dialect.match(/^mssql/)) {
+  describe('[MSSQL Specific] Query Queue', function () {
+    it('should work with handleDisconnects', function() {
+      var sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, idle: 5000}})
+        , cm = sequelize.connectionManager
+        , conn;
+
+      return sequelize.sync()
+        .then(function() {
+          return cm.getConnection();
+        })
+        .then(function(connection) {
+          // Save current connection
+          conn = connection;
+
+          // simulate a unexpected end
+          connection.unwrap().emit('error', {code: 'ECONNRESET'});
+        })
+        .then(function() {
+          return cm.releaseConnection(conn);
+        })
+        .then(function() {
+          // Get next available connection
+          return cm.getConnection();
+        })
+        .then(function(connection) {
+          expect(conn).to.not.be.equal(connection);
+          expect(cm.validate(conn)).to.not.be.ok;
+
+          return cm.releaseConnection(connection);
+        });
+    });
+  });
+}

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -110,7 +110,7 @@ describe(Support.getTestDialectTeaser('Include'), function() {
       });
     });
 
-    it('should count on a where and not use an uneeded include', function() {
+    it('should count on a where', function() {
       var Project = this.sequelize.define('Project', {
         id: { type: DataTypes.INTEGER, allowNull: false, primaryKey: true, autoIncrement: true },
         project_name: { type: DataTypes.STRING}
@@ -136,7 +136,8 @@ describe(Support.getTestDialectTeaser('Include'), function() {
       }).then(function() {
         return User.findAndCountAll({
           where: {id: userId},
-          include: [Project]
+          include: [Project],
+          distinct: true
         });
       }).then(function(result) {
         expect(result.rows.length).to.equal(1);
@@ -197,7 +198,8 @@ describe(Support.getTestDialectTeaser('Include'), function() {
         // Query for the first instance of Foo which have related Bars with m === 'yes'
         return Foo.findAndCountAll({
           include: [{ model: Bar, where: { m: 'yes' } }],
-          limit: 1
+          limit: 1,
+          distinct: true
         });
       }).then(function(result) {
         // There should be 2 instances matching the query (Instances 1 and 2), see the findAll statement

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -51,5 +51,23 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }]
       })).to.eventually.equal(1);
     });
+
+    it('should be able to use where clause on included models', function() {
+      var self = this;
+      var queryObject = {
+        col: 'username',
+        include: [self.Project],
+        where: {
+          '$Projects.name$': 'project1'
+        }
+      };
+      return self.User.count(queryObject).then(function(count) {
+        expect(parseInt(count)).to.be.eql(1);
+        queryObject.where['$Projects.name$'] = 'project2';
+        return self.User.count(queryObject);
+      }).then(function(count) {
+        expect(parseInt(count)).to.be.eql(0);
+      });
+    });
   });
 });

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -10,6 +10,58 @@ var chai = require('chai')
 describe(Support.getTestDialectTeaser('Model'), function() {
   describe('findAll', function () {
     describe('order', function () {
+      it('should work on a model field whose name doesnt match the database, while offsetting and including a hasMany.', function() {
+        var Foo = current.define('foo', {
+          fooId: {
+            field: 'foo_id',
+            type: DataTypes.UUID,
+            primaryKey: true
+          },
+          baseNumber: {
+            field: 'base_number',
+            type: DataTypes.STRING(25)
+          }
+        }, {
+          timestamps: false
+        }),
+          Bar = current.define('bar', {
+            barId: {
+              field: 'bar_id',
+              type: DataTypes.UUID,
+              primaryKey: true
+            },
+            fooId: {
+              field: 'foo_id',
+              type: DataTypes.UUID,
+              allowNull: false
+            }
+          }, {
+            timestamps: false
+          });
+
+        Foo.hasMany(Bar, {foreignKey: 'foo_id', as: 'bars'});
+
+        return current.sync({force: true})
+          .then(function () {
+            var options = {
+              include: [
+                {
+                  model: Bar, as: 'bars'
+                }
+              ],
+              offset: 0,
+              limit: 50,
+              order: [['base_number', 'ASC']]
+            };
+
+            return Foo.findAll(options).then(function () {
+              console.log('success!');
+            }, function (err) {
+              throw err;
+            });
+          });        
+       });
+
       describe('Sequelize.literal()', function () {
         beforeEach(function () {
           this.User = this.sequelize.define('User', {

--- a/test/unit/model/count.test.js
+++ b/test/unit/model/count.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support')
+  , current = Support.sequelize
+  , sinon = require('sinon')
+  , DataTypes = require(__dirname + '/../../../lib/data-types')
+  , Promise = require('bluebird');
+
+describe(Support.getTestDialectTeaser('Model'), function () {
+  describe('method count', function () {
+    before(function () {
+      this.oldFindAll = current.Model.prototype.findAll;
+      this.oldAggregate = current.Model.prototype.aggregate;
+
+      current.Model.prototype.findAll = sinon.stub().returns(Promise.resolve());
+
+      this.User = current.define('User', {
+        username: DataTypes.STRING,
+        age: DataTypes.INTEGER
+      });
+      this.Project = current.define('Project', {
+        name: DataTypes.STRING
+      });
+
+      this.User.hasMany(this.Project);
+      this.Project.belongsTo(this.User);
+    });
+
+    beforeEach(function () {
+      this.stub = current.Model.prototype.aggregate = sinon.stub().returns(Promise.resolve());
+    });
+
+    after(function () {
+      current.Model.prototype.findAll = this.oldFindAll;
+      current.Model.prototype.aggregate = this.oldAggregate;
+    });
+
+    describe('should pass the same options to model.aggregate as findAndCount', function () {
+      it('with includes', function () {
+        var self = this;
+        var queryObject = {
+          include: [self.Project]
+        };
+        return self.User.count(queryObject).then(function () {
+          return self.User.findAndCount(queryObject);
+        }).then(function () {
+          var count = self.stub.getCall(0).args;
+          var findAndCount = self.stub.getCall(1).args;
+          expect(count).to.eql(findAndCount);
+        });
+      });
+
+      it('attributes should be stripped in case of findAndCount', function () {
+        var self = this;
+        var queryObject = {
+          attributes: ['username']
+        };
+        return self.User.count(queryObject).then(function () {
+          return self.User.findAndCount(queryObject);
+        }).then(function () {
+          var count = self.stub.getCall(0).args;
+          var findAndCount = self.stub.getCall(1).args;
+          expect(count[2].attributes).to.eql(['username']);
+          expect(count).not.to.eql(findAndCount);
+          count[2].attributes = undefined;
+          expect(count).to.eql(findAndCount);
+        });
+      });
+    });
+
+  });
+});

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -158,6 +158,27 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         +') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id];'
       });
 
+      testsql({
+        table: User.getTableName(),
+        model: User,
+        include: include,
+        attributes: [
+          ['id_user', 'id'],
+          'email',
+          ['first_name', 'firstName'],
+          ['last_name', 'lastName']
+        ],
+        order: '`user`.`last_name` ASC',
+        limit: 30,
+        offset: 10,
+        subQuery: true
+      }, {
+          default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +
+                       'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC' +
+                       sql.addLimitAndOffset({ limit: 30, offset:10, order: '`user`.`last_name` ASC' }) +
+                   ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;'
+      });
+
       var nestedInclude = Model.$validateIncludedElements({
         include: [{
           attributes: ['title'],


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

Note: because I use `postgres v9.3` few test cases (14) does not pass because of unsupported new features which were introduces in postgres v9.4 like (jsonb, type geometry)... I expect the tests to work including those which are using new features of postgres v9.4. Although I did not run tests wit postgres v9.4 installed.

### Description of change

The problem is that if you make a select query with `order`,`limit`,`offset` clauses and with `include` of a association which will cause subquery generation. The `order` clause is not included in the subquery when you provide `order` option in form of plain string (not an array). This pull request fixes that.