### PR TITLE
Add check for toSql function when constructing query for tables with …

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -124,7 +124,9 @@ const QueryGenerator = {
                 outputColumns += ',';
               }
 
-              tmpColumns += this.quoteIdentifier(attribute.field) + ' ' + attribute.type.toSql();
+              let attributeType = attribute.type.toSql ? attribute.type.toSql() : attribute.type;
+
+              tmpColumns += this.quoteIdentifier(attribute.field) + ' ' + attributeType;
               outputColumns += 'INSERTED.' + this.quoteIdentifier(attribute.field);
             }
           }
@@ -314,7 +316,9 @@ const QueryGenerator = {
                 outputColumns += ',';
               }
 
-              tmpColumns += this.quoteIdentifier(attribute.field) + ' ' + attribute.type.toSql();
+              let attributeType = attribute.type.toSql ? attribute.type.toSql() : attribute.type;
+
+              tmpColumns += this.quoteIdentifier(attribute.field) + ' ' + attributeType;
               outputColumns += 'INSERTED.' + this.quoteIdentifier(attribute.field);
             }
           }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_
- [N] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
  - Couldn't get it to run on my machine
- [Y] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [N] Have you added new tests to prevent regressions?
- [N/A] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [N] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._
### Description of change

Found an issue that arose on SQL server tables with triggers, when the data type for the fields on the table was defined as a string rather than a `DataTypes.{DATA_TYPE}` format. The hasTrigger option, when enabled looks for an `attributes.type.toSql()` function in the `lib/dialects/abstract/query-generator.js` file, but when the data type is a string describing a valid, but not explicitly built in sequelize data type (such as `Money` or `SmallDateTime`) it will error trying to call the function. This minor check for the function before calling it (and instead just giving the query the data type directly (`attribute.type`), solves this problem for us.
