### PR TITLE
V3 Using schema name for postgres dialect in methods showAllTables

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -102,8 +102,9 @@ var QueryGenerator = {
     });
   },
 
-  showTablesQuery: function() {
-    return "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type LIKE '%TABLE' AND table_name != 'spatial_ref_sys';";
+  showTablesQuery: function(schemaName) {
+    schemaName = schemaName || 'public';
+    return "SELECT table_name FROM information_schema.tables WHERE table_schema = '"+ schemaName +"' AND table_type LIKE '%TABLE' AND table_name != 'spatial_ref_sys';";
   },
 
   describeTableQuery: function(tableName, schema) {
@@ -863,8 +864,12 @@ var QueryGenerator = {
    * @return {String}            The generated sql query.
    */
   getForeignKeysQuery: function(tableName, schemaName) {
-    return 'SELECT conname as constraint_name, pg_catalog.pg_get_constraintdef(r.oid, true) as condef FROM pg_catalog.pg_constraint r ' +
-      "WHERE r.conrelid = (SELECT oid FROM pg_class WHERE relname = '" + tableName + "' LIMIT 1) AND r.contype = 'f' ORDER BY 1;";
+    schemaName = schemaName || 'public';
+    return 'SELECT conname as constraint_name, ' +
+      'pg_catalog.pg_get_constraintdef(r.oid, true) as condef ' +
+      'FROM pg_catalog.pg_constraint r ' +
+      'WHERE r.conrelid = (SELECT p.oid FROM pg_class p JOIN pg_catalog.pg_namespace n ON n.oid = p.relnamespace ' +
+      "WHERE p.relname = '" + tableName + "' AND n.nspname = '" + schemaName +"' LIMIT 1) AND r.contype = 'f' ORDER BY 1;";
   },
 
   /**
@@ -872,10 +877,12 @@ var QueryGenerator = {
    *
    * @param  {String} tableName  The name of the table.
    * @param  {String} foreignKey The name of the foreign key constraint.
+   * @param  {String} schemaName The name of the schema.
    * @return {String}            The generated sql query.
    */
-  dropForeignKeyQuery: function(tableName, foreignKey) {
-    return 'ALTER TABLE ' + this.quoteTable(tableName) + ' DROP CONSTRAINT ' + this.quoteIdentifier(foreignKey) + ';';
+  dropForeignKeyQuery: function(tableName, foreignKey, schemaName) {
+    schemaName = schemaName || 'public';
+    return 'ALTER TABLE ' + this.quoteTable(schemaName) + '.' + this.quoteTable(tableName) + ' DROP CONSTRAINT ' + this.quoteIdentifier(foreignKey) + ';';
   },
 
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -306,12 +306,10 @@ QueryInterface.prototype.showAllTables = function(options) {
   });
 
   var showTablesSql = null;
-  if (options.schema){
+  if (options.schema)
     showTablesSql = this.QueryGenerator.showTablesQuery(options.schema);
-  }
-  else{
+  else
     showTablesSql = this.QueryGenerator.showTablesQuery();
-  }
 
   return self.sequelize.query(showTablesSql, options).then(function(tableNames) {
     return Utils._.flatten(tableNames);

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -306,10 +306,12 @@ QueryInterface.prototype.showAllTables = function(options) {
   });
 
   var showTablesSql = null;
-  if (options.schema)
+  if (options.schema){
     showTablesSql = this.QueryGenerator.showTablesQuery(options.schema);
-  else
+  }
+  else{
     showTablesSql = this.QueryGenerator.showTablesQuery();
+  }
 
   return self.sequelize.query(showTablesSql, options).then(function(tableNames) {
     return Utils._.flatten(tableNames);

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -305,7 +305,12 @@ QueryInterface.prototype.showAllTables = function(options) {
     type: QueryTypes.SHOWTABLES
   });
 
-  var showTablesSql = self.QueryGenerator.showTablesQuery();
+  var showTablesSql = null;
+  if (options.schema)
+    showTablesSql = this.QueryGenerator.showTablesQuery(options.schema);
+  else
+    showTablesSql = this.QueryGenerator.showTablesQuery();
+
   return self.sequelize.query(showTablesSql, options).then(function(tableNames) {
     return Utils._.flatten(tableNames);
   });

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -732,7 +732,12 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
     });
 
     it('should get a list of foreign keys for the table', function() {
-      var sql = this.queryInterface.QueryGenerator.getForeignKeysQuery('hosts', this.sequelize.config.database);
+      var sql = '';
+      if (dialect === 'postgres' || dialect === 'postgres-native') {
+        sql = this.queryInterface.QueryGenerator.getForeignKeysQuery('hosts', this.sequelize.config.schema);
+      } else {
+        sql = this.queryInterface.QueryGenerator.getForeignKeysQuery('hosts', this.sequelize.config.database);
+      }
       var self = this;
       return this.sequelize.query(sql, {type: this.sequelize.QueryTypes.FOREIGNKEYS}).then(function(fks) {
         expect(fks).to.have.length(3);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

Hi.
I want to use sequelize-auto with postgresql databases. Normally, I separate my tables into schemas, so I need to be able to use the schemas when executing the showAllTables method. So I added in the dialect of postgresql this support, based on the options of the Sequelize instance.

Reggards.
