### PR TITLE
has-many association: fix possible ambiguous field in count()

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] has-many association: fix possible ambiguous field in count()
 - [FIXED] MSSQL bulkInsertQuery when options and attributes are not passed
 - [FIXED] `DATEONLY` now returns `YYYY-MM-DD` date string [#4858] (https://github.com/sequelize/sequelize/issues/4858)
 - [FIXED] Issues with `createFunction` and `dropFunction` (PostgresSQL)

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -346,7 +346,7 @@ class HasMany extends Association {
 
     options = Utils.cloneDeep(options);
     options.attributes = [
-      [sequelize.fn('COUNT', sequelize.col(model.primaryKeyField)), 'count']
+      [sequelize.fn('COUNT', sequelize.col(model.name.concat('.', model.primaryKeyField))), 'count']
     ];
     options.raw = true;
     options.plain = true;


### PR DESCRIPTION

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

has-many association: fix possible ambiguous field in count()
