### PR TITLE
Fix typo

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3048,7 +3048,7 @@ class Model {
         originalValue = this.dataValues[key];
       }
 
-      // If not raw, and there's a customer setter
+      // If not raw, and there's a custom setter
       if (!options.raw && this._customSetters[key]) {
         this._customSetters[key].call(this, value, key);
       } else {


### PR DESCRIPTION
Changed `customer` into `custom`.
Code below the comment strongly suggests custom was intended.