### PR TITLE
'clarifying the return value of findOrCreate'

### DIFF
--- a/docs/docs/models-usage.md
+++ b/docs/docs/models-usage.md
@@ -43,14 +43,18 @@ User
     console.log(created)
 
     /*
-      {
+     findOrCreate returns an array containing the object that was found or created and a boolean that will be true if a new object was created an false if not, like so:
+     
+    [ {
         username: 'sdepold',
         job: 'Technical Lead JavaScript',
         id: 1,
         createdAt: Fri Mar 22 2013 21: 28: 34 GMT + 0100(CET),
         updatedAt: Fri Mar 22 2013 21: 28: 34 GMT + 0100(CET)
-      }
-      created: true
+      },
+      true ]
+      
+ In the example above, the "spread" on line 39 will divide that array into its 2 parts pass them as arguments to the callback function defined beginning at line 39, which will then treat them as "user" and "created." (So "user" will be the object from index 0 of the returned array and "created" will equal "true".)
     */
   })
 ```
@@ -69,14 +73,17 @@ User
         console.log(created)
 
         /*
-          {
+     In this example, findOrCreate will return an array like this:
+        [ {
             username: 'fnord',
             job: 'omnomnom',
             id: 2,
             createdAt: Fri Mar 22 2013 21: 28: 34 GMT + 0100(CET),
             updatedAt: Fri Mar 22 2013 21: 28: 34 GMT + 0100(CET)
-          }
-          created: false
+          },
+          false
+        ]
+       That array gets spread into its 2 parts by the "spread" on line 69, and the parts will be passed as 2 arguments to the callback function beginning on line 69, which will then treat them as "user" and "created." (So "user" will be the object from index 0 of the returned array and "created" will equal "false".)
         */
       })
   })

--- a/docs/docs/models-usage.md
+++ b/docs/docs/models-usage.md
@@ -54,7 +54,7 @@ User
       },
       true ]
       
- In the example above, the "spread" on line 39 will divide that array into its 2 parts and pass them as arguments to the callback function defined beginning at line 39, which will then treat them as "user" and "created." (So "user" will be the object from index 0 of the returned array and "created" will equal "true".)
+ In the example above, the "spread" on line 39 divides the array into its 2 parts and passes them as arguments to the callback function defined beginning at line 39, which treats them as "user" and "created" in this case. (So "user" will be the object from index 0 of the returned array and "created" will equal "true".)
     */
   })
 ```
@@ -73,7 +73,7 @@ User
         console.log(created)
 
         /*
-     In this example, findOrCreate will return an array like this:
+     In this example, findOrCreate returns an array like this:
         [ {
             username: 'fnord',
             job: 'omnomnom',
@@ -83,7 +83,7 @@ User
           },
           false
         ]
-       That array gets spread into its 2 parts by the "spread" on line 69, and the parts will be passed as 2 arguments to the callback function beginning on line 69, which will then treat them as "user" and "created." (So "user" will be the object from index 0 of the returned array and "created" will equal "false".)
+       The array returned by findOrCreate gets spread into its 2 parts by the "spread" on line 69, and the parts will be passed as 2 arguments to the callback function beginning on line 69, which will then treat them as "user" and "created" in this case. (So "user" will be the object from index 0 of the returned array and "created" will equal "false".)
         */
       })
   })

--- a/docs/docs/models-usage.md
+++ b/docs/docs/models-usage.md
@@ -43,7 +43,7 @@ User
     console.log(created)
 
     /*
-     findOrCreate returns an array containing the object that was found or created and a boolean that will be true if a new object was created an false if not, like so:
+     findOrCreate returns an array containing the object that was found or created and a boolean that will be true if a new object was created and false if not, like so:
      
     [ {
         username: 'sdepold',
@@ -54,7 +54,7 @@ User
       },
       true ]
       
- In the example above, the "spread" on line 39 will divide that array into its 2 parts pass them as arguments to the callback function defined beginning at line 39, which will then treat them as "user" and "created." (So "user" will be the object from index 0 of the returned array and "created" will equal "true".)
+ In the example above, the "spread" on line 39 will divide that array into its 2 parts and pass them as arguments to the callback function defined beginning at line 39, which will then treat them as "user" and "created." (So "user" will be the object from index 0 of the returned array and "created" will equal "true".)
     */
   })
 ```


### PR DESCRIPTION
The documentation of findOrCreate previously had no precise indication of what to expect findOrCreate to return. I added that it returns an array with two parts in the comments that had already existed in the examples. I also fixed an inconsistency where it looked as if the first item would be returned anonymously and the second would be returned as a key/value pair of 'created' and a boolean. In fact, both are returned anonymously.

I only changed the documentation.

_If your PR only contains changes to documentation, you may skip the template below._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

_Please provide a description of the change here._
