### PR TITLE
Integration Test - Add a test to prevent regression on findAll with group option on a non primary key attribute

### DIFF
--- a/test/integration/model/findAll/group.test.js
+++ b/test/integration/model/findAll/group.test.js
@@ -52,6 +52,52 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           expect(parseInt(posts[1].get('comment_count'))).to.be.equal(2);
         });
       });
+
+      it('should create a valid sql request without querying the id', function() {
+        var Post = current.define('Post', {
+          id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+          name: { type: DataTypes.STRING, allowNull: false }
+        });
+
+        var Comment = current.define('Comment', {
+          id: { type: DataTypes.INTEGER, autoIncrement: true, primaryKey: true },
+          text: { type: DataTypes.STRING, allowNull: false }
+        });
+
+        Post.hasMany(Comment);
+
+        return current.sync({ force: true }).then(function() {
+          return Post.bulkCreate([
+            { name: 'post-1' },
+            { name: 'post-2' }
+          ]);
+        }).then(function() {
+          return Comment.bulkCreate([
+            { text: 'Market', PostId: 1},
+            { text: 'Text', PostId: 2},
+            { text: 'Abc', PostId: 2},
+            { text: 'Semaphor', PostId: 1},
+            { text: 'Text', PostId: 1},
+          ]);
+        }).then(function() {
+          return Post.findAll({
+            attributes: [
+              [ Sequelize.fn('COUNT', Sequelize.col('Comments.id')), 'comment_count' ],
+              'Post.name'
+            ],
+            include: [
+              { model: Comment, attributes: [] }
+            ],
+            group: ['Post.name'],
+            raw: true
+          });
+        }).then(function(posts) {
+          expect(parseInt(posts[0].comment_count)).to.be.equal(3);
+          expect(posts[0].name).to.be.equal('post-1');
+          expect(parseInt(posts[1].comment_count)).to.be.equal(2);
+          expect(posts[1].name).to.be.equal('post-2');
+        });
+      });
     });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?

### Description of change
I wanted to fix the following issue (https://github.com/sequelize/sequelize/issues/5987), so I built a test to fix it. But I finally found out that the `raw: true` option would be a good workaround for the specific queries that had the issue.

If you want to keep the test to prevent regressions in the future, here it is!