### PR TITLE
removing check for notNull violation when receiving undefined values

### DIFF
--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -306,7 +306,7 @@ InstanceValidator.prototype._extractValidatorArgs = function(test, validatorType
 InstanceValidator.prototype._validateSchema = function(rawAttribute, field, value) {
   var error;
 
-  if (rawAttribute.allowNull === false && ((value === null) || (value === undefined))) {
+  if (rawAttribute.allowNull === false && value === null) {
     error = new sequelizeError.ValidationErrorItem(field + ' cannot be null', 'notNull Violation', field, value);
     this.errors.push(error);
   }

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -41,6 +41,30 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
     });
+      
+    it('should not check for notNull Violation for undefined values', function () {
+      var ownerId = 2
+        , accountRowId;
+      return Account.create({
+        ownerId: ownerId,
+        name: Math.random().toString()
+      }).then(function (account) {
+        accountRowId = account.get('id');
+        var accountVal = {
+          name: Math.random().toString(),
+          ownerId: undefined
+        };
+        return Account.update(accountVal, {
+          where: {
+            id: accountRowId
+          }
+        });
+      }).then(function(rows) {
+        return Account.findById(accountRowId);
+      }).then(function(account) {
+        expect(account.ownerId).to.be.equal(ownerId);  
+      });
+    });      
 
 
     if (_.get(current.dialect.supports, 'returnValues.returning')) {


### PR DESCRIPTION
V3 fixes issue #7056

removing check for notNull violation when receiving undefined values as properties with undefined values are skipped.

currently, we need to check in mappers each field in order to do population :
```js
if (field) {
  model.db_field = field;
}
```

instead of just:
```js
model.db_field = field;
```

affects only for fields with allowNull: false. others behave correctly.