### PR TITLE
fix a bulkCreate bug when use updateOnDuplicate

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2266,7 +2266,7 @@ class Model {
         return this.QueryInterface.bulkInsert(this.getTableName(options), records, options, attributes).then(results => {
           if (Array.isArray(results)) {
             results.forEach((result, i) => {
-              instances[i].set(this.primaryKeyAttribute, result[this.rawAttributes[this.primaryKeyAttribute].field], {raw: true});
+              instances[i] && instances[i].set(this.primaryKeyAttribute, result[this.rawAttributes[this.primaryKeyAttribute].field], {raw: true});
             });
           }
           return results;


### PR DESCRIPTION
There's a bug when use bulkCreate with option updateOnDuplicate, bulkInsert results length not equal instances length.
