### PR TITLE
MSSQL - Changed DataTypes.DATE to use DATETIMEOFFSET datatype

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [CHANGED] `DataTypes.DATE` to use `DATETIMEOFFSET` [MSSQL] [#5403](https://github.com/sequelize/sequelize/issues/5403)
 - [FIXED] Properly pass options to `sequelize.query` in `removeColumn` [MSSQL] [#7193](https://github.com/sequelize/sequelize/pull/7193)
 - [FIXED] Updating `VIRTUAL` field throw `ER_EMPTY_QUERY` [#6356](https://github.com/sequelize/sequelize/issues/6356)
 - [FIXED] Fix `Instance.decrement` precision problems [#7112](https://github.com/sequelize/sequelize/pull/7112)
@@ -50,6 +51,7 @@
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type
 - With `BelongsToMany` relationships `add/set/create` setters now set `through` attributes by passing them as `options.through` (previously second argument was used as `through` attributes, now its considered `options` with `through` being a sub option)
+- `DataTypes.DATE` now uses `DATETIMEOFFSET` instead of `DATETIME2` sql datatype in case of MSSQL to record timezone [#5403](https://github.com/sequelize/sequelize/issues/5403)
 
 # 4.0.0-2
 - [ADDED] include now supports string as an argument (on top of model/association), string will expand into an association matched literally from Model.associations

--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -7,7 +7,7 @@ const inherits = require('../../utils/inherits');
 module.exports = BaseTypes => {
   const warn = BaseTypes.ABSTRACT.warn.bind(undefined, 'https://msdn.microsoft.com/en-us/library/ms187752%28v=sql.110%29.aspx');
 
-  BaseTypes.DATE.types.mssql = [42];
+  BaseTypes.DATE.types.mssql = [43];
   BaseTypes.STRING.types.mssql = [231, 173];
   BaseTypes.CHAR.types.mssql = [175];
   BaseTypes.TEXT.types.mssql = false;
@@ -126,14 +126,7 @@ module.exports = BaseTypes => {
   inherits(DATE, BaseTypes.DATE);
 
   DATE.prototype.toSql = function toSql() {
-    return 'DATETIME2';
-  };
-
-  DATE.prototype._stringify = function _stringify(date, options) {
-    date = this._applyTimezone(date, options);
-
-    // mssql not allow +timezone datetime format
-    return date.format('YYYY-MM-DD HH:mm:ss.SSS');
+    return 'DATETIMEOFFSET';
   };
 
   function DATEONLY() {

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -169,14 +169,14 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
     suite('DATE', function () {
       testsql('DATE', DataTypes.DATE, {
         postgres: 'TIMESTAMP WITH TIME ZONE',
-        mssql: 'DATETIME2',
+        mssql: 'DATETIMEOFFSET',
         mysql: 'DATETIME',
         sqlite: 'DATETIME'
       });
 
       testsql('DATE(6)', DataTypes.DATE(6), {
         postgres: 'TIMESTAMP WITH TIME ZONE',
-        mssql: 'DATETIME2',
+        mssql: 'DATETIMEOFFSET',
         mysql: 'DATETIME(6)',
         sqlite: 'DATETIME'
       });

--- a/test/unit/sql/insert.js
+++ b/test/unit/sql/insert.js
@@ -54,7 +54,7 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
         {
           postgres: 'INSERT INTO "users" ("date") VALUES (\'2015-01-20 01:00:00.000 +01:00\');',
           sqlite: 'INSERT INTO `users` (`date`) VALUES (\'2015-01-20 00:00:00.000 +00:00\');',
-          mssql: 'INSERT INTO [users] ([date]) VALUES (N\'2015-01-20 01:00:00.000\');',
+          mssql: 'INSERT INTO [users] ([date]) VALUES (N\'2015-01-20 01:00:00.000 +01:00\');',
           mysql: "INSERT INTO `users` (`date`) VALUES ('2015-01-20 01:00:00');"
         });
     });
@@ -76,7 +76,7 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
         {
           postgres: 'INSERT INTO "users" ("date") VALUES (\'2015-01-20 02:02:03.089 +01:00\');',
           sqlite: 'INSERT INTO `users` (`date`) VALUES (\'2015-01-20 01:02:03.089 +00:00\');',
-          mssql: 'INSERT INTO [users] ([date]) VALUES (N\'2015-01-20 02:02:03.089\');',
+          mssql: 'INSERT INTO [users] ([date]) VALUES (N\'2015-01-20 02:02:03.089 +01:00\');',
           mysql: "INSERT INTO `users` (`date`) VALUES ('2015-01-20 02:02:03.089');"
         });
     });


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?
### Description of change
 
Closes https://github.com/sequelize/sequelize/issues/5403