### PR TITLE
V3 options.where are erased when a belongsToMany is called

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1320,12 +1320,18 @@ var QueryGenerator = {
                   }, topInclude.model);
                 }
 
-                options.where['__' + throughAs] = self.sequelize.asIs([
+                var queryWhere = self.sequelize.asIs([
                   '(',
                     $query.replace(/\;$/, ''),
                   ')',
                   'IS NOT NULL'
                 ].join(' '));
+
+                if (_.isPlainObject(options.where)) {
+                  options.where['__' + throughAs] = queryWhere;
+                } else {
+                  options.where = { $and: [options.where, queryWhere] };
+                }
               })(include);
             }
           }

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -408,10 +408,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
         });
       });
     });
-  });
 
-
-  it('supports where in include with required', function () {
+    it('supports where in include with required', function () {
       var User = this.sequelize.define('User', {
         id: {
           type: DataTypes.INTEGER,
@@ -476,18 +474,18 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
         }).then(function () {
           return Promise.join(
             Company.scope([{
-              attributes : ["company_id"],
+              attributes : ['company_id'],
               where : [{
-                  "company_id" : {
+                  'company_id' : {
                     $ne : null
                   }
               }],
               include: [{
                   model: Group, 
                   required : true,
-                  attributes : ["group_id"],
+                  attributes : ['group_id'],
                   where : [{
-                    "group_id" : {
+                    'group_id' : {
                       $eq : 1
                     }
                   }]
@@ -496,7 +494,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
               offset : 0,
               limit : 1,
             })
-            .then(result => {
+            .then(function(result) {
               return expect(result.length).to.equal(1);
             })
           );

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -472,8 +472,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
             company2.addGroup(group2)
           );
         }).then(function () {
-          return Promise.join(
-            Company.scope([{
+            Company.addScope('includeGroup', {
               attributes : ['company_id'],
               where : [{
                   'company_id' : {
@@ -490,14 +489,15 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), function() {
                     }
                   }]
                 }]
-            }]).findAll({
+            });
+            
+            return Company.scope('includeGroup').findAll({
               offset : 0,
               limit : 1,
             })
             .then(function(result) {
               return expect(result.length).to.equal(1);
-            })
-          );
+            });
         });
       });
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?


In some findAll using belongsToMany and offset, the subquery is generated but not applied to the final request, leading to bad results.

### Description of change

The where generated for subquery in ```generateJoinQueries``` erase the options.where attribute.
This PR adds it if a where condition is already declared.

A PR was already created (https://github.com/sequelize/sequelize/pull/7417), but some merging problems forced me to delete / recreate the repository.

Just waiting for code review to create the same PR in master.