### PR TITLE
Clone defaultScope so it doesn't get overwritten in Model#init

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -685,9 +685,7 @@ class Model {
 
     const globalOptions = this.sequelize.options;
 
-    if (globalOptions.define) {
-      options = Utils.merge(globalOptions.define, options);
-    }
+    options = Utils.merge(_.cloneDeep(globalOptions.define), options);
 
     if (!options.modelName) {
       options.modelName = this.name;


### PR DESCRIPTION
### Pull Request check-list

(I have not been able to test against `master` due to  `npm install` failing with `gyp: Call to 'pg_config --libdir' returned exit status 127 while in binding.gyp.  However this is reproduceable with latest version in npm and the code seems largely unchanged, so I'm assuming this is still an issue...?)

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

https://gist.github.com/broofa/cee97d28e3923ad62438561438f7e12a is a standalone test case showing how sequelized.options.define.defaultScope.options.attributes is overwritten when defining a model.    It logs the state of of this property before, between, and after doing two define() calls.  The output I see (Sequelized v3.27.0) is this:

```
kieffer@Roberts-MacBook-Pro$ node defaultScope_test.js
attributes before defining ModelA: { exclude: [ 'createdAt', 'updatedAt', 'deletedAt' ] }
attributes after defining ModelA: [ 'modelAUuid', 'fooA', 'barA' ]
attributes after defining ModelB: [ 'modelAUuid', 'fooA', 'barA' ]
```

Cloning defaultScope in Model.init() as per this PR fixes this, however I'm not 100% sure this is the correct solution.  (If nothing else, doing a deep-copy would probably be more resistent to similar bugs emerging in the future).