### PR TITLE
fix(uniqueConstraintError): Add parent, original and sql properties, …

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Next
+- [FIXED] Add `parent`, `original` and `sql` properties to `UniqueConstraintError`
+
 # 3.24.0
 - [ADDED] `restartIdentity` option for truncate in postgres [#5356](https://github.com/sequelize/sequelize/issues/5356)
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -146,6 +146,9 @@ error.UniqueConstraintError = function (options) {
   this.message = options.message;
   this.errors = options.errors;
   this.fields = options.fields;
+  this.parent = options.parent;
+  this.original = options.parent;
+  this.sql = options.parent.sql;
 };
 util.inherits(error.UniqueConstraintError, error.ValidationError);
 

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -244,5 +244,25 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), function () {
         return expect(this.sequelize.query('INSERT INTO users (name) VALUES (\'jan\')')).to.be.rejectedWith(this.sequelize.UniqueConstraintError);
       });
     });
+
+    it('adds parent and sql properties', function () {
+      var User = this.sequelize.define('user', {
+        name: {
+          type: Sequelize.STRING,
+          unique: 'unique',
+        }
+      }, { timestamps: false });
+
+      return this.sequelize.sync({ force: true }).bind(this).then(function () {
+        return User.create({ name: 'jan' });
+      }).then(function () {
+        return expect(User.create({ name: 'jan' })).to.be.rejected;
+      }).then(function (error) {
+        expect(error).to.be.instanceOf(this.sequelize.UniqueConstraintError);
+        expect(error).to.have.property('parent');
+        expect(error).to.have.property('original');
+        expect(error).to.have.property('sql');
+      });
+    });
   });
 });


### PR DESCRIPTION
Just letting travis do its thing - master PR coming later

Since `UniqueConstraintError` inherits from `ValidationError` (and not `DatabaseError`, see https://github.com/sequelize/sequelize/pull/2760), the `parent` and `sql` properties were not added automagically. They are now :)