### PR TITLE
Use prototypal inheritance for QueryGenerators

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -12,6 +12,8 @@ var throwMethodUndefined = function(methodName) {
 };
 
 var QueryGenerator = {
+  /* jshint proto:true */
+  __proto__: AbstractQueryGenerator,
   options: {},
   dialect: 'mssql',
 
@@ -710,4 +712,4 @@ function wrapSingleQuote(identifier){
   return Utils.addTicks(identifier, "'");
 }
 
-module.exports = Utils._.extend(Utils._.clone(AbstractQueryGenerator), QueryGenerator);
+module.exports = QueryGenerator;

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -1,8 +1,11 @@
 'use strict';
 
 const Utils = require('../../utils');
+const AbstractQueryGenerator = require('../abstract/query-generator');
 
 const QueryGenerator = {
+  /* jshint proto:true */
+  __proto__: AbstractQueryGenerator,
   dialect: 'mysql',
 
   createSchema() {
@@ -343,4 +346,4 @@ function wrapSingleQuote(identifier){
   return Utils.addTicks(identifier, '\'');
 }
 
-module.exports = Utils._.extend(Utils._.clone(require('../abstract/query-generator')), QueryGenerator);
+module.exports = QueryGenerator;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -9,6 +9,8 @@ const semver = require('semver');
 const _ = require('lodash');
 
 const QueryGenerator = {
+  /* jshint proto:true */
+  __proto__: AbstractQueryGenerator,
   options: {},
   dialect: 'postgres',
 
@@ -801,4 +803,4 @@ const QueryGenerator = {
   }
 };
 
-module.exports = Utils._.extend(Utils._.clone(AbstractQueryGenerator), QueryGenerator);
+module.exports = QueryGenerator;

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -4,13 +4,11 @@
 const Utils = require('../../utils');
 const Transaction = require('../../transaction');
 const _ = require('lodash');
-
-const MySqlQueryGenerator = Utils._.extend(
-  Utils._.clone(require('../abstract/query-generator')),
-  Utils._.clone(require('../mysql/query-generator'))
-);
+const MySqlQueryGenerator = require('../mysql/query-generator');
 
 const QueryGenerator = {
+  /* jshint proto:true */
+  __proto__: MySqlQueryGenerator,
   options: {},
   dialect: 'sqlite',
 
@@ -349,4 +347,4 @@ const QueryGenerator = {
   }
 };
 
-module.exports = Utils._.extend({}, MySqlQueryGenerator, QueryGenerator);
+module.exports = QueryGenerator;


### PR DESCRIPTION
This changes the QueryGenerators to use real prototypal inheritance instead of copying over properties with `_.extend` and `_.clone`. This uses a new ES6 feature, prototype initialization in object literals. This is not mutation of the prototype at runtime, but at object creation, it is the syntactic equivalent to `Object.create()` (JSHint is too stupid to detect this, ESLint will not complain). Turning these into classes doesnt make sense because they are just static objects with some methods on them. I feel this is probably one of the best use cases out there for this feature.