### PR TITLE
Fix type validations being to strict for dates

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Accept dates as string while using `typeValidation` [#6453](https://github.com/sequelize/sequelize/issues/6453)
+
 # 3.24.1
 - [FIXED] Add `parent`, `original` and `sql` properties to `UniqueConstraintError`
 

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -458,7 +458,7 @@ DATE.prototype.toSql = function() {
   return 'DATETIME';
 };
 DATE.prototype.validate = function(value) {
-  if (!_.isDate(value)) {
+  if (!Validator.isDate(String(value))) {
     throw new sequelizeErrors.ValidationError(util.format('%j is not a valid date', value));
   }
 

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -274,7 +274,8 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
       name: Sequelize.STRING,
       awesome: Sequelize.BOOLEAN,
       number: Sequelize.DECIMAL,
-      uid: Sequelize.UUID
+      uid: Sequelize.UUID,
+      date: Sequelize.DATE
     });
 
     before(function () {
@@ -300,6 +301,14 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
         it('should allow decimal as a string', function () {
           return expect(User.create({
             number: '12.6'
+          })).not.to.be.rejected;
+        });
+
+        it('should allow dates as a string', function() {
+          return expect(User.find({
+            where: {
+              date: '2000-12-16'
+            }
           })).not.to.be.rejected;
         });
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Currently the type validations for dates are very strict. Most of the type validations accept strings as input and this should also be the case for dates as far as I see it.
