### PR TITLE
Fix `showIndex()` query regexp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -65,6 +65,7 @@
 - [FIXED] Model.validate runs validation hooks by default [#7182](https://github.com/sequelize/sequelize/pull/7182)
 - [ADDED] Added support for associations aliases in orders and groups. [#7425](https://github.com/sequelize/sequelize/issues/7425)
 - [REMOVED] Removes support for `{raw: 'injection goes here'}` for order and group. [#7188](https://github.com/sequelize/sequelize/issues/7188)
+- [FIXED] `showIndex` breaks with newline characters [#7492](https://github.com/sequelize/sequelize/pull/7492)
 
 ## BC breaks:
 - Model.validate instance method now runs validation hooks by default. Previously you needed to pass { hooks: true }. You can override this behavior by passing { hooks: false }

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -137,7 +137,7 @@ class Query extends AbstractQuery {
 
       if (this.isShowIndexesQuery()) {
         for (const result of results) {
-          const attributes = /ON .*? (?:USING .*?\s)?\((.*)\)/gi.exec(result.definition)[1].split(',');
+          const attributes = /ON .*? (?:USING .*?\s)?\(([^]*)\)/gi.exec(result.definition)[1].split(',');
 
           // Map column index in table to column name
           const columns = _.zipObject(

--- a/test/integration/dialects/postgres/query-interface.test.js
+++ b/test/integration/dialects/postgres/query-interface.test.js
@@ -205,6 +205,21 @@ if (dialect.match(/^postgres/)) {
           }));
       });
 
+      it('supports newlines', function() {
+        return this.queryInterface.addIndex('Group', [this.sequelize.literal(`(
+            CASE "username"
+              WHEN 'foo' THEN 'bar'
+              ELSE 'baz'
+            END
+          )`)], { name: 'group_username_case' })
+          .then(() => this.queryInterface.showIndex('Group'))
+          .then(indexes => {
+            const indexColumns = _.uniq(indexes.map(index => index.name));
+
+            expect(indexColumns).to.include('group_username_case');
+          });
+      });
+
       it('adds, reads and removes a named functional index to the table', function() {
         return this.queryInterface.addIndex('Group', [this.sequelize.fn('lower', this.sequelize.col('username'))], {
           name: 'group_username_lower'


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Have you added new tests to prevent regressions?

### Description of change

Fixes an issue when calling `showIndex()` on an index that contains a newline in its "fields". Example:

```sql
CREATE INDEX "foobar" ON "users" USING btree ((
CASE (settings->>'type')
    WHEN 'foo' THEN 'biz'
    WHEN 'bar' THEN 'baz'
    ELSE 'qux'
END)) WITH (fillfactor='70')
```

The issue is with a regexp that is matching against `.*` (which doesn't match newlines). This PR replaces that expression with `[^]*` which matches any character that is not _nothing_.

The error that was previously seen when a newline was present was:

```
TypeError: Cannot read property '1' of null
  at node_modules/sequelize/lib/dialects/postgres/query.js:139:85
  at Array.forEach (native)
  at node_modules/sequelize/lib/dialects/postgres/query.js:135:15
```