### PR TITLE
[master] COUNT on HasMany association is not ambiguous anymore

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -65,6 +65,7 @@
 - [FIXED] Model.validate runs validation hooks by default [#7182](https://github.com/sequelize/sequelize/pull/7182)
 - [ADDED] Added support for associations aliases in orders and groups. [#7425](https://github.com/sequelize/sequelize/issues/7425)
 - [REMOVED] Removes support for `{raw: 'injection goes here'}` for order and group. [#7188](https://github.com/sequelize/sequelize/issues/7188)
+- [FIXED] `.count` for `HasMany` association now counts on `Model.primaryKey` instead of `primaryKey` [#6488](https://github.com/sequelize/sequelize/issues/6488)
 
 ## BC breaks:
 - Model.validate instance method now runs validation hooks by default. Previously you needed to pass { hooks: true }. You can override this behavior by passing { hooks: false }

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -330,7 +330,7 @@ class HasMany extends Association {
 
     options = Utils.cloneDeep(options);
     options.attributes = [
-      [sequelize.fn('COUNT', sequelize.col(model.primaryKeyField)), 'count']
+      [sequelize.fn('COUNT', sequelize.col([model.name, model.primaryKeyField].join('.'))), 'count']
     ];
     options.raw = true;
     options.plain = true;

--- a/test/unit/associations/has-many.test.js
+++ b/test/unit/associations/has-many.test.js
@@ -117,6 +117,37 @@ describe(Support.getTestDialectTeaser('hasMany'), function() {
     });
   });
 
+  describe('count', function () {
+    var User = current.define('User', {})
+      , Task = current.define('Task', {});
+
+    var user = User.build({});
+
+    it('the COUNT() attribute should be Model.id', function () {
+      var as = Math.random().toString()
+        , association = new HasMany(User, Task, { as: as });
+
+      var get = stub(association, 'get');
+
+        get.onFirstCall().returns(Promise.resolve({
+          count: 10,
+        }));
+
+      return association.count(user)
+        .then(function () {
+
+          expect(get).to.have.been.calledOnce;
+          expect(get.firstCall.args[1].attributes[0][0].args[0].col).to.equal(
+            [association.target.name, association.target.primaryKeyField].join('.')
+          );
+
+        })
+        .finally(function () {
+          get.restore();
+        });
+    });
+  });
+
   describe('get', function () {
     var User = current.define('User', {})
       , Task = current.define('Task', {})


### PR DESCRIPTION
### Description of change

When counting on an `HasMany` assocation, the column `id` can be ambiguous if an other model is included. This fixes it by appending the target model name.

This should also fix #6488.
Master port of #7493.