### PR TITLE
MSSQL - Skip isolationLevel query, enable tedious debugging

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [CHANGED] `setIsolationLevelQuery` to skip under MSSQL dialect, added debug listener for tedious [#7130](https://github.com/sequelize/sequelize/pull/7130)
 - [FIXED] `removeColumn` method to support dropping primaryKey column (MSSQL) [#7081](https://github.com/sequelize/sequelize/pull/7081)
 - [ADDED] Filtered Indexes support for SQL Server [#7016](https://github.com/sequelize/sequelize/issues/7016)
 - [FIXED] Set `timestamps` and `paranoid` options from through model on `belongsToMany` association

--- a/docs/docs/transactions.md
+++ b/docs/docs/transactions.md
@@ -134,6 +134,8 @@ return sequelize.transaction({
   });
 ```
 
+Note: The SET ISOLATION LEVEL queries are not logged in case of MSSQL as the specified isolationLevel is passed directly to tedious
+
 # Unmanaged transaction (then-callback)
 Unmanaged transactions force you to manually rollback or commit the transaction. If you don't do that, the transaction will hang until it times out. To start an unmanaged transaction, call `sequelize.transaction()` without a callback (you can still pass an options object) and call `then` on the returned promise. Notice that `commit()` and `rollback()` returns a promise.
 

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -5,6 +5,7 @@ const ResourceLock = require('./resource-lock');
 const Promise = require('../../promise');
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('connection:mssql');
+const debugTedious = Utils.getLogger().debugContext('connection:mssql:tedious');
 const sequelizeErrors = require('../../errors');
 const parserStore = require('../parserStore')('mssql');
 const _ = require('lodash');
@@ -112,6 +113,10 @@ class ConnectionManager extends AbstractConnectionManager {
             break;
         }
       });
+      
+      if (config.dialectOptions.debug) {
+        connection.on('debug', debugTedious);        
+      }
 
       if (config.pool.handleDisconnects) {
         connection.on('error', err => {

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -730,11 +730,7 @@ var QueryGenerator = {
   },
 
   setIsolationLevelQuery(value, options) {
-    if (options.parent) {
-      return;
-    }
-
-    return 'SET TRANSACTION ISOLATION LEVEL ' + value + ';';
+    
   },
 
   generateTransactionId() {


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change
1. Tedious accepts isolationLevel to be passed to beginTransaction query. Since we do the same [here](https://github.com/sequelize/sequelize/blob/master/lib/dialects/mssql/query.js#L54), we can skip the `setIsolationLevelQuery`. The `setIsolationLevel` query is skipped by the [this](https://github.com/sequelize/sequelize/blob/master/lib/query-interface.js#L833-L837) existing snippet.
2. Enable debugging of tedious. Tedious can be run in debug mode by passing debug object with available options from [tedious api](http://tediousjs.github.io/tedious/api-connection.html) via `dialectOptions`. Added debug listener