### PR TITLE
Bugfix: Return value in MSSQL soft-delete

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,8 @@
 - [FIXED] Issue with overrriding custom methods with association mixins (all association methods are now exposed) [#6682](https://github.com/sequelize/sequelize/issues/6682)
 - [ADDED] Support condition objects in utility functions [#6685](https://github.com/sequelize/sequelize/pull/6685)
 - [FIXED] HSTORE and JSON fields being renamed when `options.field` is specified on a matching model attribute
+- [FIXED] Soft-delete not returning number of affected rows on mssql [#6930](https://github.com/sequelize/sequelize/pull/6930)
+
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/model.js
+++ b/lib/model.js
@@ -2380,6 +2380,9 @@ class Model {
     }).then(() => {
       // Run delete query (or update if paranoid)
       if (this._timestampAttributes.deletedAt && !options.force) {
+        // Set query type appropriately when running soft delete
+        options.type = QueryTypes.BULKUPDATE;
+
         const attrValueHash = {};
         const deletedAtAttribute = this.rawAttributes[this._timestampAttributes.deletedAt];
         const field = this.rawAttributes[this._timestampAttributes.deletedAt].field;

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -38,7 +38,10 @@ describe(Support.getTestDialectTeaser('Model'), function () {
         .then(() => Account.count())
         .then((count) => {
           expect(count).to.be.equal(1);
-          return Account.destroy({ where: { ownerId: 12 }});
+          return Account.destroy({ where: { ownerId: 12 }})
+          .then((result) => {
+            expect(result).to.be.equal(1);
+          });
         })
         .then(() => Account.count())
         .then((count) => {


### PR DESCRIPTION
This is a version of #6916, ported against `master`.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does ~`npm run test`~ or `npm run test-mssql` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] ~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

This fixes an issue where `undefined` was returned when using a soft-delete on MSSQL because the query type of the `UPDATE` query that ran the soft-delete was not properly set.