### PR TITLE
Reimplement support for column-level comments on mysql dialect.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,6 +70,7 @@
 - [FIXED] Update or soft delete breaks when querying on `JSON/JSONB` [#7376](https://github.com/sequelize/sequelize/issues/7376) [#7400](https://github.com/sequelize/sequelize/issues/7400) [#7444](https://github.com/sequelize/sequelize/issues/7444)
 - [REMOVED] Removes support for interpretation of raw properties and values in the where object. [#7568](https://github.com/sequelize/sequelize/issues/7568)
 - [FIXED] Upsert now updates all changed fields by default
+- [FIXED] Reimplement support for MySQL-dialect column-level comments. [#7611](https://github.com/sequelize/sequelize/pull/7611)
 
 ## BC breaks:
 - Model.validate instance method now runs validation hooks by default. Previously you needed to pass { hooks: true }. You can override this behavior by passing { hooks: false }

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -251,6 +251,10 @@ const QueryGenerator = {
       template += ' PRIMARY KEY';
     }
 
+    if (attribute.comment) {
+      template += ' COMMENT ' + this.escape(attribute.comment);
+    }
+
     if (attribute.after) {
       template += ' AFTER ' + this.quoteIdentifier(attribute.after);
     }

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -62,6 +62,10 @@ if (dialect === 'mysql') {
           expectation: {id: 'INTEGER DEFAULT 0'}
         },
         {
+          arguments: [{id: {type: 'INTEGER', comment: 'Test'}}],
+          expectation: {id: 'INTEGER COMMENT \'Test\''}
+        },
+        {
           arguments: [{id: {type: 'INTEGER', unique: true}}],
           expectation: {id: 'INTEGER UNIQUE'}
         },


### PR DESCRIPTION
Reimplement support for MySQL column-level comments - because comments are a good idea.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change
Reimplement support for column-level comments on mysql dialect.
Ref issue #4386 - this handles mysql support for column comments. Does not affect pgsql.