### PR TITLE
Fix unescaped field in MSSQL query generation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Future
 - [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)
 - [FIXED] Issue with belongsTo association and foreign keys [#6400](https://github.com/sequelize/sequelize/issues/6400)
+- [FIXED] Issue with query generation in MSSQL, an identifier was not escaped [#6686]
 
 # 4.0.0-2
 - [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Future
 - [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)
 - [FIXED] Issue with belongsTo association and foreign keys [#6400](https://github.com/sequelize/sequelize/issues/6400)
-- [FIXED] Issue with query generation in MSSQL, an identifier was not escaped [#6686]
+- [FIXED] Issue with query generation in MSSQL, an identifier was not escaped [#6686] (https://github.com/sequelize/sequelize/pull/6686)
 
 # 4.0.0-2
 - [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -383,7 +383,7 @@ var QueryGenerator = {
 
       // enums are a special case
       template = attribute.type.toSql();
-      template += ' CHECK (' + attribute.field + ' IN(' + Utils._.map(attribute.values, function(value) {
+      template += ' CHECK (' + this.quoteIdentifier(attribute.field) + ' IN(' + Utils._.map(attribute.values, function(value) {
         return this.escape(value);
       }.bind(this)).join(', ') + '))';
       return template;

--- a/test/unit/sql/create-table.test.js
+++ b/test/unit/sql/create-table.test.js
@@ -23,7 +23,7 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
           sqlite: 'CREATE TABLE IF NOT EXISTS `foo.users` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `mood` TEXT);',
           postgres: 'CREATE TABLE IF NOT EXISTS "foo"."users" ("id"   SERIAL , "mood" "foo"."enum_users_mood", PRIMARY KEY ("id"));',
           mysql: "CREATE TABLE IF NOT EXISTS `foo.users` (`id` INTEGER NOT NULL auto_increment , `mood` ENUM('happy', 'sad'), PRIMARY KEY (`id`)) ENGINE=InnoDB;",
-          mssql: "IF OBJECT_ID('[foo].[users]', 'U') IS NULL CREATE TABLE [foo].[users] ([id] INTEGER NOT NULL IDENTITY(1,1) , [mood] VARCHAR(255) CHECK (mood IN(N'happy', N'sad')), PRIMARY KEY ([id]));"
+          mssql: "IF OBJECT_ID('[foo].[users]', 'U') IS NULL CREATE TABLE [foo].[users] ([id] INTEGER NOT NULL IDENTITY(1,1) , [mood] VARCHAR(255) CHECK ([mood] IN(N'happy', N'sad')), PRIMARY KEY ([id]));"
         });
       });
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions? **No, but I changed a previous test**
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Prior than this fix this query was generated:
```SQL
CREATE TABLE [viz] ([right] VARCHAR(255) CHECK (right IN(...
```
`right` was not escaped and MSSQL didn't like it.

