### PR TITLE
V3: test/integration/assets/es6project.js gets deleted

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-- [FIXED] `after` hook removed so `test/integration/assets/es6project.js` is no longer removed when running tests.
+- [FIXED] `after` hook removed so `test/integration/assets/es6project.js` is no longer removed when running tests [#7143](https://github.com/sequelize/sequelize/issues/7143)
 
 # 3.30.0
 - [FIXED] `removeColumn` method to support dropping primaryKey column (MSSQL) [#7081](https://github.com/sequelize/sequelize/pull/7081)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,4 @@
+# Future
 - [FIXED] `after` hook removed so `test/integration/assets/es6project.js` is no longer removed when running tests [#7143](https://github.com/sequelize/sequelize/issues/7143)
 
 # 3.30.0

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,3 @@
-# Future
-- [FIXED] `after` hook removed so `test/integration/assets/es6project.js` is no longer removed when running tests [#7143](https://github.com/sequelize/sequelize/issues/7143)
-
 # 3.30.0
 - [FIXED] `removeColumn` method to support dropping primaryKey column (MSSQL) [#7081](https://github.com/sequelize/sequelize/pull/7081)
 - [ADDED] Support `sourceKey` for `hasMany` relationships [#4258](https://github.com/sequelize/sequelize/issues/4258)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+- [FIXED] `after` hook removed so `test/integration/assets/es6project.js` is no longer removed when running tests.
+
 # 3.30.0
 - [FIXED] `removeColumn` method to support dropping primaryKey column (MSSQL) [#7081](https://github.com/sequelize/sequelize/pull/7081)
 - [ADDED] Support `sourceKey` for `hasMany` relationships [#4258](https://github.com/sequelize/sequelize/issues/4258)

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -14,7 +14,6 @@ var chai = require('chai')
   , moment = require('moment')
   , Transaction = require(__dirname + '/../../lib/transaction')
   , sinon = require('sinon')
-  , fs = require('fs')
   , current = Support.sequelize;
 
 
@@ -1254,10 +1253,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), function() {
     it('imports a dao definition with a default export', function () {
       var Project = this.sequelize.import(__dirname + '/assets/es6project');
       expect(Project).to.exist;
-    });
-
-    after(function(){
-      fs.unlink(__dirname + '/assets/es6project.js');
     });
 
     it('imports a dao definition from a function', function() {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? (There are 2 tests that fail, and they failed from the initial download before code was added)
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions (this actually fixed a test, not the actual module)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This removes the after function from `test/integration/sequelize.test.js` that unlinks `test/integration/assets/es6project.js` as well as the `fs` requirement at the top.
