### PR TITLE
IN operator should be = when only 1 element

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2038,23 +2038,23 @@ const QueryGenerator = {
     if (Array.isArray(value) && fieldType instanceof DataTypes.ARRAY) {
       value = this.escape(value, field);
     } else if (value && (value.$in || value.$notIn)) {
-      if (value.$in && value.$in.length === 1) {
-        comparator = '=';
-        value = value.$in;
-      } else {
-        comparator = 'IN';
-        if (value.$notIn) comparator = 'NOT IN';
+      comparator = 'IN';
+      if (value.$notIn) comparator = 'NOT IN';
 
-        if ((value.$in || value.$notIn) instanceof Utils.Literal) {
-          value = (value.$in || value.$notIn).val;
-        } else if ((value.$in || value.$notIn).length) {
-          value = '('+(value.$in || value.$notIn).map(item => this.escape(item)).join(', ')+')';
+      if ((value.$in || value.$notIn) instanceof Utils.Literal) {
+        value = (value.$in || value.$notIn).val;
+      } else if ((value.$in || value.$notIn).length) {
+        if ((value.$in || value.$notIn).length === 1) {
+          comparator = value.$in ? comparatorMap.$eq : comparatorMap.$ne;
+          value = this.escape(value.$in || value.$notIn);
         } else {
-          if (value.$in) {
-            value = '(NULL)';
-          } else {
-            return '';
-          }
+          value = '('+(value.$in || value.$notIn).map(item => this.escape(item)).join(', ')+')';
+        }
+      } else {
+        if (value.$in) {
+          value = '(NULL)';
+        } else {
+          return '';
         }
       }
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -293,7 +293,7 @@ const QueryGenerator = {
 
     if (this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
       if (this.dialect !== 'mssql') {
-        query += ' LIMIT ' + this.escape(options.limit) + ' ';        
+        query += ' LIMIT ' + this.escape(options.limit) + ' ';
       }
     }
 
@@ -2038,20 +2038,26 @@ const QueryGenerator = {
     if (Array.isArray(value) && fieldType instanceof DataTypes.ARRAY) {
       value = this.escape(value, field);
     } else if (value && (value.$in || value.$notIn)) {
-      comparator = 'IN';
-      if (value.$notIn) comparator = 'NOT IN';
-
-      if ((value.$in || value.$notIn) instanceof Utils.Literal) {
-        value = (value.$in || value.$notIn).val;
-      } else if ((value.$in || value.$notIn).length) {
-        value = '('+(value.$in || value.$notIn).map(item => this.escape(item)).join(', ')+')';
+      if (value.$in && value.$in.length === 1) {
+        comparator = '=';
+        value = value.$in;
       } else {
-        if (value.$in) {
-          value = '(NULL)';
+        comparator = 'IN';
+        if (value.$notIn) comparator = 'NOT IN';
+
+        if ((value.$in || value.$notIn) instanceof Utils.Literal) {
+          value = (value.$in || value.$notIn).val;
+        } else if ((value.$in || value.$notIn).length) {
+          value = '('+(value.$in || value.$notIn).map(item => this.escape(item)).join(', ')+')';
         } else {
-          return '';
+          if (value.$in) {
+            value = '(NULL)';
+          } else {
+            return '';
+          }
         }
       }
+
     } else if (value && (value.$any || value.$all)) {
       comparator = value.$any ? '= ANY' : '= ALL';
       if (value.$any && value.$any.$values || value.$all && value.$all.$values) {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -330,13 +330,6 @@ if (dialect.match(/^postgres/)) {
           context: QueryGenerator,
           needsSequelize: true
         }, {
-          title: 'IN operator should become = operator when only one element is in array',
-          arguments: ['myTable', {where: {number: {in: [1]}}}],
-          expectation: 'SELECT * FROM "myTable" WHERE "myTable"."number" = 1;',
-          context: QueryGenerator,
-          needsSequelize: true
-        },
-        {
           title: 'single string argument is not quoted',
           arguments: ['myTable', {group: 'name'}],
           expectation: 'SELECT * FROM \"myTable\" GROUP BY name;'

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -330,6 +330,13 @@ if (dialect.match(/^postgres/)) {
           context: QueryGenerator,
           needsSequelize: true
         }, {
+          title: 'IN operator should become = operator when only one element is in array',
+          arguments: ['myTable', {where: {number: {in: [1]}}}],
+          expectation: 'SELECT * FROM "myTable" WHERE "myTable"."number" = 1;',
+          context: QueryGenerator,
+          needsSequelize: true
+        },
+        {
           title: 'single string argument is not quoted',
           arguments: ['myTable', {group: 'name'}],
           expectation: 'SELECT * FROM \"myTable\" GROUP BY name;'

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -104,6 +104,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         default: '[equipment] IN (NULL)'
       });
 
+      testsql('equipment', {
+        $in: [1]
+      }, {
+        default: '[equipment] = 1'
+      });
+
       testsql('muscles', {
         in: [2, 4]
       }, {
@@ -161,6 +167,12 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         $notIn: [4, 19]
       }, {
         default: '[equipment] NOT IN (4, 19)'
+      });
+
+      testsql('equipment', {
+        $notIn: [1]
+      }, {
+        default: '[equipment] != 1'
       });
 
       testsql('equipment', {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

Fixes https://github.com/sequelize/sequelize/issues/6959

IN and NOT IN operators turn into = and != when dealing with 1 element arrays.

Doc not updated as this is an internal perf detail and i didn't think it'd need it.