### PR TITLE
documentation: update transactions.md to use `cls` property instead of `useCLS()`

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -65,12 +65,12 @@ To enable CLS you must tell sequelize which namespace to use by using a static m
 
 ```js
 var Sequelize = require('sequelize');
-Sequelize.useCLS(namespace);
+Sequelize.cls = namespace;
 
 new Sequelize(....);
 ```
 
-Notice, that the `useCLS()` method is on the *constructor*, not on an instance of sequelize. This means that all instances will share the same namespace, and that CLS is all-or-nothing - you cannot enable it only for some instances.
+Notice, that the `cls` property is on the *constructor*, not on an instance of sequelize. This means that all instances will share the same namespace, and that CLS is all-or-nothing - you cannot enable it only for some instances.
 
 CLS works like a thread-local storage for callbacks. What this means in practice is that different callback chains can access local variables by using the CLS namespace. When CLS is enabled sequelize will set the `transaction` property on the namespace when a new transaction is created. Since variables set within a callback chain are private to that chain several concurrent transactions can exist at the same time:
 
@@ -93,7 +93,7 @@ sequelize.transaction(function (t1) {
 });
 ```
 
-After you've used `Sequelize.useCLS()` all promises returned from sequelize will be patched to maintain CLS context. CLS is a complicated subject - more details in the docs for [cls-bluebird](https://www.npmjs.com/package/cls-bluebird), the patch used to make bluebird promises work with CLS.
+After you've set `Sequelize.cls` all promises returned from sequelize will be patched to maintain CLS context. CLS is a complicated subject - more details in the docs for [cls-bluebird](https://www.npmjs.com/package/cls-bluebird), the patch used to make bluebird promises work with CLS.
 
 ## Concurrent/Partial transactions
 


### PR DESCRIPTION
### Description of change

The documentation on `transactions.md` doesn't reflect the latest sequelize: `useCLS` has been replaced with the `cls` property. This pull request updates the documentation around this.
