### PR TITLE
restore setDataValue, fixed set issue with customGetter/Setter

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -853,7 +853,7 @@ class Model {
           }
         }
       }
-      
+
       return index;
     });
 
@@ -2993,12 +2993,11 @@ class Model {
    * @param {any} value
    */
   setDataValue(key, value) {
-    const originalValue = this.dataValues[key];
+    const originalValue = this._previousDataValues[key];
     if (!Utils.isPrimitive(value) || value !== originalValue) {
       this.changed(key, true);
     }
 
-    this._previousDataValues[key] = originalValue;
     this.dataValues[key] = value;
   }
 
@@ -3142,6 +3141,10 @@ class Model {
       // If not raw, and there's a custom setter
       if (!options.raw && this._customSetters[key]) {
         this._customSetters[key].call(this, value, key);
+        if (!Utils.isPrimitive(value) && value !== null || value !== originalValue) {
+          this._previousDataValues[key] = originalValue;
+          this.changed(key, true);
+        }
       } else {
         // Check if we have included models, and if this key matches the include model names/aliases
 

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -1,21 +1,17 @@
 'use strict';
 
 /* jshint -W030 */
-var Support = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , chai = require('chai')
-  , expect = chai.expect
-  , Support = require(__dirname + '/../support')
-  , current = Support.sequelize
-  , _ = require('lodash');
+const Support = require(__dirname + '/../support');
+const DataTypes = require(__dirname + '/../../../lib/data-types');
+const chai = require('chai');
+const expect = chai.expect;
+const current = Support.sequelize;
+const _ = require('lodash');
 
-describe(Support.getTestDialectTeaser('Model'), function() {
+describe(Support.getTestDialectTeaser('Model'), function () {
   describe('update', function () {
-
-    var Account;
-
     beforeEach(function() {
-      Account = this.sequelize.define('Account', {
+      this.Account = this.sequelize.define('Account', {
         ownerId: {
           type: DataTypes.INTEGER,
           allowNull: false,
@@ -25,59 +21,53 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           type: DataTypes.STRING
         }
       });
-      return Account.sync({force: true});
+      return this.Account.sync({force: true});
     });
 
     it('should only update the passed fields', function () {
-      return Account.create({
-        ownerId: 2
-      }).then(function (account) {
-        return Account.update({
+      return this.Account
+        .create({ ownerId: 2 })
+        .then(account => this.Account.update({
           name: Math.random().toString()
         }, {
           where: {
             id: account.get('id')
           }
-        });
-      });
+        }));
     });
 
 
     if (_.get(current.dialect.supports, 'returnValues.returning')) {
       it('should return the updated record', function () {
-        return Account.create({
-          ownerId: 2
-        }).then(function (account) {
-          return Account.update({
-            name: 'FooBar'
-          }, {
+        return this.Account.create({ ownerId: 2 }).then(account => {
+          return this.Account.update({ name: 'FooBar' }, {
             where: {
               id: account.get('id')
             },
             returning: true
-          }).spread(function(count, accounts) {
-            var account = accounts[0];
-            expect(account.ownerId).to.be.equal(2);
-            expect(account.name).to.be.equal('FooBar');
+          }).spread((count, accounts) => {
+            const firstAcc = accounts[0];
+            expect(firstAcc.ownerId).to.be.equal(2);
+            expect(firstAcc.name).to.be.equal('FooBar');
           });
         });
       });
     }
 
     if (current.dialect.supports['LIMIT ON UPDATE']) {
-      it('Should only update one row', function () {
-        return Account.create({
+      it('should only update one row', function () {
+        return this.Account.create({
           ownerId: 2,
           name: 'Account Name 1'
         })
         .then(() => {
-          return Account.create({
+          return this.Account.create({
             ownerId: 2,
             name: 'Account Name 2'
           });
         })
         .then(() => {
-          return Account.create({
+          return this.Account.create({
             ownerId: 2,
             name: 'Account Name 3'
           });
@@ -89,13 +79,12 @@ describe(Support.getTestDialectTeaser('Model'), function() {
             },
             limit: 1
           };
-          return Account.update({ name: 'New Name' }, options);
+          return this.Account.update({ name: 'New Name' }, options);
         })
         .then(account => {
           expect(account[0]).to.equal(1);
         });
       });
     }
-
   });
 });

--- a/test/unit/instance/previous.test.js
+++ b/test/unit/instance/previous.test.js
@@ -1,42 +1,37 @@
 'use strict';
 
 /* jshint -W030 */
-var chai = require('chai')
-  , expect = chai.expect
-  , Support   = require(__dirname + '/../support')
-  , DataTypes = require(__dirname + '/../../../lib/data-types')
-  , current   = Support.sequelize;
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../support');
+const DataTypes = require(__dirname + '/../../../lib/data-types');
+const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), function () {
   describe('previous', function () {
     it('should return correct previous value', function () {
-      var Model = current.define('Model', {
-          text: {
-            type: DataTypes.STRING,
-            get: function (name) {
-              return this.getDataValue(name);
-            },
-            set: function (value, name) {
-              this.setDataValue(name, value);
-            }
+      const Model = current.define('Model', {
+        text: DataTypes.STRING,
+        textCustom: {
+          type: DataTypes.STRING,
+          set(val) {
+            this.setDataValue('textCustom', val);
+          },
+          get() {
+            this.getDataValue('textCustom');
           }
-        })
-        , instance
-        , shouldBeEmpty
-        , shouldBeA;
-
-      instance = Model.build({ text: 'a' }, {
-        isNewRecord: false
+        }
       });
 
-      shouldBeEmpty = instance.previous('text');
+      const instance = Model.build({ text: 'a', textCustom: 'abc' });
+      expect(instance.previous('text')).to.be.not.ok;
+      expect(instance.previous('textCustom')).to.be.not.ok;
 
       instance.set('text', 'b');
+      instance.set('textCustom', 'def');
 
-      shouldBeA = instance.previous('text');
-
-      expect(shouldBeEmpty).to.be.not.ok;
-      expect(shouldBeA).to.be.equal('a');
+      expect(instance.previous('text')).to.be.equal('a');
+      expect(instance.previous('textCustom')).to.be.equal('abc');
     });
   });
 });


### PR DESCRIPTION
Fixed incorrect changes in `previous` method working from https://github.com/sequelize/sequelize/pull/7189#issuecomment-281325021

Actual issue that PR was trying to solve was `incorrect previous value when using custom getter / setter`. So I have added few more unit tests and a fix for that issue @nemisj 

This will also conform with the fact that `_previousDataValues` should be set in last stage of hook lifecycle.

@BorisKozo @barriber initially pointed out this issue, you guys please have a look on new changes as well