### PR TITLE
Fix #3899 no value in built-in/custom validation errors

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -20,7 +20,7 @@
 - [ADDED] Support condition objects in utility functions [#6685](https://github.com/sequelize/sequelize/pull/6685)
 - [FIXED] HSTORE and JSON fields being renamed when `options.field` is specified on a matching model attribute
 - [FIXED] Soft-delete not returning number of affected rows on mssql [#6930](https://github.com/sequelize/sequelize/pull/6930)
-
+- [FIXED] No `value` in built-in/custom validation errors [#3899](https://github.com/sequelize/sequelize/pull/3899)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -209,7 +209,7 @@ class ValidationErrorItem {
     this.message = message || '';
     this.type = type || null;
     this.path = path || null;
-    this.value = value || null;
+    this.value = value !== undefined ? value : null;
   }
 }
 exports.ValidationErrorItem = ValidationErrorItem;

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -198,7 +198,9 @@ class InstanceValidator {
       validators.push(validatorPromise.reflect());
     });
 
-    return Promise.all(validators).then(this._handleReflectedResult.bind(this, field, value));
+    return Promise
+            .all(validators)
+            .then(results => this._handleReflectedResult(field, value, results));
   }
 
   /**
@@ -239,7 +241,7 @@ class InstanceValidator {
               .catch(e => this._pushError(false, errorKey, e, optValue));
     } else {
       return Promise
-              .try(validator.bind(this.modelInstance, invokeArgs))
+              .try(() => validator.call(this.modelInstance, invokeArgs))
               .catch(e => this._pushError(false, errorKey, e, optValue));
     }
   }

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -198,7 +198,7 @@ class InstanceValidator {
       validators.push(validatorPromise.reflect());
     });
 
-    return Promise.all(validators).then(this._handleReflectedResult.bind(this, field));
+    return Promise.all(validators).then(this._handleReflectedResult.bind(this, field, value));
   }
 
   /**
@@ -235,9 +235,12 @@ class InstanceValidator {
       } else {
         validatorFunction = Promise.promisify(validator.bind(this.modelInstance));
       }
-      return validatorFunction().catch(this._pushError.bind(this, false, errorKey));
+      return validatorFunction()
+              .catch(e => this._pushError(false, errorKey, e, optValue));
     } else {
-      return Promise.try(validator.bind(this.modelInstance, invokeArgs)).catch(this._pushError.bind(this, false, errorKey));
+      return Promise
+              .try(validator.bind(this.modelInstance, invokeArgs))
+              .catch(e => this._pushError(false, errorKey, e, optValue));
     }
   }
 
@@ -324,14 +327,15 @@ class InstanceValidator {
    * If errors are found it populates this.error.
    *
    * @param {string} field The attribute name.
+   * @param {string|number} value The data value.
    * @param {Array.<Promise.PromiseInspection>} Promise inspection objects.
    * @private
    */
-  _handleReflectedResult(field, promiseInspections) {
+  _handleReflectedResult(field, value, promiseInspections) {
     for (const promiseInspection of promiseInspections) {
       if (promiseInspection.isRejected()) {
         const rejection = promiseInspection.error();
-        this._pushError(true, field, rejection);
+        this._pushError(true, field, rejection, value);
       }
     }
   }
@@ -342,11 +346,12 @@ class InstanceValidator {
    * @param {boolean} isBuiltin Determines if error is from builtin validator.
    * @param {string} errorKey The error key to assign on this.errors object.
    * @param {Error|string} rawError The original error.
+   * @param {string|number} value The data that triggered the error.
    * @private
    */
-  _pushError(isBuiltin, errorKey, rawError) {
+  _pushError(isBuiltin, errorKey, rawError, value) {
     const message = rawError.message || rawError || 'Validation error';
-    const error = new sequelizeError.ValidationErrorItem(message, 'Validation error', errorKey, rawError);
+    const error = new sequelizeError.ValidationErrorItem(message, 'Validation error', errorKey, value);
     error[InstanceValidator.RAW_KEY_NAME] = rawError;
 
     this.errors.push(error);

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -201,6 +201,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), function() {
 
           return expect(failingUser.validate()).to.be.rejected.then(function(_errors) {
             expect(_errors.get('name')[0].message).to.equal(message);
+            expect(_errors.get('name')[0].value).to.equal(failingValue);
           });
         });
       }


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

Fixes #3899 , Error object for validation error was always missing `value` field, which is important for front end validation etc. It was broken for `custom` and `builtIn` validators. Now its fixed, regression included

Will add change log after reviews

