### PR TITLE
Added unique indexes to rawAttributes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] Add `unique` indexes defined via options to `rawAttributes` [#7196]
 - [FIXED] Removed support where `order` value is string and interpreted as `Sequelize.literal()`. [#6935](https://github.com/sequelize/sequelize/issues/6935)
 - [CHANGED] `DataTypes.DATE` to use `DATETIMEOFFSET` [MSSQL] [#5403](https://github.com/sequelize/sequelize/issues/5403)
 - [FIXED] Properly pass options to `sequelize.query` in `removeColumn` [MSSQL] [#7193](https://github.com/sequelize/sequelize/pull/7193)

--- a/lib/model.js
+++ b/lib/model.js
@@ -842,7 +842,19 @@ class Model {
       }
     });
 
-    this.options.indexes = this.options.indexes.map(this._conformIndex);
+    this.options.indexes = this.options.indexes.map(index => {
+      index = this._conformIndex(index);
+      //Add unique indexes to rawAttributes
+      if (index.unique && index.fields) {
+        index.fields.forEach(field => {
+          const fieldName =  (typeof field === 'string') ? field : (field.name || field.attribute);
+          if (this.rawAttributes[fieldName]) {
+            this.rawAttributes[fieldName].unique = this.attributes[fieldName].unique = index.name || index.unique;
+          }
+        });
+      }
+      return index;
+    });
 
     this.sequelize.modelManager.addModel(this);
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -826,21 +826,6 @@ class Model {
     this._hasReadOnlyAttributes = this._readOnlyAttributes && this._readOnlyAttributes.length;
     this._isReadOnlyAttribute = Utils._.memoize(key => this._hasReadOnlyAttributes && this._readOnlyAttributes.indexOf(key) !== -1);
     this._addDefaultAttributes();
-
-    this.options.indexes = this.options.indexes.map(index => {
-      index = this._conformIndex(index);
-      //Add unique indexes to rawAttributes
-      if (index.unique && index.fields) {
-        for (const field of index.fields) {
-          const fieldName = typeof field === 'string' ? field : field.name || field.attribute;
-          if (this.rawAttributes[fieldName]) {
-            this.rawAttributes[fieldName].unique = this.attributes[fieldName].unique = index.name || index.unique;
-          }
-        }
-      }
-      return index;
-    });
-
     this.refreshAttributes();
 
     this._findAutoIncrementField();
@@ -855,6 +840,21 @@ class Model {
       if (_.isPlainObject(scope)) {
         this._conformOptions(scope, this);
       }
+    });
+
+    this.options.indexes = this.options.indexes.map(index => {
+      index = this._conformIndex(index);
+      //Add unique indexes to rawAttributes
+      if (index.unique && index.fields) {
+        for (const field of index.fields) {
+          const fieldName = typeof field === 'string' ? field : field.name || field.attribute;
+          if (this.rawAttributes[fieldName]) {
+            this.rawAttributes[fieldName].unique = this.attributes[fieldName].unique = index.name || index.unique;
+          }
+        }
+      }
+      
+      return index;
     });
 
     this.sequelize.modelManager.addModel(this);

--- a/lib/model.js
+++ b/lib/model.js
@@ -826,6 +826,21 @@ class Model {
     this._hasReadOnlyAttributes = this._readOnlyAttributes && this._readOnlyAttributes.length;
     this._isReadOnlyAttribute = Utils._.memoize(key => this._hasReadOnlyAttributes && this._readOnlyAttributes.indexOf(key) !== -1);
     this._addDefaultAttributes();
+
+    this.options.indexes = this.options.indexes.map(index => {
+      index = this._conformIndex(index);
+      //Add unique indexes to rawAttributes
+      if (index.unique && index.fields) {
+        for (const field of index.fields) {
+          const fieldName = typeof field === 'string' ? field : field.name || field.attribute;
+          if (this.rawAttributes[fieldName]) {
+            this.rawAttributes[fieldName].unique = this.attributes[fieldName].unique = index.name || index.unique;
+          }
+        }
+      }
+      return index;
+    });
+
     this.refreshAttributes();
 
     this._findAutoIncrementField();
@@ -840,20 +855,6 @@ class Model {
       if (_.isPlainObject(scope)) {
         this._conformOptions(scope, this);
       }
-    });
-
-    this.options.indexes = this.options.indexes.map(index => {
-      index = this._conformIndex(index);
-      //Add unique indexes to rawAttributes
-      if (index.unique && index.fields) {
-        index.fields.forEach(field => {
-          const fieldName =  (typeof field === 'string') ? field : (field.name || field.attribute);
-          if (this.rawAttributes[fieldName]) {
-            this.rawAttributes[fieldName].unique = this.attributes[fieldName].unique = index.name || index.unique;
-          }
-        });
-      }
-      return index;
     });
 
     this.sequelize.modelManager.addModel(this);

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -494,7 +494,7 @@ class QueryInterface {
     });
 
     Utils._.each(model.options.indexes, value => {
-      if (value.unique === true) {
+      if (value.unique) {
         // fields in the index may both the strings or objects with an attribute property - lets sanitize that
         indexFields = Utils._.map(value.fields, field => {
           if (Utils._.isPlainObject(field)) {

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -429,7 +429,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
 
-      it('works when indexes are created via indexes array', function() {
+      it('works when composite indexes are created via indexes array', function() {
         const User = current.define('User', {
           name: DataTypes.STRING,
           address: DataTypes.STRING,

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -390,6 +390,46 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
       });
       
+      it('works when indexes are created via indexes array', function() {
+        const User = this.sequelize.define('User', {
+          username: Sequelize.STRING,
+          email: Sequelize.STRING,
+          city: Sequelize.STRING
+        }, {
+          indexes: [{
+            unique: true,
+            fields: ['username']
+          }, {
+            unique: true,
+            fields: ['email']
+          }]
+        });
+
+        return User.sync({ force: true }).then(() => {
+          return User.upsert({ username: 'user1', email: 'user1@domain.ext', city: 'City' })
+            .then(created => {
+              if (dialect === 'sqlite') {
+                expect(created).to.be.undefined;
+              } else {
+                expect(created).to.be.ok;
+              }
+              return User.upsert({ username: 'user1', email: 'user1@domain.ext', city: 'New City' });
+            }).then(created => {
+              if (dialect === 'sqlite') {
+                expect(created).to.be.undefined;
+              } else {
+                expect(created).not.to.be.ok;
+              }
+              return User.findOne({ where: { username: 'user1', email: 'user1@domain.ext' }});
+            })
+            .then(user => {
+              expect(user.createdAt).to.be.ok;
+              expect(user.city).to.equal('New City');
+            });
+        });
+      });
+      
+
       if (dialect === 'mssql') {
         it('Should throw foreignKey violation for MERGE statement as ForeignKeyConstraintError', function () {
           const User = this.sequelize.define('User', {

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -428,7 +428,42 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             });
         });
       });
-      
+
+      it('works when indexes are created via indexes array', function() {
+        const User = current.define('User', {
+          name: DataTypes.STRING,
+          address: DataTypes.STRING,
+          city: DataTypes.STRING
+        }, {
+          indexes: [{
+            unique: 'users_name_address',
+            fields: ['name', 'address']
+          }]
+        });
+
+        return User.sync({ force: true }).then(() => {
+          return User.upsert({ name: 'user1', address: 'address', city: 'City' })
+            .then(created => {
+              if (dialect === 'sqlite') {
+                expect(created).to.be.undefined;
+              } else {
+                expect(created).to.be.ok;
+              }
+              return User.upsert({ name: 'user1', address: 'address', city: 'New City' });
+            }).then(created => {
+              if (dialect === 'sqlite') {
+                expect(created).to.be.undefined;
+              } else {
+                expect(created).not.to.be.ok;
+              }
+              return User.findOne({ where: { name: 'user1', address: 'address' }});
+            })
+            .then(user => {
+              expect(user.createdAt).to.be.ok;
+              expect(user.city).to.equal('New City');
+            });
+        });
+      });
 
       if (dialect === 'mssql') {
         it('Should throw foreignKey violation for MERGE statement as ForeignKeyConstraintError', function () {

--- a/test/unit/model/indexes.test.js
+++ b/test/unit/model/indexes.test.js
@@ -39,5 +39,37 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       expect(Model.options.indexes[0].unique).to.eql(true);
       expect(Model.options.indexes[1].unique).to.eql(true);
     });
+    
+    it('should set rawAttributes when indexes are defined via options', function() {
+      const User = current.define('User', {
+        username: DataTypes.STRING
+      }, {
+        indexes: [{
+          unique: true,
+          fields: ['username']
+        }]
+      });
+
+      expect(User.rawAttributes.username).to.have.property('unique');
+      expect(User.rawAttributes.username.unique).to.be.true;
+    });
+
+    it('should set rawAttributes when composite unique indexes are defined via options', function() {
+      const User = current.define('User', {
+        name: DataTypes.STRING,
+        address: DataTypes.STRING
+      }, {
+        indexes: [{
+          unique: 'users_name_address',
+          fields: ['name', 'address']
+        }]
+      });
+
+      expect(User.rawAttributes.name).to.have.property('unique');
+      expect(User.rawAttributes.name.unique).to.be.equal('users_name_address');
+
+      expect(User.rawAttributes.address).to.have.property('unique');
+      expect(User.rawAttributes.address.unique).to.be.equal('users_name_address');
+    });
   });
 });


### PR DESCRIPTION
## Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change
`indexes` defined via the following snippet are not added to `Model.rawAttributes`.

```javascript
const User = current.define('User', {
    name: DataTypes.STRING,
    address: DataTypes.STRING
}, {
    indexes: [{
        unique: true,
        fields: ['name', 'address']
    }]
});

```

`Model.upsert` query uses `rawAttributes` to find primary/unique indexes and hence the upsert query would fail in case of the above model definition.

Fixes https://github.com/sequelize/sequelize/pull/6842#issuecomment-274774286