### PR TITLE
docs: Add documentation for [options.fields] on instance.validate().

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 - [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)
 - [FIXED] Issue with belongsTo association and foreign keys [#6400](https://github.com/sequelize/sequelize/issues/6400)
 - [FIXED] Issue with query generation in MSSQL, an identifier was not escaped [#6686] (https://github.com/sequelize/sequelize/pull/6686)
+- [FIXED] Add documentation for `[options.fields]` on `instance.validate()` [#6703] (https://github.com/sequelize/sequelize/issues/6703)
 
 # 4.0.0-2
 - [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations

--- a/docs/api/instance.md
+++ b/docs/api/instance.md
@@ -256,7 +256,8 @@ Emits null if and only if validation successful; otherwise an Error instance con
 | Name | Type | Description |
 | ---- | ---- | ----------- |
 | [options] | Object | Options that are passed to the validator |
-| [options.skip] | Array | An array of strings. All properties that are in this array will not be validated |
+| [options.fields] | Array | An array of strings. Only the properties that are in this array will be validated |
+| [options.skip] | Array | An array of strings. All properties that are in this array will not be validated. If this option is specified, `[options.fields]` will be ignored |
 
 
 ***


### PR DESCRIPTION
Closes #6703 
