### PR TITLE
Add preserveValuesOnNull option to bulkInsert to prevent NULLing of d…

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,6 @@
 # Future
+- [ADDED] `options.preserveValuesOnNull` to model.bulkInsert() to preserve existing data
+[#7462](https://github.com/sequelize/sequelize/issues/7462)
 - [ADDED] `options.alter` to sequelize.sync() to alter existing tables.[#537](https://github.com/sequelize/sequelize/issues/537)
 - [ADDED] Ability to run transactions on a read-replica by marking transactions as read only [#7323](https://github.com/sequelize/sequelize/issues/7323)
 - [FIXED] Show a reasonable message when using renameColumn with a missing column  [#6606](https://github.com/sequelize/sequelize/issues/6606)

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -251,6 +251,9 @@ const QueryGenerator = {
       onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + options.updateOnDuplicate.map(attr => {
         const field = rawAttributes && rawAttributes[attr] && rawAttributes[attr].field || attr;
         const key = this.quoteIdentifier(field);
+        if (options.preserveValuesOnNull && options.preserveValuesOnNull.indexOf(attr) !== -1) {
+          return key + '=IF(VALUES(' + key +') IS NOT NULL, VALUES(' + key +'), ' + key +')';
+        }
         return key + '=VALUES(' + key + ')';
       }).join(',');
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -2254,6 +2254,7 @@ class Model {
    * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {Boolean}      [options.returning=false] Append RETURNING * to get back auto generated values (Postgres only)
    * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {Array}        [options.preserveValuesOnNull]   Fields to preserve current values if row key already exists (on duplicate key update) and the value in the record is NULL? (only supported by mysql). By default, no fields are preserved.
    *
    * @return {Promise<Array<Instance>>}
    */
@@ -2266,7 +2267,7 @@ class Model {
       validate: false,
       hooks: true,
       individualHooks: false,
-      ignoreDuplicates: false
+      ignoreDuplicates: false,
     }, options || {});
 
     options.fields = options.fields || Object.keys(this.tableAttributes);
@@ -2278,6 +2279,9 @@ class Model {
     if (options.updateOnDuplicate && dialect !== 'mysql') {
       return Promise.reject(new Error(dialect + ' does not support the \'updateOnDuplicate\' option.'));
     }
+    if (options.preserveValuesOnNull && dialect !== 'mysql') {
+      return Promise.reject(new Error(dialect + ' does not support the \'preserveValuesOnNull\' option.'));
+    }
 
     if (options.updateOnDuplicate) {
       // By default, all attributes except 'createdAt' can be updated
@@ -2286,6 +2290,15 @@ class Model {
         updatableFields = Utils._.intersection(updatableFields, options.updateOnDuplicate);
       }
       options.updateOnDuplicate = updatableFields;
+    }
+
+    if (options.preserveValuesOnNull) {
+      // By default, all attributes except 'createdAt' can be updated
+      let updatableFields = Utils._.pull(Object.keys(this.tableAttributes), 'createdAt');
+      if (Utils._.isArray(options.preserveValuesOnNull) && !Utils._.isEmpty(options.preserveValuesOnNull)) {
+        updatableFields = Utils._.intersection(updatableFields, options.preserveValuesOnNull);
+      }
+      options.preserveValuesOnNull = updatableFields;
     }
 
     options.model = this;

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -491,6 +491,9 @@ if (dialect === 'mysql') {
         }, {
           arguments: ['myTable', [{name: 'foo'}, {name: 'bar'}], {updateOnDuplicate: ['name']}],
           expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON DUPLICATE KEY UPDATE `name`=VALUES(`name`);"
+        }, {
+          arguments: ['myTable', [{name: 'foo'}, {name: 'bar'}], {updateOnDuplicate: ['name'], preserveValuesOnNull: ['name']}],
+          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON DUPLICATE KEY UPDATE `name`=IF(VALUES(`name`) IS NOT NULL, VALUES(`name`), `name`);"
         }
       ],
 

--- a/test/unit/sql/insert.js
+++ b/test/unit/sql/insert.js
@@ -118,4 +118,41 @@ describe(Support.getTestDialectTeaser('SQL'), function() {
       });
     });
   });
+
+  describe('bulkCreate', function () {
+    it('bulk create with preserveValuesOnNull', function () {
+      // Skip mssql for now, it seems broken
+      if (Support.getTestDialect() === 'mssql') {
+        return;
+      }
+
+      var User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name'
+        },
+        password: {
+          type: DataTypes.STRING,
+          field: 'pass_word'
+        },
+        createdAt: {
+          type: DataTypes.DATE,
+          field: 'created_at'
+        },
+        updatedAt: {
+          type: DataTypes.DATE,
+          field: 'updated_at'
+        }
+      },{
+        timestamps:true
+      });
+
+      expectsql(sql.bulkInsertQuery(User.tableName, [{ user_name: 'testuser', pass_word: '12345' }], { updateOnDuplicate: ['username', 'password', 'updatedAt'], preserveValuesOnNull: ['username', 'password', 'updatedAt'] }, User.rawAttributes),
+      {
+        default:'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
+        postgres:'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\');',
+        mysql:'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=IF(VALUES(`user_name`) IS NOT NULL, VALUES(`user_name`), `user_name`),`pass_word`=IF(VALUES(`pass_word`) IS NOT NULL, VALUES(`pass_word`), `pass_word`),`updated_at`=IF(VALUES(`updated_at`) IS NOT NULL, VALUES(`updated_at`), `updated_at`);'
+      });
+    });
+  });
 });


### PR DESCRIPTION
…ata during updateOnDuplicate (#7462)

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Added preserveValuesOnNull option for bulkInsert to prevent NULLing of existing data when the database has more data than the record used for update.

Resolves [#7462](https://github.com/sequelize/sequelize/issues/7462)
