### PR TITLE
Close #5356 : Add option to restart identity when truncate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] `restartIdentity` option for truncate in postgres [#5356](https://github.com/sequelize/sequelize/issues/5356)
 - [INTERNAL] Migrated to `node-mysql2` for prepared statements [#6354](https://github.com/sequelize/sequelize/issues/6354)
 - [ADDED] SQLCipher support via the SQLite connection manager
 - [CHANGED] Range type bounds now default to [postgres default](https://www.postgresql.org/docs/9.5/static/rangetypes.html#RANGETYPES-CONSTRUCT) `[)` (inclusive, exclusive) [#5990](https://github.com/sequelize/sequelize/issues/5990)

--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -726,6 +726,7 @@ Delete multiple instances, or set their deletedAt timestamp to the current time 
 | [options.force=false] | Boolean | Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled) |
 | [options.truncate=false] | Boolean | If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored |
 | [options.cascade=false] | Boolean | Only used in conjunction with TRUNCATE. Truncates all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE. |
+| [options.restartIdentity=false] | Boolean | Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table. Postgres only. |
 | [options.transaction] | Transaction | Transaction to run query under |
 | [options.logging=false] | Function | A function that gets executed while running the query to log the sql. |
 | [options.benchmark=false] | Boolean | Print query execution time in milliseconds when logging SQL. |

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -308,6 +308,10 @@ const QueryGenerator = {
         query += ' CASCADE';
       }
 
+      if (options.restartIdentity) {
+        query += ' RESTART IDENTITY';
+      }
+
       return query;
     }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2181,6 +2181,7 @@ class Model {
    * @param  {Boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
    * @param  {Boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored
    * @param  {Boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
+   * @param  {Boolean}      [options.restartIdentity=false] Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table.
    * @param  {Transaction}  [options.transaction] Transaction to run query under
    * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
    * @param  {Boolean}      [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
@@ -2202,7 +2203,8 @@ class Model {
       hooks: true,
       individualHooks: false,
       force: false,
-      cascade: false
+      cascade: false,
+      restartIdentity: false
     });
 
     options.type = QueryTypes.BULKDELETE;

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -43,6 +43,33 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
 
+    suite('truncate with cascade and restartIdentity', function () {
+      var options = {
+        table: User.getTableName(),
+        where: {},
+        truncate: true,
+        cascade: true,
+        restartIdentity: true,
+        limit: 10
+      };
+
+      test(util.inspect(options, {depth: 2}), function () {
+        return expectsql(
+          sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            User
+          ), {
+            postgres: 'TRUNCATE "public"."test_users" CASCADE RESTART IDENTITY',
+            mssql:    'TRUNCATE TABLE [public].[test_users]',
+            mysql:    'TRUNCATE `public.test_users`',
+            sqlite:   'DELETE FROM `public.test_users`'
+          }
+        );
+      });
+    });
+
     suite('delete without limit', function () {
       var options = {
         table: User.getTableName(),


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

Model.truncate() is optionally allow to reset the sequence of the primary key 
by passing the option restartIdentity to true.
```sql
 TRUNCATE table_name RESTART IDENTITY;
```
This change is only for Postgres because MySQL and SSQL already restart the counter when you truncate a table.