### PR TITLE
Fix documentation typo for creating belongsTo associations with an alias

### DIFF
--- a/docs/docs/associations.md
+++ b/docs/docs/associations.md
@@ -793,7 +793,10 @@ return Product.create({
     last_name: 'Hansen'
   }
 }, {
-  include: [ Creator ]
+  include: [{
+    model: Creator,
+    as: 'creator'
+  }]
 });
 ```
 


### PR DESCRIPTION
The include should be a hash containing the "model" and "as" keys