### PR TITLE
Remove references to io.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com)
 [![npm](https://img.shields.io/npm/dt/sequelize.svg?maxAge=2592000?style=plastic)](https://www.npmjs.com/package/sequelize)
 
-Sequelize is a promise-based Node.js/io.js ORM for Postgres, MySQL, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.
+Sequelize is a promise-based Node.js ORM for Postgres, MySQL, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.
 
 [Documentation](http://sequelize.readthedocs.org/en/latest/)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
   <span>Sequelize</span>
 </div>
 
-Sequelize is a promise-based ORM for Node.js and io.js. It supports the dialects PostgreSQL, MySQL, SQLite and MSSQL and features solid transaction support, relations, read replication and
+Sequelize is a promise-based ORM for Node.js. It supports the dialects PostgreSQL, MySQL, SQLite and MSSQL and features solid transaction support, relations, read replication and
 more.
 
 [Installation](docs/getting-started/)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Sequelize | The Node.js / io.js ORM for PostgreSQL, MySQL, SQLite and MSSQL
-site_description: Sequelize is an ORM for Node.js and io.js. It supports the dialects PostgreSQL, MySQL, SQLite and MSSQL.
+site_description: Sequelize is an ORM for Node.js. It supports the dialects PostgreSQL, MySQL, SQLite and MSSQL.
 repo_url: https://github.com/sequelize/sequelize
 site_favicon: favicon.ico
 site_url: http://docs.sequelizejs.com

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sequelize",
-  "description": "Multi dialect ORM for Node.JS/io.js",
+  "description": "Multi dialect ORM for Node.JS",
   "version": "4.0.0-0",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [


### PR DESCRIPTION
### Description of change

Since io.js has been merged into the main Node.js project and there hasn't been a new release in almost a year, I think it's safe to remove any references of it from the project. I did notice there was a pre-existing PR for this (#4791), but it was closed without explanation. So, pushing this again. 
