### PR TITLE
Using stringification of the identifier for update and delete queries

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -478,7 +478,9 @@ var QueryGenerator = {
       table: this.quoteTable(tableName),
       values: values.join(','),
       output: outputFragment,
-      where: this.whereQuery(where),
+      where: this.whereQuery(where, {
+        model: options.model
+      }),
       tmpTable: tmpTable
     };
 

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -184,7 +184,7 @@ var QueryGenerator = {
     return this.insertQuery(tableName, insertValues, rawAttributes, options);
   },
 
-  deleteQuery: function(tableName, where, options) {
+  deleteQuery: function(tableName, where, options, model) {
     options = options || {};
 
     var table = this.quoteTable(tableName);
@@ -193,7 +193,7 @@ var QueryGenerator = {
       return 'TRUNCATE ' + table;
     }
 
-    where = this.getWhereConditions(where);
+    where = this.getWhereConditions(where, tableName, model);
     var limit = '';
 
     if (Utils._.isUndefined(options.limit)) {

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -571,6 +571,7 @@ QueryInterface.prototype.bulkInsert = function(tableName, records, options, attr
 
 QueryInterface.prototype.update = function(instance, tableName, values, identifier, options) {
   options = _.clone(options || {});
+  options.model = instance.Model;
   options.hasTrigger = !!(instance && instance.$modelOptions && instance.$modelOptions.hasTrigger);
 
 


### PR DESCRIPTION
Guys, this is WIP PR, which means that unit tests are not passing, but in order to resolve this I need your help.

### Description of change

Currently sequelize does not pass model with where conditions of the `update` and `delete` queries. Because of this,where clause is not passed through the $stringify method of the type object and passes incorrect value to the DB. In my example, we use uuid-16bit-binary as primary key with custom type, which has own $stringify method. This method is called on `select` but not on modify and delete.

This change makes where clause of both queries more explicit, which breaks the unit testst for myqsl. For example: `DELETE FROM `public.test_users` WHERE `name` = 'foo'` becomes `DELETE FROM `public.test_users` WHERE `public.test_users`.`name` = 'foo\';`

Question is, do you allow such change, and what else should be done to get this PR through? Another question, is there another workround to have custom binary type as primary?
