### PR TITLE
Add quotes around column names for unique constraints in sqlite (fixes #4407)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,7 @@
 - [INTERNAL] Updated to `generic-pool@3.1.6` [#7109](https://github.com/sequelize/sequelize/issues/7109)
 - [FIXED] findAll throws error if attributes option is formatted incorrectly [#7162](https://github.com/sequelize/sequelize/issues/7163)
 - [FIXED] previous gave wrong value back [#7189](https://github.com/sequelize/sequelize/pull/7189)
+- [FIXED] Add quotes around column names for unique constraints in sqlite [#7224](https://github.com/sequelize/sequelize/pull/7224)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/changelog.md
+++ b/changelog.md
@@ -48,7 +48,7 @@
 - [INTERNAL] Updated to `generic-pool@3.1.6` [#7109](https://github.com/sequelize/sequelize/issues/7109)
 - [FIXED] findAll throws error if attributes option is formatted incorrectly [#7162](https://github.com/sequelize/sequelize/issues/7163)
 - [FIXED] previous gave wrong value back [#7189](https://github.com/sequelize/sequelize/pull/7189)
-- [FIXED] Add quotes around column names for unique constraints in sqlite [#7224](https://github.com/sequelize/sequelize/pull/7224)
+- [FIXED] Add quotes around column names for unique constraints in sqlite [#4407](https://github.com/sequelize/sequelize/pull/4407)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -62,7 +62,7 @@ const QueryGenerator = {
     if (!!options.uniqueKeys) {
       Utils._.each(options.uniqueKeys, columns => {
         if (!columns.singleField) { // If it's a single field its handled in column def, not as an index
-          attrStr += ', UNIQUE (' + columns.fields.join(', ') + ')';
+          attrStr += ', UNIQUE (' + columns.fields.map(field => this.quoteIdentifier(field)).join(', ') + ')';
         }
       });
     }

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -135,6 +135,10 @@ if (dialect === 'sqlite') {
         {
           arguments: ['myTable', {id: 'INTEGER PRIMARY KEY AUTOINCREMENT', name: 'VARCHAR(255)'}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255));'
+        },
+        {
+          arguments: ['myTable', {id: 'INTEGER PRIMARY KEY AUTOINCREMENT', name: 'VARCHAR(255)', surname: 'VARCHAR(255)'}, {uniqueKeys: {uniqueConstraint: {fields: ['name', 'surname']}}}],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255), `surname` VARCHAR(255), UNIQUE (`name`, `surname`));'
         }
       ],
 


### PR DESCRIPTION
This PR fixes a bug in the query generator for Sqlite, in which the definition of a composite unique constraint would not properly wrap in quotes the column names. This causes the statement to fail whenever a column name is the same as a reserved keyword (like `order`, `group`, `index`, ...), or when it contains certain non alpha-numerical characters (like a space).

For example the following declaration:

```js
this.sequelize.define('user', {
  name: {
    type: Sequelize.STRING,
    unique: 'uniqueConstraint'
  },
  'column with space': {
    type: Sequelize.INTEGER,
    unique: 'uniqueConstraint'
  }
});
```

would generate the following statement (new lines added for readability):

```sql
CREATE TABLE IF NOT EXISTS `users` (
  `id` INTEGER PRIMARY KEY AUTOINCREMENT,
  `name` VARCHAR(255),
  `column with space` VARCHAR(255),
  `createdAt` DATETIME NOT NULL,
  `updatedAt` DATETIME NOT NULL,
  UNIQUE (name, column with space)
);
```

The above statement contains a syntax error, as the name `column with space` inside the `UNIQUE` constraint must be wrapped in quotes.

This PR modifies the logic that builds that statement to ensure that those names are properly wrapped.

I have also provided a couple of tests to prevent regression.