### PR TITLE
Added feature to alter tables on sync. Fixes #537

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] `options.alter` to sequelize.sync() to alter existing tables.[#7230](https://github.com/sequelize/sequelize/pull/7230)
 - [FIXED] Removed support where `order` value is string and interpreted as `Sequelize.literal()`. [#6935](https://github.com/sequelize/sequelize/issues/6935)
 - [CHANGED] `DataTypes.DATE` to use `DATETIMEOFFSET` [MSSQL] [#5403](https://github.com/sequelize/sequelize/issues/5403)
 - [FIXED] Properly pass options to `sequelize.query` in `removeColumn` [MSSQL] [#7193](https://github.com/sequelize/sequelize/pull/7193)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Future
-- [ADDED] `options.alter` to sequelize.sync() to alter existing tables.[#7230](https://github.com/sequelize/sequelize/pull/7230)
+- [ADDED] `options.alter` to sequelize.sync() to alter existing tables.[#537](https://github.com/sequelize/sequelize/issues/537)
 - [FIXED] Show a reasonable message when using renameColumn with a missing column  [#6606](https://github.com/sequelize/sequelize/issues/6606)
 - [PERFORMANCE] more efficient array handing for certain large queries [#7175](https://github.com/sequelize/sequelize/pull/7175)
 - [FIXED] Add `unique` indexes defined via options to `rawAttributes` [#7196]

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -789,7 +789,7 @@ Sync all defined models to the DB.
 | [options.schema='public'] | String | The schema that the tables should be created in. This can be overriden for each table in sequelize.define |
 | [options.searchPath=DEFAULT] | String | An optional parameter to specify the schema search_path (Postgres only) |
 | [options.hooks=true] | Boolean | If hooks is true then beforeSync, afterSync, beforBulkSync, afterBulkSync hooks will be called |
-| [options.alter=false] | Boolean | Modify existing tables to fit models |
+| [options.alter=false] | Boolean | Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model. |
 
 
 ***

--- a/docs/api/sequelize.md
+++ b/docs/api/sequelize.md
@@ -790,6 +790,7 @@ Sync all defined models to the DB.
 | [options.schema='public'] | String | The schema that the tables should be created in. This can be overriden for each table in sequelize.define |
 | [options.searchPath=DEFAULT] | String | An optional parameter to specify the schema search_path (Postgres only) |
 | [options.hooks=true] | Boolean | If hooks is true then beforeSync, afterSync, beforBulkSync, afterBulkSync hooks will be called |
+| [options.alter=false] | Boolean | Modify existing tables to fit models |
 
 
 ***

--- a/lib/model.js
+++ b/lib/model.js
@@ -1115,20 +1115,17 @@ class Model {
       if(options.alter) {
         return this.QueryInterface.describeTable(this.getTableName(options))
           .then((columns) => {
-            var self = this;
             var changes = []; // array of promises to run
-            _.each(attributes, function(columnDesc, columnName) {
+            _.each(attributes, (columnDesc, columnName) => {
               if(!columns[columnName]) {
-                changes.push(() => self.QueryInterface.addColumn(self.getTableName(options), columnName, attributes[columnName]));
+                changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), columnName, attributes[columnName]));
               }
             });
-            _.each(columns, function(columnDesc, columnName) {
+            _.each(columns, (columnDesc, columnName) => {
               if(!attributes[columnName]) {
-                changes.push(() => self.QueryInterface.removeColumn(self.getTableName(options), columnName, options));
-              } else {
-                if(!attributes[columnName].primaryKey) {
-                  changes.push(() => self.QueryInterface.changeColumn(self.getTableName(options), columnName, attributes[columnName]));
-                }
+                changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
+              } else if(!attributes[columnName].primaryKey) {
+                changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnName, attributes[columnName]));
               }
             });
             return changes.reduce((p, fn) => p.then(fn), Promise.resolve());

--- a/lib/model.js
+++ b/lib/model.js
@@ -1115,7 +1115,7 @@ class Model {
       if (options.alter) {
         return this.QueryInterface.describeTable(this.getTableName(options))
           .then(columns => {
-            let changes = []; // array of promises to run
+            const changes = []; // array of promises to run
             _.each(attributes, (columnDesc, columnName) => {
               if (!columns[columnName]) {
                 changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), columnName, attributes[columnName]));

--- a/lib/model.js
+++ b/lib/model.js
@@ -1106,19 +1106,19 @@ class Model {
             var changes = []; // array of promises to run
             _.each(attributes, function(columnDesc, columnName) {
               if(!columns[columnName]) {
-                changes.push(self.QueryInterface.addColumn(self.getTableName(options), columnName, attributes[columnName]));
+                changes.push(() => self.QueryInterface.addColumn(self.getTableName(options), columnName, attributes[columnName]));
               }
             });
             _.each(columns, function(columnDesc, columnName) {
               if(!attributes[columnName]) {
-                changes.push(self.QueryInterface.removeColumn(self.getTableName(options), columnName, options));
+                changes.push(() => self.QueryInterface.removeColumn(self.getTableName(options), columnName, options));
               } else {
                 if(!attributes[columnName].primaryKey) {
-                  changes.push(self.QueryInterface.changeColumn(self.getTableName(options), columnName, attributes[columnName]));
+                  changes.push(() => self.QueryInterface.changeColumn(self.getTableName(options), columnName, attributes[columnName]));
                 }
               }
             });
-            return Promise.all(changes);
+            return changes.reduce((p, fn) => p.then(fn), Promise.resolve());
           });
         }
     })

--- a/lib/model.js
+++ b/lib/model.js
@@ -1115,7 +1115,7 @@ class Model {
       if(options.alter) {
         return this.QueryInterface.describeTable(this.getTableName(options))
           .then((columns) => {
-            var changes = []; // array of promises to run
+            let changes = []; // array of promises to run
             _.each(attributes, (columnDesc, columnName) => {
               if(!columns[columnName]) {
                 changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), columnName, attributes[columnName]));

--- a/lib/model.js
+++ b/lib/model.js
@@ -1112,19 +1112,19 @@ class Model {
     })
     .then(() => this.QueryInterface.createTable(this.getTableName(options), attributes, options, this))
     .then(() => {
-      if(options.alter) {
+      if (options.alter) {
         return this.QueryInterface.describeTable(this.getTableName(options))
-          .then((columns) => {
+          .then(columns => {
             let changes = []; // array of promises to run
             _.each(attributes, (columnDesc, columnName) => {
-              if(!columns[columnName]) {
+              if (!columns[columnName]) {
                 changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), columnName, attributes[columnName]));
               }
             });
             _.each(columns, (columnDesc, columnName) => {
-              if(!attributes[columnName]) {
+              if (!attributes[columnName]) {
                 changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
-              } else if(!attributes[columnName].primaryKey) {
+              } else if (!attributes[columnName].primaryKey) {
                 changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnName, attributes[columnName]));
               }
             });

--- a/lib/model.js
+++ b/lib/model.js
@@ -1098,6 +1098,30 @@ class Model {
       }
     })
     .then(() => this.QueryInterface.createTable(this.getTableName(options), attributes, options, this))
+    .then(() => {
+      if(options.alter) {
+        return this.QueryInterface.describeTable(this.getTableName(options))
+          .then((columns) => {
+            var self = this;
+            var changes = []; // array of promises to run
+            _.each(attributes, function(columnDesc, columnName) {
+              if(!columns[columnName]) {
+                changes.push(self.QueryInterface.addColumn(self.getTableName(options), columnName, attributes[columnName]));
+              }
+            });
+            _.each(columns, function(columnDesc, columnName) {
+              if(!attributes[columnName]) {
+                changes.push(self.QueryInterface.removeColumn(self.getTableName(options), columnName, options));
+              } else {
+                if(!attributes[columnName].primaryKey) {
+                  changes.push(self.QueryInterface.changeColumn(self.getTableName(options), columnName, attributes[columnName]));
+                }
+              }
+            });
+            return Promise.all(changes);
+          });
+        }
+    })
     .then(() => this.QueryInterface.showIndex(this.getTableName(options), options))
     .then(indexes => {
       // Assign an auto-generated name to indexes which are not named by the user

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -678,6 +678,7 @@ class Sequelize {
    * @param {String} [options.schema='public'] The schema that the tables should be created in. This can be overriden for each table in sequelize.define
    * @param  {String} [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param {Boolean} [options.hooks=true] If hooks is true then beforeSync, afterSync, beforBulkSync, afterBulkSync hooks will be called
+   * @param {Boolean} [options.alter=false] Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
    * @return {Promise}
    */
   sync(options) {

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -29,7 +29,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         })
         .then(() => this.sequelize.sync({alter: true}))
         .then(() => User.describe())
-        .then(data => expect(data).to.not.have.ownProperty('age'));
+        .then(data => {
+          expect(data).to.not.have.ownProperty('age')
+          expect(data).to.have.ownProperty('name')
+        });
     });
 
     it('should add a column if it exists in the model but not the database', function() {
@@ -64,7 +67,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
     });
 
-    it('should not modify data if the data type does not change', function() {
+    it('should not alter table if data type does not change', function() {
       var testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.STRING

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -13,74 +13,59 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       this.testSync = this.sequelize.define('testSync', {
         dummy: Sequelize.STRING
       });
-
       return this.testSync.drop();
     });
 
     it('should remove a column if it exists in the databases schema but not the model', function() {
-      let User = this.sequelize.define('testSync', {
+      const User = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
       });
       return this.sequelize.sync()
-        .bind(this)
         .then(() => {
           this.sequelize.define('testSync', {
             name: Sequelize.STRING
           });
         })
         .then(() => this.sequelize.sync({alter: true}))
-        .then(() => {
-          return User.describe().then(data => {
-            expect(data).to.not.ownProperty('age');
-          });
-        });
+        .then(() => User.describe())
+        .then(data => expect(data).to.not.have.ownProperty('age'));
     });
 
     it('should add a column if it exists in the model but not the database', function() {
-      let testSync = this.sequelize.define('testSync', {
+      const testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING
       });
       return this.sequelize.sync()
-        .bind(this)
-        .then(() => {
-          this.sequelize.define('testSync', {
+        .then(() => this.sequelize.define('testSync', {
             name: Sequelize.STRING,
             age: Sequelize.INTEGER
-          });
-        })
+          }))
         .then(() => this.sequelize.sync({alter: true}))
-        .then(() => {
-          return testSync.describe().then(data => {
-            expect(data).to.ownProperty('age');
-          });
-        });
+        .then(() => testSync.describe())
+        .then(data => expect(data).to.have.ownProperty('age'));
     });
 
     it('should change a column if it exists in the model but is different in the database', function() {
-      let testSync = this.sequelize.define('testSync', {
+      var testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
       });
       return this.sequelize.sync()
-        .bind(this)
-        .then(() => {
-          this.sequelize.define('testSync', {
+        .then(() => this.sequelize.define('testSync', {
             name: Sequelize.STRING,
             age: Sequelize.STRING
-          });
-        })
+          }))
         .then(() => this.sequelize.sync({alter: true}))
-        .then(() => {
-          return testSync.describe().then(data => {
-            expect(data).to.ownProperty('age');
-            expect(data.age.type).to.have.string('CHAR'); // CHARACTER VARYING, VARCHAR(n)
-          });
+        .then(() => testSync.describe())
+        .then(data => {
+          expect(data).to.have.ownProperty('age');
+          expect(data.age.type).to.have.string('CHAR'); // CHARACTER VARYING, VARCHAR(n)
         });
     });
 
     it('should not modify data if the data type does not change', function() {
-      let testSync = this.sequelize.define('testSync', {
+      var testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.STRING
       });

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -7,9 +7,9 @@ const chai = require('chai')
   , expect = chai.expect
   , Support = require(__dirname + '/../support');
 
-describe(Support.getTestDialectTeaser('Model'), function() {
-  describe('sync', function () {
-    beforeEach(function() {
+describe(Support.getTestDialectTeaser('Model'), () => {
+  describe('sync', () => {
+    beforeEach(() => {
       this.testSync = this.sequelize.define('testSync', {
         dummy: Sequelize.STRING
       });
@@ -17,61 +17,61 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       return this.testSync.drop();
     });
 
-    it('should remove a column if it exists in the databases schema but not the model', function() {
+    it('should remove a column if it exists in the databases schema but not the model', () => {
       let User = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
       });
       return this.sequelize.sync()
         .bind(this)
-        .then(function() {
+        .then(() => {
           this.sequelize.define('testSync', {
             name: Sequelize.STRING
           });
         })
         .then(() => this.sequelize.sync({alter: true}))
-        .then(function() {
+        .then(() => {
           return User.describe().then((data) => {
             expect(data).to.not.ownProperty('age');
           });
         });
     });
 
-    it('should add a column if it exists in the model but not the database', function() {
+    it('should add a column if it exists in the model but not the database', () => {
       let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING
       });
       return this.sequelize.sync()
         .bind(this)
-        .then(function() {
+        .then(() => {
           this.sequelize.define('testSync', {
             name: Sequelize.STRING,
             age: Sequelize.INTEGER
           });
         })
         .then(() => this.sequelize.sync({alter: true}))
-        .then(function() {
+        .then(() => {
           return testSync.describe().then((data) => {
             expect(data).to.ownProperty('age');
           });
         });
     });
 
-    it('should change a column if it exists in the model but is different in the database', function() {
+    it('should change a column if it exists in the model but is different in the database', () => {
       let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
       });
       return this.sequelize.sync()
         .bind(this)
-        .then(function() {
+        .then(() => {
           this.sequelize.define('testSync', {
             name: Sequelize.STRING,
             age: Sequelize.STRING
           });
         })
         .then(() => this.sequelize.sync({alter: true}))
-        .then(function() {
+        .then(() => {
           return testSync.describe().then((data) => {
             expect(data).to.ownProperty('age');
             expect(data.age.type).to.have.string('CHAR'); // CHARACTER VARYING, VARCHAR(n)
@@ -79,7 +79,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         });
     });
 
-    it('should not modify data if the data type does not change', function() {
+    it('should not modify data if the data type does not change', () => {
       let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.STRING

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -50,7 +50,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('should change a column if it exists in the model but is different in the database', function() {
-      var testSync = this.sequelize.define('testSync', {
+      const testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
       });
@@ -68,7 +68,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('should not alter table if data type does not change', function() {
-      var testSync = this.sequelize.define('testSync', {
+      const testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.STRING
       });

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -30,8 +30,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         .then(() => this.sequelize.sync({alter: true}))
         .then(() => User.describe())
         .then(data => {
-          expect(data).to.not.have.ownProperty('age')
-          expect(data).to.have.ownProperty('name')
+          expect(data).to.not.have.ownProperty('age');
+          expect(data).to.have.ownProperty('name');
         });
     });
 

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -2,7 +2,7 @@
 
 /* jshint -W030 */
 /* jshint -W110 */
-var chai = require('chai')
+const chai = require('chai')
   , Sequelize = require('../../../index')
   , expect = chai.expect
   , Support = require(__dirname + '/../support');
@@ -87,11 +87,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       return this.sequelize.sync()
         .then(() => testSync.create({name: 'test', age: '1'}))
         .then(() => this.sequelize.sync({alter: true}))
-        .then(function() {
-          return testSync.findOne().then((data) => {
-            expect(data.dataValues.name).to.eql('test');
-            expect(data.dataValues.age).to.eql('1');
-          });
+        .then(() => testSync.findOne())
+        .then(data => {
+          expect(data.dataValues.name).to.eql('test');
+          expect(data.dataValues.age).to.eql('1');
         });
     });
   });

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -60,21 +60,21 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     it('should change a column if it exists in the model but is different in the database', function() {
       var testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
-        age: Sequelize.STRING
+        age: Sequelize.INTEGER
       });
       return this.sequelize.sync()
         .bind(this)
         .then(function() {
           this.sequelize.define('testSync', {
             name: Sequelize.STRING,
-            age: Sequelize.INTEGER
+            age: Sequelize.STRING
           });
         })
         .then(() => this.sequelize.sync({alter: true}))
         .then(function() {
           return testSync.describe().then((data) => {
             expect(data).to.ownProperty('age');
-            expect(data.age.type).to.eql('INT(11)');
+            expect(data.age.type).to.have.string('CHAR'); // CHARACTER VARYING, VARCHAR(n)
           });
         });
     });

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/* jshint -W030 */
+/* jshint -W110 */
+var chai = require('chai')
+  , Sequelize = require('../../../index')
+  , expect = chai.expect
+  , Support = require(__dirname + '/../support');
+
+describe(Support.getTestDialectTeaser('Model'), function() {
+  describe('sync', function () {
+    beforeEach(function() {
+      this.testSync = this.sequelize.define('testSync', {
+        dummy: Sequelize.STRING
+      });
+
+      return this.testSync.drop();
+    });
+
+    it('should remove a column if it exists in the databases schema but not the model', function() {
+      var User = this.sequelize.define('testSync', {
+        name: Sequelize.STRING,
+        age: Sequelize.INTEGER
+      });
+      return this.sequelize.sync()
+        .bind(this)
+        .then(function() {
+          this.sequelize.define('testSync', {
+            name: Sequelize.STRING
+          });
+        })
+        .then(() => this.sequelize.sync({alter: true}))
+        .then(function() {
+          return User.describe().then((data) => {
+            expect(data).to.not.ownProperty('age');
+          });
+        });
+    });
+
+    it('should add a column if it exists in the model but not the database', function() {
+      var testSync = this.sequelize.define('testSync', {
+        name: Sequelize.STRING
+      });
+      return this.sequelize.sync()
+        .bind(this)
+        .then(function() {
+          this.sequelize.define('testSync', {
+            name: Sequelize.STRING,
+            age: Sequelize.INTEGER
+          });
+        })
+        .then(() => this.sequelize.sync({alter: true}))
+        .then(function() {
+          return testSync.describe().then((data) => {
+            expect(data).to.ownProperty('age');
+          });
+        });
+    });
+
+    it('should change a column if it exists in the model but is different in the database', function() {
+      var testSync = this.sequelize.define('testSync', {
+        name: Sequelize.STRING,
+        age: Sequelize.STRING
+      });
+      return this.sequelize.sync()
+        .bind(this)
+        .then(function() {
+          this.sequelize.define('testSync', {
+            name: Sequelize.STRING,
+            age: Sequelize.INTEGER
+          });
+        })
+        .then(() => this.sequelize.sync({alter: true}))
+        .then(function() {
+          return testSync.describe().then((data) => {
+            expect(data).to.ownProperty('age');
+            expect(data.age.type).to.eql('INT(11)');
+          });
+        });
+    });
+
+    it('should not modify data if the data type does not change', function() {
+      var testSync = this.sequelize.define('testSync', {
+        name: Sequelize.STRING,
+        age: Sequelize.STRING
+      });
+      return this.sequelize.sync()
+        .then(() => testSync.create({name: 'test', age: '1'}))
+        .then(() => this.sequelize.sync({alter: true}))
+        .then(function() {
+          return testSync.findOne().then((data) => {
+            expect(data.dataValues.name).to.eql('test');
+            expect(data.dataValues.age).to.eql('1');
+          });
+        });
+    });
+  });
+});

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -18,7 +18,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('should remove a column if it exists in the databases schema but not the model', function() {
-      var User = this.sequelize.define('testSync', {
+      let User = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
       });
@@ -38,7 +38,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('should add a column if it exists in the model but not the database', function() {
-      var testSync = this.sequelize.define('testSync', {
+      let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING
       });
       return this.sequelize.sync()
@@ -58,7 +58,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('should change a column if it exists in the model but is different in the database', function() {
-      var testSync = this.sequelize.define('testSync', {
+      let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
       });
@@ -80,7 +80,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
     });
 
     it('should not modify data if the data type does not change', function() {
-      var testSync = this.sequelize.define('testSync', {
+      let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.STRING
       });

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -7,9 +7,9 @@ const chai = require('chai')
   , expect = chai.expect
   , Support = require(__dirname + '/../support');
 
-describe(Support.getTestDialectTeaser('Model'), () => {
-  describe('sync', () => {
-    beforeEach(() => {
+describe(Support.getTestDialectTeaser('Model'), function() {
+  describe('sync', function() {
+    beforeEach(function() {
       this.testSync = this.sequelize.define('testSync', {
         dummy: Sequelize.STRING
       });
@@ -17,7 +17,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return this.testSync.drop();
     });
 
-    it('should remove a column if it exists in the databases schema but not the model', () => {
+    it('should remove a column if it exists in the databases schema but not the model', function() {
       let User = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
@@ -31,13 +31,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         })
         .then(() => this.sequelize.sync({alter: true}))
         .then(() => {
-          return User.describe().then((data) => {
+          return User.describe().then(data => {
             expect(data).to.not.ownProperty('age');
           });
         });
     });
 
-    it('should add a column if it exists in the model but not the database', () => {
+    it('should add a column if it exists in the model but not the database', function() {
       let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING
       });
@@ -51,13 +51,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         })
         .then(() => this.sequelize.sync({alter: true}))
         .then(() => {
-          return testSync.describe().then((data) => {
+          return testSync.describe().then(data => {
             expect(data).to.ownProperty('age');
           });
         });
     });
 
-    it('should change a column if it exists in the model but is different in the database', () => {
+    it('should change a column if it exists in the model but is different in the database', function() {
       let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.INTEGER
@@ -72,14 +72,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         })
         .then(() => this.sequelize.sync({alter: true}))
         .then(() => {
-          return testSync.describe().then((data) => {
+          return testSync.describe().then(data => {
             expect(data).to.ownProperty('age');
             expect(data.age.type).to.have.string('CHAR'); // CHARACTER VARYING, VARCHAR(n)
           });
         });
     });
 
-    it('should not modify data if the data type does not change', () => {
+    it('should not modify data if the data type does not change', function() {
       let testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING,
         age: Sequelize.STRING


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

This patch should provide an easy way to migrate the database automatically on the fly in a development environment. This is my first PR to an open source project, so let me know if anything should be structured differently.

This patch allows for altering existing tables when syncing. This will sometimes destroy data if there is no direct conversion from the existing type to the new type. When removing a column, the data in the deleted column will be destroyed. When adding a column, the data in the added column will be the default value.

~~Also, where should I put the tests as I couldn't find `sync` being tested anywhere I could only find sync being used in the hooks test and in most tests as a prerequisite.~~

Everything is tested and ready to merge.
