### PR TITLE
SQLite JSON datatype support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Future
 - [FIXED] Accept dates as string while using `typeValidation` [#6453](https://github.com/sequelize/sequelize/issues/6453)
+- [ADDED] Sqlite JSON datatype support ([#6500](https://github.com/sequelize/sequelize/pull/6500))
 
 # 4.0.0-1
 - [CHANGED] Removed `modelManager` parameter from `Model.init()` [#6437](https://github.com/sequelize/sequelize/issues/6437)

--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -22,7 +22,18 @@ module.exports = BaseTypes => {
   BaseTypes.ENUM.types.sqlite = false;
   BaseTypes.REAL.types.sqlite = ['REAL'];
   BaseTypes.DOUBLE.types.sqlite = ['DOUBLE PRECISION'];
+  BaseTypes.JSON.types.sqlite = ['JSON'];
   BaseTypes.GEOMETRY.types.sqlite = false;
+
+  function JSONTYPE() {
+    if (!(this instanceof JSONTYPE)) return new JSONTYPE();
+    BaseTypes.JSON.apply(this, arguments);
+  }
+  inherits(JSONTYPE, BaseTypes.JSON);
+
+  JSONTYPE.parse = function parse(data) {
+    return JSON.parse(data);
+  };
 
   function DATE(length) {
     if (!(this instanceof DATE)) return new DATE(length);
@@ -194,7 +205,8 @@ module.exports = BaseTypes => {
     INTEGER,
     BIGINT,
     TEXT,
-    ENUM
+    ENUM,
+    JSON: JSONTYPE
   };
 
   _.forIn(exports, (DataType, key) => {

--- a/lib/dialects/sqlite/index.js
+++ b/lib/dialects/sqlite/index.js
@@ -34,7 +34,8 @@ SqliteDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   },
   joinTableDependent: false,
   groupedLimit: false,
-  ignoreDuplicates: ' OR IGNORE'
+  ignoreDuplicates: ' OR IGNORE',
+  JSON: true
 });
 
 ConnectionManager.prototype.defaultVersion = '3.8.0';

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -121,6 +121,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           using: 'gin',
           operator: 'jsonb_path_ops'
         }), {
+          sqlite: 'CREATE INDEX `table_event` ON `table` (`gin`)',
           postgres: 'CREATE INDEX "table_event" ON "table" USING gin ("event" jsonb_path_ops)'
         });
       });

--- a/test/unit/sql/json.test.js
+++ b/test/unit/sql/json.test.js
@@ -48,16 +48,33 @@ if (current.dialect.supports.JSON) {
             default: '\'{"some":"nested","more":{"nested":true},"answer":42}\''
           });
         });
+      });
+    });
+  });
+}
 
+if (current.dialect.supports.JSON && current.dialect.supports.ARRAY) {
+  suite(Support.getTestDialectTeaser('SQL'), function() {
+    suite('JSONB', function () {
+      suite('escape', function () {
         test('array of JSON', function () {
           expectsql(sql.escape([
             { some: 'nested', more: { nested: true }, answer: 42 },
             43,
             'joe'
-          ], { type: DataTypes.ARRAY(DataTypes.JSON)}), {
+          ], { type: DataTypes.ARRAY(DataTypes.JSONB)}), {
             postgres: 'ARRAY[\'{"some":"nested","more":{"nested":true},"answer":42}\',\'43\',\'"joe"\']::JSON[]'
           });
         });
+      });
+    });
+  });
+}
+
+if (current.dialect.supports.JSONB && current.dialect.supports.ARRAY) {
+  suite(Support.getTestDialectTeaser('SQL'), function() {
+    suite('JSONB', function () {
+      suite('escape', function () {
         test('array of JSONB', function () {
           expectsql(sql.escape([
             { some: 'nested', more: { nested: true }, answer: 42 },

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -715,8 +715,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       });
     }
 
-    if (current.dialect.supports.JSON) {
-      suite('JSON', function () {
+    if (current.dialect.supports.JSONB) {
+      suite('JSONB', function () {
         test('sequelize.json("profile->>\'id\', sequelize.cast(2, \'text\')")', function () {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.json("profile->>'id'", this.sequelize.cast('12346-78912', 'text'))), {
             postgres: "profile->>'id' = CAST('12346-78912' AS TEXT)"


### PR DESCRIPTION
### Pull Request check-list
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #4873)
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?
- [x] ~~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~~
### Description of change

Partial fix for #4873 (cc @mickhansen) - only add JSON support to SQLite, because I don't use MySQL and MSSQL, and I feel much less confident writing tests for these environments (especially since I won't be able to see it myself if something is wrong).

I haven't been able to fix a test, because I'm not familiar enough with how `CREATE INDEX` queries should look like :disappointed: Some help on this would be great here.

I wasn't sure if JSONB should also be implemented or if there was too much differences for it to matter, so I figured I should first submit this PR and ask for your input.

Due to the previous point, I splitted some tests in order for a dialect to be able to run JSON-related tests but not JSONB-related tests nor ARRAY-related tests.
