### PR TITLE
Documentation: Bolded that through is required for Belongs-To-Many associations

### DIFF
--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -203,7 +203,7 @@ User.belongsToMany(Project, {through: 'UserProject'});
 
 This will create a new model called UserProject with the equivalent foreign keys `projectId` and `userId`. Whether the attributes are camelcase or not depends on the two models joined by the table (in this case User and Project).
 
-Defining `through` is required. Sequelize would previously attempt to autogenerate names but that would not always lead to the most logical setups.
+Defining `through` is **required**. Sequelize would previously attempt to autogenerate names but that would not always lead to the most logical setups.
 
 This will add methods `getUsers`, `setUsers`, `addUser`,`addUsers` to `Project`, and `getProjects`, `setProjects`, `addProject`, and `addProjects` to `User`.
 


### PR DESCRIPTION
> Defining ``through`` is required. 

When I was reading through I accidentally read over this a few times, bolding will make it stand out more.

New:

> Defining ``through`` is **required**. 