### PR TITLE
fix: Make bulkCreate run in O(N) time. Closes issue #4247.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,7 @@
 - [FIXED] Connection error when fetching OIDs for unspported types in Postgres 8.2 or below [POSTGRES] [#5254](https://github.com/sequelize/sequelize/issues/5254)
 - [FIXED] Expose OptimisticLockError on Sequelize object [#7291](https://github.com/sequelize/sequelize/pull/7291)
 - [FIXED] Deleted paranoid records can be queried in the same second. [#7204](https://github.com/sequelize/sequelize/issues/7204)/[#7332](https://github.com/sequelize/sequelize/pull/7332)
+- [FIXED] `bulkCreate` now runs in O(N) time instead of O(N^2) time. [#4247](https://github.com/sequelize/sequelize/issues/4247)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -222,7 +222,7 @@ const QueryGenerator = {
 
     const query = 'INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>) VALUES <%= tuples %><%= onDuplicateKeyUpdate %><%= returning %>;';
     const tuples = [];
-    const serials = [];
+    const serials = {};
     const allAttributes = [];
     let onDuplicateKeyUpdate = '';
 
@@ -233,14 +233,14 @@ const QueryGenerator = {
         }
 
         if (rawAttributes[key] && rawAttributes[key].autoIncrement === true) {
-          serials.push(key);
+          serials[key] = true;
         }
       });
     }
 
     for (const attrValueHash of attrValueHashes) {
       tuples.push('(' + allAttributes.map(key => {
-        if (this._dialect.supports.bulkDefault && serials.indexOf(key) !== -1) {
+        if (this._dialect.supports.bulkDefault && serials[key] === true) {
           return attrValueHash[key] || 'DEFAULT';
         }
         return this.escape(attrValueHash[key], rawAttributes[key], { context: 'INSERT' });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions? (performance fix, not required)
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (doesn't change existing APIs)
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

In generating the bulk insert query, the serials are stored in an array. This array can potentially be up to size N, which is the number of rows to be created.

When generating the tuples at a later stage, we walk through the records one-by-one - O(N) iterations. However, in a single iteration, we were performing a lookup in the serials array (indexOf costs O(N)),
leading to a O(N^2) runtime and poor performance for large number of records inserted.

This patch converts the serials array into an object map instead, so lookups cost O(1) time.
