### PR TITLE
MSSQL removeColumn method fix for primaryKey column

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] `removeColumn` method to support dropping primaryKey column (MSSQL) [#7081](https://github.com/sequelize/sequelize/pull/7081)
 - [ADDED] Filtered Indexes support for SQL Server [#7016](https://github.com/sequelize/sequelize/issues/7016)
 - [FIXED] Set `timestamps` and `paranoid` options from through model on `belongsToMany` association
 - [FIXED] Properly apply paranoid condition when `groupedLimit.on` association is `paranoid`

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -680,6 +680,25 @@ var QueryGenerator = {
     return sql;
   },
 
+  getPrimaryKeyConstraint(table, attributeName) {
+    const tableName = wrapSingleQuote(table.tableName || table);
+    const sql = [
+      'SELECT K.TABLE_NAME AS tableName,',
+      'K.COLUMN_NAME AS columnName,',
+      'K.CONSTRAINT_NAME AS constraintName',
+      'FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS C',
+      'JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS K',
+      'ON C.TABLE_NAME = K.TABLE_NAME',
+      'AND C.CONSTRAINT_CATALOG = K.CONSTRAINT_CATALOG',
+      'AND C.CONSTRAINT_SCHEMA = K.CONSTRAINT_SCHEMA',
+      'AND C.CONSTRAINT_NAME = K.CONSTRAINT_NAME',
+      'WHERE C.CONSTRAINT_TYPE = \'PRIMARY KEY\'',
+      `AND K.COLUMN_NAME = ${wrapSingleQuote(attributeName)}`,
+      `AND K.TABLE_NAME = ${tableName};`
+    ].join(' ');
+    return sql;
+  },
+
   dropForeignKeyQuery(tableName, foreignKey) {
     return Utils._.template('ALTER TABLE <%= table %> DROP <%= key %>')({
       table: this.quoteTable(tableName),

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -680,9 +680,9 @@ var QueryGenerator = {
     return sql;
   },
 
-  getPrimaryKeyConstraint(table, attributeName) {
+  getPrimaryKeyConstraintQuery(table, attributeName) {
     const tableName = wrapSingleQuote(table.tableName || table);
-    const sql = [
+    return [
       'SELECT K.TABLE_NAME AS tableName,',
       'K.COLUMN_NAME AS columnName,',
       'K.CONSTRAINT_NAME AS constraintName',
@@ -696,7 +696,6 @@ var QueryGenerator = {
       `AND K.COLUMN_NAME = ${wrapSingleQuote(attributeName)}`,
       `AND K.TABLE_NAME = ${tableName};`
     ].join(' ');
-    return sql;
   },
 
   dropForeignKeyQuery(tableName, foreignKey) {

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -46,6 +46,18 @@ var removeColumn = function(tableName, attributeName, options) {
       var dropForeignKeySql = self.QueryGenerator.dropForeignKeyQuery(tableName, results[0].constraint_name);
       return self.sequelize.query(dropForeignKeySql, { raw: true, logging: options.logging});
     })
+    .then(() => {
+      //Check if the current column is a primaryKey
+      const primaryKeyConstraintSql = self.QueryGenerator.getPrimaryKeyConstraint(tableName, attributeName);
+      return self.sequelize.query(primaryKeyConstraintSql, { raw: true, logging: options.logging });
+    })
+    .spread(result => {
+      if (!result.length) {
+        return;
+      }
+      const dropConstraintSql = self.QueryGenerator.dropConstraintQuery(tableName, result[0].constraintName);
+      return self.sequelize.query(dropConstraintSql, { raw: true, logging: options.logging});
+    })
     .then(function() {
       var removeSql = self.QueryGenerator.removeColumnQuery(tableName, attributeName);
       return self.sequelize.query(removeSql, { raw: true, logging: options.logging});

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -48,7 +48,7 @@ var removeColumn = function(tableName, attributeName, options) {
     })
     .then(() => {
       //Check if the current column is a primaryKey
-      const primaryKeyConstraintSql = self.QueryGenerator.getPrimaryKeyConstraint(tableName, attributeName);
+      const primaryKeyConstraintSql = self.QueryGenerator.getPrimaryKeyConstraintQuery(tableName, attributeName);
       return self.sequelize.query(primaryKeyConstraintSql, { raw: true, logging: options.logging });
     })
     .spread(result => {

--- a/lib/dialects/mysql/query-interface.js
+++ b/lib/dialects/mysql/query-interface.js
@@ -30,7 +30,8 @@ function removeColumn(tableName, columnName, options) {
       _.assign({ raw: true }, options)
     )
     .spread(results => {
-      if (!results.length) {
+      //Exclude primary key constraint
+      if (!results.length || results[0].constraint_name === 'PRIMARY') {
         // No foreign key constraints found, so we can remove the column
         return;
       }

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -639,7 +639,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
         });
       });
 
-      it('Should be able to remove a column with primaryKey', function () {
+      it('should be able to remove a column with primaryKey', function () {
         return this.queryInterface.removeColumn('users', 'manager').bind(this).then(function() {
           return this.queryInterface.describeTable('users');
         }).then(function(table) {
@@ -707,7 +707,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
           });
       });
 
-      it('Should be able to remove a column with primaryKey', function () {
+      it('should be able to remove a column with primaryKey', function () {
         return this.queryInterface.removeColumn({
           tableName: 'users',
           schema: 'archive'

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -638,6 +638,20 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
             expect(table).to.not.have.property('manager');
         });
       });
+
+      it('Should be able to remove a column with primaryKey', function () {
+        return this.queryInterface.removeColumn('users', 'manager').bind(this).then(function() {
+          return this.queryInterface.describeTable('users');
+        }).then(function(table) {
+          expect(table).to.not.have.property('manager');
+          return this.queryInterface.removeColumn('users', 'id');
+        }).then(function() {
+          return this.queryInterface.describeTable('users');
+        }).then(function(table) {
+          expect(table).to.not.have.property('id');
+        });
+      });
+      
     });
 
     describe('(with a schema)', function() {
@@ -691,6 +705,20 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
           }).then(function(table) {
             expect(table).to.not.have.property('lastName');
           });
+      });
+
+      it('Should be able to remove a column with primaryKey', function () {
+        return this.queryInterface.removeColumn({
+          tableName: 'users',
+          schema: 'archive'
+        }, 'id').bind(this).then(function() {
+          return this.queryInterface.describeTable({
+            tableName: 'users',
+            schema: 'archive'
+          });
+        }).then(function(table) {
+          expect(table).to.not.have.property('id');
+        });
       });
     });
   });

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -100,8 +100,8 @@ if (current.dialect.name === 'mssql') {
       });
     });
 
-    test('getPrimaryKeyConstraint', function () {
-      expectsql(QueryGenerator.getPrimaryKeyConstraint('myTable', 'myColumnName'), {
+    test('getPrimaryKeyConstraintQuery', function () {
+      expectsql(QueryGenerator.getPrimaryKeyConstraintQuery('myTable', 'myColumnName'), {
         mssql: 'SELECT K.TABLE_NAME AS tableName, K.COLUMN_NAME AS columnName, K.CONSTRAINT_NAME AS constraintName FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS C JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS K ON C.TABLE_NAME = K.TABLE_NAME AND C.CONSTRAINT_CATALOG = K.CONSTRAINT_CATALOG AND C.CONSTRAINT_SCHEMA = K.CONSTRAINT_SCHEMA AND C.CONSTRAINT_NAME = K.CONSTRAINT_NAME WHERE C.CONSTRAINT_TYPE = \'PRIMARY KEY\' AND K.COLUMN_NAME = \'myColumnName\' AND K.TABLE_NAME = \'myTable\';'
       });
     });

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -99,5 +99,11 @@ if (current.dialect.name === 'mssql') {
         mssql: "SELECT TOP 100 PERCENT id, name FROM (SELECT TOP 10 * FROM (SELECT ROW_NUMBER() OVER (ORDER BY [id]) as row_num, *  FROM myTable AS myOtherName) AS myOtherName WHERE row_num > 10) AS myOtherName"
       });
     });
+
+    test('getPrimaryKeyConstraint', function () {
+      expectsql(QueryGenerator.getPrimaryKeyConstraint('myTable', 'myColumnName'), {
+        mssql: 'SELECT K.TABLE_NAME AS tableName, K.COLUMN_NAME AS columnName, K.CONSTRAINT_NAME AS constraintName FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS AS C JOIN INFORMATION_SCHEMA.KEY_COLUMN_USAGE AS K ON C.TABLE_NAME = K.TABLE_NAME AND C.CONSTRAINT_CATALOG = K.CONSTRAINT_CATALOG AND C.CONSTRAINT_SCHEMA = K.CONSTRAINT_SCHEMA AND C.CONSTRAINT_NAME = K.CONSTRAINT_NAME WHERE C.CONSTRAINT_TYPE = \'PRIMARY KEY\' AND K.COLUMN_NAME = \'myColumnName\' AND K.TABLE_NAME = \'myTable\';'
+      });
+    });
   });
 }


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

When the `removeColumn` method is called on a primaryKey column, SQL Server errors as the primaryKey column has an associated constraint which should be dropped before dropping the primaryKey column.

- Added `getPrimaryKeyConstraint` method to retrieve primary key constraint based on tableName and columnName.
- Extends #4943 