### PR TITLE
[MSSQL] Format Merge Statement foreignKey violation as ForeignKeyConstraintError

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Future
-- [FIXED] Format MSSQL MERGE Statement foreignKey violations as ForeignKeyConstraintError, [#7024](https://github.com/sequelize/sequelize/pull/7024)
+- [FIXED] Throw MSSQL MERGE Statement foreignKey violations as ForeignKeyConstraintError [#7024](https://github.com/sequelize/sequelize/pull/7024)
 - [FIXED] Transaction Name too long, transaction savepoints for SQL Server [#6972](https://github.com/sequelize/sequelize/pull/6972)
 - [FIXED] Issue with sync hooks (before/afterInit, before/afterDefine) [#6680](https://github.com/sequelize/sequelize/issues/6680)
 - [FIXED] MSSQL handle large bulk inserts [#6866](https://github.com/sequelize/sequelize/issues/6866)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] Format MSSQL MERGE Statement foreignKey violations as ForeignKeyConstraintError, [#7024](https://github.com/sequelize/sequelize/pull/7024)
 - [FIXED] Transaction Name too long, transaction savepoints for SQL Server [#6972](https://github.com/sequelize/sequelize/pull/6972)
 - [FIXED] Issue with sync hooks (before/afterInit, before/afterDefine) [#6680](https://github.com/sequelize/sequelize/issues/6680)
 - [FIXED] MSSQL handle large bulk inserts [#6866](https://github.com/sequelize/sequelize/issues/6866)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Future
-- [FIXED] Throw MSSQL MERGE Statement foreignKey violations as ForeignKeyConstraintError [#7024](https://github.com/sequelize/sequelize/pull/7024)
+- [FIXED] Throw MSSQL MERGE Statement foreignKey violations as ForeignKeyConstraintError [#7011](https://github.com/sequelize/sequelize/pull/7011)
 - [FIXED] Transaction Name too long, transaction savepoints for SQL Server [#6972](https://github.com/sequelize/sequelize/pull/6972)
 - [FIXED] Issue with sync hooks (before/afterInit, before/afterDefine) [#6680](https://github.com/sequelize/sequelize/issues/6680)
 - [FIXED] MSSQL handle large bulk inserts [#6866](https://github.com/sequelize/sequelize/issues/6866)

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -246,6 +246,7 @@ class Query extends AbstractQuery {
     match = err.message.match(/Failed on step '(.*)'.Could not create constraint. See previous errors./) ||
             err.message.match(/The DELETE statement conflicted with the REFERENCE constraint "(.*)". The conflict occurred in database "(.*)", table "(.*)", column '(.*)'./) ||
             err.message.match(/The INSERT statement conflicted with the FOREIGN KEY constraint "(.*)". The conflict occurred in database "(.*)", table "(.*)", column '(.*)'./) ||
+            err.message.match(/The MERGE statement conflicted with the FOREIGN KEY constraint "(.*)". The conflict occurred in database "(.*)", table "(.*)", column '(.*)'./) ||
             err.message.match(/The UPDATE statement conflicted with the FOREIGN KEY constraint "(.*)". The conflict occurred in database "(.*)", table "(.*)", column '(.*)'./);
     if (match && match.length > 0) {
       return new sequelizeErrors.ForeignKeyConstraintError({

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -389,6 +389,30 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             });
         });
       });
+      
+      if (dialect === 'mssql') {
+        it('Should throw foreignKey violation for MERGE statement as ForeignKeyConstraintError', function () {
+          const User = this.sequelize.define('User', {
+            username: {
+              type: DataTypes.STRING,
+              primaryKey: true
+            }
+          });
+          const Posts = this.sequelize.define('Posts', {
+            title: {
+              type: DataTypes.STRING,
+              primaryKey: true
+            },
+            username: DataTypes.STRING
+          });
+          Posts.belongsTo(User, { foreignKey: 'username' });
+          return this.sequelize.sync({ force: true })
+            .then(() => User.create({ username: 'user1' }))
+            .then(() => {
+              return expect(Posts.upsert({ title: 'Title', username: 'user2' })).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
+            });
+        });
+      }
     });
   }
 });


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

SQL SERVER `MERGE` statement is used in upsert query. The foreignKey violations were formatted as sequelizeDatabaseError. Added `MERGE` statement to mssql formatError method
Closes #7011 