### PR TITLE
Make Model#$expandAttributes respect scope attributes.exclude

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2647,6 +2647,9 @@ Model.prototype.$getDefaultTimestamp = function(attr) {
 Model.prototype.$expandAttributes = function (options) {
   if (_.isPlainObject(options.attributes)) {
     var attributes = Object.keys(this.rawAttributes);
+    if (Array.isArray(this.$scope.attributes)) {
+      attributes = this.$scope.attributes;
+    }
 
     if (options.attributes.exclude) {
       attributes = attributes.filter(function (elem) {

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -73,4 +73,35 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
   });
+
+  describe('with scope', function() {
+    describe('combining excludes', function() {
+      it('should combine find exclude with scope excludes', function() {
+        var User = this.sequelize.define('user', {
+          password: Sequelize.STRING,
+          firstName: Sequelize.STRING,
+          lastName: Sequelize.STRING
+        }, {
+          defaultScope: {
+            attributes: {
+              exclude: ['password']
+            }
+          }
+        });
+        return this.sequelize.sync({force: true}).then(function() {
+          return User.create({ firstName: 'John', lastName: 'Doe', password: 'abc123' }).then(function() {
+            return User.findOne({
+              attributes: {
+                exclude: ['lastName']
+              }
+            }).then(function(user) {
+              expect(user.firstName).to.eql('John');
+              expect(user.lastName).to.eql(undefined);
+              expect(user.password).to.eql(undefined);
+            });
+          });
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
The treatment of attributes.excludes does not respect scopes, which is unexpected.  This also leads to situations where you might accidentally expose information that you do not want to.

This makes Model#$expandAttributes respect scope attributes.exclude

## What are you doing?
```js
var User = this.sequelize.define('user', {
  password: Sequelize.STRING,
  firstName: Sequelize.STRING,
  lastName: Sequelize.STRING,
}, {
  defaultScope: {
    attributes: {
      exclude: ['password']
    }
  }
})

User.create({
  firstName: 'John',
  lastName: 'Doe',
  password: 'abc123',
}).then((createdRecord) => {
  User.findOne({
    where: {
      id: createdRecord.id,
    },
    attributes: {
      exclude: ['lastName'],
    }
  }).then((user) => console.log(user.get({ plain: true })))
})
```

## What do you expect to happen?
The exclude specified in scope is respected:
```
// log output
{
  firstName: 'John'
}
```

## What is actually happening?
The exclude specified in scope is ignored:
```
// log output
{
  firstName: 'John',
  pasword: 'abc123'
}
```

## Which dialect you are using (postgres, mysql etc)?

any

## Which sequelize version you are using?

v3.30.4
