### PR TITLE
Fix the unstable test "should work with two schema models in a hasMany association"

### DIFF
--- a/test/integration/include/seperate.test.js
+++ b/test/integration/include/seperate.test.js
@@ -389,6 +389,7 @@ if (current.dialect.supports.groupedLimit) {
             return this.sequelize.sync({force: true}).then(() => {
               return Promise.join(
                 User.create({
+                  id:1,
                   tasks: [
                     {id: 1, title: 'b'},
                     {id: 2, title: 'd'},
@@ -399,6 +400,7 @@ if (current.dialect.supports.groupedLimit) {
                   include: [User.Tasks]
                 }),
                 User.create({
+                  id:2,
                   tasks: [
                     {id: 5, title: 'a'},
                     {id: 6, title: 'c'},
@@ -410,7 +412,7 @@ if (current.dialect.supports.groupedLimit) {
               );
             }).then((users) => {
               return User.findAll({
-                include: [{ model: Task, limit: 2, as: 'tasks' }],
+                include: [{ model: Task, limit: 2, as: 'tasks', order:[['id', 'ASC']] }],
                 order: [
                   ['id', 'ASC']
                 ],


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?


### Description of change

The origin  test "should work with two schema models in a hasMany association" relys on the record insert order which makes the result randomly
Add record id explicitly and query in explicitly order