### PR TITLE
(fix) restore ignore field from deletedAt attr

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] `restore` dont use `field` from `deletedAt` column 
 - [FIXED] MSSQL bulkInsertQuery when options and attributes are not passed
 - [FIXED] `DATEONLY` now returns `YYYY-MM-DD` date string [#4858] (https://github.com/sequelize/sequelize/issues/4858)
 - [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Future
-- [FIXED] `restore` dont use `field` from `deletedAt` column 
+- [FIXED] `restore` now uses `field` from `deletedAt` 
 - [FIXED] MSSQL bulkInsertQuery when options and attributes are not passed
 - [FIXED] `DATEONLY` now returns `YYYY-MM-DD` date string [#4858] (https://github.com/sequelize/sequelize/issues/4858)
 - [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)

--- a/lib/model.js
+++ b/lib/model.js
@@ -2452,7 +2452,7 @@ class Model {
       const deletedAtAttribute = this.rawAttributes[deletedAtCol];
       const deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-      attrValueHash[deletedAtCol] = deletedAtDefaultValue;
+      attrValueHash[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
       options.omitNull = false;
       return this.QueryInterface.bulkUpdate(this.getTableName(options), attrValueHash, options.where, options, this._timestampAttributes.deletedAt);
     }).tap(() => {

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -67,7 +67,8 @@ describe(Support.getTestDialectTeaser('Model'), function () {
         },
         deletedAt: {
           type: DataTypes.DATE,
-          allowNull: true
+          allowNull: true,
+          field: 'deleted_at'
         }
       }, {
         paranoid: true,


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

`restore` was ignoring the `field` attribute from `deletedAt`, trying to query to non existing column. I have fixed it by using `field` if available

