### PR TITLE
Fixed spelling mistake from "popuplate" to "populate"

### DIFF
--- a/test/unit/instance/build.test.js
+++ b/test/unit/instance/build.test.js
@@ -9,7 +9,7 @@ var chai = require('chai')
 
 describe(Support.getTestDialectTeaser('Instance'), function() {
   describe('build', function () {
-    it('should popuplate NOW default values', function () {
+    it('should populate NOW default values', function () {
       var Model = current.define('Model', {
           created_time: {
             type: DataTypes.DATE,
@@ -53,7 +53,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       });
     });
 
-    it('should popuplate explicitely undefined UUID primary keys', function () {
+    it('should populate explicitely undefined UUID primary keys', function () {
       var Model = current.define('Model', {
         id: {
           type: DataTypes.UUID,


### PR DESCRIPTION
### Description of change

Rectified spelling mistake from "popuplate" to "populate"