### PR TITLE
Fix postgis insert empty coordinates for point test case

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Future
-- [FIXED] Fixed test-case. Postgis >=2.1.7 will now throw an error when passing a geojson object with an empty coordinates array (instead of just using [0,0])
+- [REMOVED] Postgis >=2.1.7 will now throw an error when passing a geojson object with an empty coordinates array (instead of just using [0,0]), so just remove the test case as no backends really supports an empty array (mysql will just return null)
 
 # 4.0.0-1
 - [CHANGED] Removed `modelManager` parameter from `Model.init()` [#6437](https://github.com/sequelize/sequelize/issues/6437)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Fixed test-case. Postgis >=2.1.7 will now throw an error when passing a geojson object with an empty coordinates array (instead of just using [0,0])
+
 # 4.0.0-1
 - [CHANGED] Removed `modelManager` parameter from `Model.init()` [#6437](https://github.com/sequelize/sequelize/issues/6437)
 - [FIXED] Made `Model.init()` behave like `sequelize.define()` (hooks are called and options have proper defaults) [#6437](https://github.com/sequelize/sequelize/issues/6437)

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -274,45 +274,6 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
     testFailure(Type);
   });
 
-  it('should parse an empty GEOMETRY field', function () {
-   var Type = new Sequelize.GEOMETRY();
-
-   if (current.dialect.supports.GEOMETRY) {
-     current.refreshTypes();
-
-     var User = current.define('user', { field: Type }, { timestamps: false });
-     var point = { type: "Point", coordinates: [] };
-
-     return current.sync({ force: true }).then(function () {
-       return User.create({
-          //insert a null GEOMETRY type
-          field: point
-        });
-      }).then(function () {
-        //This case throw unhandled exception
-        return User.findAll();
-      }).then(function(users){
-        if (dialect === 'mysql') {
-          // MySQL will return NULL, becuase they lack EMPTY geometry data support.
-          expect(users[0].field).to.be.eql(null);
-        } else if (dialect === 'postgres' || dialect === 'postgres-native') {
-          // Used to return [0,0] but change made around postgis 2.1.7 to throw error instead:
-          // https://trac.osgeo.org/postgis/changeset/13401 (L96-101)
-          expect(!'Should throw error. Postgis >=2.1.7 does not support empty coordinates.');
-        } else {
-          expect(users[0].field).to.be.deep.eql(point);
-        }
-      })
-      .catch(function(e) {
-        if (dialect === 'postgres' || dialect === 'postgres-native') {
-          expect(e.message === 'Too few ordinates in GeoJSON');
-          return;
-        }
-        throw e;
-      });
-   }
- });
-
   if (dialect === 'postgres' || dialect === 'sqlite') {
     // postgres actively supports IEEE floating point literals, and sqlite doesn't care what we throw at it
     it('should store and parse IEEE floating point literals (NaN and Infinity)', function () {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -296,11 +296,19 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
           // MySQL will return NULL, becuase they lack EMPTY geometry data support.
           expect(users[0].field).to.be.eql(null);
         } else if (dialect === 'postgres' || dialect === 'postgres-native') {
-          //Empty Geometry data [0,0] as per https://trac.osgeo.org/postgis/ticket/1996
-          expect(users[0].field).to.be.deep.eql({ type: "Point", coordinates: [0,0] });
+          // Used to return [0,0] but change made around postgis 2.1.7 to throw error instead:
+          // https://trac.osgeo.org/postgis/changeset/13401 (L96-101)
+          expect(!'Should throw error. Postgis >=2.1.7 does not support empty coordinates.');
         } else {
           expect(users[0].field).to.be.deep.eql(point);
         }
+      })
+      .catch(function(e) {
+        if (dialect === 'postgres' || dialect === 'postgres-native') {
+          expect(e.message === 'Too few ordinates in GeoJSON');
+          return;
+        }
+        throw e;
       });
    }
  });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? **Yes**
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving? **The test case change fixes postgres errors in #6279 & #6443**
- [x] Have you added new tests to prevent regressions? **No new tests needed**
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **No**
- [x] Have you added an entry under `Future` in the changelog? **Yes**

### Description of change

Fixed a test case for postgres/postgis that was failing do to attempting to insert a geojson object with an empty coordinates array.

`Postgis >=2.1.7` made a change to throw an error if a geojson object was created with an empty coordinates array (instead of using `[0,0]` as it was previously doing). This was not very well documented in the postgis [changelog](http://postgis.net/docs/release_notes.html#idm38454) (see malformed GeoJSON inputs), but the change can be found in this [diff](https://trac.osgeo.org/postgis/changeset/13401/) (L96-101)

This will fail under the current travis build as I am guessing travis uses a lower postgis version. But it will fix travis postgres failing test cases for #6443 