### PR TITLE
Fix error 'Index column size too large.'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] support for ROW_FORMAT
 - [FIXED] `restore` now uses `field` from `deletedAt` 
 - [FIXED] MSSQL bulkInsertQuery when options and attributes are not passed
 - [FIXED] `DATEONLY` now returns `YYYY-MM-DD` date string [#4858] (https://github.com/sequelize/sequelize/issues/4858)

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -545,6 +545,7 @@ For more about validation, see [Validations](http://docs.sequelizejs.com/en/late
 | [options.schema='public'] | String |  |
 | [options.engine] | String |  |
 | [options.charset] | String |  |
+| [options.rowFormat] | String |  |
 | [options.comment] | String |  |
 | [options.collate] | String |  |
 | [options.initialAutoIncrement] | String | Set the initial AUTO_INCREMENT value for the table in MySQL. |

--- a/docs/docs/migrations.md
+++ b/docs/docs/migrations.md
@@ -121,6 +121,7 @@ queryInterface.createTable(
   {
     engine: 'MYISAM',                     // default: 'InnoDB'
     charset: 'latin1',                    // default: null
+    rowFormat: 'DYNAMIC',                 // default: null
     schema: 'public'                      // default: public, PostgreSQL only.
   }
 )

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -23,10 +23,11 @@ const QueryGenerator = {
   createTableQuery(tableName, attributes, options) {
     options = Utils._.extend({
       engine: 'InnoDB',
-      charset: null
+      charset: null,
+      rowFormat: null
     }, options || {});
 
-    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %>';
+    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= rowFormat %><%= collation %><%= initialAutoIncrement %>';
     const primaryKeys = [];
     const foreignKeys = {};
     const attrStr = [];
@@ -64,6 +65,7 @@ const QueryGenerator = {
       comment: options.comment && Utils._.isString(options.comment) ? ' COMMENT ' + this.escape(options.comment) : '',
       engine: options.engine,
       charset: (options.charset ? ' DEFAULT CHARSET=' + options.charset : ''),
+      rowFormat: (options.rowFormat ? ' ROW_FORMAT=' + options.rowFormat: ''),
       collation: (options.collate ? ' COLLATE ' + options.collate : ''),
       initialAutoIncrement: (options.initialAutoIncrement ? ' AUTO_INCREMENT=' + options.initialAutoIncrement : '')
     };

--- a/test/integration/dialects/mysql/query-interface.test.js
+++ b/test/integration/dialects/mysql/query-interface.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/* jshint -W030 */
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require(__dirname + '/../../../../lib/data-types');
+const _ = require('lodash');
+
+if (dialect === 'mysql') {
+  describe('[MYSQL Specific] QueryInterface', () => {
+    beforeEach(function() {
+      this.sequelize.options.quoteIdenifiers = true;
+      this.queryInterface = this.sequelize.getQueryInterface();
+    });
+
+    describe('indexes', () => {
+      const tableName = 'utf8mb4';
+      const indexName = 'utf8mb4_first_name_last_name';
+
+      describe('rowFormat is not set', () => {
+        beforeEach(function() {
+          return this.queryInterface.dropTable(tableName)
+            .then(() => this.queryInterface.createTable(tableName, {
+              firstName: DataTypes.STRING,
+              lastName: DataTypes.STRING
+            }, {
+              charset: 'utf8mb4'
+            }));
+        });
+
+        it('should throw error', function() {
+          return this.queryInterface.addIndex(tableName, ['firstName', 'lastName'], {
+            name: indexName
+          })
+            .then(() => this.queryInterface.showIndex(tableName))
+            .then(indexes => {
+              const indexColumns = _.uniq(indexes.map(index => index.name));
+
+              expect(indexColumns).to.include(indexName);
+            })
+            .catch((err) => {
+              expect(err.message).to.be.equal('Index column size too large. The maximum column size is 767 bytes.');
+            });
+        });
+      });
+
+      describe('rowFormat=DYNAMIC', () => {
+        beforeEach(function() {
+          return this.queryInterface.dropTable(tableName)
+            .then(() => this.queryInterface.createTable(tableName, {
+              firstName: DataTypes.STRING,
+              lastName: DataTypes.STRING
+            }, {
+              charset: 'utf8mb4',
+              rowFormat: 'DYNAMIC'
+            }));
+        });
+
+        it('should add a index to the table', function() {
+          return this.queryInterface.addIndex(tableName, ['firstName', 'lastName'], {
+            name: indexName
+          })
+            .then(() => this.queryInterface.showIndex(tableName))
+            .then(indexes => {
+              const indexColumns = _.uniq(indexes.map(index => index.name));
+
+              expect(indexColumns).to.include(indexName);
+            });
+        });
+      });
+    });
+  });
+}

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -116,6 +116,10 @@ if (dialect === 'mysql') {
         {
           arguments: ['myTable', {id: 'INTEGER auto_increment PRIMARY KEY'}, {initialAutoIncrement: 1000001}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER auto_increment , PRIMARY KEY (`id`)) ENGINE=InnoDB AUTO_INCREMENT=1000001;'
+        },
+        {
+          arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, {charset: 'utf8mb4', rowFormat: 'DYNAMIC'}],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 ROW_FORMAT=DYNAMIC;'
         }
       ],
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Setting `charset = utf8mb4` and attempting to index to a column larger than varchar (255) results in the following error.
```
SequelizeDatabaseError: Index column size too large. The maximum column
size is 767 bytes.
```
If it can be solved by setting ROW_FORMAT to DYNAMIC or COMPRESSED, it changed so that ROW_FORMAT option can be set.