### PR TITLE
#7432 MSSQL rowversion datatype

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -802,6 +802,18 @@ ENUM.prototype.validate = function validate(value) {
 };
 
 /**
+ * A rowversion column (time-based sequential number). Only available in mssql.
+ * @property ROWVERSION
+ */
+
+function ROWVERSION() {
+  if (!(this instanceof ROWVERSION)) return new ROWVERSION();
+}
+inherits(ROWVERSION, ABSTRACT);
+
+ROWVERSION.prototype.key = ROWVERSION.key = 'ROWVERSION';
+
+/**
  * An array of `type`, e.g. `DataTypes.ARRAY(DataTypes.DECIMAL)`. Only available in postgres.
  *
  * @memberof DataTypes
@@ -972,6 +984,7 @@ const dataTypes = {
   ARRAY,
   NONE: VIRTUAL,
   ENUM,
+  ROWVERSION,
   RANGE,
   REAL,
   DOUBLE,

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -118,7 +118,7 @@ const QueryGenerator = {
 
           for (const modelKey in modelAttributes){
             const attribute = modelAttributes[modelKey];
-            if(!(attribute.type instanceof DataTypes.VIRTUAL)){
+            if(!(attribute.type instanceof DataTypes.VIRTUAL || attribute.type instanceof DataTypes.ROWVERSION)){
               if (tmpColumns.length > 0){
                 tmpColumns += ',';
                 outputColumns += ',';
@@ -310,7 +310,7 @@ const QueryGenerator = {
 
           for (const modelKey in attributes){
             const attribute = attributes[modelKey];
-            if(!(attribute.type instanceof DataTypes.VIRTUAL)){
+            if(!(attribute.type instanceof DataTypes.VIRTUAL || attribute.type instanceof DataTypes.ROWVERSION)){
               if (tmpColumns.length > 0){
                 tmpColumns += ',';
                 outputColumns += ',';

--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -222,6 +222,20 @@ module.exports = BaseTypes => {
     return 'VARCHAR(255)';
   };
 
+  function ROWVERSION() {
+    if (!(this instanceof ROWVERSION)) {
+      const obj = Object.create(ROWVERSION.prototype);
+      ROWVERSION.apply(obj, arguments);
+      return obj;
+    }
+    BaseTypes.ROWVERSION.apply(this, arguments);
+  }
+  inherits(ROWVERSION, BaseTypes.ROWVERSION);
+
+  ROWVERSION.prototype.toSql = function toSql() {
+    return 'TIMESTAMP';
+  };
+
   const exports = {
     BLOB,
     BOOLEAN,
@@ -235,7 +249,8 @@ module.exports = BaseTypes => {
     BIGINT,
     REAL,
     FLOAT,
-    TEXT
+    TEXT,
+    ROWVERSION
   };
 
   _.forIn(exports, (DataType, key) => {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -460,5 +460,26 @@ describe(Support.getTestDialectTeaser('DataTypes'), function () {
         expect(record.stamp).to.be.eql(testDate);
       });
   });
+  
+  if (dialect === 'mssql') {
+    it('should parse ROWVERSION field', function () {
+      const Model = this.sequelize.define('model', {
+        name: Sequelize.STRING,
+        version: Sequelize.ROWVERSION
+      });
 
+      const sampleData = {
+        name: 'test'
+      };
+
+      return Model.sync({ force: true }).then(() => {
+        return Model.create(sampleData);
+      }).then(() => {
+        return Model.findAll().get(0);
+      }).then(model => {
+        expect(model.get('version')).to.be.ok;
+        expect(typeof model.get('version')).to.be.eql('object');
+      });
+    });
+  }
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

This PR includes support for `rowversion` column type for **MSSQL only**. New test cases only covers MSSQL.

It also supports scenarios where table's options specify `hasTrigger: true` - As `timestamp/rowversion` is an auto-generated column in MSSQL, [query-generator.js](https://github.com/sequelize/sequelize/pull/7432/files#diff-1) will not create columns for temp table if the column type is `Sequelize.VIRTUAL` or `Sequelize.ROWVERSION`.

Refer to #7432 for version 3's PR.

### Points to Note:

Newer versions of MSSQL suggests `rowversion` over `timestamp`, but this PR uses `timestamp` in SQL statement instead to support older versions of MSSQL.