### PR TITLE
Make Eager Loading Error Messages More User-Friendly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@
 - [FIXED] HSTORE and JSON fields being renamed when `options.field` is specified on a matching model attribute
 - [FIXED] Soft-delete not returning number of affected rows on mssql [#6930](https://github.com/sequelize/sequelize/pull/6930)
 - [FIXED] No `value` in built-in/custom validation errors [#3899](https://github.com/sequelize/sequelize/pull/3899)
+- [FIXED] Custom error messages used for incorrect eager loading [#7005](https://github.com/sequelize/sequelize/pull/7005)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -210,18 +210,12 @@ const Mixin = {
   },
 
   getAssociations(target) {
-    return Object.values(this.associations).filter(association => association.target.name === target.name);
+    return _.values(this.associations).filter(association => association.target.name === target.name);
   },
 
   getAssociationForAlias(target, alias) {
     // Two associations cannot have the same alias, so we can use find instead of filter
-    const association = this.getAssociations(target)
-      .find(association => this.verifyAssociationAlias(association, alias));
-    if (!association) {
-      return null;
-    } else {
-      return association;
-    }
+    return this.getAssociations(target).find(association => this.verifyAssociationAlias(association, alias)) || null;
   },
 
   verifyAssociationAlias(association, alias) {

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -209,18 +209,27 @@ const Mixin = {
     return association;
   },
 
-  getAssociation(target, alias) {
-    for (const associationName in this.associations) {
-      if (this.associations.hasOwnProperty(associationName)) {
-        const association = this.associations[associationName];
+  getAssociations(target) {
+    return Object.values(this.associations).filter(association => association.target.name === target.name);
+  },
 
-        if (association.target.name === target.name && (alias === undefined ? !association.isAliased : association.as === alias)) {
-          return association;
-        }
-      }
+  getAssociationForAlias(target, alias) {
+    // Two associations cannot have the same alias, so we can use find instead of filter
+    const association = this.getAssociations(target)
+      .find(association => this.verifyAssociationAlias(association, alias));
+    if (!association) {
+      return null;
+    } else {
+      return association;
     }
+  },
 
-    return null;
+  verifyAssociationAlias(association, alias) {
+    if (alias) {
+      return association.as === alias;
+    } else {
+      return !association.isAliased;
+    }
   }
 };
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -651,7 +651,7 @@ const QueryGenerator = {
           association = {as: model.name};
         } else {
           // find applicable association for linking parent to this model
-          association = parent.getAssociation(model, as);
+          association = parent.getAssociationForAlias(model, as);
         }
 
         if (association) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -355,3 +355,17 @@ class EmptyResultError extends BaseError {
   }
 }
 exports.EmptyResultError = EmptyResultError;
+
+/**
+ * Thrown when an include statement is improperly constructed (see message for details)
+ * @extends BaseError
+ * @memberof Errors
+ */
+class EagerLoadingError extends BaseError {
+  constructor(message) {
+    super(message);
+    this.name = 'SequelizeEagerLoadingError';
+    this.message = message;
+  }
+}
+exports.EagerLoadingError = EagerLoadingError;

--- a/lib/model.js
+++ b/lib/model.js
@@ -556,39 +556,26 @@ class Model {
     const associations = this.getAssociations(targetModel);
     let association = null;
     if (associations.length === 0) {
-      noAssociationError(this.name, targetModel.name);
+      throw new sequelizeErrors.EagerLoadingError(`${targetModel.name} is not associated to ${this.name}!`);
     } else if (associations.length === 1) {
       association = this.getAssociationForAlias(targetModel, targetAlias);
       if (!association) {
         if (targetAlias) {
-          aliasMismatchError(this.name, targetModel.name, targetAlias);
+          throw new sequelizeErrors.EagerLoadingError(`${targetModel.name} is associated to ${this.name} using an alias. ` + 
+            `You've included an alias (${targetAlias}), but it does not match the alias defined in your association.`);
         } else {
-          associationButMissingAliasError(this.name, targetModel.name);
+          throw new sequelizeErrors.EagerLoadingError(`${targetModel.name} is associated to ${this.name} using an alias. ` +
+            `You must use the 'as' keyword to specify the alias within your include statement.`);
         }
       }
     } else {
       association = this.getAssociationForAlias(targetModel, targetAlias);
       if (!association){
-        multipleAssociationError(this.name, targetModel.name);
-      }    
-    }
+        throw new sequelizeErrors.EagerLoadingError(`${targetModel.name} is associated to ${this.name} multiple times. ` +
+          `To identify the correct association, you must use the 'as' keyword to specify the alias of the association you want to include.`);
+      }
+    }    
     return association;
-    
-    function noAssociationError(source, target) { 
-      throw new Error(`${target} is not associated to ${source}!`);
-    }
-
-    function multipleAssociationError(source, target) { 
-      throw new Error(`${target} is associated to ${source} multiple times. To identify the correct association, you must use the 'as' keyword to specify the alias of the association you want to include.`);
-    }
-
-    function associationButMissingAliasError(source, target) {
-      throw new Error(`${target} is associated to ${source} using an alias. You must use the 'as' keyword to specify the alias within your include statement.`);
-    }
-
-    function aliasMismatchError(source, target, targetAlias) { 
-      throw new Error(`${target} is associated to ${source} using an alias. You've included an alias (${targetAlias}), but it does not match the alias defined in your association.`);
-    }
   }
 
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -274,7 +274,7 @@ class Model {
 
         const types = validTypes[type];
         if (!types) {
-          throw new Error('include all \'' + type + '\' is not valid - must be BelongsTo, HasOne, HasMany, One, Has, Many or All');
+          throw new sequelizeErrors.EagerLoadingError('include all \'' + type + '\' is not valid - must be BelongsTo, HasOne, HasMany, One, Has, Many or All');
         }
 
         if (types !== true) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -472,19 +472,7 @@ class Model {
     }
 
     // check if the current Model is actually associated with the passed Model - or it's a pseudo include
-    const association = include.association || this.getAssociationForAlias(include.model, include.as);
-
-    if (!association) {
-      let msg = include.model.name;
-
-      if (include.as) {
-        msg += ' (' + include.as + ')';
-      }
-
-      msg += ' is not associated to ' + this.name + '!';
-
-      throw new Error(msg);
-    }
+    const association = include.association || this._getIncludedAssociation(include.model, include.as);
 
     include.association = association;
     include.as = association.as;
@@ -563,6 +551,61 @@ class Model {
 
     return include;
   }
+
+  static _getIncludedAssociation(targetModel, targetAlias) {
+    const associations = this.getAssociations(targetModel);
+    let association = null;
+    if (associations.length === 0) {
+      noAssociationError(this.name, targetModel.name);
+    } else if (associations.length === 1) {
+      association = this.getAssociationForAlias(targetModel, targetAlias);
+      if (!association) {
+        if (targetAlias) {
+          aliasMismatchError(this.name, targetModel.name, targetAlias);
+        } else {
+          associationButMissingAliasError(this.name, targetModel.name);
+        }
+      }
+    } else {
+      association = this.getAssociationForAlias(targetModel, targetAlias);
+      if (!association){
+        multipleAssociationError(this.name, targetModel.name);
+      }    
+    }
+    // } else if (associations.length > 1) {
+    //   association = this.getAssociationForAlias(targetModel, targetAlias);
+    //   if (!association){
+    //     multipleAssociationError(this.name, targetModel.name);
+    //   }
+    // } else {
+    //   association = this.getAssociationForAlias(targetModel, targetAlias);
+    //   if (!association) {
+    //     if (!targetAlias) {
+    //       associationButMissingAliasError(this.name, targetModel.name);
+    //     } else {
+    //       aliasMismatchError(this.name, targetModel.name, targetAlias);
+    //     }
+    //   }
+    // }
+    return association;
+    
+    function noAssociationError(source, target) { 
+      throw new Error(`${target} is not associated to ${source}!`);
+    }
+
+    function multipleAssociationError(source, target) { 
+      throw new Error(`${target} is associated to ${source} multiple times. To identify the correct association, you must use the 'as' keyword to specify the alias of the association you want to include.`);
+    }
+
+    function associationButMissingAliasError(source, target) {
+      throw new Error(`${target} is associated to ${source} using an alias. You must use the 'as' keyword to specify the alias within your include statement.`);
+    }
+
+    function aliasMismatchError(source, target, targetAlias) { 
+      throw new Error(`${target} is associated to ${source} using an alias. You've included an alias (${targetAlias}), but it does not match the alias defined in your association.`);
+    }
+  }
+
 
   static _expandIncludeAll(options) {
     const includes = options.include;

--- a/lib/model.js
+++ b/lib/model.js
@@ -574,7 +574,7 @@ class Model {
         throw new sequelizeErrors.EagerLoadingError(`${targetModel.name} is associated to ${this.name} multiple times. ` +
           `To identify the correct association, you must use the 'as' keyword to specify the alias of the association you want to include.`);
       }
-    }    
+    } 
     return association;
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -572,21 +572,6 @@ class Model {
         multipleAssociationError(this.name, targetModel.name);
       }    
     }
