### PR TITLE
Grammar fix and more explanation of sequelize.col

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -786,7 +786,7 @@ class Sequelize {
   }
 
   /**
-   * Creates a object representing a database function. This can be used in search queries, both in where and order parts, and as default values in column definitions.
+   * Creates an object representing a database function. This can be used in search queries, both in where and order parts, and as default values in column definitions.
    * If you want to refer to columns in your function, you should use `sequelize.col`, so that the columns are properly interpreted as columns and not a strings.
    *
    * Convert a user's username to upper case
@@ -813,7 +813,7 @@ class Sequelize {
   }
 
   /**
-   * Creates a object representing a column in the DB. This is often useful in conjunction with `sequelize.fn`, since raw string arguments to fn will be escaped.
+   * Creates an object which represents a column in the DB, this allows referencing another column in your query. This is often useful in conjunction with `sequelize.fn`, since raw string arguments to fn will be escaped.
    * @see {@link Sequelize#fn}
    *
    * @method col
@@ -827,7 +827,7 @@ class Sequelize {
   }
 
   /**
-   * Creates a object representing a call to the cast function.
+   * Creates an object representing a call to the cast function.
    *
    * @method cast
    * @param {any} val The value to cast
@@ -841,7 +841,7 @@ class Sequelize {
   }
 
   /**
-   * Creates a object representing a literal, i.e. something that will not be escaped.
+   * Creates an object representing a literal, i.e. something that will not be escaped.
    *
    * @method literal
    * @param {any} val


### PR DESCRIPTION
Template skipped (documentation only).

Based on [this stackoverflow](https://stackoverflow.com/questions/30452977/sequelize-query-compare-dates-in-two-columns) I added some more explanation as to what sequelize.col does.

Also, changed 'a object' to 'an object'.

Fixed version of [this pr](https://github.com/sequelize/sequelize/pull/7449)