### PR TITLE
fix the date in the mysql database does not match the date taken

### DIFF
--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -95,7 +95,7 @@ module.exports = BaseTypes => {
       value = new Date(value + ' ' + options.timezone);
     }
 
-    return value;
+    return value.toLocaleString();
   };
 
   function DATEONLY() {


### PR DESCRIPTION
_Thanks for wanting to fix something on Sequelize - we already love you long time! Please delete this text and fill in the template below. If unsure about something, just do as best as you're able._

_If your PR only contains changes to documentation, you may skip the template below._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

```js
return value.toLocaleString();
```
I config the timezone '+08:00',and the date in the mysql database does not match the date taken.I find the reason that parse date-type don‘t use toLocaleString() function.
