### PR TITLE
Grouped limit include

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -277,7 +277,7 @@ class HasMany extends Association {
       if (options.limit && instances.length > 1) {
         options.groupedLimit = {
           limit: options.limit,
-          on: association.foreignKeyField,
+          on: association,
           values
         };
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1386,46 +1386,97 @@ const QueryGenerator = {
         if (!mainTableAs) {
           mainTableAs = table;
         }
+
+        const where = Object.assign({}, options.where);
+        const order = options.order;
+        let whereKey
+          , include
+          , groupedTableName = mainTableAs;
+
+        if (typeof options.groupedLimit.on === 'string') {
+          whereKey = options.groupedLimit.on;
+        } else if (options.groupedLimit.on instanceof HasMany) {
+          whereKey = options.groupedLimit.on.foreignKeyField;
+        }
+
+        if (options.groupedLimit.on instanceof BelongsToMany) {
+          // BTM includes needs to join the through table on to check ID
+          groupedTableName = options.groupedLimit.on.throughModel.tableName;
+          const groupedLimitOptions = Model._validateIncludedElements({
+            include: [{
+              association: options.groupedLimit.on.manyFromSource,
+              duplicating: false, // The UNION'ed query may contain duplicates, but each sub-query cannot
+              required: true,
+              where: {
+                '$$PLACEHOLDER$$': true
+              }
+            }],
+            model
+          });
+
+          // Make sure attributes from the join table are mapped back to models
+          options.hasJoin = true;
+          options.hasMultiAssociation = true;
+          options.includeMap = Object.assign(groupedLimitOptions.includeMap, options.includeMap);
+          options.includeNames = groupedLimitOptions.includeNames.concat(options.includeNames || []);
+          include = groupedLimitOptions.include;
+
+          if (Array.isArray(options.order)) {
+            // We need to make sure the order by attributes are available to the parent query
+            options.order.forEach((order, i) => {
+              if (Array.isArray(order)) {
+                order = order[0];
+              }
+
+              // Otherwise, alias it
+              const alias = `subquery_order_${i}`;
+              options.attributes.push([order, alias]);
+
+              if (Array.isArray(options.order[i])) {
+                options.order[i][0] = alias;
+              } else {
+                options.order[i] = alias;
+              }
+            });
+          }
+        } else {
+          // Ordering is handled by the subqueries, so ordering the UNION'ed result is not needed
+          delete options.order;
+          where['$$PLACEHOLDER$$'] = true;
+        }
+
+        // Caching the base query and splicing the where part into it is consistently > twice
+        // as fast than generating from scratch each time for values.length >= 5
+        const baseQuery = '('+this.selectQuery(
+          tableName,
+          {
+            attributes: options.attributes,
+            limit: options.groupedLimit.limit,
+            order,
+            where,
+            include,
+            model
+          },
+          model
+        ).replace(/;$/, '')+')';
+        const placeHolder = this.whereItemQuery('$$PLACEHOLDER$$', true, { model });
+        const splicePos = baseQuery.indexOf(placeHolder);
+
         mainQueryItems.push(this.selectFromTableFragment(options, model, mainAttributes, '('+
           options.groupedLimit.values.map(value => {
-            let where = options.where || {}
-              , whereKey
-              , include;
-
-            if (typeof options.groupedLimit.on === 'string') {
-              whereKey = options.groupedLimit.on;
-            } else if (options.groupedLimit.on instanceof HasMany) {
-              whereKey = options.groupedLimit.on.foreignKeyField;
-            } else if (options.groupedLimit.on instanceof BelongsToMany) {
-              include = Model._validateIncludedElements({
-                include: [{
-                  association: options.groupedLimit.on.manyFromSource,
-                  where: {
-                    [options.groupedLimit.on.otherKey]: value
-                  },
-                  duplicating: false
-                }],
-                model
-              }).include;
-            }
-
+            let groupWhere;
             if (whereKey) {
-              where = Object.assign({}, where);
-              where[whereKey] = value;
+              groupWhere = {
+                [whereKey]: value
+              };
+            }
+            if (include) {
+              groupWhere = {
+                [options.groupedLimit.on.otherKey]: value
+              };
             }
 
-            return '('+this.selectQuery(
-              tableName,
-              {
-                attributes: options.attributes,
-                limit: options.groupedLimit.limit,
-                order: options.order,
-                where,
-                include,
-                model
-              },
-              model
-            ).replace(/;$/, '')+')';
+            return Utils.spliceStr(baseQuery, splicePos, placeHolder.length, this.getWhereConditions(groupWhere, groupedTableName));
           }).join(
             this._dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION '
           )
@@ -1474,7 +1525,7 @@ const QueryGenerator = {
       }
     }
     // Add ORDER to sub or main query
-    if (options.order && !options.groupedLimit) {
+    if (options.order) {
       const orders = this.getQueryOrders(options, model, subQuery);
 
       if (orders.mainQueryOrder.length) {
@@ -1578,7 +1629,7 @@ const QueryGenerator = {
     return {mainQueryOrder, subQueryOrder};
   },
 
-  selectFromTableFragment(options, model, attributes, tables, mainTableAs, whereClause) {
+  selectFromTableFragment(options, model, attributes, tables, mainTableAs) {
     let fragment = 'SELECT ' + attributes.join(', ') + ' FROM ' + tables;
 
     if(mainTableAs) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1428,7 +1428,6 @@ const QueryGenerator = {
                 order = order[0];
               }
 
-              // Otherwise, alias it
               const alias = `subquery_order_${i}`;
               options.attributes.push([order, alias]);
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1386,12 +1386,20 @@ const QueryGenerator = {
         }
         mainQueryItems.push(this.selectFromTableFragment(options, model, mainAttributes, '('+
           options.groupedLimit.values.map(value => {
-            let where = options.where || {};
+            let where = options.where || {}
+              , include;
 
-            if (options.groupedLimit.include) {
-              options.groupedLimit.include[0].where = _.assign({}, options.groupedLimit.include[0].where);
-              options.groupedLimit.include[0].required = true;
-              options.groupedLimit.include[0].where[options.groupedLimit.on] = value;
+            if (Array.isArray(options.groupedLimit.on)) {
+              include = Model._validateIncludedElements({
+                include: [{
+                  attributes: [],
+                  association: options.groupedLimit.on[0],
+                  where: {
+                    [options.groupedLimit.on[1]]: value
+                  }
+                }],
+                model
+              }).include;
             } else {
               where = _.assign(options.where);
               where[options.groupedLimit.on] = value;
@@ -1404,7 +1412,7 @@ const QueryGenerator = {
                 limit: options.groupedLimit.limit,
                 order: options.order,
                 where,
-                include: options.groupedLimit.include,
+                include,
                 model
               },
               model

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1399,11 +1399,11 @@ const QueryGenerator = {
             } else if (options.groupedLimit.on instanceof BelongsToMany) {
               include = Model._validateIncludedElements({
                 include: [{
-                  attributes: options.groupedLimit.attributes || [],
                   association: options.groupedLimit.on.manyFromSource,
                   where: {
                     [options.groupedLimit.on.otherKey]: value
-                  }
+                  },
+                  duplicating: false
                 }],
                 model
               }).include;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1441,7 +1441,7 @@ const QueryGenerator = {
         } else {
           // Ordering is handled by the subqueries, so ordering the UNION'ed result is not needed
           delete options.order;
-          where['$$PLACEHOLDER$$'] = true;
+          where.$$PLACEHOLDER$$ = true;
         }
 
         // Caching the base query and splicing the where part into it is consistently > twice

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1401,7 +1401,7 @@ const QueryGenerator = {
 
         if (options.groupedLimit.on instanceof BelongsToMany) {
           // BTM includes needs to join the through table on to check ID
-          groupedTableName = options.groupedLimit.on.throughModel.tableName;
+          groupedTableName = options.groupedLimit.on.manyFromSource.as;
           const groupedLimitOptions = Model._validateIncludedElements({
             include: [{
               association: options.groupedLimit.on.manyFromSource,

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1388,8 +1388,8 @@ const QueryGenerator = {
         }
 
         const where = Object.assign({}, options.where);
-        const order = options.order;
-        let whereKey
+        let groupedLimitOrder
+          , whereKey
           , include
           , groupedTableName = mainTableAs;
 
@@ -1428,8 +1428,11 @@ const QueryGenerator = {
                 order = order[0];
               }
 
-              const alias = `subquery_order_${i}`;
+              let alias = `subquery_order_${i}`;
               options.attributes.push([order, alias]);
+
+              // We don't want to prepend model name when we alias the attributes, so quote them here
+              alias = this.sequelize.literal(this.quote(alias));
 
               if (Array.isArray(options.order[i])) {
                 options.order[i][0] = alias;
@@ -1437,9 +1440,11 @@ const QueryGenerator = {
                 options.order[i] = alias;
               }
             });
+            groupedLimitOrder = options.order;
           }
         } else {
           // Ordering is handled by the subqueries, so ordering the UNION'ed result is not needed
+          groupedLimitOrder = options.order;
           delete options.order;
           where.$$PLACEHOLDER$$ = true;
         }
@@ -1451,7 +1456,7 @@ const QueryGenerator = {
           {
             attributes: options.attributes,
             limit: options.groupedLimit.limit,
-            order,
+            order: groupedLimitOrder,
             where,
             include,
             model

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1386,8 +1386,16 @@ const QueryGenerator = {
         }
         mainQueryItems.push(this.selectFromTableFragment(options, model, mainAttributes, '('+
           options.groupedLimit.values.map(value => {
-            const where = _.assign({}, options.where);
-            where[options.groupedLimit.on] = value;
+            let where = options.where || {};
+
+            if (options.groupedLimit.include) {
+              options.groupedLimit.include[0].where = _.assign({}, options.groupedLimit.include[0].where);
+              options.groupedLimit.include[0].required = true;
+              options.groupedLimit.include[0].where[options.groupedLimit.on] = value;
+            } else {
+              where = _.assign(options.where);
+              where[options.groupedLimit.on] = value;
+            }
 
             return '('+this.selectQuery(
               tableName,
@@ -1395,7 +1403,9 @@ const QueryGenerator = {
                 attributes: options.attributes,
                 limit: options.groupedLimit.limit,
                 order: options.order,
-                where
+                where,
+                include: options.groupedLimit.include,
+                model
               },
               model
             ).replace(/;$/, '')+')';

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1410,7 +1410,7 @@ const QueryGenerator = {
             }
 
             if (whereKey) {
-              where = Object.assign(where);
+              where = Object.assign({}, where);
               where[whereKey] = value;
             }
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -8,6 +8,8 @@ const _ = require('lodash');
 const util = require('util');
 const Dottie = require('dottie');
 const BelongsTo = require('../../associations/belongs-to');
+const BelongsToMany = require('../../associations/belongs-to-many');
+const HasMany = require('../../associations/has-many');
 const uuid = require('node-uuid');
 const semver = require('semver');
 
@@ -1387,22 +1389,29 @@ const QueryGenerator = {
         mainQueryItems.push(this.selectFromTableFragment(options, model, mainAttributes, '('+
           options.groupedLimit.values.map(value => {
             let where = options.where || {}
+              , whereKey
               , include;
 
-            if (Array.isArray(options.groupedLimit.on)) {
+            if (typeof options.groupedLimit.on === 'string') {
+              whereKey = options.groupedLimit.on;
+            } else if (options.groupedLimit.on instanceof HasMany) {
+              whereKey = options.groupedLimit.on.foreignKeyField;
+            } else if (options.groupedLimit.on instanceof BelongsToMany) {
               include = Model._validateIncludedElements({
                 include: [{
-                  attributes: [],
-                  association: options.groupedLimit.on[0],
+                  attributes: options.groupedLimit.attributes || [],
+                  association: options.groupedLimit.on.manyFromSource,
                   where: {
-                    [options.groupedLimit.on[1]]: value
+                    [options.groupedLimit.on.otherKey]: value
                   }
                 }],
                 model
               }).include;
-            } else {
-              where = _.assign(options.where);
-              where[options.groupedLimit.on] = value;
+            }
+
+            if (whereKey) {
+              where = Object.assign(where);
+              where[whereKey] = value;
             }
 
             return '('+this.selectQuery(

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -10,147 +10,149 @@ var chai = require('chai')
   , Promise = current.Promise
   , _ = require('lodash');
 
-describe(Support.getTestDialectTeaser('Model'), function() {
-  describe('findAll', function () {
-    describe('groupedLimit', function () {
-      beforeEach(function () {
-        this.User = this.sequelize.define('user', {
-          age: Sequelize.INTEGER
-        });
-        this.Project = this.sequelize.define('project', {
-          title: DataTypes.STRING
-        });
-        this.Task = this.sequelize.define('task');
-
-        this.ProjectUser = this.sequelize.define('project_user', {}, {timestamps: false});
-
-        this.User.Projects = this.User.belongsToMany(this.Project, {through: this.ProjectUser});
-        this.Project.belongsToMany(this.User, {as: 'members', through: this.ProjectUser});
-
-        this.User.Tasks = this.User.hasMany(this.Task);
-
-        return this.sequelize.sync({force: true}).then(() => {
-          return Promise.join(
-            this.User.bulkCreate([{age: -5}, {age: 45}, {age: 7}, {age: -9}, {age: 8}, {age: 15}]),
-            this.Project.bulkCreate([{}, {}]),
-            this.Task.bulkCreate([{}, {}])
-          );
-        })
-          .then(() => [this.User.findAll(), this.Project.findAll(), this.Task.findAll()])
-          .spread((users, projects, tasks) => {
-            this.projects = projects;
-            return Promise.join(
-              projects[0].setMembers(users.slice(0, 4)),
-              projects[1].setMembers(users.slice(2)),
-              users[2].setTasks(tasks)
-            );
-          });
-      });
-
-      describe('on: belongsToMany', function () {
-        it('maps attributes from a grouped limit to models', function () {
-          return this.User.findAll({
-            groupedLimit: {
-              limit: 3,
-              on: this.User.Projects,
-              values: this.projects.map(item => item.get('id'))
-            }
-          }).then(users => {
-            expect(users).to.have.length(5);
-            users.filter(u => u.get('id') !== 3).forEach(u => {
-              expect(u.get('project_users')).to.have.length(1);
-            });
-            users.filter(u => u.get('id') === 3).forEach(u => {
-              expect(u.get('project_users')).to.have.length(2);
-            });
-          });
-        });
-
-        it('maps attributes from a grouped limit to models with include', function () {
-          return this.User.findAll({
-            groupedLimit: {
-              limit: 3,
-              on: this.User.Projects,
-              values: this.projects.map(item => item.get('id'))
-            },
-            order: ['id'],
-            include: [this.User.Tasks]
-          }).then(users => {
-            expect(users).to.have.length(5);
-
-            expect(users[2].get('tasks')).to.have.length(2);
-            users.filter(u => u.get('id') !== 3).forEach(u => {
-              expect(u.get('project_users')).to.have.length(1);
-            });
-            users.filter(u => u.get('id') === 3).forEach(u => {
-              expect(u.get('project_users')).to.have.length(2);
-            });
-          });
-        });
-
-        it('works with computed order', function () {
-          return this.User.findAll({
-            attributes: ['id'],
-            groupedLimit: {
-              limit: 3,
-              on: this.User.Projects,
-              values: this.projects.map(item => item.get('id'))
-            },
-            order: [
-              Sequelize.fn('ABS', Sequelize.col('age'))
-            ],
-            include: [this.User.Tasks]
-          }).then(users => {
-            expect(users).to.have.length(4);
-            expect(users.map(u => u.get('id'))).to.deep.equal([1, 3, 5, 4]);
-          });
-        });
-      });
-
-      describe('on: hasMany', function () {
+if (current.dialect.supports['UNION ALL']) {
+  describe(Support.getTestDialectTeaser('Model'), function() {
+    describe('findAll', function () {
+      describe('groupedLimit', function () {
         beforeEach(function () {
-          this.User = this.sequelize.define('user');
+          this.User = this.sequelize.define('user', {
+            age: Sequelize.INTEGER
+          });
+          this.Project = this.sequelize.define('project', {
+            title: DataTypes.STRING
+          });
           this.Task = this.sequelize.define('task');
+
+          this.ProjectUser = this.sequelize.define('project_user', {}, {timestamps: false});
+
+          this.User.Projects = this.User.belongsToMany(this.Project, {through: this.ProjectUser});
+          this.Project.belongsToMany(this.User, {as: 'members', through: this.ProjectUser});
+
           this.User.Tasks = this.User.hasMany(this.Task);
 
           return this.sequelize.sync({force: true}).then(() => {
             return Promise.join(
-              this.User.bulkCreate([{}, {}, {}]),
-              this.Task.bulkCreate([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}])
+              this.User.bulkCreate([{age: -5}, {age: 45}, {age: 7}, {age: -9}, {age: 8}, {age: 15}]),
+              this.Project.bulkCreate([{}, {}]),
+              this.Task.bulkCreate([{}, {}])
             );
           })
-            .then(() => [this.User.findAll(), this.Task.findAll()])
-            .spread((users, tasks) => {
-              this.users = users;
+            .then(() => [this.User.findAll(), this.Project.findAll(), this.Task.findAll()])
+            .spread((users, projects, tasks) => {
+              this.projects = projects;
               return Promise.join(
-                users[0].setTasks(tasks[0]),
-                users[1].setTasks(tasks.slice(1, 4)),
-                users[2].setTasks(tasks.slice(4))
+                projects[0].setMembers(users.slice(0, 4)),
+                projects[1].setMembers(users.slice(2)),
+                users[2].setTasks(tasks)
               );
             });
         });
 
-        it('Applies limit and order correctly', function () {
-          return this.Task.findAll({
-            order: [
-              ['id', 'DESC']
-            ],
-            groupedLimit: {
-              limit: 3,
-              on: this.User.Tasks,
-              values: this.users.map(item => item.get('id'))
-            }
-          }).then(tasks => {
-            const byUser = _.groupBy(tasks, _.property('userId'));
-            expect(Object.keys(byUser)).to.have.length(3);
+        describe('on: belongsToMany', function () {
+          it('maps attributes from a grouped limit to models', function () {
+            return this.User.findAll({
+              groupedLimit: {
+                limit: 3,
+                on: this.User.Projects,
+                values: this.projects.map(item => item.get('id'))
+              }
+            }).then(users => {
+              expect(users).to.have.length(5);
+              users.filter(u => u.get('id') !== 3).forEach(u => {
+                expect(u.get('project_users')).to.have.length(1);
+              });
+              users.filter(u => u.get('id') === 3).forEach(u => {
+                expect(u.get('project_users')).to.have.length(2);
+              });
+            });
+          });
 
-            expect(byUser[1]).to.have.length(1);
-            expect(byUser[2]).to.have.length(3);
-            expect(_.invokeMap(byUser[2], 'get', 'id')).to.deep.equal([4, 3, 2]);
-            expect(byUser[3]).to.have.length(2);
+          it('maps attributes from a grouped limit to models with include', function () {
+            return this.User.findAll({
+              groupedLimit: {
+                limit: 3,
+                on: this.User.Projects,
+                values: this.projects.map(item => item.get('id'))
+              },
+              order: ['id'],
+              include: [this.User.Tasks]
+            }).then(users => {
+              expect(users).to.have.length(5);
+
+              expect(users[2].get('tasks')).to.have.length(2);
+              users.filter(u => u.get('id') !== 3).forEach(u => {
+                expect(u.get('project_users')).to.have.length(1);
+              });
+              users.filter(u => u.get('id') === 3).forEach(u => {
+                expect(u.get('project_users')).to.have.length(2);
+              });
+            });
+          });
+
+          it('works with computed order', function () {
+            return this.User.findAll({
+              attributes: ['id'],
+              groupedLimit: {
+                limit: 3,
+                on: this.User.Projects,
+                values: this.projects.map(item => item.get('id'))
+              },
+              order: [
+                Sequelize.fn('ABS', Sequelize.col('age'))
+              ],
+              include: [this.User.Tasks]
+            }).then(users => {
+              expect(users).to.have.length(4);
+              expect(users.map(u => u.get('id'))).to.deep.equal([1, 3, 5, 4]);
+            });
+          });
+        });
+
+        describe('on: hasMany', function () {
+          beforeEach(function () {
+            this.User = this.sequelize.define('user');
+            this.Task = this.sequelize.define('task');
+            this.User.Tasks = this.User.hasMany(this.Task);
+
+            return this.sequelize.sync({force: true}).then(() => {
+              return Promise.join(
+                this.User.bulkCreate([{}, {}, {}]),
+                this.Task.bulkCreate([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}])
+              );
+            })
+              .then(() => [this.User.findAll(), this.Task.findAll()])
+              .spread((users, tasks) => {
+                this.users = users;
+                return Promise.join(
+                  users[0].setTasks(tasks[0]),
+                  users[1].setTasks(tasks.slice(1, 4)),
+                  users[2].setTasks(tasks.slice(4))
+                );
+              });
+          });
+
+          it('Applies limit and order correctly', function () {
+            return this.Task.findAll({
+              order: [
+                ['id', 'DESC']
+              ],
+              groupedLimit: {
+                limit: 3,
+                on: this.User.Tasks,
+                values: this.users.map(item => item.get('id'))
+              }
+            }).then(tasks => {
+              const byUser = _.groupBy(tasks, _.property('userId'));
+              expect(Object.keys(byUser)).to.have.length(3);
+
+              expect(byUser[1]).to.have.length(1);
+              expect(byUser[2]).to.have.length(3);
+              expect(_.invokeMap(byUser[2], 'get', 'id')).to.deep.equal([4, 3, 2]);
+              expect(byUser[3]).to.have.length(2);
+            });
           });
         });
       });
     });
   });
-});
+}

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -22,11 +22,8 @@ if (current.dialect.supports['UNION ALL']) {
             title: DataTypes.STRING
           });
           this.Task = this.sequelize.define('task');
-
-          this.ProjectUser = this.sequelize.define('project_user', {}, {timestamps: false});
-
-          this.User.Projects = this.User.belongsToMany(this.Project, {through: this.ProjectUser});
-          this.Project.belongsToMany(this.User, {as: 'members', through: this.ProjectUser});
+          this.User.Projects = this.User.belongsToMany(this.Project, {through: 'project_user' });
+          this.Project.belongsToMany(this.User, {as: 'members', through: 'project_user' });
 
           this.User.Tasks = this.User.hasMany(this.Task);
 
@@ -59,10 +56,10 @@ if (current.dialect.supports['UNION ALL']) {
             }).then(users => {
               expect(users).to.have.length(5);
               users.filter(u => u.get('id') !== 3).forEach(u => {
-                expect(u.get('project_users')).to.have.length(1);
+                expect(u.get('projects')).to.have.length(1);
               });
               users.filter(u => u.get('id') === 3).forEach(u => {
-                expect(u.get('project_users')).to.have.length(2);
+                expect(u.get('projects')).to.have.length(2);
               });
             });
           });
@@ -86,10 +83,10 @@ if (current.dialect.supports['UNION ALL']) {
 
               expect(users[2].get('tasks')).to.have.length(2);
               users.filter(u => u.get('id') !== 3).forEach(u => {
-                expect(u.get('project_users')).to.have.length(1);
+                expect(u.get('projects')).to.have.length(1);
               });
               users.filter(u => u.get('id') === 3).forEach(u => {
-                expect(u.get('project_users')).to.have.length(2);
+                expect(u.get('projects')).to.have.length(2);
               });
             });
           });

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+/* jshint -W030 */
+var chai = require('chai')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../../support')
+  , Sequelize = Support.Sequelize
+  , DataTypes = require(__dirname + '/../../../../lib/data-types')
+  , current = Support.sequelize
+  , Promise = current.Promise
+  , _ = require('lodash');
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+  describe('findAll', function () {
+    describe('groupedLimit', function () {
+      beforeEach(function () {
+        this.User = this.sequelize.define('user', {
+          age: Sequelize.INTEGER
+        });
+        this.Project = this.sequelize.define('project', {
+          title: DataTypes.STRING
+        });
+        this.Task = this.sequelize.define('task');
+
+        this.ProjectUser = this.sequelize.define('project_user', {}, {timestamps: false});
+
+        this.User.Projects = this.User.belongsToMany(this.Project, {through: this.ProjectUser});
+        this.Project.belongsToMany(this.User, {as: 'members', through: this.ProjectUser});
+
+        this.User.Tasks = this.User.hasMany(this.Task);
+
+        return this.sequelize.sync({force: true}).then(() => {
+          return Promise.join(
+            this.User.bulkCreate([{age: -5}, {age: 45}, {age: 7}, {age: -9}, {age: 8}, {age: 15}]),
+            this.Project.bulkCreate([{}, {}]),
+            this.Task.bulkCreate([{}, {}])
+          );
+        })
+          .then(() => [this.User.findAll(), this.Project.findAll(), this.Task.findAll()])
+          .spread((users, projects, tasks) => {
+            this.projects = projects;
+            return Promise.join(
+              projects[0].setMembers(users.slice(0, 4)),
+              projects[1].setMembers(users.slice(2)),
+              users[2].setTasks(tasks)
+            );
+          });
+      });
+
+      describe('on: belongsToMany', function () {
+        it('maps attributes from a grouped limit to models', function () {
+          return this.User.findAll({
+            groupedLimit: {
+              limit: 3,
+              on: this.User.Projects,
+              values: this.projects.map(item => item.get('id'))
+            }
+          }).then(users => {
+            expect(users).to.have.length(5);
+            users.filter(u => u.get('id') !== 3).forEach(u => {
+              expect(u.get('project_users')).to.have.length(1);
+            });
+            users.filter(u => u.get('id') === 3).forEach(u => {
+              expect(u.get('project_users')).to.have.length(2);
+            });
+          });
+        });
+
+        it('maps attributes from a grouped limit to models with include', function () {
+          return this.User.findAll({
+            groupedLimit: {
+              limit: 3,
+              on: this.User.Projects,
+              values: this.projects.map(item => item.get('id'))
+            },
+            order: ['id'],
+            include: [this.User.Tasks]
+          }).then(users => {
+            expect(users).to.have.length(5);
+
+            expect(users[2].get('tasks')).to.have.length(2);
+            users.filter(u => u.get('id') !== 3).forEach(u => {
+              expect(u.get('project_users')).to.have.length(1);
+            });
+            users.filter(u => u.get('id') === 3).forEach(u => {
+              expect(u.get('project_users')).to.have.length(2);
+            });
+          });
+        });
+
+        it('works with computed order', function () {
+          return this.User.findAll({
+            attributes: ['id'],
+            groupedLimit: {
+              limit: 3,
+              on: this.User.Projects,
+              values: this.projects.map(item => item.get('id'))
+            },
+            order: [
+              Sequelize.fn('ABS', Sequelize.col('age'))
+            ],
+            include: [this.User.Tasks]
+          }).then(users => {
+            expect(users).to.have.length(4);
+            expect(users.map(u => u.get('id'))).to.deep.equal([1, 3, 5, 4]);
+          });
+        });
+      });
+
+      describe('on: hasMany', function () {
+        beforeEach(function () {
+          this.User = this.sequelize.define('user');
+          this.Task = this.sequelize.define('task');
+          this.User.Tasks = this.User.hasMany(this.Task);
+
+          return this.sequelize.sync({force: true}).then(() => {
+            return Promise.join(
+              this.User.bulkCreate([{}, {}, {}]),
+              this.Task.bulkCreate([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}])
+            );
+          })
+            .then(() => [this.User.findAll(), this.Task.findAll()])
+            .spread((users, tasks) => {
+              this.users = users;
+              return Promise.join(
+                users[0].setTasks(tasks[0]),
+                users[1].setTasks(tasks.slice(1, 4)),
+                users[2].setTasks(tasks.slice(4))
+              );
+            });
+        });
+
+        it('Applies limit and order correctly', function () {
+          return this.Task.findAll({
+            order: [
+              ['id', 'DESC']
+            ],
+            groupedLimit: {
+              limit: 3,
+              on: this.User.Tasks,
+              values: this.users.map(item => item.get('id'))
+            }
+          }).then(tasks => {
+            const byUser = _.groupBy(tasks, _.property('userId'));
+            expect(Object.keys(byUser)).to.have.length(3);
+
+            expect(byUser[1]).to.have.length(1);
+            expect(byUser[2]).to.have.length(3);
+            expect(_.invokeMap(byUser[2], 'get', 'id')).to.deep.equal([4, 3, 2]);
+            expect(byUser[3]).to.have.length(2);
+          });
+        });
+      });
+    });
+  });
+});

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -179,7 +179,7 @@ if (current.dialect.supports['UNION ALL']) {
 
               expect(byUser[1]).to.have.length(1);
               expect(byUser[2]).to.have.length(3);
-              expect(_.invokeMap(byUser[2], 'get', 'id')).to.deep.equal([2, 3, 4]);
+              expect(_.invokeMap(byUser[2], 'get', 'id')).to.deep.equal([4, 3, 2]);
               expect(byUser[3]).to.have.length(2);
             });
           });

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -86,8 +86,10 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         title: DataTypes.STRING
       });
 
-      User.Projects = User.belongsToMany(Project, { through: 'project_user' });
-      Project.belongsToMany(User, { through: 'project_user' });
+      const ProjectUser = Support.sequelize.define('project_user', {}, { timestamps: false });
+
+      User.Projects = User.belongsToMany(Project, { through: ProjectUser });
+      Project.belongsToMany(User, { through: ProjectUser });
 
       testsql({
         table: User.getTableName(),
@@ -100,7 +102,6 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         ],
         groupedLimit: {
           limit: 3,
-          attributes: ['projectId'],
           on: User.Projects,
           values: [
             1,
@@ -110,8 +111,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       }, {
         default: 'SELECT [user].* FROM ('+
           [
-            '(SELECT [user].[id_user] AS [id], [projects].[userId] AS [projects.userId], [projects].[projectId] AS [projects.projectId] FROM [users] AS [user] INNER JOIN [project_user] AS [projects] ON [user].[id_user] = [projects].[userId] AND [projects].[projectId] = 1 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
-            '(SELECT [user].[id_user] AS [id], [projects].[userId] AS [projects.userId], [projects].[projectId] AS [projects.projectId] FROM [users] AS [user] INNER JOIN [project_user] AS [projects] ON [user].[id_user] = [projects].[userId] AND [projects].[projectId] = 5 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
+            '(SELECT [user].[id_user] AS [id], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
+            '(SELECT [user].[id_user] AS [id], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
         +') AS [user];'
       });

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -89,14 +89,6 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       User.Projects = User.belongsToMany(Project, { through: 'project_user' });
       Project.belongsToMany(User, { through: 'project_user' });
 
-      var include = Model._validateIncludedElements({
-        include: [{
-          attributes: [],
-          association: User.Projects.manyFromSource
-        }],
-        model: User
-      }).include;
-
       testsql({
         table: User.getTableName(),
         model: User,
@@ -107,9 +99,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           ['last_name', 'ASC']
         ],
         groupedLimit: {
-          include,
           limit: 3,
-          on: 'companyId',
+          on: [User.Projects.manyFromSource, 'companyId'],
           values: [
             1,
             5

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -73,8 +73,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       +') AS [User];'
     });
 
-    (function () {
-      var User = Support.sequelize.define('user', {
+    (function() {
+      const User = Support.sequelize.define('user', {
         id: {
           type: DataTypes.INTEGER,
           primaryKey: true,
@@ -82,7 +82,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
           field: 'id_user'
         }
       });
-      var Project = Support.sequelize.define('project', {
+      const Project = Support.sequelize.define('project', {
         title: DataTypes.STRING
       });
 
@@ -100,7 +100,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         ],
         groupedLimit: {
           limit: 3,
-          on: [User.Projects.manyFromSource, 'companyId'],
+          attributes: ['projectId'],
+          on: User.Projects,
           values: [
             1,
             5
@@ -109,8 +110,8 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       }, {
         default: 'SELECT [user].* FROM ('+
           [
-            '(SELECT [user].[id_user] AS [id] FROM [users] AS [user] INNER JOIN [project_user] AS [projects] ON [user].[id_user] = [projects].[userId] AND [projects[.[companyId] = 1 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
-            '(SELECT [user].[id_user] AS [id] FROM [users] AS [user] INNER JOIN [project_user] AS [projects] ON [user].[id_user] = [projects].[userId] AND [projects[.[companyId] = 5 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
+            '(SELECT [user].[id_user] AS [id], [projects].[userId] AS [projects.userId], [projects].[projectId] AS [projects.projectId] FROM [users] AS [user] INNER JOIN [project_user] AS [projects] ON [user].[id_user] = [projects].[userId] AND [projects].[projectId] = 1 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
+            '(SELECT [user].[id_user] AS [id], [projects].[userId] AS [projects.userId], [projects].[projectId] AS [projects.projectId] FROM [users] AS [user] INNER JOIN [project_user] AS [projects] ON [user].[id_user] = [projects].[userId] AND [projects].[projectId] = 5 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
         +') AS [user];'
       });

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -111,10 +111,41 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       }, {
         default: 'SELECT [user].* FROM ('+
           [
-            '(SELECT [user].[id_user] AS [id], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
-            '(SELECT [user].[id_user] AS [id], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 ORDER BY [user].[last_name] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
+            '(SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
+            '(SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user];'
+        +') AS [user] ORDER BY [user].[subquery_order_0] ASC;'
+      });
+
+      testsql({
+        table: User.getTableName(),
+        model: User,
+        attributes: [
+          ['id_user', 'id']
+        ],
+        order: [
+          ['id_user', 'ASC']
+        ],
+        where: {
+          age: {
+            $gte: 21
+          }
+        },
+        groupedLimit: {
+          limit: 3,
+          on: User.Projects,
+          values: [
+            1,
+            5
+          ]
+        }
+      }, {
+        default: 'SELECT [user].* FROM ('+
+          [
+            '(SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 WHERE [user].[age] >= 21 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
+            '(SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 WHERE [user].[age] >= 21 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
+          ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
+        +') AS [user] ORDER BY [user].[subquery_order_0] ASC;'
       });
     }());
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -111,10 +111,10 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       }, {
         default: 'SELECT [user].* FROM ('+
           [
-            '(SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
-            '(SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
+            '(SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
+            '(SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user] ORDER BY [user].[subquery_order_0] ASC;'
+        +') AS [user] ORDER BY [subquery_order_0] ASC;'
       });
 
       testsql({
@@ -142,10 +142,10 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       }, {
         default: 'SELECT [user].* FROM ('+
           [
-            '(SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 WHERE [user].[age] >= 21 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
-            '(SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 WHERE [user].[age] >= 21 ORDER BY [user].[subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
+            '(SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 1 WHERE [user].[age] >= 21 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')',
+            '(SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[userId] AS [project_users.userId], [project_users].[projectId] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[userId] AND [project_users].[projectId] = 5 WHERE [user].[age] >= 21 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+')'
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user] ORDER BY [user].[subquery_order_0] ASC;'
+        +') AS [user] ORDER BY [subquery_order_0] ASC;'
       });
     }());
 


### PR DESCRIPTION
This code is the first step towards better support for BTM associations in https://github.com/mickhansen/dataloader-sequelize/

TL;DR - Dataloader batches multiple simultaneous calls to `BTM.get` e.g. `project.getMembers()`, into a single query. This is similar to what `include.separate` does for hasMany, with some extra smarts.

I've changed the `groupedLimit.on` code to accept an an array of `[association, string]` to signify that reach row should be joined. We need this to support BTM, because we need to filter on the join table. In the project <-> users example, we already have a list of project ids, and we want to find a limited amount of matching users for each project.

This should also be the first step towards `include.separate` support for belongs to many. 