### PR TITLE
Implement ON CONFLICT for postgres 9.5

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -256,6 +256,9 @@ class ConnectionManager {
             //avoiding a useless round trip
             if (this.sequelize.options.databaseVersion === 0) {
               return this.sequelize.databaseVersion(_options).then(version => {
+                if (this.dialectName === 'postgres' && _.isString(version) && !version.match(/\.\d+\./)) {
+                  version += '.0';
+                }
                 this.sequelize.options.databaseVersion = semver.valid(version) ? version : this.defaultVersion;
                 this.versionPromise = null;
                 return this._disconnect(connection);

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -147,7 +147,7 @@ class QueryGenerator {
       }
     }
 
-    if (this._dialect.supports.returnValues && options.returning) {
+    if (this._dialect.supports.returnValues && options.returning && !options.isPgUpsert) {
       if (this._dialect.supports.returnValues.returning) {
         valueQuery += ' RETURNING *';
         emptyQuery += ' RETURNING *';

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -326,9 +326,11 @@ class QueryGenerator {
     const onConflictDoNothing = options.ignoreDuplicates ? this._dialect.supports.inserts.onConflictDoNothing : '';
 
     if (this._dialect.supports.updateOnConflict && options.updateOnConflict) {
-      options.updateOnConflict = Utils._.extend({
-        target: 'id',
-        update: attrValueHashes.map(value => value.name).filter(value => value !== 'id')
+      const { primaryKeyField, rawAttributes } = options.model;
+      options.updateOnConflict = _.extend({
+        constraint: '',
+        target: primaryKeyField,
+        update: allAttributes.filter(value => value !== primaryKeyField)
       }, options.updateOnConflict || {});
 
       const { constraint, target, update } = options.updateOnConflict;
@@ -343,7 +345,7 @@ class QueryGenerator {
         onConflictKeyUpdate += ' DO NOTHING ';
       } else {
         onConflictKeyUpdate += `${conflict} DO UPDATE SET ${update.map(attr => {
-          const field = rawAttributes && rawAttributes[attr] && rawAttributes[attr].field || attr;
+          const field = rawAttributes[attr] ? rawAttributes[attr].fieldName : attr;
           const key = this.quoteIdentifier(field);
           return key + ' = EXCLUDED.' + key;
         }).join(',')}`;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -134,12 +134,19 @@ class QueryGenerator {
     if (this.dialect === 'postgres') {
       if (options.onConflict && semver.gte(this.sequelize.options.databaseVersion, '9.5.0')) {
         const constraint = options.conflict.constraint;
-        const target = options.conflict.target;
+        const target = Array.isArray(options.conflict.target) ? options.conflict.target : [options.conflict.target];
         if (constraint) {
           valueQuery += ` ON CONFLICT ON CONSTRAINT ${this.quoteIdentifier(constraint)}${options.onConflict}`;
         } else if (target) {
           const conflictTarget = target.map(e => this.quoteIdentifier(e)).join(', ');
-          valueQuery += ` ON CONFLICT (${conflictTarget}) ${options.onConflict}`;
+          valueQuery += ` ON CONFLICT (${conflictTarget}) `;
+
+          const conflictPredicate = options.conflict.update.where;
+          if (conflictPredicate) {
+            valueQuery += `WHERE ${this.whereItemsQuery(conflictPredicate, options)} `;
+          }
+
+          valueQuery += options.onConflict;
         }
         valueQuery += ` RETURNING ${options.returning}`;
       } else {
@@ -330,21 +337,30 @@ class QueryGenerator {
       options.updateOnConflict = _.extend({
         constraint: '',
         target: primaryKeyField,
-        update: allAttributes.filter(value => value !== primaryKeyField)
+        update: {}
       }, options.updateOnConflict || {});
+      if (!options.updateOnConflict.update.columns) {
+        options.updateOnConflict.update.columns = allAttributes.filter(value => value !== primaryKeyField);
+      }
 
       const { constraint, target, update } = options.updateOnConflict;
       let conflict = '';
       if (constraint) {
         conflict = ` ON CONFLICT ON CONSTRAINT ${this.quoteIdentifier(constraint)}`;
       } else {
-        conflict = ` ON CONFLICT (${this.quoteIdentifier(target)})`;
+        const targetArr = Array.isArray(target) ? target : [target];
+        const conflictTarget = targetArr.map(e => this.quoteIdentifier(e)).join(', ');
+        conflict = ` ON CONFLICT (${conflictTarget})`;
+
+        if (update.where) {
+          conflict += ' WHERE ' + this.whereItemsQuery(update.where, options);
+        }
       }
 
       if (update === false) {
         onConflictKeyUpdate += ' DO NOTHING ';
       } else {
-        onConflictKeyUpdate += `${conflict} DO UPDATE SET ${update.map(attr => {
+        onConflictKeyUpdate += `${conflict} DO UPDATE SET ${update.columns.map(attr => {
           const field = rawAttributes[attr] ? rawAttributes[attr].fieldName : attr;
           const key = this.quoteIdentifier(field);
           return key + ' = EXCLUDED.' + key;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -131,6 +131,22 @@ class QueryGenerator {
       emptyQuery += ' VALUES ()';
     }
 
+    if (this.dialect === 'postgres') {
+      if (options.onConflict && semver.gte(this.sequelize.options.databaseVersion, '9.5.0')) {
+        const constraint = options.conflict.constraint;
+        const target = options.conflict.target;
+        if (constraint) {
+          valueQuery += ` ON CONFLICT ON CONSTRAINT ${this.quoteIdentifier(constraint)}${options.onConflict}`;
+        } else if (target) {
+          const conflictTarget = target.map(e => this.quoteIdentifier(e)).join(', ');
+          valueQuery += ` ON CONFLICT (${conflictTarget}) ${options.onConflict}`;
+        }
+        valueQuery += ` RETURNING ${options.returning}`;
+      } else {
+        options.onConflictFallback = true;
+      }
+    }
+
     if (this._dialect.supports.returnValues && options.returning) {
       if (this._dialect.supports.returnValues.returning) {
         valueQuery += ' RETURNING *';
@@ -266,6 +282,7 @@ class QueryGenerator {
     const serials = {};
     const allAttributes = [];
     let onDuplicateKeyUpdate = '';
+    let onConflictKeyUpdate = '';
 
     for (const fieldValueHash of fieldValueHashes) {
       _.forOwn(fieldValueHash, (value, key) => {
@@ -308,7 +325,34 @@ class QueryGenerator {
     const returning = this._dialect.supports.returnValues && options.returning ? ' RETURNING *' : '';
     const onConflictDoNothing = options.ignoreDuplicates ? this._dialect.supports.inserts.onConflictDoNothing : '';
 
-    return `INSERT${ignoreDuplicates} INTO ${this.quoteTable(tableName)} (${attributes}) VALUES ${tuples.join(',')}${onDuplicateKeyUpdate}${onConflictDoNothing}${returning};`;
+    if (this._dialect.supports.updateOnConflict && options.updateOnConflict) {
+      options.updateOnConflict = Utils._.extend({
+        target: 'id',
+        update: attrValueHashes.map(value => value.name).filter(value => value !== 'id')
+      }, options.updateOnConflict || {});
+
+      const { constraint, target, update } = options.updateOnConflict;
+      let conflict = '';
+      if (constraint) {
+        conflict = ` ON CONFLICT ON CONSTRAINT ${this.quoteIdentifier(constraint)}`;
+      } else {
+        conflict = ` ON CONFLICT (${this.quoteIdentifier(target)})`;
+      }
+
+      if (update === false) {
+        onConflictKeyUpdate += ' DO NOTHING ';
+      } else {
+        onConflictKeyUpdate += `${conflict} DO UPDATE SET ${update.map(attr => {
+          const field = rawAttributes && rawAttributes[attr] && rawAttributes[attr].field || attr;
+          const key = this.quoteIdentifier(field);
+          return key + ' = EXCLUDED.' + key;
+        }).join(',')}`;
+      }
+    }
+
+
+
+    return `INSERT${ignoreDuplicates} INTO ${this.quoteTable(tableName)} (${attributes}) VALUES ${tuples.join(',')}${onDuplicateKeyUpdate}${onConflictDoNothing}${onConflictKeyUpdate}${returning};`;
   }
 
   /**

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -54,6 +54,7 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
   JSONB: true,
   HSTORE: true,
   deferrableConstraints: true,
+  updateOnConflict: true,
   searchPath: true
 });
 

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -342,22 +342,75 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   }
 
   upsertQuery(tableName, insertValues, updateValues, where, model, options) {
-    const primaryField = this.quoteIdentifier(model.primaryKeyField);
+    const rawAttributes = model.rawAttributes;
+    const indexes = model.options.indexes;
+    const uniqueKeys = Object.keys(rawAttributes).filter(e => rawAttributes[e].unique);
+    const uniqueIndexes = indexes.filter(e => e.unique).map(e => e.name);
+    const uniqueCount = uniqueKeys.length + uniqueIndexes.length;
+    if (uniqueCount > 1 && (!options.conflict || options.conflict && !options.conflict.constraint) ||
+      semver.lt(this.sequelize.options.databaseVersion, '9.5.0')) {
+      options.onConflictFallback = true;
+      const primaryField = this.quoteIdentifier(model.primaryKeyField);
 
-    const upsertOptions = _.defaults({ bindParam: false }, options);
-    const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, upsertOptions);
-    const update = this.updateQuery(tableName, updateValues, where, upsertOptions, model.rawAttributes);
+      const upsertOptions = _.defaults({ bindParam: false }, options);
+      const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, upsertOptions);
+      const update = this.updateQuery(tableName, updateValues, where, upsertOptions, model.rawAttributes);
 
-    insert.query = insert.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
-    update.query = update.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
+      insert.query = insert.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
+      update.query = update.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
 
-    return this.exceptionFn(
-      'sequelize_upsert',
-      tableName,
-      'OUT created boolean, OUT primary_key text',
-      `${insert.query} created := true;`,
-      `${update.query}; created := false`
-    );
+      return this.exceptionFn(
+        'sequelize_upsert',
+        tableName,
+        'OUT created boolean, OUT primary_key text',
+        `${insert.query} created := true;`,
+        `${update.query}; created := false`
+      );
+    }
+
+    if (!options.conflict) {
+      let target = 'id';
+      for (const key of Object.keys(rawAttributes)) {
+        if (rawAttributes[key].primaryKey) {
+          target = rawAttributes[key].field;
+        }
+      }
+      options.conflict = {
+        target,
+        update: Object.keys(updateValues).filter(value => value !== target)
+      };
+    }
+
+    if (options.conflict.update === false) {
+      options.onConflict = ' DO NOTHING';
+    } else {
+      options.conflict.target = options.conflict.target || uniqueKeys;
+      if (!Array.isArray(options.conflict.target)) {
+        options.conflict.target = [options.conflict.target];
+      }
+      if (!options.conflict.update) {
+        options.conflict.update = Object.keys(updateValues)
+          .filter(value => options.conflict.target.indexOf(value) === -1);
+      }
+
+      if (rawAttributes.updatedAt) {
+        insertValues.updatedAt = new Date();
+        if (options.conflict.update.indexOf('updatedAt') === -1) {
+          options.conflict.update.push('updatedAt');
+        }
+      }
+
+      options.onConflict = `DO UPDATE SET ${options.conflict.update.map(key => {
+        key = this.quoteIdentifier(key);
+        return `${key} = EXCLUDED.${key}`;
+      }).join(', ')}`;
+    }
+
+    if (options.returning === undefined) {
+      options.returning = '*';
+    }
+
+    return this.insertQuery(tableName, insertValues, rawAttributes, options);
   }
 
   truncateTableQuery(tableName, options = {}) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -383,12 +383,16 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     options.isPgUpsert = true;
     if (!options.conflict) {
       options.conflict = {
-        target: uniqueKeys,
-        update: getUpdateArray(updateValues, uniqueKeys)
+        target: uniqueKeys
+      };
+    }
+    if (!options.conflict.update) {
+      options.conflict.update = {
+        columns: getUpdateArray(updateValues, uniqueKeys)
       };
     }
 
-    if (options.conflict.update === false) {
+    if (options.conflict.update.columns === false) {
       options.onConflict = ' DO NOTHING';
     } else {
       options.conflict.target = options.conflict.target || uniqueKeys;
@@ -396,18 +400,18 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
         options.conflict.target = [options.conflict.target];
       }
       options.conflict.target = options.conflict.target.map(key => fieldMap[key] || key);
-      if (!options.conflict.update) {
-        options.conflict.update = getUpdateArray(updateValues, options.conflict.target);
+      if (!options.conflict.update.columns) {
+        options.conflict.update.columns = getUpdateArray(updateValues, options.conflict.target);
       }
 
       if (rawAttributes.updatedAt) {
         insertValues.updatedAt = new Date();
-        if (options.conflict.update.indexOf('updatedAt') === -1) {
-          options.conflict.update.push('updatedAt');
+        if (options.conflict.update.columns.indexOf('updatedAt') === -1) {
+          options.conflict.update.columns.push('updatedAt');
         }
       }
 
-      options.onConflict = `DO UPDATE SET ${options.conflict.update.map(key => {
+      options.onConflict = `DO UPDATE SET ${options.conflict.update.columns.map(key => {
         key = this.quoteIdentifier(key);
         return `${key} = EXCLUDED.${key}`;
       }).join(', ')}`;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -345,8 +345,17 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const rawAttributes = model.rawAttributes;
     const indexes = model.options.indexes;
     const uniqueKeys = Object.keys(rawAttributes).filter(e => rawAttributes[e].unique);
+    if (!uniqueKeys.length) {
+      uniqueKeys.push(model.primaryKeyField);
+    }
     const uniqueIndexes = indexes.filter(e => e.unique).map(e => e.name);
     const uniqueCount = uniqueKeys.length + uniqueIndexes.length;
+    const fields = Object.keys(model.fieldAttributeMap);
+    const fieldMap = {};
+    fields.forEach(field => {
+      fieldMap[model.fieldAttributeMap[field]] = field;
+    });
+
     if (uniqueCount > 1 && (!options.conflict || options.conflict && !options.conflict.constraint) ||
       semver.lt(this.sequelize.options.databaseVersion, '9.5.0')) {
       options.onConflictFallback = true;
@@ -368,16 +377,14 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       );
     }
 
+    const getUpdateArray = (values, target) =>
+      Object.keys(values).map(key => fieldMap[key] || key).filter(value => target.indexOf(value) === -1);
+
+    options.isPgUpsert = true;
     if (!options.conflict) {
-      let target = 'id';
-      for (const key of Object.keys(rawAttributes)) {
-        if (rawAttributes[key].primaryKey) {
-          target = rawAttributes[key].field;
-        }
-      }
       options.conflict = {
-        target,
-        update: Object.keys(updateValues).filter(value => value !== target)
+        target: uniqueKeys,
+        update: getUpdateArray(updateValues, uniqueKeys)
       };
     }
 
@@ -388,9 +395,9 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       if (!Array.isArray(options.conflict.target)) {
         options.conflict.target = [options.conflict.target];
       }
+      options.conflict.target = options.conflict.target.map(key => fieldMap[key] || key);
       if (!options.conflict.update) {
-        options.conflict.update = Object.keys(updateValues)
-          .filter(value => options.conflict.target.indexOf(value) === -1);
+        options.conflict.update = getUpdateArray(updateValues, options.conflict.target);
       }
 
       if (rawAttributes.updatedAt) {
@@ -406,9 +413,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       }).join(', ')}`;
     }
 
-    if (options.returning === undefined) {
-      options.returning = '*';
-    }
+    options.returning = '*, (xmax = 0)::bool AS xmax';
 
     return this.insertQuery(tableName, insertValues, rawAttributes, options);
   }

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -256,7 +256,12 @@ class Query extends AbstractQuery {
           return parseInt(rowCount, 10);
         }
         if (this.isUpsertQuery()) {
-          return rows[0];
+          if (this.options.onConflictFallback) {
+            return rows[0];
+          }
+          const item = this.options.plain ? rows[0] :
+            this.options.instance.build(rows[0]);
+          return this.options.returning === true ? item : rows.length;
         }
         if (this.isInsertQuery() || this.isUpdateQuery()) {
           if (this.instance && this.instance.dataValues) {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -259,9 +259,9 @@ class Query extends AbstractQuery {
           if (this.options.onConflictFallback) {
             return rows[0];
           }
-          const item = this.options.plain ? rows[0] :
-            this.options.instance.build(rows[0]);
-          return this.options.returning === true ? item : rows.length;
+          this.options.fieldMap = this.options.model.fieldAttributeMap;
+          const items = this.options.plain ? rows : this.handleSelectQuery(rows);
+          return [items[0], rows[0].xmax];
         }
         if (this.isInsertQuery() || this.isUpdateQuery()) {
           if (this.instance && this.instance.dataValues) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -2437,6 +2437,9 @@ class Model {
           return this.QueryInterface.upsert(this.getTableName(options), insertValues, updateValues, instance.where(), this, options);
         })
         .then(([created, primaryKey]) => {
+          if (primaryKey === true || primaryKey === false) {
+            return options.returning === true ? [created, primaryKey] : primaryKey;
+          }
           if (options.returning === true && primaryKey) {
             return this.findByPk(primaryKey, options).then(record => [record, created]);
           }

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -932,13 +932,13 @@ class QueryInterface {
     where = { [Op.or]: wheres };
 
     options.type = QueryTypes.UPSERT;
-    options.raw = true;
+    options.raw = options.isPgUpsert || false;
 
     const sql = this.QueryGenerator.upsertQuery(tableName, insertValues, updateValues, where, model, options);
     return this.sequelize.query(sql, options).then(result => {
       switch (this.sequelize.options.dialect) {
         case 'postgres':
-          return [result.created, result.primary_key];
+          return options.isPgUpsert ? result : [result.created, result.primary_key];
 
         case 'mssql':
           return [

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -552,6 +552,35 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             });
           });
         });
+
+        it('works with bulkCreate', function() {
+          const User = this.sequelize.define('User', {
+            name: {
+              type: DataTypes.STRING,
+              primaryKey: true
+            },
+            address: DataTypes.STRING
+          });
+
+          return User.sync({ force: true }).then(() => {
+            return User.bulkCreate([
+              { name: 'user1', address: 'user1' },
+              { name: 'user2' }
+            ]).then(() => {
+              return User.bulkCreate([
+                { name: 'user1' },
+                { name: 'user2', address: 'user2' }
+              ], { updateOnConflict: true });
+            }).then(() => {
+              return User.findAll({
+                where: { address: null }
+              });
+            }).then(users => {
+              expect(users).to.have.lengthOf(1);
+              expect(users[0].name).to.equal('user1');
+            });
+          });
+        });
       }
 
       if (current.dialect.supports.returnValues) {

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -86,7 +86,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('works with upsert on a composite key', function() {
-        return this.User.upsert({ foo: 'baz', bar: 19, username: 'john' }).then(created => {
+        const options = { conflict: { constraint: 'users_foo_bar_key' } };
+        return this.User.upsert({ foo: 'baz', bar: 19, username: 'john' }, options).then(created => {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
           } else {
@@ -94,7 +95,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           this.clock.tick(1000);
-          return this.User.upsert({ foo: 'baz', bar: 19, username: 'doe' });
+          return this.User.upsert({ foo: 'baz', bar: 19, username: 'doe' }, options);
         }).then(created => {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
@@ -142,12 +143,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           },
           username: DataTypes.STRING
         });
+        const options = { conflict: { constraint: 'users_pkey' } };
 
         return User.sync({ force: true }).then(() => {
           return Promise.all([
             // Create two users
-            User.upsert({ a: 'a', b: 'b', username: 'john' }),
-            User.upsert({ a: 'a', b: 'a', username: 'curt' })
+            User.upsert({ a: 'a', b: 'b', username: 'john' }, options),
+            User.upsert({ a: 'a', b: 'a', username: 'curt' }, options)
           ]);
         }).then(([created1, created2]) => {
           if (dialect === 'sqlite') {
@@ -160,7 +162,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           this.clock.tick(1000);
           // Update the first one
-          return User.upsert({ a: 'a', b: 'b', username: 'doe' });
+          return User.upsert({ a: 'a', b: 'b', username: 'doe' }, options);
         }).then(created => {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
@@ -268,7 +270,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('works with primary key using .field', function() {
-        return this.ModelWithFieldPK.upsert({ userId: 42, foo: 'first' }).then(created => {
+        const options = { conflict: { target: 'userId' } };
+        return this.ModelWithFieldPK.upsert({ userId: 42, foo: 'first' }, options).then(created => {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
           } else {
@@ -276,7 +279,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           this.clock.tick(1000);
-          return this.ModelWithFieldPK.upsert({ userId: 42, foo: 'second' });
+          return this.ModelWithFieldPK.upsert({ userId: 42, foo: 'second' }, options);
         }).then(created => {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
@@ -464,14 +467,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return User.sync({ force: true }).then(() => {
-          return User.upsert({ name: 'user1', address: 'address', city: 'City' })
+          const options = { conflict: { target: ['name', 'address'] } };
+          return User.upsert({ name: 'user1', address: 'address', city: 'City' }, options)
             .then(created => {
               if (dialect === 'sqlite') {
                 expect(created).to.be.undefined;
               } else {
                 expect(created).to.be.ok;
               }
-              return User.upsert({ name: 'user1', address: 'address', city: 'New City' });
+              return User.upsert({ name: 'user1', address: 'address', city: 'New City' }, options);
             }).then(created => {
               if (dialect === 'sqlite') {
                 expect(created).to.be.undefined;
@@ -537,7 +541,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               // this record is soft deleted
               User.create({ name: 'user3', deletedAt: -Infinity })
             ]).then(() => {
-              return User.upsert({ name: 'user1', address: 'address' });
+              const options = { conflict: { target: ['name', 'deletedAt'] } };
+              return User.upsert({ name: 'user1', address: 'address' }, options);
             }).then(() => {
               return User.findAll({
                 where: { address: null }


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._
### Description of change

Implement `ON CONFLICT for postgres 9.5, Fix #4132 #3354.
It's a draft version since it's a breaking change.

I've used @ncwhale suggestion on `.upsert()`, but review is needed.
### API: Model.upsert()

``` js
/**
   * @param  {Object}          values
   * @param  {Object}          [options]
   * ...
   * @param  {Object}          [options.conflict] Actions on conflict
   * @param  {String}          [options.conflict.constraint=[primaryKey]] constraint_name
   * @param  {String}          [options.conflict.target] index_column_name OR index_expression
   * @param  {Object}          [options.conflict.where] constraint_name
   * @param  {Boolean|Array}   [options.update=[Columns exclude options.conflict.target]] "DO UPDATE SET" if provided an array of column name or not specific this option, "DO NOTHING" if false. 
   * @param  {Boolean}         [options.returning] Return updated instance if true
   *
   * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated or updated instance.
   */
```
- For `options.conflict.constraint` and `options.conflict.target` please refer to https://www.postgresql.org/docs/9.5/static/sql-insert.html
- Currently if no `option.conflict` is provided, auto detection for primary key is applied.
- `bulkInsert` use the same options but under `options.updateOnConflict` namespace.
### Usage

``` js
// Use id as conflict target
Model.upsert(instance, {
  conflict: {
    target: 'id'
  }
});

// Use composite key as constraint
Model.upsert(instance, {
  conflict: {
    constraint: 'users_foo_bar_key'
  }
});

// Use complex primary key as constraint
Model.upsert(instance, {
  conflict: {
    constraint: 'users_pkey'
  }
});

// Choose which field to be updated
Model.upsert(instance, {
  conflict: {
    update: ['foo', 'bar']
  }
});

// Do nothing when conflicted
Model.upsert(instance, {
  conflict: {
    update: false
  }
});
```
### Todo
- [ ] Auto generate `constraint_name` for `options.conflict.constraint`
- [ ] More test cases after API is confirmed
