### PR TITLE
Correct usage of returning option for model update (fixed mssql error)

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -297,7 +297,7 @@ const QueryGenerator = {
     }
 
     if (this._dialect.supports.returnValues) {
-      if (this._dialect.supports.returnValues.output) {
+      if (this._dialect.supports.returnValues.output && options.returning) {
         // we always need this for mssql
         outputFragment = ' OUTPUT INSERTED.*';
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1966,7 +1966,7 @@ class Model {
    * @param {Boolean}       [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param {Transaction}   [options.transaction] Transaction to run query under
    * @param {String}        [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
-   * @param  {Boolean}      [options.returning=true] Return the affected rows (only for postgres)
+   * @param  {Boolean}      [options.returning=true] Return the affected rows
    *
    * @return {Promise<Model>}
    *

--- a/test/unit/sql/update.test.js
+++ b/test/unit/sql/update.test.js
@@ -47,7 +47,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
 
       expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }), {
-        mssql: "UPDATE TOP(1) [Users] SET [username]=N'new.username' OUTPUT INSERTED.* WHERE [username] = N'username'",
+        mssql: "UPDATE TOP(1) [Users] SET [username]=N'new.username' WHERE [username] = N'username'",
         mysql: "UPDATE `Users` SET `username`='new.username' WHERE `username` = 'username' LIMIT 1",
         default: "UPDATE [Users] SET [username]='new.username' WHERE [username] = 'username'"
       });


### PR DESCRIPTION
_If your PR only contains changes to documentation, you may skip the template below._

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

When we use view in model, and update record, mssql returns error Msg 404, Level 16, State 1 "The column reference "inserted.<COLUMN_NAME>" is not allowed because it refers to a base table that is not being modified in this statement" for each data column in model, because of "... OUTPUT INSERTED. into ...", that sequelize adds without any possibility to disable it. And there is no sense at all to use " OUTPUT INSERTED. " in update clause, because we get only count of processed records: const [count] = await this.update(props, opts).
