### PR TITLE
Mssql upsert

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -302,59 +302,6 @@ var QueryGenerator = {
     return generatedQuery;
   },
 
-  // this is partially copy/paste programmed from abstract query generator
-  // but the problem is that the elements that we need to compose
-  // in the merge context ARE Sql Server specific
-  upsertValues(attrValueHash, modelAttributes, context) {
-    var values = [];
-    var fields = [];
-    const modelAttributeMap = {};
-    if (modelAttributes) {
-      Utils._.each(modelAttributes, (attribute, key) => {
-        modelAttributeMap[key] = attribute;
-        if (attribute.field) {
-          modelAttributeMap[attribute.field] = attribute;
-        }
-      });
-    }
-    for (const key in attrValueHash) {
-        const value = attrValueHash[key];
-        const map =  (modelAttributeMap && modelAttributeMap[key]) || undefined;
-        if (context === 'UPDATE') {
-          values.push(this.quoteIdentifier(key) + '=' + this.escape(value, map, { context: context }));
-        }
-        else {
-            fields.push(this.quoteIdentifier(key));
-            values.push(this.escape(value, map, { context: context }));
-        }
-    }
-    return (context === 'UPDATE') ?
-      'UPDATE SET ' + values.join(',')
-      :
-      'INSERT ' + '('+ fields.join(',') +')' + 'VALUES ('+ values.join(',') +')'
-      ;
-  },
-  upsertUpdate(attrValueHash, attributes) {
-    var values = this.upsertValues(attrValueHash, attributes, 'UPDATE');
-    return values;
-  },
-  upsertInsert(attrValueHash, attributes) {
-    var values = this.upsertValues(attrValueHash, attributes, 'INSERT');
-    return values;
-  },
-  upsertQuery(tableName, insertValues, updateValues, where, rawAttributes, options) {
-    const insert = this.upsertInsert(insertValues, rawAttributes);
-    const update = this.upsertUpdate(updateValues, rawAttributes);
-    var generatedQuery = [
-      'MERGE', this.quoteTable(tableName),
-      'USING', '(select 1 as dummy) as [DuMmYmErGeSrc]',
-      'ON', this.getWhereConditions(where),
-      'WHEN MATCHED THEN', update,
-      'WHEN NOT MATCHED THEN', insert
-    ].join(' ') + ';';
-    return generatedQuery;
-  },
-
   deleteQuery(tableName, where, options) {
     options = options || {};
 

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -302,6 +302,59 @@ var QueryGenerator = {
     return generatedQuery;
   },
 
+  // this is partially copy/paste programmed from abstract query generator
+  // but the problem is that the elements that we need to compose
+  // in the merge context ARE Sql Server specific
+  upsertValues(attrValueHash, modelAttributes, context) {
+    var values = [];
+    var fields = [];
+    const modelAttributeMap = {};
+    if (modelAttributes) {
+      Utils._.each(modelAttributes, (attribute, key) => {
+        modelAttributeMap[key] = attribute;
+        if (attribute.field) {
+          modelAttributeMap[attribute.field] = attribute;
+        }
+      });
+    }
+    for (const key in attrValueHash) {
+        const value = attrValueHash[key];
+        const map =  (modelAttributeMap && modelAttributeMap[key]) || undefined;
+        if (context === 'UPDATE') {
+          values.push(this.quoteIdentifier(key) + '=' + this.escape(value, map, { context: context }));
+        }
+        else {
+            fields.push(this.quoteIdentifier(key));
+            values.push(this.escape(value, map, { context: context }));
+        }
+    }
+    return (context === 'UPDATE') ?
+      'UPDATE SET ' + values.join(',')
+      :
+      'INSERT ' + '('+ fields.join(',') +')' + 'VALUES ('+ values.join(',') +')'
+      ;
+  },
+  upsertUpdate(attrValueHash, attributes) {
+    var values = this.upsertValues(attrValueHash, attributes, 'UPDATE');
+    return values;
+  },
+  upsertInsert(attrValueHash, attributes) {
+    var values = this.upsertValues(attrValueHash, attributes, 'INSERT');
+    return values;
+  },
+  upsertQuery(tableName, insertValues, updateValues, where, rawAttributes, options) {
+    const insert = this.upsertInsert(insertValues, rawAttributes);
+    const update = this.upsertUpdate(updateValues, rawAttributes);
+    var generatedQuery = [
+      'MERGE', this.quoteTable(tableName),
+      'USING', '(select 1 as dummy) as [DuMmYmErGeSrc]',
+      'ON', this.getWhereConditions(where),
+      'WHEN MATCHED THEN', update,
+      'WHEN NOT MATCHED THEN', insert
+    ].join(' ') + ';';
+    return generatedQuery;
+  },
+
   deleteQuery(tableName, where, options) {
     options = options || {};
 


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This change adds the upsert command for mssql. No documentation required as it just brings it up to the same functionality as the other dialects.

Using the SQL Server MERGE command (since SQL 2008 - so should be reasonable) seems to be the main recommendation (e.g. on stackoverflow) for how to do this on SQL server.
