### PR TITLE
Fix mysql LIKE where condition on date fields

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] MySQL LIKE condition did not work as expected with DATE fields [PR#6372](https://github.com/sequelize/sequelize/pull/6372)
 - [ADDED] SQLCipher support via the SQLite connection manager
 - [CHANGED] Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive) [#5990](https://github.com/sequelize/sequelize/issues/5990)
 - [ADDED] Support for range operators [#5990](https://github.com/sequelize/sequelize/issues/5990)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -935,7 +935,7 @@ const QueryGenerator = {
             // Users shouldn't have to worry about these args - just give them a function that takes a single arg
             const simpleEscape = _.partialRight(SqlString.escape, this.options.timezone, this.dialect);
 
-            value = field.type.stringify(value, { escape: simpleEscape, field, timezone: this.options.timezone });
+            value = field.type.stringify(value, { escape: simpleEscape, field, timezone: this.options.timezone, acceptStrings: options.acceptStrings || false });
 
             if (field.type.escape === false) {
               // The data-type already did the required escaping

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -56,6 +56,9 @@ module.exports = BaseTypes => {
   };
 
   DATE.prototype._stringify = function _stringify(date, options) {
+    if (options.acceptStrings === true) {
+      return String(date);
+    }
     date = BaseTypes.DATE.prototype._applyTimezone(date, options);
     // Fractional DATETIMEs only supported on MySQL 5.6.4+
     if (this._length) {

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -608,7 +608,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           });
 
           testsql('createdAt', {
-            $like: { '2016-%' }
+            $like: '2016-%'
           }, {
             mysql: "`createdAt` LIKE '2016-%'"
           });

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -606,6 +606,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           }, {
             postgres: "\"userId\" NOT ILIKE ALL ARRAY['foo','bar','baz']"
           });
+
+          testsql('createdAt', {
+            $like: { '2016-%' }
+          }, {
+            mysql: "`createdAt` LIKE '2016-%'"
+          });
         });
       });
     }

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -607,11 +607,13 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
             postgres: "\"userId\" NOT ILIKE ALL ARRAY['foo','bar','baz']"
           });
 
-          testsql('createdAt', {
-            $like: '2016-%'
-          }, {
-            mysql: "`createdAt` LIKE '2016-%'"
-          });
+          if (current.dialect.name === 'mysql') {
+            testsql('createdAt', {
+              $like: '2016-%'
+            }, {
+              mysql: "`createdAt` LIKE '2016-%'"
+            });
+          }
         });
       });
     }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

I am using the MySQL dialect and when I run this query:

```js
model.findAll({
  where: {
    startedAt: { $like: '2016-07-%' },
  }
})
```

I get something like this :
`where startedAt LIKE '2016-07-01 04:00:00'`

But what I should get is this :
`where startedAt LIKE '2016-07-%'`