### PR TITLE
Fix `Instance.decrement` precision problems

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] Fix `Instance.decrement` precision problems [#7118](https://github.com/sequelize/sequelize/pull/7118)
 - [FIXED] MSSQL tedious debug regression fix when dialectOptions are not passed [#7130](https://github.com/sequelize/sequelize/pull/7130)
 - [CHANGED] `setIsolationLevelQuery` to skip under MSSQL dialect, added debug listener for tedious [#7130](https://github.com/sequelize/sequelize/pull/7130)
 - [FIXED] `sourceKey` FOR `hasMany` now also works if a `where` was specified in an `include` [#7141](https://github.com/sequelize/sequelize/issues/7141)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Future
-- [FIXED] Fix `Instance.decrement` precision problems [#7118](https://github.com/sequelize/sequelize/pull/7118)
+- [FIXED] Fix `Instance.decrement` precision problems [#7112](https://github.com/sequelize/sequelize/pull/7112)
 - [FIXED] MSSQL tedious debug regression fix when dialectOptions are not passed [#7130](https://github.com/sequelize/sequelize/pull/7130)
 - [CHANGED] `setIsolationLevelQuery` to skip under MSSQL dialect, added debug listener for tedious [#7130](https://github.com/sequelize/sequelize/pull/7130)
 - [FIXED] `sourceKey` FOR `hasMany` now also works if a `where` was specified in an `include` [#7141](https://github.com/sequelize/sequelize/issues/7141)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -377,6 +377,7 @@ const QueryGenerator = {
   /*
     Returns an update query.
     Parameters:
+      - operator -> String with the arithmetic operator (e.g. '+' or '-')
       - tableName -> Name of the table
       - values -> A hash with attribute-value-pairs
       - where -> A hash with conditions (e.g. {name: 'foo'})
@@ -385,7 +386,7 @@ const QueryGenerator = {
                  If you use a string, you have to escape it on your own.
    @private
   */
-  incrementQuery(tableName, attrValueHash, where, options) {
+  arithmeticQuery(operator, tableName, attrValueHash, where, options) {
     attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull);
 
     const values = [];
@@ -402,7 +403,7 @@ const QueryGenerator = {
 
     for (const key in attrValueHash) {
       const value = attrValueHash[key];
-      values.push(this.quoteIdentifier(key) + '=' + this.quoteIdentifier(key) + ' + ' + this.escape(value));
+      values.push(this.quoteIdentifier(key) + '=' + this.quoteIdentifier(key) + operator + this.escape(value));
     }
 
     options = options || {};

--- a/lib/model.js
+++ b/lib/model.js
@@ -3777,7 +3777,8 @@ class Model {
     options = _.defaults({}, options, {
       by: 1,
       attributes: {},
-      where: {}
+      where: {},
+      increment: true
     });
 
     const where = _.extend({}, options.where, identifier);
@@ -3806,6 +3807,10 @@ class Model {
         values[this.constructor.rawAttributes[attr].field] = values[attr];
         delete values[attr];
       }
+    }
+
+    if (!options.increment) {
+      return this.sequelize.getQueryInterface().decrement(this, this.constructor.getTableName(options), values, where, options).return(this);
     }
 
     return this.sequelize.getQueryInterface().increment(this, this.constructor.getTableName(options), values, where, options).return(this);
@@ -3837,17 +3842,9 @@ class Model {
    * @return {Promise}
    */
   decrement(fields, options) {
-    options = _.defaults({}, options, {
+    options = _.defaults({ increment: false }, options, {
       by: 1
     });
-
-    if (!Utils._.isString(fields) && !Utils._.isArray(fields)) { // Assume fields is key-value pairs
-      Utils._.each(fields, (value, field) => {
-        fields[field] = -value;
-      });
-    }
-
-    options.by = 0 - options.by;
 
     return this.increment(fields, options);
   }

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -638,7 +638,17 @@ class QueryInterface {
   }
 
   increment(instance, tableName, values, identifier, options) {
-    const sql = this.QueryGenerator.incrementQuery(tableName, values, identifier, options.attributes);
+    const sql = this.QueryGenerator.arithmeticQuery('+', tableName, values, identifier, options.attributes);
+
+    options = _.clone(options) || {};
+
+    options.type = QueryTypes.UPDATE;
+    options.instance = instance;
+    return this.sequelize.query(sql, options);
+  }
+
+  decrement(instance, tableName, values, identifier, options) {
+    const sql = this.QueryGenerator.arithmeticQuery('-', tableName, values, identifier, options.attributes);
 
     options = _.clone(options) || {};
 

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -171,5 +171,34 @@ if (current.dialect.name === 'mssql') {
         mssql: 'ALTER TABLE [myTable] DROP [myColumnKey]'
       });
     });
+
+    test('arithmeticQuery', () => {
+      [{
+        title:'Should use the plus operator',
+        arguments: ['+', 'myTable', { foo: 'bar' }, {}],
+        expectation: 'UPDATE myTable SET foo=foo+\'bar\' '
+      },
+      {
+        title:'Should use the plus operator with where clause',
+        arguments: ['+', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+        expectation: 'UPDATE myTable SET foo=foo+\'bar\' WHERE bar = \'biz\''
+      },
+      {
+        title:'Should use the minus operator',
+        arguments: ['-', 'myTable', { foo: 'bar' }],
+        expectation: 'UPDATE myTable SET foo=foo-\'bar\' '
+      },
+      {
+        title:'Should use the minus operator with where clause',
+        arguments: ['-', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+        expectation: 'UPDATE myTable SET foo=foo-\'bar\' WHERE bar = \'biz\''
+      }].forEach(test => {
+        it(test.title, () => {
+          expectsql(QueryGenerator.arithmeticQuery.call(QueryGenerator, test.arguments), {
+            mssql: test.expectation
+          });
+        });
+      });
+    });
   });
 }

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -11,6 +11,28 @@ var chai = require('chai')
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] QueryGenerator', function() {
     var suites = {
+      arithmeticQuery: [
+        {
+          title:'Should use the plus operator',
+          arguments: ['+', 'myTable', { foo: 'bar' }, {}],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`+\'bar\' '
+        },
+        {
+          title:'Should use the plus operator with where clause',
+          arguments: ['+', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`+\'bar\' WHERE `bar` = \'biz\''
+        },
+        {
+          title:'Should use the minus operator',
+          arguments: ['-', 'myTable', { foo: 'bar' }],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`-\'bar\' '
+        },
+        {
+          title:'Should use the minus operator with where clause',
+          arguments: ['-', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`-\'bar\' WHERE `bar` = \'biz\''
+        }
+      ],
       attributesToSQL: [
         {
           arguments: [{id: 'INTEGER'}],

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -14,6 +14,28 @@ var chai = require('chai')
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] QueryGenerator', function() {
     var suites = {
+      arithmeticQuery: [
+        {
+          title:'Should use the plus operator',
+          arguments: ['+', 'myTable', { foo: 'bar' }, {}],
+          expectation: 'UPDATE "myTable" SET "foo"="foo"+\'bar\'  RETURNING *'
+        },
+        {
+          title:'Should use the plus operator with where clause',
+          arguments: ['+', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+          expectation: 'UPDATE "myTable" SET "foo"="foo"+\'bar\' WHERE "bar" = \'biz\' RETURNING *'
+        },
+        {
+          title:'Should use the minus operator',
+          arguments: ['-', 'myTable', { foo: 'bar' }],
+          expectation: 'UPDATE "myTable" SET "foo"="foo"-\'bar\'  RETURNING *'
+        },
+        {
+          title:'Should use the minus operator with where clause',
+          arguments: ['-', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+          expectation: 'UPDATE "myTable" SET "foo"="foo"-\'bar\' WHERE "bar" = \'biz\' RETURNING *'
+        }
+      ],
       attributesToSQL: [
         {
           arguments: [{id: 'INTEGER'}],

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -20,6 +20,28 @@ if (dialect === 'sqlite') {
     });
 
     var suites = {
+      arithmeticQuery: [
+        {
+          title:'Should use the plus operator',
+          arguments: ['+', 'myTable', { foo: 'bar' }, {}],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`+\'bar\' '
+        },
+        {
+          title:'Should use the plus operator with where clause',
+          arguments: ['+', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`+\'bar\' WHERE `bar` = \'biz\''
+        },
+        {
+          title:'Should use the minus operator',
+          arguments: ['-', 'myTable', { foo: 'bar' }],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`-\'bar\' '
+        },
+        {
+          title:'Should use the minus operator with where clause',
+          arguments: ['-', 'myTable', { foo: 'bar' }, { bar: 'biz'}],
+          expectation: 'UPDATE `myTable` SET `foo`=`foo`-\'bar\' WHERE `bar` = \'biz\''
+        }
+      ],
       attributesToSQL: [
         {
           arguments: [{id: 'INTEGER'}],


### PR DESCRIPTION
Closes #7112.

### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?

### Description of change

As suggested by the issue #7112:
- Reuse and rename the `query-generator::incrementQuery()` to `query-generator::incrementOrDecrementQuery()`, which now receives a boolean argument to represent the intention of incrementing or decrementing.
- Rename `query-interface::increment()` to `query-interface::incrementOrDecrement()` to pass the option `options.increment`.
- Change the `model::decrement()` implementation to call `model::increment()` with the option `increment = false`.


Doubts: Tests are passing (`npm run test-docker`), but should we add any test for this internal change?