### PR TITLE
Fixes MSSQL Limit in update query, closes #6636

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] MSSQL LIMIT IN UPDATE [#6636](https://github.com/sequelize/sequelize/issues/6636)
 - [FIXED] Custom error message not used for `notNull` validation [#6531](https://github.com/sequelize/sequelize/issues/6531)
 - [FIXED] N:M `through` option naming collisions [#4597](https://github.com/sequelize/sequelize/issues/4597)
  [#6444](https://github.com/sequelize/sequelize/issues/6444)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -286,13 +286,18 @@ const QueryGenerator = {
 
     const values = [];
     const modelAttributeMap = {};
-    let query = '<%= tmpTable %>UPDATE <%= table %> SET <%= values %><%= output %> <%= where %>';
+    let query = '<%= tmpTable %>UPDATE <%=updateArgs%><%= table %> SET <%= values %><%= output %> <%= where %>';
     let outputFragment;
     let tmpTable = '';        // tmpTable declaration for trigger
     let selectFromTmp = '';   // Select statement for trigger
+    let updateArgs = '';
 
     if (this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
-      query += ' LIMIT ' + this.escape(options.limit) + ' ';
+      if (this.dialect === 'mssql') {
+        updateArgs = `TOP(${this.escape(options.limit)}) `;
+      } else {
+        query += ' LIMIT ' + this.escape(options.limit) + ' ';        
+      }
     }
 
     if (this._dialect.supports.returnValues) {
@@ -362,7 +367,8 @@ const QueryGenerator = {
       values: values.join(','),
       output: outputFragment,
       where: this.whereQuery(where),
-      tmpTable
+      tmpTable,
+      updateArgs
     };
 
     if (values.length === 0) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -286,16 +286,13 @@ const QueryGenerator = {
 
     const values = [];
     const modelAttributeMap = {};
-    let query = '<%= tmpTable %>UPDATE <%=updateArgs%><%= table %> SET <%= values %><%= output %> <%= where %>';
+    let query = '<%= tmpTable %>UPDATE <%= table %> SET <%= values %><%= output %> <%= where %>';
     let outputFragment;
     let tmpTable = '';        // tmpTable declaration for trigger
     let selectFromTmp = '';   // Select statement for trigger
-    let updateArgs = '';
 
     if (this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
-      if (this.dialect === 'mssql') {
-        updateArgs = `TOP(${this.escape(options.limit)}) `;
-      } else {
+      if (this.dialect !== 'mssql') {
         query += ' LIMIT ' + this.escape(options.limit) + ' ';        
       }
     }
@@ -367,8 +364,7 @@ const QueryGenerator = {
       values: values.join(','),
       output: outputFragment,
       where: this.whereQuery(where),
-      tmpTable,
-      updateArgs
+      tmpTable
     };
 
     if (values.length === 0) {

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -302,6 +302,15 @@ var QueryGenerator = {
     return generatedQuery;
   },
 
+  updateQuery(tableName, attrValueHash, where, options, attributes) {
+    let sql = super.updateQuery.call(this, tableName, attrValueHash, where, options, attributes);
+    if (options.limit) {
+      const updateArgs = `UPDATE TOP(${this.escape(options.limit)})`;
+      sql = sql.replace('UPDATE', updateArgs);
+    }
+    return sql;
+  },
+
   upsertQuery(tableName, insertValues, updateValues, where, rawAttributes, options) {
     const targetTableAlias = this.quoteTable(`${tableName}_target`);
     const sourceTableAlias = this.quoteTable(`${tableName}_source`);

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -303,7 +303,7 @@ var QueryGenerator = {
   },
 
   updateQuery(tableName, attrValueHash, where, options, attributes) {
-    let sql = super.updateQuery.call(this, tableName, attrValueHash, where, options, attributes);
+    let sql = super.updateQuery(tableName, attrValueHash, where, options, attributes);
     if (options.limit) {
       const updateArgs = `UPDATE TOP(${this.escape(options.limit)})`;
       sql = sql.replace('UPDATE', updateArgs);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2487,7 +2487,7 @@ class Model {
    * @param  {Boolean}      [options.sideEffects=true] Whether or not to update the side effects of any virtual setters.
    * @param  {Boolean}      [options.individualHooks=false] Run before / after update hooks?. If true, this will execute a SELECT followed by individual UPDATEs. A select is needed, because the row data needs to be passed to the hooks
    * @param  {Boolean}      [options.returning=false]       Return the affected rows (only for postgres)
-   * @param  {Number}       [options.limit]                 How many rows to update (only for mysql and mariadb)
+   * @param  {Number}       [options.limit]                 How many rows to update (only for mysql and mariadb, implemented as TOP(n) for MSSQL)
    * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {Transaction}  [options.transaction] Transaction to run query under

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -64,5 +64,38 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     }
 
+    if (current.dialect.supports['LIMIT ON UPDATE']) {
+      it('Should only update one row', function () {
+        return Account.create({
+          ownerId: 2,
+          name: 'Account Name 1'
+        })
+        .then(() => {
+          return Account.create({
+            ownerId: 2,
+            name: 'Account Name 2'
+          });
+        })
+        .then(() => {
+          return Account.create({
+            ownerId: 2,
+            name: 'Account Name 3'
+          });
+        })
+        .then(() => {
+          const options = {
+            where: {
+              ownerId: 2
+            },
+            limit: 1
+          };
+          return Account.update({ name: 'New Name' }, options);
+        })
+        .then(account => {
+          expect(account[0]).to.equal(1);
+        });
+      });
+    }
+
   });
 });

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -45,6 +45,46 @@ if (current.dialect.name === 'mssql') {
       });
     });
 
+    test('updateQuery', function () {
+      expectsql(QueryGenerator.updateQuery('myTable', {name: 'foo', birthday: new Date(Date.UTC(2011, 2, 27, 10, 1, 55))}, { id: 2 }), {
+        mssql: "UPDATE [myTable] SET [name]=N'foo',[birthday]='2011-03-27 15:31:55.000' OUTPUT INSERTED.* WHERE [id] = 2"
+      });
+
+      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2}, {name: 'foo'}), {
+        mssql: "UPDATE [myTable] SET [bar]=2 OUTPUT INSERTED.* WHERE [name] = N'foo'"
+      });
+
+      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2, nullValue: null}, {name: 'foo'}), {
+        mssql: "UPDATE [myTable] SET [bar]=2,[nullValue]=NULL OUTPUT INSERTED.* WHERE [name] = N'foo'"
+      });
+
+      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2, nullValue: null}, {name: 'foo'}, { omitNull: false }), {
+        mssql: "UPDATE [myTable] SET [bar]=2,[nullValue]=NULL OUTPUT INSERTED.* WHERE [name] = N'foo'"
+      });
+
+      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2, nullValue: null}, {name: 'foo'}, { omitNull: true }), {
+        mssql: "UPDATE [myTable] SET [bar]=2 OUTPUT INSERTED.* WHERE [name] = N'foo'"
+      });
+
+      expectsql(QueryGenerator.updateQuery('myTable', {bar:false}, {name: 'foo'}), {
+        mssql: "UPDATE [myTable] SET [bar]=0 OUTPUT INSERTED.* WHERE [name] = N'foo'"
+      });
+
+      expectsql(QueryGenerator.updateQuery('myTable', {bar:true}, {name: 'foo'}), {
+        mssql: "UPDATE [myTable] SET [bar]=1 OUTPUT INSERTED.* WHERE [name] = N'foo'"
+      });
+
+      //Limit
+      expectsql(QueryGenerator.updateQuery('myTable', { foo: 'bar' }, {}, { limit: 1 }), {
+        mssql: "UPDATE TOP(1) [myTable] SET [foo]=N'bar' OUTPUT INSERTED.*"
+      });
+
+      expectsql(QueryGenerator.updateQuery('myTable', { foo: 'bar' }, { foo: 'value' }, { limit: 1 }), {
+        mssql: "UPDATE TOP(1) [myTable] SET [foo]=N'bar' OUTPUT INSERTED.* WHERE [foo] = N'value'"
+      });
+
+    });
+
     test('selectFromTableFragment', function() {
       var modifiedGen = _.clone(QueryGenerator);
       // Test newer versions first

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -47,7 +47,7 @@ if (current.dialect.name === 'mssql') {
 
     test('updateQuery', function () {
       expectsql(QueryGenerator.updateQuery('myTable', {name: 'foo', birthday: new Date(Date.UTC(2011, 2, 27, 10, 1, 55))}, { id: 2 }), {
-        mssql: "UPDATE [myTable] SET [name]=N'foo',[birthday]='2011-03-27 15:31:55.000' OUTPUT INSERTED.* WHERE [id] = 2"
+        mssql: "UPDATE [myTable] SET [name]=N'foo',[birthday]='2011-03-27 10:01:55.000' OUTPUT INSERTED.* WHERE [id] = 2"
       });
 
       expectsql(QueryGenerator.updateQuery('myTable', {bar: 2}, {name: 'foo'}), {

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -45,46 +45,6 @@ if (current.dialect.name === 'mssql') {
       });
     });
 
-    test('updateQuery', function () {
-      expectsql(QueryGenerator.updateQuery('myTable', {name: 'foo', birthday: new Date(Date.UTC(2011, 2, 27, 10, 1, 55))}, { id: 2 }), {
-        mssql: "UPDATE [myTable] SET [name]=N'foo',[birthday]='2011-03-27 10:01:55.000' OUTPUT INSERTED.* WHERE [id] = 2"
-      });
-
-      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2}, {name: 'foo'}), {
-        mssql: "UPDATE [myTable] SET [bar]=2 OUTPUT INSERTED.* WHERE [name] = N'foo'"
-      });
-
-      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2, nullValue: null}, {name: 'foo'}), {
-        mssql: "UPDATE [myTable] SET [bar]=2,[nullValue]=NULL OUTPUT INSERTED.* WHERE [name] = N'foo'"
-      });
-
-      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2, nullValue: null}, {name: 'foo'}, { omitNull: false }), {
-        mssql: "UPDATE [myTable] SET [bar]=2,[nullValue]=NULL OUTPUT INSERTED.* WHERE [name] = N'foo'"
-      });
-
-      expectsql(QueryGenerator.updateQuery('myTable', {bar: 2, nullValue: null}, {name: 'foo'}, { omitNull: true }), {
-        mssql: "UPDATE [myTable] SET [bar]=2 OUTPUT INSERTED.* WHERE [name] = N'foo'"
-      });
-
-      expectsql(QueryGenerator.updateQuery('myTable', {bar:false}, {name: 'foo'}), {
-        mssql: "UPDATE [myTable] SET [bar]=0 OUTPUT INSERTED.* WHERE [name] = N'foo'"
-      });
-
-      expectsql(QueryGenerator.updateQuery('myTable', {bar:true}, {name: 'foo'}), {
-        mssql: "UPDATE [myTable] SET [bar]=1 OUTPUT INSERTED.* WHERE [name] = N'foo'"
-      });
-
-      //Limit
-      expectsql(QueryGenerator.updateQuery('myTable', { foo: 'bar' }, {}, { limit: 1 }), {
-        mssql: "UPDATE TOP(1) [myTable] SET [foo]=N'bar' OUTPUT INSERTED.*"
-      });
-
-      expectsql(QueryGenerator.updateQuery('myTable', { foo: 'bar' }, { foo: 'value' }, { limit: 1 }), {
-        mssql: "UPDATE TOP(1) [myTable] SET [foo]=N'bar' OUTPUT INSERTED.* WHERE [foo] = N'value'"
-      });
-
-    });
-
     test('selectFromTableFragment', function() {
       var modifiedGen = _.clone(QueryGenerator);
       // Test newer versions first

--- a/test/unit/sql/update.js
+++ b/test/unit/sql/update.js
@@ -34,5 +34,27 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
 
+    
+    it('Works with limit', function () {
+      const User = Support.sequelize.define('User', {
+        username: {
+          type: DataTypes.STRING
+        },
+        userId: {
+          type: DataTypes.INTEGER
+        }
+      }, {
+        timestamps: false
+      });
+
+      expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }),
+      {
+        mssql: "UPDATE TOP(1) [Users] SET [username]=N'new.username' OUTPUT INSERTED.* WHERE [username] = N'username'",
+        postgres: "UPDATE \"Users\" SET \"username\"=\'new.username\' WHERE \"username\" = \'username\'",
+        default: "UPDATE `Users` SET `username`=\'new.username\' WHERE `username` = \'username\' LIMIT 1"
+      });
+    });
+    
+
   });
 });

