### PR TITLE
Fixed attribute:[] issues when using them in include or through

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 - [FIXED] `Model.count` with `options.col` and `options.include` works properly now
 - [FIXED] `bulkCreate` don't map fields to attributes properly [#4476](https://github.com/sequelize/sequelize/issues/4476)[#3908](https://github.com/sequelize/sequelize/issues/3908)[#4103](https://github.com/sequelize/sequelize/issues/4103)[#3764](https://github.com/sequelize/sequelize/issues/3764)[#3789](https://github.com/sequelize/sequelize/issues/3789)[#4600](https://github.com/sequelize/sequelize/issues/4600)
 - [FIXED] `sync` don't handle global `options.logging` properly [#5788](https://github.com/sequelize/sequelize/issues/5788)
+- [FIXED] `attribute:[]` throw errors with `include` or `through` [#5078](https://github.com/sequelize/sequelize/issues/5078) [#4222](https://github.com/sequelize/sequelize/issues/4222) [#5958](https://github.com/sequelize/sequelize/issues/5958) [#5590](https://github.com/sequelize/sequelize/issues/5590) [#6139](https://github.com/sequelize/sequelize/issues/6139) [#4866](https://github.com/sequelize/sequelize/issues/4866) [#6242](https://github.com/sequelize/sequelize/issues/6242)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -580,7 +580,9 @@ class AbstractQuery {
                 $lastKeyPrefix = lastKeyPrefix(prevKey);
 
                 if (includeMap[prevKey].association.isSingleAssociation) {
-                  $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+                  if ($parent) {
+                    $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+                  }
                 } else {
                   if (!$parent[$lastKeyPrefix]) {
                     $parent[$lastKeyPrefix] = [];
@@ -667,7 +669,9 @@ class AbstractQuery {
             $lastKeyPrefix = lastKeyPrefix(prevKey);
 
             if (includeMap[prevKey].association.isSingleAssociation) {
-              $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+              if ($parent) {
+                $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+              }
             } else {
               if (!$parent[$lastKeyPrefix]) {
                 $parent[$lastKeyPrefix] = [];


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Using `through.attributes:[]` or `include.attributes: []` doesn't ignore any attributes, It throws error in most cases. Fixed it by checking if parent include exists before trying to push child include in it.

Closes #5078
Closes #4222
Closes #5958
Closes #5590
Closes #6139
Closes #4866
Closes #6242 