-    // } else if (associations.length > 1) {
-    //   association = this.getAssociationForAlias(targetModel, targetAlias);
-    //   if (!association){
-    //     multipleAssociationError(this.name, targetModel.name);
-    //   }
-    // } else {
-    //   association = this.getAssociationForAlias(targetModel, targetAlias);
-    //   if (!association) {
-    //     if (!targetAlias) {
-    //       associationButMissingAliasError(this.name, targetModel.name);
-    //     } else {
-    //       aliasMismatchError(this.name, targetModel.name, targetAlias);
-    //     }
-    //   }
-    // }
     return association;
     
     function noAssociationError(source, target) { 

--- a/lib/model.js
+++ b/lib/model.js
@@ -472,7 +472,7 @@ class Model {
     }
 
     // check if the current Model is actually associated with the passed Model - or it's a pseudo include
-    const association = include.association || this.getAssociation(include.model, include.as);
+    const association = include.association || this.getAssociationForAlias(include.model, include.as);
 
     if (!association) {
       let msg = include.model.name;
@@ -2761,7 +2761,7 @@ class Model {
           if (scopeInclude.as) {
             return item.as === scopeInclude.as;
           } else {
-            const association = scopeInclude.association || this.getAssociation(scopeInclude.model, scopeInclude.as);
+            const association = scopeInclude.association || this.getAssociationForAlias(scopeInclude.model, scopeInclude.as);
             return association ? item.as === association.as : false;
           }
         })) {

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -551,10 +551,11 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             });
           });
 
