### PR TITLE
feat(validation): new properties for ValidationErrorItem class

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -293,7 +293,10 @@ class Query extends AbstractQuery {
       _.forOwn(fields, (value, field) => {
         errors.push(new sequelizeErrors.ValidationErrorItem(
           this.getUniqueConstraintErrorMessage(field),
-          'unique violation', field, value
+          'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+          field,
+          value,
+          this.instance
         ));
       });
 

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -293,7 +293,7 @@ class Query extends AbstractQuery {
       _.forOwn(fields, (value, field) => {
         errors.push(new sequelizeErrors.ValidationErrorItem(
           this.getUniqueConstraintErrorMessage(field),
-          'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+          'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
           field,
           value,
           this.instance,

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -293,7 +293,7 @@ class Query extends AbstractQuery {
       _.forOwn(fields, (value, field) => {
         errors.push(new sequelizeErrors.ValidationErrorItem(
           this.getUniqueConstraintErrorMessage(field),
-          'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
+          'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,
           field,
           value,
           this.instance,

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -296,7 +296,8 @@ class Query extends AbstractQuery {
           'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
           field,
           value,
-          this.instance
+          this.instance,
+          'not_unique'
         ));
       });
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -196,7 +196,7 @@ class Query extends AbstractQuery {
         _.forOwn(fields, (value, field) => {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
-            'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
+            'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,
             field,
             value,
             this.instance,

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -196,7 +196,7 @@ class Query extends AbstractQuery {
         _.forOwn(fields, (value, field) => {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
-            'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+            'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
             field,
             value,
             this.instance,

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -210,15 +210,16 @@ class Query extends AbstractQuery {
       case 1451:
       case 1452: {
         // e.g. CONSTRAINT `example_constraint_name` FOREIGN KEY (`example_id`) REFERENCES `examples` (`id`)
-        const match  = err.message.match(/CONSTRAINT `(.*)` FOREIGN KEY \(`(.*)`\) REFERENCES `(.*)` \(`(.*)`\)/);
-        const fields = match ? match[2].split(/`, *`/) : undefined;
+        const match  = err.message.match(/CONSTRAINT ([`"])(.*)\1 FOREIGN KEY \(\1(.*)\1\) REFERENCES \1(.*)\1 \(\1(.*)\1\)/);
+        const quoteChar = match ? match[1] : '`';
+        const fields = match ? match[3].split(new RegExp(`${quoteChar}, *${quoteChar}`)) : undefined;
 
         return new sequelizeErrors.ForeignKeyConstraintError({
           reltype: String(errCode) === '1451' ? 'parent' : 'child',
-          table: match ? match[3] : undefined,
+          table: match ? match[4] : undefined,
           fields,
-          value: fields.length && this.instance && this.instance[fields[0]] || undefined,
-          index: match ? match[1] : undefined,
+          value: fields && fields.length && this.instance && this.instance[fields[0]] || undefined,
+          index: match ? match[2] : undefined,
           parent: err
         });
       }

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -199,7 +199,8 @@ class Query extends AbstractQuery {
             'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
             field,
             value,
-            this.instance
+            this.instance,
+            'not_unique'
           ));
         });
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -196,7 +196,10 @@ class Query extends AbstractQuery {
         _.forOwn(fields, (value, field) => {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
-            'unique violation', field, value
+            'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+            field,
+            value,
+            this.instance
           ));
         });
 

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -298,7 +298,7 @@ class Query extends AbstractQuery {
           _.forOwn(fields, (value, field) => {
             errors.push(new sequelizeErrors.ValidationErrorItem(
               this.getUniqueConstraintErrorMessage(field),
-              'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
+              'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,
               field,
               value,
               this.instance,

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -298,7 +298,11 @@ class Query extends AbstractQuery {
           _.forOwn(fields, (value, field) => {
             errors.push(new sequelizeErrors.ValidationErrorItem(
               this.getUniqueConstraintErrorMessage(field),
-              'unique violation', field, value));
+              'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+              field,
+              value,
+              this.instance
+            ));
           });
 
           if (this.model && this.model.uniqueKeys) {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -301,7 +301,8 @@ class Query extends AbstractQuery {
               'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
               field,
               value,
-              this.instance
+              this.instance,
+              'not_unique'
             ));
           });
 

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -298,7 +298,7 @@ class Query extends AbstractQuery {
           _.forOwn(fields, (value, field) => {
             errors.push(new sequelizeErrors.ValidationErrorItem(
               this.getUniqueConstraintErrorMessage(field),
-              'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+              'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
               field,
               value,
               this.instance,

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -397,7 +397,7 @@ class Query extends AbstractQuery {
         for (const field of fields) {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
-            'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
+            'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,
             field,
             this.instance && this.instance[field],
             this.instance,

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -397,7 +397,11 @@ class Query extends AbstractQuery {
         for (const field of fields) {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
-            'unique violation', field, this.instance && this.instance[field]));
+            'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+            field,
+            this.instance && this.instance[field],
+            this.instance
+          ));
         }
 
         if (this.model) {

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -397,7 +397,7 @@ class Query extends AbstractQuery {
         for (const field of fields) {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
-            'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
+            'unique violation', // sequelizeErrors.ValidationErrorItem.ORIGINS.DB,
             field,
             this.instance && this.instance[field],
             this.instance,

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -400,7 +400,8 @@ class Query extends AbstractQuery {
             'unique violation', // sequelizeErrors.ValidationErrorItem.TYPES.DB
             field,
             this.instance && this.instance[field],
-            this.instance
+            this.instance,
+            'not_unique'
           ));
         }
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -54,7 +54,7 @@ class ValidationError extends BaseError {
 
       // ... otherwise create a concatenated message out of existing errors.
     } else if (this.errors.length > 0 && this.errors[0].message) {
-      this.message = this.errors.map(err => err.type + ': ' + err.message).join(',\n');
+      this.message = this.errors.map(err => (err.original_type || err.type) + ': ' + err.message).join(',\n');
     }
     Error.captureStackTrace(this, this.constructor);
   }
@@ -224,21 +224,56 @@ exports.UnknownConstraintError = UnknownConstraintError;
  * Validation Error Item
  * Instances of this class are included in the `ValidationError.errors` property.
  *
- * @param {string} message An error message
- * @param {string} type The type of the validation error
- * @param {string} path The field that triggered the validation error
+ * @param {String} message  - An error message
+ * @param {String} type     - The type of the validation error
+ * @param {String} path     - The field that triggered the validation error
+ * @param {String} value    - The value that generated the error
+ * @param {Object} inst     - optional, the DAO instance that caused the validation error
+ * @param {String} fn_name  - optional, property name of the validator that caused the validation error (e.g. "in" or "len")
+ * @param {String} fn_args  - optional, parameters used with the validator (this is only relevant to built in validators)
+ *
  * @param {string} value The value that generated the error
  */
 class ValidationErrorItem {
-  constructor(message, type, path, value) {
+  constructor(message, type, path, value, inst, fn_name, fn_args) {
     this.message = message || '';
-    this.type = type || null;
+    this.type = null;
     this.path = path || null;
     this.value = value !== undefined ? value : null;
-    //This doesn't need captureStackTrace because it's not a subclass of Error
+
+    this.instance = inst || null;
+    this.validator_name = fn_name || null;
+    this.validator_args = fn_args || [];
+
+    if (type) {
+      if (ValidationErrorItem.TYPES[ type ]) {
+        this.type = type;
+      } else {
+        const lctype = (type + '').toLowerCase().trim();
+        const rtype  = ValidationErrorItem.TypeStringMap[ lctype ]; // "real type" ... but also https://en.wikipedia.org/wiki/R-Type :-D
+
+        if (rtype && ValidationErrorItem.TYPES[ rtype ]) {
+          this.type           = ValidationErrorItem.TypeStringMap[ rtype ];
+          this.original_type  = type; // expose the value of "type" as it was in previous version (just in case someone is reliant on it?)
+        }
+      }
+    }
   }
 }
-exports.ValidationErrorItem = ValidationErrorItem;
+exports.ValidationErrorItem       = ValidationErrorItem;
+
+ValidationErrorItem.TYPES         = Object.freeze({
+  CORE      : 'CORE',
+  DB        : 'DB',
+  FUNCTION  : 'FUNCTION'
+});
+
+ValidationErrorItem.TypeStringMap = {
+  'notnull violation'             : 'CORE',
+  'string violation'              : 'DB',
+  'validation error'              : '',
+  'unique violation'              : '',
+};
 
 /**
  * A base class for all connection related errors.

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -275,13 +275,18 @@ class ValidationErrorItem {
    * @throws  {Error}                 - thrown if NSSeparator is found to be invalid.
    * @return  {String}
    */
-  getValidatorKey(useTypeAsNS = true, NSSeparator = '.') {
+  getValidatorKey(useTypeAsNS/* = true */, NSSeparator/* = '.'*/) {
+    // parameter defaults: some CI instances give a syntax error on actual parameter default values
+    const
+      useTANS = typeof useTypeAsNS === 'undefined' ?  true : !!useTypeAsNS,
+      NSSep   = typeof NSSeparator === 'undefined' ? '.' : NSSeparator;
+
     const
       type  = this.type,
       key   = this.validatorKey || this.validatorName,
-      useNS = useTypeAsNS && type && ValidationErrorItem.TYPES[ type ];
+      useNS = useTANS && type && ValidationErrorItem.TYPES[ type ];
 
-    if (useNS && (typeof NSSeparator !== 'string' || !NSSeparator.length)) {
+    if (useNS && (typeof NSSep !== 'string' || !NSSep.length)) {
       throw new Error('Invalid namespace separator given, must be a non-empty string');
     }
 
@@ -289,7 +294,7 @@ class ValidationErrorItem {
       return '';
     }
 
-    return (useNS ? [type, key].join(NSSeparator) : key).trim().toLowerCase();
+    return (useNS ? [type, key].join(NSSep) : key).trim().toLowerCase();
   }
 }
 exports.ValidationErrorItem       = ValidationErrorItem;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -296,6 +296,28 @@ class ValidationErrorItem {
 
     return (useNS ? [type, key].join(NSSep) : key).trim().toLowerCase();
   }
+
+
+  /**
+   * generate custom output for JSON.stringify(),
+   * this avoids errors related to serializing circular-refs (due to the `this.instance` property)
+   *
+   * @return  {String}
+   */
+  toJSON() {
+    const o = {
+      message       : this.message,
+      type          : this.type,
+      path          : this.path,
+      value         : this.value,
+      validatorKey  : this.validatorKey,
+      validatorName : this.validatorName,
+      validatorArgs : this.validatorArgs,
+      instance      : this.instance ? this.instance.get({ plain: true }) : null
+    };
+
+    return o;
+  }
 }
 exports.ValidationErrorItem       = ValidationErrorItem;
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -253,7 +253,7 @@ class ValidationErrorItem {
         const rtype  = ValidationErrorItem.TypeStringMap[ lctype ]; // "real type" ... but also https://en.wikipedia.org/wiki/R-Type :-D
 
         if (rtype && ValidationErrorItem.TYPES[ rtype ]) {
-          this.type           = ValidationErrorItem.TypeStringMap[ rtype ];
+          this.type           = rtype;
           this.original_type  = type; // expose the value of "type" as it was in previous version (just in case someone is reliant on it?)
         }
       }

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const _ = require('lodash');
+
 /**
  * Sequelize provides a host of custom error classes, to allow you to do easier debugging. All of these errors are exposed on the sequelize object and the sequelize constructor.
  * All sequelize errors inherit from the base JS error object.
@@ -224,14 +226,14 @@ exports.UnknownConstraintError = UnknownConstraintError;
  * Validation Error Item
  * Instances of this class are included in the `ValidationError.errors` property.
  *
- * @param {String} message      - An error message
- * @param {String} type         - The type/origin of the validation error
- * @param {String} path         - The field that triggered the validation error
- * @param {String} value        - The value that generated the error
- * @param {Object} inst         - optional, the DAO instance that caused the validation error
- * @param {Object} validatorKey - optional, a validation "key", used for identification
- * @param {String} fnName       - optional, property name of the BUILT-IN validator function that caused the validation error (e.g. "in" or "len"), if applicable
- * @param {String} fnArgs       - optional, parameters used with the BUILT-IN validator function, if applicable
+ * @param {String} message An error message
+ * @param {String} type The type/origin of the validation error
+ * @param {String} path The field that triggered the validation error
+ * @param {String} value The value that generated the error
+ * @param {Object} inst optional, the DAO instance that caused the validation error
+ * @param {Object} validatorKey optional, a validation "key", used for identification
+ * @param {String} fnName optional, property name of the BUILT-IN validator function that caused the validation error (e.g. "in" or "len"), if applicable
+ * @param {String} fnArgs optional, parameters used with the BUILT-IN validator function, if applicable
  *
  * @param {string} value The value that generated the error
  */
@@ -242,17 +244,17 @@ class ValidationErrorItem {
     this.path = path || null;
     this.value = value !== undefined ? value : null;
 
-    this.origin         = null;
-    this.instance       = inst || null;
-    this.validatorKey   = validatorKey || null;
-    this.validatorName  = fnName || null;
-    this.validatorArgs  = fnArgs || [];
+    this.origin = null;
+    this.instance = inst || null;
+    this.validatorKey = validatorKey || null;
+    this.validatorName = fnName || null;
+    this.validatorArgs = fnArgs || [];
 
     if (type) {
       if (ValidationErrorItem.Origins[ type ]) {
         this.origin = type;
       } else {
-        const lowercaseType = (type + '').toLowerCase().trim();
+        const lowercaseType = _.toLower(type + '').trim();
         const realType  = ValidationErrorItem.TypeStringMap[ lowercaseType ];
 
         if (realType && ValidationErrorItem.Origins[ realType ]) {
@@ -261,26 +263,28 @@ class ValidationErrorItem {
         }
       }
     }
+
+    // This doesn't need captureStackTrace because it's not a subclass of Error
   }
 
   /**
    * return a lowercase, trimmed string "key" that identifies the validator.
    *
-   * N.B. the string will be empty if the instance has neither a valid `validatorKey` property nor a valid `validatorName` property
+   * Note: the string will be empty if the instance has neither a valid `validatorKey` property nor a valid `validatorName` property
    *
-   * @param   {Boolean} [useTypeAsNS=true]    - optional, defaults to TRUE, controls whether the returned value is "namespace",
+   * @param   {Boolean} [useTypeAsNS=true]      optional, defaults to TRUE, controls whether the returned value is "namespace",
    *                                            this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.Origins
-   * @param   {String}  [NSSeparator='.']     - a separator string for concatenating the namespace, must be not be empty,
+   * @param   {String}  [NSSeparator='.']       a separator string for concatenating the namespace, must be not be empty,
    *                                            defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
-   * @throws  {Error}                         - thrown if NSSeparator is found to be invalid.
+   * @throws  {Error}                           thrown if NSSeparator is found to be invalid.
    * @return  {String}
    */
   getValidatorKey(useTypeAsNS, NSSeparator) {
     const useTANS = typeof useTypeAsNS === 'undefined' ?  true : !!useTypeAsNS;
-    const NSSep   = typeof NSSeparator === 'undefined' ? '.' : NSSeparator;
+    const NSSep = typeof NSSeparator === 'undefined' ? '.' : NSSeparator;
 
-    const type  = this.origin;
-    const key   = this.validatorKey || this.validatorName;
+    const type = this.origin;
+    const key = this.validatorKey || this.validatorName;
     const useNS = useTANS && type && ValidationErrorItem.Origins[ type ];
 
     if (useNS && (typeof NSSep !== 'string' || !NSSep.length)) {
@@ -291,10 +295,11 @@ class ValidationErrorItem {
       return '';
     }
 
-    return (useNS ? [type, key].join(NSSep) : key).trim().toLowerCase();
+    return _.toLower(useNS ? [type, key].join(NSSep) : key).trim();
   }
 }
-exports.ValidationErrorItem       = ValidationErrorItem;
+
+exports.ValidationErrorItem = ValidationErrorItem;
 
 /**
  * An enum that defines valid ValidationErrorItem `origin` values
@@ -304,12 +309,11 @@ exports.ValidationErrorItem       = ValidationErrorItem;
  * @property DB         {String}  specifies validation errors that originate from the storage engine
  * @property FUNCTION   {String}  specifies validation errors that originate from validator functions (both built-in and custom) defined for a given attribute
  */
-ValidationErrorItem.Origins       = {
-  CORE                            : 'CORE',
-  DB                              : 'DB',
-  FUNCTION                        : 'FUNCTION'
+ValidationErrorItem.Origins = {
+  CORE : 'CORE',
+  DB : 'DB',
+  FUNCTION : 'FUNCTION'
 };
-
 
 /**
  * An object that is used internally by the `ValidationErrorItem` class
@@ -319,10 +323,10 @@ ValidationErrorItem.Origins       = {
  * @type {Object}
  */
 ValidationErrorItem.TypeStringMap = {
-  'notnull violation'             : 'CORE',
-  'string violation'              : 'CORE',
-  'unique violation'              : 'DB',
-  'validation error'              : 'FUNCTION'
+  'notnull violation' : 'CORE',
+  'string violation' : 'CORE',
+  'unique violation' : 'DB',
+  'validation error' : 'FUNCTION'
 };
 
 /**

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -54,7 +54,7 @@ class ValidationError extends BaseError {
 
       // ... otherwise create a concatenated message out of existing errors.
     } else if (this.errors.length > 0 && this.errors[0].message) {
-      this.message = this.errors.map(err => (err.original_type || err.type) + ': ' + err.message).join(',\n');
+      this.message = this.errors.map(err => (err.originalType || err.type) + ': ' + err.message).join(',\n');
     }
     Error.captureStackTrace(this, this.constructor);
   }
@@ -229,24 +229,24 @@ exports.UnknownConstraintError = UnknownConstraintError;
  * @param {String} path     - The field that triggered the validation error
  * @param {String} value    - The value that generated the error
  * @param {Object} inst     - optional, the DAO instance that caused the validation error
- * @param {String} fn_name  - optional, property name of the validator that caused the validation error (e.g. "in" or "len")
- * @param {String} fn_args  - optional, parameters used with the validator (this is only relevant to built in validators)
+ * @param {String} fnName  - optional, property name of the validator that caused the validation error (e.g. "in" or "len")
+ * @param {String} fnArgs  - optional, parameters used with the validator (this is only relevant to built in validators)
  *
  * @param {string} value The value that generated the error
  */
 class ValidationErrorItem {
-  constructor(message, type, path, value, inst, fn_name, fn_args) {
+  constructor(message, type, path, value, inst, fnName, fnArgs) {
     this.message = message || '';
     this.type = null;
     this.path = path || null;
     this.value = value !== undefined ? value : null;
 
     this.instance = inst || null;
-    this.validator_name = fn_name || null;
-    this.validator_args = fn_args || [];
+    this.validatorName = fnName || null;
+    this.validatorArgs = fnArgs || [];
 
     if (type) {
-      if (ValidationErrorItem.TYPES[ type ]) {
+      if (ValidationErrorItem.USE_OLD_TYPES || ValidationErrorItem.TYPES[ type ]) {
         this.type = type;
       } else {
         const lctype = (type + '').toLowerCase().trim();
@@ -254,7 +254,7 @@ class ValidationErrorItem {
 
         if (rtype && ValidationErrorItem.TYPES[ rtype ]) {
           this.type           = rtype;
-          this.original_type  = type; // expose the value of "type" as it was in previous version (just in case someone is reliant on it?)
+          this.originalType   = type; // expose the value of "type" as it was in previous version (just in case someone is reliant on it?)
         }
       }
     }
@@ -263,16 +263,16 @@ class ValidationErrorItem {
 exports.ValidationErrorItem       = ValidationErrorItem;
 
 ValidationErrorItem.TYPES         = Object.freeze({
-  CORE      : 'CORE',
-  DB        : 'DB',
-  FUNCTION  : 'FUNCTION'
+  CORE                            : 'CORE',
+  DB                              : 'DB',
+  FUNCTION                        : 'FUNCTION'
 });
 
 ValidationErrorItem.TypeStringMap = {
   'notnull violation'             : 'CORE',
-  'string violation'              : 'DB',
-  'validation error'              : '',
-  'unique violation'              : '',
+  'string violation'              : 'CORE',
+  'unique violation'              : 'DB',
+  'validation error'              : 'FUNCTION'
 };
 
 /**

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -249,13 +249,13 @@ class ValidationErrorItem {
     this.validatorArgs  = fnArgs || [];
 
     if (type) {
-      if (ValidationErrorItem.ORIGINS[ type ]) {
+      if (ValidationErrorItem.Origins[ type ]) {
         this.origin = type;
       } else {
         const lowercaseType = (type + '').toLowerCase().trim();
         const realType  = ValidationErrorItem.TypeStringMap[ lowercaseType ];
 
-        if (realType && ValidationErrorItem.ORIGINS[ realType ]) {
+        if (realType && ValidationErrorItem.Origins[ realType ]) {
           this.origin = realType;
           this.type = type;
         }
@@ -269,7 +269,7 @@ class ValidationErrorItem {
    * N.B. the string will be empty if the instance has neither a valid `validatorKey` property nor a valid `validatorName` property
    *
    * @param   {Boolean} [useTypeAsNS=true]    - optional, defaults to TRUE, controls whether the returned value is "namespace",
-   *                                            this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.ORIGINS
+   *                                            this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.Origins
    * @param   {String}  [NSSeparato='.']      - a separator string for concatenating the namespace, must be not be empty,
    *                                            defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
    * @throws  {Error}                         - thrown if NSSeparator is found to be invalid.
@@ -281,7 +281,7 @@ class ValidationErrorItem {
 
     const type  = this.origin;
     const key   = this.validatorKey || this.validatorName;
-    const useNS = useTANS && type && ValidationErrorItem.ORIGINS[ type ];
+    const useNS = useTANS && type && ValidationErrorItem.Origins[ type ];
 
     if (useNS && (typeof NSSep !== 'string' || !NSSep.length)) {
       throw new Error('Invalid namespace separator given, must be a non-empty string');
@@ -304,11 +304,11 @@ exports.ValidationErrorItem       = ValidationErrorItem;
  * @property DB         {String}  specifies validation errors that originate from the storage engine
  * @property FUNCTION   {String}  specifies validation errors that originate from validator functions (both built-in and custom) defined for a given attribute
  */
-ValidationErrorItem.ORIGINS         = Object.freeze({
+ValidationErrorItem.Origins       = {
   CORE                            : 'CORE',
   DB                              : 'DB',
   FUNCTION                        : 'FUNCTION'
-});
+};
 
 
 /**

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -229,21 +229,24 @@ exports.UnknownConstraintError = UnknownConstraintError;
  * @param {String} path     - The field that triggered the validation error
  * @param {String} value    - The value that generated the error
  * @param {Object} inst     - optional, the DAO instance that caused the validation error
- * @param {String} fnName  - optional, property name of the validator that caused the validation error (e.g. "in" or "len")
- * @param {String} fnArgs  - optional, parameters used with the validator (this is only relevant to built in validators)
+ * @param {Object} vKey     - optional, a validation "key", used for identification
+ * @param {String} fnName   - optional, property name of the BUILT-IN validator function that caused the validation error (e.g. "in" or "len"), if applicable
+ * @param {String} fnArgs   - optional, parameters used with the BUILT-IN validator function, if applicable
  *
  * @param {string} value The value that generated the error
  */
 class ValidationErrorItem {
-  constructor(message, type, path, value, inst, fnName, fnArgs) {
+  constructor(message, type, path, value, inst, vKey, fnName, fnArgs) {
     this.message = message || '';
     this.type = null;
     this.path = path || null;
     this.value = value !== undefined ? value : null;
 
-    this.instance = inst || null;
-    this.validatorName = fnName || null;
-    this.validatorArgs = fnArgs || [];
+    this.instance       = inst || null;
+
+    this.validatorKey   = vKey || null;
+    this.validatorName  = fnName || null;
+    this.validatorArgs  = fnArgs || [];
 
     if (type) {
       if (ValidationErrorItem.USE_OLD_TYPES || ValidationErrorItem.TYPES[ type ]) {
@@ -259,12 +262,44 @@ class ValidationErrorItem {
       }
     }
   }
+
+  /**
+   * return a lowercase, trimmed string "key" that identifies the validator.
+   *
+   * N.B. the string will be empty if the instance has neither a valid `validatorKey` property nor a valid `validatorName` property
+   *
+   * @param   {Boolean} useTypeAsNS   - optional, defaults to TRUE, controls whether the returned value is "namespace",
+   *                                    this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.TYPES
+   * @param   {String}  NSSeparator   - a separator string for concatenating the namespace, must be not be empty,
+   *                                    defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
+   * @throws  {Error}                 - thrown if NSSeparator is found to be invalid.
+   * @return  {String}
+   */
+  getValidatorKey(useTypeAsNS = true, NSSeparator = '.') {
+    const
+      type  = this.type,
+      key   = this.validatorKey || this.validatorName,
+      useNS = useTypeAsNS && type && ValidationErrorItem.TYPES[ type ];
+
+    if (useNS && (typeof NSSeparator !== 'string' || !NSSeparator.length)) {
+      throw new Error('Invalid namespace separator given, must be a non-empty string');
+    }
+
+    if (!(typeof key === 'string' && key.length)) {
+      return '';
+    }
+
+    return (useNS ? [type, key].join(NSSeparator) : key).trim().toLowerCase();
+  }
 }
 exports.ValidationErrorItem       = ValidationErrorItem;
 
 ValidationErrorItem.TYPES         = Object.freeze({
+  // fValidation errors that orignate from checks thats Sequelize does based on 'core' attribute definitions (e.g. "notNull")
   CORE                            : 'CORE',
+  // Validation errors that originate from the storage engine
   DB                              : 'DB',
+  // Validation errors that originate from validator functions (both built-in and custom) defined for a given attribute
   FUNCTION                        : 'FUNCTION'
 });
 

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -230,10 +230,10 @@ exports.UnknownConstraintError = UnknownConstraintError;
  * @param {String} type The type/origin of the validation error
  * @param {String} path The field that triggered the validation error
  * @param {String} value The value that generated the error
- * @param {Object} inst optional, the DAO instance that caused the validation error
- * @param {Object} validatorKey optional, a validation "key", used for identification
- * @param {String} fnName optional, property name of the BUILT-IN validator function that caused the validation error (e.g. "in" or "len"), if applicable
- * @param {String} fnArgs optional, parameters used with the BUILT-IN validator function, if applicable
+ * @param {Object} [inst] the DAO instance that caused the validation error
+ * @param {Object} [validatorKey] a validation "key", used for identification
+ * @param {String} [fnName] property name of the BUILT-IN validator function that caused the validation error (e.g. "in" or "len"), if applicable
+ * @param {String} [fnArgs] parameters used with the BUILT-IN validator function, if applicable
  *
  * @param {string} value The value that generated the error
  */
@@ -272,7 +272,7 @@ class ValidationErrorItem {
    *
    * Note: the string will be empty if the instance has neither a valid `validatorKey` property nor a valid `validatorName` property
    *
-   * @param   {Boolean} [useTypeAsNS=true]      optional, defaults to TRUE, controls whether the returned value is "namespace",
+   * @param   {Boolean} [useTypeAsNS=true]      controls whether the returned value is "namespace",
    *                                            this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.Origins
    * @param   {String}  [NSSeparator='.']       a separator string for concatenating the namespace, must be not be empty,
    *                                            defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -297,29 +297,27 @@ class ValidationErrorItem {
 exports.ValidationErrorItem       = ValidationErrorItem;
 
 /**
- * defines valid ValidationErrorItem origins
+ * An enum that defines valid ValidationErrorItem `origin` values
  *
  * @type {Object}
+ * @property CORE       {String}  specifies errors that originate from the sequelize "core"
+ * @property DB         {String}  specifies validation errors that originate from the storage engine
+ * @property FUNCTION   {String}  specifies validation errors that originate from validator functions (both built-in and custom) defined for a given attribute
  */
 ValidationErrorItem.ORIGINS         = Object.freeze({
-  /**
-   * specifies errors that originate from the sequelize "core"
-   * @type {String}
-   */
   CORE                            : 'CORE',
-  /**
-   * specifies validation errors that originate from the storage engine
-   * @type {String}
-   */
   DB                              : 'DB',
-  /**
-   * specifies validation errors that originate from validator functions (both built-in and custom) defined for a given attribute
-   * @type {String}
-   */
-  //
   FUNCTION                        : 'FUNCTION'
 });
 
+
+/**
+ * An object that is used internally by the `ValidationErrorItem` class
+ * that maps current `type` strings (as given to ValidationErrorItem.constructor()) to
+ * our new `origin` values.
+ *
+ * @type {Object}
+ */
 ValidationErrorItem.TypeStringMap = {
   'notnull violation'             : 'CORE',
   'string violation'              : 'CORE',

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -224,19 +224,19 @@ exports.UnknownConstraintError = UnknownConstraintError;
  * Validation Error Item
  * Instances of this class are included in the `ValidationError.errors` property.
  *
- * @param {String} message  - An error message
- * @param {String} type     - The type of the validation error
- * @param {String} path     - The field that triggered the validation error
- * @param {String} value    - The value that generated the error
- * @param {Object} inst     - optional, the DAO instance that caused the validation error
- * @param {Object} vKey     - optional, a validation "key", used for identification
- * @param {String} fnName   - optional, property name of the BUILT-IN validator function that caused the validation error (e.g. "in" or "len"), if applicable
- * @param {String} fnArgs   - optional, parameters used with the BUILT-IN validator function, if applicable
+ * @param {String} message      - An error message
+ * @param {String} type         - The type of the validation error
+ * @param {String} path         - The field that triggered the validation error
+ * @param {String} value        - The value that generated the error
+ * @param {Object} inst         - optional, the DAO instance that caused the validation error
+ * @param {Object} validatorKey - optional, a validation "key", used for identification
+ * @param {String} fnName       - optional, property name of the BUILT-IN validator function that caused the validation error (e.g. "in" or "len"), if applicable
+ * @param {String} fnArgs       - optional, parameters used with the BUILT-IN validator function, if applicable
  *
  * @param {string} value The value that generated the error
  */
 class ValidationErrorItem {
-  constructor(message, type, path, value, inst, vKey, fnName, fnArgs) {
+  constructor(message, type, path, value, inst, validatorKey, fnName, fnArgs) {
     this.message = message || '';
     this.type = null;
     this.path = path || null;
@@ -244,7 +244,7 @@ class ValidationErrorItem {
 
     this.instance       = inst || null;
 
-    this.validatorKey   = vKey || null;
+    this.validatorKey   = validatorKey || null;
     this.validatorName  = fnName || null;
     this.validatorArgs  = fnArgs || [];
 
@@ -252,11 +252,11 @@ class ValidationErrorItem {
       if (ValidationErrorItem.USE_OLD_TYPES || ValidationErrorItem.TYPES[ type ]) {
         this.type = type;
       } else {
-        const lctype = (type + '').toLowerCase().trim();
-        const rtype  = ValidationErrorItem.TypeStringMap[ lctype ]; // "real type" ... but also https://en.wikipedia.org/wiki/R-Type :-D
+        const lowercaseType = (type + '').toLowerCase().trim();
+        const realType  = ValidationErrorItem.TypeStringMap[ lowercaseType ];
 
-        if (rtype && ValidationErrorItem.TYPES[ rtype ]) {
-          this.type           = rtype;
+        if (realType && ValidationErrorItem.TYPES[ realType ]) {
+          this.type           = realType;
           this.originalType   = type; // expose the value of "type" as it was in previous version (just in case someone is reliant on it?)
         }
       }

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -54,7 +54,7 @@ class ValidationError extends BaseError {
 
       // ... otherwise create a concatenated message out of existing errors.
     } else if (this.errors.length > 0 && this.errors[0].message) {
-      this.message = this.errors.map(err => (err.originalType || err.type) + ': ' + err.message).join(',\n');
+      this.message = this.errors.map(err => (err.type || err.origin) + ': ' + err.message).join(',\n');
     }
     Error.captureStackTrace(this, this.constructor);
   }
@@ -225,7 +225,7 @@ exports.UnknownConstraintError = UnknownConstraintError;
  * Instances of this class are included in the `ValidationError.errors` property.
  *
  * @param {String} message      - An error message
- * @param {String} type         - The type of the validation error
+ * @param {String} type         - The type/origin of the validation error
  * @param {String} path         - The field that triggered the validation error
  * @param {String} value        - The value that generated the error
  * @param {Object} inst         - optional, the DAO instance that caused the validation error
@@ -242,22 +242,22 @@ class ValidationErrorItem {
     this.path = path || null;
     this.value = value !== undefined ? value : null;
 
+    this.origin         = null;
     this.instance       = inst || null;
-
     this.validatorKey   = validatorKey || null;
     this.validatorName  = fnName || null;
     this.validatorArgs  = fnArgs || [];
 
     if (type) {
-      if (ValidationErrorItem.USE_OLD_TYPES || ValidationErrorItem.TYPES[ type ]) {
-        this.type = type;
+      if (ValidationErrorItem.ORIGINS[ type ]) {
+        this.origin = type;
       } else {
         const lowercaseType = (type + '').toLowerCase().trim();
         const realType  = ValidationErrorItem.TypeStringMap[ lowercaseType ];
 
-        if (realType && ValidationErrorItem.TYPES[ realType ]) {
-          this.type           = realType;
-          this.originalType   = type; // expose the value of "type" as it was in previous version (just in case someone is reliant on it?)
+        if (realType && ValidationErrorItem.ORIGINS[ realType ]) {
+          this.origin = realType;
+          this.type = type;
         }
       }
     }
@@ -269,7 +269,7 @@ class ValidationErrorItem {
    * N.B. the string will be empty if the instance has neither a valid `validatorKey` property nor a valid `validatorName` property
    *
    * @param   {Boolean} useTypeAsNS   - optional, defaults to TRUE, controls whether the returned value is "namespace",
-   *                                    this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.TYPES
+   *                                    this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.ORIGINS
    * @param   {String}  NSSeparator   - a separator string for concatenating the namespace, must be not be empty,
    *                                    defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
    * @throws  {Error}                 - thrown if NSSeparator is found to be invalid.
@@ -282,9 +282,9 @@ class ValidationErrorItem {
       NSSep   = typeof NSSeparator === 'undefined' ? '.' : NSSeparator;
 
     const
-      type  = this.type,
+      type  = this.origin,
       key   = this.validatorKey || this.validatorName,
-      useNS = useTANS && type && ValidationErrorItem.TYPES[ type ];
+      useNS = useTANS && type && ValidationErrorItem.ORIGINS[ type ];
 
     if (useNS && (typeof NSSep !== 'string' || !NSSep.length)) {
       throw new Error('Invalid namespace separator given, must be a non-empty string');
@@ -296,32 +296,10 @@ class ValidationErrorItem {
 
     return (useNS ? [type, key].join(NSSep) : key).trim().toLowerCase();
   }
-
-
-  /**
-   * generate custom output for JSON.stringify(),
-   * this avoids errors related to serializing circular-refs (due to the `this.instance` property)
-   *
-   * @return  {String}
-   */
-  toJSON() {
-    const o = {
-      message       : this.message,
-      type          : this.type,
-      path          : this.path,
-      value         : this.value,
-      validatorKey  : this.validatorKey,
-      validatorName : this.validatorName,
-      validatorArgs : this.validatorArgs,
-      instance      : this.instance ? this.instance.get({ plain: true }) : null
-    };
-
-    return o;
-  }
 }
 exports.ValidationErrorItem       = ValidationErrorItem;
 
-ValidationErrorItem.TYPES         = Object.freeze({
+ValidationErrorItem.ORIGINS         = Object.freeze({
   // fValidation errors that orignate from checks thats Sequelize does based on 'core' attribute definitions (e.g. "notNull")
   CORE                            : 'CORE',
   // Validation errors that originate from the storage engine

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -270,7 +270,7 @@ class ValidationErrorItem {
    *
    * @param   {Boolean} [useTypeAsNS=true]    - optional, defaults to TRUE, controls whether the returned value is "namespace",
    *                                            this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.Origins
-   * @param   {String}  [NSSeparato='.']      - a separator string for concatenating the namespace, must be not be empty,
+   * @param   {String}  [NSSeparator='.']     - a separator string for concatenating the namespace, must be not be empty,
    *                                            defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
    * @throws  {Error}                         - thrown if NSSeparator is found to be invalid.
    * @return  {String}

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -268,23 +268,20 @@ class ValidationErrorItem {
    *
    * N.B. the string will be empty if the instance has neither a valid `validatorKey` property nor a valid `validatorName` property
    *
-   * @param   {Boolean} useTypeAsNS   - optional, defaults to TRUE, controls whether the returned value is "namespace",
-   *                                    this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.ORIGINS
-   * @param   {String}  NSSeparator   - a separator string for concatenating the namespace, must be not be empty,
-   *                                    defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
-   * @throws  {Error}                 - thrown if NSSeparator is found to be invalid.
+   * @param   {Boolean} [useTypeAsNS=true]    - optional, defaults to TRUE, controls whether the returned value is "namespace",
+   *                                            this parameter is ignored if the validator's `type` is not one of ValidationErrorItem.ORIGINS
+   * @param   {String}  [NSSeparato='.']      - a separator string for concatenating the namespace, must be not be empty,
+   *                                            defaults to "." (fullstop). only used and validated if useTypeAsNS is TRUE.
+   * @throws  {Error}                         - thrown if NSSeparator is found to be invalid.
    * @return  {String}
    */
-  getValidatorKey(useTypeAsNS/* = true */, NSSeparator/* = '.'*/) {
-    // parameter defaults: some CI instances give a syntax error on actual parameter default values
-    const
-      useTANS = typeof useTypeAsNS === 'undefined' ?  true : !!useTypeAsNS,
-      NSSep   = typeof NSSeparator === 'undefined' ? '.' : NSSeparator;
+  getValidatorKey(useTypeAsNS, NSSeparator) {
+    const useTANS = typeof useTypeAsNS === 'undefined' ?  true : !!useTypeAsNS;
+    const NSSep   = typeof NSSeparator === 'undefined' ? '.' : NSSeparator;
 
-    const
-      type  = this.origin,
-      key   = this.validatorKey || this.validatorName,
-      useNS = useTANS && type && ValidationErrorItem.ORIGINS[ type ];
+    const type  = this.origin;
+    const key   = this.validatorKey || this.validatorName;
+    const useNS = useTANS && type && ValidationErrorItem.ORIGINS[ type ];
 
     if (useNS && (typeof NSSep !== 'string' || !NSSep.length)) {
       throw new Error('Invalid namespace separator given, must be a non-empty string');
@@ -299,12 +296,27 @@ class ValidationErrorItem {
 }
 exports.ValidationErrorItem       = ValidationErrorItem;
 
+/**
+ * defines valid ValidationErrorItem origins
+ *
+ * @type {Object}
+ */
 ValidationErrorItem.ORIGINS         = Object.freeze({
-  // fValidation errors that orignate from checks thats Sequelize does based on 'core' attribute definitions (e.g. "notNull")
+  /**
+   * specifies errors that originate from the sequelize "core"
+   * @type {String}
+   */
   CORE                            : 'CORE',
-  // Validation errors that originate from the storage engine
+  /**
+   * specifies validation errors that originate from the storage engine
+   * @type {String}
+   */
   DB                              : 'DB',
-  // Validation errors that originate from validator functions (both built-in and custom) defined for a given attribute
+  /**
+   * specifies validation errors that originate from validator functions (both built-in and custom) defined for a given attribute
+   * @type {String}
+   */
+  //
   FUNCTION                        : 'FUNCTION'
 });
 

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -321,12 +321,7 @@ class InstanceValidator {
   _validateSchema(rawAttribute, field, value) {
     if (rawAttribute.allowNull === false && (value === null || value === undefined)) {
       const validators = this.modelInstance.validators[field];
-<<<<<<< 089504fe417310265c7823acb33ca6d2b0d4d2b6
       const errMsg = _.get(validators, 'notNull.msg', `${this.modelInstance.constructor.name}.${field} cannot be null`);
-      error = new sequelizeError.ValidationErrorItem(errMsg, 'notNull Violation', field, value);
-      this.errors.push(error);
-=======
-      const errMsg = _.get(validators, 'notNull.msg', `${field} cannot be null`);
 
       this.errors.push(new sequelizeError.ValidationErrorItem(
         errMsg,
@@ -336,7 +331,6 @@ class InstanceValidator {
         this.modelInstance,
         'is_null'
       ));
->>>>>>> initial attempt at getting extra info regarding instance/validator-func/validator-args into ValidationErrorItem instances
     }
 
     if (rawAttribute.type === DataTypes.STRING || rawAttribute.type instanceof DataTypes.STRING || rawAttribute.type === DataTypes.TEXT || rawAttribute.type instanceof DataTypes.TEXT) {

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -249,11 +249,11 @@ class InstanceValidator {
         validatorFunction = Promise.promisify(validator.bind(this.modelInstance));
       }
       return validatorFunction()
-        .catch(e => this._pushError(false, errorKey, e, optValue));
+        .catch(e => this._pushError(false, errorKey, e, optValue, validatorType));
     } else {
       return Promise
         .try(() => validator.call(this.modelInstance, invokeArgs))
-        .catch(e => this._pushError(false, errorKey, e, optValue));
+        .catch(e => this._pushError(false, errorKey, e, optValue, validatorType));
     }
   }
 
@@ -339,7 +339,8 @@ class InstanceValidator {
         'notNull Violation', // sequelizeError.ValidationErrorItem.TYPES.CORE
         field,
         value,
-        this.modelInstance
+        this.modelInstance,
+        'is_null'
       ));
 >>>>>>> initial attempt at getting extra info regarding instance/validator-func/validator-args into ValidationErrorItem instances
     }
@@ -351,7 +352,8 @@ class InstanceValidator {
           'string violation', // sequelizeError.ValidationErrorItem.TYPES.CORE
           field,
           value,
-          this.modelInstance
+          this.modelInstance,
+          'not_a_string'
         ));
       }
     }
@@ -371,8 +373,11 @@ class InstanceValidator {
   _handleReflectedResult(field, value, promiseInspections) {
     for (const promiseInspection of promiseInspections) {
       if (promiseInspection.isRejected()) {
-        const rejection = promiseInspection.error();
-        this._pushError(true, field, rejection, value, rejection.validatorName, rejection.validatorArgs);
+        const
+          rejection = promiseInspection.error(),
+          isBuiltIn = !!rejection.validatorName;
+
+        this._pushError(isBuiltIn, field, rejection, value, rejection.validatorName, rejection.validatorArgs);
       }
     }
   }
@@ -398,7 +403,8 @@ class InstanceValidator {
       value,
       this.modelInstance,
       fnName,
-      fnArgs
+      isBuiltin ? fnName : undefined,
+      isBuiltin ? fnArgs : undefined
     );
 
     error[InstanceValidator.RAW_KEY_NAME] = rawError;

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -277,8 +277,13 @@ class InstanceValidator {
       }
       const validatorArgs = this._extractValidatorArgs(test, validatorType, field);
       if (!validator[validatorType].apply(validator, [valueString].concat(validatorArgs))) {
-      // extract the error msg
-        throw new Error(test.msg || `Validation ${validatorType} on ${field} failed`);
+        // extract the error msg
+        const e = new Error(test.msg || `Validation ${validatorType} on ${field} failed`);
+
+        e.validator_name = validatorType;
+        e.validator_args = validatorArgs;
+
+        throw e;
       }
     });
   }
@@ -318,19 +323,34 @@ class InstanceValidator {
    * @private
    */
   _validateSchema(rawAttribute, field, value) {
-    let error;
-
     if (rawAttribute.allowNull === false && (value === null || value === undefined)) {
       const validators = this.modelInstance.validators[field];
+<<<<<<< 089504fe417310265c7823acb33ca6d2b0d4d2b6
       const errMsg = _.get(validators, 'notNull.msg', `${this.modelInstance.constructor.name}.${field} cannot be null`);
       error = new sequelizeError.ValidationErrorItem(errMsg, 'notNull Violation', field, value);
       this.errors.push(error);
+=======
+      const errMsg = _.get(validators, 'notNull.msg', `${field} cannot be null`);
+
+      this.errors.push(new sequelizeError.ValidationErrorItem(
+        errMsg,
+        'notNull Violation', // sequelizeError.ValidationErrorItem.TYPES.CORE
+        field,
+        value,
+        this.modelInstance
+      ));
+>>>>>>> initial attempt at getting extra info regarding instance/validator-func/validator-args into ValidationErrorItem instances
     }
 
     if (rawAttribute.type === DataTypes.STRING || rawAttribute.type instanceof DataTypes.STRING || rawAttribute.type === DataTypes.TEXT || rawAttribute.type instanceof DataTypes.TEXT) {
       if (Array.isArray(value) || _.isObject(value) && !(value instanceof Utils.SequelizeMethod) && !Buffer.isBuffer(value)) {
-        error = new sequelizeError.ValidationErrorItem(`${field} cannot be an array or an object`, 'string violation', field, value);
-        this.errors.push(error);
+        this.errors.push(new sequelizeError.ValidationErrorItem(
+          `${field} cannot be an array or an object`,
+          'string violation', // sequelizeError.ValidationErrorItem.TYPES.CORE
+          field,
+          value,
+          this.modelInstance
+        ));
       }
     }
   }
@@ -350,7 +370,7 @@ class InstanceValidator {
     for (const promiseInspection of promiseInspections) {
       if (promiseInspection.isRejected()) {
         const rejection = promiseInspection.error();
-        this._pushError(true, field, rejection, value);
+        this._pushError(true, field, rejection, value, rejection.validator_name, rejection.validator_args);
       }
     }
   }
@@ -358,15 +378,27 @@ class InstanceValidator {
   /**
    * Signs all errors retaining the original.
    *
-   * @param {boolean} isBuiltin Determines if error is from builtin validator.
-   * @param {string} errorKey The error key to assign on this.errors object.
-   * @param {Error|string} rawError The original error.
-   * @param {string|number} value The data that triggered the error.
+   * @param {Boolean}       isBuiltin   - Determines if error is from builtin validator.
+   * @param {String}        errorKey    - The error key to assign on this.errors object.
+   * @param {Error|String}  rawError    - The original error.
+   * @param {String|Number} value       - The data that triggered the error.
+   * @param {String}        fn_name     - Name of the validator, if any
+   * @param {Array}         fn_args     - Arguments for the validator [function], if any
+   *
    * @private
    */
-  _pushError(isBuiltin, errorKey, rawError, value) {
+  _pushError(isBuiltin, errorKey, rawError, value, fn_name, fn_args) {
     const message = rawError.message || rawError || 'Validation error';
-    const error = new sequelizeError.ValidationErrorItem(message, 'Validation error', errorKey, value);
+    const error = new sequelizeError.ValidationErrorItem(
+      message,
+      'Validation error', // sequelizeError.ValidationErrorItem.TYPES.FUNCTION,
+      errorKey,
+      value,
+      this.modelInstance,
+      fn_name,
+      fn_args
+    );
+
     error[InstanceValidator.RAW_KEY_NAME] = rawError;
 
     this.errors.push(error);

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -275,13 +275,15 @@ class InstanceValidator {
       if (typeof validator[validatorType] !== 'function') {
         throw new Error('Invalid validator function: ' + validatorType);
       }
+
       const validatorArgs = this._extractValidatorArgs(test, validatorType, field);
+
       if (!validator[validatorType].apply(validator, [valueString].concat(validatorArgs))) {
         // extract the error msg
         const e = new Error(test.msg || `Validation ${validatorType} on ${field} failed`);
 
-        e.validator_name = validatorType;
-        e.validator_args = validatorArgs;
+        e.validatorName = validatorType;
+        e.validatorArgs = validatorArgs;
 
         throw e;
       }
@@ -370,7 +372,7 @@ class InstanceValidator {
     for (const promiseInspection of promiseInspections) {
       if (promiseInspection.isRejected()) {
         const rejection = promiseInspection.error();
-        this._pushError(true, field, rejection, value, rejection.validator_name, rejection.validator_args);
+        this._pushError(true, field, rejection, value, rejection.validatorName, rejection.validatorArgs);
       }
     }
   }
@@ -379,15 +381,15 @@ class InstanceValidator {
    * Signs all errors retaining the original.
    *
    * @param {Boolean}       isBuiltin   - Determines if error is from builtin validator.
-   * @param {String}        errorKey    - The error key to assign on this.errors object.
+   * @param {String}        errorKey    - name of invalid attribute.
    * @param {Error|String}  rawError    - The original error.
    * @param {String|Number} value       - The data that triggered the error.
-   * @param {String}        fn_name     - Name of the validator, if any
-   * @param {Array}         fn_args     - Arguments for the validator [function], if any
+   * @param {String}        fnName      - Name of the validator, if any
+   * @param {Array}         fnArgs      - Arguments for the validator [function], if any
    *
    * @private
    */
-  _pushError(isBuiltin, errorKey, rawError, value, fn_name, fn_args) {
+  _pushError(isBuiltin, errorKey, rawError, value, fnName, fnArgs) {
     const message = rawError.message || rawError || 'Validation error';
     const error = new sequelizeError.ValidationErrorItem(
       message,
@@ -395,8 +397,8 @@ class InstanceValidator {
       errorKey,
       value,
       this.modelInstance,
-      fn_name,
-      fn_args
+      fnName,
+      fnArgs
     );
 
     error[InstanceValidator.RAW_KEY_NAME] = rawError;

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -330,7 +330,7 @@ class InstanceValidator {
 
       this.errors.push(new sequelizeError.ValidationErrorItem(
         errMsg,
-        'notNull Violation', // sequelizeError.ValidationErrorItem.TYPES.CORE
+        'notNull Violation', // sequelizeError.ValidationErrorItem.ORIGINS.CORE,
         field,
         value,
         this.modelInstance,
@@ -343,7 +343,7 @@ class InstanceValidator {
       if (Array.isArray(value) || _.isObject(value) && !(value instanceof Utils.SequelizeMethod) && !Buffer.isBuffer(value)) {
         this.errors.push(new sequelizeError.ValidationErrorItem(
           `${field} cannot be an array or an object`,
-          'string violation', // sequelizeError.ValidationErrorItem.TYPES.CORE
+          'string violation', // sequelizeError.ValidationErrorItem.ORIGINS.CORE,
           field,
           value,
           this.modelInstance,
@@ -391,7 +391,7 @@ class InstanceValidator {
     const message = rawError.message || rawError || 'Validation error';
     const error = new sequelizeError.ValidationErrorItem(
       message,
-      'Validation error', // sequelizeError.ValidationErrorItem.TYPES.FUNCTION,
+      'Validation error', // sequelizeError.ValidationErrorItem.ORIGINS.FUNCTION,
       errorKey,
       value,
       this.modelInstance,

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -279,13 +279,7 @@ class InstanceValidator {
       const validatorArgs = this._extractValidatorArgs(test, validatorType, field);
 
       if (!validator[validatorType].apply(validator, [valueString].concat(validatorArgs))) {
-        // extract the error msg
-        const e = new Error(test.msg || `Validation ${validatorType} on ${field} failed`);
-
-        e.validatorName = validatorType;
-        e.validatorArgs = validatorArgs;
-
-        throw e;
+        throw Object.assign(new Error(test.msg || `Validation ${validatorType} on ${field} failed`), { validatorName : validatorType, validatorArgs });
       }
     });
   }
@@ -373,9 +367,8 @@ class InstanceValidator {
   _handleReflectedResult(field, value, promiseInspections) {
     for (const promiseInspection of promiseInspections) {
       if (promiseInspection.isRejected()) {
-        const
-          rejection = promiseInspection.error(),
-          isBuiltIn = !!rejection.validatorName;
+        const rejection = promiseInspection.error();
+        const isBuiltIn = !!rejection.validatorName;
 
         this._pushError(isBuiltIn, field, rejection, value, rejection.validatorName, rejection.validatorArgs);
       }

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -330,7 +330,7 @@ class InstanceValidator {
 
       this.errors.push(new sequelizeError.ValidationErrorItem(
         errMsg,
-        'notNull Violation', // sequelizeError.ValidationErrorItem.ORIGINS.CORE,
+        'notNull Violation', // sequelizeError.ValidationErrorItem.Origins.CORE,
         field,
         value,
         this.modelInstance,
@@ -343,7 +343,7 @@ class InstanceValidator {
       if (Array.isArray(value) || _.isObject(value) && !(value instanceof Utils.SequelizeMethod) && !Buffer.isBuffer(value)) {
         this.errors.push(new sequelizeError.ValidationErrorItem(
           `${field} cannot be an array or an object`,
-          'string violation', // sequelizeError.ValidationErrorItem.ORIGINS.CORE,
+          'string violation', // sequelizeError.ValidationErrorItem.Origins.CORE,
           field,
           value,
           this.modelInstance,
@@ -391,7 +391,7 @@ class InstanceValidator {
     const message = rawError.message || rawError || 'Validation error';
     const error = new sequelizeError.ValidationErrorItem(
       message,
-      'Validation error', // sequelizeError.ValidationErrorItem.ORIGINS.FUNCTION,
+      'Validation error', // sequelizeError.ValidationErrorItem.Origins.FUNCTION,
       errorKey,
       value,
       this.modelInstance,

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -119,39 +119,39 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       expect(error).to.have.property('getValidatorKey');
       expect(error.getValidatorKey).to.be.a('function');
 
-      expect(error.getValidatorKey())           .to.equal('function.klen');
-      expect(error.getValidatorKey(false))      .to.equal('klen');
-      expect(error.getValidatorKey(0))          .to.equal('klen');
-      expect(error.getValidatorKey(1, ':'))     .to.equal('function:klen');
+      expect(error.getValidatorKey()).to.equal('function.klen');
+      expect(error.getValidatorKey(false)).to.equal('klen');
+      expect(error.getValidatorKey(0)).to.equal('klen');
+      expect(error.getValidatorKey(1, ':')).to.equal('function:klen');
       expect(error.getValidatorKey(true, '-:-')).to.equal('function-:-klen');
 
       const empty = new Sequelize.ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar');
 
-      expect(empty.getValidatorKey())           .to.equal('');
-      expect(empty.getValidatorKey(false))      .to.equal('');
-      expect(empty.getValidatorKey(0))          .to.equal('');
-      expect(empty.getValidatorKey(1, ':'))     .to.equal('');
+      expect(empty.getValidatorKey()).to.equal('');
+      expect(empty.getValidatorKey(false)).to.equal('');
+      expect(empty.getValidatorKey(0)).to.equal('');
+      expect(empty.getValidatorKey(1, ':')).to.equal('');
       expect(empty.getValidatorKey(true, '-:-')).to.equal('');
     });
 
     it('SequelizeValidationErrorItem.getValidatorKey() should throw if namespace separator is invalid (only if NS is used & available)', () => {
       const error = new Sequelize.ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar', null, 'klen', 'len', [4]);
 
-      expect(() => error.getValidatorKey(false, {}))       .to.not.throw();
-      expect(() => error.getValidatorKey(false, []))       .to.not.throw();
-      expect(() => error.getValidatorKey(false, null))     .to.not.throw();
-      expect(() => error.getValidatorKey(false, ''))       .to.not.throw();
-      expect(() => error.getValidatorKey(false, false))    .to.not.throw();
-      expect(() => error.getValidatorKey(false, true))     .to.not.throw();
+      expect(() => error.getValidatorKey(false, {})).to.not.throw();
+      expect(() => error.getValidatorKey(false, [])).to.not.throw();
+      expect(() => error.getValidatorKey(false, null)).to.not.throw();
+      expect(() => error.getValidatorKey(false, '')).to.not.throw();
+      expect(() => error.getValidatorKey(false, false)).to.not.throw();
+      expect(() => error.getValidatorKey(false, true)).to.not.throw();
       expect(() => error.getValidatorKey(false, undefined)).to.not.throw();
-      expect(() => error.getValidatorKey(true, undefined)) .to.not.throw(); // undefined will trigger use of function parameter default
+      expect(() => error.getValidatorKey(true, undefined)).to.not.throw(); // undefined will trigger use of function parameter default
 
-      expect(() => error.getValidatorKey(true, {}))        .to.throw(Error);
-      expect(() => error.getValidatorKey(true, []))        .to.throw(Error);
-      expect(() => error.getValidatorKey(true, null))      .to.throw(Error);
-      expect(() => error.getValidatorKey(true, ''))        .to.throw(Error);
-      expect(() => error.getValidatorKey(true, false))     .to.throw(Error);
-      expect(() => error.getValidatorKey(true, true))      .to.throw(Error);
+      expect(() => error.getValidatorKey(true, {})).to.throw(Error);
+      expect(() => error.getValidatorKey(true, [])).to.throw(Error);
+      expect(() => error.getValidatorKey(true, null)).to.throw(Error);
+      expect(() => error.getValidatorKey(true, '')).to.throw(Error);
+      expect(() => error.getValidatorKey(true, false)).to.throw(Error);
+      expect(() => error.getValidatorKey(true, true)).to.throw(Error);
     });
 
     it('SequelizeValidationErrorItem should map deprecated "type" values to new "origin" values', () => {
@@ -166,15 +166,15 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
         const error = new Sequelize.ValidationErrorItem('error!', k, 'foo', null);
 
         expect(error).to.have.property('origin', data[k]);
-        expect(error).to.have.property('type',   k);
+        expect(error).to.have.property('type', k);
       });
     });
 
     it('SequelizeValidationErrorItem.Origins is valid', () => {
       const ORIGINS = errors.ValidationErrorItem.Origins;
 
-      expect(ORIGINS).to.have.property('CORE',     'CORE');
-      expect(ORIGINS).to.have.property('DB',       'DB');
+      expect(ORIGINS).to.have.property('CORE', 'CORE');
+      expect(ORIGINS).to.have.property('DB', 'DB');
       expect(ORIGINS).to.have.property('FUNCTION', 'FUNCTION');
 
     });

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -154,7 +154,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       expect(() => error.getValidatorKey(true, true))      .to.throw(Error);
     });
 
-    it('SequelizeValidationErrorItem should map old types and expose an originalType property', () => {
+    it('SequelizeValidationErrorItem should map deprecated "type" values to new "origin" values', () => {
       const data  = {
         'notNull Violation' : 'CORE',
         'string violation'  : 'CORE',
@@ -165,38 +165,18 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       Object.keys(data).forEach(k => {
         const error = new Sequelize.ValidationErrorItem('error!', k, 'foo', null);
 
-        expect(error).to.have.property('type',         data[k]);
-        expect(error).to.have.property('originalType', k);
+        expect(error).to.have.property('origin', data[k]);
+        expect(error).to.have.property('type',   k);
       });
     });
 
-    it('activating SequelizeValidationErrorItem.USE_OLD_TYPES should turn off the new type-functionality', () => {
-      Sequelize.ValidationErrorItem.USE_OLD_TYPES = true;
+    it('SequelizeValidationErrorItem.ORIGINS is valid & frozen', () => {
+      const ORIGINS = errors.ValidationErrorItem.ORIGINS;
 
-      const data  = {
-        'notNull Violation' : 'CORE',
-        'string violation'  : 'CORE',
-        'unique violation'  : 'DB',
-        'Validation error'  : 'FUNCTION'
-      };
-
-      Object.keys(data).forEach(k => {
-        const error = new Sequelize.ValidationErrorItem('error!', k, 'foo', null);
-
-        expect(error).to.have.property('type', k);
-        expect(error).to.not.have.property('originalType');
-      });
-
-      errors.ValidationErrorItem.USE_OLD_TYPES = false; // turn off again to avoid screwing up other tests!
-    });
-
-    it('SequelizeValidationErrorItem.TYPES is valid & frozen', () => {
-      const TYPES = errors.ValidationErrorItem.TYPES;
-
-      expect(TYPES).to.be.frozen;
-      expect(TYPES).to.have.property('CORE',     'CORE');
-      expect(TYPES).to.have.property('DB',       'DB');
-      expect(TYPES).to.have.property('FUNCTION', 'FUNCTION');
+      expect(ORIGINS).to.be.frozen;
+      expect(ORIGINS).to.have.property('CORE',     'CORE');
+      expect(ORIGINS).to.have.property('DB',       'DB');
+      expect(ORIGINS).to.have.property('FUNCTION', 'FUNCTION');
 
     });
 

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -170,10 +170,9 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       });
     });
 
-    it('SequelizeValidationErrorItem.ORIGINS is valid & frozen', () => {
-      const ORIGINS = errors.ValidationErrorItem.ORIGINS;
+    it('SequelizeValidationErrorItem.Origins is valid', () => {
+      const ORIGINS = errors.ValidationErrorItem.Origins;
 
-      expect(ORIGINS).to.be.frozen;
       expect(ORIGINS).to.have.property('CORE',     'CORE');
       expect(ORIGINS).to.have.property('DB',       'DB');
       expect(ORIGINS).to.have.property('FUNCTION', 'FUNCTION');

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -991,7 +991,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const smth1 = err.get('smth')[0] || {};
 
           expect(smth1.path).to.equal('smth');
-          expect(smth1.originalType || smth1.type).to.match(/notNull Violation/);
+          expect(smth1.type || smth1.origin).to.match(/notNull Violation/);
 
           /*
           // TODO: code below specifies different tests for different dialects but all the test are exactly the same.
@@ -1683,7 +1683,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const e0name0 = errors[0].errors.get('name')[0];
 
           expect(errors[0].record.code).to.equal('1234');
-          expect(e0name0.originalType || e0name0.type).to.equal('notNull Violation');
+          expect(e0name0.type || e0name0.origin).to.equal('notNull Violation');
 
           expect(errors[1].record.name).to.equal('bar');
           expect(errors[1].record.code).to.equal('1');

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -987,7 +987,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return UserNull.sync({ force: true }).then(() => {
         return UserNull.create({ username: 'foo2', smth: null }).catch(err => {
           expect(err).to.exist;
-          expect(err.get('smth')[0].path).to.equal('smth');
+
+          const smth1 = err.get('smth')[0] || {};
+
+          expect(smth1.path).to.equal('smth');
+          expect(smth1.originalType || smth1.type).to.match(/notNull Violation/);
+
+          /*
+          // TODO: code below specifies different tests for different dialects but all the test are exactly the same.
+                   can we remove this or do we need to add tests to actually support different dialects?
           if (dialect === 'mysql') {
             // We need to allow two different errors for MySQL, see:
             // http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_strict_trans_tables
@@ -998,6 +1006,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           } else {
             expect(err.get('smth')[0].type).to.match(/notNull Violation/);
           }
+          //*/
         });
       });
     });
@@ -1670,8 +1679,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ], { validate: true }).catch(errors => {
           expect(errors).to.be.instanceof(Promise.AggregateError);
           expect(errors).to.have.length(2);
+
+          const e0name0 = errors[0].errors.get('name')[0];
+
           expect(errors[0].record.code).to.equal('1234');
-          expect(errors[0].errors.get('name')[0].type).to.equal('notNull Violation');
+          expect(e0name0.originalType || e0name0.type).to.equal('notNull Violation');
+
           expect(errors[1].record.name).to.equal('bar');
           expect(errors[1].record.code).to.equal('1');
           expect(errors[1].errors.get('code')[0].message).to.equal('Validation len on code failed');

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -992,21 +992,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           expect(smth1.path).to.equal('smth');
           expect(smth1.type || smth1.origin).to.match(/notNull Violation/);
-
-          /*
-          // TODO: code below specifies different tests for different dialects but all the test are exactly the same.
-                   can we remove this or do we need to add tests to actually support different dialects?
-          if (dialect === 'mysql') {
-            // We need to allow two different errors for MySQL, see:
-            // http://dev.mysql.com/doc/refman/5.0/en/server-sql-mode.html#sqlmode_strict_trans_tables
-            expect(err.get('smth')[0].type).to.match(/notNull Violation/);
-          }
-          else if (dialect === 'sqlite') {
-            expect(err.get('smth')[0].type).to.match(/notNull Violation/);
-          } else {
-            expect(err.get('smth')[0].type).to.match(/notNull Violation/);
-          }
-          //*/
         });
       });
     });

--- a/test/unit/dialects/mysql/errors.test.js
+++ b/test/unit/dialects/mysql/errors.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
+const queryProto = Support.sequelize.dialect.Query.prototype;
+
+if (dialect === 'mysql') {
+  describe('[MYSQL Specific] ForeignKeyConstraintError - error message parsing', () => {
+    it('FK Errors with ` quotation char are parsed correctly', () => {
+      const fakeErr = new Error('Cannot delete or update a parent row: a foreign key constraint fails (`table`.`brothers`, CONSTRAINT `brothers_ibfk_1` FOREIGN KEY (`personId`) REFERENCES `people` (`id`) ON UPDATE CASCADE).');
+
+      fakeErr.code = 1451;
+
+      const parsedErr = queryProto.formatError(fakeErr);
+
+      expect(parsedErr).to.be.instanceOf(Support.sequelize.ForeignKeyConstraintError);
+      expect(parsedErr.parent).to.equal(fakeErr);
+      expect(parsedErr.reltype).to.equal('parent');
+      expect(parsedErr.table).to.equal('people');
+      expect(parsedErr.fields).to.be.an('array').to.deep.equal(['personId']);
+      expect(parsedErr.value).to.be.undefined;
+      expect(parsedErr.index).to.equal('brothers_ibfk_1');
+    });
+
+    it('FK Errors with " quotation char are parsed correctly', () => {
+      const fakeErr = new Error('Cannot delete or update a parent row: a foreign key constraint fails ("table"."brothers", CONSTRAINT "brothers_ibfk_1" FOREIGN KEY ("personId") REFERENCES "people" ("id") ON UPDATE CASCADE).');
+
+      fakeErr.code = 1451;
+
+      const parsedErr = queryProto.formatError(fakeErr);
+
+      expect(parsedErr).to.be.instanceOf(Support.sequelize.ForeignKeyConstraintError);
+      expect(parsedErr.parent).to.equal(fakeErr);
+      expect(parsedErr.reltype).to.equal('parent');
+      expect(parsedErr.table).to.equal('people');
+      expect(parsedErr.fields).to.be.an('array').to.deep.equal(['personId']);
+      expect(parsedErr.value).to.be.undefined;
+      expect(parsedErr.index).to.equal('brothers_ibfk_1');
+    });
+  });
+}


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

This PR is looking to make the `ValidationErrorItem` class more useful by adding extra/new structured data to the instances. 

The reasoning for these changes are:

1. in order to expose more useful validation-error information at the point that we want to output/log/display the errors so that we can facilitate showing/creating messages in different languages and for different types of users - in multi-lingual systems the internal error message property is unlikely to be in the current users' language and is likely to be technical in nature - we want to be able to generate localized error messages "after the fact" and in order to create useful message we need the extra information about which validator (if applicable), and it's arguments (e.g. so you can generate a message such as "lengte moet minimaal 3 zijn" (this is dutch for "length must be at least 3" :-)).

2. we desire the ability for a REST API service to respond to a [mutation] request, in the case that there are validation errors, with both the instance data and the information about the error - this is inline with [JSONAPI](http://jsonapi.org/) spec, where an `error` property has a `pointer` (akin to `ValidationErrorItem.path`) that points to some data in the response's `data` property. Attaching the DOA `instance` to the `ValidationErrorItem` instance means that we do not need to manually track which DOA instance needs to be potentially returned with which error in our service/app. 
#### new `ValidationErrorItem` instance properties

1. `validatorKey` - a string identifier for the validation error
2. `validatorName` - name of a  built-in validator function, if applicable (e.g. "in" or "len")
3. `validatorArgs` - an array of arguments that the validator was called with (only relevant to some built-in validators)
4. `instance` - a refence to the DAO instance that triggered the error, if available.
5. `origin` - contains the value of the "type" parameter (as passed in by constructor callers) mapped to a valid value in `ValidationErrorItem.ORIGINS`. 

#### new `ValidationErrorItem.getValidatorKey` instance method

this method returns a lowercased string, by default namespaced with the instance's `type` (assuming it is a valid built-in ValidationErrorItem.ORIGINS value) e.g. `"function.len"`

#### an evil `type` of property ...

the current `type` property of `ValidationErrorItem` is set to arbitrary strings making it a bad candidate for anything other that string-concatenation (with regard to generating error message), This PR suggest to deprecate `type` in favour of the new `origin` property, the fixed/valid valuesfor which are:

- **CORE** - for general [model] validation errors that sequelize [can] perform regardless (e.g. not null checks and general data-type violations)
- **DB** - for any error being triggered by the DB (e.g. constraint violations)        
- **FUNCTION** - for validation errors from explicitly defined model/attrib validation rules

At a future date when the sun sets on the `ValidationErrorItem.type` property we can remove it completely, change the `ValidationErrorItem` constructor to use it's current `type` parameter as the value for `ValidationErrorItem.origin` and update the various places in the code where `ValidationErrorItem` is instantiated to pass in a valid `origin` in place of the current `type` string (there are 4-5 places this will need to happen - this PR include comments in all these places that stipulate what the `origin` parameter will be - i.e. what the `type` parameter is currently being mapped internally by `ValidationErrorItem`)

## Caveat

1. some totally unrelated tests fail on my local machine, I am ignoring these because they have absolutely nothing to do with the changes in this PR (I checked) and because I branched from `master` which was in a v4 beta state (so not unlikely that a few tests are not currently passing), additionally I have only run tests against MySQLv5.7

2. the new `instance` and `validator` properties of the `ValidationErrorItem` class are all optional as far as the class itself is concerned, in the case of bulk processing it is possible that (at the least) a DOA instance will not be available to attach to an error - this is something I feel the user of the lib needs to be aware of and work around (if applicable). 

3. I made a couple of slight changes to existing tests related to validation errors - the tests were checking [generated] error message values in order to determine whether an error instance is valid (IMHO these tests are brittle anyway)

4. I felt that updating documentation for this was a bit much given that ValidationError and ValidationErrorItem classes are not documented at all save for the following snippet ([found here](https://github.com/sequelize/sequelize/blob/master/docs/instances.md)):
```
Tasks.bulkCreate([
  {name: 'foo', code: '123'},
  {code: '1234'},
  {name: 'bar', code: '1'}
], { validate: true }).catch(function(errors) {
  /* console.log(errors) would look like:
  [
    { record:
    ...
    errors:
      { name: 'SequelizeValidationError',
        message: 'Validation error',
        errors: [Object] } },
    { record:
      ...
      errors:
        { name: 'SequelizeValidationError',
        message: 'Validation error',
        errors: [Object] } }
  ]
  */
})
``` 