### PR TITLE
Paranoid without timestamps

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [ADDED] Allow paranoid to be used without `timestamps` [#6803](https://github.com/sequelize/sequelize/pull/6803)
+
 # 3.24.7
 - [FIXED] MSSQL bulkInsertQuery when options and attributes are not passed [#6782]
 
@@ -14,7 +17,7 @@
 - [FIXED] Default options for insert queries [#6644](https://github.com/sequelize/sequelize/pull/6644)
 
 # 3.24.3
-- [ADDED] Backport of grouped limit include support 
+- [ADDED] Backport of grouped limit include support
 - [ADDED] Export datatypes [#6578](https://github.com/sequelize/sequelize/pull/6578)
 
 # 3.24.2

--- a/docs/docs/models-definition.md
+++ b/docs/docs/models-definition.md
@@ -107,7 +107,7 @@ Sequelize.DECIMAL                     // DECIMAL
 Sequelize.DECIMAL(10, 2)              // DECIMAL(10,2)
 
 Sequelize.DATE                        // DATETIME for mysql / sqlite, TIMESTAMP WITH TIME ZONE for postgres
-Sequelize.DATE(6)                     // DATETIME(6) for mysql 5.6.4+. Fractional seconds support with up to 6 digits of precision 
+Sequelize.DATE(6)                     // DATETIME(6) for mysql 5.6.4+. Fractional seconds support with up to 6 digits of precision
 Sequelize.DATEONLY                    // DATE without time.
 Sequelize.BOOLEAN                     // TINYINT(1)
 
@@ -425,7 +425,7 @@ var Bar = sequelize.define('bar', { /* bla */ }, {
 
   // don't delete database entries but set the newly added attribute deletedAt
   // to the current date (when deletion was done). paranoid will only work if
-  // timestamps are enabled
+  // timestamps are enabled or option `deletedAt` is set
   paranoid: true,
 
   // don't use camelcase for automatically added attributes but underscore style

--- a/lib/model.js
+++ b/lib/model.js
@@ -130,7 +130,7 @@ var paranoidClause = function(model, options) {
     });
   }
 
-  if (!model.options.timestamps || !model.options.paranoid || options.paranoid === false) {
+  if ((!model.options.timestamps && !model.options.deletedAt) || !model.options.paranoid || options.paranoid === false) {
     // This model is not paranoid, nothing to do here;
     return options;
   }
@@ -665,9 +665,10 @@ Model.prototype.init = function(modelManager) {
     if (this.options.updatedAt !== false) {
       this._timestampAttributes.updatedAt = this.options.updatedAt || Utils.underscoredIf('updatedAt', this.options.underscored);
     }
-    if (this.options.paranoid && this.options.deletedAt !== false) {
-      this._timestampAttributes.deletedAt = this.options.deletedAt || Utils.underscoredIf('deletedAt', this.options.underscored);
-    }
+  }
+
+  if (this.options.paranoid && this.options.deletedAt !== false) {
+    this._timestampAttributes.deletedAt = this.options.deletedAt || Utils.underscoredIf('deletedAt', this.options.underscored);
   }
 
   // Add head and tail default attributes (id, timestamps)

--- a/test/integration/assets/es6project.js
+++ b/test/integration/assets/es6project.js
@@ -1,0 +1,6 @@
+'use strict';
+exports.default = function(sequelize, DataTypes) {
+  return sequelize.define('Project' + parseInt(Math.random() * 9999999999999999), {
+    name: DataTypes.STRING
+  });
+};

--- a/test/integration/assets/es6project.js
+++ b/test/integration/assets/es6project.js
@@ -1,6 +1,0 @@
-'use strict';
-exports.default = function(sequelize, DataTypes) {
-  return sequelize.define('Project' + parseInt(Math.random() * 9999999999999999), {
-    name: DataTypes.STRING
-  });
-};

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+/* jshint -W030 */
+var Support = require(__dirname + '/../support');
+var DataTypes = require(__dirname + '/../../../lib/data-types');
+var chai = require('chai');
+var expect = chai.expect;
+var sinon = require('sinon');
+var Support = require(__dirname + '/../support');
+
+describe(Support.getTestDialectTeaser('Model'), function () {
+  describe('paranoid', function () {
+    before(function () {
+      this.clock = sinon.useFakeTimers();
+    });
+
+    after(function () {
+      this.clock.restore();
+    });
+
+    it('should be able to soft delete with timestamps', function () {
+      var Account = this.sequelize.define('Account', {
+        ownerId: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          field: 'owner_id'
+        },
+        name: {
+          type: DataTypes.STRING
+        }
+      }, {
+        paranoid: true,
+        timestamps: true
+      });
+
+      return Account.sync({force: true})
+        .then(function () { return Account.create({ ownerId: 12 }); })
+        .then(function () { return Account.count(); })
+        .then(function (count) {
+          expect(count).to.be.equal(1);
+          return Account.destroy({ where: { ownerId: 12 }});
+        })
+        .then(function () { return Account.count(); })
+        .then(function (count) {
+          expect(count).to.be.equal(0);
+          return Account.count({ paranoid: false });
+        })
+        .then(function (count) {
+          expect(count).to.be.equal(1);
+          return Account.restore({ where: { ownerId: 12 }});
+        })
+        .then(function () { return Account.count(); })
+        .then(function (count) {
+          expect(count).to.be.equal(1);
+        });
+    });
+
+    it('should be able to soft delete without timestamps', function () {
+      var Account = this.sequelize.define('Account', {
+        ownerId: {
+          type: DataTypes.INTEGER,
+          allowNull: false,
+          field: 'owner_id'
+        },
+        name: {
+          type: DataTypes.STRING
+        },
+        deletedAt: {
+          type: DataTypes.DATE,
+          allowNull: true
+        }
+      }, {
+        paranoid: true,
+        timestamps: false,
+        deletedAt: 'deletedAt'
+      });
+
+      return Account.sync({force: true})
+        .then(function () { return Account.create({ ownerId: 12 }); })
+        .then(function () { return Account.count(); })
+        .then(function (count) {
+          expect(count).to.be.equal(1);
+          return Account.destroy({ where: { ownerId: 12 }});
+        })
+        .then(function () { return Account.count(); })
+        .then(function (count) {
+          expect(count).to.be.equal(0);
+          return Account.count({ paranoid: false });
+        })
+        .then(function (count) {
+          expect(count).to.be.equal(1);
+          return Account.restore({ where: { ownerId: 12 }});
+        })
+        .then(function () { return Account.count(); })
+        .then(function (count) {
+          expect(count).to.be.equal(1);
+        });
+    });
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Paranoid option requires `timestamps` to be enabled, but sometime you just need the `deletedAt` field and dont want to use `createdAt` and `updatedAt`. With this PR either `timestamps` OR `deletedAt` can be used to make a model `paranoid`
