### PR TITLE
Show a reasonable message when column is missing in renameColumn

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FIXED] Show a reasonable message when using renameColumn with a missing column  [#6606](https://github.com/sequelize/sequelize/issues/6606)
 - [PERFORMANCE] more efficient array handing for certain large queries [#7175](https://github.com/sequelize/sequelize/pull/7175)
 - [FIXED] Add `unique` indexes defined via options to `rawAttributes` [#7196]
 - [FIXED] Removed support where `order` value is string and interpreted as `Sequelize.literal()`. [#6935](https://github.com/sequelize/sequelize/issues/6935)

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -373,6 +373,10 @@ class QueryInterface {
   renameColumn(tableName, attrNameBefore, attrNameAfter, options) {
     options = options || {};
     return this.describeTable(tableName, options).then(data => {
+      if (!data[attrNameBefore]) {
+        throw new Error('Table ' + tableName + ' doesn\'t have the column ' + attrNameBefore);
+      }
+
       data = data[attrNameBefore] || {};
 
       const _options = {};

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -421,6 +421,19 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
         expect(table).to.not.have.property('fruitId');
       });
     });
+
+    it('shows a reasonable error message when column is missing', function() {
+      var self = this;
+      var Users = self.sequelize.define('_Users', {
+        username: DataTypes.STRING
+      }, { freezeTableName: true });
+
+      var outcome = Users.sync({ force: true }).then(function() {
+        return self.queryInterface.renameColumn('_Users', 'email', 'pseudo');
+      });
+
+      return expect(outcome).to.be.rejectedWith('Table _Users doesn\'t have the column email');
+    });
   });
 
   describe('changeColumn', function() {


### PR DESCRIPTION
This fixes #6606.

