### PR TITLE
Ease dialect require for webpack

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -16,7 +16,11 @@ class ConnectionManager extends AbstractConnectionManager {
     this.sequelize = sequelize;
     this.sequelize.config.port = this.sequelize.config.port || 1433;
     try {
-      this.lib = require(sequelize.config.dialectModulePath || 'tedious');
+      if (sequelize.config.dialectModulePath) {
+        this.lib = require(sequelize.config.dialectModulePath);
+      } else {
+        this.lib = require('tedious');
+      }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         throw new Error('Please install tedious package manually');
@@ -53,7 +57,7 @@ class ConnectionManager extends AbstractConnectionManager {
         }
 
         // The 'tedious' driver needs domain property to be in the main Connection config object
-        if(config.dialectOptions.domain) {
+        if (config.dialectOptions.domain) {
           connectionConfig.domain = config.dialectOptions.domain;
         }
 

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -21,7 +21,11 @@ class ConnectionManager extends AbstractConnectionManager {
     if (this.sequelize.options.host === 'localhost') delete this.sequelize.options.host;
 
     try {
-      this.lib = require(sequelize.config.dialectModulePath || 'sqlite3').verbose();
+      if (sequelize.config.dialectModulePath) {
+        this.lib = require(sequelize.config.dialectModulePath).verbose();
+      } else {
+        this.lib = require('sqlite3').verbose();
+      }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         throw new Error('Please install sqlite3 package manually');


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This is a simple fix for webpack and probably browserify to pick up the dialect packages. postgres and mysql already contain this logic, I needed for mssql but I also added for sqlite for consistency. 
