### PR TITLE
V3 MSSQL rowversion datatype

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -798,6 +798,15 @@ ENUM.prototype.validate = function(value) {
 };
 
 /**
+ * A rowversion column (time-based sequential number). Only available in mssql.
+ * @property ROWVERSION
+ */
+
+var ROWVERSION =  ABSTRACT.inherits();
+
+ROWVERSION.prototype.key = ROWVERSION.key = 'ROWVERSION';
+
+/**
  * An array of `type`, e.g. `DataTypes.ARRAY(DataTypes.DECIMAL)`. Only available in postgres.
  * @property ARRAY
  */
@@ -972,6 +981,7 @@ var dataTypes = {
   ARRAY: ARRAY,
   NONE: VIRTUAL,
   ENUM: ENUM,
+  ROWVERSION: ROWVERSION,
   RANGE: RANGE,
   REAL: REAL,
   DOUBLE: DOUBLE,

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -229,7 +229,7 @@ var QueryGenerator = {
 
             for (modelKey in modelAttributes){
               attribute = modelAttributes[modelKey];
-              if(!(attribute.type instanceof DataTypes.VIRTUAL)){
+              if(!(attribute.type instanceof DataTypes.VIRTUAL || attribute.type instanceof DataTypes.ROWVERSION)){
                 if (tmpColumns.length > 0){
                   tmpColumns += ',';
                   outputColumns += ',';
@@ -425,7 +425,7 @@ var QueryGenerator = {
 
             for (modelKey in attributes){
               attribute = attributes[modelKey];
-              if(!(attribute.type instanceof DataTypes.VIRTUAL)){
+              if(!(attribute.type instanceof DataTypes.VIRTUAL || attribute.type instanceof DataTypes.ROWVERSION)){
                 if (tmpColumns.length > 0){
                   tmpColumns += ',';
                   outputColumns += ',';

--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -175,6 +175,15 @@ module.exports = function (BaseTypes) {
   ENUM.prototype.toSql = function() {
     return 'VARCHAR(255)';
   };
+  
+  var ROWVERSION = BaseTypes.ROWVERSION.inherits(function() {
+    if (!(this instanceof ROWVERSION)) return new ROWVERSION();
+    BaseTypes.ROWVERSION.apply(this, arguments);
+  });
+  
+  ROWVERSION.prototype.toSql = function () {
+    return 'TIMESTAMP';
+  };
 
   var exports = {
     BLOB: BLOB,
@@ -188,7 +197,8 @@ module.exports = function (BaseTypes) {
     BIGINT: BIGINT,
     REAL: REAL,
     FLOAT: FLOAT,
-    TEXT: TEXT
+    TEXT: TEXT,
+    ROWVERSION: ROWVERSION
   };
 
   _.forIn(exports, function (DataType, key) {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -390,5 +390,23 @@ describe(Support.getTestDialectTeaser('DataTypes'), function() {
         });
     });
   }
+  
+  if (dialect === 'mssql') {
+    it('should parse ROWVERSION field', function () {
+      var Type = new Sequelize.ROWVERSION();
 
+      var User = current.define('user', { name: Sequelize.STRING, version: Type }, { timestamps: false });
+
+      return current.sync({ force: true }).then(function () {
+        return User.create({
+           name: 'test'
+        });
+      }).then(function () {
+        return User.findAll();
+      }).then(function(users){
+        expect(users[0].version).to.be.ok;
+        expect(typeof users[0].version).to.be.eql('object');
+      });
+    });
+  }
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

This PR includes support for `rowversion` column type for **MSSQL only**. New test cases only covers MSSQL.

It also supports scenarios where table's options specify `hasTrigger: true` - As `timestamp/rowversion` is an auto-generated column in MSSQL, [query-generator.js](https://github.com/sequelize/sequelize/pull/7432/files#diff-1) will not create columns for temp table if the column type is `Sequelize.VIRTUAL` or `Sequelize.ROWVERSION`.

### Points to Note:

Newer versions of MSSQL suggests `rowversion` over `timestamp`, but this PR uses `timestamp` in SQL statement instead to support older versions of MSSQL.

###  Question

~Will it be better to use `Sequelize.ROWVERSION` instead of `Sequelize.TIMESTAMP` as variable name? In case existing systems have its own custom TIMESTAMP. Just that during SQL generation, the SQL statement should still use `timestamp` instead of `rowversion`.~

Changed TIMESTAMP to ROWVERSION.