### PR TITLE
Fix benchmark logging for custom logging function

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -500,7 +500,7 @@ class Sequelize {
       if (options.replacements && options.bind) {
         throw new Error('Both `replacements` and `bind` cannot be set at the same time');
       }
-      
+
       if (options.replacements) {
         if (Array.isArray(options.replacements)) {
           sql = Utils.format([sql].concat(options.replacements), this.options.dialect);
@@ -1068,7 +1068,7 @@ class Sequelize {
       }
 
       // second argument is sql-timings, when benchmarking option enabled
-      if ((this.options.benchmark || options.benchmark) && options.logging === console.log) {
+      if ((this.options.benchmark || options.benchmark) && (typeof options.logging === 'function')) {
         args = [args[0] + ' Elapsed time: ' + args[1] + 'ms'];
       }
 


### PR DESCRIPTION
Quick fix for logging benchmark when using a custom logging function in the options.

Related issue is : https://github.com/sequelize/sequelize/issues/6947
