### PR TITLE
Remove note about io.js

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Sequelize | The Node.js / io.js ORM for PostgreSQL, MySQL, SQLite and MSSQL
+site_name: Sequelize | The Node.js ORM for PostgreSQL, MySQL, SQLite and MSSQL
 site_description: Sequelize is an ORM for Node.js. It supports the dialects PostgreSQL, MySQL, SQLite and MSSQL.
 repo_url: https://github.com/sequelize/sequelize
 site_favicon: favicon.ico


### PR DESCRIPTION
I think it's time to ignore the io.js past and focus and just Node