### PR TITLE
V3 backport: Fixes QueryInterface#changeColumn for enums

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Future
 - [FIXED] Passing parameters to model getters [#7404](https://github.com/sequelize/sequelize/issues/7404)
+- [FIXED] `changeColumn` generates incorrect query with ENUM type [#7456](https://github.com/sequelize/sequelize/pull/7456)
 
 # 3.30.3
 - [ADDED] Ability to run transactions on a read-replica by marking transactions as read only [#7323](https://github.com/sequelize/sequelize/issues/7323)

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -243,9 +243,9 @@ var QueryGenerator = {
       }
 
       if (attributes[attributeName].match(/^ENUM\(/)) {
-        query = this.pgEnum(tableName, attributeName, attributes[attributeName]) + query;
-        definition = definition.replace(/^ENUM\(.+\)/, this.quoteIdentifier('enum_' + tableName + '_' + attributeName));
-        definition += ' USING (' + this.quoteIdentifier(attributeName) + '::' + this.quoteIdentifier(definition) + ')';
+        attrSql += this.pgEnum(tableName, attributeName, attributes[attributeName]);
+        definition = definition.replace(/^ENUM\(.+\)/, this.pgEnumName(tableName, attributeName, { schema: false }));
+        definition += ' USING (' + this.quoteIdentifier(attributeName) + '::' + this.pgEnumName(tableName, attributeName) + ')';
       }
 
       if (definition.match(/UNIQUE;*$/)) {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -253,6 +253,18 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
       });
     });
 
+    it('should work with enums (4)', function() {
+      return this.queryInterface.createSchema('archive').bind(this).then(function() {
+        return this.queryInterface.createTable('SomeTable', {
+          someEnum: {
+            type: DataTypes.ENUM,
+            values: ['value1', 'value2', 'value3'],
+            field: 'otherName'
+          }
+        }, { schema: 'archive' });
+      });
+    });
+
     it('should work with schemas', function() {
       var self = this;
       return self.sequelize.createSchema('hero').then(function() {
@@ -407,33 +419,63 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
     });
 
     it('should change columns', function() {
-        return this.queryInterface.createTable({
+      return this.queryInterface.createTable({
+        tableName: 'users'
+      }, {
+        id: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+          autoIncrement: true
+        },
+        currency: DataTypes.INTEGER
+      }).bind(this).then(function() {
+        return this.queryInterface.changeColumn('users', 'currency', {
+          type: DataTypes.FLOAT,
+          allowNull: true
+        });
+      }).then(function() {
+        return this.queryInterface.describeTable({
           tableName: 'users'
-        }, {
-          id: {
-            type: DataTypes.INTEGER,
-            primaryKey: true,
-            autoIncrement: true
-          },
-          currency: DataTypes.INTEGER
-        }).bind(this).then(function() {
-          return this.queryInterface.changeColumn('users', 'currency', {
-            type: DataTypes.FLOAT,
-            allowNull: true
-          });
-        }).then(function() {
-            return this.queryInterface.describeTable({
-              tableName: 'users'
-            });
-        }).then(function (table) {
-          if (dialect === 'postgres' || dialect === 'postgres-native') {
-            expect(table.currency.type).to.equal('DOUBLE PRECISION');
-          } else {
-            expect(table.currency.type).to.equal('FLOAT');
-          }
+        });
+      }).then(function (table) {
+        if (dialect === 'postgres' || dialect === 'postgres-native') {
+          expect(table.currency.type).to.equal('DOUBLE PRECISION');
+        } else {
+          expect(table.currency.type).to.equal('FLOAT');
+        }
+      });
+    });
+
+    it('should work with enums', function() {
+      return this.queryInterface.createTable({
+        tableName: 'users'
+      }, {
+        firstName: DataTypes.STRING
+      }).bind(this).then(function() {
+        return this.queryInterface.changeColumn('users', 'firstName', {
+          type: DataTypes.ENUM(['value1', 'value2', 'value3'])
         });
       });
     });
+
+    it('should work with enums with schemas', function() {
+      return this.sequelize.createSchema('archive').bind(this).then(function() {
+        return this.queryInterface.createTable({
+          tableName: 'users',
+          schema: 'archive'
+        }, {
+          firstName: DataTypes.STRING
+        });
+      }).bind(this).then(function() {
+        return this.queryInterface.changeColumn({
+          tableName: 'users',
+          schema: 'archive'
+        }, 'firstName', {
+          type: DataTypes.ENUM(['value1', 'value2', 'value3'])
+        });
+      });
+    });
+  });
 
     //SQlite navitely doesnt support ALTER Foreign key
     if (dialect !== 'sqlite') {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -446,35 +446,39 @@ describe(Support.getTestDialectTeaser('QueryInterface'), function() {
       });
     });
 
-    it('should work with enums', function() {
-      return this.queryInterface.createTable({
-        tableName: 'users'
-      }, {
-        firstName: DataTypes.STRING
-      }).bind(this).then(function() {
-        return this.queryInterface.changeColumn('users', 'firstName', {
-          type: DataTypes.ENUM(['value1', 'value2', 'value3'])
-        });
-      });
-    });
-
-    it('should work with enums with schemas', function() {
-      return this.sequelize.createSchema('archive').bind(this).then(function() {
+    // MSSQL doesn't support using a modified column in a check constraint.
+    // https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql
+    if (dialect !== 'mssql') {
+      it('should work with enums', function() {
         return this.queryInterface.createTable({
-          tableName: 'users',
-          schema: 'archive'
+          tableName: 'users'
         }, {
           firstName: DataTypes.STRING
-        });
-      }).bind(this).then(function() {
-        return this.queryInterface.changeColumn({
-          tableName: 'users',
-          schema: 'archive'
-        }, 'firstName', {
-          type: DataTypes.ENUM(['value1', 'value2', 'value3'])
+        }).bind(this).then(function() {
+          return this.queryInterface.changeColumn('users', 'firstName', {
+            type: DataTypes.ENUM(['value1', 'value2', 'value3'])
+          });
         });
       });
-    });
+
+      it('should work with enums with schemas', function() {
+        return this.sequelize.createSchema('archive').bind(this).then(function() {
+          return this.queryInterface.createTable({
+            tableName: 'users',
+            schema: 'archive'
+          }, {
+            firstName: DataTypes.STRING
+          });
+        }).bind(this).then(function() {
+          return this.queryInterface.changeColumn({
+            tableName: 'users',
+            schema: 'archive'
+          }, 'firstName', {
+            type: DataTypes.ENUM(['value1', 'value2', 'value3'])
+          });
+        });
+      });
+    }
   });
 
     //SQlite navitely doesnt support ALTER Foreign key

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -250,6 +250,16 @@ if (dialect.match(/^postgres/)) {
         }
       ],
 
+      changeColumnQuery: [
+        {
+          arguments: ['myTable', {
+            col_1: "ENUM('value 1', 'value 2') NOT NULL",
+            col_2: "ENUM('value 3', 'value 4') NOT NULL"
+          }],
+          expectation: 'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(\'value 1\', \'value 2\');ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(\'value 3\', \'value 4\');ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");'
+        }
+      ],
+
       selectQuery: [
         {
           arguments: ['myTable'],


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

Previous changes to support schemas in QueryInterface generated invalid Postgres SQL when attempting to change a column to an enum value.

Instead of generating
```sql
ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public.enum_myTable_col_1");
```
with this change we will now generate
```sql
ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");
```