### PR TITLE
Rename Sequelize class to Connection

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -109,7 +109,7 @@ const _ = require('lodash');
  *
  * @param {object} [options={}] See above for possible options
  */
-class Sequelize {
+class Connection {
 
   constructor(database, username, password, options) {
     let config;
@@ -140,9 +140,9 @@ class Sequelize {
 
       if (urlParts.auth) {
         const authParts = urlParts.auth.split(':');
-        
+
         config.username = authParts[0];
-        
+
         if (authParts.length > 1)
           config.password = authParts.slice(1).join(':');
       }
@@ -152,7 +152,7 @@ class Sequelize {
       config = {database, username, password};
     }
 
-    Sequelize.runHooks('beforeInit', config, options);
+    Connection.runHooks('beforeInit', config, options);
 
     this.options = Utils._.extend({
       dialect: null,
@@ -262,7 +262,7 @@ class Sequelize {
       }
     };
 
-    Sequelize.runHooks('afterInit', this);
+    Connection.runHooks('afterInit', this);
   }
 
   get connectorManager() {
@@ -596,8 +596,8 @@ class Sequelize {
       searchPath: this.options.hasOwnProperty('searchPath') ? this.options.searchPath : 'DEFAULT',
     });
 
-    if (options.transaction === undefined && Sequelize.cls) {
-      options.transaction = Sequelize.cls.get('transaction');
+    if (options.transaction === undefined && Connection.cls) {
+      options.transaction = Connection.cls.get('transaction');
     }
 
     if (!options.type) {
@@ -1048,7 +1048,7 @@ class Sequelize {
     // testhint argsConform.end
 
     const transaction = new Transaction(this, options);
-    const ns = Sequelize.cls;
+    const ns = Connection.cls;
 
     if (autoCallback) {
       let transactionResolver = (resolve, reject) => {
@@ -1174,59 +1174,59 @@ class Sequelize {
 }
 
 // Aliases
-Sequelize.prototype.fn = Sequelize.fn;
-Sequelize.prototype.col = Sequelize.col;
-Sequelize.prototype.cast = Sequelize.cast;
-Sequelize.prototype.literal = Sequelize.asIs = Sequelize.prototype.asIs = Sequelize.literal;
-Sequelize.prototype.and = Sequelize.and;
-Sequelize.prototype.or = Sequelize.or;
-Sequelize.prototype.json = Sequelize.json;
-Sequelize.prototype.where = Sequelize.condition = Sequelize.prototype.condition = Sequelize.where;
-Sequelize.prototype.validate = Sequelize.prototype.authenticate;
+Connection.prototype.fn = Connection.fn;
+Connection.prototype.col = Connection.col;
+Connection.prototype.cast = Connection.cast;
+Connection.prototype.literal = Connection.asIs = Connection.prototype.asIs = Connection.literal;
+Connection.prototype.and = Connection.and;
+Connection.prototype.or = Connection.or;
+Connection.prototype.json = Connection.json;
+Connection.prototype.where = Connection.condition = Connection.prototype.condition = Connection.where;
+Connection.prototype.validate = Connection.prototype.authenticate;
 
 /**
  * Sequelize version number.
  * @property version
  */
-Sequelize.version = require('../package.json').version;
+Connection.version = require('../package.json').version;
 
-Sequelize.options = {hooks: {}};
+Connection.options = {hooks: {}};
 
 /**
  * A reference to Sequelize constructor from sequelize. Useful for accessing DataTypes, Errors etc.
  * @property Sequelize
  * @see {Sequelize}
  */
-Sequelize.prototype.Sequelize = Sequelize;
+Connection.prototype.Sequelize = Connection;
 
 /**
  * @private
  */
-Sequelize.prototype.Utils = Sequelize.Utils = Utils;
+Connection.prototype.Utils = Connection.Utils = Utils;
 
 /**
  * A handy reference to the bluebird Promise class
  * @property Promise
  */
-Sequelize.prototype.Promise = Sequelize.Promise = Promise;
+Connection.prototype.Promise = Connection.Promise = Promise;
 
 /**
  * Available query types for use with `sequelize.query`
  * @property QueryTypes
  */
-Sequelize.prototype.QueryTypes = Sequelize.QueryTypes = QueryTypes;
+Connection.prototype.QueryTypes = Connection.QueryTypes = QueryTypes;
 
 /**
  * Exposes the validator.js object, so you can extend it with custom validation functions. The validator is exposed both on the instance, and on the constructor.
  * @property Validator
  * @see https://github.com/chriso/validator.js
  */
-Sequelize.prototype.Validator = Sequelize.Validator = Validator;
+Connection.prototype.Validator = Connection.Validator = Validator;
 
-Sequelize.prototype.Model = Sequelize.Model = Model;
+Connection.prototype.Model = Connection.Model = Model;
 
 for (const dataType in DataTypes) {
-  Sequelize[dataType] = DataTypes[dataType];
+  Connection[dataType] = DataTypes[dataType];
 }
 
 /**
@@ -1235,7 +1235,7 @@ for (const dataType in DataTypes) {
  * @see {Transaction}
  * @see {Sequelize#transaction}
  */
-Sequelize.prototype.Transaction = Sequelize.Transaction = Transaction;
+Connection.prototype.Transaction = Connection.Transaction = Transaction;
 
 /**
  * A reference to the deferrable collection. Use this to access the different deferrable options.
@@ -1243,34 +1243,34 @@ Sequelize.prototype.Transaction = Sequelize.Transaction = Transaction;
  * @see {Deferrable}
  * @see {Sequelize#transaction}
  */
-Sequelize.prototype.Deferrable = Sequelize.Deferrable = Deferrable;
+Connection.prototype.Deferrable = Connection.Deferrable = Deferrable;
 
 /**
  * A reference to the sequelize association class.
  * @property Association
  * @see {Association}
  */
-Sequelize.prototype.Association = Sequelize.Association = Association;
+Connection.prototype.Association = Connection.Association = Association;
 
 /**
  * Provide alternative version of `inflection` module to be used by `Utils.pluralize` etc.
  * @param {Object} _inflection - `inflection` module
  */
-Sequelize.useInflection = Utils.useInflection;
+Connection.useInflection = Utils.useInflection;
 
 /**
  * Allow hooks to be defined on Sequelize + on sequelize instance as universal hooks to run on all models
  * and on Sequelize/sequelize methods e.g. Sequelize(), Sequelize#define()
  */
-Hooks.applyTo(Sequelize);
-Hooks.applyTo(Sequelize.prototype);
+Hooks.applyTo(Connection);
+Hooks.applyTo(Connection.prototype);
 
 /**
  * A general error class
  * @property Error
  * @see {Errors#BaseError}
  */
-Sequelize.prototype.Error = Sequelize.Error =
+Connection.prototype.Error = Connection.Error =
   sequelizeErrors.BaseError;
 
 /**
@@ -1278,7 +1278,7 @@ Sequelize.prototype.Error = Sequelize.Error =
  * @property ValidationError
  * @see {Errors#ValidationError}
  */
-Sequelize.prototype.ValidationError = Sequelize.ValidationError =
+Connection.prototype.ValidationError = Connection.ValidationError =
   sequelizeErrors.ValidationError;
 
 /**
@@ -1286,108 +1286,108 @@ Sequelize.prototype.ValidationError = Sequelize.ValidationError =
  * @property ValidationErrorItem
  * @see {Errors#ValidationErrorItem}
  */
-Sequelize.prototype.ValidationErrorItem = Sequelize.ValidationErrorItem =
+Connection.prototype.ValidationErrorItem = Connection.ValidationErrorItem =
   sequelizeErrors.ValidationErrorItem;
 
 /**
  * A base class for all database related errors.
  * @see {Errors#DatabaseError}
  */
-Sequelize.prototype.DatabaseError = Sequelize.DatabaseError =
+Connection.prototype.DatabaseError = Connection.DatabaseError =
   sequelizeErrors.DatabaseError;
 
 /**
  * Thrown when a database query times out because of a deadlock
  * @see {Errors#TimeoutError}
  */
-Sequelize.prototype.TimeoutError = Sequelize.TimeoutError =
+Connection.prototype.TimeoutError = Connection.TimeoutError =
   sequelizeErrors.TimeoutError;
 
 /**
  * Thrown when a unique constraint is violated in the database
  * @see {Errors#UniqueConstraintError}
  */
-Sequelize.prototype.UniqueConstraintError = Sequelize.UniqueConstraintError =
+Connection.prototype.UniqueConstraintError = Connection.UniqueConstraintError =
   sequelizeErrors.UniqueConstraintError;
 
 /**
  * Thrown when an exclusion constraint is violated in the database
  * @see {Errors#ExclusionConstraintError}
  */
-Sequelize.prototype.ExclusionConstraintError = Sequelize.ExclusionConstraintError =
+Connection.prototype.ExclusionConstraintError = Connection.ExclusionConstraintError =
   sequelizeErrors.ExclusionConstraintError;
 
 /**
  * Thrown when a foreign key constraint is violated in the database
  * @see {Errors#ForeignKeyConstraintError}
  */
-Sequelize.prototype.ForeignKeyConstraintError = Sequelize.ForeignKeyConstraintError =
+Connection.prototype.ForeignKeyConstraintError = Connection.ForeignKeyConstraintError =
   sequelizeErrors.ForeignKeyConstraintError;
 
 /**
  * A base class for all connection related errors.
  * @see {Errors#ConnectionError}
  */
-Sequelize.prototype.ConnectionError = Sequelize.ConnectionError =
+Connection.prototype.ConnectionError = Connection.ConnectionError =
   sequelizeErrors.ConnectionError;
 
 /**
  * Thrown when a connection to a database is refused
  * @see {Errors#ConnectionRefusedError}
  */
-Sequelize.prototype.ConnectionRefusedError = Sequelize.ConnectionRefusedError =
+Connection.prototype.ConnectionRefusedError = Connection.ConnectionRefusedError =
   sequelizeErrors.ConnectionRefusedError;
 
 /**
  * Thrown when a connection to a database is refused due to insufficient access
  * @see {Errors#AccessDeniedError}
  */
-Sequelize.prototype.AccessDeniedError = Sequelize.AccessDeniedError =
+Connection.prototype.AccessDeniedError = Connection.AccessDeniedError =
   sequelizeErrors.AccessDeniedError;
 
 /**
  * Thrown when a connection to a database has a hostname that was not found
  * @see {Errors#HostNotFoundError}
  */
-Sequelize.prototype.HostNotFoundError = Sequelize.HostNotFoundError =
+Connection.prototype.HostNotFoundError = Connection.HostNotFoundError =
   sequelizeErrors.HostNotFoundError;
 
 /**
  * Thrown when a connection to a database has a hostname that was not reachable
  * @see {Errors#HostNotReachableError}
  */
-Sequelize.prototype.HostNotReachableError = Sequelize.HostNotReachableError =
+Connection.prototype.HostNotReachableError = Connection.HostNotReachableError =
   sequelizeErrors.HostNotReachableError;
 
 /**
  * Thrown when a connection to a database has invalid values for any of the connection parameters
  * @see {Errors#InvalidConnectionError}
  */
-Sequelize.prototype.InvalidConnectionError = Sequelize.InvalidConnectionError =
+Connection.prototype.InvalidConnectionError = Connection.InvalidConnectionError =
   sequelizeErrors.InvalidConnectionError;
 
 /**
  * Thrown when a connection to a database times out
  * @see {Errors#ConnectionTimedOutError}
  */
-Sequelize.prototype.ConnectionTimedOutError = Sequelize.ConnectionTimedOutError =
+Connection.prototype.ConnectionTimedOutError = Connection.ConnectionTimedOutError =
   sequelizeErrors.ConnectionTimedOutError;
 
 /**
  * Thrown when a some problem occurred with Instance methods (see message for details)
  * @see {Errors#InstanceError}
  */
-Sequelize.prototype.InstanceError = Sequelize.InstanceError =
+Connection.prototype.InstanceError = Connection.InstanceError =
   sequelizeErrors.InstanceError;
 
 /**
   * Thrown when a record was not found, Usually used with rejectOnEmpty mode (see message for details)
   * @see {Errors#RecordNotFoundError}
   */
-Sequelize.prototype.EmptyResultError = Sequelize.EmptyResultError =
+Connection.prototype.EmptyResultError = Connection.EmptyResultError =
   sequelizeErrors.EmptyResultError;
 
 // Allows the promise to access cls namespaces
-module.exports = Promise.Sequelize = Sequelize;
-module.exports.Sequelize = Sequelize;
-module.exports.default = Sequelize;
+module.exports = Promise.Sequelize = Connection;
+module.exports.Sequelize = Connection;
+module.exports.default = Connection;


### PR DESCRIPTION
Reasoning: In ES6 / TypeScript, it feels extremely weird to do
```js
import * as Sequelize from 'sequelize';
const sequelize = new Sequelize.Sequelize(process.env.DB);
```
For ES5 users, nothing changes.