### PR TITLE
Remove Babel devDependency

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -401,9 +401,9 @@ class Sequelize {
 
     if (!this.importCache[path]) {
       let defineCall = arguments.length > 1 ? arguments[1] : require(path);
-      if (typeof defineCall === 'object' && defineCall.__esModule) {
-        // Babel/ES6 module compatability
-        defineCall = defineCall['default'];
+      if (typeof defineCall === 'object') {
+        // ES6 module compatability
+        defineCall = defineCall.default;
       }
       this.importCache[path] = defineCall(this, DataTypes);
     }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,6 @@
     "wkx": "0.3.0"
   },
   "devDependencies": {
-    "babel-core": "^6.10.4",
-    "babel-preset-es2015": "^6.6.0",
     "chai": "^3.5.0",
     "chai-as-promised": "^5.1.0",
     "chai-datetime": "^1.4.0",

--- a/test/integration/assets/es6project.js
+++ b/test/integration/assets/es6project.js
@@ -1,4 +1,5 @@
-export default function(sequelize, DataTypes) {
+'use strict';
+exports.default = function(sequelize, DataTypes) {
   return sequelize.define('Project' + parseInt(Math.random() * 9999999999999999), {
     name: DataTypes.STRING
   });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -14,7 +14,6 @@ var chai = require('chai')
   , moment = require('moment')
   , Transaction = require(__dirname + '/../../lib/transaction')
   , sinon = require('sinon')
-  , babel = require('babel-core')
   , fs = require('fs')
   , current = Support.sequelize;
 
@@ -1171,14 +1170,9 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       expect(Project).to.exist;
     });
 
-    it('imports a dao definition from a file compiled with babel', function () {
-      var es6project = babel.transformFileSync(__dirname + '/assets/es6project.es6', {
-        presets: ['es2015']
-      }).code;
-      fs.writeFileSync(__dirname + '/assets/es6project.js', es6project);
+    it('imports a dao definition with a default export', function () {
       var Project = this.sequelize.import(__dirname + '/assets/es6project');
       expect(Project).to.exist;
-
     });
 
     after(function(){


### PR DESCRIPTION
https://github.com/sequelize/sequelize/pull/6493#issuecomment-242351497

> @janmeier I don't know why the test needs a babel dep though. The issue you linked was that `sequelize.import()` did not support models exported as a `default` export instead of `module.exports`. If we need a test at all for this, it should be enough to import a simple model that is exported with `exports.default`. The change in Babel was more a fix than a change, previously it was not conforming to the ES6 spec. The issue therefor is more about ES6 support for model files and not Babel support - TypeScript uses ES6 modules aswell, and I don't think we should test integration with every possible transpiler out there.