### PR TITLE
Bug in docs: mysql package needed, NOT mysql2?

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -7,7 +7,7 @@ $ npm install --save sequelize
 
 # And one of the following:
 $ npm install --save pg pg-hstore
-$ npm install --save mysql2
+$ npm install --save mysql
 $ npm install --save sqlite3
 $ npm install --save tedious // MSSQL
 ```


### PR DESCRIPTION
The example connection code would throw an error until I installed mysql as apposed to mysql2.