--- a/test/unit/sql/update.js
+++ b/test/unit/sql/update.js
@@ -51,6 +51,7 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
       {
         mssql: "UPDATE TOP(1) [Users] SET [username]=N'new.username' OUTPUT INSERTED.* WHERE [username] = N'username'",
         postgres: "UPDATE \"Users\" SET \"username\"=\'new.username\' WHERE \"username\" = \'username\'",
+        sqlite: "UPDATE `Users` SET `username`='new.username' WHERE `username` = 'username' LIMIT 1",
         default: "UPDATE `Users` SET `username`=\'new.username\' WHERE `username` = \'username\' LIMIT 1"
       });
     });

--- a/test/unit/sql/update.js
+++ b/test/unit/sql/update.js
@@ -30,7 +30,7 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
       {
         mssql: 'declare @tmp table ([id] INTEGER,[user_name] NVARCHAR(255));UPDATE [users] SET [user_name]=N\'triggertest\' OUTPUT INSERTED.[id],INSERTED.[user_name] into @tmp WHERE [id] = 2;select * from @tmp',
         postgres:'UPDATE "users" SET "user_name"=\'triggertest\' WHERE "id" = 2 RETURNING *',
-        default: "UPDATE `users` SET `user_name`=\'triggertest\' WHERE `id` = 2",
+        default: "UPDATE `users` SET `user_name`=\'triggertest\' WHERE `id` = 2"
       });
     });
 
@@ -47,15 +47,11 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
         timestamps: false
       });
 
-      expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }),
-      {
+      expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }), {
         mssql: "UPDATE TOP(1) [Users] SET [username]=N'new.username' OUTPUT INSERTED.* WHERE [username] = N'username'",
-        postgres: "UPDATE \"Users\" SET \"username\"=\'new.username\' WHERE \"username\" = \'username\'",
-        sqlite: "UPDATE `Users` SET `username`='new.username' WHERE `username` = 'username' LIMIT 1",
-        default: "UPDATE `Users` SET `username`=\'new.username\' WHERE `username` = \'username\' LIMIT 1"
+        mysql: "UPDATE `Users` SET `username`='new.username' WHERE `username` = 'username' LIMIT 1",
+        default: "UPDATE [Users] SET [username]='new.username' WHERE [username] = 'username'"
       });
     });
-    
-
   });
 });


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

SQL Server uses TOP(n) keyword to limit the number of updated rows.
https://msdn.microsoft.com/en-us/library/ms177523.aspx

Closes #6636 
 

