### PR TITLE
Migrate to Node-MySQL2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [INTERNAL] Migrated to `node-mysql2` for prepared statements [#6354](https://github.com/sequelize/sequelize/issues/6354)
 - [ADDED] SQLCipher support via the SQLite connection manager
 - [CHANGED] Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive) [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [ADDED] Support for range operators [#5990](https://github.com/sequelize/sequelize/issues/5990)

--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -33,7 +33,7 @@ Once done, you can install Sequelize and the connector for your database of choi
 ```bash
 $ npm install --save sequelize
 $ npm install --save pg       # for postgres
-$ npm install --save mysql    # for mysql
+$ npm install --save mysql2   # for mysql
 $ npm install --save sqlite3  # for sqlite
 ```
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -7,7 +7,7 @@ $ npm install --save sequelize
 
 # And one of the following:
 $ npm install --save pg pg-hstore
-$ npm install --save mysql
+$ npm install --save mysql2
 $ npm install --save sqlite3
 $ npm install --save tedious // MSSQL
 ```

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -52,7 +52,6 @@ var sequelize = new Sequelize('database', 'username', 'password', {
   logging: false,
  
   // the sql dialect of the database
-  // - default is 'mysql'
   // - currently supported: 'mysql', 'sqlite', 'postgres', 'mssql'
   dialect: 'mysql',
  
@@ -166,13 +165,10 @@ With the release of Sequelize`1.6.0`, the library got independent from specific 
 
 ### MySQL
 
-In order to get Sequelize working nicely together with MySQL, you'll need to install`mysql@~2.5.0`or higher. Once that's done you can use it like this:
+In order to get Sequelize working nicely together with MySQL, you'll need to install`mysql2@^1.0.0-rc.8`or higher. Once that's done you can use it like this:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {
-  // mysql is the default dialect, but you know...
-  // for demo purposes we are defining it nevertheless :)
-  // so: we want mysql!
   dialect: 'mysql'
 })
 ```

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -165,7 +165,7 @@ With the release of Sequelize`1.6.0`, the library got independent from specific 
 
 ### MySQL
 
-In order to get Sequelize working nicely together with MySQL, you'll need to install`mysql2@^1.0.0-rc.8`or higher. Once that's done you can use it like this:
+In order to get Sequelize working nicely together with MySQL, you'll need to install`mysql2@^1.0.0-rc.9`or higher. Once that's done you can use it like this:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {

--- a/docs/docs/usage.md
+++ b/docs/docs/usage.md
@@ -165,7 +165,7 @@ With the release of Sequelize`1.6.0`, the library got independent from specific 
 
 ### MySQL
 
-In order to get Sequelize working nicely together with MySQL, you'll need to install`mysql2@^1.0.0-rc.9`or higher. Once that's done you can use it like this:
+In order to get Sequelize working nicely together with MySQL, you'll need to install`mysql2@^1.0.0-rc.10`or higher. Once that's done you can use it like this:
 
 ```js
 var sequelize = new Sequelize('database', 'username', 'password', {

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const AbstractConnectionManager = require('../abstract/connection-manager');
+const SequelizeErrors = require('../../errors');
 const Utils = require('../../utils');
+const DataTypes = require('../../data-types').mysql;
+
 const debug = Utils.getLogger().debugContext('connection:mysql');
-const Promise = require('../../promise');
-const sequelizeErrors = require('../../errors');
-const dataTypes = require('../../data-types').mysql;
 const parserMap = new Map();
 
 class ConnectionManager extends AbstractConnectionManager {
@@ -16,9 +16,9 @@ class ConnectionManager extends AbstractConnectionManager {
     this.sequelize.config.port = this.sequelize.config.port || 3306;
     try {
       if (sequelize.config.dialectModulePath) {
-        this.lib = require(sequelize.config.dialectModulePath);
+        this.lib = require(sequelize.config.dialectModulePath + '/promise');
       } else {
-        this.lib = require('mysql2');
+        this.lib = require('mysql2/promise');
       }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
@@ -27,7 +27,7 @@ class ConnectionManager extends AbstractConnectionManager {
       throw err;
     }
 
-    this.refreshTypeParser(dataTypes);
+    this.refreshTypeParser(DataTypes);
   }
 
   // Expose this as a method so that the parsing may be updated when the user has added additional, custom types
@@ -56,7 +56,6 @@ class ConnectionManager extends AbstractConnectionManager {
    * @return Promise<Connection>
    */
   connect(config) {
-    return new Promise((resolve, reject) => {
       const connectionConfig = {
         host: config.host,
         port: config.port,
@@ -75,59 +74,58 @@ class ConnectionManager extends AbstractConnectionManager {
         }
       }
 
-      const connection = this.lib.createConnection(connectionConfig);
+      this.lib.createConnection(connectionConfig)
+      .then((connection) => {
 
-      connection.connect((err) => {
-        if (err && err.code) {
+        if (config.pool.handleDisconnects) {
+          // Connection to the MySQL server is usually
+          // lost due to either server restart, or a
+          // connection idle timeout (the wait_timeout
+          // server variable configures this)
+          //
+          // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
+          connection.connection.on('error', (err) => {
+            if (err.code === 'PROTOCOL_CONNECTION_LOST') {
+              // Remove it from read/write pool
+              this.pool.destroy(connection);
+            }
+            debug(`connection error ${err.code}`);
+          });
+        }
+
+        debug(`connection acquired`);
+        return connection;
+      })
+      .then((connection) => {
+        return connection.query(`SET time_zone = '${this.sequelize.options.timezone}'`)
+        // return the actual connection object
+        .then(() => connection.connection);
+      })
+      .catch((err) => {
+        if (err.code) {
           switch (err.code) {
             case 'ECONNREFUSED':
-              reject(new sequelizeErrors.ConnectionRefusedError(err));
+              throw new SequelizeErrors.ConnectionRefusedError(err);
               break;
             case 'ER_ACCESS_DENIED_ERROR':
-              reject(new sequelizeErrors.AccessDeniedError(err));
+              throw new SequelizeErrors.AccessDeniedError(err);
               break;
             case 'ENOTFOUND':
-              reject(new sequelizeErrors.HostNotFoundError(err));
+              throw new SequelizeErrors.HostNotFoundError(err);
               break;
             case 'EHOSTUNREACH':
-              reject(new sequelizeErrors.HostNotReachableError(err));
+              throw new SequelizeErrors.HostNotReachableError(err);
               break;
             case 'EINVAL':
-              reject(new sequelizeErrors.InvalidConnectionError(err));
+              throw new SequelizeErrors.InvalidConnectionError(err);
               break;
             default:
-              reject(new sequelizeErrors.ConnectionError(err));
+              throw new SequelizeErrors.ConnectionError(err);
           }
-        } else if(err && !err.code) {
-            reject(new sequelizeErrors.ConnectionError(err));
-        } else if (!err) {
-          resolve(connection);
+        } else {
+          throw new SequelizeErrors.ConnectionError(err);
         }
       });
-    })
-    .then((connection) => {
-      if (config.pool.handleDisconnects) {
-        // Connection to the MySQL server is usually
-        // lost due to either server restart, or a
-        // connection idle timeout (the wait_timeout
-        // server variable configures this)
-        //
-        // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
-        connection.on('error', err => {
-          if (err.code === 'PROTOCOL_CONNECTION_LOST') {
-            // Remove it from read/write pool
-            this.pool.destroy(connection);
-          }
-          debug(`connection error ${err.code}`);
-        });
-      }
-
-      debug(`connection acquired`);
-      return connection;
-    })
-    .tap((connection) => {
-      connection.query(`SET time_zone = '${this.sequelize.options.timezone}'`);
-    });
   }
 
   disconnect(connection) {
@@ -136,14 +134,17 @@ class ConnectionManager extends AbstractConnectionManager {
     // That wil trigger a connection error
     if (connection._closing) {
       debug(`connection tried to disconnect but was already at CLOSED state`);
-      return Promise.resolve();
+      return Utils.Promise.resolve();
     }
 
-    return new Promise((resolve, reject) => {
-      connection.end(err => {
-        if (err) return reject(new sequelizeErrors.ConnectionError(err));
-        debug(`connection disconnected`);
-        resolve();
+    return new Utils.Promise((resolve, reject) => {
+      connection.end((err) => {
+        if (err) {
+          reject(new SequelizeErrors.ConnectionError(err));
+        } else {
+          debug(`connection disconnected`);
+          resolve();
+        }
       });
     });
   }

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -74,7 +74,10 @@ class ConnectionManager extends AbstractConnectionManager {
         }
       }
 
-      this.lib.createConnection(connectionConfig)
+      // use Sequelize's bluebird Promise instance
+      connectionConfig.Promise = Utils.Promise;
+
+      return this.lib.createConnection(connectionConfig)
       .then((connection) => {
 
         if (config.pool.handleDisconnects) {

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -4,9 +4,33 @@ const AbstractConnectionManager = require('../abstract/connection-manager');
 const SequelizeErrors = require('../../errors');
 const Utils = require('../../utils');
 const DataTypes = require('../../data-types').mysql;
-
+const domain = require('domain');
 const debug = Utils.getLogger().debugContext('connection:mysql');
 const parserMap = new Map();
+
+/**
+ * Remove extra domain info from Error objects
+ */
+const cleanDomainError = (err) => {
+  if (err.domain) {
+    err.domainEmitter.end();
+    delete err.domain;
+    delete err.domainEmitter;
+    delete err.domainThrown;
+  }
+  return err;
+};
+
+/**
+ * MySQL Connection Managger
+ *
+ * Get connections, validate and disconnect them.
+ * AbstractConnectionManager pooling use it to handle MySQL specific connections
+ * Use https://github.com/sidorares/node-mysql2 to connect with MySQL server
+ *
+ * @extends AbstractConnectionManager
+ * @return Class<ConnectionManager>
+ */
 
 class ConnectionManager extends AbstractConnectionManager {
   constructor(dialect, sequelize) {
@@ -30,7 +54,7 @@ class ConnectionManager extends AbstractConnectionManager {
     this.refreshTypeParser(DataTypes);
   }
 
-  // Expose this as a method so that the parsing may be updated when the user has added additional, custom types
+  // Update parsing when the user has added additional, custom types
   _refreshTypeParser(dataType) {
     for (const type of dataType.types.mysql) {
       parserMap.set(type, dataType.parse);
@@ -45,13 +69,13 @@ class ConnectionManager extends AbstractConnectionManager {
     if (parserMap.has(field.type)) {
       return parserMap.get(field.type)(field, this.sequelize.options);
     }
-
     return next();
   }
 
   /**
-   * Connect with mysql database based on config
-   * Set the pool handlers when connection is closed
+   * Connect with MySQL database based on config, Handle any errors in connection
+   * Set the pool handlers on connection.error
+   * Also set proper timezone once conection is connected
    *
    * @return Promise<Connection>
    */
@@ -77,7 +101,29 @@ class ConnectionManager extends AbstractConnectionManager {
       // use Sequelize's bluebird Promise instance
       connectionConfig.Promise = Utils.Promise;
 
-      return this.lib.createConnection(connectionConfig)
+      return new Utils.Promise((resolve, reject) => {
+        const conDomain = domain.create();
+
+        conDomain.once('error', (err) => {
+          reject(cleanDomainError(err));
+          conDomain.exit();
+        });
+
+        // createConnection automatically try to connect with server
+        // It can throw EventEmitter based error that can't be caught
+        // like AccessDeniedError if wrong credentials used
+        // So we use domains to catch those errors
+        conDomain.run(() => {
+          this.lib.createConnection(connectionConfig)
+          .then(resolve)
+          .catch((err) => {
+            reject(cleanDomainError(err));
+          })
+          .finally(() => {
+            conDomain.exit();
+          });
+        });
+      })
       .then((connection) => {
 
         if (config.pool.handleDisconnects) {
@@ -109,19 +155,14 @@ class ConnectionManager extends AbstractConnectionManager {
           switch (err.code) {
             case 'ECONNREFUSED':
               throw new SequelizeErrors.ConnectionRefusedError(err);
-              break;
             case 'ER_ACCESS_DENIED_ERROR':
               throw new SequelizeErrors.AccessDeniedError(err);
-              break;
             case 'ENOTFOUND':
               throw new SequelizeErrors.HostNotFoundError(err);
-              break;
             case 'EHOSTUNREACH':
               throw new SequelizeErrors.HostNotReachableError(err);
-              break;
             case 'EINVAL':
               throw new SequelizeErrors.InvalidConnectionError(err);
-              break;
             default:
               throw new SequelizeErrors.ConnectionError(err);
           }
@@ -134,7 +175,6 @@ class ConnectionManager extends AbstractConnectionManager {
   disconnect(connection) {
 
     // Dont disconnect connections with CLOSED state
-    // That wil trigger a connection error
     if (connection._closing) {
       debug(`connection tried to disconnect but was already at CLOSED state`);
       return Utils.Promise.resolve();

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -18,7 +18,7 @@ class ConnectionManager extends AbstractConnectionManager {
       if (sequelize.config.dialectModulePath) {
         this.lib = require(sequelize.config.dialectModulePath);
       } else {
-        this.lib = require('mysql');
+        this.lib = require('mysql2');
       }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
@@ -127,12 +127,13 @@ class ConnectionManager extends AbstractConnectionManager {
 
   disconnect(connection) {
 
+    /*
     // Dont disconnect connections with an ended protocol
     // That wil trigger a connection error
     if (connection._protocol._ended) {
       debug(`connection tried to disconnect but was already at ENDED state`);
       return Promise.resolve();
-    }
+    } */
 
     return new Promise((resolve, reject) => {
       connection.end(err => {
@@ -144,7 +145,7 @@ class ConnectionManager extends AbstractConnectionManager {
   }
 
   validate(connection) {
-    return connection && ['disconnected', 'protocol_error'].indexOf(connection.state) === -1;
+    return connection && connection._fatalError === null && !connection._closing;
   }
 }
 

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -4,23 +4,9 @@ const AbstractConnectionManager = require('../abstract/connection-manager');
 const SequelizeErrors = require('../../errors');
 const Utils = require('../../utils');
 const DataTypes = require('../../data-types').mysql;
-const domain = require('domain');
 const momentTz = require('moment-timezone');
 const debug = Utils.getLogger().debugContext('connection:mysql');
 const parserMap = new Map();
-
-/**
- * Remove extra domain info from Error objects
- */
-const cleanDomainError = (err) => {
-  if (err.domain) {
-    err.domainEmitter.end();
-    delete err.domain;
-    delete err.domainEmitter;
-    delete err.domainThrown;
-  }
-  return err;
-};
 
 /**
  * MySQL Connection Managger
@@ -41,9 +27,9 @@ class ConnectionManager extends AbstractConnectionManager {
     this.sequelize.config.port = this.sequelize.config.port || 3306;
     try {
       if (sequelize.config.dialectModulePath) {
-        this.lib = require(sequelize.config.dialectModulePath + '/promise');
+        this.lib = require(sequelize.config.dialectModulePath);
       } else {
-        this.lib = require('mysql2/promise');
+        this.lib = require('mysql2');
       }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
@@ -99,30 +85,13 @@ class ConnectionManager extends AbstractConnectionManager {
         }
       }
 
-      // use Sequelize's bluebird Promise instance
-      connectionConfig.Promise = Utils.Promise;
-
       return new Utils.Promise((resolve, reject) => {
-        const conDomain = domain.create();
-
-        conDomain.once('error', (err) => {
-          reject(cleanDomainError(err));
-          conDomain.exit();
+        const connection = this.lib.createConnection(connectionConfig);
+        connection.on('error', (err) => {
+          reject(err);
         });
-
-        // createConnection automatically try to connect with server
-        // It can throw EventEmitter based error that can't be caught
-        // like AccessDeniedError if wrong credentials used
-        // So we use domains to catch those errors
-        conDomain.run(() => {
-          this.lib.createConnection(connectionConfig)
-          .then(resolve)
-          .catch((err) => {
-            reject(cleanDomainError(err));
-          })
-          .finally(() => {
-            conDomain.exit();
-          });
+        connection.once('connect', () => {
+          resolve(connection);
         });
       })
       .then((connection) => {
@@ -134,7 +103,7 @@ class ConnectionManager extends AbstractConnectionManager {
           // server variable configures this)
           //
           // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
-          connection.connection.on('error', (err) => {
+          connection.on('error', (err) => {
             if (err.code === 'PROTOCOL_CONNECTION_LOST') {
               // Remove it from read/write pool
               this.pool.destroy(connection);
@@ -147,13 +116,16 @@ class ConnectionManager extends AbstractConnectionManager {
         return connection;
       })
       .then((connection) => {
-        // set timezone for this connection
-        // but named timezone are not directly supported in mysql, so get its offset first
-        let tzOffset = this.sequelize.options.timezone;
-        tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
+        return new Utils.Promise((resolve, reject) => {
+          // set timezone for this connection
+          // but named timezone are not directly supported in mysql, so get its offset first
+          let tzOffset = this.sequelize.options.timezone;
+          tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
 
-        return connection.query(`SET time_zone = '${tzOffset}'`)
-        .then(() => connection.connection); // pass connection object
+          connection.query(`SET time_zone = '${tzOffset}'`, (err) => {
+            if (err) { reject(err); } else { resolve(connection); }
+          });
+        });
       })
       .catch((err) => {
         if (err.code) {

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -68,7 +68,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
   static _typecast(field, next) {
     if (parserMap.has(field.type)) {
-      return parserMap.get(field.type)(field, this.sequelize.options);
+      return parserMap.get(field.type)(field, this.sequelize.options, next);
     }
     return next();
   }

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -56,7 +56,7 @@ class ConnectionManager extends AbstractConnectionManager {
    * @return Promise<Connection>
    */
   connect(config) {
-    return Promise.try(() => {
+    return new Promise((resolve, reject) => {
       const connectionConfig = {
         host: config.host,
         port: config.port,
@@ -75,13 +75,41 @@ class ConnectionManager extends AbstractConnectionManager {
         }
       }
 
-      return this.lib.createConnection(connectionConfig);
+      const connection = this.lib.createConnection(connectionConfig);
+
+      connection.connect((err) => {
+        if (err && err.code) {
+          switch (err.code) {
+            case 'ECONNREFUSED':
+              reject(new sequelizeErrors.ConnectionRefusedError(err));
+              break;
+            case 'ER_ACCESS_DENIED_ERROR':
+              reject(new sequelizeErrors.AccessDeniedError(err));
+              break;
+            case 'ENOTFOUND':
+              reject(new sequelizeErrors.HostNotFoundError(err));
+              break;
+            case 'EHOSTUNREACH':
+              reject(new sequelizeErrors.HostNotReachableError(err));
+              break;
+            case 'EINVAL':
+              reject(new sequelizeErrors.InvalidConnectionError(err));
+              break;
+            default:
+              reject(new sequelizeErrors.ConnectionError(err));
+          }
+        } else if(err && !err.code) {
+            reject(new sequelizeErrors.ConnectionError(err));
+        } else if (!err) {
+          resolve(connection);
+        }
+      });
     })
     .then((connection) => {
       if (config.pool.handleDisconnects) {
         // Connection to the MySQL server is usually
         // lost due to either server restart, or a
-        // connnection idle timeout (the wait_timeout
+        // connection idle timeout (the wait_timeout
         // server variable configures this)
         //
         // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
@@ -97,30 +125,8 @@ class ConnectionManager extends AbstractConnectionManager {
       debug(`connection acquired`);
       return connection;
     })
-    .tap(connection => {
-      return Promise.promisify(connection.query, {
-        context: connection
-      })(`SET time_zone = '${this.sequelize.options.timezone}'`);
-    })
-    .catch((err) => {
-      if (err.code) {
-        switch (err.code) {
-        case 'ECONNREFUSED':
-          throw new sequelizeErrors.ConnectionRefusedError(err);
-        case 'ER_ACCESS_DENIED_ERROR':
-          throw new sequelizeErrors.AccessDeniedError(err);
-        case 'ENOTFOUND':
-          throw new sequelizeErrors.HostNotFoundError(err);
-        case 'EHOSTUNREACH':
-          throw new sequelizeErrors.HostNotReachableError(err);
-        case 'EINVAL':
-          throw new sequelizeErrors.InvalidConnectionError(err);
-        default:
-          throw new sequelizeErrors.ConnectionError(err);
-        }
-      } else {
-        throw new sequelizeErrors.ConnectionError(err);
-      }
+    .tap((connection) => {
+      connection.query(`SET time_zone = '${this.sequelize.options.timezone}'`);
     });
   }
 

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -22,7 +22,7 @@ class ConnectionManager extends AbstractConnectionManager {
       }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
-        throw new Error('Please install mysql package manually');
+        throw new Error('Please install mysql2 package manually');
       }
       throw err;
     }
@@ -49,6 +49,12 @@ class ConnectionManager extends AbstractConnectionManager {
     return next();
   }
 
+  /**
+   * Connect with mysql database based on config
+   * Set the pool handlers when connection is closed
+   *
+   * @return Promise<Connection>
+   */
   connect(config) {
     return Promise.try(() => {
       const connectionConfig = {
@@ -92,7 +98,9 @@ class ConnectionManager extends AbstractConnectionManager {
       return connection;
     })
     .tap(connection => {
-      connection.query("SET time_zone = '" + this.sequelize.options.timezone + "'"); /* jshint ignore: line */
+      return Promise.promisify(connection.query, {
+        context: connection
+      })(`SET time_zone = '${this.sequelize.options.timezone}'`);
     })
     .catch((err) => {
       if (err.code) {
@@ -118,13 +126,12 @@ class ConnectionManager extends AbstractConnectionManager {
 
   disconnect(connection) {
 
-    /*
-    // Dont disconnect connections with an ended protocol
+    // Dont disconnect connections with CLOSED state
     // That wil trigger a connection error
-    if (connection._protocol._ended) {
-      debug(`connection tried to disconnect but was already at ENDED state`);
+    if (connection._closing) {
+      debug(`connection tried to disconnect but was already at CLOSED state`);
       return Promise.resolve();
-    } */
+    }
 
     return new Promise((resolve, reject) => {
       connection.end(err => {

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -5,6 +5,7 @@ const SequelizeErrors = require('../../errors');
 const Utils = require('../../utils');
 const DataTypes = require('../../data-types').mysql;
 const domain = require('domain');
+const momentTz = require('moment-timezone');
 const debug = Utils.getLogger().debugContext('connection:mysql');
 const parserMap = new Map();
 
@@ -146,9 +147,13 @@ class ConnectionManager extends AbstractConnectionManager {
         return connection;
       })
       .then((connection) => {
-        return connection.query(`SET time_zone = '${this.sequelize.options.timezone}'`)
-        // return the actual connection object
-        .then(() => connection.connection);
+        // set timezone for this connection
+        // but named timezone are not directly supported in mysql, so get its offset first
+        let tzOffset = this.sequelize.options.timezone;
+        tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
+
+        return connection.query(`SET time_zone = '${tzOffset}'`)
+        .then(() => connection.connection); // pass connection object
       })
       .catch((err) => {
         if (err.code) {

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -50,7 +50,7 @@ class ConnectionManager extends AbstractConnectionManager {
   }
 
   connect(config) {
-    return new Promise((resolve, reject) => {
+    return Promise.try(() => {
       const connectionConfig = {
         host: config.host,
         port: config.port,
@@ -69,59 +69,50 @@ class ConnectionManager extends AbstractConnectionManager {
         }
       }
 
-      const connection = this.lib.createConnection(connectionConfig);
-
-      connection.connect(err => {
-        if (err) {
-          if (err.code) {
-            switch (err.code) {
-            case 'ECONNREFUSED':
-              reject(new sequelizeErrors.ConnectionRefusedError(err));
-              break;
-            case 'ER_ACCESS_DENIED_ERROR':
-              reject(new sequelizeErrors.AccessDeniedError(err));
-              break;
-            case 'ENOTFOUND':
-              reject(new sequelizeErrors.HostNotFoundError(err));
-              break;
-            case 'EHOSTUNREACH':
-              reject(new sequelizeErrors.HostNotReachableError(err));
-              break;
-            case 'EINVAL':
-              reject(new sequelizeErrors.InvalidConnectionError(err));
-              break;
-            default:
-              reject(new sequelizeErrors.ConnectionError(err));
-              break;
-            }
-          } else {
-            reject(new sequelizeErrors.ConnectionError(err));
+      return this.lib.createConnection(connectionConfig);
+    })
+    .then((connection) => {
+      if (config.pool.handleDisconnects) {
+        // Connection to the MySQL server is usually
+        // lost due to either server restart, or a
+        // connnection idle timeout (the wait_timeout
+        // server variable configures this)
+        //
+        // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
+        connection.on('error', err => {
+          if (err.code === 'PROTOCOL_CONNECTION_LOST') {
+            // Remove it from read/write pool
+            this.pool.destroy(connection);
           }
+          debug(`connection error ${err.code}`);
+        });
+      }
 
-          return;
-        }
-
-        if (config.pool.handleDisconnects) {
-          // Connection to the MySQL server is usually
-          // lost due to either server restart, or a
-          // connnection idle timeout (the wait_timeout
-          // server variable configures this)
-          //
-          // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
-          connection.on('error', err => {
-            if (err.code === 'PROTOCOL_CONNECTION_LOST') {
-              // Remove it from read/write pool
-              this.pool.destroy(connection);
-            }
-            debug(`connection error ${err.code}`);
-          });
-        }
-        debug(`connection acquired`);
-        resolve(connection);
-      });
-
-    }).tap(connection => {
+      debug(`connection acquired`);
+      return connection;
+    })
+    .tap(connection => {
       connection.query("SET time_zone = '" + this.sequelize.options.timezone + "'"); /* jshint ignore: line */
+    })
+    .catch((err) => {
+      if (err.code) {
+        switch (err.code) {
+        case 'ECONNREFUSED':
+          throw new sequelizeErrors.ConnectionRefusedError(err);
+        case 'ER_ACCESS_DENIED_ERROR':
+          throw new sequelizeErrors.AccessDeniedError(err);
+        case 'ENOTFOUND':
+          throw new sequelizeErrors.HostNotFoundError(err);
+        case 'EHOSTUNREACH':
+          throw new sequelizeErrors.HostNotReachableError(err);
+        case 'EINVAL':
+          throw new sequelizeErrors.InvalidConnectionError(err);
+        default:
+          throw new sequelizeErrors.ConnectionError(err);
+        }
+      } else {
+        throw new sequelizeErrors.ConnectionError(err);
+      }
     });
   }
 

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -88,12 +88,16 @@ class ConnectionManager extends AbstractConnectionManager {
       return new Utils.Promise((resolve, reject) => {
         const connection = this.lib.createConnection(connectionConfig);
 
-        // clean up event
-        let errorHandler = (e) => {
+        let errorHandler, connectHandler;
+
+        errorHandler = (e) => {
+          // clean up event
           connection.removeListener('connect', connectHandler);
           reject(e);
         };
-        let connectHandler = () => {
+        
+        connectHandler = () => {
+          // clean up event
           connection.removeListener('error', errorHandler);
           resolve(connection);
         };

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -87,13 +87,19 @@ class ConnectionManager extends AbstractConnectionManager {
 
       return new Utils.Promise((resolve, reject) => {
         const connection = this.lib.createConnection(connectionConfig);
-        connection.once('error', (err) => {
-          reject(err);
-        });
-        connection.once('connect', () => {
-          connection.removeAllListeners('error');
+
+        // clean up event
+        let errorHandler = (e) => {
+          connection.removeListener('connect', connectHandler);
+          reject(e);
+        };
+        let connectHandler = () => {
+          connection.removeListener('error', errorHandler);
           resolve(connection);
-        });
+        };
+
+        connection.once('error', errorHandler);
+        connection.once('connect', connectHandler);
       })
       .then((connection) => {
 
@@ -171,7 +177,7 @@ class ConnectionManager extends AbstractConnectionManager {
   }
 
   validate(connection) {
-    return connection && connection._fatalError === null && !connection._closing;
+    return connection && connection._fatalError === null && connection._protocolError === null && !connection._closing;
   }
 }
 

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -88,19 +88,19 @@ class ConnectionManager extends AbstractConnectionManager {
       return new Utils.Promise((resolve, reject) => {
         const connection = this.lib.createConnection(connectionConfig);
 
-        let errorHandler, connectHandler;
-
-        errorHandler = (e) => {
-          // clean up event
+        /*jshint latedef:false*/
+        const errorHandler = (e) => {
+          // clean up connect event if there is error
           connection.removeListener('connect', connectHandler);
           reject(e);
         };
-        
-        connectHandler = () => {
-          // clean up event
+
+        const connectHandler = () => {
+          // clean up error event if connected
           connection.removeListener('error', errorHandler);
           resolve(connection);
         };
+        /*jshint latedef:true*/
 
         connection.once('error', errorHandler);
         connection.once('connect', connectHandler);

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -87,10 +87,11 @@ class ConnectionManager extends AbstractConnectionManager {
 
       return new Utils.Promise((resolve, reject) => {
         const connection = this.lib.createConnection(connectionConfig);
-        connection.on('error', (err) => {
+        connection.once('error', (err) => {
           reject(err);
         });
         connection.once('connect', () => {
+          connection.removeAllListeners('error');
           resolve(connection);
         });
       })

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -91,17 +91,6 @@ module.exports = BaseTypes => {
     return 'CHAR(36) BINARY';
   };
 
-  function BLOB(length) {
-    if (!(this instanceof BLOB)) return new BLOB(length);
-    BaseTypes.BLOB.apply(this, arguments);
-  }
-  inherits(BLOB, BaseTypes.BLOB);
-
-  BLOB.parse = function (value) {
-    value = value.buffer();
-
-    return value.length === 0 ? null : value;
-  }
 
   const SUPPORTED_GEOMETRY_TYPES = ['POINT', 'LINESTRING', 'POLYGON'];
 

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -108,7 +108,7 @@ module.exports = BaseTypes => {
   inherits(GEOMETRY, BaseTypes.GEOMETRY);
 
   GEOMETRY.parse = GEOMETRY.prototype.parse = function parse(value) {
-    value = value.buffer();
+    value = value.string();
 
     //MySQL doesn't support POINT EMPTY, https://dev.mysql.com/worklog/task/?id=2381
     if (value === null) {

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -91,6 +91,18 @@ module.exports = BaseTypes => {
     return 'CHAR(36) BINARY';
   };
 
+  function BLOB(length) {
+    if (!(this instanceof BLOB)) return new BLOB(length);
+    BaseTypes.BLOB.apply(this, arguments);
+  }
+  inherits(BLOB, BaseTypes.BLOB);
+
+  BLOB.parse = function (value) {
+    value = value.buffer();
+
+    return value.length === 0 ? null : value;
+  }
+
   const SUPPORTED_GEOMETRY_TYPES = ['POINT', 'LINESTRING', 'POLYGON'];
 
   function GEOMETRY(type, srid) {
@@ -108,10 +120,11 @@ module.exports = BaseTypes => {
   inherits(GEOMETRY, BaseTypes.GEOMETRY);
 
   GEOMETRY.parse = GEOMETRY.prototype.parse = function parse(value) {
-    value = value.string();
+    value = value.buffer();
 
-    //MySQL doesn't support POINT EMPTY, https://dev.mysql.com/worklog/task/?id=2381
-    if (value === null) {
+    // Empty buffer, MySQL doesn't support POINT EMPTY
+    // check, https://dev.mysql.com/worklog/task/?id=2381
+    if (value.length === 0) {
       return null;
     }
 
@@ -146,7 +159,8 @@ module.exports = BaseTypes => {
     DATE,
     UUID,
     GEOMETRY,
-    DECIMAL
+    DECIMAL,
+    BLOB
   };
 
   _.forIn(exports, (DataType, key) => {

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -25,6 +25,22 @@ module.exports = BaseTypes => {
   BaseTypes.REAL.types.mysql = ['DOUBLE'];
   BaseTypes.DOUBLE.types.mysql = ['DOUBLE'];
 
+  function BLOB(length) {
+    if (!(this instanceof BLOB)) return new BLOB(length);
+    BaseTypes.BLOB.apply(this, arguments);
+  }
+  inherits(BLOB, BaseTypes.BLOB);
+
+  BLOB.parse = function (value, options, next) {
+    let data = next();
+
+    if (Buffer.isBuffer(data) && data.length === 0) {
+      return null;
+    }
+
+    return data;
+  };
+
   function DECIMAL(precision, scale) {
     if (!(this instanceof DECIMAL)) return new DECIMAL(precision, scale);
     BaseTypes.DECIMAL.apply(this, arguments);

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -43,7 +43,6 @@ class Query extends AbstractQuery {
 
     return new Utils.Promise((resolve, reject) => {
       this.connection.query({ sql: this.sql }, (err, results) => {
-
         debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
@@ -61,7 +60,7 @@ class Query extends AbstractQuery {
     })
     // Log warnings if we've got them.
     .then(results => {
-      if (showWarnings && results && results.warningCount > 0) {
+      if (showWarnings && results && results.warningStatus > 0) {
         return this.logWarnings(results);
       }
       return results;
@@ -136,7 +135,6 @@ class Query extends AbstractQuery {
     return this.run('SHOW WARNINGS').then(warningResults => {
       const warningMessage = 'MySQL Warnings (' + (this.connection.uuid||'default') + '): ';
       const messages = [];
-
       for (const _warningRow of warningResults) {
         for (const _warningResult of _warningRow) {
           if (_warningResult.hasOwnProperty('Message')) {

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -42,7 +42,8 @@ class Query extends AbstractQuery {
     debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
     return new Utils.Promise((resolve, reject) => {
-      this.connection.query(this.sql, (err, results) => {
+      // TODO: remove typeCast once https://github.com/sidorares/node-mysql2/issues/347 closed
+      this.connection.query({ sql: this.sql, typeCast: this.connection.config.typeCast }, (err, results) => {
 
         debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -42,7 +42,6 @@ class Query extends AbstractQuery {
     debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
     return new Utils.Promise((resolve, reject) => {
-      // TODO: remove typeCast once https://github.com/sidorares/node-mysql2/issues/347 closed
       this.connection.query({ sql: this.sql }, (err, results) => {
 
         debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -43,7 +43,7 @@ class Query extends AbstractQuery {
 
     return new Utils.Promise((resolve, reject) => {
       // TODO: remove typeCast once https://github.com/sidorares/node-mysql2/issues/347 closed
-      this.connection.query({ sql: this.sql, typeCast: this.connection.config.typeCast }, (err, results) => {
+      this.connection.query({ sql: this.sql }, (err, results) => {
 
         debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jshint": "^2.9.2",
     "lcov-result-merger": "^1.2.0",
     "mocha": "^3.0.2",
-    "mysql2": "^1.0.0-rc.8",
+    "mysql2": "^1.0.0-rc.9",
     "pg": "^6.0.0",
     "pg-hstore": "^2.3.1",
     "pg-native": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jshint": "^2.9.2",
     "lcov-result-merger": "^1.2.0",
     "mocha": "^3.0.2",
-    "mysql2": "^1.0.0-rc.9",
+    "mysql2": "^1.0.0-rc.10",
     "pg": "^6.0.0",
     "pg-hstore": "^2.3.1",
     "pg-native": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "jshint": "^2.9.2",
     "lcov-result-merger": "^1.2.0",
     "mocha": "^3.0.2",
-    "mysql": "~2.11.1",
+    "mysql2": "^1.0.0-rc.8",
     "pg": "^6.0.0",
     "pg-hstore": "^2.3.1",
     "pg-native": "^1.8.0",

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -396,7 +396,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
       return Model.sync({ force: true }).then(function () {
         return Model.create(sampleData);
       }).then(function () {
-        return Model.find({id: 1});
+        return Model.findById(1);
       }).then(function (user) {
         expect(user.get('jewelPurity')).to.be.eql(sampleData.jewelPurity);
         expect(user.get('jewelPurity')).to.be.string;

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -100,7 +100,7 @@ if (dialect === 'mysql') {
             conn = connection;
 
             // simulate a unexpected end
-            connection._protocol.end();
+            connection.close();
           })
           .then(function() {
             return cm.releaseConnection(conn);

--- a/test/integration/include/seperate.test.js
+++ b/test/integration/include/seperate.test.js
@@ -415,8 +415,7 @@ if (current.dialect.supports.groupedLimit) {
                 include: [{ model: Task, limit: 2, as: 'tasks', order:[['id', 'ASC']] }],
                 order: [
                   ['id', 'ASC']
-                ],
-                logging: console.log
+                ]
               }).then((result) => {
                 expect(result[0].tasks.length).to.equal(2);
                 expect(result[0].tasks[0].title).to.equal('b');

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -2383,7 +2383,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         return;
       }).catch (function(err) {
         if (dialect === 'mysql') {
-          expect(err.message).to.match(/ER_CANNOT_ADD_FOREIGN|ER_CANT_CREATE_TABLE/);
+          expect(err.message).to.match(/Can\'t create table/);
         } else if (dialect === 'sqlite') {
           // the parser should not end up here ... see above
           expect(1).to.equal(2);

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -991,7 +991,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
           } else if (dialect === 'mssql') {
             expect(err.message).to.match(/.*ECONNREFUSED.*/);
           } else {
-            console.log(err)
             expect(err.message.toString()).to.match(/.*Access\ denied.*/);
           }
         });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -991,6 +991,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
           } else if (dialect === 'mssql') {
             expect(err.message).to.match(/.*ECONNREFUSED.*/);
           } else {
+            console.log(err)
             expect(err.message.toString()).to.match(/.*Access\ denied.*/);
           }
         });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes #6327 , With this all dialects driver support the ability to use the prepared statements. Its first step towards #3495 

**Notable changes**

- `MySQL` doesn't support named timezones ( out of box ) so I have used `moment-timezone` to convert named timezone to their relative offsets.
- ~~`node-mysql2` provides `createConnection()`, which directly connect with server ( `node-mysql2` offers `connect` method). It can throw `EventEmitter` based errors which can only be caught using `domains`. I am open to other ideas if we do not want to use `domains`~~ We no longer use `domains`, thanks @felixfbecker for pushing me to find alternate solution :)
- `mysql` dialect now parse `BLOB` , to return `null` in case we get an empty buffer.

**Performance**

`sequelize-benchmark` reports improvement in performance.

`MySQL Server 5.7`
`Intel® Core™ i3-3240T CPU @ 2.90GHz × 4 `
`4GB RAM` 

`node-mysql2`
![mysql2](https://cloud.githubusercontent.com/assets/9989487/17244181/31d34142-559e-11e6-95dc-2374b6ffafa1.png)

`node-mysql`
![mysql](https://cloud.githubusercontent.com/assets/9989487/17244196/45ec81c0-559e-11e6-96b8-e78705d943ca.png)

