### PR TITLE
add a more informative error message

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -82,7 +82,10 @@ exports.escape = escape;
 
 function format(sql, values, timeZone, dialect) {
   values = [].concat(values);
-
+  
+  if (typeof sql !== 'string') {
+    throw new Error('Invalid SQL string provided: ' + sql);
+  }
   return sql.replace(/\?/g, match => {
     if (!values.length) {
       return match;


### PR DESCRIPTION
This PR adds a more informative error message so you actually know what caused the error.

Before:

```
TypeError: sql.replace is not a function
        at Object.format (/Users/contra/Projects/staeco/node_modules/sequelize/lib/sql-string.js:87:14)
        at Object.format (/Users/contra/Projects/staeco/node_modules/sequelize/lib/utils.js:119:20)
        at Object.getWhereConditions (/Users/contra/Projects/staeco/node_modules/sequelize/lib/dialects/abstract/query-generator.js:2303:24)
```

After:

```js
Error: Invalid SQL string provided: ST_Intersects(123)
        at Object.format (/Users/contra/Projects/staeco/node_modules/sequelize/lib/sql-string.js:87:14)
        at Object.format (/Users/contra/Projects/staeco/node_modules/sequelize/lib/utils.js:119:20)
        at Object.getWhereConditions (/Users/contra/Projects/staeco/node_modules/sequelize/lib/dialects/abstract/query-generator.js:2303:24)
```