### PR TITLE
Adding support for populating db outputted values inserted with Sequelize.literal

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -315,6 +315,16 @@ class Query extends AbstractQuery {
       id = id || (results && results[0][autoIncrementField]);
       id = id || (autoIncrementFieldAlias && results && results[0][autoIncrementFieldAlias]);
 
+      const dataValues = this.instance.dataValues
+      for (let key in dataValues) {
+        if (dataValues.hasOwnProperty(key) && dataValues[key]) {
+          if (dataValues[key].constructor.name === 'literal') {
+            const field = this.model.rawAttributes[key].field
+            this.instance[key] = results[0][field]
+          }
+        }
+      }
+
       this.instance[autoIncrementField] = id;
     }
   }

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -316,14 +316,10 @@ class Query extends AbstractQuery {
       id = id || (autoIncrementFieldAlias && results && results[0][autoIncrementFieldAlias]);
 
       const dataValues = this.instance.dataValues;
-      for (let key in dataValues) {
-        if (dataValues.hasOwnProperty(key) && dataValues[key]) {
-          if (dataValues[key].constructor.name === 'literal') {
-            const field = this.model.rawAttributes[key].field;
-            this.instance[key] = results[0][field];
-          }
-        }
-      }
+      dataValues.keys().forEach(key => {
+        const field = this.model.rawAttributes[key].field
+        this.instance[key] = results[0][field]
+      })
 
       this.instance[autoIncrementField] = id;
     }

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -315,12 +315,12 @@ class Query extends AbstractQuery {
       id = id || (results && results[0][autoIncrementField]);
       id = id || (autoIncrementFieldAlias && results && results[0][autoIncrementFieldAlias]);
 
-      const dataValues = this.instance.dataValues
+      const dataValues = this.instance.dataValues;
       for (let key in dataValues) {
         if (dataValues.hasOwnProperty(key) && dataValues[key]) {
           if (dataValues[key].constructor.name === 'literal') {
-            const field = this.model.rawAttributes[key].field
-            this.instance[key] = results[0][field]
+            const field = this.model.rawAttributes[key].field;
+            this.instance[key] = results[0][field];
           }
         }
       }

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -315,10 +315,11 @@ class Query extends AbstractQuery {
       id = id || (results && results[0][autoIncrementField]);
       id = id || (autoIncrementFieldAlias && results && results[0][autoIncrementFieldAlias]);
 
-      Object.keys(this.instance.dataValues).forEach(key => {
+      const dataValues = this.instance.dataValues;
+      for (const key of Object.keys(dataValues)) {
         const field = this.model.rawAttributes[key].field;
         this.instance[key] = results[0][field];
-      })
+      }
 
       this.instance[autoIncrementField] = id;
     }

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -315,8 +315,7 @@ class Query extends AbstractQuery {
       id = id || (results && results[0][autoIncrementField]);
       id = id || (autoIncrementFieldAlias && results && results[0][autoIncrementFieldAlias]);
 
-      const dataValues = this.instance.dataValues;
-      dataValues.keys().forEach(key => {
+      Object.keys(this.instance.dataValues).forEach(key => {
         const field = this.model.rawAttributes[key].field
         this.instance[key] = results[0][field]
       })

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -316,8 +316,8 @@ class Query extends AbstractQuery {
       id = id || (autoIncrementFieldAlias && results && results[0][autoIncrementFieldAlias]);
 
       Object.keys(this.instance.dataValues).forEach(key => {
-        const field = this.model.rawAttributes[key].field
-        this.instance[key] = results[0][field]
+        const field = this.model.rawAttributes[key].field;
+        this.instance[key] = results[0][field];
       })
 
       this.instance[autoIncrementField] = id;


### PR DESCRIPTION
I am opening this PR just to run the tests which I tried running locally but weren't able

### Description of change

Detailed in issue #6870 

When you run:

```js
Model.create({
  name: 'Foo',
  description: 'bar',
  order: Sequelize.literal('(SELECT MAX(order) + 1 FROM doesntMatter)') // valid subquery
})
```
 you get

```js
{ 
  id: 100, 
  name: 'foo', 
  description: 'bar', 
  order: '(SELECT MAX(order) + 1 FROM doesntMatter)' // here is the problem
}
```
 instead of
```js
{ 
  id: 100, 
  name: 'foo', 
  description: 'bar', 
  order: 19283 // MSSQL will return the correct value for this field
}
```

PS.: I believe this is a naive approach and should be peer reviewed.