### PR TITLE
Consecutive function scopes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,7 @@
 - [FIXED] Custom error messages used for incorrect eager loading [#7005](https://github.com/sequelize/sequelize/pull/7005)
 - [FIXED] Enforce unique association aliases [#7025](https://github.com/sequelize/sequelize/pull/7025)
 - [FIXED] Information warnings when findAll is given incorrect inputs [#7047](https://github.com/sequelize/sequelize/pull/7047)
+- [FIXED] scope method syntax loses parameters when used multiple times [#7058](https://github.com/sequelize/sequelize/issues/7058)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/model.js
+++ b/lib/model.js
@@ -1303,7 +1303,7 @@ class Model {
         if (!!option.method) {
           if (Array.isArray(option.method) && !!self.options.scopes[option.method[0]]) {
             scopeName = option.method[0];
-            scope = self.options.scopes[scopeName].apply(self, option.method.splice(1));
+            scope = self.options.scopes[scopeName].apply(self, option.method.slice(1));
           }
           else if (!!self.options.scopes[option.method]) {
             scopeName = option.method;

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -161,6 +161,21 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    it.only('should work with consecutive function scopes', function () {
+      var scope = {method: ['actualValue', 11]};
+      expect(Company.scope(scope)._scope).to.deep.equal({
+        where: {
+          other_value: 11
+        }
+      });
+
+      expect(Company.scope(scope)._scope).to.deep.equal({
+        where: {
+          other_value: 11
+        }
+      });
+    });
+
     it('should be able to merge two scoped includes', function () {
       expect(Company.scope('users', 'projects')._scope).to.deep.equal({
         include: [

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -161,7 +161,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
-    it.only('should work with consecutive function scopes', function () {
+    it('should work with consecutive function scopes', function () {
       var scope = {method: ['actualValue', 11]};
       expect(Company.scope(scope)._scope).to.deep.equal({
         where: {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
  `npm run test-sqlite` and `npm run test-postgres` pass. I don't have the other dialects setup and configured locally.
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
  Closes #7058 
- [x] Have you added new tests to prevent regressions?
  Add test that fails before the change.
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

This PR changes [.splice](https://github.com/sequelize/sequelize/blob/master/lib/model.js#L1306) to `.slice` to ensure that the original methods array is not modified so the scope objects may be reused in consecutive calls to `.scope`.