### PR TITLE
Critical bug fix for Model#count()

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -672,7 +672,7 @@ class QueryInterface {
         return data;
       }
 
-      let result = data ? data[attributeSelector] : null;
+      let result = data ? (data[attributeSelector] === undefined ? data.dataValues[attributeSelector] : data[attributeSelector]) : null;
 
       if (options && options.dataType) {
         const dataType = options.dataType;


### PR DESCRIPTION
`Model#count()` will now return a proper number when the query object has an `include` field. Previously the result was `NaN`.
This breaks our production code, please respond ASAP!
