### PR TITLE
make it possible to use ":" in passwords in a DSN

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -139,8 +139,12 @@ class Sequelize {
       }
 
       if (urlParts.auth) {
-        config.username = urlParts.auth.split(':')[0];
-        config.password = urlParts.auth.split(':')[1];
+        const authParts = urlParts.auth.split(':');
+        
+        config.username = authParts[0];
+        
+        if (authParts.length > 1)
+          config.password = authParts.slice(1).join(':');
       }
     } else {
       // new Sequelize(database, username, password, { ... options })


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving? (**_THERE IS NO EXISTING ISSUE THAT I KNOW OF_**)
- [ ] Have you added new tests to prevent regressions?
- [ ] Have you added an entry under `Future` in the changelog? (**_WAT?_**)

### Description of change

this change makes it possible to initialize Sequelize with a DSN that contains a password which contains one or more ":" characters, e.q.

```js
const Sequelize = require('sequelize')
const instance = Sequelize('mysql://root:234*%25%26%23%24%5E%40%23%7B%7D::\'.%26%40%40@localhost:3600', {});
```

in this example the MySQL password would be: `234*%&#$^@#{}::'.&@@`

without this change Sequelize attempts to connect to MySQL with a password of `234*%&#$^@#{}` ... this is a truncated password that results in a failed connection.