### PR TITLE
Closes #[7625] Ignore generic-pool release/destroy exceptions

### DIFF
--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -109,7 +109,7 @@ class ConnectionManager extends AbstractConnectionManager {
       .then(connection => {
 
         if (config.pool.handleDisconnects) {
-          connection.on('error', (err) => {
+          connection.on('error', err => {
             //NO-OP: generic-pool already handles connection resets
             //when it validates the connection after acquiring it, see: testOnBorrow.
             debug(`connection error ${err.code}`);

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -109,17 +109,9 @@ class ConnectionManager extends AbstractConnectionManager {
       .then(connection => {
 
         if (config.pool.handleDisconnects) {
-          // Connection to the MySQL server is usually
-          // lost due to either server restart, or a
-          // connection idle timeout (the wait_timeout
-          // server variable configures this)
-          //
-          // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
-          connection.on('error', err => {
-            if (err.code === 'PROTOCOL_CONNECTION_LOST') {
-              // Remove it from read/write pool
-              this.pool.destroy(connection);
-            }
+          connection.on('error', (err) => {
+            //NO-OP: generic-pool already handles connection resets
+            //when it validates the connection after acquiring it, see: testOnBorrow.
             debug(`connection error ${err.code}`);
           });
         }

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -76,6 +76,36 @@ if (dialect === 'mysql') {
         });
     });
 
+    it('should work with handleDisconnects before release', () => {
+      const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
+      const cm = sequelize.connectionManager;
+      let conn;
+
+      return sequelize
+        .sync()
+        .then(() => cm.getConnection())
+        .then((connection) => {
+          // Save current connection
+          conn = connection;
+          // simulate a unexpected end from MySQL2
+          connection._protocolError = new Error('Connection lost: The server closed the connection.');
+          connection._protocolError.fatal = true;
+          connection._protocolError.code = 'PROTOCOL_CONNECTION_LOST';
+          connection._notifyError(connection._protocolError);
+        })
+        .then(() => cm.releaseConnection(conn))
+        .then(() => {
+          // Get next available connection
+          return cm.getConnection();
+        })
+        .then((connection) => {
+          // Old threadId should be different from current new one
+          expect(conn.threadId).to.not.be.equal(connection.threadId);
+          expect(cm.validate(conn)).to.not.be.ok;
+          return cm.releaseConnection(connection);
+        });
+    });
+
     it('should work with handleDisconnects', () => {
       const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
       const cm = sequelize.connectionManager;
@@ -87,11 +117,14 @@ if (dialect === 'mysql') {
         .then(connection => {
           // Save current connection
           conn = connection;
-          // simulate a unexpected end
-          connection.close();
+          return cm.releaseConnection(conn)
         })
-        .then(() => cm.releaseConnection(conn))
         .then(() => {
+          // simulate a unexpected end from MySQL2 AFTER releasing the connection
+          conn._protocolError = new Error('Connection lost: The server closed the connection.');
+          conn._protocolError.fatal = true;
+          conn._protocolError.code = 'PROTOCOL_CONNECTION_LOST';
+          conn._notifyError(conn._protocolError);
           // Get next available connection
           return cm.getConnection();
         })

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -88,10 +88,7 @@ if (dialect === 'mysql') {
           // Save current connection
           conn = connection;
           // simulate a unexpected end from MySQL2
-          connection._protocolError = new Error('Connection lost: The server closed the connection.');
-          connection._protocolError.fatal = true;
-          connection._protocolError.code = 'PROTOCOL_CONNECTION_LOST';
-          connection._notifyError(connection._protocolError);
+          conn.stream.emit('end');
         })
         .then(() => cm.releaseConnection(conn))
         .then(() => {
@@ -121,10 +118,8 @@ if (dialect === 'mysql') {
         })
         .then(() => {
           // simulate a unexpected end from MySQL2 AFTER releasing the connection
-          conn._protocolError = new Error('Connection lost: The server closed the connection.');
-          conn._protocolError.fatal = true;
-          conn._protocolError.code = 'PROTOCOL_CONNECTION_LOST';
-          conn._notifyError(conn._protocolError);
+          conn.stream.emit('end');
+
           // Get next available connection
           return cm.getConnection();
         })

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -84,7 +84,7 @@ if (dialect === 'mysql') {
       return sequelize
         .sync()
         .then(() => cm.getConnection())
-        .then((connection) => {
+        .then(connection => {
           // Save current connection
           conn = connection;
           // simulate a unexpected end from MySQL2
@@ -98,7 +98,7 @@ if (dialect === 'mysql') {
           // Get next available connection
           return cm.getConnection();
         })
-        .then((connection) => {
+        .then(connection => {
           // Old threadId should be different from current new one
           expect(conn.threadId).to.not.be.equal(connection.threadId);
           expect(cm.validate(conn)).to.not.be.ok;
@@ -117,7 +117,7 @@ if (dialect === 'mysql') {
         .then(connection => {
           // Save current connection
           conn = connection;
-          return cm.releaseConnection(conn)
+          return cm.releaseConnection(conn);
         })
         .then(() => {
           // simulate a unexpected end from MySQL2 AFTER releasing the connection


### PR DESCRIPTION
Cleaning up dead connections to MySQL is a bit messy: the connection can die before/after it has been returned to the pool. This prevents generic-pool from throwing errors when we attempt to clean up connections that we know to be dead, but have already cleaned up.

Closes #7625