### PR TITLE
Fix: custom msg not used for notNull validations

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] Custom error message not used for `notNull` validation [#6531](https://github.com/sequelize/sequelize/issues/6531)
 - [FIXED] N:M `through` option naming collisions [#4597](https://github.com/sequelize/sequelize/issues/4597)
  [#6444](https://github.com/sequelize/sequelize/issues/6444)
 - [CHANGED] Updated deprecated `node-uuid` package to `uuid` [#6919](https://github.com/sequelize/sequelize/pull/6919)

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -304,14 +304,18 @@ class InstanceValidator {
   _validateSchema(rawAttribute, field, value) {
     let error;
 
-    if (rawAttribute.allowNull === false && ((value === null) || (value === undefined))) {
-      error = new sequelizeError.ValidationErrorItem(field + ' cannot be null', 'notNull Violation', field, value);
+    if (rawAttribute.allowNull === false && (value === null || value === undefined)) {
+      const validators = this.modelInstance.validators[field];
+      const errMsg = validators
+                      ? (validators.notNull || {}).msg
+                      : `${field} cannot be null`;
+      error = new sequelizeError.ValidationErrorItem(errMsg, 'notNull Violation', field, value);
       this.errors.push(error);
     }
 
     if (rawAttribute.type === DataTypes.STRING || rawAttribute.type instanceof DataTypes.STRING || rawAttribute.type === DataTypes.TEXT || rawAttribute.type instanceof DataTypes.TEXT) {
       if (Array.isArray(value) || (_.isObject(value) && !value._isSequelizeMethod) && !Buffer.isBuffer(value)) {
-        error = new sequelizeError.ValidationErrorItem(field + ' cannot be an array or an object', 'string violation', field, value);
+        error = new sequelizeError.ValidationErrorItem(`${field} cannot be an array or an object`, 'string violation', field, value);
         this.errors.push(error);
       }
     }


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #6531]) or a description of the issue you are solving?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change
Closes #6531 

Will add the changelog after reviews

