### PR TITLE
Add eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,47 @@
+{
+  "rules": {
+    "no-console": "off",
+    "no-extra-parens": "warn",
+    "valid-jsdoc": "off",
+    "new-cap": ["warn", {"properties": false}],
+    "comma-spacing": ["error", {"before": false, "after": true}],
+    "no-extra-boolean-cast": "warn",
+    "strict": ["warn", "global"],
+    "no-var": "error",
+    "prefer-const": "error",
+    "semi": ["error", "always"],
+    "space-before-function-paren": ["warn", "never"],
+    "prefer-arrow-callback": "error",
+    "comma-style": ["warn", "last"],
+    "no-bitwise": "off",
+    "no-cond-assign": ["error", "except-parens"],
+    "curly": "off",
+    "eqeqeq": "error",
+    "no-extend-native": "error",
+    "wrap-iife": ["error", "any"],
+    "indent": ["error", 2, {"SwitchCase": 1}],
+    "no-use-before-define": "off",
+    "no-caller": "error",
+    "no-undef": "error",
+    "no-unused-vars": "error",
+    "no-irregular-whitespace": "error",
+    "max-depth": ["error", 8],
+    "quotes": ["error", "single", {"avoidEscape": true}],
+    "linebreak-style": "error",
+    "no-loop-func": "warn",
+    "object-shorthand": "error",
+    "one-var-declaration-per-line": "warn",
+    "comma-dangle": "warn",
+    "no-shadow": "warn",
+    "camelcase": "warn"
+  },
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "script"
+  },
+  "env": {
+    "node": true,
+    "mocha": true,
+    "es6": true
+  }
+}

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "continuation-local-storage": "^3.1.4",
     "coveralls": "^2.11.9",
     "dox": "~0.8.0",
+    "eslint": "^3.1.0",
     "git": "^0.1.5",
     "hints": "^1.1.0",
     "istanbul": "^0.4.3",
@@ -94,6 +95,7 @@
   ],
   "main": "index",
   "scripts": {
+    "lint": "eslint lib test",
     "test": "if [ $COVERAGE ]; then npm run coveralls; else npm run jshint && npm run teaser && npm run test-unit && npm run test-integration; fi",
     "test-docker": "docker-compose run sequelize /bin/sh -c \"npm run test-all\"",
     "test-docker-unit": "docker-compose run sequelize /bin/sh -c \"npm run test-unit-all\"",


### PR DESCRIPTION
First step towards #5963 

Even though a great part of the library (tests) is not in ES6 yet and there are a whole lot of lint issues, I noticed that the continued development already introduced more style issues that did not get caught by JSHint. I decided it would be the best to add the `.eslintrc` now, so IDEs can pick it up and warn contributors about style issues while writing code.

I tried to match the current code style of the library as much as possible. Some issues like `no-extra-boolean-cast` are heavily used in the whole library, so I added them as warning for now. It is configured to especially error on not using ES6 (let/const/arrow functions etc) and I already used this file to do my refactors. One really nice thing is also that ESLint detects indentation errors while JSHint did not.

After this, I will try to fix as many style issues I find, starting with the simple ones like indentation, and when everything is resolved we can remove JSHint and add ESLint to Travis.