### PR TITLE
Deleted records can be queried in the same second

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -53,6 +53,7 @@
 - [FIXED] previous gave wrong value back [#7189](https://github.com/sequelize/sequelize/pull/7189)
 - [FIXED] Add quotes around column names for unique constraints in sqlite [#4407](https://github.com/sequelize/sequelize/pull/4407)
 - [FIXED] Connection error when fetching OIDs for unspported types in Postgres 8.2 or below [POSTGRES] [#5254](https://github.com/sequelize/sequelize/issues/5254)
+- [FIXED] Deleted paranoid records can be queried in the same second. [#7204](https://github.com/sequelize/sequelize/issues/7204)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/model.js
+++ b/lib/model.js
@@ -77,7 +77,7 @@ class Model {
     const deletedAtObject = {};
     let deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gte: model.sequelize.literal('CURRENT_TIMESTAMP'), $eq: null } };
+    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gt: model.sequelize.literal('CURRENT_TIMESTAMP'), $eq: null } };
 
     deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 


### PR DESCRIPTION
This is a revision of PR #7290 to address part 2 of issue #7204. The clause used for soft deletes should compare `deletedAt` using `$gt` and not `$gte` so records are *never* returned after they've been deleted.

The original PR for this issue also attempted to address server/database timezone inconsistencies but these changes have been abandoned in favor of configuring the database for UTC (see #7290 for details).