### PR TITLE
V4 fix belongsto foreignkeys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Future
 - [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)
-
+- [FIXED] Issue with belongsTo association and foreign keys [#6400](https://github.com/sequelize/sequelize/issues/6400)
 
 # 4.0.0-2
 - [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1058,7 +1058,7 @@ const QueryGenerator = {
       mainQuery: [],
       subQuery: [],
     };
-    const mainChildIncludes = [];    
+    const mainChildIncludes = [];
     const subChildIncludes = [];
     let requiredMismatch = false;
     let includeAs = {
@@ -1189,7 +1189,7 @@ const QueryGenerator = {
         if (include.required === false && childInclude.required === true) {
           requiredMismatch = true;
         }
-        // if the child is a sub query we just give it to the 
+        // if the child is a sub query we just give it to the
         if (childInclude.subQuery && topLevelInfo.subQuery) {
           subChildIncludes.push(childJoinQueries.subQuery);
         }
@@ -1445,14 +1445,16 @@ const QueryGenerator = {
             includeIgnoreAttributes: false
           }, topInclude.through.model);
         } else {
+          const isBelongsTo = topInclude.association.associationType === 'BelongsTo';
+          const join = [
+            this.quoteTable(topParent.model.name) + '.' + this.quoteIdentifier(isBelongsTo ? topInclude.association.identifierField : topParent.model.primaryKeyAttributes[0]),
+            this.quoteIdentifier(topInclude.model.name) + '.' + this.quoteIdentifier(isBelongsTo ? topParent.model.primaryKeyAttributes[0] : topInclude.association.identifierField)
+          ].join(' = ');
           query = this.selectQuery(topInclude.model.tableName, {
             attributes: [topInclude.model.primaryKeyAttributes[0]],
             include: topInclude.include,
             where: {
-              $join: this.sequelize.asIs([
-                this.quoteTable(topParent.model.name) + '.' + this.quoteIdentifier(topParent.model.primaryKeyAttributes[0]),
-                this.quoteIdentifier(topInclude.model.name) + '.' + this.quoteIdentifier(topInclude.association.identifierField)
-              ].join(' = '))
+              $join: this.sequelize.asIs(join)
             },
             limit: 1,
             includeIgnoreAttributes: false

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -839,9 +839,9 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
 
 describe('Association', function() {
   it('should set foreignKey on foreign table', function () {
-    const Mail = this.sequelize.define('mail', {});
-    const Entry = this.sequelize.define('entry', {});
-    const User = this.sequelize.define('user', {});
+    const Mail = this.sequelize.define('mail', {}, { timestamps: false });
+    const Entry = this.sequelize.define('entry', {}, { timestamps: false });
+    const User = this.sequelize.define('user', {}, { timestamps: false });
     Entry.belongsTo(User, { as: 'owner', foreignKey: { name: 'ownerId', allowNull: false } });
     Entry.belongsTo(Mail, {
       as: 'mail',
@@ -860,7 +860,8 @@ describe('Association', function() {
       foreignKey: {
         name: 'mailId',
         allowNull: false
-      }
+      },
+      timestamps: false
     });
     Mail.hasMany(Entry, {
       as: 'entries',
@@ -906,6 +907,25 @@ describe('Association', function() {
             required: true
           }
         ]
-      }));
+      })).then(result => {
+        expect(result.count).to.equal(2);
+        expect(result.rows[0].get({ plain: true })).to.deep.equal(
+          {
+            id: 2,
+            ownerId: 1,
+            mailId: 1,
+            mail: {
+              id: 1,
+              recipients: [{
+                id: 1,
+                MailRecipients: {
+                  mailId: 1,
+                  recipientId: 1
+                }
+              }]
+            }
+          }
+        );
+      });
   });
 });

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -836,3 +836,76 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
     });
   });
 });
+
+describe.only('Association', function() {
+  it('should set foreignKey on foreign table', function () {
+    const Mail = this.sequelize.define('mail', {});
+    const Entry = this.sequelize.define('entry', {});
+    const User = this.sequelize.define('user', {});
+    Entry.belongsTo(User, { as: 'owner', foreignKey: { name: 'ownerId', allowNull: false } });
+    Entry.belongsTo(Mail, {
+      as: 'mail',
+      foreignKey: {
+        name: 'mailId',
+        allowNull: false
+      }
+    });
+    Mail.belongsToMany(User, {
+      as: 'recipients',
+      through: 'MailRecipients',
+      otherKey: {
+        name: 'recipientId',
+        allowNull: false
+      },
+      foreignKey: {
+        name: 'mailId',
+        allowNull: false
+      }
+    });
+    Mail.hasMany(Entry, {
+      as: 'entries',
+      foreignKey: {
+        name: 'mailId',
+        allowNull: false
+      }
+    });
+    User.hasMany(Entry, {
+      as: 'entries',
+      foreignKey: {
+        name: 'ownerId',
+        allowNull: false
+      }
+    });
+    return this.sequelize.sync({ force: true })
+      .then(() => User.create({}))
+      .then(() => Mail.create({}))
+      .then(mail =>
+        Entry.create({ mailId: mail.id, ownerId: 1 })
+          .then(() => Entry.create({ mailId: mail.id, ownerId: 1 }))
+          // set recipients
+          .then(() => mail.setRecipients([1]))
+      )
+      .then(() => Entry.findAndCount({
+        offset: 0,
+        limit: 10,
+        order: [['id', 'DESC']],
+        include: [
+          {
+            association: Entry.associations.mail,
+            include: [
+              {
+                association: Mail.associations.recipients,
+                through: {
+                  where: {
+                    recipientId: 1
+                  }
+                },
+                required: true
+              }
+            ],
+            required: true
+          }
+        ]
+      }));
+  });
+});

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -837,7 +837,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
   });
 });
 
-describe.only('Association', function() {
+describe('Association', function() {
   it('should set foreignKey on foreign table', function () {
     const Mail = this.sequelize.define('mail', {});
     const Entry = this.sequelize.define('entry', {});


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Changelog entry

### Description of change

Fixes the reversed keys issued in #6400 for a belongsTo-association join.

Closes #6400 