### PR TITLE
Improved findall warnings

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -31,7 +31,7 @@
 - [FIXED] No `value` in built-in/custom validation errors [#3899](https://github.com/sequelize/sequelize/pull/3899)
 - [FIXED] Custom error messages used for incorrect eager loading [#7005](https://github.com/sequelize/sequelize/pull/7005)
 - [FIXED] Enforce unique association aliases [#7025](https://github.com/sequelize/sequelize/pull/7025)
-- [FIXED] Information warnings when findAll is given incorrect inputs [#7030](https://github.com/sequelize/sequelize/pull/7030)
+- [FIXED] Information warnings when findAll is given incorrect inputs [#7047](https://github.com/sequelize/sequelize/pull/7047)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/changelog.md
+++ b/changelog.md
@@ -31,6 +31,7 @@
 - [FIXED] No `value` in built-in/custom validation errors [#3899](https://github.com/sequelize/sequelize/pull/3899)
 - [FIXED] Custom error messages used for incorrect eager loading [#7005](https://github.com/sequelize/sequelize/pull/7005)
 - [FIXED] Enforce unique association aliases [#7025](https://github.com/sequelize/sequelize/pull/7025)
+- [FIXED] Information warnings when findAll is given incorrect inputs [#7030](https://github.com/sequelize/sequelize/pull/7030)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/model.js
+++ b/lib/model.js
@@ -1529,17 +1529,18 @@ class Model {
       return;
     }
 
+    // This list will quickly become dated, but failing to maintain this list just means
+    // we won't throw a warning when we should. At least most common cases will forever be covered
+    // so we stop throwing erroneous warnings when we shouldn't.
     const validQueryKeywords = ['where', 'attributes', 'paranoid', 'include', 'order', 'limit', 'offset',
-      'transaction', 'lock', 'raw', 'logging', 'benchmark', 'having', 'searchPath', 'rejectOnEmpty'];
+      'transaction', 'lock', 'raw', 'logging', 'benchmark', 'having', 'searchPath', 'rejectOnEmpty', 'plain',
+      'scope', 'group', 'through', 'defaults', 'distinct', 'primary', 'exception', 'type', 'hooks', 'force',
+      'name'];
 
     const unrecognizedOptions = _.difference(Object.keys(options), validQueryKeywords);
-    if (unrecognizedOptions.length > 0) {
-      const unexpectedModelAttributes = _.intersection(unrecognizedOptions, validColumnNames);
-      if (!options.where && unexpectedModelAttributes.length > 0) {
-        Utils.warn(`Model attributes (${unexpectedModelAttributes.join(', ')}) passed into finder method options, but the options.where object is empty. Did you forget to use options.where?`);
-      } else {
-        Utils.warn(`Invalid selections (${unrecognizedOptions.join(', ')}) passed into finder method options. These selections will be ignored.`);
-      }
+    const unexpectedModelAttributes = _.intersection(unrecognizedOptions, validColumnNames);
+    if (!options.where && unexpectedModelAttributes.length > 0) {
+      Utils.warn(`Model attributes (${unexpectedModelAttributes.join(', ')}) passed into finder method options, but the options.where object is empty. Did you forget to use options.where?`);
     }
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1446,6 +1446,8 @@ class Model {
       throw new Error('The argument passed to findAll must be an options object, use findById if you wish to pass a single primary key value');
     }
 
+    this.warnOnInvalidOptions(options, Object.keys(this.rawAttributes));
+
     const tableNames = {};
     let originalOptions;
 
@@ -1456,13 +1458,6 @@ class Model {
 
     // set rejectOnEmpty option from model config
     options.rejectOnEmpty = options.rejectOnEmpty || this.options.rejectOnEmpty;
-
-    // forgot to pass options.where ?
-    if (!options.where) {
-      const commonKeys =  _.intersection(_.keys(options), _.keys(this.rawAttributes));
-      // jshint -W030
-      commonKeys.length && Utils.warn(`Model attributes (${commonKeys.join(',')}) found in finder method options but options.where object is empty. Did you forget to use options.where?`);
-    }
 
     return Promise.try(() => {
       this._injectScope(options);
@@ -1527,6 +1522,25 @@ class Model {
 
       return Model._findSeparate(results, originalOptions);
     });
+  }
+
+  static warnOnInvalidOptions(options, validColumnNames) {
+    if (!_.isPlainObject(options)) {
+      return;
+    }
+
+    const validQueryKeywords = ['where', 'attributes', 'paranoid', 'include', 'order', 'limit', 'offset',
+      'transaction', 'lock', 'raw', 'logging', 'benchmark', 'having', 'searchPath', 'rejectOnEmpty'];
+
+    const unrecognizedOptions = _.difference(Object.keys(options), validQueryKeywords);
+    if (unrecognizedOptions.length > 0) {
+      const unexpectedModelAttributes = _.intersection(unrecognizedOptions, validColumnNames);
+      if (!options.where && unexpectedModelAttributes.length > 0) {
+        Utils.warn(`Model attributes (${unexpectedModelAttributes.join(', ')}) passed into finder method options, but the options.where object is empty. Did you forget to use options.where?`);
+      } else {
+        Utils.warn(`Invalid selections (${unrecognizedOptions.join(', ')}) passed into finder method options. These selections will be ignored.`);
+      }
+    }
   }
 
   static _findSeparate(results, options) {

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -22,26 +22,26 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const User = current.define('User');
       User.warnOnInvalidOptions({fakeOption1 : 12, fakeOption2 : 'hi', order: []});
       const expectedError = 'Invalid selections (fakeOption1, fakeOption2) passed into finder method options. These selections will be ignored.';
-      expect(this.loggerSpy.calledWith(expectedError)).to.be.true;
+      expect(this.loggerSpy.calledWith(expectedError)).to.equal(true);
     });
 
     it('Warns the user if they a model attribute without a where clause', () => {
       const User = current.define('User', {name: 'string'});
       User.warnOnInvalidOptions({name : 12, order: []}, ['name']);
       const expectedError = 'Model attributes (name) passed into finder method options, but the options.where object is empty. Did you forget to use options.where?';
-      expect(this.loggerSpy.calledWith(expectedError)).to.be.true;
+      expect(this.loggerSpy.calledWith(expectedError)).to.equal(true);
     });
 
     it('Does not warn the user if they use a model attribute without a where clause that shares its name with a query option', () => {
       const User = current.define('User', {order: 'string'});
       User.warnOnInvalidOptions({order: []});
-      expect(this.loggerSpy.called).to.be.false;
+      expect(this.loggerSpy.called).to.equal(false);
     });
 
     it('Does not warn the user if they use valid query options', () => {
       const User = current.define('User', {order: 'string'});
       User.warnOnInvalidOptions({where: {order: 1}, order: []});
-      expect(this.loggerSpy.called).to.be.false;
+      expect(this.loggerSpy.called).to.equal(false);
     });
   });
 

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 const DataTypes = require(__dirname + '/../../../lib/data-types');
 const Utils = require('../../../lib/utils.js');
 
-describe.only(Support.getTestDialectTeaser('Model'), () => {
+describe(Support.getTestDialectTeaser('Model'), () => {
   describe('warnOnInvalidOptions', () => {
     beforeEach(() => {
       this.loggerSpy = sinon.spy(Utils, 'warn');

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -8,8 +8,8 @@ const sinon = require('sinon');
 const DataTypes = require(__dirname + '/../../../lib/data-types');
 const Utils = require('../../../lib/utils.js');
 
-describe(Support.getTestDialectTeaser('Model'), function() {
-  describe.only('throws warnings on bad input', () => {
+describe(Support.getTestDialectTeaser('Model'), () => {
+  describe('warnOnInvalidOptions', () => {
     beforeEach(() => {
       this.loggerSpy = sinon.spy(Utils, 'warn');
     });
@@ -35,7 +35,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     it('Does not warn the user if they use a model attribute without a where clause that shares its name with a query option', () => {
       const User = current.define('User', {order: 'string'});
       User.warnOnInvalidOptions({order: []});
-      expect(this.loggerSpy.called).to.be.false;
+      expect(this.loggerSpy.called).to.be.false;  
     });
 
     it('Does not warn the user if they use valid query options', () => {
@@ -45,32 +45,32 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
   });
 
-  describe('method findAll', function () {
+  describe('method findAll', () => {
     const Model = current.define('model', {
       name: DataTypes.STRING
     }, { timestamps: false });
 
-    before(function () {
-      this.stub = sinon.stub(current.getQueryInterface(), 'select', function () {
+    before(() => {
+      this.stub = sinon.stub(current.getQueryInterface(), 'select', () => {
         return Model.build({});
       });
     });
 
-    beforeEach(function () {
+    beforeEach(() => {
       this.stub.reset();
     });
 
-    after(function () {
+    after(() => {
       this.stub.restore();
     });
 
-    describe('attributes include / exclude', function () {
-      it('allows me to include additional attributes', function () {
+    describe('attributes include / exclude', () => {
+      it('allows me to include additional attributes', () => {
         return Model.findAll({
           attributes: {
             include: ['foobar']
           }
-        }).bind(this).then(function () {
+        }).bind(this).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'id',
             'name',
@@ -79,25 +79,25 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
 
-      it('allows me to exclude attributes', function () {
+      it('allows me to exclude attributes', () => {
         return Model.findAll({
           attributes: {
             exclude: ['name']
           }
-        }).bind(this).then(function () {
+        }).bind(this).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'id'
           ]);
         });
       });
 
-      it('include takes precendence over exclude', function () {
+      it('include takes precendence over exclude', () => {
         return Model.findAll({
           attributes: {
             exclude: ['name'],
             include: ['name']
           }
-        }).bind(this).then(function () {
+        }).bind(this).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'id',
             'name'
@@ -105,7 +105,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
 
-      it('works for models without PK #4607', function () {
+      it('works for models without PK #4607', () => {
         const Model = current.define('model', {}, { timestamps: false });
         const Foo = current.define('foo');
         Model.hasOne(Foo);
@@ -117,7 +117,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             include: ['name']
           },
           include: [Foo]
-        }).bind(this).then(function () {
+        }).bind(this).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'name'
           ]);

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -18,23 +18,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       this.loggerSpy.restore();
     });
 
-    it('Warns the user if they use unrecognized options', () => {
-      const User = current.define('User');
-      User.warnOnInvalidOptions({fakeOption1 : 12, fakeOption2 : 'hi', order: []});
-      const expectedError = 'Invalid selections (fakeOption1, fakeOption2) passed into finder method options. These selections will be ignored.';
-      expect(this.loggerSpy.calledWith(expectedError)).to.equal(true);
-    });
-
-    it('Warns the user if they a model attribute without a where clause', () => {
-      const User = current.define('User', {name: 'string'});
-      User.warnOnInvalidOptions({name : 12, order: []}, ['name']);
-      const expectedError = 'Model attributes (name) passed into finder method options, but the options.where object is empty. Did you forget to use options.where?';
+    it('Warns the user if they use a model attribute without a where clause', () => {
+      const User = current.define('User', {firstName: 'string'});
+      User.warnOnInvalidOptions({firstName : 12, order: []}, ['firstName']);
+      const expectedError = 'Model attributes (firstName) passed into finder method options, but the options.where object is empty. Did you forget to use options.where?';
       expect(this.loggerSpy.calledWith(expectedError)).to.equal(true);
     });
 
     it('Does not warn the user if they use a model attribute without a where clause that shares its name with a query option', () => {
       const User = current.define('User', {order: 'string'});
-      User.warnOnInvalidOptions({order: []});
+      User.warnOnInvalidOptions({order: []}, ['order']);
       expect(this.loggerSpy.called).to.equal(false);
     });
 

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -8,7 +8,7 @@ const sinon = require('sinon');
 const DataTypes = require(__dirname + '/../../../lib/data-types');
 const Utils = require('../../../lib/utils.js');
 
-describe(Support.getTestDialectTeaser('Model'), () => {
+describe.only(Support.getTestDialectTeaser('Model'), () => {
   describe('warnOnInvalidOptions', () => {
     beforeEach(() => {
       this.loggerSpy = sinon.spy(Utils, 'warn');
@@ -54,14 +54,24 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       this.stub = sinon.stub(current.getQueryInterface(), 'select', () => {
         return Model.build({});
       });
+      this.warnOnInvalidOptionsStub = sinon.stub(Model, 'warnOnInvalidOptions');
     });
 
     beforeEach(() => {
       this.stub.reset();
+      this.warnOnInvalidOptionsStub.reset();
     });
 
     after(() => {
       this.stub.restore();
+      this.warnOnInvalidOptionsStub.restore();
+    });
+
+    describe('handles input validation', () => {
+      it('calls warnOnInvalidOptions', () => {
+        Model.findAll();
+        expect(this.warnOnInvalidOptionsStub.calledOnce).to.equal(true);
+      });
     });
 
     describe('attributes include / exclude', () => {

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -35,7 +35,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('Does not warn the user if they use a model attribute without a where clause that shares its name with a query option', () => {
       const User = current.define('User', {order: 'string'});
       User.warnOnInvalidOptions({order: []});
-      expect(this.loggerSpy.called).to.be.false;  
+      expect(this.loggerSpy.called).to.be.false;
     });
 
     it('Does not warn the user if they use valid query options', () => {

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -70,7 +70,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           attributes: {
             include: ['foobar']
           }
-        }).bind(this).then(() => {
+        }).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'id',
             'name',
@@ -84,7 +84,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           attributes: {
             exclude: ['name']
           }
-        }).bind(this).then(() => {
+        }).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'id'
           ]);
@@ -97,7 +97,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             exclude: ['name'],
             include: ['name']
           }
-        }).bind(this).then(() => {
+        }).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'id',
             'name'
@@ -117,7 +117,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             include: ['name']
           },
           include: [Foo]
-        }).bind(this).then(() => {
+        }).then(() => {
           expect(this.stub.getCall(0).args[2].attributes).to.deep.equal([
             'name'
           ]);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change
This PR resolves issue #7030. In addition, it adds an additional warning when invalid options are provided to findAll (and all of its callers). If a user passes an invalid option to this function, chances are his intention was to do something else. The goal of this PR is to help developers identify and correct their mistakes early.