-          it('throws an error if alias is not associated', function() {
+          it(`throws an error indicating an incorrect alias was entered if an association 
+              and alias exist but the alias doesn't match`, function() {
             var self = this;
             return self.Worker.findOne({ include: [{ model: self.Task, as: 'Work' }] }).catch (function(err) {
-              expect(err.message).to.equal('Task (Work) is not associated to Worker!');
+              expect(err.message).to.equal(`Task is associated to Worker using an alias. You've included an alias (Work), but it does not match the alias defined in your association.`);
             });
           });
 
@@ -712,10 +713,11 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             });
           });
 
-          it('throws an error if alias is not associated', function() {
+          it(`throws an error indicating an incorrect alias was entered if an association 
+              and alias exist but the alias doesn't match`, function() {
             var self = this;
             return self.Worker.findOne({ include: [{ model: self.Task, as: 'Work' }] }).catch (function(err) {
-              expect(err.message).to.equal('Task (Work) is not associated to Worker!');
+              expect(err.message).to.equal(`Task is associated to Worker using an alias. You've included an alias (Work), but it does not match the alias defined in your association.`);
             });
           });
 

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -601,14 +601,16 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         it('throws an error if included DaoFactory is not referenced by alias', function() {
           var self = this;
           return self.Worker.findAll({ include: [self.Task] }).catch (function(err) {
-            expect(err.message).to.equal('Task is not associated to Worker!');
+            expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
+            'You must use the \'as\' keyword to specify the alias within your include statement.');
           });
         });
 
         it('throws an error if alias is not associated', function() {
           var self = this;
           return self.Worker.findAll({ include: [{ model: self.Task, as: 'Work' }] }).catch (function(err) {
-            expect(err.message).to.equal('Task (Work) is not associated to Worker!');
+            expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
+            'You\'ve included an alias (Work), but it does not match the alias defined in your association.');
           });
         });
 
