### PR TITLE
Backport data types under DataTypes namespace to v3.

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -300,6 +300,12 @@ Sequelize.prototype.Validator = Sequelize.Validator = require('validator');
 
 Sequelize.prototype.Model = Sequelize.Model = Model;
 
+/**
+ * A reference to the sequelize class holding commonly used data types. The datatypes are used when defining a new model using `sequelize.define`
+ * @property DataTypes
+ */
+Sequelize.DataTypes = DataTypes;
+
 for (var dataType in DataTypes) {
   Sequelize[dataType] = DataTypes[dataType];
 }


### PR DESCRIPTION
Addresses #6435 in v3, as discussed in PR #6438.

### Pull Request check-list
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?
 - Not sure about how the Future log works. Should that only be used for v4?
- [ ] Have you added new tests to prevent regressions?
  - Not sure if this needs tests. If could add something to check if DataTypes exists on the Sequelize prototype, but there is no precedent for this, such as with Validator or Transaction.

### Description of change
Currently, DataTypes are accessed on the Sequelize object by using the type's name: `Sequelize.INTEGER`.

This change _additionally_ adds data types under the DataTypes namespace: `Sequelize.DataTypes.INTEGER`
