### PR TITLE
Update installation docs to include Yarn

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -2,9 +2,10 @@
 
 ## Installation
 
-Sequelize is available via NPM.
+Sequelize is available via NPM and Yarn.
 
 ```bash
+// Using NPM
 $ npm install --save sequelize
 
 # And one of the following:
@@ -12,6 +13,15 @@ $ npm install --save pg pg-hstore
 $ npm install --save mysql2
 $ npm install --save sqlite3
 $ npm install --save tedious // MSSQL
+
+// Using Yarn
+$ yarn add sequelize
+
+# And one of the following:
+$ yarn add pg pg-hstore
+$ yarn add mysql2
+$ yarn add sqlite3
+$ yarn add tedious // MSSQL
 ```
 
 ## Setting up a connection


### PR DESCRIPTION
Add Yarn installation scripts to getting started documentation. With many developers making use of Yarn as of late, providing quick copy/paste scripts will prevent developers from having to type the scripts manually.

_If your PR only contains changes to documentation, you may skip the template below._