@@ -693,14 +695,16 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         it('throws an error if included DaoFactory is not referenced by alias', function() {
           var self = this;
           return self.Worker.findAll({ include: [self.Task] }).catch (function(err) {
-            expect(err.message).to.equal('Task is not associated to Worker!');
+            expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
+            'You must use the \'as\' keyword to specify the alias within your include statement.');
           });
         });
 
         it('throws an error if alias is not associated', function() {
           var self = this;
           return self.Worker.findAll({ include: [{ model: self.Task, as: 'Work' }] }).catch (function(err) {
-            expect(err.message).to.equal('Task (Work) is not associated to Worker!');
+            expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
+            'You\'ve included an alias (Work), but it does not match the alias defined in your association.');
           });
         });
 

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -285,7 +285,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
-    describe.only('_getIncludedAssociation', function () {
+    describe('_getIncludedAssociation', function () {
       it('returns an association when there is a single unaliased association', function () {
         expect(this.User._getIncludedAssociation(this.Task)).to.equal(this.User.Tasks);
       });

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -285,6 +285,23 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    describe.only('_getIncludedAssociation', function () {
+      it('returns an association when there is a single unaliased association', function () {
+        expect(this.User._getIncludedAssociation(this.Task)).to.equal(this.User.Tasks);
+      });
+
+      it('returns an association when there is a single aliased association', function () {
+        const User = this.sequelize.define('User');
+        const Task = this.sequelize.define('Task');
+        const Tasks = Task.belongsTo(User, {as: 'owner'});
+        expect(Task._getIncludedAssociation(User, 'owner')).to.equal(Tasks);
+      });
+
+      it('returns an association when there are multiple aliased associations', function () {
+        expect(this.Company._getIncludedAssociation(this.User, 'Owner')).to.equal(this.Company.Owner);
+      });
+    });
+
     describe('subQuery', function () {
       it('should be true if theres a duplicating association', function () {
         var options = Sequelize.Model._validateIncludedElements({


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

## Background
This PR aims to make error messages that appear when using the `include` keyword more user friendly. Currently, if a user specifies an association incorrectly within the `include` keyword, Sequelize throws an error stating: "Target is not associated with Source!", substituting model names where appropriate. This error message is very helpful in the instances when the target and source models are not associated; however, this is currently the only error message thrown when `include` statements are erroneously specified, even when the source and target models are associated!

## Description of Change
I've broken down incorrect `include` statement usage into 4 possible scenarios, each of which now has it's own custom error message.

# Scenario 1:

_Source and target models are not associated_

```
const User = db.define('user')
const Message = db.define('message')

db.sync({force: true})
    .then(function() {
        return Message.findAll({
            include: [User]
        });
    })
```

This scenario will preserve existing functionality, throwing an error message stating:

"User is not associated to Message!

# Scenario 2:

_Source and target models are associated **multiple** times, and an alias is not specified_

```
const User = db.define('user')
const Message = db.define('message')

Message.belongsTo(User, { as: 'toMessage' });
Message.belongsTo(User, { as: 'fromMessage' });

db.sync({force: true})
    .then(function() {
        return Message.findAll({
            include: [User]
        });
    })
```
This scenario will throw and error message stating:

"User is associated to Message multiple times. To identify the correct association, you must use the 'as' keyword to specify the alias of the association you want to include."

# Scenario 3:

_Source and target models are associated a **single** time, and an alias is not specified_

```
const User = db.define('user')
const Message = db.define('message')

Message.belongsTo(User, { as: 'message' });

db.sync({force: true})
    .then(function() {
        return Message.findAll({
            include: [User]
        });
    })
```

This scenario will throw and error message stating:

"User is associated to Message using an alias. You must use the 'as' keyword to specify the alias within your include statement."

# Scenario 4

_Source and target models are associated, but the included alias does not match the alias defined on the association._

```
const User = db.define('user')
const Message = db.define('message')

Message.belongsTo(User, { as: 'message' });

db.sync({force: true})
    .then(function() {
        return Message.findAll({
            include: [{model: User, as: 'toMessage'}]
        });
    })
```

This scenario will throw and error message stating:

"User is associated to Message using an alias. You've included an alias (toMessage), but it does not match the alias defined in your association."

## Next Steps
What do you all think of this PR? I am a teacher by day, and this PR was motivated by student confusion. My hope is that more precise and instructive error messages will help new Sequelize developers become acclimated to its API.

I want to include some more tests before merging, but I wanted to get the community's take on the PR first.