### PR TITLE
Update postgres query interface

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+# Future
+- [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)
+
+
 # 4.0.0-2
 - [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations
 - [FIXED] Accept dates as string while using `typeValidation` [#6453](https://github.com/sequelize/sequelize/issues/6453)

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -530,6 +530,7 @@ const QueryGenerator = {
   },
 
   createFunction(functionName, params, returnType, language, body, options) {
+    if (!functionName || !returnType || !language || !body) throw new Error('createFunction missing some parameters. Did you pass functionName, returnType, language and body?');
 
     const paramList = this.expandFunctionParamList(params);
     const indentedBody = body.replace('\n', '\n\t');
@@ -544,9 +545,10 @@ const QueryGenerator = {
   },
 
   dropFunction(functionName, params) {
+    if (!functionName) throw new Error('requires functionName');
     // RESTRICT is (currently, as of 9.2) default but we'll be explicit
     const paramList = this.expandFunctionParamList(params);
-    return `DROP FUNCTION${functionName}(${paramList}) RESTRICT;`;
+    return `DROP FUNCTION ${functionName}(${paramList}) RESTRICT;`;
   },
 
   renameFunction(oldFunctionName, params, newFunctionName) {
@@ -575,19 +577,25 @@ const QueryGenerator = {
       throw new Error('expandFunctionParamList: function parameters array required, including an empty one for no arguments');
     }
 
-    const paramList = Utils._.each(params, curParam => {
+    const paramList = [];
+    Utils._.each(params, curParam => {
       const paramDef = [];
       if (Utils._.has(curParam, 'type')) {
         if (Utils._.has(curParam, 'direction')) { paramDef.push(curParam.direction); }
         if (Utils._.has(curParam, 'name')) { paramDef.push(curParam.name); }
         paramDef.push(curParam.type);
       } else {
-        throw new Error('createFunction called with a parameter with no type');
+        throw new Error('function or trigger used with a parameter without any type');
       }
-      return paramDef.join(' ');
+
+      var joined = paramDef.join(' ');
+      if (joined) paramList.push(joined);
+
     });
+
     return paramList.join(', ');
   },
+  
 
   expandOptions(options) {
     return Utils._.isUndefined(options) || Utils._.isEmpty(options) ?

--- a/test/integration/dialects/postgres/query-interface.test.js
+++ b/test/integration/dialects/postgres/query-interface.test.js
@@ -115,7 +115,6 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('can drop a function', function () {
-        
         //call drop function
         return expect(this.queryInterface.dropFunction('droptest',[{type:'varchar',name:'test'}])
         //now call the function we attempted to drop.. if dropFunction worked as expect it should produce an error.
@@ -128,7 +127,6 @@ if (dialect.match(/^postgres/)) {
       });
 
       it('produces an error when missing expected parameters', function () {
-       
         return Promise.all([
           expect( () => {
             return this.queryInterface.dropFunction(); 

--- a/test/integration/dialects/postgres/query-interface.test.js
+++ b/test/integration/dialects/postgres/query-interface.test.js
@@ -6,13 +6,143 @@ var chai = require('chai')
   , Support = require(__dirname + '/../../support')
   , dialect = Support.getTestDialect()
   , DataTypes = require(__dirname + '/../../../../lib/data-types')
+  , Sequelize = require('../../../../index')
+  , Promise = Sequelize.Promise
   , _ = require('lodash');
+
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] QueryInterface', function () {
     beforeEach(function () {
       this.sequelize.options.quoteIdenifiers = true;
       this.queryInterface = this.sequelize.getQueryInterface();
+    });
+
+    describe('createFunction', function () {
+
+      beforeEach( function () {
+        //make sure we don't have a pre-existing function called create_job
+        //this is needed to cover the edge case of afterEach not getting called because of an unexpected issue or stopage with the 
+        //test suite causing a failure of afterEach's cleanup to be called.
+        return this.queryInterface.dropFunction('create_job',[{type:'varchar',name:'test'}])
+        //suppress errors here. if create_job doesn't exist thats ok.
+        .catch( err => {});
+      });
+
+      after( function () {
+        //cleanup
+        return this.queryInterface.dropFunction('create_job',[{type:'varchar',name:'test'}])
+        //suppress errors here. if create_job doesn't exist thats ok.
+        .catch( err => {});
+      });
+
+      it('creates a stored procedure', function () {
+        var body = 'return test;';
+        var options = {};
+
+        //make our call to create a function
+        return this.queryInterface.createFunction('create_job', [{type:'varchar',name:'test'}], 'varchar', 'plpgsql', body, options)
+        //validate
+        .then( () =>  {
+          return this.sequelize.query('select create_job(\'test\');', { type: this.sequelize.QueryTypes.SELECT });
+        })
+        .then( res => {
+          return expect(res[0].create_job).to.be.eql('test');
+        });
+      });
+
+      it('treats options as optional', function () {
+        var body = 'return test;';
+
+        //run with null options parameter
+        return this.queryInterface.createFunction('create_job', [{type:'varchar',name:'test'}], 'varchar', 'plpgsql', body, null)
+        //validate
+        .then( () => { 
+          return this.sequelize.query('select create_job(\'test\');', { type: this.sequelize.QueryTypes.SELECT });
+        })
+        .then( res => {
+          return expect(res[0].create_job).to.be.eql('test');
+        });
+      });
+
+      it('produces an error when missing expected parameters', function () {
+        var body = 'return 1;';
+        var options = {};
+        
+        return Promise.all([
+          //requires functionName  
+          expect( () => {
+            return this.queryInterface.createFunction(null, [{name:'test'}], 'integer', 'plpgsql', body, options);
+          }).to.throw(/createFunction missing some parameters. Did you pass functionName, returnType, language and body/)
+        
+          //requires Parameters array
+          ,expect( () => {
+            return this.queryInterface.createFunction('create_job',null, 'integer', 'plpgsql', body, options);
+          }).to.throw(/function parameters array required/)
+          
+          //requires returnType
+          ,expect( () => {
+            return this.queryInterface.createFunction('create_job', [{type:'varchar',name:'test'}], null, 'plpgsql', body, options);
+          }).to.throw(/createFunction missing some parameters. Did you pass functionName, returnType, language and body/)
+        
+          //requires type in parameter array
+          ,expect( () => {
+            return this.queryInterface.createFunction('create_job', [{name:'test'}], 'integer', 'plpgsql', body, options);
+          }).to.throw(/function or trigger used with a parameter without any type/)
+          
+          //requires language
+          ,expect( () => {
+            return this.queryInterface.createFunction('create_job', [{type:'varchar',name:'test'}], 'varchar', null, body, options);
+          }).to.throw(/createFunction missing some parameters. Did you pass functionName, returnType, language and body/)
+
+          //requires body
+          ,expect( () => {
+            return this.queryInterface.createFunction('create_job', [{type:'varchar',name:'test'}], 'varchar', 'plpgsql', null, options);
+          }).to.throw(/createFunction missing some parameters. Did you pass functionName, returnType, language and body/)
+        ]);
+      });
+    });
+
+    describe('dropFunction',function () {
+      beforeEach( function () {
+        var body = 'return test;';
+        var options = {};
+
+        //make sure we have a droptest function in place.
+        return this.queryInterface.createFunction('droptest', [{type:'varchar',name:'test'}], 'varchar', 'plpgsql', body, options)
+        //suppress errors.. this could fail if the function is already there.. thats ok. 
+        .catch( function (err) { });
+      });
+
+      it('can drop a function', function () {
+        
+        //call drop function
+        return expect(this.queryInterface.dropFunction('droptest',[{type:'varchar',name:'test'}])
+        //now call the function we attempted to drop.. if dropFunction worked as expect it should produce an error.
+        .then( () => {
+          // call the function we attempted to drop.. if it is still there then throw an error informing that the expected behavior is not met. 
+          return this.sequelize.query('select droptest(\'test\');', { type: this.sequelize.QueryTypes.SELECT });  
+        }))
+        //test that we did get the expected error indicating that droptest was properly removed.
+        .to.be.rejectedWith(/.*function droptest.* does not exist/);
+      });
+
+      it('produces an error when missing expected parameters', function () {
+       
+        return Promise.all([
+          expect( () => {
+            return this.queryInterface.dropFunction(); 
+          }).to.throw(/.*requires functionName/)
+          ,
+          expect( () => {
+            return this.queryInterface.dropFunction('droptest'); 
+          }).to.throw(/.*function parameters array required/)
+          ,
+          expect( () => { 
+            return this.queryInterface.dropFunction('droptest', [{name:'test'}]);
+          }).to.be.throw(/.*function or trigger used with a parameter without any type/)
+        ]);
+      });
     });
 
     describe('indexes', function () {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)
I have 1 failing testing on my system with the current master branch before adding my changes 
Failing test:
[POSTGRES] DataTypes should parse an empty GEOMETRY field:
     SequelizeDatabaseError: Too few ordinates in GeoJSON
All others are passing.

- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
no

- [x] Have you added new tests to prevent regressions? yes
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?  na
- [x] Have you added an entry under `Future` in the changelog? yes


### Description of change
Changes are around the postgres query generator to address some issues I found when attempting to use dropFunction and createFunction. The root cause of the issue was due to the function expandFunctionParamList. Along the way I also found an issue with dropFunction in which the generated sql lacked a space after the keyword 'FUNCTION' ex: "FUNCTION myfunc" vs "FUNCTIONmyfunc".  I've also added tests for createFunction and dropFunction and I've stubbed out some tests for renameFunction.
