### PR TITLE
Docs: Small formatting fix

### DIFF
--- a/docs/api/model.md
+++ b/docs/api/model.md
@@ -576,7 +576,7 @@ Find a row that matches the query, or build and save the row if none is found
 The successful result of the promise will be (instance, created) - Make sure to use .spread()
 
 If no transaction is passed in the `options` object, a new transaction will be created internally, to prevent the race condition where a matching row is created by another connection after the find but before the insert call.
-However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has committed. In this case, an instance of sequelize.TimeoutError will be thrown instead.
+However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has committed. In this case, an instance of sequelize. TimeoutError will be thrown instead.
 If a transaction is created, a savepoint will be created instead, and any unique constraint violation will be handled internally.
 
 **See:**

--- a/lib/model.js
+++ b/lib/model.js
@@ -1931,7 +1931,7 @@ class Model {
    * The successful result of the promise will be (instance, created) - Make sure to use .spread()
    *
    * If no transaction is passed in the `options` object, a new transaction will be created internally, to prevent the race condition where a matching row is created by another connection after the find but before the insert call.
-   * However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has committed. In this case, an instance of sequelize.TimeoutError will be thrown instead.
+   * However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has committed. In this case, an instance of sequelize. TimeoutError will be thrown instead.
    * If a transaction is created, a savepoint will be created instead, and any unique constraint violation will be handled internally.
    *
    * @param {Object}      options


### PR DESCRIPTION
### Description of change

Small documentation fix; added space after period in two places.
