### PR TITLE
performance: replace a critical usage of Array.concat with for loop/push

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [PERFORMANCE] more efficient array handing for certain large queries [#7175](https://github.com/sequelize/sequelize/pull/7175)
 - [FIXED] MSSQL tedious debug regression fix when dialectOptions are not passed [#7130](https://github.com/sequelize/sequelize/pull/7130)
 - [CHANGED] `setIsolationLevelQuery` to skip under MSSQL dialect, added debug listener for tedious [#7130](https://github.com/sequelize/sequelize/pull/7130)
 - [FIXED] `sourceKey` FOR `hasMany` now also works if a `where` was specified in an `include` [#7141](https://github.com/sequelize/sequelize/issues/7141)

--- a/lib/model.js
+++ b/lib/model.js
@@ -1578,7 +1578,10 @@ class Model {
             // Force array so we can concat no matter if it's 1:1 or :M
             if (!Array.isArray(associations)) associations = [associations];
 
-            return memo.concat(associations);
+            for (let i = 0, len = associations.length; i !== len; ++i) {
+              memo.push(associations[i]);
+            }
+            return memo;
           }, []),
           _.assign(
             {},


### PR DESCRIPTION
replace a critical usage of `Array.concat` with a `for` loop and `Array.prototype.push` for a performance improvement on large queries

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This change provides a performance boost to large queries. I found this when profiling an ugly query that returns tens of thousands of rows, with `include`s 4 levels deep. The line with `Array.concat()` is called hundreds of thousands of times and is a bottleneck.

For loops are [much faster](https://jsperf.com/array-concat-vs-push-sequelize) and in my real-world testing with the ugly query, was about 3 times faster, going from 60-90s down to about 21s.

Attached: part of the `node --profile` output that pointed me to this section of code. Profiling was based on Sequelize 4.0.0-2. [profiling-partial.txt](https://github.com/sequelize/sequelize/files/743526/profiling-partial.txt)

\* `npm run test` passes except for two tests that I don’t think are related (login information and incorrect credentials)