### PR TITLE
Replace a `@link` in a comment by a Markdown link

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -596,7 +596,7 @@ BLOB.prototype._hexify = function _hexify(hex) {
 /**
  * Range types are data types representing a range of values of some element type (called the range's subtype).
  * Only available in postgres.
- * See {@link http://www.postgresql.org/docs/9.4/static/rangetypes.html|Postgres documentation} for more details
+ * See [Postgres documentation](http://www.postgresql.org/docs/9.4/static/rangetypes.html) for more details
  *
  * @memberof DataTypes
  */


### PR DESCRIPTION
Tiny documentation update.

The `@link` tag doesn't seem to be recognised by Dox [in the v3 docs](http://docs.sequelizejs.com/en/latest/api/datatypes/#range). Moreover, the other links in this file are written in Markdown.