### PR TITLE
Pass options object to MSSQL removeColumn queries

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [CHANGED] MSSQL `removeColumn` query to pass options to `sequelize.query` [#7139](https://github.com/sequelize/sequelize/pull/7193)
 - [FIXED] Updating `VIRTUAL` field throw `ER_EMPTY_QUERY` [#6356](https://github.com/sequelize/sequelize/issues/6356)
 - [FIXED] Fix `Instance.decrement` precision problems [#7112](https://github.com/sequelize/sequelize/pull/7112)
 - [FIXED] MSSQL tedious debug regression fix when dialectOptions are not passed [#7130](https://github.com/sequelize/sequelize/pull/7130)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Future
-- [CHANGED] MSSQL `removeColumn` query to pass options to `sequelize.query` [#7139](https://github.com/sequelize/sequelize/pull/7193)
+- [FIXED] Properly pass options to `sequelize.query` in `removeColumn` [MSSQL] [#7193](https://github.com/sequelize/sequelize/pull/7193)
 - [FIXED] Updating `VIRTUAL` field throw `ER_EMPTY_QUERY` [#6356](https://github.com/sequelize/sequelize/issues/6356)
 - [FIXED] Fix `Instance.decrement` precision problems [#7112](https://github.com/sequelize/sequelize/pull/7112)
 - [FIXED] MSSQL tedious debug regression fix when dialectOptions are not passed [#7130](https://github.com/sequelize/sequelize/pull/7130)

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const _ = require('lodash');
+
 /**
  Returns an object that treats MSSQL's inabilities to do certain queries.
 
@@ -20,47 +22,47 @@
   @param  {Boolean|Function} [options.logging] A function that logs the sql queries, or false for explicitly not logging these queries
  @private
  */
-var removeColumn = function(tableName, attributeName, options) {
-  var self = this;
+const removeColumn = function(tableName, attributeName, options) {
   options = options || {};
+  options = _.assign({ raw: true, logging: options.logging}, options);
 
-  var findConstraintSql = self.QueryGenerator.getDefaultConstraintQuery(tableName, attributeName);
-  return self.sequelize.query(findConstraintSql, { raw: true, logging: options.logging})
-    .spread(function(results) {
+  const findConstraintSql = this.QueryGenerator.getDefaultConstraintQuery(tableName, attributeName);
+  return this.sequelize.query(findConstraintSql, options)
+    .spread(results => {
       if (!results.length) {
         // No default constraint found -- we can cleanly remove the column
         return;
       }
-      var dropConstraintSql = self.QueryGenerator.dropConstraintQuery(tableName, results[0].name);
-      return self.sequelize.query(dropConstraintSql, { raw: true, logging: options.logging});
+      const dropConstraintSql = this.QueryGenerator.dropConstraintQuery(tableName, results[0].name);
+      return this.sequelize.query(dropConstraintSql, options);
     })
-    .then(function() {
-      var findForeignKeySql = self.QueryGenerator.getForeignKeyQuery(tableName, attributeName);
-      return self.sequelize.query(findForeignKeySql, { raw: true, logging: options.logging});
+    .then(() => {
+      const findForeignKeySql = this.QueryGenerator.getForeignKeyQuery(tableName, attributeName);
+      return this.sequelize.query(findForeignKeySql, options);
     })
-    .spread(function(results) {
+    .spread(results => {
       if (!results.length) {
         // No foreign key constraints found, so we can remove the column
         return;
       }
-      var dropForeignKeySql = self.QueryGenerator.dropForeignKeyQuery(tableName, results[0].constraint_name);
-      return self.sequelize.query(dropForeignKeySql, { raw: true, logging: options.logging});
+      const dropForeignKeySql = this.QueryGenerator.dropForeignKeyQuery(tableName, results[0].constraint_name);
+      return this.sequelize.query(dropForeignKeySql, options);
     })
     .then(() => {
       //Check if the current column is a primaryKey
-      const primaryKeyConstraintSql = self.QueryGenerator.getPrimaryKeyConstraintQuery(tableName, attributeName);
-      return self.sequelize.query(primaryKeyConstraintSql, { raw: true, logging: options.logging });
+      const primaryKeyConstraintSql = this.QueryGenerator.getPrimaryKeyConstraintQuery(tableName, attributeName);
+      return this.sequelize.query(primaryKeyConstraintSql, options);
     })
     .spread(result => {
       if (!result.length) {
         return;
       }
-      const dropConstraintSql = self.QueryGenerator.dropConstraintQuery(tableName, result[0].constraintName);
-      return self.sequelize.query(dropConstraintSql, { raw: true, logging: options.logging});
+      const dropConstraintSql = this.QueryGenerator.dropConstraintQuery(tableName, result[0].constraintName);
+      return this.sequelize.query(dropConstraintSql, options);
     })
-    .then(function() {
-      var removeSql = self.QueryGenerator.removeColumnQuery(tableName, attributeName);
-      return self.sequelize.query(removeSql, { raw: true, logging: options.logging});
+    .then(() => {
+      const removeSql = this.QueryGenerator.removeColumnQuery(tableName, attributeName);
+      return this.sequelize.query(removeSql, options);
     });
 };
 

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -21,8 +21,7 @@
  @private
  */
 const removeColumn = function(tableName, attributeName, options) {
-  options = options || {};
-  options = Object.assign({}, options);
+  options = Object.assign({ raw: true }, options || {});
 
   const findConstraintSql = this.QueryGenerator.getDefaultConstraintQuery(tableName, attributeName);
   return this.sequelize.query(findConstraintSql, options)

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-
 /**
  Returns an object that treats MSSQL's inabilities to do certain queries.
 
@@ -24,7 +22,7 @@ const _ = require('lodash');
  */
 const removeColumn = function(tableName, attributeName, options) {
   options = options || {};
-  options = _.assign({ raw: true, logging: options.logging}, options);
+  options = Object.assign({}, options);
 
   const findConstraintSql = this.QueryGenerator.getDefaultConstraintQuery(tableName, attributeName);
   return this.sequelize.query(findConstraintSql, options)


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?


### Description of change

Use lodash `_.assign` to pass user defined options such as transaction to MSSQL `removeColumn` queries
