### PR TITLE
fix instance.set '1970-01-01' to null field

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -346,11 +346,13 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
             if (!(value instanceof Date)) {
               value = new Date(value);
             }
-            if (!(originalValue instanceof Date)) {
-              originalValue = new Date(originalValue);
-            }
-            if (originalValue && value.getTime() === originalValue.getTime()) {
-              return this;
+            if (originalValue) {
+              if (!(originalValue instanceof Date)) {
+                originalValue = new Date(originalValue);
+              }
+              if (value.getTime() === originalValue.getTime()) {
+                return this;
+              }
             }
           }
         }

--- a/test/unit/instance/set.test.js
+++ b/test/unit/instance/set.test.js
@@ -44,5 +44,36 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       var user2 = User.build({});
       expect(user2.get('meta')).to.deep.equal({});
     });
+
+    it('sets the date "1970-01-01" to previously null field', function() {
+      var User = current.define('User', {
+        date: {
+          type: DataTypes.DATE,
+          allowNull: true
+        }
+      });
+      var user1 = User.build({
+        date: null
+      });
+      user1.set('date', '1970-01-01');
+      expect(user1.get('date')).to.be.ok;
+      expect(user1.get('date').getTime()).to.equal(new Date('1970-01-01').getTime());
+    });
+
+    it('overwrites non-date originalValue with date', function() {
+      var User = current.define('User', {
+        date: DataTypes.DATE
+      });
+      var user = User.build({
+        date: ' '
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      user.set('date', new Date());
+      expect(user.get('date')).to.be.an.instanceof(Date);
+      expect(user.get('date')).not.to.be.NaN;
+    });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

Before this change it is not possible to use `instance.set('date', '1970-01-01')` when:
-  model has allowNull: true
- instance retrieved from database and thus date having null as value.