### PR TITLE
don't include esdoc in npm release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 docs
+esdoc
 examples
 test
 README.md


### PR DESCRIPTION
Including esdoc in the latest v3.30.3 release adds an additional 130MB to what was previously 14MB in the v3.30.2 npm release. This change brings it back down to something sane.