### PR TITLE
Backport #6008 - Avoid duplicate MySQL foreign key names

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -103,6 +103,7 @@ var QueryGenerator = {
         key: this.quoteIdentifier(key),
         definition: this.attributeToSQL(dataType, {
           context: 'addColumn',
+          tableName: table,
           foreignKey: key
         })
       });
@@ -129,7 +130,7 @@ var QueryGenerator = {
       var definition = attributes[attributeName];
       if (definition.match(/REFERENCES/)) {
         constraintString.push(Utils._.template('<%= fkName %> FOREIGN KEY (<%= attrName %>) <%= definition %>')({
-          fkName: this.quoteIdentifier(attributeName + '_foreign_idx'),
+          fkName: this.quoteIdentifier(tableName + '_' + attributeName + '_foreign_idx'),
           attrName: this.quoteIdentifier(attributeName),
           definition: definition.replace(/.+?(?=REFERENCES)/,'')
         }));
@@ -271,7 +272,7 @@ var QueryGenerator = {
         var attrName = options.foreignKey;
 
         template += Utils._.template(', ADD CONSTRAINT <%= fkName %> FOREIGN KEY (<%= attrName %>)')({
-          fkName: this.quoteIdentifier(attrName + '_foreign_idx'),
+          fkName: this.quoteIdentifier(options.tableName + '_' + attrName + '_foreign_idx'),
           attrName: this.quoteIdentifier(attrName)
         });
       }

--- a/test/unit/sql/add-column.test.js
+++ b/test/unit/sql/add-column.test.js
@@ -39,7 +39,7 @@ if (current.dialect.name === 'mysql') {
           onUpdate: 'cascade',
           onDelete: 'cascade'
         })), {
-            mysql: 'ALTER TABLE `users` ADD `level_id` INTEGER, ADD CONSTRAINT `level_id_foreign_idx` FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+            mysql: 'ALTER TABLE `users` ADD `level_id` INTEGER, ADD CONSTRAINT `users_level_id_foreign_idx` FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
         });
       });
 

--- a/test/unit/sql/change-column.test.js
+++ b/test/unit/sql/change-column.test.js
@@ -64,7 +64,7 @@ if (current.dialect.name !== 'sqlite') {
         }).then(function(sql){
           expectsql(sql, {
             mssql: 'ALTER TABLE [users] ADD CONSTRAINT [level_id_foreign_idx] FOREIGN KEY ([level_id]) REFERENCES [level] ([id]) ON DELETE CASCADE;',
-            mysql: 'ALTER TABLE `users` ADD CONSTRAINT `level_id_foreign_idx` FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+            mysql: 'ALTER TABLE `users` ADD CONSTRAINT `users_level_id_foreign_idx` FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
             postgres: 'ALTER TABLE "users"  ADD CONSTRAINT "level_id_foreign_idx" FOREIGN KEY ("level_id") REFERENCES "level" ("id") ON DELETE CASCADE ON UPDATE CASCADE;',
           });
         });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This is simply a backport of #6008 which is already accepted on master and part of the v4 branch.

This fixes a problem with duplicate foreign key constrain names in MySQL (issue #5826). Instead of using the collision-prone template `{attribute}_foreign_idx`, this change will cause `{referring_table}_{attribute}_foreign_idx` to be used instead.