### PR TITLE
Fixes creation of polymorphic belongToMany associations in one step #7159

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3527,6 +3527,8 @@ class Model {
                   const values = {};
                   values[include.association.foreignKey] = this.get(this.constructor.primaryKeyAttribute, {raw: true});
                   values[include.association.otherKey] = instance.get(instance.constructor.primaryKeyAttribute, {raw: true});
+                  // Include values defined in the scope of the association
+                  _.assign(values, include.association.through.scope);
                   return include.association.throughModel.create(values, includeOptions);
                 });
               } else {

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -325,7 +325,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           },
           taggable_id: {
             type: DataTypes.INTEGER,
-            unique: 'item_tag'
+            unique: 'item_tag',
+            references: null
           },
           taggable: {
             type: DataTypes.STRING,

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -317,7 +317,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         var ItemTag = this.sequelize.define('ItemTag', {
           tag_id: {
             type: DataTypes.INTEGER,
-            unique: 'item_tag',
             references: {
               model: 'tags',
               key: 'id'
@@ -325,12 +324,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           },
           taggable_id: {
             type: DataTypes.INTEGER,
-            unique: 'item_tag',
             references: null
           },
           taggable: {
             type: DataTypes.STRING,
-            unique: 'item_tag'
           },
         }, {
             tableName: 'item_tag',
@@ -343,7 +340,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           constraints: false,
           through: {
             model: ItemTag,
-            unique: false,
             scope: {
               taggable: 'post'
             }
@@ -356,7 +352,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           constraints: false,
           through: {
             model: ItemTag,
-            unique: false,
             scope: {
               taggable: 'post'
             }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Fixes the issue I described in the comments of #7159, which is exactly the same issue except it's located in a different code path.

The following example from the documentation mentions the creation of associations with belongsToMany relations in one step, but it didn't actually work. This PR makes it work.
http://docs.sequelizejs.com/en/latest/docs/associations/#creating-elements-of-a-hasmany-or-belongstomany-association
