### PR TITLE
Fixes #6194 (v4), GEOMETRY and GEOGRAPHY types now properly escaped

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 - [FIXED] `bulkCreate` don't map fields to attributes properly [#4476](https://github.com/sequelize/sequelize/issues/4476)[#3908](https://github.com/sequelize/sequelize/issues/3908)[#4103](https://github.com/sequelize/sequelize/issues/4103)[#3764](https://github.com/sequelize/sequelize/issues/3764)[#3789](https://github.com/sequelize/sequelize/issues/3789)[#4600](https://github.com/sequelize/sequelize/issues/4600)
 - [FIXED] `sync` don't handle global `options.logging` properly [#5788](https://github.com/sequelize/sequelize/issues/5788)
 - [FIXED] `attribute:[]` throw errors with `include` or `through` [#5078](https://github.com/sequelize/sequelize/issues/5078) [#4222](https://github.com/sequelize/sequelize/issues/4222) [#5958](https://github.com/sequelize/sequelize/issues/5958) [#5590](https://github.com/sequelize/sequelize/issues/5590) [#6139](https://github.com/sequelize/sequelize/issues/6139) [#4866](https://github.com/sequelize/sequelize/issues/4866) [#6242](https://github.com/sequelize/sequelize/issues/6242)
+- [SECURITY] `GEOMETRY` and `GEOGRAPHY` SQL injection attacks [#6194](https://github.com/sequelize/sequelize/issues/6194)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -305,8 +305,8 @@ module.exports = BaseTypes => {
     return wkx.Geometry.parse(b).toGeoJSON();
   };
 
-  GEOMETRY.prototype._stringify = function _stringify(value) {
-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
+  GEOMETRY.prototype._stringify = function _stringify(value, options) {
+    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
   };
 
   function GEOGRAPHY(type, srid) {
@@ -341,8 +341,8 @@ module.exports = BaseTypes => {
     return wkx.Geometry.parse(b).toGeoJSON();
   };
 
-  GEOGRAPHY.prototype._stringify = function _stringify(value) {
-    return 'ST_GeomFromGeoJSON(\'' + JSON.stringify(value) + '\')';
+  GEOGRAPHY.prototype._stringify = function _stringify(value, options) {
+    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
   };
 
   let hstore;

--- a/test/integration/model/geography.test.js
+++ b/test/integration/model/geography.test.js
@@ -177,5 +177,26 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
     });
+
+    describe('sql injection attacks', function () {
+      beforeEach(function() {
+        this.Model = this.sequelize.define('Model', {
+          location: DataTypes.GEOGRAPHY
+        });
+        return this.sequelize.sync({ force: true });
+      });
+
+      it('should properly escape the single quotes', function () {
+        return this.Model.create({
+          location: {
+            type: "Point",
+            properties: {
+              exploit: "'); DELETE YOLO INJECTIONS; -- "
+            },
+            coordinates: [39.807222,-76.984722]
+          }
+        });
+      });
+    });
   }
 });

--- a/test/integration/model/geometry.test.js
+++ b/test/integration/model/geometry.test.js
@@ -177,5 +177,26 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
     });
+    
+    describe('sql injection attacks', function () {
+      beforeEach(function() {
+        this.Model = this.sequelize.define('Model', {
+          location: DataTypes.GEOMETRY
+        });
+        return this.sequelize.sync({ force: true });
+      });
+
+      it('should properly escape the single quotes', function () {
+        return this.Model.create({
+          location: {
+            type: "Point",
+            properties: {
+              exploit: "'); DELETE YOLO INJECTIONS; -- "
+            },
+            coordinates: [39.807222,-76.984722]
+          }
+        });
+      });
+    });
   }
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Fixes #6194 for `master v4` branch. Now we properly escape the `GEOMETRY` and `GEOGRAPHY`. `v3` fix can be found in PR #6302

