### PR TITLE
fix: add type checking for function to escape func

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -14,6 +14,9 @@ exports.escapeId = escapeId;
 
 function escape(val, timeZone, dialect, format) {
   let prependN = false;
+  if (typeof val === 'function') {
+    throw new TypeError('Value can\'t be a function');
+  }
   if (val === undefined || val === null) {
     return 'NULL';
   }


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of issue
When you mistakenly passing an function to one of model fields - **escape** method of sql-string.js interprets it like string and fails with such unhandled error:
```
TypeError: val.replace is not a function
      at Object.SqlString.escape (core/node_modules/sequelize/lib/sql-string.js:61:15)
      at Object.QueryGenerator.escape (core/node_modules/sequelize/lib/dialects/abstract/query-generator.js:978:22)
      at Object.<anonymous> (core/node_modules/sequelize/lib/dialects/abstract/query-generator.js:357:23)
      at Array.map (native)
      at Object.<anonymous> (core/node_modules/sequelize/lib/dialects/abstract/query-generator.js:353:23)
      at Array.forEach (native)
      at Object.QueryGenerator.bulkInsertQuery (core/node_modules/sequelize/lib/dialects/abstract/query-generator.js:351:21)
      at QueryInterface.bulkInsert (core/node_modules/sequelize/lib/query-interface.js:568:33)
      at core/node_modules/sequelize/lib/model.js:2191:34
      at tryCatcher (core/node_modules/bluebird/js/release/util.js:16:23)
      at Promise._settlePromiseFromHandler (core/node_modules/bluebird/js/release/promise.js:510:31)
      at Promise._settlePromise (core/node_modules/bluebird/js/release/promise.js:567:18)
      at Promise._settlePromise0 (core/node_modules/bluebird/js/release/promise.js:612:10)
      at Promise._settlePromises (core/node_modules/bluebird/js/release/promise.js:691:18)
      at Async._drainQueue (core/node_modules/bluebird/js/release/async.js:138:16)
      at Async._drainQueues (core/node_modules/bluebird/js/release/async.js:148:10)
      at Immediate.Async.drainQueues [as _onImmediate] (core/node_modules/bluebird/js/release/async.js:17:14)
```

### Description of change

Added additional checking for type of value in **escape** method.

