### PR TITLE
V3 fixes callback beforeUpdate with model.update and individualHooks:…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# 3.30.3
+- [FIXED] instance model callback beforeUpdate with model.update and individualHooks:true not providing the changed value updates in callback. Utils._.extend was overriding changed values before they were copied to _previousDataValues with Utils._.forIn in model.js.
+
 # 3.30.2
 - [FIXED] `previous` method gave wrong value back [#7189](https://github.com/sequelize/sequelize/pull/7189)
 - [FIXED] Fixes setAssociation with scope [#7223](https://github.com/sequelize/sequelize/pull/7223)

--- a/lib/model.js
+++ b/lib/model.js
@@ -2530,16 +2530,17 @@ Model.prototype.update = function(values, options) {
           , different = false;
 
         return Promise.map(instances, function(instance) {
-          // Record updates in instances dataValues
-          Utils._.extend(instance.dataValues, values);
-          // Set the changed fields on the instance
+          // First, set the changed fields on the instance
           Utils._.forIn(valuesUse, function(newValue, attr) {
             if (newValue !== instance._previousDataValues[attr]) {
               instance.setDataValue(attr, newValue);
             }
           });
 
-          // Run beforeUpdate hook
+          // Second, record updates in instances dataValues
+          Utils._.extend(instance.dataValues, values);
+
+          // Third, run beforeUpdate hook
           return self.runHooks('beforeUpdate', instance, options).then(function() {
             if (!different) {
               var thisChangedValues = {};


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Fixes callback beforeUpdate with model.update and individualHooks:true not providing correct changed values in callback. Utils._.extend was overriding changed values before they were copied to _previousDataValues with Utils._.forIn in model.js.