### PR TITLE
Fixes #6674 - updates a logic error for throughAttributes in add

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -712,13 +712,14 @@ BelongsToMany.prototype.injectSetter = function(obj) {
       }
 
       changedAssociations.forEach(function(assoc) {
-        var throughAttributes = assoc[association.through.model.name]
-          , attributes = _.defaults({}, throughAttributes, defaultAttributes)
-          , where = {};
+        var throughAttributes = assoc[association.through.model.name];
         // Quick-fix for subtle bug when using existing objects that might have the through model attached (not as an attribute object)
         if (throughAttributes instanceof association.through.model.Instance) {
           throughAttributes = {};
         }
+
+        var attributes = _.defaults({}, throughAttributes, defaultAttributes)
+        , where = {};
 
         where[identifier] = instance.get(sourceKey);
         where[foreignIdentifier] = assoc.get(targetKey);


### PR DESCRIPTION
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
### Description of change

Fixing logic error for throughAttributes when adding single or multiple associations.
