### PR TITLE
 removeAttribute('id') results in undefined: null data value (#7318)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 - [FIXED] Connection error when fetching OIDs for unspported types in Postgres 8.2 or below [POSTGRES] [#5254](https://github.com/sequelize/sequelize/issues/5254)
 - [FIXED] Expose OptimisticLockError on Sequelize object [#7291](https://github.com/sequelize/sequelize/pull/7291)
 - [FIXED] Deleted paranoid records can be queried in the same second. [#7204](https://github.com/sequelize/sequelize/issues/7204)/[#7332](https://github.com/sequelize/sequelize/pull/7332)
+- [FIXES] `removeAttribute('id')` results in `undefined: null` data value  [#7318] https://github.com/sequelize/sequelize/issues/7318
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/changelog.md
+++ b/changelog.md
@@ -56,7 +56,7 @@
 - [FIXED] Connection error when fetching OIDs for unspported types in Postgres 8.2 or below [POSTGRES] [#5254](https://github.com/sequelize/sequelize/issues/5254)
 - [FIXED] Expose OptimisticLockError on Sequelize object [#7291](https://github.com/sequelize/sequelize/pull/7291)
 - [FIXED] Deleted paranoid records can be queried in the same second. [#7204](https://github.com/sequelize/sequelize/issues/7204)/[#7332](https://github.com/sequelize/sequelize/pull/7332)
-- [FIXES] `removeAttribute('id')` results in `undefined: null` data value  [#7318] https://github.com/sequelize/sequelize/issues/7318
+- [FIXED] `removeAttribute('id')` results in `undefined: null` data value  [#7318] https://github.com/sequelize/sequelize/issues/7318
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/model.js
+++ b/lib/model.js
@@ -2908,7 +2908,7 @@ class Model {
       // set id to null if not passed as value, a newly created dao has no id
       // removing this breaks bulkCreate
       // do after default values since it might have UUID as a default value
-      if (!defaults.hasOwnProperty(this.constructor.primaryKeyAttribute)) {
+      if (this.constructor.primaryKeyAttribute && !defaults.hasOwnProperty(this.constructor.primaryKeyAttribute)) {
         defaults[this.constructor.primaryKeyAttribute] = null;
       }
 

--- a/test/unit/model/removeAttribute.test.js
+++ b/test/unit/model/removeAttribute.test.js
@@ -24,7 +24,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       expect(_.size(Model.primaryKeys)).to.equal(0);
     });
 
-      it('should not add undefined attribute after removing primary key attribute', function () {
+      it('should not add undefined attribute after removing primary key', function () {
           var Model = current.define('m', {
               name: DataTypes.STRING
           });

--- a/test/unit/model/removeAttribute.test.js
+++ b/test/unit/model/removeAttribute.test.js
@@ -23,5 +23,16 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       expect(Model.primaryKeyAttribute).to.be.undefined;
       expect(_.size(Model.primaryKeys)).to.equal(0);
     });
+
+      it('should not add undefined attribute after removing primary key', function () {
+          var Model = current.define('m', {
+              name: DataTypes.STRING
+          });
+
+          Model.removeAttribute('id');
+          const instance = Model.build();
+
+          expect(instance.dataValues).not.to.include.keys('undefined');
+      });
   });
 });

--- a/test/unit/model/removeAttribute.test.js
+++ b/test/unit/model/removeAttribute.test.js
@@ -24,7 +24,7 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       expect(_.size(Model.primaryKeys)).to.equal(0);
     });
 
-      it('should not add undefined attribute after removing primary key', function () {
+      it('should not add undefined attribute after removing primary key attribute', function () {
           var Model = current.define('m', {
               name: DataTypes.STRING
           });

--- a/test/unit/model/removeAttribute.test.js
+++ b/test/unit/model/removeAttribute.test.js
@@ -30,8 +30,8 @@ describe(Support.getTestDialectTeaser('Model'), function() {
           });
 
           Model.removeAttribute('id');
-          const instance = Model.build();
 
+          const instance = Model.build();
           expect(instance.dataValues).not.to.include.keys('undefined');
       });
   });


### PR DESCRIPTION
Fix for Issue #7318 - removeAttribute('id') results in undefined: null data value (https://github.com/sequelize/sequelize/issues/7318)
Added regression test for the fix