### PR TITLE
Fix #4780, defaults to individualHooks:true for belongsToMany

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,8 @@
 - [FIXED] `attribute:[]` throw errors with `include` or `through` [#5078](https://github.com/sequelize/sequelize/issues/5078) [#4222](https://github.com/sequelize/sequelize/issues/4222) [#5958](https://github.com/sequelize/sequelize/issues/5958) [#5590](https://github.com/sequelize/sequelize/issues/5590) [#6139](https://github.com/sequelize/sequelize/issues/6139) [#4866](https://github.com/sequelize/sequelize/issues/4866) [#6242](https://github.com/sequelize/sequelize/issues/6242)
 - [SECURITY] `GEOMETRY` and `GEOGRAPHY` SQL injection attacks [#6194](https://github.com/sequelize/sequelize/issues/6194)
 - [FIXED] `DECIMAL` now supports `UNSIGNED` / `ZEROFILL` (MySQL) [#2038](https://github.com/sequelize/sequelize/issues/2038)
+- [CHANGED] `BelongsToMany.removeAssociation` now defaults to `individualHooks:true` [#4780](https://github.com/sequelize/sequelize/issues/4780)
+- [CHANGED] `Hooks.hasHooks` now accepts an array of hooks. Second argument will allow searching for any or all hooks in the array.
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)
@@ -38,6 +40,8 @@
 - Dropped support for `classMethods` and `instanceMethods`. As Models are now ES6 classes `classMethods` can be directly assigned and `instanceMethods` should be added to `Model.prototype`
 - `Sequelize.Validator` is now a cloned version of `validator`, It will not pollute global library methods.
 - `ignore` for create was renamed to `ignoreDuplicates`
+- `BelongsToMany` now defaults to `individualHooks:true` when removing the associations. So if `through` model have any destroy hooks, they will run as well. You can override this by passing `individualHooks:false` to `removeAssociation()` options.
+- `hasHooks` is no longer a proxy to `hasHook`. Now it accepts array of hooks to look for. It also allow searching with any or all flag.
 
 # 4.0.0-0
 - [FIXED] Pass ResourceLock instead of raw connection in MSSQL disconnect handling

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -700,7 +700,13 @@ class BelongsToMany extends Association {
       where[association.identifier] = this.get(association.source.primaryKeyAttribute);
       where[association.foreignIdentifier] = oldAssociatedObjects.map(newInstance => newInstance.get(association.target.primaryKeyAttribute));
 
-      return association.through.model.destroy(_.defaults({where}, options));
+      let hooksDefaults = {};
+      // through model has any destroy hooks, the set individualHooks:true
+      if (association.through.model.hasHooks(['beforeDestroy', 'afterDestroy'], true)) {
+        hooksDefaults.individualHooks = true;
+      }
+
+      return association.through.model.destroy(_.defaults(hooksDefaults, {where}, options));
     };
 
     return this;

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -222,18 +222,38 @@ const Hooks = {
   },
 
   /*
-   * Check whether the mode has any hooks of this type
+   * Check whether the model has any hook of this type
    *
    * @param {String}  hookType
    *
-   * @alias hasHooks
+   * @return {Boolean}
    */
   hasHook(hookType) {
-    return this.options.hooks[hookType] && !!this.options.hooks[hookType].length;
+    return this.options.hooks[hookType] ? !!this.options.hooks[hookType].length : false;
   },
-};
-Hooks.hasHooks = Hooks.hasHook;
 
+  /*
+   * Check whether model has any hooks of this type
+   *
+   * @param {Array}    hookTypes, Array of hooks to look for
+   * @param {Boolean}  anyHook,   Match for any hook or all hooks, defaults to false
+   *
+   * @return {Boolean}
+   */
+  hasHooks(hookTypes, anyHook) {
+    anyHook = !!anyHook;
+
+    if (typeof hookTypes === 'string') {
+      return this.hasHook(hookTypes);
+    } else if (Utils._.isArray(hookTypes)) {
+      return anyHook
+             ? Utils._.some(hookTypes, (hook) => this.hasHook(hook) )
+             : Utils._.every(hookTypes, (hook) => this.hasHook(hook) );
+    } else {
+      return false;
+    }
+  }
+};
 
 function applyTo(target) {
   Utils._.mixin(target, Hooks);


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?
### Description of change

Closes #4780 , Full discussion in #4777 

`BelongsToMany` will now default to `individualHooks: true` when removing the associations. This will only happen if `through` model have any `beforeDestroy` or `afterDestroy` hooks
