### PR TITLE
Added missing conformOptions to scope when options is an object

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1180,10 +1180,12 @@ Model.prototype.scope = function(option) {
         if (Array.isArray(option.method) && !!self.options.scopes[option.method[0]]) {
           scopeName = option.method[0];
           scope = self.options.scopes[scopeName].apply(self, option.method.splice(1));
+          conformOptions(scope, self);
         }
         else if (!!self.options.scopes[option.method]) {
           scopeName = option.method;
           scope = self.options.scopes[scopeName].apply(self);
+          conformOptions(scope, self);
         }
       } else {
         scope = option;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._
### Description of change

This will fix scope options when called with parameters to enable returning an attributes object with an include list for example:
`db.Project.scope({ method: ['custom', 19]}).findAll();`

```
...
    scopes: {
      custom: (custom) => {
        return {
          attributes: {
            include: [
              [sequelize.literal('(select ' + custom + ')'), 'custom_field']
            ]
          }
        }
      }
    },
...
```

No documentation updated, as this is done as specified therein.
