### PR TITLE
Diff on save

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3556,9 +3556,16 @@ class Model {
         values[field] = new Date();
         where[field] = attribute.hasOwnProperty('defaultValue') ? attribute.defaultValue : null;
 
-        this.setDataValue(field, values[field]);
-
-        return this.sequelize.getQueryInterface().update(this, this.constructor.getTableName(options), values, where, _.defaults({ hooks: false }, options));
+        return this.sequelize.getQueryInterface().update(
+          this,
+          this.constructor.getTableName(options),
+          values,
+          where,
+          _.defaults({ hooks: false }, options)
+        ).then(() => {
+          this.setDataValue(field, values[field]);
+          this._previousDataValues[field] = values[field];
+        });
       } else {
         return this.sequelize.getQueryInterface().delete(this, this.constructor.getTableName(options), where, _.assign({ type: QueryTypes.DELETE, limit: null }, options));
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3546,16 +3546,28 @@ class Model {
         return this.constructor.runHooks('beforeDestroy', this, options);
       }
     }).then(() => {
+      const where = this.where();
 
       if (this.constructor._timestampAttributes.deletedAt && options.force === false) {
         const attribute = this.constructor.rawAttributes[this.constructor._timestampAttributes.deletedAt];
         const field = attribute.field || this.constructor._timestampAttributes.deletedAt;
-        const values = {[field]: new Date()};
-        const where = {[field]: attribute.hasOwnProperty('defaultValue') ? attribute.defaultValue : null};
+        const values = {};
 
-        return this.update(values, Object.assign({hooks: false}, options, {where}));
+        values[field] = new Date();
+        where[field] = attribute.hasOwnProperty('defaultValue') ? attribute.defaultValue : null;
+
+        return this.sequelize.getQueryInterface().update(
+          this,
+          this.constructor.getTableName(options),
+          values,
+          where,
+          _.defaults({ hooks: false }, options)
+        ).then(() => {
+          this.setDataValue(field, values[field]);
+          this._previousDataValues[field] = values[field];
+        });
       } else {
-        return this.sequelize.getQueryInterface().delete(this, this.constructor.getTableName(options), this.where(), _.assign({ type: QueryTypes.DELETE, limit: null }, options));
+        return this.sequelize.getQueryInterface().delete(this, this.constructor.getTableName(options), where, _.assign({ type: QueryTypes.DELETE, limit: null }, options));
       }
     }).tap(() => {
       // Run after hook

--- a/lib/model.js
+++ b/lib/model.js
@@ -2850,7 +2850,7 @@ class Model {
       }
     }
 
-    this.set(values, options);
+    this.set(values, Object.assign({raw: options.isNewRecord}, options));
   }
 
   /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -3546,28 +3546,16 @@ class Model {
         return this.constructor.runHooks('beforeDestroy', this, options);
       }
     }).then(() => {
-      const where = this.where();
 
       if (this.constructor._timestampAttributes.deletedAt && options.force === false) {
         const attribute = this.constructor.rawAttributes[this.constructor._timestampAttributes.deletedAt];
         const field = attribute.field || this.constructor._timestampAttributes.deletedAt;
-        const values = {};
+        const values = {[field]: new Date()};
+        const where = {[field]: attribute.hasOwnProperty('defaultValue') ? attribute.defaultValue : null};
 
-        values[field] = new Date();
-        where[field] = attribute.hasOwnProperty('defaultValue') ? attribute.defaultValue : null;
-
-        return this.sequelize.getQueryInterface().update(
-          this,
-          this.constructor.getTableName(options),
-          values,
-          where,
-          _.defaults({ hooks: false }, options)
-        ).then(() => {
-          this.setDataValue(field, values[field]);
-          this._previousDataValues[field] = values[field];
-        });
+        return this.update(values, Object.assign({hooks: false}, options, {where}));
       } else {
-        return this.sequelize.getQueryInterface().delete(this, this.constructor.getTableName(options), where, _.assign({ type: QueryTypes.DELETE, limit: null }, options));
+        return this.sequelize.getQueryInterface().delete(this, this.constructor.getTableName(options), this.where(), _.assign({ type: QueryTypes.DELETE, limit: null }, options));
       }
     }).tap(() => {
       // Run after hook

--- a/lib/model.js
+++ b/lib/model.js
@@ -2097,7 +2097,7 @@ class Model {
 
     return instance.validate(options).then(() => {
       // Map field names
-      const updatedDataValues = _.pick(instance.dataValues, Object.keys(instance._changed));
+      const updatedDataValues = _.pick(instance.dataValues, instance.changed());
       const insertValues = Utils.mapValueFieldNames(instance.dataValues, instance.attributes, this);
       const updateValues = Utils.mapValueFieldNames(updatedDataValues, options.fields, this);
       const now = Utils.now(this.sequelize.options.dialect);
@@ -3107,9 +3107,7 @@ class Model {
             }
           }
 
-          if (!options.raw && ((!Utils.isPrimitive(value) && value !== null) || value !== originalValue)) {
-            this._previousDataValues[key] = originalValue;
-          }
+          this._previousDataValues[key] = _.cloneDeep(originalValue);
           this.dataValues[key] = value;
         }
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -2781,7 +2781,6 @@ class Model {
 
     this.dataValues = {};
     this._previousDataValues = {};
-    this._changed = {};
     this._modelOptions = this.constructor.options;
     this._options = options || {};
     this.hasPrimaryKeys = this.constructor.options.hasPrimaryKeys;
@@ -2903,11 +2902,6 @@ class Model {
    * @param {any} value
    */
   setDataValue(key, value) {
-    const originalValue = this._previousDataValues[key];
-    if (!Utils.isPrimitive(value) || value !== originalValue) {
-      this.changed(key, true);
-    }
-
     this.dataValues[key] = value;
   }
 
@@ -3011,7 +3005,7 @@ class Model {
           this.dataValues = values;
         }
         // If raw, .changed() shouldn't be true
-        this._previousDataValues = _.clone(this.dataValues);
+        this._previousDataValues = _.cloneDeep(this.dataValues);
       } else {
         // Loop and call set
 
@@ -3038,7 +3032,7 @@ class Model {
 
         if (options.raw) {
           // If raw, .changed() shouldn't be true
-          this._previousDataValues = _.clone(this.dataValues);
+          this._previousDataValues = _.cloneDeep(this.dataValues);
         }
       }
     } else {
@@ -3067,7 +3061,6 @@ class Model {
                 const previousDottieValue = Dottie.get(this.dataValues, key);
                 if (!_.isEqual(previousDottieValue, value)) {
                   Dottie.set(this.dataValues, key, value);
-                  this.changed(key.split('.')[0], true);
                 }
               }
               return this;
@@ -3116,7 +3109,6 @@ class Model {
 
           if (!options.raw && ((!Utils.isPrimitive(value) && value !== null) || value !== originalValue)) {
             this._previousDataValues[key] = originalValue;
-            this.changed(key, true);
           }
           this.dataValues[key] = value;
         }
@@ -3140,13 +3132,9 @@ class Model {
    * @param {String} [key]
    * @return {Boolean|Array}
    */
-  changed(key, value) {
+  changed(key) {
     if (key) {
-      if (value !== undefined) {
-        this._changed[key] = value;
-        return this;
-      }
-      return this._changed[key] || false;
+      return !_.isEqual(this.dataValues[key], this._previousDataValues[key]);
     }
 
     const changed = Object.keys(this.dataValues).filter(key => this.changed(key));
@@ -3442,8 +3430,7 @@ class Model {
         })
         .then(result => {
           for (const field of options.fields) {
-            result._previousDataValues[field] = result.dataValues[field];
-            this.changed(field, false);
+            result._previousDataValues[field] = _.cloneDeep(result.dataValues[field]);
           }
           this.isNewRecord = false;
           return result;

--- a/test/unit/instance/changed.test.js
+++ b/test/unit/instance/changed.test.js
@@ -78,7 +78,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       expect(user.changed('birthdate')).to.equal(false);
     });
 
-    it('should return true for changed JSON with same object', function () {
+    it('should return true for changed JSON', function () {
       var user = this.User.build({
         meta: {
           city: 'Copenhagen'
@@ -91,8 +91,22 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       var meta = user.get('meta');
       meta.city = 'Stockholm';
 
-      user.set('meta', meta);
       expect(user.changed('meta')).to.equal(true);
+    });
+
+    it('should return false for unchanged JSON', function () {
+      var user = this.User.build({
+        meta: {
+          city: 'Copenhagen'
+        }
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.meta = {city: 'Copenhagen'};
+
+      expect(user.changed('meta')).to.equal(false);
     });
 
     it('should return true for JSON dot.separated key with changed values', function() {


### PR DESCRIPTION
The first part of #6270 
- [x] `_previousDataValues` is set to a deep clone of `dataValues`
- [x] `changed()` does deep change detection with `_.isEqual`
- [ ] `isNewRecord: false` should initialize `_previousDataValues`

Don't know why tests fail, help appreciated
### Thoughts
- When doing `new Model({what: 'ever'}, isNewRecord: false})` `_previousDataValues` should probably be set to `{what: 'ever'}`.
- Should there be a method to take a snapshot of the current state?
