### PR TITLE
#7184 Regression in affected rows reporting for updates

### DIFF
--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -102,5 +102,20 @@ if (dialect === 'mysql') {
           return cm.releaseConnection(connection);
         });
     });
+
+    it('-FOUND_ROWS can be suppressed to get back legacy behavior', () => {
+      const sequelize = Support.createSequelizeInstance({ dialectOptions: { flags: '' }});
+      const User = sequelize.define('User', { username: DataTypes.STRING });
+
+      return User.sync({force: true})
+        .then(() => User.create({ id: 1, username: 'jozef' }))
+        .then(() => User.update({ username: 'jozef'}, {
+          where: {
+            id: 1
+          }
+        }))
+        // https://github.com/sequelize/sequelize/issues/7184
+        .spread(affectedCount => affectedCount.should.equal(1));
+    });
   });
 }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Introduces dialectOptions.foundRows configuration option that can be set to bring back
update behavior from before this commit https://github.com/sequelize/sequelize/commit/4f95f176eba4a7ad7c71108dd48955884d16eb6b

https://github.com/sequelize/sequelize/issues/7184