### PR TITLE
v3 Bugfix: Return value in MSSQL soft-delete

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Soft-delete not returning number of affected rows on mssql [#6916](https://github.com/sequelize/sequelize/pull/6916)
+
 # 3.27.0
 - [FIXED] Incorrect column name for generateThroughJoin [#6878](https://github.com/sequelize/sequelize/pull/6878)
 - [ADDED] Support condition objects in utility functions [#6685](https://github.com/sequelize/sequelize/pull/6685)

--- a/lib/model.js
+++ b/lib/model.js
@@ -2298,8 +2298,12 @@ Model.prototype.destroy = function(options) {
       });
     }
   }).then(function() {
+
     // Run delete query (or update if paranoid)
     if (self._timestampAttributes.deletedAt && !options.force) {
+      // Set query type appropriately when running soft delete
+      options.type = QueryTypes.BULKUPDATE;
+
       var attrValueHash = {}
         , deletedAtAttribute = self.rawAttributes[self._timestampAttributes.deletedAt]
         , field = self.rawAttributes[self._timestampAttributes.deletedAt].field

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -38,7 +38,10 @@ describe(Support.getTestDialectTeaser('Model'), function () {
         .then(function () { return Account.count(); })
         .then(function (count) {
           expect(count).to.be.equal(1);
-          return Account.destroy({ where: { ownerId: 12 }});
+          return Account.destroy({ where: { ownerId: 12 }})
+          .then(function (result) {
+            expect(result).to.be.equal(1);
+          });
         })
         .then(function () { return Account.count(); })
         .then(function (count) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does ~`npm run test`~ or `npm run test-mssql` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] ~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

This fixes an issue where `undefined` was returned when using a soft-delete on MSSQL because the query type of the `UPDATE` query that ran the soft-delete was not properly set.