### PR TITLE
Support INSERT... ON CONFLICT for upserts in v3

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -216,6 +216,12 @@ var QueryGenerator = {
       emptyQuery += ' VALUES ()';
     }
 
+    if (this._dialect.supports.insertOnConflict && options.onConflict) {
+      valueQuery += ' ON CONFLICT ' + options.onConflict;
+      emptyQuery += ' ON CONFLICT ' + options.onConflict;
+      options.onConflictUsed = true;
+    }
+
     if (this._dialect.supports.returnValues && options.returning) {
       if (!!this._dialect.supports.returnValues.returning) {
         valueQuery += ' RETURNING *';

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -134,6 +134,10 @@ ConnectionManager.prototype.connect = function(config) {
     // Disable escape characters in strings, see https://github.com/sequelize/sequelize/issues/3545
     var query = '';
 
+    if (self.sequelize.options.databaseVersion !== 0 && semver.gte(self.sequelize.options.databaseVersion, '9.5.0')) {
+      self.dialect.supports.insertOnConflict = true;
+    }
+
     if (self.sequelize.options.databaseVersion !== 0 && semver.gte(self.sequelize.options.databaseVersion, '8.2.0')) {
       query += 'SET standard_conforming_strings=on;';
     }

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -46,7 +46,8 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(Abstract.prototype.supp
   JSON: true,
   JSONB: true,
   deferrableConstraints: true,
-  searchPath : true
+  searchPath : true,
+  insertOnConflict: true
 });
 
 ConnectionManager.prototype.defaultVersion = '9.4.0';

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -322,18 +322,63 @@ var QueryGenerator = {
   },
 
   upsertQuery: function (tableName, insertValues, updateValues, where, rawAttributes, options) {
-    var insert = this.insertQuery(tableName, insertValues, rawAttributes, options);
-    var update = this.updateQuery(tableName, updateValues, where, options, rawAttributes);
+    var self = this;
+    var databaseVersion = Utils._.get(self, 'sequelize.options.databaseVersion', 0);
 
-    // The numbers here are selected to match the number of affected rows returned by MySQL
-    return this.exceptionFn(
-      'sequelize_upsert',
-      tableName,
-      insert + ' RETURN 1;',
-      update + '; RETURN 2',
-      'unique_violation',
-      'integer'
-    );
+    var upsertFn = function() {
+      var insert = self.insertQuery(tableName, insertValues, rawAttributes, options);
+      var update = self.updateQuery(tableName, updateValues, where, options, rawAttributes);
+
+      // The numbers here are selected to match the number of affected rows returned by MySQL
+      return self.exceptionFn(
+        'sequelize_upsert',
+        tableName,
+        insert + ' RETURN 1;',
+        update + '; RETURN 2',
+        'unique_violation',
+        'integer'
+      );
+    };
+
+    var uniqueKeys = Object.keys(rawAttributes).filter(function(a) {
+      return rawAttributes[a].unique === true;
+    });
+    if (semver.lt(databaseVersion, '9.5.0') || uniqueKeys.length > 1) {
+      return upsertFn();
+    }
+
+    if (options.conflict && options.conflict.constraint) {
+      options.onConflict = 'ON CONSTRAINT ' + this.quoteIdentifier(options.conflict.constraint);
+    } else {
+      var targets = options.conflict && options.conflict.targets;
+      if (!targets) {
+        // If no conflict target columns were specified, use the primary key as
+        // the target
+        targets = [];
+        Object.keys(rawAttributes).forEach(function(key) {
+          if (rawAttributes[key].primaryKey) {
+            targets.push(rawAttributes[key].field);
+          }
+        });
+      }
+      if (!targets) {
+        // Fallback to stored procedure when we lack a target for ON CONFLICT
+        return upsertFn();
+      }
+      options.onConflict = "("+targets.join(',')+")";
+    }
+
+    options.onConflict += " DO UPDATE SET ";
+    options.onConflict += Object.keys(updateValues).map(function (key) {
+      key = this.quoteIdentifier(key);
+      return key + ' = excluded.'+key;
+    }, this).join(', ');
+
+    if (options.returning === undefined) {
+      options.returning = '*';
+    }
+
+    return self.insertQuery(tableName, insertValues, rawAttributes, options);
   },
 
   deleteQuery: function(tableName, where, options, model) {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -246,7 +246,10 @@ Query.prototype.run = function(sql, parameters) {
     } else if (QueryTypes.BULKDELETE === self.options.type) {
       return parseInt(result.rowCount, 10);
     } else if (self.isUpsertQuery()) {
-      return rows[0].sequelize_upsert;
+      if (!self.options.onConflictUsed) {
+        return rows[0].sequelize_upsert;
+      }
+      return self.options.returning === true ? rows[0] : rows.length;
     } else if (self.isInsertQuery() || self.isUpdateQuery()) {
       if (self.instance && self.instance.dataValues) {
         for (var key in rows[0]) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1997,7 +1997,7 @@ Model.prototype.findCreateFind = function(options) {
  * **Implementation details:**
  *
  * * MySQL - Implemented as a single query `INSERT values ON DUPLICATE KEY UPDATE values`
- * * PostgreSQL - Implemented as a temporary function with exception handling: INSERT EXCEPTION WHEN unique_constraint UPDATE
+ * * PostgreSQL - For Postgres >=9.5, implemented as INSERT values ON CONFLICT target UPDATE values. For earlier versions, implemented as a temporary function with exception handling: INSERT EXCEPTION WHEN unique_constraint UPDATE
  * * SQLite - Implemented as two queries `INSERT; UPDATE`. This means that the update is executed regardless of whether the row already existed or not
  * * MSSQL - Implemented as a single query using `MERGE` and `WHEN (NOT) MATCHED THEN`
  * **Note** that SQLite returns undefined for created, no matter if the row was created or updated. This is because SQLite always runs INSERT OR IGNORE + UPDATE, in a single query, so there is no way to know whether the row was inserted or not.
@@ -2010,6 +2010,8 @@ Model.prototype.findCreateFind = function(options) {
  * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
  * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
  * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+ * @param  {String}       [options.conflict.constraint] Name of constraint to be the target for ON CONFLICT (Postgres only)
+ * @param  {Array}        [options.conflict.targets] List of columns to be the target for ON CONFLICT (Postgres only)
  *
  * @alias insertOrUpdate
  * @return {Promise<created>} Returns a boolean indicating whether the row was created or updated.

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -552,7 +552,7 @@ QueryInterface.prototype.upsert = function(tableName, valuesByField, updateValue
 
   var sql = this.QueryGenerator.upsertQuery(tableName, valuesByField, updateValues, where, model.rawAttributes, options);
   return this.sequelize.query(sql, options).then(function (rowCount) {
-    if (rowCount === undefined) {
+    if (options.returning === true || rowCount === undefined) {
       return rowCount;
     }
 

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -2,6 +2,7 @@
 
 /* jshint -W030 */
 var chai = require('chai')
+  , semver = require('semver')
   , sinon = require('sinon')
   , Sequelize = require('../../../index')
   , Promise = Sequelize.Promise
@@ -10,6 +11,10 @@ var chai = require('chai')
   , DataTypes = require(__dirname + '/../../../lib/data-types')
   , dialect = Support.getTestDialect()
   , current = Support.sequelize;
+
+var supportsOnConflict = function() {
+  return dialect === 'postgres' && semver.gte(current.options.databaseVersion, '9.5.0');
+};
 
 describe(Support.getTestDialectTeaser('Model'), function() {
   before(function () {
@@ -70,6 +75,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).not.to.be.ok;
           }
@@ -83,7 +90,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
 
       it('works with upsert on a composite key', function() {
-        return this.User.upsert({ foo: 'baz', bar: 19, username: 'john' }).bind(this).then(function(created) {
+        var options = { conflict: { constraint: 'users_foo_bar_key' } };
+        return this.User.upsert({ foo: 'baz', bar: 19, username: 'john' }, options).bind(this).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
           } else {
@@ -91,10 +99,12 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           }
 
           this.clock.tick(1000);
-          return this.User.upsert({ foo: 'baz', bar: 19, username: 'doe' });
+          return this.User.upsert({ foo: 'baz', bar: 19, username: 'doe' }, options);
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).not.to.be.ok;
           }
@@ -162,6 +172,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).not.to.be.ok;
           }
@@ -208,6 +220,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).not.to.be.ok;
           }
@@ -225,6 +239,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         return this.User.upsert({ id: 42, baz: 'foo' }).bind(this).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).to.be.ok;
           }
@@ -233,6 +249,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).not.to.be.ok;
           }
@@ -247,6 +265,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         return this.ModelWithFieldPK.upsert({ userId: 42, foo: 'first' }).bind(this).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).to.be.ok;
           }
@@ -257,6 +277,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).not.to.be.ok;
           }
@@ -271,6 +293,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         return this.User.upsert({ id: 42, username: 'john', foo: this.sequelize.fn('upper', 'mixedCase1')}).bind(this).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).to.be.ok;
           }
@@ -281,6 +305,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             expect(created).not.to.be.ok;
           }
@@ -341,7 +367,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         }).then(function(created) {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
-
+          } else if (supportsOnConflict()) {
+            expect(created).to.be.ok;
           } else {
             // After set node-mysql flags = '-FOUND_ROWS' in connection of mysql,
             // result from upsert should be false when upsert a row to its current value


### PR DESCRIPTION
Resolves #4132

Heavily inspired by #6325

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This change adds the small extensions `options.conflict.target` and `options.conflict.constraint` to `Model.upsert` to support using PostgreSQL 9.5's `INSERT... ON CONFLICT` feature. This replaces  the stored procedure that's currently used. If Postgres >= 9.5 is used and no `options.conflict.*` options are specified, the primary key column(s) are implicitly used as the conflict target. If Sequelize is used with PostgreSQL prior to 9.5, we still use the existing stored procedure.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sequelize/sequelize/7174)
<!-- Reviewable:end -->
