### PR TITLE
fix: groupedLimit on paranoid junction table

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Future
+- [FIXED] Set `timestamps` and `paranoid` options from through model on `belongsToMany` association
+- [FIXED] Properly apply paranoid condition when `groupedLimit.on` association is `paranoid`
 - [FIXED] `restore` now uses `field` from `deletedAt`
 - [ADDED] `option.silent` for increment and decrement [#6793](https://github.com/sequelize/sequelize/pull/6793)
 

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -169,6 +169,10 @@ var BelongsToMany = function(source, target, options) {
     }
   }
 
+  this.options = _.assign(this.options, _.pick(this.through.model.options, [
+    'timestamps', 'createdAt', 'updatedAt', 'deletedAt', 'paranoid'
+  ]));
+
   if (this.paired) {
     if (this.otherKeyDefault) {
       this.otherKey = this.paired.foreignKey;

--- a/lib/model.js
+++ b/lib/model.js
@@ -130,6 +130,14 @@ var paranoidClause = function(model, options) {
     });
   }
 
+  // apply paranoid when groupedLimit is used
+  if (_.get(options, 'groupedLimit.on.options.paranoid')) {
+    var throughModel = _.get(options, 'groupedLimit.on.through.model');
+    if (throughModel) {
+      options.groupedLimit.through = paranoidClause(throughModel, options.groupedLimit.through);
+    }
+  }
+
   if (!model.options.timestamps || !model.options.paranoid || options.paranoid === false) {
     // This model is not paranoid, nothing to do here;
     return options;

--- a/test/integration/assets/es6project.js
+++ b/test/integration/assets/es6project.js
@@ -1,0 +1,6 @@
+'use strict';
+exports.default = function(sequelize, DataTypes) {
+  return sequelize.define('Project' + parseInt(Math.random() * 9999999999999999), {
+    name: DataTypes.STRING
+  });
+};

--- a/test/integration/assets/es6project.js
+++ b/test/integration/assets/es6project.js
@@ -1,6 +1,0 @@
-'use strict';
-exports.default = function(sequelize, DataTypes) {
-  return sequelize.define('Project' + parseInt(Math.random() * 9999999999999999), {
-    name: DataTypes.STRING
-  });
-};


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

When `groupedLimit` was used on a N:M relationship whoes junction/through model was paranoid, queries generated didn't include the paranoid clause. I have fixed it by applying paranoid clause when we have this case

Also `BelongsToMany` options incorrectly uses source model `options`, this is fixed as well

