### PR TITLE
Add `isSoftDeleted` helper method to model instances

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [FEATURE] Add `isSoftDeleted` helper method to model instances [#7531](https://github.com/sequelize/sequelize/pull/7531)
 - [FEATURE] `addConstraint`, `removeConstraint`, `showConstraint` [#7108](https://github.com/sequelize/sequelize/pull/7108)
 - [FIXED] `changeColumn` generates incorrect query with ENUM type [#7455](https://github.com/sequelize/sequelize/pull/7455)
 - [ADDED] `options.alter` to sequelize.sync() to alter existing tables.[#537](https://github.com/sequelize/sequelize/issues/537)

--- a/lib/model.js
+++ b/lib/model.js
@@ -3760,8 +3760,22 @@ class Model {
 
     const deletedAtAttribute = this.constructor.rawAttributes[this.constructor._timestampAttributes.deletedAt];
     const defaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
+    const deletedAt = this.get(this.constructor._timestampAttributes.deletedAt);
+    const isNotSet = deletedAt === defaultValue;
 
-    return this.get(this.constructor._timestampAttributes.deletedAt) !== defaultValue;
+    // No need to check the value of deletedAt if it's equal to the default
+    // value.  If so return the inverse of `isNotSet` since we are asking if
+    // the model *is* soft-deleted.
+    if (isNotSet) {
+      return !isNotSet;
+    }
+
+    const now = moment();
+    const deletedAtIsInTheFuture = moment(deletedAt).isSameOrAfter(now);
+
+    // If deletedAt is a datetime in the future or now then the model is *not* soft-deleted.
+    // Therefore, return the inverse of `deletedAtIsInTheFuture`.
+    return !deletedAtIsInTheFuture;
   }
 
   /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -3747,6 +3747,24 @@ class Model {
   }
 
   /**
+   * Helper method to determine if a instance is "soft deleted".  This is
+   * particularly useful if the implementer renamed the `deletedAt` attribute
+   * to something different.  This method requires `paranoid` to be enabled.
+   *
+   * @returns {Boolean}
+   */
+  isSoftDeleted() {
+    if (!this.constructor._timestampAttributes.deletedAt) {
+      throw new Error('Model is not paranoid');
+    }
+
+    const deletedAtAttribute = this.constructor.rawAttributes[this.constructor._timestampAttributes.deletedAt];
+    const defaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
+
+    return this.get(this.constructor._timestampAttributes.deletedAt) !== defaultValue;
+  }
+
+  /**
    * Restore the row corresponding to this instance. Only available for paranoid models.
    *
    * @param {Object}      [options={}]

--- a/lib/model.js
+++ b/lib/model.js
@@ -3761,13 +3761,13 @@ class Model {
     const deletedAtAttribute = this.constructor.rawAttributes[this.constructor._timestampAttributes.deletedAt];
     const defaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
     const deletedAt = this.get(this.constructor._timestampAttributes.deletedAt);
-    const isNotSet = deletedAt === defaultValue;
+    const isSet = deletedAt !== defaultValue;
 
     // No need to check the value of deletedAt if it's equal to the default
     // value.  If so return the inverse of `isNotSet` since we are asking if
     // the model *is* soft-deleted.
-    if (isNotSet) {
-      return !isNotSet;
+    if (!isSet) {
+      return isSet;
     }
 
     const now = moment();

--- a/lib/model.js
+++ b/lib/model.js
@@ -3771,9 +3771,9 @@ class Model {
     }
 
     const now = moment();
-    const deletedAtIsInTheFuture = moment(deletedAt).isSameOrAfter(now);
+    const deletedAtIsInTheFuture = moment(deletedAt).isAfter(now);
 
-    // If deletedAt is a datetime in the future or now then the model is *not* soft-deleted.
+    // If deletedAt is a datetime in the future then the model is *not* soft-deleted.
     // Therefore, return the inverse of `deletedAtIsInTheFuture`.
     return !deletedAtIsInTheFuture;
   }

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -2082,7 +2082,6 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         username: { type: DataTypes.STRING }
       }, { paranoid: true });
 
-      this.ParanoidUser.hasOne(this.ParanoidUser);
       return this.ParanoidUser.sync({ force: true });
     });
 
@@ -2095,9 +2094,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('returns true if user is soft deleted', function() {
-      const self = this;
       return this.ParanoidUser.create({ username: 'fnord' }).then(() => {
-        return self.ParanoidUser.findAll().then((users) => {
+        return this.ParanoidUser.findAll().then((users) => {
           return users[0].destroy().then(() => {
             expect(users[0].isSoftDeleted()).to.be.true;
 

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -2076,6 +2076,68 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
   });
 
+  describe('isSoftDeleted', () => {
+    beforeEach(function() {
+      this.ParanoidUser = this.sequelize.define('ParanoidUser', {
+        username: { type: DataTypes.STRING }
+      }, { paranoid: true });
+
+      this.ParanoidUser.hasOne(this.ParanoidUser);
+      return this.ParanoidUser.sync({ force: true });
+    });
+
+    it('returns false if user is not soft deleted', function() {
+      return this.ParanoidUser.create({ username: 'fnord' }).then(() => {
+        return this.ParanoidUser.findAll().then((users) => {
+          expect(users[0].isSoftDeleted()).to.be.false;
+        });
+      });
+    });
+
+    it('returns true if user is soft deleted', function() {
+      const self = this;
+      return this.ParanoidUser.create({ username: 'fnord' }).then(() => {
+        return self.ParanoidUser.findAll().then((users) => {
+          return users[0].destroy().then(() => {
+            expect(users[0].isSoftDeleted()).to.be.true;
+
+            return users[0].reload({ paranoid: false }).then((user) => {
+              expect(user.isSoftDeleted()).to.be.true;
+            });
+          });
+        });
+      });
+    });
+
+    it('works with custom `deletedAt` field name', function() {
+      const self = this;
+      this.ParanoidUserWithCustomDeletedAt = this.sequelize.define('ParanoidUserWithCustomDeletedAt', {
+        username: { type: DataTypes.STRING }
+      }, {
+        deletedAt: 'deletedAtThisTime',
+        paranoid: true
+      });
+
+      this.ParanoidUserWithCustomDeletedAt.hasOne(this.ParanoidUser);
+
+      return this.ParanoidUserWithCustomDeletedAt.sync({ force: true }).then(() => {
+        return this.ParanoidUserWithCustomDeletedAt.create({ username: 'fnord' }).then(() => {
+          return self.ParanoidUserWithCustomDeletedAt.findAll().then((users) => {
+            expect(users[0].isSoftDeleted()).to.be.false;
+
+            return users[0].destroy().then(() => {
+              expect(users[0].isSoftDeleted()).to.be.true;
+
+              return users[0].reload({ paranoid: false }).then((user) => {
+                expect(user.isSoftDeleted()).to.be.true;
+              });
+            });
+          });
+        });
+      });
+    });
+  });
+
   describe('restore', () => {
     it('returns an error if the model is not paranoid', function() {
       return this.User.create({username: 'Peter', secretValue: '42'}).then((user) => {

--- a/test/unit/instance/is-soft-deleted.test.js
+++ b/test/unit/instance/is-soft-deleted.test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support   = require(__dirname + '/../support'),
+  current   = Support.sequelize,
+  DataTypes = require(__dirname + '/../../../lib/data-types'),
+  Sequelize = Support.Sequelize;
+
+describe(Support.getTestDialectTeaser('Instance'), () => {
+  describe('isSoftDeleted', () => {
+    beforeEach(function() {
+      const User = current.define('User', {
+        name: DataTypes.STRING,
+        birthdate: DataTypes.DATE,
+        meta: DataTypes.JSON,
+        deletedAt: {
+          type: Sequelize.DATE
+        }
+      });
+
+      const ParanoidUser = current.define('User', {
+        name: DataTypes.STRING,
+        birthdate: DataTypes.DATE,
+        meta: DataTypes.JSON,
+        deletedAt: {
+          type: Sequelize.DATE
+        }
+      }, {
+        paranoid: true
+      });
+
+      this.paranoidUser = ParanoidUser.build({
+        name: 'a'
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+
+      this.user = User.build({
+        name: 'a'
+      }, {
+        isNewRecord: false,
+        raw: true
+      });
+    });
+
+    it('should not throw if paranoid is set to true', function() {
+      expect(() => {
+        this.paranoidUser.isSoftDeleted();
+      }).to.not.throw();
+    });
+
+    it('should throw if paranoid is set to false', function() {
+      expect(() => {
+        this.user.isSoftDeleted();
+      }).to.throw('Model is not paranoid');
+    });
+  });
+});

--- a/test/unit/instance/is-soft-deleted.test.js
+++ b/test/unit/instance/is-soft-deleted.test.js
@@ -5,7 +5,8 @@ const chai = require('chai'),
   Support   = require(__dirname + '/../support'),
   current   = Support.sequelize,
   DataTypes = require(__dirname + '/../../../lib/data-types'),
-  Sequelize = Support.Sequelize;
+  Sequelize = Support.Sequelize,
+  moment    = require('moment');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
   describe('isSoftDeleted', () => {
@@ -55,6 +56,24 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       expect(() => {
         this.user.isSoftDeleted();
       }).to.throw('Model is not paranoid');
+    });
+
+    it('should return false if the soft-delete property is the same as ' +
+      'the default value', function() {
+      this.paranoidUser.setDataValue('deletedAt', null);
+      expect(this.paranoidUser.isSoftDeleted()).to.be.false;
+    });
+
+    it('should return false if the soft-delete property is set to a date in ' +
+      'the future', function() {
+      this.paranoidUser.setDataValue('deletedAt', moment().add(5, 'days').format());
+      expect(this.paranoidUser.isSoftDeleted()).to.be.false;
+    });
+
+    it('should return true if the soft-delete property is set to a date ' +
+      'before now', function() {
+      this.paranoidUser.setDataValue('deletedAt', moment().subtract(5, 'days').format());
+      expect(this.paranoidUser.isSoftDeleted()).to.be.true;
     });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? **I need to fix failing tests**
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Since users can rename the `deletedAt` field when creating a model it is helpful to have a `isSoftDeleted` so other users of the DB don't have to hard code the custom `deletedAt` field name throughout their codebase.

Addresses: https://github.com/sequelize/sequelize/issues/7408