### PR TITLE
Throw an error when attribute options are not formatted correctly

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
 - [FIXED] Information warnings when findAll is given incorrect inputs [#7047](https://github.com/sequelize/sequelize/pull/7047)
 - [FIXED] scope method syntax loses parameters when used multiple times [#7058](https://github.com/sequelize/sequelize/issues/7058)
 - [INTERNAL] Updated to `generic-pool@3.1.6` [#7109](https://github.com/sequelize/sequelize/issues/7109)
+- [FIXED] findAll throws error if attributes option is formatted incorrectly [#7162](https://github.com/sequelize/sequelize/issues/7163)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -383,3 +383,16 @@ class AssociationError extends BaseError {
   }
 }
 exports.AssociationError = AssociationError;
+/**
+ * Thrown when a query is passed invalid options (see message for details)
+ * @extends BaseError
+ * @memberof Errors
+ */
+class QueryError extends BaseError {
+  constructor(message) {
+    super(message);
+    this.name = 'SequelizeQueryError';
+    this.message = message;
+  }
+}
+exports.QueryError = QueryError;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1451,7 +1451,13 @@ class Model {
    */
   static findAll(options) {
     if (options !== undefined && !_.isPlainObject(options)) {
-      throw new Error('The argument passed to findAll must be an options object, use findById if you wish to pass a single primary key value');
+      throw new sequelizeErrors.QueryError('The argument passed to findAll must be an options object, use findById if you wish to pass a single primary key value');
+    }
+
+    if (options !== undefined && options.attributes) {
+      if (!Array.isArray(options.attributes) && !_.isPlainObject(options.attributes)) {
+        throw new sequelizeErrors.QueryError('The attributes option must be an array of column names or an object');
+      }
     }
 
     this.warnOnInvalidOptions(options, Object.keys(this.rawAttributes));

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -7,6 +7,7 @@ const current = Support.sequelize;
 const sinon = require('sinon');
 const DataTypes = require(__dirname + '/../../../lib/data-types');
 const Utils = require('../../../lib/utils.js');
+const sequelizeErrors = require('../../../lib/errors');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('warnOnInvalidOptions', () => {
@@ -65,7 +66,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         Model.findAll();
         expect(this.warnOnInvalidOptionsStub.calledOnce).to.equal(true);
       });
+
+      it('Throws an error when the attributes option is formatted incorrectly', () => {
+        const errorFunction = Model.findAll.bind(Model, {attributes: 'name'});
+        expect(errorFunction).to.throw(sequelizeErrors.QueryError);
+      });
     });
+
 
     describe('attributes include / exclude', () => {
       it('allows me to include additional attributes', () => {

--- a/test/unit/model/findall.test.js
+++ b/test/unit/model/findall.test.js
@@ -73,7 +73,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
-
     describe('attributes include / exclude', () => {
       it('allows me to include additional attributes', () => {
         return Model.findAll({


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Currently, if a user attempts to pass a string into the attributes option of findAll, Sequelize throws the following error:

    Unhandled rejection TypeError: attributes.map is not a function
    at Object.escapeAttributes (/Users/nickdrane/coding/patch/sequelize/lib/dialects/abstract/query-generator.js:1028:37)
    at Object.selectQuery (/Users/nickdrane/coding/patch/sequelize/lib/dialects/abstract/query-generator.js:800:28)
    at QueryInterface.select (/Users/nickdrane/coding/patch/sequelize/lib/query-interface.js:635:27)
    at Promise.try.then.then.then (/Users/nickdrane/coding/patch/sequelize/lib/model.js:1513:34)
    at tryCatcher (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/nickdrane/coding/patch/sequelize/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:637:20)
    at tryOnImmediate (timers.js:610:5)
    at processImmediate [as _immediateCallback] (timers.js:582:5)

This change adds a check to the findAll function to catch this error preemptively, throwing an error that accurately describes the cause of the problem. Now if the user attempts to include a single attribute by using a string, the Sequelize will say:

    Unhandled rejection SequelizeQueryError: The attributes option must be an array of column names or an object