### PR TITLE
Let nested include query returns results when quoteIdentifiers is false on Postgres

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -32,6 +32,7 @@
 - [SECURITY] `GEOMETRY` and `GEOGRAPHY` SQL injection attacks [#6194](https://github.com/sequelize/sequelize/issues/6194)
 - [FIXED] `DECIMAL` now supports `UNSIGNED` / `ZEROFILL` (MySQL) [#2038](https://github.com/sequelize/sequelize/issues/2038)
 - [FIXED] Generate correct SQL of nested include when quoteIdentifiers is false. (Postgres) [#6351](https://github.com/sequelize/sequelize/issues/6351)
+- [FIXED] Nested query return correct result when quoteIdentifiers is false. (Postgres) [#6363](https://github.com/sequelize/sequelize/issues/6363)
 
 ## BC breaks:
 - Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive), previously was `()` (exclusive, exclusive)

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -199,7 +199,7 @@ class Query extends AbstractQuery {
               const targetAttr = attrsMap[key];
               if (typeof targetAttr === 'string' && targetAttr !== key) {
                 return targetAttr;
-              }else{
+              } else {
                 return key;
               }
             });

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -194,17 +194,17 @@ class Query extends AbstractQuery {
             m[k.toLowerCase()] = k;
             return m;
           }, {});
-          for (const row of rows) {
-            for (const key of Object.keys(row)) {
+          rows = _.map(rows,function(row) {
+            return _.mapKeys(row, function(value, key) {
               const targetAttr = attrsMap[key];
               if (typeof targetAttr === 'string' && targetAttr !== key) {
-                row[targetAttr] = row[key];
-                delete row[key];
+                return targetAttr;
+              }else{
+                return key;
               }
-            }
-          }
+            });
+          });
         }
-
         return this.handleSelectQuery(rows);
       } else if (QueryTypes.DESCRIBE === this.options.type) {
         result = {};

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -194,8 +194,8 @@ class Query extends AbstractQuery {
             m[k.toLowerCase()] = k;
             return m;
           }, {});
-          rows = _.map(rows,function(row) {
-            return _.mapKeys(row, function(value, key) {
+          rows = _.map(rows,(row)=> {
+            return _.mapKeys(row, (value, key)=> {
               const targetAttr = attrsMap[key];
               if (typeof targetAttr === 'string' && targetAttr !== key) {
                 return targetAttr;

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -942,7 +942,6 @@ if (dialect.match(/^postgres/)) {
         });
       });
       it('can select nested include', function() {
-        var self = this;
         this.sequelize.options.quoteIdentifiers = false;
         this.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = false;
         this.Professor  = this.sequelize.define('Professor', {
@@ -970,17 +969,17 @@ if (dialect.match(/^postgres/)) {
         this.Class.belongsToMany(this.Student,{through: this.ClassStudent});
         this.Student.belongsToMany(this.Class,{through: this.ClassStudent});
         return this.Professor.sync({ force: true })
-          .then(function() {
-            return self.Student.sync({ force: true });
+          .then(()=> {
+            return this.Student.sync({ force: true });
           })
-          .then(function() {
-            return self.Class.sync({ force: true });
+          .then(()=> {
+            return this.Class.sync({ force: true });
           })
-          .then(function() {
-            return self.ClassStudent.sync({ force: true });
+          .then(()=> {
+            return this.ClassStudent.sync({ force: true });
           })
-          .then(function() {
-              return self.Professor.bulkCreate([
+          .then(()=> {
+              return this.Professor.bulkCreate([
                 {
                   id: 1,
                   fullName: 'Albus Dumbledore'
@@ -991,8 +990,8 @@ if (dialect.match(/^postgres/)) {
                 }
               ]);
             })
-          .then(function() {
-            return self.Class.bulkCreate([
+          .then(()=> {
+            return this.Class.bulkCreate([
               {
                 id: 1,
                 name: 'Transfiguration',
@@ -1010,8 +1009,8 @@ if (dialect.match(/^postgres/)) {
               }
             ]);
           })
-          .then(function(classes) {
-            return self.Student.bulkCreate([
+          .then(()=> {
+            return this.Student.bulkCreate([
               {
                 id: 1,
                 fullName: 'Harry Potter',
@@ -1030,53 +1029,53 @@ if (dialect.match(/^postgres/)) {
               }
             ]);
           })
-          .then(function() {
+          .then(()=> {
             return Promise.all([
-              self.Student.findById(1)
-                .then(function(Harry){
+              this.Student.findById(1)
+                .then((Harry)=> {
                   return Harry.setClasses([1,2,3]);
                 }),
-              self.Student.findById(2)
-                .then(function(Ron){
+              this.Student.findById(2)
+                .then((Ron)=> {
                   return Ron.setClasses([1,2]);
                 }),
-              self.Student.findById(3)
-                .then(function(Ginny){
+              this.Student.findById(3)
+                .then((Ginny)=> {
                   return Ginny.setClasses([2,3]);
                 }),
-              self.Student.findById(4)
-                .then(function(Hermione){
+              this.Student.findById(4)
+                .then((Hermione)=> {
                   return Hermione.setClasses([1,2,3]);
                 })
             ]);
           })
-          .then(function() {
-            return self.Professor.findAll({
+          .then(()=> {
+            return this.Professor.findAll({
               include:[
                 {
-                  model: self.Class,
+                  model: this.Class,
                   include: [
                     {
-                      model: self.Student
+                      model: this.Student
                     }
                   ]
                 }
               ],
               order: [
                 ['id'],
-                [self.Class, 'id'],
-                [self.Class, self.Student, 'id']
+                [this.Class, 'id'],
+                [this.Class, this.Student, 'id']
               ]
             });
           })
-          .then(function(professors) {
+          .then((professors)=> {
             expect(professors.length).to.eql(2);
             expect(professors[0].fullName).to.eql('Albus Dumbledore');
             expect(professors[0].Classes.length).to.eql(1);
             expect(professors[0].Classes[0].Students.length).to.eql(3);
           })
-          .finally(function (){
-            self.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = true;
+          .finally(()=> {
+            this.sequelize.getQueryInterface().QueryGenerator.options.quoteIdentifiers = true;
           });
       });
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving? #6363
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?


### Description of change

The origin code change the row attributes order which makes  AbstractQuery._groupJoinData can't append the join data to the root.
Modify the code to keep the key sequence when translate the lower case key name to camelcase name

### To reviewer:
Another solution is to modify https://github.com/sequelize/sequelize/blob/master/lib/dialects/abstract/query.js#L481. However, I don't want to introduce the performance overhead on other database. But the order returned by Object.keys is arbitrary. So AbstractQuery._groupJoinData is builtin on a specific JS runtime behavior and may be wrong in the future.
