### PR TITLE
V3 fix belongsto foreignkeys

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Future
 - [FIXED] Accept dates as string while using `typeValidation` [#6453](https://github.com/sequelize/sequelize/issues/6453)
 - [FIXED] - ORDER clause was not included in subquery if `order` option value was provided as plain string (not as an array value)
+- [FIXED] Issue with belongsTo association and foreign keys [#6400](https://github.com/sequelize/sequelize/issues/6400)
 
 # 3.24.1
 - [FIXED] Add `parent`, `original` and `sql` properties to `UniqueConstraintError`

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1305,14 +1305,16 @@ var QueryGenerator = {
                     includeIgnoreAttributes: false
                   }, topInclude.through.model);
                 } else {
+                  var isBelongsTo = topInclude.association.associationType === 'BelongsTo';
+                  var join = [
+                    self.quoteTable(topParent.model.name) + '.' + self.quoteIdentifier(isBelongsTo ? topInclude.association.identifierField : topParent.model.primaryKeyAttributes[0]),
+                    self.quoteIdentifier(topInclude.model.name) + '.' + self.quoteIdentifier(isBelongsTo ? topParent.model.primaryKeyAttributes[0] : topInclude.association.identifierField)
+                  ].join(' = ');
                   $query = self.selectQuery(topInclude.model.tableName, {
                     attributes: [topInclude.model.primaryKeyAttributes[0]],
                     include: topInclude.include,
                     where: {
-                      $join: self.sequelize.asIs([
-                        self.quoteTable(topParent.model.name) + '.' + self.quoteIdentifier(topParent.model.primaryKeyAttributes[0]),
-                        self.quoteIdentifier(topInclude.model.name) + '.' + self.quoteIdentifier(topInclude.association.identifierField)
-                      ].join(' = '))
+                      $join: self.sequelize.asIs(join)
                     },
                     limit: 1,
                     includeIgnoreAttributes: false

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -837,28 +837,20 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
   });
 });
 
