### PR TITLE
Added SQCipher support for SQLite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] SQLCipher support via the SQLite connection manager
 - [CHANGED] Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive) [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [ADDED] Support for range operators [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [FIXED] Broken transactions in `MySQL` [#3568](https://github.com/sequelize/sequelize/issues/3568)

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -67,6 +67,10 @@ class ConnectionManager extends AbstractConnectionManager {
         }
       );
     }).tap(connection => {
+      if (this.sequelize.config.password) {
+        // Make it possible to define and use password for sqlite encryption plugin like sqlcipher
+        connection.run('PRAGMA KEY=' + this.sequelize.escape(this.sequelize.config.password));
+      }
       if (this.sequelize.options.foreignKeys !== false) {
         // Make it possible to define and use foreign key constraints unless
         // explicitly disallowed. It's still opt-in per relation

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -57,7 +57,7 @@ const _ = require('lodash');
   *
   * @param {String}   database The name of the database
   * @param {String}   [username=null] The username which is used to authenticate against the database.
-  * @param {String}   [password=null] The password which is used to authenticate against the database.
+  * @param {String}   [password=null] The password which is used to authenticate against the database. Supports SQLCipher encryption for SQLite.
   * @param {Object}   [options={}] An object with options.
   * @param {String}   [options.host='localhost'] The host of the relational database.
   * @param {Integer}  [options.port=] The port of the relational database.


### PR DESCRIPTION
### Pull Request check-list

- [Y] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [N] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [N] Have you added new tests to prevent regressions?
- [Y] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [Y] Have you added an entry under `Future` in the changelog?

### Description of change

Added SQLCipher support to SQLite by utilising the password connection parameter. No unit tests were written as they would be unsuitable. Integration tests weren't written as it requires changing the project from using SQLite to SQLCipher. It was tested against my own project and the encryption was correctly applied.

Same change as described in #6020 and originally made by @asinbow. However it also contains the suggestions made by @janmeier. Namely updated documentation and resolved conflicts. The previous PR was stagnating, Thanks to @asinbow again.

