### PR TITLE
Deprecate stuff / Update critical libs

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -10,6 +10,7 @@ const warnings = {};
 const Validator = require('./utils/validator-extras').validator;
 const momentTz = require('moment-timezone');
 const moment = require('moment');
+const Utils = require('./utils');
 
 /**
  * A convenience class holding commonly used data types. The datatypes are used when defining a new model using `Sequelize.define`, like this:
@@ -69,7 +70,7 @@ ABSTRACT.prototype.toSql = function toSql() {
 ABSTRACT.warn = function warn(link, text) {
   if (!warnings[text]) {
     warnings[text] = true;
-    console.warn('>> WARNING:', text, '\n>> Check:', link);
+    Utils.warn(`${text}, '\n>> Check:', ${link}`);
   }
 };
 ABSTRACT.prototype.stringify = function stringify(value, options) {

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -109,7 +109,7 @@ class AbstractQuery {
    */
   checkLoggingOption() {
     if (this.options.logging === true) {
-      console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
+      Utils.deprecate('The logging-option should be either a function or false. Default: console.log');
       this.options.logging = console.log;
     }
   }

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1068,7 +1068,7 @@ class Sequelize {
 
     if (options.logging) {
       if (options.logging === true) {
-        console.log('DEPRECATION WARNING: The logging-option should be either a function or false. Default: console.log');
+        Utils.deprecate('The logging-option should be either a function or false. Default: console.log');
         options.logging = console.log;
       }
 

--- a/lib/utils/parameter-validator.js
+++ b/lib/utils/parameter-validator.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const util = require('util');
+const Utils = require('../utils');
 
 function validateDeprecation(value, expectation, options) {
   if (!options.deprecated) {
@@ -12,8 +13,7 @@ function validateDeprecation(value, expectation, options) {
 
   if (valid) {
     const message = `${util.inspect(value)} should not be of type "${options.deprecated.name}"`;
-
-    console.log('DEPRECATION WARNING:', options.deprecationWarning || message);
+    Utils.deprecate(options.deprecationWarning || message);
   }
 
   return valid;

--- a/lib/utils/validator-extras.js
+++ b/lib/utils/validator-extras.js
@@ -38,7 +38,7 @@ const extensions = {
     return !this.regex(str, pattern, modifiers);
   },
   isDecimal(str) {
-    return str !== '' && !!str.match(/^(?:-?(?:[0-9]+))?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/);    
+    return str !== '' && !!str.match(/^(?:-?(?:[0-9]+))?(?:\.[0-9]*)?(?:[eE][\+\-]?(?:[0-9]+))?$/);
   },
   min(str, val) {
     const number = parseFloat(str);
@@ -81,9 +81,13 @@ validator.notNull = function() {
   throw new Error('Warning "notNull" validation has been deprecated in favor of Schema based "allowNull"');
 };
 
-// https://github.com/chriso/validator.js/blob/1.5.0/lib/validators.js
+// https://github.com/chriso/validator.js/blob/6.20.0/validator.js
 _.forEach(extensions, (extend, key) => {
   validator[key] = extend;
 });
+
+// map isNull to isEmpty
+// https://github.com/chriso/validator.js/commit/e33d38a26ee2f9666b319adb67c7fc0d3dea7125
+validator.isNull = validator.isEmpty;
 
 exports.validator = validator;

--- a/lib/utils/validator-extras.js
+++ b/lib/utils/validator-extras.js
@@ -81,7 +81,7 @@ validator.notNull = function() {
   throw new Error('Warning "notNull" validation has been deprecated in favor of Schema based "allowNull"');
 };
 
-// https://github.com/chriso/validator.js/blob/6.20.0/validator.js
+// https://github.com/chriso/validator.js/blob/6.2.0/validator.js
 _.forEach(extensions, (extend, key) => {
   validator[key] = extend;
 });

--- a/package.json
+++ b/package.json
@@ -47,12 +47,12 @@
     "lodash": "^4.17.1",
     "moment": "^2.13.0",
     "moment-timezone": "^0.5.4",
-    "uuid": "^3.0.0",
     "retry-as-promised": "^2.0.0",
     "semver": "^5.0.1",
     "terraformer-wkt-parser": "^1.1.2",
     "toposort-class": "^1.0.1",
-    "validator": "^5.6.0",
+    "uuid": "^3.0.0",
+    "validator": "^6.2.0",
     "wkx": "^0.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "toposort-class": "^1.0.1",
     "uuid": "^3.0.0",
     "validator": "^6.2.0",
-    "wkx": "^0.3.0"
+    "wkx": "^0.4.1"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?

### Description of change

**Updated**
https://github.com/chriso/validator.js/releases/tag/6.2.0
https://github.com/cschwarz/wkx/releases/tag/v0.4.1

**Deprecation / Warning / Logging**
Various warning and logging message, we now fully use `Utils.<Logging>` stuff for this
