### PR TITLE
Optimize ForInStatement with non local each variable

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -289,8 +289,8 @@ Instance.prototype.set = function(key, value, options) { // testhint options:non
           }
         }
       } else {
-        for (key in values) {
-          this.set(key, values[key], options);
+        for (var objKey in values) {
+          this.set(objKey, values[objKey], options);
         }
       }
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?

### Description of change

I noticed that V8 could not optimize Instance.prototype.set when doing some profiling:

![profile](https://cloud.githubusercontent.com/assets/280807/20645587/845fa400-b417-11e6-9cf5-3fb2f75b3acf.png)

This fixes the problem by making the each variable for the for-in loop a local one (and renaming it to satisfy the linter). I noticed this is fixed in v4 but since it's not out I figured it would be nice to optimize this hot path in v3.



