### PR TITLE
[v3] COUNT on HasMany association is not ambiguous anymore

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Future
 - [FIXED] Passing parameters to model getters [#7404](https://github.com/sequelize/sequelize/issues/7404)
+- [FIXED] `.count` for `HasMany` association now counts on `Model.primaryKey` instead of `primaryKey` [#6488](https://github.com/sequelize/sequelize/issues/6488)
 
 # 3.30.3
 - [ADDED] Ability to run transactions on a read-replica by marking transactions as read only [#7323](https://github.com/sequelize/sequelize/issues/7323)

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -355,7 +355,7 @@ HasMany.prototype.count = function(instance, options) {
 
   options = Utils.cloneDeep(options);
   options.attributes = [
-    [sequelize.fn('COUNT', sequelize.col(model.primaryKeyField)), 'count']
+    [sequelize.fn('COUNT', sequelize.col([model.name, model.primaryKeyField].join('.'))), 'count']
   ];
   options.raw = true;
   options.plain = true;

--- a/test/unit/associations/has-many.test.js
+++ b/test/unit/associations/has-many.test.js
@@ -86,6 +86,37 @@ describe(Support.getTestDialectTeaser('hasMany'), function() {
     });
   });
 
+  describe('count', function () {
+    var User = current.define('User', {})
+      , Task = current.define('Task', {});
+
+    var user = User.build({});
+
+    it('the COUNT() attribute should be Model.id', function () {
+      var as = Math.random().toString()
+        , association = new HasMany(User, Task, { as: as });
+
+      var get = stub(association, 'get');
+
+        get.onFirstCall().returns(Promise.resolve({
+          count: 10,
+        }));
+
+      return association.count(user)
+        .then(function () {
+
+          expect(get).to.have.been.calledOnce;
+          expect(get.firstCall.args[1].attributes[0][0].args[0].col).to.equal(
+            [association.target.name, association.target.primaryKeyField].join('.')
+          );
+
+        })
+        .finally(function () {
+          get.restore();
+        });
+    });
+  });
+
   describe('get', function () {
     var User = current.define('User', {})
       , Task = current.define('Task', {})


### PR DESCRIPTION
### Description of change

When counting on an `HasMany` assocation, the column `id` can be ambiguous if an other model is included. This fixes it by appending the target model name.

This should also fix #6488.
