### PR TITLE
Clone defaultScope so it doesn't get overwritten in Model#init v3

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -604,7 +604,7 @@ Sequelize.prototype.define = function(modelName, attributes, options) { // testh
   var globalOptions = this.options;
 
   if (globalOptions.define) {
-    options = Utils.merge(globalOptions.define, options);
+    options = Utils.merge(_.cloneDeep(globalOptions.define), options);
   }
 
   options = Utils.merge({


### PR DESCRIPTION
As the title says. #6971 for details