### PR TITLE
#7404 make it possible to pass parameters to getter functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -60,6 +60,7 @@
 - [FIXED] Deleted paranoid records can be queried in the same second. [#7204](https://github.com/sequelize/sequelize/issues/7204)/[#7332](https://github.com/sequelize/sequelize/pull/7332)
 - [FIXED] `removeAttribute('id')` results in `undefined: null` data value [#7318](https://github.com/sequelize/sequelize/issues/7318)
 - [FIXED] `bulkCreate` now runs in O(N) time instead of O(N^2) time. [#4247](https://github.com/sequelize/sequelize/issues/4247)
+- [FIXED] Passing parameters to model getters [#7404](https://github.com/sequelize/sequelize/issues/7404)
 
 ## BC breaks:
 - `DATEONLY` now returns string in `YYYY-MM-DD` format rather than `Date` type

--- a/lib/model.js
+++ b/lib/model.js
@@ -3043,13 +3043,13 @@ class Model {
 
     if (key) {
       if (this._customGetters[key] && !options.raw) {
-        return this._customGetters[key].call(this, key);
+        return this._customGetters[key].call(this, key, options);
       }
       if (options.plain && this._options.include && this._options.includeNames.indexOf(key) !== -1) {
         if (Array.isArray(this.dataValues[key])) {
-          return this.dataValues[key].map(instance => instance.get({plain: options.plain}));
+          return this.dataValues[key].map(instance => instance.get(options));
         } else if (this.dataValues[key] instanceof Model) {
-          return this.dataValues[key].get({plain: options.plain});
+          return this.dataValues[key].get(options);
         } else {
           return this.dataValues[key];
         }

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -372,6 +372,67 @@ describe(Support.getTestDialectTeaser('DAO'), function() {
           expect(product.get({clone: true}).title).to.be.ok;
         });
       });
+
+      it('can pass parameters to getters', function () {
+        var Product = this.sequelize.define('product', {
+          title: Sequelize.STRING
+        }, {
+          getterMethods: {
+            rating: function (key, options) {
+              if (options.apiVersion > 1) {
+                return 100;
+              }
+
+              return 5;
+            }
+          }
+        });
+
+        var User = this.sequelize.define('user', {
+          first_name: Sequelize.STRING,
+          last_name: Sequelize.STRING
+        }, {
+          getterMethods: {
+            height: function (key, options) {
+              if (options.apiVersion > 1) {
+                return 185; // cm
+              }
+
+              return 6.06; // ft
+            }
+          }
+        });
+
+        Product.belongsTo(User);
+
+        var product = Product.build({}, {
+          include: [
+            User
+          ]
+        });
+
+        product.set({
+          id: 1,
+          title: 'Chair',
+          user: {
+            id: 1,
+            first_name: 'Jozef',
+            last_name: 'Hartinger'
+          }
+        });
+
+        expect(product.get('rating')).to.equal(5);
+        expect(product.get('rating', {apiVersion: 2})).to.equal(100);
+
+        expect(product.get({plain: true})).to.have.property('rating', 5);
+        expect(product.get({plain: true}).user).to.have.property('height', 6.06);
+        expect(product.get({plain: true, apiVersion: 1})).to.have.property('rating', 5);
+        expect(product.get({plain: true, apiVersion: 1}).user).to.have.property('height', 6.06);
+        expect(product.get({plain: true, apiVersion: 2})).to.have.property('rating', 100);
+        expect(product.get({plain: true, apiVersion: 2}).user).to.have.property('height', 185);
+
+        expect(product.get('user').get('height', {apiVersion: 2})).to.equal(185);
+      });
     });
 
     describe('changed', function() {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Makes it possible for model getters to behave differently in different contexts. For example, a model definition may need to be different for different version of a RESTful API.

```js
rating: function (key, options) {
  const value = this.getDataValue('rating'); // rating is stored as integer with values 1-100

  if (context.apiVersion === 1) {
      return value / 20; // in /v1 we use 1-5 rating system
  }

  return value;  // in /v2 and newer we use 1-100 point rating system
}
```

the parameter is passed like this:

```js
product.get({plain: true, apiVersion: req.param.apiVersion}
```
