### PR TITLE
add options.silent support for Instance increment and decrement.

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -938,6 +938,7 @@ Instance.prototype.restore = function(options) {
  * @param {String|Array|Object} fields If a string is provided, that column is incremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is incremented by the value given.
  * @param {Object} [options]
  * @param {Integer} [options.by=1] The number to increment by
+ * @param {Boolean} [options.silent=false] If true, the updatedAt timestamp will not be updated.
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
  * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
@@ -968,7 +969,7 @@ Instance.prototype.increment = function(fields, options) {
     values = fields;
   }
 
-  if (updatedAtAttr && !values[updatedAtAttr]) {
+  if (!options.silent && updatedAtAttr && !values[updatedAtAttr]) {
     options.attributes[updatedAtAttr] = this.Model.$getDefaultTimestamp(updatedAtAttr) || Utils.now(this.sequelize.options.dialect);
   }
 
@@ -1001,6 +1002,7 @@ Instance.prototype.increment = function(fields, options) {
  * @param {String|Array|Object} fields If a string is provided, that column is decremented by the value of `by` given in options. If an array is provided, the same is true for each column. If and object is provided, each column is decremented by the value given
  * @param {Object} [options]
  * @param {Integer} [options.by=1] The number to decrement by
+ * @param {Boolean} [options.silent=false] If true, the updatedAt timestamp will not be updated.
  * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param {Transaction} [options.transaction]
  * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -264,6 +264,23 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         return expect(User.findById(1)).to.eventually.have.property('updatedAt').afterTime(oldDate);
       });
     });
+
+    it('with timestamps set to true and options.silent set to true', function() {
+      var User = this.sequelize.define('IncrementUser', {
+        aNumber: DataTypes.INTEGER
+      }, { timestamps: true })
+        , oldDate;
+
+      return User.sync({ force: true }).bind(this).then(function() {
+        return User.create({aNumber: 1});
+      }).then(function(user) {
+        oldDate = user.updatedAt;
+        this.clock.tick(1000);
+        return user.increment('aNumber', {by: 1, silent: true});
+      }).then(function() {
+        return expect(User.findById(1)).to.eventually.have.property('updatedAt').equalTime(oldDate);
+      });
+    });
   });
 
   describe('decrement', function() {
@@ -387,6 +404,23 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
         return user.decrement('aNumber', {by: 1});
       }).then(function() {
         return expect(User.findById(1)).to.eventually.have.property('updatedAt').afterTime(oldDate);
+      });
+    });
+
+    it('with timestamps set to true and options.silent set to true', function() {
+      var User = this.sequelize.define('IncrementUser', {
+        aNumber: DataTypes.INTEGER
+      }, { timestamps: true })
+        , oldDate;
+
+      return User.sync({ force: true }).bind(this).then(function() {
+        return User.create({aNumber: 1});
+      }).then(function(user) {
+        oldDate = user.updatedAt;
+        this.clock.tick(1000);
+        return user.decrement('aNumber', {by: 1, silent: true});
+      }).then(function() {
+        return expect(User.findById(1)).to.eventually.have.property('updatedAt').equalTime(oldDate);
       });
     });
   });


### PR DESCRIPTION
_Thanks for wanting to fix something on Sequelize - we already love you long time! Please delete this text and fill in the template below. If unsure about something, just do as best as you're able._

_If your PR only contains changes to documentation, you may skip the template below._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [√ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [√] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change
add options.silent support for Instance increment and decrement method, so you can use 
```
user.increment('count', {silent: true} 
```
to prevent update the updatedAt field.

But I got a error run npm run docs, so I don't update the docs, please help me do this.

