### PR TITLE
Use typeof instead of _.isPlainObject

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -545,7 +545,7 @@ class Sequelize {
       options.fieldMap =  options.model.fieldAttributeMap;
     }
 
-    if (_.isPlainObject(sql)) {
+    if (typeof sql === 'object') {
       if (sql.values !== undefined) {
         if (options.replacements !== undefined) {
           throw new Error('Both `sql.values` and `options.replacements` cannot be set at the same time');

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -497,6 +497,22 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       });
     });
 
+    it('it allows to pass custom class instances', function() {
+      let logSql;
+      class SQLStatement {
+        constructor() {
+          this.values = [1, 2];
+        }
+        get query() {
+          return 'select ? as foo, ? as bar';
+        }
+      }
+      return this.sequelize.query(new SQLStatement(), { type: this.sequelize.QueryTypes.SELECT, logging: s => logSql = s } ).then(result => {
+        expect(result).to.deep.equal([{ foo: 1, bar: 2 }]);
+        expect(logSql.indexOf('?')).to.equal(-1);
+      });
+    });
+
     it('uses properties `query` and `values` if query is tagged', function() {
       var logSql;
       return this.sequelize.query({ query: 'select ? as foo, ? as bar', values: [1, 2] }, { type: this.sequelize.QueryTypes.SELECT, logging: function(s) { logSql = s; } }).then(function(result) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

Changes from using `_.isPlainObject` to checking with `typeof === 'object'` to support custom class instances like from `sql-template-strings`.