### PR TITLE
ES6 import v3

### DIFF
--- a/lib/associations/base.js
+++ b/lib/associations/base.js
@@ -24,3 +24,5 @@ Association.prototype.inspect = function() {
 };
 
 module.exports = Association;
+module.exports.Association = Association;
+module.exports.default = Association;

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -784,3 +784,5 @@ BelongsToMany.prototype.injectCreator = function(obj) {
 };
 
 module.exports = BelongsToMany;
+module.exports.BelongsToMany = BelongsToMany;
+module.exports.default = BelongsToMany;

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -257,3 +257,5 @@ BelongsTo.prototype.injectCreator = function(instancePrototype) {
 };
 
 module.exports = BelongsTo;
+module.exports.BelongsTo = BelongsTo;
+module.exports.default = BelongsTo;

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -535,3 +535,5 @@ HasMany.prototype.create = function(sourceInstance, values, options) {
 };
 
 module.exports = HasMany;
+module.exports.HasMany = HasMany;
+module.exports.default = HasMany;

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -272,3 +272,5 @@ HasOne.prototype.injectCreator = function(instancePrototype) {
 };
 
 module.exports = HasOne;
+module.exports.HasOne = HasOne;
+module.exports.default = HasOne;

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -47,7 +47,7 @@ function InstanceValidator(modelInstance, options) {
   this.inProgress = false;
 
   extendModelValidations(modelInstance);
-};
+}
 
 /** @define {string} The error key for arguments as passed by custom validators */
 InstanceValidator.RAW_KEY_NAME = '__raw';

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -15,7 +15,7 @@ var validator = require('./utils/validator-extras').validator
  * @param {Object} options A dict with options.
  * @constructor
  */
-var InstanceValidator = module.exports = function(modelInstance, options) {
+function InstanceValidator(modelInstance, options) {
   options = _.clone(options) || {};
 
   if (options.fields && !options.skip) {
@@ -354,3 +354,7 @@ InstanceValidator.prototype._pushError = function(isBuiltin, errorKey, rawError)
 
   this.errors.push(error);
 };
+
+module.exports = InstanceValidator;
+module.exports.InstanceValidator = InstanceValidator;
+module.exports.default = InstanceValidator;

--- a/lib/instance.js
+++ b/lib/instance.js
@@ -1082,3 +1082,5 @@ Instance.prototype.toJSON = function() {
 };
 
 module.exports = Instance;
+module.exports.Instance = Instance;
+module.exports.default = Instance;

--- a/lib/model-manager.js
+++ b/lib/model-manager.js
@@ -99,3 +99,5 @@ ModelManager.prototype.forEachModel = function(iterator, options) {
 };
 
 module.exports = ModelManager;
+module.exports.ModelManager = ModelManager;
+module.exports.default = ModelManager;

--- a/lib/model.js
+++ b/lib/model.js
@@ -2702,3 +2702,5 @@ Utils._.extend(Model.prototype, associationsMixin);
 Hooks.applyTo(Model);
 
 module.exports = Model;
+module.exports.Model = Model;
+module.exports.default = Model;

--- a/lib/model/attribute.js
+++ b/lib/model/attribute.js
@@ -6,3 +6,5 @@ var Attribute = function(options) {
 };
 
 module.exports = Attribute;
+module.exports.Attribute = Attribute;
+module.exports.default = Attribute;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1405,3 +1405,5 @@ Sequelize.prototype.normalizeAttribute = function(attribute) {
 
 // Allows the promise to access cls namespaces
 module.exports = Promise.Sequelize = Sequelize;
+module.exports.Sequelize = Sequelize;
+module.exports.default = Sequelize;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -16,7 +16,7 @@ var Utils = require('./utils');
  * @param {String} options.isolationLevel=true Sets the isolation level of the transaction.
  * @param {String} options.deferrable Sets the constraints to be deferred or immediately checked.
  */
-var Transaction = module.exports = function(sequelize, options) {
+function Transaction(sequelize, options) {
   this.sequelize = sequelize;
   this.savepoints = [];
   var generateTransactionId = this.sequelize.dialect.QueryGenerator.generateTransactionId;
@@ -39,7 +39,7 @@ var Transaction = module.exports = function(sequelize, options) {
   }
 
   delete this.options.transaction;
-};
+}
 
 /**
  * Types can be set per-transaction by passing `options.type` to `sequelize.transaction`.
@@ -292,3 +292,7 @@ Transaction.prototype.$clearCls = function () {
     }
   }
 };
+
+module.exports = Transaction;
+module.exports.Transaction = Transaction;
+module.exports.default = Transaction;


### PR DESCRIPTION
Small backport of my ES6 refactor for v3. Makes imports like
```ts
import {Sequelize} from 'sequelize'
```
possible and the TypeScript definitions easier.
