### PR TITLE
V3 Add quotes around column names for unique constraints in sqlite (fixes #4407)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+# Future
+- [FIXED] Add quotes around column names for unique constraints in sqlite [#4407](https://github.com/sequelize/sequelize/issues/4407)
+
 # 3.30.2
 - [FIXED] `previous` method gave wrong value back [#7189](https://github.com/sequelize/sequelize/pull/7189)
 - [FIXED] Fixes setAssociation with scope [#7223](https://github.com/sequelize/sequelize/pull/7223)

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -69,9 +69,10 @@ var QueryGenerator = {
     , pkString = primaryKeys.map(function(pk) { return this.quoteIdentifier(pk); }.bind(this)).join(', ');
 
     if (!!options.uniqueKeys) {
+      var quoteIdentifier = this.quoteIdentifier.bind(this);
       Utils._.each(options.uniqueKeys, function(columns) {
         if (!columns.singleField) { // If it's a single field its handled in column def, not as an index
-          values.attributes += ', UNIQUE (' + columns.fields.join(', ') + ')';
+          values.attributes += ', UNIQUE (' + columns.fields.map(function(field) { return quoteIdentifier(field); }).join(', ') + ')';
         }
       });
     }

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -135,6 +135,10 @@ if (dialect === 'sqlite') {
         {
           arguments: ['myTable', {id: 'INTEGER PRIMARY KEY AUTOINCREMENT', name: 'VARCHAR(255)'}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255));'
+        },
+        {
+          arguments: ['myTable', {id: 'INTEGER PRIMARY KEY AUTOINCREMENT', name: 'VARCHAR(255)', surname: 'VARCHAR(255)'}, {uniqueKeys: {uniqueConstraint: {fields: ['name', 'surname']}}}],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255), `surname` VARCHAR(255), UNIQUE (`name`, `surname`));'
         }
       ],
 


### PR DESCRIPTION
This is a backport to V3 of the fix to the issue addressed in the PR #7224. It fixes the issue #4407.