### PR TITLE
Inconsistent behavior for paranoid records since #5897 (see issue #7204)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,8 @@
 - [FIXED] previous gave wrong value back [#7189](https://github.com/sequelize/sequelize/pull/7189)
 - [FIXED] Add quotes around column names for unique constraints in sqlite [#4407](https://github.com/sequelize/sequelize/pull/4407)
 - [FIXED] Connection error when fetching OIDs for unspported types in Postgres 8.2 or below [POSTGRES] [#5254](https://github.com/sequelize/sequelize/issues/5254)
+- [FIXED] Always use database time for populating and evaluating deletedAt field on paranoid records. [#7204](https://github.com/sequelize/sequelize/issues/7204)
+- [FIXED] Deleted paranoid records can be queried in the same second. [#7204](https://github.com/sequelize/sequelize/issues/7204)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/model.js
+++ b/lib/model.js
@@ -77,7 +77,7 @@ class Model {
     const deletedAtObject = {};
     let deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gte: model.sequelize.literal('CURRENT_TIMESTAMP'), $eq: null } };
+    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gt: model.sequelize.literal('CURRENT_TIMESTAMP'), $eq: null } };
 
     deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -2465,7 +2465,7 @@ class Model {
 
         where[field] = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-        attrValueHash[field] = Utils.now(this.sequelize.options.dialect);
+        attrValueHash[field] = this.sequelize.literal('CURRENT_TIMESTAMP');
         return this.QueryInterface.bulkUpdate(this.getTableName(options), attrValueHash, _.defaults(where, options.where), options, this.rawAttributes);
       } else {
         return this.QueryInterface.bulkDelete(this.getTableName(options), options.where, options, this);
@@ -3697,7 +3697,7 @@ class Model {
         const field = attribute.field || this.constructor._timestampAttributes.deletedAt;
         const values = {};
 
-        values[field] = new Date();
+        values[field] = this.sequelize.literal('CURRENT_TIMESTAMP');
         where[field] = attribute.hasOwnProperty('defaultValue') ? attribute.defaultValue : null;
 
         this.setDataValue(field, values[field]);

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -1810,7 +1810,7 @@ describe(Support.getTestDialectTeaser('Instance'), function() {
       return this.ParanoidUser.create({ username: 'fnord' }).then(function() {
         return self.ParanoidUser.findAll().then(function(users) {
           return users[0].destroy().then(function() {
-            expect(users[0].deletedAt.getMonth).to.exist;
+            expect(users[0].deletedAt.val).to.be.equal('CURRENT_TIMESTAMP');
 
             return users[0].reload({ paranoid: false }).then(function(user) {
               expect(user.deletedAt.getMonth).to.exist;

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1333,8 +1333,6 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       return ParanoidUser.sync({ force: true }).then(function() {
         return ParanoidUser.bulkCreate(data);
       }).bind({}).then(function() {
-        // since we save in UTC, let's format to UTC time
-        this.date = moment().utc().format('YYYY-MM-DD h:mm');
         return ParanoidUser.destroy({where: {secretValue: '42'}});
       }).then(function() {
         return ParanoidUser.findAll({order: ['id']});
@@ -1342,13 +1340,10 @@ describe(Support.getTestDialectTeaser('Model'), function() {
         expect(users.length).to.equal(1);
         expect(users[0].username).to.equal('Bob');
 
-        return self.sequelize.query('SELECT * FROM ' + qi('ParanoidUsers') + ' WHERE ' + qi('deletedAt') + ' IS NOT NULL ORDER BY ' + qi('id'));
+        return self.sequelize.query('SELECT * FROM ' + qi('ParanoidUsers') + ' WHERE ' + qi('deletedAt') + ' IS NOT NULL AND ' + qi('deletedAt') + ' <= CURRENT_TIMESTAMP ORDER BY ' + qi('id'));
       }).spread(function(users) {
         expect(users[0].username).to.equal('Peter');
         expect(users[1].username).to.equal('Paul');
-
-        expect(moment(new Date(users[0].deletedAt)).utc().format('YYYY-MM-DD h:mm')).to.equal(this.date);
-        expect(moment(new Date(users[1].deletedAt)).utc().format('YYYY-MM-DD h:mm')).to.equal(this.date);
       });
     });
 


### PR DESCRIPTION
This is a fix for 2 issues introduced by #5880/#5897 and documented in #7204:

1. Paranoid records remain visible for several hours after they've been deleted. How long the records take to delete seems to depend on how far the server is from UTC. The solution is to always use database time when populating and later evaluating the deletedAt field.
2. Deleted records can be queried in the same second. The paranoid clause should use 'greater than' instead of 'greater than or equal to' when evaluating the deletedAt field.

Given that this issue fundamentally affects the ability to delete paranoid records, I'd advocate for getting this into v4.

Relevant tests have been updated and now pass, and this change has been added to the 'future' section of the changelog. Please let me know if there's anything else I can do to expedite this!
