### PR TITLE
V3 backport: #7184 Regression in affected rows reporting for updates

### DIFF
--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -113,7 +113,24 @@ if (Support.dialectIsMySQL()) {
             return cm.releaseConnection(connection);
           });
       });
-    }
 
+      it('-FOUND_ROWS can be suppressed to get back legacy behavior', function() {
+        var sequelize = Support.createSequelizeInstance({ dialectOptions: { flags: '' }});
+        var User = sequelize.define('User', { username: DataTypes.STRING });
+
+        return User.sync({force: true}).then(function () {
+          return User.create({ id: 1, username: 'jozef' });
+        }).then(function() {
+          return User.update({ username: 'jozef'}, {
+            where: {
+              id: 1
+            }
+          });
+        }).spread(function(affectedCount) {
+          // https://github.com/sequelize/sequelize/issues/7184
+          affectedCount.should.equal(1);
+        });
+      });
+    }
   });
 }


### PR DESCRIPTION
Introduces dialectOptions.foundRows configuration option that can be set to bring back
update behavior from before this commit https://github.com/sequelize/sequelize/commit/4f95f176eba4a7ad7c71108dd48955884d16eb6b

https://github.com/sequelize/sequelize/issues/7184

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?
