### PR TITLE
Add hint about migrations section

### DIFF
--- a/docs/docs/schema.md
+++ b/docs/docs/schema.md
@@ -8,6 +8,8 @@ If `force: true` it will first drop tables before recreating them.
 Sequelize has a [sister library](https://github.com/sequelize/umzug) for handling execution and logging of migration tasks.
 Sequelize provides a list of ways to programmatically create or change a table schema.
 
+To read more about below functions go to [Migrations section of docs.](migrations)
+
 ### createTable
 
 ### addColumn


### PR DESCRIPTION
### Description of change

I was just browsing through documentation and it wasn't really too easy for me to find about migrations when I was in "Working with table schemas". So I just added a hint where user can read more about below functions since they don't link to 
