### PR TITLE
Fixes #6824 Add ROW_FORMAT support to mysql query-generator

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 - [FIXED] groupedLimit.through.where support
 - [ADDED] `option.silent` for increment and decrement [#6795](https://github.com/sequelize/sequelize/pull/6795)
 - [CHANGED] `now` function allow milliseconds in timestamps on mysql [#6441](https://github.com/sequelize/sequelize/issues/6441)
-- [ADDED] `options.format` added to Query Generator for MySQL dialect using InnoDB engines [#6824] (https://github.com/sequelize/sequelize/issues/6824)
+- [ADDED] `options.rowFormat` added to Query Generator for MySQL dialect using InnoDB engines [#6824] (https://github.com/sequelize/sequelize/issues/6824)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 - [FIXED] groupedLimit.through.where support
 - [ADDED] `option.silent` for increment and decrement [#6795](https://github.com/sequelize/sequelize/pull/6795)
 - [CHANGED] `now` function allow milliseconds in timestamps on mysql [#6441](https://github.com/sequelize/sequelize/issues/6441)
-- [ADDED] `options.format` added to Query Generator for MySQL dialect using InnoDB engines [#6825] (https://github.com/sequelize/sequelize/issues/6824)
+- [ADDED] `options.format` added to Query Generator for MySQL dialect using InnoDB engines [#6824] (https://github.com/sequelize/sequelize/issues/6824)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 - [FIXED] groupedLimit.through.where support
 - [ADDED] `option.silent` for increment and decrement [#6795](https://github.com/sequelize/sequelize/pull/6795)
 - [CHANGED] `now` function allow milliseconds in timestamps on mysql [#6441](https://github.com/sequelize/sequelize/issues/6441)
+- [ADDED] `options.format` added to Query Generator for MySQL dialect using InnoDB engines [#6825] (https://github.com/sequelize/sequelize/issues/6824)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -547,7 +547,7 @@ For more about validation, see [Validations](http://docs.sequelizejs.com/en/late
 | [options.charset] | String |  |
 | [options.comment] | String |  |
 | [options.collate] | String |  |
-| [options.format] | String |  Specify the ROW_FORMAT for use with the MySQL InnoDB engine. |
+| [options.rowFormat] | String |  Specify the ROW_FORMAT for use with the MySQL InnoDB engine. |
 | [options.initialAutoIncrement] | String | Set the initial AUTO_INCREMENT value for the table in MySQL. |
 | [options.hooks] | Object | An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate, afterBulkCreate, afterBulkDestory and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions. |
 | [options.validate] | Object | An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error. |

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -547,6 +547,7 @@ For more about validation, see [Validations](http://docs.sequelizejs.com/en/late
 | [options.charset] | String |  |
 | [options.comment] | String |  |
 | [options.collate] | String |  |
+| [options.format] | String |  Specify the ROW_FORMAT for use with the MySQL InnoDB engine. |
 | [options.initialAutoIncrement] | String | Set the initial AUTO_INCREMENT value for the table in MySQL. |
 | [options.hooks] | Object | An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate, afterBulkCreate, afterBulkDestory and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions. |
 | [options.validate] | Object | An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error. |

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -23,10 +23,11 @@ const QueryGenerator = {
   createTableQuery(tableName, attributes, options) {
     options = Utils._.extend({
       engine: 'InnoDB',
-      charset: null
+      charset: null,
+      format: null
     }, options || {});
 
-    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %>';
+    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %><%= format %>';
     const primaryKeys = [];
     const foreignKeys = {};
     const attrStr = [];
@@ -65,6 +66,7 @@ const QueryGenerator = {
       engine: options.engine,
       charset: (options.charset ? ' DEFAULT CHARSET=' + options.charset : ''),
       collation: (options.collate ? ' COLLATE ' + options.collate : ''),
+      format: options.format ? ' ROW_FORMAT=' + options.format : '',
       initialAutoIncrement: (options.initialAutoIncrement ? ' AUTO_INCREMENT=' + options.initialAutoIncrement : '')
     };
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -24,10 +24,10 @@ const QueryGenerator = {
     options = Utils._.extend({
       engine: 'InnoDB',
       charset: null,
-      format: null
+      rowFormat: null
     }, options || {});
 
-    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %><%= format %>';
+    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %><%= rowFormat %>';
     const primaryKeys = [];
     const foreignKeys = {};
     const attrStr = [];
@@ -66,7 +66,7 @@ const QueryGenerator = {
       engine: options.engine,
       charset: (options.charset ? ' DEFAULT CHARSET=' + options.charset : ''),
       collation: (options.collate ? ' COLLATE ' + options.collate : ''),
-      format: options.format ? ' ROW_FORMAT=' + options.format : '',
+      rowFormat: options.format ? ' ROW_FORMAT=' + options.rowFormat : '',
       initialAutoIncrement: (options.initialAutoIncrement ? ' AUTO_INCREMENT=' + options.initialAutoIncrement : '')
     };
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -66,7 +66,7 @@ const QueryGenerator = {
       engine: options.engine,
       charset: (options.charset ? ' DEFAULT CHARSET=' + options.charset : ''),
       collation: (options.collate ? ' COLLATE ' + options.collate : ''),
-      rowFormat: options.format ? ' ROW_FORMAT=' + options.rowFormat : '',
+      rowFormat: options.rowFormat ? ' ROW_FORMAT=' + options.rowFormat : '',
       initialAutoIncrement: (options.initialAutoIncrement ? ' AUTO_INCREMENT=' + options.initialAutoIncrement : '')
     };
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -924,10 +924,22 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       expect(DAO.options.collate).to.equal('utf8_bin');
     });
 
+    it('overwrites global format options', function() {
+      var sequelize = Support.createSequelizeInstance({ define: { collate: 'utf8_general_ci', format: 'compact' } });
+      var DAO = sequelize.define('foo', {bar: DataTypes.STRING}, {collate: 'utf8_bin', format: 'default'});
+      expect(DAO.options.collate).to.equal('utf8_bin');
+    });
+
     it('inherits global collate option', function() {
       var sequelize = Support.createSequelizeInstance({ define: { collate: 'utf8_general_ci' } });
       var DAO = sequelize.define('foo', {bar: DataTypes.STRING});
       expect(DAO.options.collate).to.equal('utf8_general_ci');
+    });
+
+    it('inherits global format option', function() {
+      var sequelize = Support.createSequelizeInstance({ define: { format: 'default' } });
+      var DAO = sequelize.define('foo', {bar: DataTypes.STRING});
+      expect(DAO.options.format).to.equal('default');
     });
 
     it('uses the passed tableName', function() {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -927,7 +927,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
     it('overwrites global format options', function() {
       var sequelize = Support.createSequelizeInstance({ define: { format: 'compact' } });
       var DAO = sequelize.define('foo', {bar: DataTypes.STRING}, { format: 'default' });
-      expect(DAO.options.format).to.equal('utf8_bin');
+      expect(DAO.options.format).to.equal('default');
     });
 
     it('inherits global collate option', function() {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -924,10 +924,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       expect(DAO.options.collate).to.equal('utf8_bin');
     });
 
-    it('overwrites global format options', function() {
-      var sequelize = Support.createSequelizeInstance({ define: { format: 'compact' } });
-      var DAO = sequelize.define('foo', {bar: DataTypes.STRING}, { format: 'default' });
-      expect(DAO.options.format).to.equal('default');
+    it('overwrites global rowFormat options', function() {
+      var sequelize = Support.createSequelizeInstance({ define: { rowFormat: 'compact' } });
+      var DAO = sequelize.define('foo', {bar: DataTypes.STRING}, { rowFormat: 'default' });
+      expect(DAO.options.rowFormat).to.equal('default');
     });
 
     it('inherits global collate option', function() {
@@ -936,10 +936,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
       expect(DAO.options.collate).to.equal('utf8_general_ci');
     });
 
-    it('inherits global format option', function() {
-      var sequelize = Support.createSequelizeInstance({ define: { format: 'default' } });
+    it('inherits global rowFormat option', function() {
+      var sequelize = Support.createSequelizeInstance({ define: { rowFormat: 'default' } });
       var DAO = sequelize.define('foo', {bar: DataTypes.STRING});
-      expect(DAO.options.format).to.equal('default');
+      expect(DAO.options.rowFormat).to.equal('default');
     });
 
     it('uses the passed tableName', function() {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -925,9 +925,9 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
     });
 
     it('overwrites global format options', function() {
-      var sequelize = Support.createSequelizeInstance({ define: { collate: 'utf8_general_ci', format: 'compact' } });
-      var DAO = sequelize.define('foo', {bar: DataTypes.STRING}, {collate: 'utf8_bin', format: 'default'});
-      expect(DAO.options.collate).to.equal('utf8_bin');
+      var sequelize = Support.createSequelizeInstance({ define: { format: 'compact' } });
+      var DAO = sequelize.define('foo', {bar: DataTypes.STRING}, { format: 'default' });
+      expect(DAO.options.format).to.equal('utf8_bin');
     });
 
     it('inherits global collate option', function() {

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -102,7 +102,7 @@ if (dialect === 'mysql') {
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` ENUM(\"A\", \"B\", \"C\"), `name` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=latin1;'
         },
         {
-          arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, {charset: 'utf8', collate: 'utf8_unicode_ci', format: 'default'}],
+          arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, {format: 'default'}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=default;'
         },
         {

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -103,7 +103,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, {charset: 'utf8', collate: 'utf8_unicode_ci', format: 'default'}],
-          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci ROW_FORMAT=default;'
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=default;'
         },
         {
           arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)', id: 'INTEGER PRIMARY KEY'}],

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -102,6 +102,10 @@ if (dialect === 'mysql') {
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` ENUM(\"A\", \"B\", \"C\"), `name` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=latin1;'
         },
         {
+          arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, {charset: 'utf8', collate: 'utf8_unicode_ci', format: 'default'}],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci ROW_FORMAT=default;'
+        },
+        {
           arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)', id: 'INTEGER PRIMARY KEY'}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255), `id` INTEGER , PRIMARY KEY (`id`)) ENGINE=InnoDB;'
         },

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -102,7 +102,7 @@ if (dialect === 'mysql') {
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` ENUM(\"A\", \"B\", \"C\"), `name` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=latin1;'
         },
         {
-          arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, {format: 'default'}],
+          arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, { rowFormat: 'default' }],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=InnoDB ROW_FORMAT=default;'
         },
         {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

This commit adds `ROW_FORMAT` support to the query-generator for
the mysql dialect by adding `options.format` for sequelize.define().

InnoDB's new Barracuda file format offers 2 new types of row formats
which offer significant improvements if working with utf8mb4 collation
by supporting index key prefixes up to 3072 bytes instead of the
default of 767 bytes offered with COMPACT or REDUNDANT row types
offered in the legacy Antelope file format.

Fixes #6824