### PR TITLE
Bugfix/order clause in subquery - for the `v3`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Future
 - [FIXED] Accept dates as string while using `typeValidation` [#6453](https://github.com/sequelize/sequelize/issues/6453)
+- [FIXED] - ORDER clause was not included in subquery if `order` option value was provided as plain string (not as an array value)
 
 # 3.24.1
 - [FIXED] Add `parent`, `original` and `sql` properties to `UniqueConstraintError`
@@ -8,6 +9,8 @@
 - [ADDED] `restartIdentity` option for truncate in postgres [#5356](https://github.com/sequelize/sequelize/issues/5356)
 
 # 3.23.5
+
+# 3.23.4
 - [FIXED] Fixed an issue where custom-named model fields break when offsetting, ordering, and including hasMany simultaneously. [#5985](https://github.com/sequelize/sequelize/issues/5985)
 - [FIXED] Don't remove includes from count queries and unify findAndCount and count queries. [#6123](https://github.com/sequelize/sequelize/issues/6123)
 - [FIXED] `Model.count` don't include attributes [#5057](https://github.com/sequelize/sequelize/issues/5057)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1667,7 +1667,11 @@ var QueryGenerator = {
         mainQueryOrder.push(this.quote(t, model));
       }.bind(this));
     } else {
-      mainQueryOrder.push(this.quote(typeof options.order === 'string' ? new Utils.literal(options.order) : options.order, model));
+      var sql = this.quote(typeof options.order === 'string' ? new Utils.literal(options.order) : options.order, model);
+      if (subQuery) {
+        subQueryOrder.push(sql);
+      }
+      mainQueryOrder.push(sql);
     }
 
     return {

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -234,6 +234,27 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         +') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id];'
       });
 
+      testsql({
+        table: User.getTableName(),
+        model: User,
+        include: include,
+        attributes: [
+          ['id_user', 'id'],
+          'email',
+          ['first_name', 'firstName'],
+          ['last_name', 'lastName']
+        ],
+        order: '`user`.`last_name` ASC',
+        limit: 30,
+        offset: 10,
+        subQuery: true
+      }, {
+          default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +
+                       'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC' +
+                       sql.addLimitAndOffset({ limit: 30, offset:10, order: '`user`.`last_name` ASC' }) +
+                   ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;'
+      });
+
       var nestedInclude = Model.$validateIncludedElements({
         include: [{
           attributes: ['title'],

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -244,7 +244,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           ['first_name', 'firstName'],
           ['last_name', 'lastName']
         ],
-        order: '`user`.`last_name` ASC',
+        order: '[user].[last_name] ASC'.replace(/\[/g, Support.sequelize.dialect.TICK_CHAR_LEFT).replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT),
         limit: 30,
         offset: 10,
         subQuery: true

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -251,9 +251,9 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         subQuery: true
       }, {
           default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +
-                       'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC' +
-                       sql.addLimitAndOffset({ limit: 30, offset:10, order: '`user`.`last_name` ASC' }) +
-                   ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;'
+            'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC' +
+             sql.addLimitAndOffset({ limit: 30, offset:10, order: '`user`.`last_name` ASC' }) +
+          ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;'
       });
 
       var nestedInclude = Model.$validateIncludedElements({

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -247,6 +247,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         order: '[user].[last_name] ASC'.replace(/\[/g, Support.sequelize.dialect.TICK_CHAR_LEFT).replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT),
         limit: 30,
         offset: 10,
+        hasMultiAssociation: true,//must be set only for mssql dialect here
         subQuery: true
       }, {
           default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

Note: because I use `postgres v9.3` few test cases (14) does not pass because of unsupported new features which were introduces in postgres v9.4 like (jsonb, type geometry)... I expect the tests to work including those which are using new features of postgres v9.4. Although I did not run tests wit postgres v9.4 installed.

### Description of change

The problem is that if you make a select query with `order`,`limit`,`offset` clauses and with `include` of a association which will cause subquery generation. The `order` clause is not included in the subquery when you provide `order` option in form of plain string (not an array). This pull request fixes that.