### PR TITLE
Fixes #2038, Added missing UNSIGNED / ZEROFILL support for DECIMAL

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,7 @@
 - [FIXED] `sync` don't handle global `options.logging` properly [#5788](https://github.com/sequelize/sequelize/issues/5788)
 - [FIXED] `attribute:[]` throw errors with `include` or `through` [#5078](https://github.com/sequelize/sequelize/issues/5078) [#4222](https://github.com/sequelize/sequelize/issues/4222) [#5958](https://github.com/sequelize/sequelize/issues/5958) [#5590](https://github.com/sequelize/sequelize/issues/5590) [#6139](https://github.com/sequelize/sequelize/issues/6139) [#4866](https://github.com/sequelize/sequelize/issues/4866) [#6242](https://github.com/sequelize/sequelize/issues/6242)
 - [SECURITY] `GEOMETRY` and `GEOGRAPHY` SQL injection attacks [#6194](https://github.com/sequelize/sequelize/issues/6194)
+- [FIXED] `DECIMAL` now supports `UNSIGNED` / `ZEROFILL` (MySQL) [#2038](https://github.com/sequelize/sequelize/issues/2038)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -345,11 +345,13 @@ inherits(DECIMAL, NUMBER);
 
 DECIMAL.prototype.key = DECIMAL.key = 'DECIMAL';
 DECIMAL.prototype.toSql = function toSql() {
+  let colDefinition = 'DECIMAL';
+
   if (this._precision || this._scale) {
-    return 'DECIMAL(' + [this._precision, this._scale].filter(_.identity).join(',') + ')';
+   colDefinition += '(' + [this._precision, this._scale].filter(_.identity).join(',') + ')';
   }
 
-  return 'DECIMAL';
+  return colDefinition;
 };
 DECIMAL.prototype.validate = function validate(value) {
   if (!Validator.isDecimal(String(value))) {
@@ -811,8 +813,8 @@ ARRAY.is = function is(obj, type) {
 
 const helpers = {
   BINARY: [STRING, CHAR],
-  UNSIGNED: [NUMBER, INTEGER, BIGINT, FLOAT, DOUBLE, REAL],
-  ZEROFILL: [NUMBER, INTEGER, BIGINT, FLOAT, DOUBLE, REAL],
+  UNSIGNED: [NUMBER, INTEGER, BIGINT, FLOAT, DOUBLE, REAL, DECIMAL],
+  ZEROFILL: [NUMBER, INTEGER, BIGINT, FLOAT, DOUBLE, REAL, DECIMAL],
   PRECISION: [DECIMAL],
   SCALE: [DECIMAL]
 };

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -345,13 +345,12 @@ inherits(DECIMAL, NUMBER);
 
 DECIMAL.prototype.key = DECIMAL.key = 'DECIMAL';
 DECIMAL.prototype.toSql = function toSql() {
-  let colDefinition = 'DECIMAL';
 
   if (this._precision || this._scale) {
-   colDefinition += '(' + [this._precision, this._scale].filter(_.identity).join(',') + ')';
+   return 'DECIMAL(' + [this._precision, this._scale].filter(_.identity).join(',') + ')';
   }
 
-  return colDefinition;
+  return 'DECIMAL';
 };
 DECIMAL.prototype.validate = function validate(value) {
   if (!Validator.isDecimal(String(value))) {

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -32,17 +32,17 @@ module.exports = BaseTypes => {
   inherits(DECIMAL, BaseTypes.DECIMAL);
 
   DECIMAL.prototype.toSql = function toSql() {
-    let colDefinition = BaseTypes.DECIMAL.prototype.toSql.apply(this);
+    let definition = BaseTypes.DECIMAL.prototype.toSql.apply(this);
 
     if (this._unsigned) {
-     colDefinition += ' UNSIGNED';
+     definition += ' UNSIGNED';
     }
 
     if (this._zerofill) {
-     colDefinition += ' ZEROFILL';
+     definition += ' ZEROFILL';
     }
 
-    return colDefinition;
+    return definition;
   };
 
   function DATE(length) {

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -25,6 +25,26 @@ module.exports = BaseTypes => {
   BaseTypes.REAL.types.mysql = ['DOUBLE'];
   BaseTypes.DOUBLE.types.mysql = ['DOUBLE'];
 
+  function DECIMAL(precision, scale) {
+    if (!(this instanceof DECIMAL)) return new DECIMAL(precision, scale);
+    BaseTypes.DECIMAL.apply(this, arguments);
+  }
+  inherits(DECIMAL, BaseTypes.DECIMAL);
+
+  DECIMAL.prototype.toSql = function toSql() {
+    let colDefinition = BaseTypes.DECIMAL.prototype.toSql.apply(this);
+
+    if (this._unsigned) {
+     colDefinition += ' UNSIGNED';
+    }
+
+    if (this._zerofill) {
+     colDefinition += ' ZEROFILL';
+    }
+
+    return colDefinition;
+  };
+
   function DATE(length) {
     if (!(this instanceof DATE)) return new Date(length);
     BaseTypes.DATE.apply(this, arguments);
@@ -125,7 +145,8 @@ module.exports = BaseTypes => {
     ENUM,
     DATE,
     UUID,
-    GEOMETRY
+    GEOMETRY,
+    DECIMAL
   };
 
   _.forIn(exports, (DataType, key) => {

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -804,6 +804,21 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         default: 'DECIMAL(10)'
       });
 
+      testsql('DECIMAL.UNSIGNED', DataTypes.DECIMAL.UNSIGNED, {
+        mysql: 'DECIMAL UNSIGNED',
+        default: 'DECIMAL'
+      });
+
+      testsql('DECIMAL.UNSIGNED.ZEROFILL', DataTypes.DECIMAL.UNSIGNED.ZEROFILL, {
+        mysql: 'DECIMAL UNSIGNED ZEROFILL',
+        default: 'DECIMAL'
+      });
+
+      testsql('DECIMAL({ precision: 10, scale: 2 }).UNSIGNED', DataTypes.DECIMAL({ precision: 10, scale: 2 }).UNSIGNED, {
+        mysql: 'DECIMAL(10,2) UNSIGNED',
+        default: 'DECIMAL(10,2)'
+      });
+
       suite('validate', function () {
         test('should throw an error if `value` is invalid', function() {
           var type = DataTypes.DECIMAL(10);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #2038 , `DECIMAL` was missing implementation for `UNSIGNED` and `ZEROFILL`, Added for `MySQL`