-describe('Association', function () {
+describe('Association', function() {
   it('should set foreignKey on foreign table', function () {
-    var self = this;
-    self.Mail = self.sequelize.define('mail', {});
-    self.Entry = self.sequelize.define('entry', {});
-    self.User = self.sequelize.define('user', {});
-    self.Entry.belongsTo(self.User, { as: 'owner', foreignKey: { name: 'ownerId', allowNull: false } });
-    self.Entry.belongsTo(self.Mail, {
+    const Mail = this.sequelize.define('mail', {});
+    const Entry = this.sequelize.define('entry', {});
+    const User = this.sequelize.define('user', {});
+    Entry.belongsTo(User, { as: 'owner', foreignKey: { name: 'ownerId', allowNull: false } });
+    Entry.belongsTo(Mail, {
       as: 'mail',
       foreignKey: {
         name: 'mailId',
         allowNull: false
       }
     });
-    self.Mail.belongsTo(self.User, {
-      as: 'sender',
-      foreignKey: {
-        name: 'senderId',
-        allowNull: false
-      }
-    });
-    self.Mail.belongsToMany(self.User, {
+    Mail.belongsToMany(User, {
       as: 'recipients',
       through: 'MailRecipients',
       otherKey: {
@@ -870,85 +862,50 @@ describe('Association', function () {
         allowNull: false
       }
     });
-    self.Mail.hasMany(self.Entry, {
+    Mail.hasMany(Entry, {
       as: 'entries',
       foreignKey: {
         name: 'mailId',
         allowNull: false
       }
     });
-    self.User.hasMany(self.Entry, {
+    User.hasMany(Entry, {
       as: 'entries',
       foreignKey: {
         name: 'ownerId',
         allowNull: false
       }
     });
-    return self.sequelize.sync({ force: true })
-      .then(() => self.User.bulkCreate([{}, {}]))
-      .then(() => self.Mail.bulkCreate(
-        [
-          {
-            senderId: 1,
-            subject: 'Lorem Dolor',
-            content: 'Dolor has send ipsum dolor emailit'
-          },
-          {
-            senderId: 2,
-            subject: 'John Mail',
-            content: 'John_doe'
-          },
-          {
-            senderId: 1,
-            subject: 'Lorem Dolor',
-            content: 'Dolor has send ipsum dolor emailit'
-          },
-          {
-            senderId: 2,
-            subject: 'John Mail',
-            content: 'John_doe'
-          }
-        ],
-        { returning: true }
-      ))
-      .then(mails =>
-        self.Entry.create({ mailId: mails[0].id, ownerId: 2 })
-          .then(() => self.Entry.create({ mailId: mails[1].id, ownerId: 1 }))
-          .then(() => self.Entry.create({ mailId: mails[0].id, ownerId: 1 }))
-          .then(() => self.Entry.create({ mailId: mails[1].id, ownerId: 2 }))
-          .then(() => self.Entry.create({ mailId: mails[2].id, ownerId: 1, movedToTrashAt: new Date() }))
-          .then(() => self.Entry.create({ mailId: mails[2].id, ownerId: 2, movedToTrashAt: new Date() }))
-          .then(() => self.Entry.create({ mailId: mails[3].id, ownerId: 1, movedToTrashAt: new Date() }))
-          .then(() => self.Entry.create({ mailId: mails[3].id, ownerId: 2, movedToTrashAt: new Date() }))
+    return this.sequelize.sync({ force: true })
+      .then(() => User.create({}))
+      .then(() => Mail.create({}))
+      .then(mail =>
+        Entry.create({ mailId: mail.id, ownerId: 1 })
+          .then(() => Entry.create({ mailId: mail.id, ownerId: 1 }))
           // set recipients
-          .then(() => mails[0].setRecipients([2]))
-          .then(() => mails[1].setRecipients([1]))
-          .then(() => mails[2].setRecipients([2]))
-          .then(() => mails[3].setRecipients([1]))
-          .then(() => self.Entry.findAndCount({
-            offset: 0,
-            limit: 10,
-            order: [['id', 'DESC']],
+          .then(() => mail.setRecipients([1]))
+      )
+      .then(() => Entry.findAndCount({
+        offset: 0,
+        limit: 10,
+        order: [['id', 'DESC']],
+        include: [
+          {
+            association: Entry.associations.mail,
             include: [
               {
-                association: self.Entry.associations.mail,
-                include: [
-                  {
-                    association: self.Mail.associations.recipients,
-                    through: {
-                      where: {
-                        recipientId: 1
-                      }
-                    },
-                    required: true
+                association: Mail.associations.recipients,
+                through: {
+                  where: {
+                    recipientId: 1
                   }
-                ],
+                },
                 required: true
               }
-            ]
-          }))
-          .then(function () {
-            // empty
-          }))
+            ],
+            required: true
+          }
+        ]
+      }));
   });
 });

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -837,13 +837,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
   });
 });
 
-describe('Association', function() {
+describe.only('Association', function() {
   it('should set foreignKey on foreign table', function () {
     var self = this;
-    var Mail = self.Mail = this.sequelize.define('mail', {});
-    var Entry = self.Entry = this.sequelize.define('entry', {});
-    var User = self.User = this.sequelize.define('user', {});
-    Entry.belongsTo(User, { as: 'owner', foreignKey: { name: 'ownerId', allowNull: false } });
+    var Mail = self.Mail = this.sequelize.define('mail', {}, { updatedAt: false, createdAt: false });
+    var Entry = self.Entry = this.sequelize.define('entry', {}, { updatedAt: false, createdAt: false });
+    var User = self.User = this.sequelize.define('user', {}, { updatedAt: false, createdAt: false });
+    Entry.belongsTo(User, { as: 'owner', foreignKey: { name: 'ownerId', allowNull: false }});
     Entry.belongsTo(Mail, {
       as: 'mail',
       foreignKey: {
@@ -889,7 +889,7 @@ describe('Association', function() {
       .then(function() {
         return self.Entry.findAndCount({
           offset: 0,
-          limit: 10,
+          limit: 1,
           order: [['id', 'DESC']],
           include: [
             {
@@ -909,6 +909,24 @@ describe('Association', function() {
             }
           ]
         });
+      }).then(function(result) {
+        expect(result.count).to.equal(2);
+        expect(result.rows[0].get({ plain: true })).to.deep.equal(
+          {
+            id: 2,
+            ownerId: 1,
+            mailId: 1,
+            mail: {
+              id: 1,
+              recipients: [{
+                id: 1,
+                MailRecipients: {
+                  mailId: 1,
+                  recipientId: 1
+                }
+              }]
+            }
+          });
       });
   });
 });

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -884,7 +884,7 @@ describe('Association', function() {
         return self.Entry.create({ mailId: mail.id, ownerId: 1 })
           .then(function() { return self.Entry.create({ mailId: mail.id, ownerId: 1 }); })
           // set recipients
-          .then(function() { return mail.setRecipients([1]); })
+          .then(function() { return mail.setRecipients([1]); });
       })
       .then(function() {
         return self.Entry.findAndCount({

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -839,9 +839,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
 
 describe('Association', function() {
   it('should set foreignKey on foreign table', function () {
-    const Mail = this.sequelize.define('mail', {});
-    const Entry = this.sequelize.define('entry', {});
-    const User = this.sequelize.define('user', {});
+    var self = this;
+    var Mail = self.Mail = this.sequelize.define('mail', {});
+    var Entry = self.Entry = this.sequelize.define('entry', {});
+    var User = self.User = this.sequelize.define('user', {});
     Entry.belongsTo(User, { as: 'owner', foreignKey: { name: 'ownerId', allowNull: false } });
     Entry.belongsTo(Mail, {
       as: 'mail',
@@ -877,35 +878,37 @@ describe('Association', function() {
       }
     });
     return this.sequelize.sync({ force: true })
-      .then(() => User.create({}))
-      .then(() => Mail.create({}))
-      .then(mail =>
-        Entry.create({ mailId: mail.id, ownerId: 1 })
-          .then(() => Entry.create({ mailId: mail.id, ownerId: 1 }))
+      .then(function() { return self.User.create({}); })
+      .then(function() { return self.Mail.create({}); })
+      .then(function(mail) {
+        return self.Entry.create({ mailId: mail.id, ownerId: 1 })
+          .then(function() { return self.Entry.create({ mailId: mail.id, ownerId: 1 }); })
           // set recipients
-          .then(() => mail.setRecipients([1]))
-      )
-      .then(() => Entry.findAndCount({
-        offset: 0,
-        limit: 10,
-        order: [['id', 'DESC']],
-        include: [
-          {
-            association: Entry.associations.mail,
-            include: [
-              {
-                association: Mail.associations.recipients,
-                through: {
-                  where: {
-                    recipientId: 1
-                  }
-                },
-                required: true
-              }
-            ],
-            required: true
-          }
-        ]
-      }));
+          .then(function() { return mail.setRecipients([1]); })
+      })
+      .then(function() {
+        return self.Entry.findAndCount({
+          offset: 0,
+          limit: 10,
+          order: [['id', 'DESC']],
+          include: [
+            {
+              association: self.Entry.associations.mail,
+              include: [
+                {
+                  association: self.Mail.associations.recipients,
+                  through: {
+                    where: {
+                      recipientId: 1
+                    }
+                  },
+                  required: true
+                }
+              ],
+              required: true
+            }
+          ]
+        });
+      });
   });
 });

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -837,7 +837,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), function() {
   });
 });
 
-describe.only('Association', function() {
+describe('Association', function() {
   it('should set foreignKey on foreign table', function () {
     var self = this;
     var Mail = self.Mail = this.sequelize.define('mail', {}, { updatedAt: false, createdAt: false });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Changelog entry

### Description of change

Fixes the reversed keys issued in #6400 for a belongsTo-association join.

Closes #6400 