### PR TITLE
Expose OptimisticLockError on Sequelize object (#6637)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,7 @@
 - [FIXED] previous gave wrong value back [#7189](https://github.com/sequelize/sequelize/pull/7189)
 - [FIXED] Add quotes around column names for unique constraints in sqlite [#4407](https://github.com/sequelize/sequelize/pull/4407)
 - [FIXED] Connection error when fetching OIDs for unspported types in Postgres 8.2 or below [POSTGRES] [#5254](https://github.com/sequelize/sequelize/issues/5254)
+- [FIXED] Expose OptimisticLockError on Sequelize object [#7291](https://github.com/sequelize/sequelize/pull/7291)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1227,6 +1227,9 @@ Sequelize.prototype.ValidationError = Sequelize.ValidationError =
 Sequelize.prototype.ValidationErrorItem = Sequelize.ValidationErrorItem =
   sequelizeErrors.ValidationErrorItem;
 
+Sequelize.prototype.OptimisticLockError = Sequelize.OptimisticLockError =
+  sequelizeErrors.OptimisticLockError;
+
 Sequelize.prototype.DatabaseError = Sequelize.DatabaseError =
   sequelizeErrors.DatabaseError;
 

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -14,22 +14,26 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), function () {
     it('Should have the Error constructors exposed', function() {
       expect(Sequelize).to.have.property('Error');
       expect(Sequelize).to.have.property('ValidationError');
+      expect(Sequelize).to.have.property('OptimisticLockError');
       var sequelize = new Sequelize('mysql://user:pass@example.com:9821/dbname');
       expect(sequelize).to.have.property('Error');
       expect(sequelize).to.have.property('ValidationError');
+      expect(sequelize).to.have.property('OptimisticLockError');
     });
 
     it('Sequelize Errors instances should be instances of Error', function() {
       var error = new Sequelize.Error();
-      var errorMessage = 'Validation Error';
+      var errorMessage = 'error message';
       var validationError = new Sequelize.ValidationError(errorMessage, [
         new errors.ValidationErrorItem('<field name> cannot be null', 'notNull Violation', '<field name>', null)
       , new errors.ValidationErrorItem('<field name> cannot be an array or an object', 'string violation', '<field name>', null)
       ]);
+      var optimisticLockError = new Sequelize.OptimisticLockError();
 
       var sequelize = new Sequelize('mysql://user:pass@example.com:9821/dbname');
       var instError = new sequelize.Error();
       var instValidationError = new sequelize.ValidationError();
+      var instOptimisticLockError = new sequelize.OptimisticLockError();
 
       expect(error).to.be.instanceOf(Sequelize.Error);
       expect(error).to.be.instanceOf(Error);
@@ -40,10 +44,16 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), function () {
       expect(validationError).to.have.property('name', 'SequelizeValidationError');
       expect(validationError.message).to.equal(errorMessage);
 
+      expect(optimisticLockError).to.be.instanceOf(Sequelize.OptimisticLockError);
+      expect(optimisticLockError).to.be.instanceOf(Error);
+      expect(optimisticLockError).to.have.property('name', 'SequelizeOptimisticLockError');
+
       expect(instError).to.be.instanceOf(Sequelize.Error);
       expect(instError).to.be.instanceOf(Error);
       expect(instValidationError).to.be.instanceOf(Sequelize.ValidationError);
       expect(instValidationError).to.be.instanceOf(Error);
+      expect(instOptimisticLockError).to.be.instanceOf(Sequelize.OptimisticLockError);
+      expect(instOptimisticLockError).to.be.instanceOf(Error);
     });
 
     it('SequelizeValidationError should find errors by path', function() {


### PR DESCRIPTION
This PR is to expose the new OptimisticLockError introduced in #6637 so users may detect and handle conflicts accordingly. Unless I'm overlooking something, optimistic locking will not be fully functional until the error is available outside the project.

Tests have been added much like those for other errors (e.g. ValidationError).