### PR TITLE
Duplicated word 'code' removed.

### DIFF
--- a/docs/docs/models-usage.md
+++ b/docs/docs/models-usage.md
@@ -223,7 +223,7 @@ Project.findOne({
 })
 ```
 
-Both pieces of code code will generate the following:
+Both pieces of code will generate the following:
 
 ```sql
 SELECT *


### PR DESCRIPTION
### Description of change

Found a spot in the documentation duplicated some text it said: 

> code code

so I removed the duplicate text.
