### PR TITLE
Milliseconds in time stamps for createdAt, updatedAt for MySQL 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 - [FIXED] GroupedLimit when foreignKey has a field alias
 - [FIXED] groupedLimit.through.where support
 - [ADDED] `option.silent` for increment and decrement [#6795](https://github.com/sequelize/sequelize/pull/6795)
+- [CHANGED] `now` function allow milliseconds in timestamps on mysql [#6441](https://github.com/sequelize/sequelize/issues/6441)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -422,7 +422,7 @@ exports.sliceArgs = sliceArgs;
 
 function now(dialect) {
   const now = new Date();
-  if (['mysql','postgres', 'sqlite'].indexOf(dialect) === -1) {
+  if (['mysql', 'postgres', 'sqlite'].indexOf(dialect) === -1) {
     now.setMilliseconds(0);
   }
   return now;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -422,7 +422,7 @@ exports.sliceArgs = sliceArgs;
 
 function now(dialect) {
   const now = new Date();
-  if (['postgres', 'sqlite'].indexOf(dialect) === -1) {
+  if (['mysql','postgres', 'sqlite'].indexOf(dialect) === -1) {
     now.setMilliseconds(0);
   }
   return now;

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -147,8 +147,8 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: DataTypes.STRING,
-          createdAt: DataTypes.DATE(6),
-          updatedAt: DataTypes.DATE(6)
+          createdAt: {type: DataTypes.DATE(6), allowNull: false},
+          updatedAt: {type: DataTypes.DATE(6), allowNull: false}
         }, {
           timestamps: true
         });

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -141,7 +141,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       });
     });
 
-    if(dialect == 'mysql') {
+    if(dialect === 'mysql') {
       it('should update timestamps w milliseconds', function() {
         var User = this.sequelize.define('User' + config.rand(), {
           name: DataTypes.STRING,

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -141,34 +141,36 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       });
     });
 
-    it('should update timestamps w milliseconds', function() {
-      var User = this.sequelize.define('User' + config.rand(), {
-        name: DataTypes.STRING,
-        bio: DataTypes.TEXT,
-        email: DataTypes.STRING,
-        createdAt: DataTypes.DATE(6),
-        updatedAt: DataTypes.DATE(6)
-      }, {
-        timestamps: true
-      });
+    if(dialect == 'mysql') {
+      it('should update timestamps w milliseconds', function() {
+        var User = this.sequelize.define('User' + config.rand(), {
+          name: DataTypes.STRING,
+          bio: DataTypes.TEXT,
+          email: DataTypes.STRING,
+          createdAt: DataTypes.DATE(6),
+          updatedAt: DataTypes.DATE(6)
+        }, {
+          timestamps: true
+        });
 
-     this.clock.tick(2100); //move the clock forward 2100 ms. 
+      this.clock.tick(2100); //move the clock forward 2100 ms. 
 
-     return User.sync({force: true}).then(function() {
-        return User.create({
-          name: 'snafu',
-          email: 'email'
-        }).then(function(user) {
-          return user.reload();
-        }).then(function(user) {
-          expect(user.get('name')).to.equal('snafu');
-          expect(user.get('email')).to.equal('email');
-          var testDate = new Date();
-          testDate.setTime(2100);
-          expect(user.get('createdAt')).to.equalTime(testDate);
+      return User.sync({force: true}).then(function() {
+          return User.create({
+            name: 'snafu',
+            email: 'email'
+          }).then(function(user) {
+            return user.reload();
+          }).then(function(user) {
+            expect(user.get('name')).to.equal('snafu');
+            expect(user.get('email')).to.equal('email');
+            var testDate = new Date();
+            testDate.setTime(2100);
+            expect(user.get('createdAt')).to.equalTime(testDate);
+          });
         });
       });
-    });
+    }
 
     it('should only save passed attributes', function () {
       var user = this.User.build();

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -141,6 +141,35 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       });
     });
 
+    it('should update timestamps w milliseconds', function() {
+      var User = this.sequelize.define('User' + config.rand(), {
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
+        email: DataTypes.STRING,
+        createdAt: DataTypes.DATE(6),
+        updatedAt: DataTypes.DATE(6)
+      }, {
+        timestamps: true
+      });
+
+     this.clock.tick(2100); //move the clock forward 2100 ms. 
+
+     return User.sync({force: true}).then(function() {
+        return User.create({
+          name: 'snafu',
+          email: 'email'
+        }).then(function(user) {
+          return user.reload();
+        }).then(function(user) {
+          expect(user.get('name')).to.equal('snafu');
+          expect(user.get('email')).to.equal('email');
+          var testDate = new Date();
+          testDate.setTime(2100);
+          expect(user.get('createdAt')).to.equalTime(testDate);
+        });
+      });
+    });
+
     it('should only save passed attributes', function () {
       var user = this.User.build();
       return user.save().then(function () {

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -52,7 +52,7 @@ if (dialect !== 'sqlite') {
           // Expect 7 hours difference, in milliseconds.
           // This difference is expected since two instances, configured for each their timezone is trying to read the same timestamp
           // this test does not apply to PG, since it stores the timezone along with the timestamp.
-          expect(this.normalUser.createdAt.getTime() - timezonedUser.createdAt.getTime()).to.be.closeTo(60 * 60 * 7 * 1000, 50);
+          expect(this.normalUser.createdAt.getTime() - timezonedUser.createdAt.getTime()).to.be.closeTo(60 * 60 * 7 * 1000, 1000);
         });
       });
 


### PR DESCRIPTION
Closes [#6441](https://github.com/sequelize/sequelize/issues/6441)
### Pull Request check-list
- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Have you added an entry under `Future` in the changelog?
### Description of change

Added mysql to the list of dialects that return milliseconds from the now function. Updated timezone test to account for milliseconds in the time being compared. 
