### PR TITLE
Bugfix/order clause in subquery - for  the `master`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Future
 - [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations
 - [FIXED] Accept dates as string while using `typeValidation` [#6453](https://github.com/sequelize/sequelize/issues/6453)
+- [FIXED] - ORDER clause was not included in subquery if `order` option value was provided as plain string (not as an array value)
 
 # 4.0.0-1
 - [CHANGED] Removed `modelManager` parameter from `Model.init()` [#6437](https://github.com/sequelize/sequelize/issues/6437)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1541,7 +1541,11 @@ const QueryGenerator = {
         mainQueryOrder.push(this.quote(t, model));
       }
     } else {
-      mainQueryOrder.push(this.quote(typeof options.order === 'string' ? new Utils.Literal(options.order) : options.order, model));
+      var sql = this.quote(typeof options.order === 'string' ? new Utils.Literal(options.order) : options.order, model);
+      if (subQuery) {
+        subQueryOrder.push(sql);
+      }
+      mainQueryOrder.push(sql);
     }
 
     return {mainQueryOrder, subQueryOrder};

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -158,6 +158,28 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         +') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id];'
       });
 
+      testsql({
+        table: User.getTableName(),
+        model: User,
+        include: include,
+        attributes: [
+          ['id_user', 'id'],
+          'email',
+          ['first_name', 'firstName'],
+          ['last_name', 'lastName']
+        ],
+        order: '[user].[last_name] ASC'.replace(/\[/g, Support.sequelize.dialect.TICK_CHAR_LEFT).replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT),
+        limit: 30,
+        offset: 10,
+        hasMultiAssociation: true,//must be set only for mssql dialect here
+        subQuery: true
+      }, {
+          default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +
+                       'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC' +
+                       sql.addLimitAndOffset({ limit: 30, offset:10, order: '`user`.`last_name` ASC' }) +
+                   ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;'
+      });
+
       var nestedInclude = Model._validateIncludedElements({
         include: [{
           attributes: ['title'],


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

The problem is that if you make a select query with `order`,`limit`,`offset` clauses and with `include` of a association which will cause subquery generation. The `order` clause is not included in the subquery when you provide `order` option in form of plain string (not an array). This pull request fixes that.