### PR TITLE
Add arrow-parens rule to ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,6 +13,7 @@
     "space-before-function-paren": ["warn", "never"],
     "keyword-spacing": ["warn"],
     "prefer-arrow-callback": "error",
+    "arrow-parens": ["error", "as-needed"],
     "comma-style": ["warn", "last"],
     "no-bitwise": "off",
     "no-cond-assign": ["error", "except-parens"],

--- a/lib/deferrable.js
+++ b/lib/deferrable.js
@@ -113,7 +113,7 @@ SET_IMMEDIATE.prototype.toSql = function(queryGenerator) {
   return queryGenerator.setImmediateQuery(this.constraints);
 };
 
-Object.keys(Deferrable).forEach((key) => {
+Object.keys(Deferrable).forEach(key => {
   const DeferrableType = Deferrable[key];
 
   DeferrableType.toString = function() {

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -45,7 +45,7 @@ class ConnectionManager {
   }
 
   refreshTypeParser(dataTypes) {
-    _.each(dataTypes, (dataType) => {
+    _.each(dataTypes, dataType => {
       if (dataType.hasOwnProperty('parse')) {
         if (dataType.types[this.dialectName]) {
           this._refreshTypeParser(dataType);
@@ -84,7 +84,7 @@ class ConnectionManager {
 
     if (!config.replication) {
       this.pool = Pooling.createPool({
-        create: () => new Promise((resolve) => {
+        create: () => new Promise(resolve => {
           this
             ._connect(config)
             .tap(() => {
@@ -98,7 +98,7 @@ class ConnectionManager {
               this.poolError = e;
             });
         }),
-        destroy: (connection) => {
+        destroy: connection => {
           return this._disconnect(connection).tap(() => {
             debug('connection destroy');
           });
@@ -173,7 +173,7 @@ class ConnectionManager {
       read: Pooling.createPool({
         create: () => {
           const nextRead = reads++ % config.replication.read.length; // round robin config
-          return new Promise((resolve) => {
+          return new Promise(resolve => {
             this
               ._connect(config.replication.read[nextRead])
               .tap(connection => {
@@ -200,7 +200,7 @@ class ConnectionManager {
         idleTimeoutMillis: config.pool.idle
       }),
       write: Pooling.createPool({
-        create: () => new Promise((resolve) => {
+        create: () => new Promise(resolve => {
           this
             ._connect(config.replication.write)
             .then(connection => {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -846,7 +846,7 @@ const QueryGenerator = {
       }
 
       // loop through everything past i and append to the sql
-      collection.slice(i).forEach((collectionItem) => {
+      collection.slice(i).forEach(collectionItem => {
         sql += this.quote(collectionItem, parent, connector);
       }, this);
 

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -85,7 +85,7 @@ const QueryGenerator = {
         table: this.quoteTable(tableName),
         attributes: attrStr.join(', ')
       },
-      pkString = primaryKeys.map((pk) => { return this.quoteIdentifier(pk); }).join(', ');
+      pkString = primaryKeys.map(pk => { return this.quoteIdentifier(pk); }).join(', ');
 
     if (options.uniqueKeys) {
       Utils._.each(options.uniqueKeys, (columns, indexName) => {
@@ -253,7 +253,7 @@ const QueryGenerator = {
       outputFragment = ' OUTPUT INSERTED.*';
     }
 
-    Utils._.forEach(attrValueHashes, (attrValueHash) => {
+    Utils._.forEach(attrValueHashes, attrValueHash => {
       // special case for empty objects with primary keys
       const fields = Object.keys(attrValueHash);
       const firstAttr = attributes[fields[0]];
@@ -278,7 +278,7 @@ const QueryGenerator = {
     });
 
     if (allAttributes.length > 0) {
-      Utils._.forEach(attrValueHashes, (attrValueHash) => {
+      Utils._.forEach(attrValueHashes, attrValueHash => {
         tuples.push('(' +
           allAttributes.map(key =>
             this.escape(attrValueHash[key])).join(',') +
@@ -515,7 +515,7 @@ const QueryGenerator = {
 
       // enums are a special case
       template = attribute.type.toSql();
-      template += ' CHECK (' + this.quoteIdentifier(attribute.field) + ' IN(' + Utils._.map(attribute.values, (value) => {
+      template += ' CHECK (' + this.quoteIdentifier(attribute.field) + ' IN(' + Utils._.map(attribute.values, value => {
         return this.escape(value);
       }).join(', ') + '))';
       return template;

--- a/lib/dialects/mssql/resource-lock.js
+++ b/lib/dialects/mssql/resource-lock.js
@@ -15,7 +15,7 @@ ResourceLock.prototype.lock = function() {
   const lock = this.previous;
   let resolve;
 
-  this.previous = new Promise((r) => {
+  this.previous = new Promise(r => {
     resolve = r;
   });
 

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -91,7 +91,7 @@ class ConnectionManager extends AbstractConnectionManager {
     return new Utils.Promise((resolve, reject) => {
       const connection = this.lib.createConnection(connectionConfig);
 
-      const errorHandler = (e) => {
+      const errorHandler = e => {
           // clean up connect event if there is error
         connection.removeListener('connect', connectHandler);
         reject(e);
@@ -106,7 +106,7 @@ class ConnectionManager extends AbstractConnectionManager {
       connection.once('error', errorHandler);
       connection.once('connect', connectHandler);
     })
-      .then((connection) => {
+      .then(connection => {
 
         if (config.pool.handleDisconnects) {
           // Connection to the MySQL server is usually
@@ -115,7 +115,7 @@ class ConnectionManager extends AbstractConnectionManager {
           // server variable configures this)
           //
           // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
-          connection.on('error', (err) => {
+          connection.on('error', err => {
             if (err.code === 'PROTOCOL_CONNECTION_LOST') {
               // Remove it from read/write pool
               this.pool.destroy(connection);
@@ -127,19 +127,19 @@ class ConnectionManager extends AbstractConnectionManager {
         debug('connection acquired');
         return connection;
       })
-      .then((connection) => {
+      .then(connection => {
         return new Utils.Promise((resolve, reject) => {
           // set timezone for this connection
           // but named timezone are not directly supported in mysql, so get its offset first
           let tzOffset = this.sequelize.options.timezone;
           tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
 
-          connection.query(`SET time_zone = '${tzOffset}'`, (err) => {
+          connection.query(`SET time_zone = '${tzOffset}'`, err => {
             if (err) { reject(err); } else { resolve(connection); }
           });
         });
       })
-      .catch((err) => {
+      .catch(err => {
         if (err.code) {
           switch (err.code) {
             case 'ECONNREFUSED':
@@ -170,7 +170,7 @@ class ConnectionManager extends AbstractConnectionManager {
     }
 
     return new Utils.Promise((resolve, reject) => {
-      connection.end((err) => {
+      connection.end(err => {
         if (err) {
           reject(new SequelizeErrors.ConnectionError(err));
         } else {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -45,7 +45,7 @@ class ConnectionManager extends AbstractConnectionManager {
     if (dataType.types.postgres.array_oids) {
       for (const oid of dataType.types.postgres.array_oids) {
         this.lib.types.setTypeParser(oid, value =>
-          this.lib.types.arrayParser.create(value, (v) =>
+          this.lib.types.arrayParser.create(value, v =>
             dataType.parse(v, oid, this.lib.types.getTypeParser)
           ).parse()
         );
@@ -123,7 +123,7 @@ class ConnectionManager extends AbstractConnectionManager {
       });
 
       // Don't let a Postgres restart (or error) to take down the whole app
-      connection.on('error', (err) => {
+      connection.on('error', err => {
         debug(`connection error ${err.code}`);
         connection._invalid = true;
       });

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -195,7 +195,7 @@ class Query extends AbstractQuery {
             m[k.toLowerCase()] = k;
             return m;
           }, {});
-          rows = _.map(rows, (row)=> {
+          rows = _.map(rows, row=> {
             return _.mapKeys(row, (value, key)=> {
               const targetAttr = attrsMap[key];
               if (typeof targetAttr === 'string' && targetAttr !== key) {

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -59,7 +59,7 @@ exports.hookAliases = hookAliases;
  * get array of current hook and its proxied hooks combined
  * @private
  */
-const getProxiedHooks = (hookType) =>
+const getProxiedHooks = hookType =>
   hookTypes[hookType].proxies
     ? hookTypes[hookType].proxies.concat(hookType)
     : [hookType]
@@ -67,11 +67,10 @@ const getProxiedHooks = (hookType) =>
 
 const Hooks = {
   replaceHookAliases(hooks) {
-    let realHookName;
-
     Utils._.each(hooks, (hooksArray, name) => {
       // Does an alias for this hook name exist?
-      if ((realHookName = hookAliases[name])) {
+      const realHookName = hookAliases[name];
+      if (realHookName) {
         // Add the hooks to the actual hook
         hooks[realHookName] = (hooks[realHookName] || []).concat(hooksArray);
 
@@ -149,7 +148,7 @@ const Hooks = {
     // check for proxies, add them too
     hookType = getProxiedHooks(hookType);
 
-    Utils._.each(hookType, (type) => {
+    Utils._.each(hookType, type => {
       this.options.hooks[type] = this.options.hooks[type] || [];
       this.options.hooks[type].push(name ? {name, fn} : fn);
     });

--- a/lib/model.js
+++ b/lib/model.js
@@ -459,7 +459,7 @@ class Model {
       if (include.attributes.length) {
         _.each(include.model.primaryKeys, (attr, key) => {
           // Include the primary key if its not already take - take into account that the pk might be aliassed (due to a .field prop)
-          if (!_.some(include.attributes, (includeAttr) => {
+          if (!_.some(include.attributes, includeAttr => {
             if (attr.field !== key) {
               return Array.isArray(includeAttr) && includeAttr[0] === attr.field && includeAttr[1] === key;
             }
@@ -1137,7 +1137,7 @@ class Model {
       // Assign an auto-generated name to indexes which are not named by the user
       this.options.indexes = this.QueryInterface.nameIndexes(this.options.indexes, this.tableName);
 
-      indexes = _.filter(this.options.indexes, (item1) =>
+      indexes = _.filter(this.options.indexes, item1 =>
         !_.some(indexes, item2 => item1.name === item2.name)
       ).sort((index1, index2) => {
         if (this.sequelize.options.dialect === 'postgres') {
@@ -2372,7 +2372,7 @@ class Model {
     }).then(() => {
 
       // map fields back to attributes
-      instances.forEach((instance) => {
+      instances.forEach(instance => {
         for (const attr in this.rawAttributes) {
           if (this.rawAttributes[attr].field &&
               instance.dataValues[this.rawAttributes[attr].field] !== undefined &&
@@ -2539,7 +2539,7 @@ class Model {
       if (options.individualHooks) {
         return this.findAll({where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark, paranoid: false})
           .map(instance => this.runHooks('beforeRestore', instance, options).then(() => instance))
-          .then((_instances) => {
+          .then(_instances => {
             instances = _instances;
           });
       }
@@ -3488,7 +3488,7 @@ class Model {
         return instance.save(includeOptions).then(() => this[include.association.accessors.set](instance, {save: false, logging: options.logging}));
       });
     }).then(() => {
-      const realFields = options.fields.filter((field) => !this.constructor._isVirtualAttribute(field));
+      const realFields = options.fields.filter(field => !this.constructor._isVirtualAttribute(field));
       if (!realFields.length) return this;
       if (!this.changed() && !this.isNewRecord) return this;
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -996,7 +996,7 @@ class Sequelize {
     if (!ns) return fn();
 
     let res;
-    ns.run((context) => res = fn(context));
+    ns.run(context => res = fn(context));
     return res;
   }
 
@@ -1024,7 +1024,7 @@ class Sequelize {
       options = last;
 
       // remove options from set of logged arguments if options.logging is equal to console.log
-      if(options.logging === console.log){
+      if (options.logging === console.log){
         args.splice(args.length-1, 1);
       }
     } else {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -229,7 +229,7 @@ class Transaction {
    * @property REPEATABLE_READ
    * @property SERIALIZABLE
    */
-  static get ISOLATION_LEVELS () {
+  static get ISOLATION_LEVELS() {
     return {
       READ_UNCOMMITTED: 'READ UNCOMMITTED',
       READ_COMMITTED: 'READ COMMITTED',

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -53,7 +53,7 @@ exports.isPrimitive = isPrimitive;
 
 // Same concept as _.merge, but don't overwrite properties that have already been assigned
 function mergeDefaults(a, b) {
-  return _.mergeWith(a, b, (objectValue) => {
+  return _.mergeWith(a, b, objectValue => {
     // If it's an object, let _ handle it this time, we will be called again for each property
     if (!this._.isPlainObject(objectValue) && objectValue !== undefined) {
       return objectValue;

--- a/test/integration/associations/alias.test.js
+++ b/test/integration/associations/alias.test.js
@@ -16,11 +16,11 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
 
     return this.sequelize.sync({ force: true }).then(() => {
       return User.create({ id: 1 });
-    }).then((user) => {
+    }).then(user => {
       expect(user.getAssignments).to.be.ok;
 
       return Task.create({ id: 1, userId: 1 });
-    }).then((task) => {
+    }).then(task => {
       expect(task.getOwner).to.be.ok;
 
       return Promise.all([
@@ -42,11 +42,11 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
 
     return this.sequelize.sync({ force: true }).then(() => {
       return User.create({ id: 1 });
-    }).then((user) => {
+    }).then(user => {
       expect(user.getASSIGNMENTS).to.be.ok;
 
       return Task.create({ id: 1, userId: 1 });
-    }).then((task) => {
+    }).then(task => {
       expect(task.getOWNER).to.be.ok;
 
       return Promise.all([
@@ -67,13 +67,13 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
 
     return this.sequelize.sync({ force: true }).then(() => {
       return User.create({ id: 1 });
-    }).then((user) => {
+    }).then(user => {
       expect(user.getTaskz).to.be.ok;
       expect(user.addTask).to.be.ok;
       expect(user.addTaskz).to.be.ok;
     }).then(() => {
       return User.find({ where: { id: 1 }, include: [{model: Task, as: 'taskz'}] });
-    }).then((user) => {
+    }).then(user => {
       expect(user.taskz).to.be.ok;
     });
   });
@@ -91,13 +91,13 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
 
     return this.sequelize.sync({ force: true }).then(() => {
       return User.create({ id: 1 });
-    }).then((user) => {
+    }).then(user => {
       expect(user.getAssignments).to.be.ok;
       expect(user.addAssignment).to.be.ok;
       expect(user.addAssignments).to.be.ok;
     }).then(() => {
       return User.find({ where: { id: 1 }, include: [Task] });
-    }).then((user) => {
+    }).then(user => {
       expect(user.assignments).to.be.ok;
     });
   });

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -57,7 +57,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           return article.setLabels([label], { transaction: t });
         }).then(function() {
           return this.Article.all({ transaction: this.t });
-        }).then((articles) => {
+        }).then(articles => {
           return articles[0].getLabels();
         }).then(function(labels) {
           expect(labels).to.have.length(0);
@@ -72,31 +72,31 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     }
 
     it('gets all associated objects with all fields', function() {
-      return this.User.find({where: {username: 'John'}}).then((john) => {
+      return this.User.find({where: {username: 'John'}}).then(john => {
         return john.getTasks();
-      }).then((tasks) => {
-        tasks[0].attributes.forEach((attr) => {
+      }).then(tasks => {
+        tasks[0].attributes.forEach(attr => {
           expect(tasks[0]).to.have.property(attr);
         });
       });
     });
 
     it('gets all associated objects when no options are passed', function() {
-      return this.User.find({where: {username: 'John'}}).then((john) => {
+      return this.User.find({where: {username: 'John'}}).then(john => {
         return john.getTasks();
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(2);
       });
     });
 
     it('only get objects that fulfill the options', function() {
-      return this.User.find({where: {username: 'John'}}).then((john) => {
+      return this.User.find({where: {username: 'John'}}).then(john => {
         return john.getTasks({
           where: {
             active: true
           }
         });
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(1);
       });
     });
@@ -106,7 +106,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         where: {
           username: 'John'
         }
-      }).then((john) => {
+      }).then(john => {
         return john.getTasks({
           where: {
             title: {
@@ -114,7 +114,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
             }
           }
         });
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(1);
       });
     });
@@ -126,7 +126,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         where: {
           username: 'John'
         }
-      }).then((john) => {
+      }).then(john => {
         return john.getTasks({
           where: {
             id: {
@@ -134,21 +134,21 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
             }
           }
         });
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(1);
       });
     });
 
     it('only gets objects that fulfill options with a formatted value', function() {
-      return this.User.find({where: {username: 'John'}}).then((john) => {
+      return this.User.find({where: {username: 'John'}}).then(john => {
         return john.getTasks({where: {active: true}});
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(1);
       });
     });
 
     it('get associated objects with an eager load', function() {
-      return this.User.find({where: {username: 'John'}, include: [this.Task]}).then((john) => {
+      return this.User.find({where: {username: 'John'}, include: [this.Task]}).then(john => {
         expect(john.Tasks).to.have.length(2);
       });
     });
@@ -170,7 +170,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
             ]}
           ]
         });
-      }).then((john) => {
+      }).then(john => {
         expect(john.Tasks).to.have.length(2);
       });
     });
@@ -210,7 +210,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return this.u.addProject(p, { through: { status: 'active', data: 42 }});
       }).then(function() {
         return this.u.getProjects();
-      }).then((projects) => {
+      }).then(projects => {
         expect(projects).to.have.length(1);
         const project = projects[0];
         expect(project.ProjectUsers).to.be.ok;
@@ -260,7 +260,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         }).then(() => {
           return User.findOne({
             where: {}
-          }).then((user) => {
+          }).then(user => {
             return user.getGroups();
           });
         });
@@ -486,12 +486,12 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
       });
 
       return Promise.join(
-        this.Task.create().then((task) => {
+        this.Task.create().then(task => {
           return user.addTask(task, {
             through: { started: true }
           });
         }),
-        this.Task.create().then((task) => {
+        this.Task.create().then(task => {
           return user.addTask(task, {
             through: { started: true }
           });
@@ -526,7 +526,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return this.task.setUsers(null);
       }).then(function() {
         return this.task.getUsers();
-      }).then((_users) => {
+      }).then(_users => {
         expect(_users).to.have.length(0);
       });
     });
@@ -554,7 +554,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return this.task.setUsers([this.user1, this.user2]);
       }).then(function() {
         return this.task.getUsers();
-      }).then((_users) => {
+      }).then(_users => {
         expect(_users).to.have.length(2);
       });
     });
@@ -579,9 +579,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         ]);
       }).spread((group, member) => {
         return group.addMember(member).return (group);
-      }).then((group) => {
+      }).then(group => {
         return group.getMembers();
-      }).then((members) => {
+      }).then(members => {
         expect(members).to.be.instanceof(Array);
         expect(members).to.have.length(1);
         expect(members[0].member_id).to.equal(10);
@@ -610,7 +610,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return this.user.setTasks([this.task2.id]);
       }).then(function() {
         return this.user.getTasks();
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(1);
         expect(tasks[0].title).to.equal('wat');
       });
@@ -661,7 +661,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return this.comment.setTags([this.tag]);
       }).then(function() {
         return this.comment.getTags();
-      }).then((_tags) => {
+      }).then(_tags => {
         expect(_tags).to.have.length(1);
       });
     });
@@ -684,7 +684,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         expect(createdUser).to.be.instanceof(User);
         expect(createdUser.username).to.equal('foo');
         return this.task.getUsers();
-      }).then((_users) => {
+      }).then(_users => {
         expect(_users).to.have.length(1);
       });
     });
@@ -734,7 +734,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       return this.sequelize.sync({ force: true }).then(() => {
         return Group.create({});
-      }).then((group) => {
+      }).then(group => {
         return Promise.join(
           group.createUser({ id: 1 }, { through: {isAdmin: true }}),
           group.createUser({ id: 2 }, { through: {isAdmin: false }}),
@@ -742,7 +742,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
             return UserGroups.findAll();
           }
         );
-      }).then((userGroups) => {
+      }).then(userGroups => {
         userGroups.sort((a, b) => {
           return a.userId < b.userId ? - 1 : 1;
         });
@@ -769,7 +769,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         expect(createdUser).to.be.instanceof(User);
         expect(createdUser.username).to.equal('foo');
         return this.task.getUsers();
-      }).then((_users) => {
+      }).then(_users => {
         expect(_users).to.have.length(1);
       });
     });
@@ -794,12 +794,12 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           user.addTask(task1),
           user.addTask([task2])
         ]).return (user);
-      }).then((user) => {
+      }).then(user => {
         return user.getTasks();
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(2);
-        expect(_.find(tasks, (item) => { return item.title === 'get started'; })).to.be.ok;
-        expect(_.find(tasks, (item) => { return item.title === 'get done'; })).to.be.ok;
+        expect(_.find(tasks, item => { return item.title === 'get started'; })).to.be.ok;
+        expect(_.find(tasks, item => { return item.title === 'get done'; })).to.be.ok;
       });
     });
 
@@ -890,9 +890,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         ]);
       }).spread((user, task) => {
         return user.addTask(task.id).return (user);
-      }).then((user) => {
+      }).then(user => {
         return user.getTasks();
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks[0].title).to.equal('get started');
       });
     });
@@ -950,12 +950,12 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           user.addTasks(task1),
           user.addTasks([task2])
         ]).return (user);
-      }).then((user) => {
+      }).then(user => {
         return user.getTasks();
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks).to.have.length(2);
-        expect(_.find(tasks, (item) => { return item.title === 'get started'; })).to.be.ok;
-        expect(_.find(tasks, (item) => { return item.title === 'get done'; })).to.be.ok;
+        expect(_.find(tasks, item => { return item.title === 'get started'; })).to.be.ok;
+        expect(_.find(tasks, item => { return item.title === 'get done'; })).to.be.ok;
       });
     });
 
@@ -995,7 +995,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           ]);
         }).then(function() {
           return this.task.getUsers();
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(3);
         });
       });
@@ -1088,7 +1088,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         this.Task.create({ title: 'task2' })
       ]).spread((user, task1, task2) => {
         return user.setTasks([task1, task2]).return (user);
-      }).then((user) => {
+      }).then(user => {
         return user.setTasks(null, {
           logging: spy
         });
@@ -1155,7 +1155,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
       expect(ParanoidUser.options.paranoid).to.be.ok;
       expect(ParanoidTask.options.paranoid).to.be.ok;
 
-      _.forEach(ParanoidUser.associations, (association) => {
+      _.forEach(ParanoidUser.associations, association => {
         expect(association.through.model.options.paranoid).not.to.be.ok;
       });
     });
@@ -1267,7 +1267,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return user.addProjects([project1, project2], {
           logging: spy
         }).return (user);
-      }).then((user) => {
+      }).then(user => {
         expect(spy).to.have.been.calledTwice;
         spy.reset();
         return Promise.join(
@@ -1281,12 +1281,12 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         const project = projects[0];
         expect(project).to.be.ok;
         return project.destroy().return (user);
-      }).then((user) => {
+      }).then(user => {
         return self.User.findOne({
           where: { id: user.id},
           include: [{model: self.Project, as: 'Projects'}]
         });
-      }).then((user) => {
+      }).then(user => {
         const projects = user.Projects,
           project = projects[0];
 
@@ -1306,13 +1306,13 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         self.user = user;
         self.project = project;
         return user.addProject(project, { logging: spy }).return (user);
-      }).then((user) => {
+      }).then(user => {
         expect(spy.calledTwice).to.be.ok; // Once for SELECT, once for INSERT
         spy.reset();
         return user.getProjects({
           logging: spy
         });
-      }).then((projects) => {
+      }).then(projects => {
         const project = projects[0];
         expect(spy.calledOnce).to.be.ok;
         spy.reset();
@@ -1365,7 +1365,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         return user.addProject(project).then(() => {
           return group.addUser(user).return (group);
         });
-      }).then((group) => {
+      }).then(group => {
         // get the group and include both the users in the group and their project's
         return self.Group.findAll({
           where: {id: group.id},
@@ -1379,7 +1379,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
             }
           ]
         });
-      }).then((groups) => {
+      }).then(groups => {
         const group = groups[0];
         expect(group).to.be.ok;
 
@@ -1442,7 +1442,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
       expect(Object.keys(this.UserTasks.primaryKeys)).to.deep.equal(['id']);
       expect(Object.keys(this.UserTasks2.primaryKeys)).to.deep.equal(['userTasksId']);
 
-      _.each([this.UserTasks, this.UserTasks2], (model) => {
+      _.each([this.UserTasks, this.UserTasks2], model => {
         fk = Object.keys(model.options.uniqueKeys)[0];
         expect(model.options.uniqueKeys[fk].fields.sort()).to.deep.equal(['TaskId', 'UserId']);
       });
@@ -1472,9 +1472,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           this.Task.create({title: 'foo'})
         ]).spread((user, task) => {
           return user.addTask(task).return (user);
-        }).then((user) => {
+        }).then(user => {
           return user.setTasks(null);
-        }).then((result) => {
+        }).then(result => {
           expect(result).to.be.ok;
         });
       });
@@ -1503,9 +1503,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           this.Project.create()
         ]).spread((user, project) => {
           return user.addProject(project, { through: { status: 'active', data: 42 }}).return (user);
-        }).then((user) => {
+        }).then(user => {
           return user.getProjects();
-        }).then((projects) => {
+        }).then(projects => {
           const project = projects[0];
 
           expect(project.UserProjects).to.be.ok;
@@ -1521,9 +1521,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           this.Project.create()
         ]).spread((user, project) => {
           return user.addProject(project, { through: { status: 'active', data: 42 }}).return (user);
-        }).then((user) => {
+        }).then(user => {
           return user.getProjects({ joinTableAttributes: ['status']});
-        }).then((projects) => {
+        }).then(projects => {
           const project = projects[0];
 
           expect(project.UserProjects).to.be.ok;
@@ -1548,7 +1548,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
             return u.addProject(p);
           }).then(function() {
             return this.UserProjects.find({ where: { UserId: this.u.id, ProjectId: this.p.id }});
-          }).then((up) => {
+          }).then(up => {
             expect(up.status).to.equal('active');
           });
         });
@@ -1564,7 +1564,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
             return u.addProject(p, { through: { status: 'active' }});
           }).then(function() {
             return this.UserProjects.findOne({ where: { UserId: this.u.id, ProjectId: this.p.id }});
-          }).then((up) => {
+          }).then(up => {
             expect(up.status).to.equal('active');
           });
         });
@@ -1685,7 +1685,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       describe('query with through.where', () => {
         it('should support query the through model', function() {
-          return this.User.create().then((user) => {
+          return this.User.create().then(user => {
             return Promise.all([
               user.createProject({}, { through: { status: 'active', data: 1 }}),
               user.createProject({}, { through: { status: 'inactive', data: 2 }}),
@@ -1730,7 +1730,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           }).then(() => {
             return worker.getTasks();
           });
-        }).then((tasks) => {
+        }).then(tasks => {
           expect(tasks.length).to.equal(1);
         });
       });
@@ -1760,7 +1760,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           }).then(() => {
             return worker.getTasks();
           });
-        }).then((tasks) => {
+        }).then(tasks => {
           expect(tasks.length).to.equal(1);
         });
       });
@@ -1793,7 +1793,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           .then(() => { return b1.save(); })
           .then(() => { return a1.setRelation1(b1); })
           .then(() => { return self.A.findOne({ where: { name: 'a1' } }); })
-          .then((a) => {
+          .then(a => {
             expect(a.relation1Id).to.be.eq(b1.id);
           });
       });
@@ -1819,7 +1819,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           .then(() => { return b1.save(); })
           .then(() => { return b1.setRelation1(a1); })
           .then(() => { return self.B.findOne({ where: { name: 'b1' } }); })
-          .then((b) => {
+          .then(b => {
             expect(b.relation1Id).to.be.eq(a1.id);
           });
       });
@@ -1837,7 +1837,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       return this.sequelize.sync({force: true}).then(() => {
         return self.sequelize.getQueryInterface().showAllTables();
-      }).then((result) => {
+      }).then(result => {
         if (dialect === 'mssql' /* current.dialect.supports.schemas */) {
           result = _.map(result, 'tableName');
         }
@@ -1857,7 +1857,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       return this.sequelize.sync({force: true}).then(() => {
         return self.sequelize.getQueryInterface().showAllTables();
-      }).then((result) => {
+      }).then(result => {
         if (dialect === 'mssql' /* current.dialect.supports.schemas */) {
           result = _.map(result, 'tableName');
         }
@@ -2042,7 +2042,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           );
         }).then(function() {
           return self.sequelize.model('tasksusers').findAll({ where: { taskId: this.task2.id }});
-        }).then((usertasks) => {
+        }).then(usertasks => {
           // This should not exist because deletes cascade
           expect(usertasks).to.have.length(0);
         });
@@ -2137,7 +2137,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           User.create({ name: 'Satya' })
         ]);
       })
-      .then((users) => {
+      .then(users => {
         return self.sequelize.Promise.all([
           users[0].addFan(users[1]),
           users[1].addUser(users[2]),
@@ -2177,7 +2177,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           User.create({ name: 'Sargrahi' })
         ]);
       })
-      .then((users) => {
+      .then(users => {
         return self.sequelize.Promise.all([
           users[0].addFollower(users[1]),
           users[1].addFollower(users[0]),

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -49,8 +49,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
               id: 3
             })
           );
-        }).then((tasks) => {
-          return Task.User.get(tasks).then((result) => {
+        }).then(tasks => {
+          return Task.User.get(tasks).then(result => {
             expect(result[tasks[0].id].id).to.equal(tasks[0].user.id);
             expect(result[tasks[1].id].id).to.equal(tasks[1].user.id);
             expect(result[tasks[2].id]).to.be.undefined;
@@ -64,22 +64,22 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING }),
             Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.belongsTo(User);
 
           return sequelize.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return Group.create({ name: 'bar' }).then((group) => {
-                return sequelize.transaction().then((t) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return Group.create({ name: 'bar' }).then(group => {
+                return sequelize.transaction().then(t => {
                   return group.setUser(user, { transaction: t }).then(() => {
-                    return Group.all().then((groups) => {
-                      return groups[0].getUser().then((associatedUser) => {
+                    return Group.all().then(groups => {
+                      return groups[0].getUser().then(associatedUser => {
                         expect(associatedUser).to.be.null;
-                        return Group.all({ transaction: t }).then((groups) => {
-                          return groups[0].getUser({ transaction: t }).then((associatedUser) => {
+                        return Group.all({ transaction: t }).then(groups => {
+                          return groups[0].getUser({ transaction: t }).then(associatedUser => {
                             expect(associatedUser).to.be.not.null;
                             return t.rollback();
                           });
@@ -114,7 +114,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         return task.setUserXYZ(userA).then(() => {
           return task.getUserXYZ({where: {gender: 'female'}});
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user).to.be.null;
       });
     });
@@ -141,7 +141,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         return task.setUserXYZ(user).then(() => {
           return task.getUserXYZ();
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user).to.be.ok;
       });
     });
@@ -151,19 +151,19 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING }),
             Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.belongsTo(User);
 
           return sequelize.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return Group.create({ name: 'bar' }).then((group) => {
-                return sequelize.transaction().then((t) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return Group.create({ name: 'bar' }).then(group => {
+                return sequelize.transaction().then(t => {
                   return group.setUser(user, { transaction: t }).then(() => {
-                    return Group.all().then((groups) => {
-                      return groups[0].getUser().then((associatedUser) => {
+                    return Group.all().then(groups => {
+                      return groups[0].getUser().then(associatedUser => {
                         expect(associatedUser).to.be.null;
                         return t.rollback();
                       });
@@ -184,14 +184,14 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User, { foreignKey: 'user_id' });
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ user_id: 1, username: 'foo' }).then((user) => {
-          return Task.create({ task_id: 1, title: 'task' }).then((task) => {
+        return User.create({ user_id: 1, username: 'foo' }).then(user => {
+          return Task.create({ task_id: 1, title: 'task' }).then(task => {
             return task.setUserXYZ(user).then(() => {
-              return task.getUserXYZ().then((user) => {
+              return task.getUserXYZ().then(user => {
                 expect(user).not.to.be.null;
 
                 return task.setUserXYZ(null).then(() => {
-                  return task.getUserXYZ().then((user) => {
+                  return task.getUserXYZ().then(user => {
                     expect(user).to.be.null;
                   });
                 });
@@ -209,14 +209,14 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User);
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'foo' }).then((user) => {
-          return Task.create({ title: 'task' }).then((task) => {
+        return User.create({ username: 'foo' }).then(user => {
+          return Task.create({ title: 'task' }).then(task => {
             return task.setUserXYZ(user).then(() => {
-              return task.getUserXYZ().then((user) => {
+              return task.getUserXYZ().then(user => {
                 expect(user).not.to.be.null;
 
                 return task.setUserXYZ(null).then(() => {
-                  return task.getUserXYZ().then((user) => {
+                  return task.getUserXYZ().then(user => {
                     expect(user).to.be.null;
                   });
                 });
@@ -235,7 +235,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       return this.sequelize.sync({ force: true }).then(() => {
         return expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => {
-          return Task.create({ title: 'task' }).then((task) => {
+          return Task.create({ title: 'task' }).then(task => {
             return expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
           });
         });
@@ -249,10 +249,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User);
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ id: 15, username: 'jansemand' }).then((user) => {
-          return Task.create({}).then((task) => {
+        return User.create({ id: 15, username: 'jansemand' }).then(user => {
+          return Task.create({}).then(task => {
             return task.setUserXYZ(user.id).then(() => {
-              return task.getUserXYZ().then((user) => {
+              return task.getUserXYZ().then(user => {
                 expect(user.username).to.equal('jansemand');
               });
             });
@@ -269,8 +269,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User);
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create().then((user) => {
-          return Task.create({}).then((task) => {
+        return User.create().then(user => {
+          return Task.create({}).then(task => {
             return task.setUserXYZ(user, {logging: spy}).then(() => {
               expect(spy.called).to.be.ok;
             });
@@ -294,10 +294,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       return this.sequelize.sync().then(() => {
         return Post.create({
           title: 'Post title'
-        }).then((post) => {
+        }).then(post => {
           return Comment.create({
             text: 'OLD VALUE'
-          }).then((comment) => {
+          }).then(comment => {
             comment.text = 'UPDATED VALUE';
             return comment.setPost(post).then(() => {
               expect(comment.text).to.equal('UPDATED VALUE');
@@ -366,9 +366,9 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User);
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return Task.create({ title: 'task' }).then((task) => {
+        return Task.create({ title: 'task' }).then(task => {
           return task.createUser({ username: 'bob' }).then(() => {
-            return task.getUser().then((user) => {
+            return task.getUser().then(user => {
               expect(user).not.to.be.null;
               expect(user.username).to.equal('bob');
             });
@@ -379,20 +379,20 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING }),
             Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.belongsTo(User);
 
           return sequelize.sync({ force: true }).then(() => {
-            return Group.create({ name: 'bar' }).then((group) => {
-              return sequelize.transaction().then((t) => {
+            return Group.create({ name: 'bar' }).then(group => {
+              return sequelize.transaction().then(t => {
                 return group.createUser({ username: 'foo' }, { transaction: t }).then(() => {
-                  return group.getUser().then((user) => {
+                  return group.getUser().then(user => {
                     expect(user).to.be.null;
 
-                    return group.getUser({ transaction: t }).then((user) => {
+                    return group.getUser({ transaction: t }).then(user => {
                       expect(user).not.to.be.null;
 
                       return t.rollback();
@@ -452,14 +452,14 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         return user.setAccount(account).then(() => {
           return user.getAccount();
         });
-      }).then((user) => {
+      }).then(user => {
         // the sql query should correctly look at task_id instead of taskId
         expect(user).to.not.be.null;
         return User.findOne({
           where: {username: 'foo'},
           include: [Account]
         });
-      }).then((task) => {
+      }).then(task => {
         expect(task.Account).to.exist;
       });
     });
@@ -473,8 +473,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User); // defaults to SET NULL
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'foo' }).then((user) => {
-          return Task.create({ title: 'task' }).then((task) => {
+        return User.create({ username: 'foo' }).then(user => {
+          return Task.create({ title: 'task' }).then(task => {
             return task.setUser(user).then(() => {
               return user.destroy().then(() => {
                 return task.reload().then(() => {
@@ -494,10 +494,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User, { foreignKey: { allowNull: false }}); // defaults to NO ACTION
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'foo' }).then((user) => {
+        return User.create({ username: 'foo' }).then(user => {
           return Task.create({ title: 'task', UserId: user.id }).then(() => {
             return expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => {
-              return Task.findAll().then((tasks) => {
+              return Task.findAll().then(tasks => {
                 expect(tasks).to.have.length(1);
               });
             });
@@ -513,8 +513,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User, { constraints: false });
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'foo' }).then((user) => {
-          return Task.create({ title: 'task' }).then((task) => {
+        return User.create({ username: 'foo' }).then(user => {
+          return Task.create({ title: 'task' }).then(task => {
             return task.setUser(user).then(() => {
               return user.destroy().then(() => {
                 return task.reload().then(() => {
@@ -534,11 +534,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User, {onDelete: 'cascade'});
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'foo' }).then((user) => {
-          return Task.create({ title: 'task' }).then((task) => {
+        return User.create({ username: 'foo' }).then(user => {
+          return Task.create({ title: 'task' }).then(task => {
             return task.setUser(user).then(() => {
               return user.destroy().then(() => {
-                return Task.findAll().then((tasks) => {
+                return Task.findAll().then(tasks => {
                   expect(tasks).to.have.length(0);
                 });
               });
@@ -556,11 +556,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         Task.belongsTo(User, {onDelete: 'restrict'});
 
         return this.sequelize.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task' }).then(task => {
               return task.setUser(user).then(() => {
                 return expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => {
-                  return Task.findAll().then((tasks) => {
+                  return Task.findAll().then(tasks => {
                     expect(tasks).to.have.length(1);
                   });
                 });
@@ -577,8 +577,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         Task.belongsTo(User, {onUpdate: 'restrict'});
 
         return this.sequelize.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task' }).then(task => {
               return task.setUser(user).then(() => {
 
                 // Changing the id of a DAO requires a little dance since
@@ -590,7 +590,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
                   user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
                 ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => {
                   // Should fail due to FK restriction
-                  return Task.findAll().then((tasks) => {
+                  return Task.findAll().then(tasks => {
                     expect(tasks).to.have.length(1);
                   });
                 });
@@ -611,8 +611,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         Task.belongsTo(User, {onUpdate: 'cascade'});
 
         return this.sequelize.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task' }).then(task => {
               return task.setUser(user).then(() => {
 
                 // Changing the id of a DAO requires a little dance since
@@ -622,7 +622,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
                 const tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
                 return user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
                 .then(() => {
-                  return Task.findAll().then((tasks) => {
+                  return Task.findAll().then(tasks => {
                     expect(tasks).to.have.length(1);
                     expect(tasks[0].UserId).to.equal(999);
                   });
@@ -667,11 +667,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'bob' }).then((newUser) => {
-          return Task.create({ title: 'some task' }).then((newTask) => {
+        return User.create({ username: 'bob' }).then(newUser => {
+          return Task.create({ title: 'some task' }).then(newTask => {
             return newTask.setUser(newUser).then(() => {
-              return Task.findOne({ where: { title: 'some task' } }).then((foundTask) => {
-                return foundTask.getUser().then((foundUser) => {
+              return Task.findOne({ where: { title: 'some task' } }).then(foundTask => {
+                return foundTask.getUser().then(foundUser => {
                   expect(foundUser.username).to.equal('bob');
                 });
               });
@@ -696,11 +696,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'bob' }).then((newUser) => {
-          return Task.create({ title: 'some task' }).then((newTask) => {
+        return User.create({ username: 'bob' }).then(newUser => {
+          return Task.create({ title: 'some task' }).then(newTask => {
             return newTask.setUser(newUser).then(() => {
-              return Task.findOne({ where: { title: 'some task' } }).then((foundTask) => {
-                return foundTask.getUser().then((foundUser) => {
+              return Task.findOne({ where: { title: 'some task' } }).then(foundTask => {
+                return foundTask.getUser().then(foundUser => {
                   expect(foundUser.username).to.equal('bob');
                 });
               });
@@ -723,11 +723,11 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'bob' }).then((newUser) => {
-          return Task.create({ title: 'some task' }).then((newTask) => {
+        return User.create({ username: 'bob' }).then(newUser => {
+          return Task.create({ title: 'some task' }).then(newTask => {
             return newTask.setUser(newUser).then(() => {
-              return Task.findOne({ where: { title: 'some task'} }).then((foundTask) => {
-                return foundTask.getUser().then((foundUser) => {
+              return Task.findOne({ where: { title: 'some task'} }).then(foundTask => {
+                return foundTask.getUser().then(foundUser => {
                   expect(foundUser.username).to.equal('bob');
                 });
               });
@@ -745,7 +745,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         self = this,
         Tasks = {};
 
-      dataTypes.forEach((dataType) => {
+      dataTypes.forEach(dataType => {
         const tableName = 'TaskXYZ_' + dataType.key;
         Tasks[dataType] = self.sequelize.define(tableName, { title: DataTypes.STRING });
 
@@ -753,7 +753,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
       });
 
       return self.sequelize.sync({ force: true }).then(() => {
-        dataTypes.forEach((dataType) => {
+        dataTypes.forEach(dataType => {
           expect(Tasks[dataType].rawAttributes.userId.type).to.be.an.instanceof(dataType);
         });
       });

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -59,8 +59,8 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
                 id: 3
               })
             );
-          }).then((users) => {
-            return User.Tasks.get(users).then((result) => {
+          }).then(users => {
+            return User.Tasks.get(users).then(result => {
               expect(result[users[0].id].length).to.equal(3);
               expect(result[users[1].id].length).to.equal(1);
               expect(result[users[2].id].length).to.equal(0);
@@ -98,13 +98,13 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
                 include: [User.Tasks]
               })
             );
-          }).then((users) => {
+          }).then(users => {
             return User.Tasks.get(users, {
               limit: 2,
               order: [
                 ['title', 'ASC']
               ]
-            }).then((result) => {
+            }).then(result => {
               expect(result[users[0].id].length).to.equal(2);
               expect(result[users[0].id][0].title).to.equal('a');
               expect(result[users[0].id][1].title).to.equal('b');
@@ -192,7 +192,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
               order: [
                 ['id', 'ASC']
               ]
-            }).then((users) => {
+            }).then(users => {
               expect(users[0].tasks.length).to.equal(2);
 
               expect(users[0].tasks[0].title).to.equal('a');
@@ -257,14 +257,14 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
                 include: [{association: User.Tasks, include: [Task.Category]}]
               })
             );
-          }).then((users) => {
+          }).then(users => {
             return User.Tasks.get(users, {
               limit: 2,
               order: [
                 ['title', 'ASC']
               ],
               include: [Task.Category]
-            }).then((result) => {
+            }).then(result => {
               expect(result[users[0].id].length).to.equal(2);
               expect(result[users[0].id][0].title).to.equal('a');
               expect(result[users[0].id][0].category).to.be.ok;
@@ -309,7 +309,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
       if (current.dialect.supports.transactions) {
         it('supports transactions', function() {
           let Article, Label, sequelize, article, label, t;
-          return Support.prepareTransactionTest(this.sequelize).then((_sequelize) => {
+          return Support.prepareTransactionTest(this.sequelize).then(_sequelize => {
             sequelize = _sequelize;
             Article = sequelize.define('Article', { 'title': DataTypes.STRING });
             Label = sequelize.define('Label', { 'text': DataTypes.STRING });
@@ -326,19 +326,19 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
             article = _article;
             label = _label;
             return sequelize.transaction();
-          }).then((_t) => {
+          }).then(_t => {
             t = _t;
             return article.setLabels([label], { transaction: t });
           }).then(() => {
             return Article.all({ transaction: t });
-          }).then((articles) => {
-            return articles[0].hasLabel(label).then((hasLabel) => {
+          }).then(articles => {
+            return articles[0].hasLabel(label).then(hasLabel => {
               expect(hasLabel).to.be.false;
             });
           }).then(() => {
             return Article.all({ transaction: t });
-          }).then((articles) => {
-            return articles[0].hasLabel(label, { transaction: t }).then((hasLabel) => {
+          }).then(articles => {
+            return articles[0].hasLabel(label, { transaction: t }).then(hasLabel => {
               expect(hasLabel).to.be.true;
               return t.rollback();
             });
@@ -460,7 +460,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           return article.addLabel(label1).then(() => {
             return article.hasLabels([label1, label2]);
           });
-        }).then((result) => {
+        }).then(result => {
           expect(result).to.be.false;
         });
       });
@@ -472,7 +472,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           this.Label.create({ text: 'Epicness' })
         ]).spread((article, label1, label2) => {
           return article.addLabel(label1).then(() => {
-            return article.hasLabels([label1.id, label2.id]).then((result) => {
+            return article.hasLabels([label1.id, label2.id]).then(result => {
               expect(result).to.be.false;
             });
           });
@@ -486,7 +486,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           this.Label.create({ text: 'Epicness' })
         ]).spread((article, label1, label2) => {
           return article.setLabels([label1, label2]).then(() => {
-            return article.hasLabels([label1, label2]).then((result) => {
+            return article.hasLabels([label1, label2]).then(result => {
               expect(result).to.be.true;
             });
           });
@@ -500,7 +500,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           this.Label.create({ text: 'Epicness' })
         ]).spread((article, label1, label2) => {
           return article.setLabels([label1, label2]).then(() => {
-            return article.hasLabels([label1.id, label2.id]).then((result) => {
+            return article.hasLabels([label1.id, label2.id]).then(result => {
               expect(result).to.be.true;
             });
           });
@@ -565,7 +565,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           return this.task.setUsers(null);
         }).then(function() {
           return this.task.getUsers();
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(0);
         });
       });
@@ -591,7 +591,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           return this.article.setLabels([this.label2.id]);
         }).then(function() {
           return this.article.getLabels();
-        }).then((labels) => {
+        }).then(labels => {
           expect(labels).to.have.length(1);
           expect(labels[0].text).to.equal('label two');
         });
@@ -649,7 +649,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           return article.addLabel(label.id);
         }).then(function() {
           return this.article.getLabels();
-        }).then((labels) => {
+        }).then(labels => {
           expect(labels[0].text).to.equal('label one'); // Make sure that we didn't modify one of the other attributes while building / saving a new instance
         });
       });
@@ -680,7 +680,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           return this.task.addUsers([this.users[1], this.users[2]]);
         }).then(function() {
           return this.task.getUsers();
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(3);
         });
       });
@@ -728,7 +728,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         return this.task.setUsers(null);
       }).then(function() {
         return this.task.getUsers();
-      }).then((_users) => {
+      }).then(_users => {
         expect(_users).to.have.length(0);
       });
     });
@@ -742,11 +742,11 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
 
         return this.sequelize.sync({ force: true }).then(() => {
           return Article.create({ title: 'foo' });
-        }).then((article) => {
+        }).then(article => {
           return article.createLabel({ text: 'bar' }).return (article);
-        }).then((article) => {
+        }).then(article => {
           return Label.findAll({ where: { ArticleId: article.id }});
-        }).then((labels) => {
+        }).then(labels => {
           expect(labels.length).to.equal(1);
         });
       });
@@ -820,15 +820,15 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
 
         return this.sequelize.sync({force: true}).then(() => {
           return Article.create();
-        }).then((article) => {
+        }).then(article => {
           return article.createLabel({
             text: 'yolo'
           }, {
             fields: ['text']
           }).return (article);
-        }).then((article) => {
+        }).then(article => {
           return article.getLabels();
-        }).then((labels) => {
+        }).then(labels => {
           expect(labels.length).to.be.ok;
         });
       });
@@ -877,7 +877,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           return article.setLabels([label1, label2]);
         }).then(function() {
           return this.article.getLabels({where: {until: {$gt: moment('2014-01-02').toDate()}}});
-        }).then((labels) => {
+        }).then(labels => {
           expect(labels).to.be.instanceof(Array);
           expect(labels).to.have.length(1);
           expect(labels[0].text).to.equal('Epicness');
@@ -885,17 +885,17 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
       });
 
       it('gets all associated objects when no options are passed', function() {
-        return this.User.find({where: {username: 'John'}}).then((john) => {
+        return this.User.find({where: {username: 'John'}}).then(john => {
           return john.getTasks();
-        }).then((tasks) => {
+        }).then(tasks => {
           expect(tasks).to.have.length(2);
         });
       });
 
       it('only get objects that fulfill the options', function() {
-        return this.User.find({ where: { username: 'John' } }).then((john) => {
+        return this.User.find({ where: { username: 'John' } }).then(john => {
           return john.getTasks({ where: { active: true }, limit: 10, order: [['id', 'DESC']]});
-        }).then((tasks) => {
+        }).then(tasks => {
           expect(tasks).to.have.length(1);
         });
       });
@@ -979,7 +979,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
               return task.reload();
             });
           });
-        }).then((task) => {
+        }).then(task => {
           expect(task.UserId).to.equal(null);
         });
       });
@@ -991,13 +991,13 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         User.hasMany(Task, { foreignKey: { allowNull: false }}); // defaults to CASCADE
 
         return this.sequelize.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
+          return User.create({ username: 'foo' }).then(user => {
             return Task.create({ title: 'task', UserId: user.id }).then(() => {
               return user.destroy().then(() => {
                 return Task.findAll();
               });
             });
-          }).then((tasks) => {
+          }).then(tasks => {
             expect(tasks).to.be.empty;
           });
         });
@@ -1046,7 +1046,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           return this.user.destroy();
         }).then(() => {
           return Task.findAll();
-        }).then((tasks) => {
+        }).then(tasks => {
           expect(tasks).to.have.length(0);
         });
       });
@@ -1066,7 +1066,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
             ]);
           }).spread((user, task) => {
             return user.setTasks([task]).return (user);
-          }).then((user) => {
+          }).then(user => {
             // Changing the id of a DAO requires a little dance since
             // the `UPDATE` query generated by `save()` uses `id` in the
             // `WHERE` clause
@@ -1075,7 +1075,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
             return user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id});
           }).then(() => {
             return Task.findAll();
-          }).then((tasks) => {
+          }).then(tasks => {
             expect(tasks).to.have.length(1);
             expect(tasks[0].UserId).to.equal(999);
           });
@@ -1104,7 +1104,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
               // Should fail due to FK violation
               return Task.findAll();
             });
-          }).then((tasks) => {
+          }).then(tasks => {
             expect(tasks).to.have.length(1);
           });
         });
@@ -1123,7 +1123,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
             ]);
           }).spread((user, task) => {
             return user.setTasks([task]).return (user);
-          }).then((user) => {
+          }).then(user => {
             // Changing the id of a DAO requires a little dance since
             // the `UPDATE` query generated by `save()` uses `id` in the
             // `WHERE` clause
@@ -1134,7 +1134,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
               // Should fail due to FK violation
               return Task.findAll();
             });
-          }).then((tasks) => {
+          }).then(tasks => {
             expect(tasks).to.have.length(1);
           });
         });
@@ -1151,7 +1151,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         self = this,
         Tasks = {};
 
-      return Promise.each(dataTypes, (dataType) => {
+      return Promise.each(dataTypes, dataType => {
         const tableName = 'TaskXYZ_' + dataType.key;
         Tasks[dataType] = self.sequelize.define(tableName, { title: DataTypes.STRING });
 
@@ -1267,9 +1267,9 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
       const User = this.User,
         Task = this.Task;
 
-      return User.create({ username: 'John', email: 'john@example.com' }).then((user) => {
+      return User.create({ username: 'John', email: 'john@example.com' }).then(user => {
         return Task.create({title: 'Fix PR', userEmail: 'john@example.com'}).then(() => {
-          return user.getTasks().then((tasks) => {
+          return user.getTasks().then(tasks => {
             expect(tasks.length).to.equal(1);
             expect(tasks[0].title).to.equal('Fix PR');
           });
@@ -1281,9 +1281,9 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
       const User = this.User,
         Task = this.Task;
 
-      return User.create({ username: 'John', email: 'john@example.com' }).then((user) => {
+      return User.create({ username: 'John', email: 'john@example.com' }).then(user => {
         return Task.create({title: 'Fix PR', userEmail: 'john@example.com'}).then(() => {
-          return user.countTasks().then((tasksCount) => {
+          return user.countTasks().then(tasksCount => {
             expect(tasksCount).to.equal(1);
           });
         });
@@ -1294,10 +1294,10 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
       const User = this.User,
         Task = this.Task;
 
-      return User.create({ username: 'John', email: 'john@example.com' }).then((user) => {
-        return Task.create({title: 'Fix PR'}).then((task) => {
+      return User.create({ username: 'John', email: 'john@example.com' }).then(user => {
+        return Task.create({title: 'Fix PR'}).then(task => {
           return user.addTask(task).then(() => {
-            return user.hasTask(task.id).then((hasTask) => {
+            return user.hasTask(task.id).then(hasTask => {
               expect(hasTask).to.be.true;
             });
           });

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -47,8 +47,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
               id: 3
             })
           );
-        }).then((players) => {
-          return Player.User.get(players).then((result) => {
+        }).then(players => {
+          return Player.User.get(players).then(result => {
             expect(result[players[0].id].id).to.equal(players[0].user.id);
             expect(result[players[1].id].id).to.equal(players[1].user.id);
             expect(result[players[2].id]).to.equal(null);
@@ -62,23 +62,23 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
   describe('getAssocation', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING }),
             Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.hasOne(User);
 
           return sequelize.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((fakeUser) => {
-              return User.create({ username: 'foo' }).then((user) => {
-                return Group.create({ name: 'bar' }).then((group) => {
-                  return sequelize.transaction().then((t) => {
+            return User.create({ username: 'foo' }).then(fakeUser => {
+              return User.create({ username: 'foo' }).then(user => {
+                return Group.create({ name: 'bar' }).then(group => {
+                  return sequelize.transaction().then(t => {
                     return group.setUser(user, { transaction: t }).then(() => {
-                      return Group.all().then((groups) => {
-                        return groups[0].getUser().then((associatedUser) => {
+                      return Group.all().then(groups => {
+                        return groups[0].getUser().then(associatedUser => {
                           expect(associatedUser).to.be.null;
-                          return Group.all({ transaction: t }).then((groups) => {
-                            return groups[0].getUser({ transaction: t }).then((associatedUser) => {
+                          return Group.all({ transaction: t }).then(groups => {
+                            return groups[0].getUser({ transaction: t }).then(associatedUser => {
                               expect(associatedUser).not.to.be.null;
                               expect(associatedUser.id).to.equal(user.id);
                               expect(associatedUser.id).not.to.equal(fakeUser.id);
@@ -105,10 +105,10 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task', status: 'inactive' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task', status: 'inactive' }).then(task => {
               return user.setTaskXYZ(task).then(() => {
-                return user.getTaskXYZ({where: {status: 'active'}}).then((task) => {
+                return user.getTaskXYZ({where: {status: 'active'}}).then(task => {
                   expect(task).to.be.null;
                 });
               });
@@ -122,19 +122,19 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
   describe('setAssociation', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING }),
             Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
 
           Group.hasOne(User);
 
           return sequelize.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return Group.create({ name: 'bar' }).then((group) => {
-                return sequelize.transaction().then((t) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return Group.create({ name: 'bar' }).then(group => {
+                return sequelize.transaction().then(t => {
                   return group.setUser(user, { transaction: t }).then(() => {
-                    return Group.all().then((groups) => {
-                      return groups[0].getUser().then((associatedUser) => {
+                    return Group.all().then(groups => {
+                      return groups[0].getUser().then(associatedUser => {
                         expect(associatedUser).to.be.null;
                         return t.rollback();
                       });
@@ -156,14 +156,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
-          return User.create({userCoolIdTag: 1, username: 'foo'}).then((user) => {
-            return Task.create({taskOrSomething: 1, title: 'bar'}).then((task) => {
+          return User.create({userCoolIdTag: 1, username: 'foo'}).then(user => {
+            return Task.create({taskOrSomething: 1, title: 'bar'}).then(task => {
               return user.setTaskXYZZ(task).then(() => {
-                return user.getTaskXYZZ().then((task) => {
+                return user.getTaskXYZZ().then(task => {
                   expect(task).not.to.be.null;
 
                   return user.setTaskXYZZ(null).then(() => {
-                    return user.getTaskXYZZ().then((_task) => {
+                    return user.getTaskXYZZ().then(_task => {
                       expect(_task).to.be.null;
                     });
                   });
@@ -183,14 +183,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task' }).then(task => {
               return user.setTaskXYZ(task).then(() => {
-                return user.getTaskXYZ().then((task) => {
+                return user.getTaskXYZ().then(task => {
                   expect(task).not.to.equal(null);
 
                   return user.setTaskXYZ(null).then(() => {
-                    return user.getTaskXYZ().then((task) => {
+                    return user.getTaskXYZ().then(task => {
                       expect(task).to.equal(null);
                     });
                   });
@@ -211,7 +211,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
           return expect(Task.create({ title: 'task', UserXYZId: 5 })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => {
-            return Task.create({ title: 'task' }).then((task) => {
+            return Task.create({ title: 'task' }).then(task => {
               return expect(Task.update({ title: 'taskUpdate', UserXYZId: 5 }, { where: { id: task.id } })).to.be.rejectedWith(Sequelize.ForeignKeyConstraintError);
             });
           });
@@ -226,10 +226,10 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
       User.hasOne(Task);
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({}).then((user) => {
-          return Task.create({ id: 19, title: 'task it!' }).then((task) => {
+        return User.create({}).then(user => {
+          return Task.create({ id: 19, title: 'task it!' }).then(task => {
             return user.setTaskXYZ(task.id).then(() => {
-              return user.getTaskXYZ().then((task) => {
+              return user.getTaskXYZ().then(task => {
                 expect(task.title).to.equal('task it!');
               });
             });
@@ -253,7 +253,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
       .spread((user, task) => {
         return user.setTaskXYZ(task.id)
           .then(() => user.getTaskXYZ())
-          .then((task) => {
+          .then(task => {
             expect(task).not.to.be.null;
             return Promise.all([
               user,
@@ -264,7 +264,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
       .spread((user, task2) => {
         return user.setTaskXYZ(task2.id)
           .then(() => user.getTaskXYZ())
-          .then((task) => {
+          .then(task => {
             expect(task).not.to.be.null;
           });
       });
@@ -301,9 +301,9 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
       User.hasOne(Task);
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'bob' }).then((user) => {
+        return User.create({ username: 'bob' }).then(user => {
           return user.createTask({ title: 'task' }).then(() => {
-            return user.getTask().then((task) => {
+            return user.getTask().then(task => {
               expect(task).not.to.be.null;
               expect(task.title).to.equal('task');
             });
@@ -314,21 +314,21 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING }),
             Group = sequelize.define('Group', { name: Sequelize.STRING });
 
           User.hasOne(Group);
 
           return sequelize.sync({ force: true }).then(() => {
-            return User.create({ username: 'bob' }).then((user) => {
-              return sequelize.transaction().then((t) => {
+            return User.create({ username: 'bob' }).then(user => {
+              return sequelize.transaction().then(t => {
                 return user.createGroup({ name: 'testgroup' }, { transaction: t }).then(() => {
-                  return User.all().then((users) => {
-                    return users[0].getGroup().then((group) => {
+                  return User.all().then(users => {
+                    return users[0].getGroup().then(group => {
                       expect(group).to.be.null;
-                      return User.all({ transaction: t }).then((users) => {
-                        return users[0].getGroup({ transaction: t }).then((group) => {
+                      return User.all({ transaction: t }).then(users => {
+                        return users[0].getGroup({ transaction: t }).then(group => {
                           expect(group).to.be.not.null;
                           return t.rollback();
                         });
@@ -389,14 +389,14 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
         return task.setUserXYZ(user).then(() => {
           return task.getUserXYZ();
         });
-      }).then((user) => {
+      }).then(user => {
         // the sql query should correctly look at task_id instead of taskId
         expect(user).to.not.be.null;
         return Task.findOne({
           where: {title: 'task'},
           include: [User]
         });
-      }).then((task) => {
+      }).then(task => {
         expect(task.UserXYZ).to.exist;
       });
     });
@@ -411,8 +411,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task' }).then(task => {
               return user.setTask(task).then(() => {
                 return user.destroy().then(() => {
                   return task.reload().then(() => {
@@ -433,13 +433,13 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
       User.hasOne(Task, { foreignKey: { allowNull: false }}); // defaults to CASCADE
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'foo' }).then((user) => {
+        return User.create({ username: 'foo' }).then(user => {
           return Task.create({ title: 'task', UserId: user.id }).then(() => {
             return user.destroy().then(() => {
               return Task.findAll();
             });
           });
-        }).then((tasks) => {
+        }).then(tasks => {
           expect(tasks).to.be.empty;
         });
       });
@@ -453,8 +453,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task' }).then(task => {
               return user.setTask(task).then(() => {
                 return user.destroy().then(() => {
                   return task.reload().then(() => {
@@ -476,11 +476,11 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
-            return Task.create({ title: 'task' }).then((task) => {
+          return User.create({ username: 'foo' }).then(user => {
+            return Task.create({ title: 'task' }).then(task => {
               return user.setTask(task).then(() => {
                 return user.destroy().then(() => {
-                  return Task.findAll().then((tasks) => {
+                  return Task.findAll().then(tasks => {
                     expect(tasks).to.have.length(0);
                   });
                 });
@@ -499,7 +499,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
       return User.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
-          return User.create({ username: 'foo' }).then((user) => {
+          return User.create({ username: 'foo' }).then(user => {
             return user.destroy();
           });
         });
@@ -516,8 +516,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
         return User.sync({ force: true }).then(() => {
           return Task.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return Task.create({ title: 'task' }).then((task) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return Task.create({ title: 'task' }).then(task => {
                 return user.setTask(task).then(() => {
 
                   // Changing the id of a DAO requires a little dance since
@@ -526,7 +526,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
                   const tableName = user.sequelize.getQueryInterface().QueryGenerator.addSchema(user.constructor);
                   return user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id}).then(() => {
-                    return Task.findAll().then((tasks) => {
+                    return Task.findAll().then(tasks => {
                       expect(tasks).to.have.length(1);
                       expect(tasks[0].UserId).to.equal(999);
                     });
@@ -549,11 +549,11 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
         return User.sync({ force: true }).then(() => {
           return Task.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return Task.create({ title: 'task' }).then((task) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return Task.create({ title: 'task' }).then(task => {
                 return user.setTask(task).then(() => {
                   return expect(user.destroy()).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => {
-                    return Task.findAll().then((tasks) => {
+                    return Task.findAll().then(tasks => {
                       expect(tasks).to.have.length(1);
                     });
                   });
@@ -572,8 +572,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
         return User.sync({ force: true }).then(() => {
           return Task.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return Task.create({ title: 'task' }).then((task) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return Task.create({ title: 'task' }).then(task => {
                 return user.setTask(task).then(() => {
 
                   // Changing the id of a DAO requires a little dance since
@@ -585,7 +585,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
                     user.sequelize.getQueryInterface().update(user, tableName, {id: 999}, {id: user.id})
                   ).to.eventually.be.rejectedWith(Sequelize.ForeignKeyConstraintError).then(() => {
                     // Should fail due to FK restriction
-                    return Task.findAll().then((tasks) => {
+                    return Task.findAll().then(tasks => {
                       expect(tasks).to.have.length(1);
                     });
                   });
@@ -630,7 +630,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
         self = this,
         Tasks = {};
 
-      return Promise.map(dataTypes, (dataType) => {
+      return Promise.map(dataTypes, dataType => {
         const tableName = 'TaskXYZ_' + dataType.key;
         Tasks[dataType] = self.sequelize.define(tableName, { title: Sequelize.STRING });
 

--- a/test/integration/associations/multiple-level-filters.test.js
+++ b/test/integration/associations/multiple-level-filters.test.js
@@ -53,7 +53,7 @@ describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
                   required: true
                 }
               ]
-            }).then((tasks) => {
+            }).then(tasks => {
 
               expect(tasks.length).to.be.equal(2);
               expect(tasks[0].title).to.be.equal('fight empire');
@@ -115,7 +115,7 @@ describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
                   required: true
                 }
               ]
-            }).then((tasks) => {
+            }).then(tasks => {
               expect(tasks.length).to.be.equal(2);
               expect(tasks[0].title).to.be.equal('fight empire');
               expect(tasks[1].title).to.be.equal('stablish republic');
@@ -173,7 +173,7 @@ describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
                   required: true
                 }
               ]
-            }).then((users) => {
+            }).then(users => {
               expect(users.length).to.be.equal(1);
               expect(users[0].username).to.be.equal('leia');
             });
@@ -201,17 +201,17 @@ describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
         }, {
           title: 'empire'
         }]).then(() => {
-          return User.findById(1).then((user) => {
-            return Project.findById(1).then((project) => {
+          return User.findById(1).then(user => {
+            return Project.findById(1).then(project => {
               return user.setProjects([project]).then(() => {
-                return User.findById(2).then((user) => {
-                  return Project.findById(2).then((project) => {
+                return User.findById(2).then(user => {
+                  return Project.findById(2).then(project => {
                     return user.setProjects([project]).then(() => {
                       return User.findAll({
                         include: [
                           {model: Project, where: {title: 'republic'}}
                         ]
-                      }).then((users) => {
+                      }).then(users => {
                         expect(users.length).to.be.equal(1);
                         expect(users[0].username).to.be.equal('leia');
                       });

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -108,7 +108,7 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           expect(comment.get('commentable')).to.equal('post');
           expect(comment.get('isMain')).to.be.false;
           return this.Post.scope('withMainComment').findById(this.post.get('id'));
-        }).then((post) => {
+        }).then(post => {
           expect(post.mainComment).to.be.null;
           return post.createMainComment({
             title: 'I am a main post comment'
@@ -131,7 +131,7 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           return this.post.setMainComment(comment);
         }).then( function() {
           return this.post.getMainComment();
-        }).then((mainComment) => {
+        }).then(mainComment => {
           expect(mainComment.get('commentable')).to.equal('post');
           expect(mainComment.get('isMain')).to.be.true;
           expect(mainComment.get('title')).to.equal('I am a future main comment');
@@ -167,11 +167,11 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           );
         }).then(() => {
           return self.Comment.findAll();
-        }).then((comments) => {
-          comments.forEach((comment) => {
+        }).then(comments => {
+          comments.forEach(comment => {
             expect(comment.get('commentable')).to.be.ok;
           });
-          expect(comments.map((comment) => {
+          expect(comments.map(comment => {
             return comment.get('commentable');
           }).sort()).to.deep.equal(['image', 'post', 'question']);
         }).then(function() {
@@ -229,7 +229,7 @@ describe(Support.getTestDialectTeaser('associations'), () => {
 
         return this.sequelize.sync({force: true}).then(() => {
           return self.Post.create();
-        }).then((post) => {
+        }).then(post => {
           return post.createComment({
             title: 'I am a post comment'
           });
@@ -503,15 +503,15 @@ describe(Support.getTestDialectTeaser('associations'), () => {
                 expect(imageTags.length).to.equal(3);
                 expect(questionTags.length).to.equal(3);
 
-                expect(postTags.map((tag) => {
+                expect(postTags.map(tag => {
                   return tag.name;
                 }).sort()).to.deep.equal(['postTag', 'tagA', 'tagB']);
 
-                expect(imageTags.map((tag) => {
+                expect(imageTags.map(tag => {
                   return tag.name;
                 }).sort()).to.deep.equal(['imageTag', 'tagB', 'tagC']);
 
-                expect(questionTags.map((tag) => {
+                expect(questionTags.map(tag => {
                   return tag.name;
                 }).sort()).to.deep.equal(['questionTag', 'tagA', 'tagC']);
               }).then(() => {
@@ -533,15 +533,15 @@ describe(Support.getTestDialectTeaser('associations'), () => {
                   expect(image.tags.length).to.equal(3);
                   expect(question.tags.length).to.equal(3);
 
-                  expect(post.tags.map((tag) => {
+                  expect(post.tags.map(tag => {
                     return tag.name;
                   }).sort()).to.deep.equal(['postTag', 'tagA', 'tagB']);
 
-                  expect(image.tags.map((tag) => {
+                  expect(image.tags.map(tag => {
                     return tag.name;
                   }).sort()).to.deep.equal(['imageTag', 'tagB', 'tagC']);
 
-                  expect(question.tags.map((tag) => {
+                  expect(question.tags.map(tag => {
                     return tag.name;
                   }).sort()).to.deep.equal(['questionTag', 'tagA', 'tagC']);
                 });

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -73,7 +73,7 @@ describe(Support.getTestDialectTeaser('Self'), () => {
           return chris.addParent(john);
         }).then(() => {
           return john.getChilds();
-        }).then((children) => {
+        }).then(children => {
           expect(_.map(children, 'id')).to.have.members([mary.id, chris.id]);
         });
       });

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -86,7 +86,7 @@ if (current.dialect.supports.transactions) {
           });
         });
 
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
           // Wait for the transaction to be setup
           const interval = setInterval(() => {
             if (transactionSetup) {

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -61,14 +61,14 @@ describe(Support.getTestDialectTeaser('Configuration'), () => {
             return Sequelize.Promise.promisify(fs.access)(p, fs.R_OK | fs.W_OK);
           } else { // Node v0.10 and older don't have fs.access
             return Sequelize.Promise.promisify(fs.open)(p, 'r+')
-            .then((fd) => {
+            .then(fd => {
               return Sequelize.Promise.promisify(fs.close)(fd);
             });
           }
         });
 
         return Sequelize.Promise.promisify(fs.unlink)(p)
-        .catch((err) => {
+        .catch(err => {
           expect(err.code).to.equal('ENOENT');
         })
         .then(() => {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -43,7 +43,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
   });
 
   it('allows me to return values from a custom parse function', () => {
-    const parse = Sequelize.DATE.parse = sinon.spy((value) => {
+    const parse = Sequelize.DATE.parse = sinon.spy(value => {
       return moment(value, 'YYYY-MM-DD HH:mm:ss');
     });
 
@@ -79,7 +79,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
   });
 
   const testSuccess = function(Type, value) {
-    const parse = Type.constructor.parse = sinon.spy((value) => {
+    const parse = Type.constructor.parse = sinon.spy(value => {
       return value;
     });
 
@@ -288,7 +288,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
       return new Sequelize.Promise((resolve, reject) => {
         if (/^postgres/.test(dialect)) {
           current.query('SELECT PostGIS_Lib_Version();')
-            .then((result) => {
+            .then(result => {
               if (result[0][0] && semver.lte(result[0][0].postgis_lib_version, '2.1.7')) {
                 resolve(true);
               } else {
@@ -298,7 +298,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
         } else {
           resolve(true);
         }
-      }).then((runTests) => {
+      }).then(runTests => {
         if (current.dialect.supports.GEOMETRY && runTests) {
           current.refreshTypes();
 
@@ -430,7 +430,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
       return Model.sync({ force: true })
               .then(() => Model.create({ interval: [1, 4] }) )
               .then(() => Model.findAll() )
-              .spread((m) => {
+              .spread(m => {
                 expect(m.interval[0]).to.be.eql(1);
                 expect(m.interval[1]).to.be.eql(4);
               });

--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -75,7 +75,7 @@ describe('Connection Manager', () => {
     const sequelize = Support.createSequelizeInstance(options);
     const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
 
-    const resolvedPromise = new Promise((resolve) => {
+    const resolvedPromise = new Promise(resolve => {
       resolve({
         queryType: 'read'
       });
@@ -121,7 +121,7 @@ describe('Connection Manager', () => {
     const sequelize = Support.createSequelizeInstance(options);
     const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
 
-    const resolvedPromise = new Promise((resolve) => {
+    const resolvedPromise = new Promise(resolve => {
       resolve({
         queryType: 'read'
       });

--- a/test/integration/dialects/mssql/query-queue.test.js
+++ b/test/integration/dialects/mssql/query-queue.test.js
@@ -22,7 +22,7 @@ if (dialect.match(/^mssql/)) {
     it('should queue concurrent requests to a connection', function() {
       const User = this.User;
 
-      return expect(this.sequelize.transaction((t) => {
+      return expect(this.sequelize.transaction(t => {
         return Promise.all([
           User.findOne({
             transaction: t

--- a/test/integration/dialects/mysql/associations.test.js
+++ b/test/integration/dialects/mysql/associations.test.js
@@ -81,8 +81,8 @@ if (dialect === 'mysql') {
           self.user = null;
           self.task = null;
 
-          return self.User.findAll().then((_users) => {
-            return self.Task.findAll().then((_tasks) => {
+          return self.User.findAll().then(_users => {
+            return self.Task.findAll().then(_tasks => {
               self.user = _users[0];
               self.task = _tasks[0];
             });
@@ -92,10 +92,10 @@ if (dialect === 'mysql') {
         it('should correctly add an association to the dao', function() {
           const self = this;
 
-          return self.user.getTasks().then((_tasks) => {
+          return self.user.getTasks().then(_tasks => {
             expect(_tasks.length).to.equal(0);
             return self.user.addTask(self.task).then(() => {
-              return self.user.getTasks().then((_tasks) => {
+              return self.user.getTasks().then(_tasks => {
                 expect(_tasks.length).to.equal(1);
               });
             });
@@ -110,8 +110,8 @@ if (dialect === 'mysql') {
           self.user = null;
           self.tasks = null;
 
-          return self.User.findAll().then((_users) => {
-            return self.Task.findAll().then((_tasks) => {
+          return self.User.findAll().then(_users => {
+            return self.Task.findAll().then(_tasks => {
               self.user = _users[0];
               self.tasks = _tasks;
             });
@@ -121,16 +121,16 @@ if (dialect === 'mysql') {
         it('should correctly remove associated objects', function() {
           const self = this;
 
-          return self.user.getTasks().then((__tasks) => {
+          return self.user.getTasks().then(__tasks => {
             expect(__tasks.length).to.equal(0);
             return self.user.setTasks(self.tasks).then(() => {
-              return self.user.getTasks().then((_tasks) => {
+              return self.user.getTasks().then(_tasks => {
                 expect(_tasks.length).to.equal(self.tasks.length);
                 return self.user.removeTask(self.tasks[0]).then(() => {
-                  return self.user.getTasks().then((_tasks) => {
+                  return self.user.getTasks().then(_tasks => {
                     expect(_tasks.length).to.equal(self.tasks.length - 1);
                     return self.user.removeTasks([self.tasks[1], self.tasks[2]]).then(() => {
-                      return self.user.getTasks().then((_tasks) => {
+                      return self.user.getTasks().then(_tasks => {
                         expect(_tasks).to.have.length(self.tasks.length - 3);
                       });
                     });

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -45,7 +45,7 @@ if (dialect === 'mysql') {
         // This query will be queued just after the `client.end` is executed and before its callback is called
         return sequelize.query('SELECT COUNT(*) AS count FROM Users', { type: sequelize.QueryTypes.SELECT });
       })
-      .then((count) => {
+      .then(count => {
         expect(count[0].count).to.equal(1);
       });
     });
@@ -67,7 +67,7 @@ if (dialect === 'mysql') {
           // Get next available connection
           return cm.getConnection();
         })
-        .then((connection) => {
+        .then(connection => {
           // Old threadId should be different from current new one
           expect(conn.threadId).to.be.equal(connection.threadId);
           expect(cm.validate(conn)).to.be.ok;
@@ -84,7 +84,7 @@ if (dialect === 'mysql') {
       return sequelize
         .sync()
         .then(() => cm.getConnection())
-        .then((connection) => {
+        .then(connection => {
           // Save current connection
           conn = connection;
           // simulate a unexpected end
@@ -95,7 +95,7 @@ if (dialect === 'mysql') {
           // Get next available connection
           return cm.getConnection();
         })
-        .then((connection) => {
+        .then(connection => {
           // Old threadId should be different from current new one
           expect(conn.threadId).to.not.be.equal(connection.threadId);
           expect(cm.validate(conn)).to.not.be.ok;

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -69,8 +69,8 @@ if (dialect.match(/^postgres/)) {
           return this.sequelize.sync({ force: true }).then(() => {
             return self.User.bulkCreate(users).then(() => {
               return self.Task.bulkCreate(tasks).then(() => {
-                return self.User.findAll().then((_users) => {
-                  return self.Task.findAll().then((_tasks) => {
+                return self.User.findAll().then(_users => {
+                  return self.Task.findAll().then(_tasks => {
                     self.user = _users[0];
                     self.task = _tasks[0];
                   });
@@ -83,10 +83,10 @@ if (dialect.match(/^postgres/)) {
         it('should correctly add an association to the dao', function() {
           const self = this;
 
-          return self.user.getTasks().then((_tasks) => {
+          return self.user.getTasks().then(_tasks => {
             expect(_tasks).to.have.length(0);
             return self.user.addTask(self.task).then(() => {
-              return self.user.getTasks().then((_tasks) => {
+              return self.user.getTasks().then(_tasks => {
                 expect(_tasks).to.have.length(1);
               });
             });
@@ -120,23 +120,23 @@ if (dialect.match(/^postgres/)) {
           return this.sequelize.sync({ force: true }).then(() => {
             return self.User.bulkCreate(users).then(() => {
               return self.Task.bulkCreate(tasks).then(() => {
-                return self.User.findAll().then((_users) => {
-                  return self.Task.findAll().then((_tasks) => {
+                return self.User.findAll().then(_users => {
+                  return self.Task.findAll().then(_tasks => {
                     self.user = _users[0];
                     self.task = _tasks[0];
                     self.users = _users;
                     self.tasks = _tasks;
 
-                    return self.user.getTasks().then((__tasks) => {
+                    return self.user.getTasks().then(__tasks => {
                       expect(__tasks).to.have.length(0);
                       return self.user.setTasks(self.tasks).then(() => {
-                        return self.user.getTasks().then((_tasks) => {
+                        return self.user.getTasks().then(_tasks => {
                           expect(_tasks).to.have.length(self.tasks.length);
                           return self.user.removeTask(self.tasks[0]).then(() => {
-                            return self.user.getTasks().then((_tasks) => {
+                            return self.user.getTasks().then(_tasks => {
                               expect(_tasks).to.have.length(self.tasks.length - 1);
                               return self.user.removeTasks([self.tasks[1], self.tasks[2]]).then(() => {
-                                return self.user.getTasks().then((_tasks) => {
+                                return self.user.getTasks().then(_tasks => {
                                   expect(_tasks).to.have.length(self.tasks.length - 3);
                                 });
                               });

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -15,7 +15,7 @@ if (dialect.match(/^postgres/)) {
 
       const tzTable = sequelize.define('tz_table', { foo: DataTypes.STRING });
       return tzTable.sync({force: true}).then(() => {
-        return tzTable.create({foo: 'test'}).then((row) => {
+        return tzTable.create({foo: 'test'}).then(row => {
           expect(row).to.be.not.null;
         });
       });

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -959,19 +959,19 @@ if (dialect.match(/^postgres/)) {
           .then(() => {
             return Promise.all([
               this.Student.findById(1)
-                .then((Harry) => {
+                .then(Harry => {
                   return Harry.setClasses([1, 2, 3]);
                 }),
               this.Student.findById(2)
-                .then((Ron) => {
+                .then(Ron => {
                   return Ron.setClasses([1, 2]);
                 }),
               this.Student.findById(3)
-                .then((Ginny) => {
+                .then(Ginny => {
                   return Ginny.setClasses([2, 3]);
                 }),
               this.Student.findById(4)
-                .then((Hermione) => {
+                .then(Hermione => {
                   return Hermione.setClasses([1, 2, 3]);
                 })
             ]);
@@ -995,7 +995,7 @@ if (dialect.match(/^postgres/)) {
               ]
             });
           })
-          .then((professors) => {
+          .then(professors => {
             expect(professors.length).to.eql(2);
             expect(professors[0].fullName).to.eql('Albus Dumbledore');
             expect(professors[0].Classes.length).to.eql(1);

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -24,7 +24,7 @@ if (dialect === 'sqlite') {
       return this.User.sync({ force: true });
     });
 
-    storages.forEach((storage) => {
+    storages.forEach(storage => {
       describe('with storage "' + storage + '"', () => {
         after(() => {
           if (storage === dbFile) {
@@ -35,13 +35,13 @@ if (dialect === 'sqlite') {
         describe('create', () => {
           it('creates a table entry', function() {
             const self = this;
-            return this.User.create({ age: 21, name: 'John Wayne', bio: 'noot noot' }).then((user) => {
+            return this.User.create({ age: 21, name: 'John Wayne', bio: 'noot noot' }).then(user => {
               expect(user.age).to.equal(21);
               expect(user.name).to.equal('John Wayne');
               expect(user.bio).to.equal('noot noot');
 
-              return self.User.findAll().then((users) => {
-                const usernames = users.map((user) => {
+              return self.User.findAll().then(users => {
+                const usernames = users.map(user => {
                   return user.name;
                 });
                 expect(usernames).to.contain('John Wayne');
@@ -61,7 +61,7 @@ if (dialect === 'sqlite') {
               return Person.create({
                 name: 'John Doe',
                 options
-              }).then((people) => {
+              }).then(people => {
                 expect(people.options).to.deep.equal(options);
               });
             });
@@ -77,7 +77,7 @@ if (dialect === 'sqlite') {
               return Person.create({
                 name: 'John Doe',
                 has_swag: true
-              }).then((people) => {
+              }).then(people => {
                 expect(people.has_swag).to.be.ok;
               });
             });
@@ -93,7 +93,7 @@ if (dialect === 'sqlite') {
               return Person.create({
                 name: 'John Doe',
                 has_swag: false
-              }).then((people) => {
+              }).then(people => {
                 expect(people.has_swag).to.not.be.ok;
               });
             });
@@ -106,13 +106,13 @@ if (dialect === 'sqlite') {
           });
 
           it('finds normal lookups', function() {
-            return this.User.find({ where: { name: 'user' } }).then((user) => {
+            return this.User.find({ where: { name: 'user' } }).then(user => {
               expect(user.name).to.equal('user');
             });
           });
 
           it.skip('should make aliased attributes available', function() {
-            return this.User.find({ where: { name: 'user' }, attributes: ['id', ['name', 'username']] }).then((user) => {
+            return this.User.find({ where: { name: 'user' }, attributes: ['id', ['name', 'username']] }).then(user => {
               expect(user.username).to.equal('user');
             });
           });
@@ -127,7 +127,7 @@ if (dialect === 'sqlite') {
           });
 
           it('should return all users', function() {
-            return this.User.findAll().then((users) => {
+            return this.User.findAll().then(users => {
               expect(users).to.have.length(2);
             });
           });
@@ -143,7 +143,7 @@ if (dialect === 'sqlite') {
             }
 
             return this.User.bulkCreate(users).then(() => {
-              return self.User.min('age').then((min) => {
+              return self.User.min('age').then(min => {
                 expect(min).to.equal(2);
               });
             });
@@ -160,7 +160,7 @@ if (dialect === 'sqlite') {
             }
 
             return this.User.bulkCreate(users).then(() => {
-              return self.User.max('age').then((min) => {
+              return self.User.max('age').then(min => {
                 expect(min).to.equal(5);
               });
             });

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -184,7 +184,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
         type: 'ValidationError',
         exception: Sequelize.ValidationError
       }
-    ].forEach((constraintTest) => {
+    ].forEach(constraintTest => {
 
       it('Can be intercepted as ' + constraintTest.type + ' using .catch', function() {
         const spy = sinon.spy(),

--- a/test/integration/hooks/associations.test.js
+++ b/test/integration/hooks/associations.test.js
@@ -72,8 +72,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             return Promise.resolve();
           });
 
-          return this.Projects.create({title: 'New Project'}).then((project) => {
-            return self.Tasks.create({title: 'New Task'}).then((task) => {
+          return this.Projects.create({title: 'New Project'}).then(project => {
+            return self.Tasks.create({title: 'New Task'}).then(task => {
               return project.setTask(task).then(() => {
                 return project.updateAttributes({id: 2}).then(() => {
                   expect(beforeHook).to.be.true;
@@ -91,9 +91,9 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             return Promise.reject(new Error('Whoops!'));
           });
 
-          return this.Projects.create({title: 'New Project'}).then((project) => {
-            return self.Tasks.create({title: 'New Task'}).then((task) => {
-              return project.setTask(task).catch((err) => {
+          return this.Projects.create({title: 'New Project'}).then(project => {
+            return self.Tasks.create({title: 'New Task'}).then(task => {
+              return project.setTask(task).catch(err => {
                 expect(err).to.be.instanceOf(Error);
               });
             });
@@ -130,8 +130,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.setTask(task).then(() => {
                   return project.destroy().then(() => {
                     expect(beforeProject).to.have.been.calledOnce;
@@ -172,8 +172,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               return Promise.resolve();
             });
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.setTask(task).then(() => {
                   return expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText).then(() => {
                     expect(beforeProject).to.be.true;
@@ -216,8 +216,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           this.Tasks.beforeUpdate(beforeHook);
           this.Tasks.afterUpdate(afterHook);
 
-          return this.Projects.create({title: 'New Project'}).then((project) => {
-            return self.Tasks.create({title: 'New Task'}).then((task) => {
+          return this.Projects.create({title: 'New Project'}).then(project => {
+            return self.Tasks.create({title: 'New Task'}).then(task => {
               return project.setTask(task).then(() => {
                 return project.updateAttributes({id: 2}).then(() => {
                   expect(beforeHook).to.have.been.calledOnce;
@@ -235,8 +235,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             throw new Error('Whoops!');
           });
 
-          return this.Projects.create({title: 'New Project'}).then((project) => {
-            return self.Tasks.create({title: 'New Task'}).then((task) => {
+          return this.Projects.create({title: 'New Project'}).then(project => {
+            return self.Tasks.create({title: 'New Task'}).then(task => {
               return expect(project.setTask(task)).to.be.rejected;
             });
           });
@@ -276,8 +276,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
                   return project.removeTask(task).then(() => {
                     expect(beforeProject).to.have.been.called;
@@ -305,9 +305,9 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             });
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
-                return project.addTask(task).catch((err) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
+                return project.addTask(task).catch(err => {
                   expect(err).to.be.instanceOf(Error);
                   expect(beforeProject).to.have.been.calledOnce;
                   expect(afterProject).to.have.been.calledOnce;
@@ -354,8 +354,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
                   return project.destroy().then(() => {
                     expect(beforeProject).to.have.been.calledOnce;
@@ -395,10 +395,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               return Promise.resolve();
             });
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
-                  return project.destroy().catch((err) => {
+                  return project.destroy().catch(err => {
                     expect(err).to.be.instanceOf(Error);
                     expect(beforeProject).to.be.true;
                     expect(afterProject).to.be.true;
@@ -441,8 +441,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
                   return project.removeTask(task).then(() => {
                     expect(beforeProject).to.have.been.called;
@@ -482,9 +482,9 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               return Promise.resolve();
             });
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
-                return project.addTask(task).catch((err) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
+                return project.addTask(task).catch(err => {
                   expect(err).to.be.instanceOf(Error);
                   expect(beforeProject).to.be.true;
                   expect(afterProject).to.be.true;
@@ -528,8 +528,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             this.Tasks.beforeDestroy(beforeTask);
             this.Tasks.afterDestroy(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
                   return project.destroy().then(() => {
                     expect(beforeProject).to.have.been.calledOnce;
@@ -570,8 +570,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               return Promise.resolve();
             });
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
                   return project.destroy().then(() => {
                     expect(beforeProject).to.be.true;
@@ -615,8 +615,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
             this.Tasks.beforeUpdate(beforeTask);
             this.Tasks.afterUpdate(afterTask);
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
                   return project.removeTask(task).then(() => {
                     expect(beforeProject).to.have.been.calledOnce;
@@ -656,8 +656,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
               return Promise.resolve();
             });
 
-            return this.Projects.create({title: 'New Project'}).then((project) => {
-              return self.Tasks.create({title: 'New Task'}).then((task) => {
+            return this.Projects.create({title: 'New Project'}).then(project => {
+              return self.Tasks.create({title: 'New Task'}).then(task => {
                 return project.addTask(task).then(() => {
                   expect(beforeProject).to.be.true;
                   expect(afterProject).to.be.true;
@@ -745,7 +745,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
                 this.MiniTasks.create({mini_title: 'New MiniTask'})
               ]).bind(this).spread((project, minitask) => {
                 return project.addMiniTask(minitask);
-              }).then((project) => {
+              }).then(project => {
                 return project.destroy();
               }).then(() => {
                 expect(beforeProject).to.be.true;
@@ -801,7 +801,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
                 this.MiniTasks.create({mini_title: 'New MiniTask'})
               ]).bind(this).spread((project, minitask) => {
                 return project.addMiniTask(minitask);
-              }).then((project) => {
+              }).then(project => {
                 return project.destroy();
               }).catch(() => {
                 expect(beforeProject).to.be.true;
@@ -891,7 +891,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
                   task.addMiniTask(minitask),
                   project.addTask(task)
                 ]).return(project);
-              }).then((project) => {
+              }).then(project => {
                 return project.destroy();
               }).then(() => {
                 expect(beforeProject).to.be.true;
@@ -946,7 +946,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
                   task.addMiniTask(minitask),
                   project.addTask(task)
                 ]).return(project);
-              }).then((project) => {
+              }).then(project => {
                 return expect(project.destroy()).to.eventually.be.rejectedWith(CustomErrorText).then(() => {
                   expect(beforeProject).to.be.true;
                   expect(afterProject).to.be.true;

--- a/test/integration/hooks/bulkOperation.test.js
+++ b/test/integration/hooks/bulkOperation.test.js
@@ -111,18 +111,18 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           return Promise.resolve();
         });
 
-        this.User.beforeCreate((user) => {
+        this.User.beforeCreate(user => {
           user.beforeHookTest = true;
           return Promise.resolve();
         });
 
-        this.User.afterCreate((user) => {
+        this.User.afterCreate(user => {
           user.username = 'User' + user.id;
           return Promise.resolve();
         });
 
-        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).then((records) => {
-          records.forEach((record) => {
+        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).then(records => {
+          records.forEach(record => {
             expect(record.username).to.equal('User' + record.id);
             expect(record.beforeHookTest).to.be.true;
           });
@@ -149,12 +149,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           return Promise.reject(new Error('You shall not pass!'));
         });
 
-        this.User.afterCreate((user) => {
+        this.User.afterCreate(user => {
           user.username = 'User' + user.id;
           return Promise.resolve();
         });
 
-        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).catch((err) => {
+        return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).catch(err => {
           expect(err).to.be.instanceOf(Error);
           expect(beforeBulkCreate).to.be.true;
           expect(afterBulkCreate).to.be.false;
@@ -246,12 +246,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         this.User.afterBulkUpdate(afterBulk);
 
-        this.User.beforeUpdate((user) => {
+        this.User.beforeUpdate(user => {
           expect(user.changed()).to.not.be.empty;
           user.beforeHookTest = true;
         });
 
-        this.User.afterUpdate((user) => {
+        this.User.afterUpdate(user => {
           user.username = 'User' + user.id;
         });
 
@@ -259,7 +259,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           {aNumber: 1}, {aNumber: 1}, {aNumber: 1}
         ]).then(() => {
           return self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).spread((affectedRows, records) => {
-            records.forEach((record) => {
+            records.forEach(record => {
               expect(record.username).to.equal('User' + record.id);
               expect(record.beforeHookTest).to.be.true;
             });
@@ -272,7 +272,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('should run the after/before functions for each item created successfully changing some data before updating', function() {
         const self = this;
 
-        this.User.beforeUpdate((user) => {
+        this.User.beforeUpdate(user => {
           expect(user.changed()).to.not.be.empty;
           if (user.get('id') === 1) {
             user.set('aNumber', user.get('aNumber') + 3);
@@ -283,7 +283,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           {aNumber: 1}, {aNumber: 1}, {aNumber: 1}
         ]).then(() => {
           return self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).spread((affectedRows, records) => {
-            records.forEach((record) => {
+            records.forEach(record => {
               expect(record.aNumber).to.equal(10 + (record.id === 1 ? 3 : 0));
             });
           });
@@ -303,12 +303,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('You shall not pass!');
         });
 
-        this.User.afterUpdate((user) => {
+        this.User.afterUpdate(user => {
           user.username = 'User' + user.id;
         });
 
         return this.User.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(() => {
-          return self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).catch((err) => {
+          return self.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).catch(err => {
             expect(err).to.be.instanceOf(Error);
             expect(err.message).to.be.equal('You shall not pass!');
             expect(beforeBulk).to.have.been.calledOnce;
@@ -440,7 +440,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         return this.User.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(() => {
-          return self.User.destroy({where: {aNumber: 1}, individualHooks: true}).catch((err) => {
+          return self.User.destroy({where: {aNumber: 1}, individualHooks: true}).catch(err => {
             expect(err).to.be.instanceOf(Error);
             expect(beforeBulk).to.be.true;
             expect(beforeHook).to.be.true;
@@ -555,7 +555,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           return self.ParanoidUser.destroy({where: {aNumber: 1}});
         }).then(() => {
           return self.ParanoidUser.restore({where: {aNumber: 1}, individualHooks: true});
-        }).catch((err) => {
+        }).catch(err => {
           expect(err).to.be.instanceOf(Error);
           expect(beforeBulk).to.have.been.calledOnce;
           expect(beforeHook).to.have.been.calledThrice;

--- a/test/integration/hooks/count.test.js
+++ b/test/integration/hooks/count.test.js
@@ -37,14 +37,14 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           beforeHook = true;
         });
 
-        return this.User.count().then((count) => {
+        return this.User.count().then(count => {
           expect(count).to.equal(3);
           expect(beforeHook).to.be.true;
         });
       });
 
       it('beforeCount hook can change options', function() {
-        this.User.beforeCount((options) => {
+        this.User.beforeCount(options => {
           options.where.username = 'adam';
         });
 

--- a/test/integration/hooks/create.test.js
+++ b/test/integration/hooks/create.test.js
@@ -126,12 +126,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('beforeValidate', function(){
         let hookCalled = 0;
 
-        this.User.beforeValidate((user) => {
+        this.User.beforeValidate(user => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({mood: 'sad', username: 'leafninja'}).then((user) => {
+        return this.User.create({mood: 'sad', username: 'leafninja'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('leafninja');
           expect(hookCalled).to.equal(1);
@@ -141,12 +141,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('afterValidate', function() {
         let hookCalled = 0;
 
-        this.User.afterValidate((user) => {
+        this.User.afterValidate(user => {
           user.mood = 'neutral';
           hookCalled++;
         });
 
-        return this.User.create({mood: 'sad', username: 'fireninja'}).then((user) => {
+        return this.User.create({mood: 'sad', username: 'fireninja'}).then(user => {
           expect(user.mood).to.equal('neutral');
           expect(user.username).to.equal('fireninja');
           expect(hookCalled).to.equal(1);
@@ -156,12 +156,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('beforeCreate', function() {
         let hookCalled = 0;
 
-        this.User.beforeCreate((user) => {
+        this.User.beforeCreate(user => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({username: 'akira'}).then((user) => {
+        return this.User.create({username: 'akira'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('akira');
           expect(hookCalled).to.equal(1);
@@ -171,12 +171,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('beforeSave', function() {
         let hookCalled = 0;
 
-        this.User.beforeSave((user) => {
+        this.User.beforeSave(user => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({username: 'akira'}).then((user) => {
+        return this.User.create({username: 'akira'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('akira');
           expect(hookCalled).to.equal(1);
@@ -186,17 +186,17 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('beforeSave with beforeCreate', function() {
         let hookCalled = 0;
 
-        this.User.beforeCreate((user) => {
+        this.User.beforeCreate(user => {
           user.mood = 'sad';
           hookCalled++;
         });
 
-        this.User.beforeSave((user) => {
+        this.User.beforeSave(user => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({username: 'akira'}).then((user) => {
+        return this.User.create({username: 'akira'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('akira');
           expect(hookCalled).to.equal(2);

--- a/test/integration/hooks/destroy.test.js
+++ b/test/integration/hooks/destroy.test.js
@@ -30,7 +30,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.User.beforeDestroy(beforeHook);
         this.User.afterDestroy(afterHook);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => {
           return user.destroy().then(() => {
             expect(beforeHook).to.have.been.calledOnce;
             expect(afterHook).to.have.been.calledOnce;
@@ -50,7 +50,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
         this.User.afterDestroy(afterHook);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => {
           return expect(user.destroy()).to.be.rejected.then(() => {
             expect(beforeHook).to.have.been.calledOnce;
             expect(afterHook).not.to.have.been.called;
@@ -68,7 +68,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Whoops!');
         });
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => {
           return expect(user.destroy()).to.be.rejected.then(() => {
             expect(beforeHook).to.have.been.calledOnce;
             expect(afterHook).to.have.been.calledOnce;

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -30,7 +30,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     it('allow changing attributes via beforeFind #5675', function() {
-      this.User.beforeFind((options) => {
+      this.User.beforeFind(options => {
         options.attributes = {
           include: ['id']
         };
@@ -61,7 +61,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           afterHook = true;
         });
 
-        return this.User.find({where: {username: 'adam'}}).then((user) => {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(beforeHook).to.be.true;
           expect(beforeHook2).to.be.true;
@@ -71,41 +71,41 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       });
 
       it('beforeFind hook can change options', function() {
-        this.User.beforeFind((options) => {
+        this.User.beforeFind(options => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then((user) => {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
 
       it('beforeFindAfterExpandIncludeAll hook can change options', function() {
-        this.User.beforeFindAfterExpandIncludeAll((options) => {
+        this.User.beforeFindAfterExpandIncludeAll(options => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then((user) => {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
 
       it('beforeFindAfterOptions hook can change options', function() {
-        this.User.beforeFindAfterOptions((options) => {
+        this.User.beforeFindAfterOptions(options => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then((user) => {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
 
       it('afterFind hook can change results', function() {
-        this.User.afterFind((user) => {
+        this.User.afterFind(user => {
           user.mood = 'sad';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then((user) => {
+        return this.User.find({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
@@ -117,7 +117,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch ((err) => {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
@@ -127,7 +127,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch ((err) => {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
@@ -137,7 +137,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch ((err) => {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
@@ -147,7 +147,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch ((err) => {
+        return this.User.find({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -43,7 +43,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         attributes.type = DataTypes.STRING;
       });
 
-      this.sequelize.addHook('afterDefine', (factory) => {
+      this.sequelize.addHook('afterDefine', factory => {
         factory.options.name.singular = 'barr';
       });
 
@@ -79,7 +79,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         options.host = 'server9';
       });
 
-      Sequelize.addHook('afterInit', (sequelize) => {
+      Sequelize.addHook('afterInit', sequelize => {
         sequelize.options.protocol = 'udp';
       });
 
@@ -186,7 +186,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         return User.sync({ force: true }).then(() => {
-          return User.create({ username: 'bob' }).then((user) => {
+          return User.create({ username: 'bob' }).then(user => {
             return user.destroy().then(() => {
               expect(beforeHooked).to.be.true;
               expect(afterHooked).to.be.true;
@@ -218,7 +218,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         return User.sync({ force: true }).then(() => {
-          return User.create({ username: 'bob' }).then((user) => {
+          return User.create({ username: 'bob' }).then(user => {
             return user.destroy().then(() => {
               expect(beforeHooked).to.be.true;
               expect(afterHooked).to.be.true;
@@ -250,7 +250,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         return User.sync({ force: true }).then(() => {
-          return User.create({ username: 'bob' }).then((user) => {
+          return User.create({ username: 'bob' }).then(user => {
             user.username = 'bawb';
             return user.save({ fields: ['username'] }).then(() => {
               expect(beforeHooked).to.be.true;
@@ -457,7 +457,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       this.User.hook('beforeSave', sasukeHook);
       this.User.hook('beforeSave', narutoHook);
 
-      return this.User.create({ username: 'makunouchi'}).then((user) => {
+      return this.User.create({ username: 'makunouchi'}).then(user => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledOnce;
         this.User.removeHook('beforeSave', sasukeHook);

--- a/test/integration/hooks/restore.test.js
+++ b/test/integration/hooks/restore.test.js
@@ -41,7 +41,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.ParanoidUser.beforeRestore(beforeHook);
         this.ParanoidUser.afterRestore(afterHook);
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => {
           return user.destroy().then(() => {
             return user.restore().then(() => {
               expect(beforeHook).to.have.been.calledOnce;
@@ -63,7 +63,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
         this.ParanoidUser.afterRestore(afterHook);
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => {
           return user.destroy().then(() => {
             return expect(user.restore()).to.be.rejected.then(() => {
               expect(beforeHook).to.have.been.calledOnce;
@@ -83,7 +83,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Whoops!');
         });
 
-        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.ParanoidUser.create({username: 'Toni', mood: 'happy'}).then(user => {
           return user.destroy().then(() => {
             return expect(user.restore()).to.be.rejected.then(() => {
               expect(beforeHook).to.have.been.calledOnce;

--- a/test/integration/hooks/updateAttributes.test.js
+++ b/test/integration/hooks/updateAttributes.test.js
@@ -34,8 +34,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.User.beforeSave(beforeSave);
         this.User.afterSave(afterSave);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then((user) => {
-          return user.updateAttributes({username: 'Chong'}).then((user) => {
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => {
+          return user.updateAttributes({username: 'Chong'}).then(user => {
             expect(beforeHook).to.have.been.calledOnce;
             expect(afterHook).to.have.been.calledOnce;
             expect(beforeSave).to.have.been.calledTwice;
@@ -61,7 +61,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.User.beforeSave(beforeSave);
         this.User.afterSave(afterSave);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => {
           return expect(user.updateAttributes({username: 'Chong'})).to.be.rejected.then(() => {
             expect(beforeHook).to.have.been.calledOnce;
             expect(beforeSave).to.have.been.calledOnce;
@@ -85,7 +85,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.User.beforeSave(beforeSave);
         this.User.afterSave(afterSave);
 
-        return this.User.create({username: 'Toni', mood: 'happy'}).then((user) => {
+        return this.User.create({username: 'Toni', mood: 'happy'}).then(user => {
           return expect(user.updateAttributes({username: 'Chong'})).to.be.rejected.then(() => {
             expect(beforeHook).to.have.been.calledOnce;
             expect(afterHook).to.have.been.calledOnce;
@@ -99,13 +99,13 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     describe('preserves changes to instance', () => {
       it('beforeValidate', function(){
 
-        this.User.beforeValidate((user) => {
+        this.User.beforeValidate(user => {
           user.mood = 'happy';
         });
 
-        return this.User.create({username: 'fireninja', mood: 'invalid'}).then((user) => {
+        return this.User.create({username: 'fireninja', mood: 'invalid'}).then(user => {
           return user.updateAttributes({username: 'hero'});
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('hero');
           expect(user.mood).to.equal('happy');
         });
@@ -113,13 +113,13 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
       it('afterValidate', function() {
 
-        this.User.afterValidate((user) => {
+        this.User.afterValidate(user => {
           user.mood = 'sad';
         });
 
-        return this.User.create({username: 'fireninja', mood: 'nuetral'}).then((user) => {
+        return this.User.create({username: 'fireninja', mood: 'nuetral'}).then(user => {
           return user.updateAttributes({username: 'spider'});
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('spider');
           expect(user.mood).to.equal('sad');
         });
@@ -128,14 +128,14 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('beforeSave', function() {
         let hookCalled = 0;
 
-        this.User.beforeSave((user) => {
+        this.User.beforeSave(user => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({username: 'fireninja', mood: 'nuetral'}).then((user) => {
+        return this.User.create({username: 'fireninja', mood: 'nuetral'}).then(user => {
           return user.updateAttributes({username: 'spider', mood: 'sad'});
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('spider');
           expect(user.mood).to.equal('happy');
           expect(hookCalled).to.equal(2);
@@ -145,19 +145,19 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('beforeSave with beforeUpdate', function() {
         let hookCalled = 0;
 
-        this.User.beforeUpdate((user) => {
+        this.User.beforeUpdate(user => {
           user.mood = 'sad';
           hookCalled++;
         });
 
-        this.User.beforeSave((user) => {
+        this.User.beforeSave(user => {
           user.mood = 'happy';
           hookCalled++;
         });
 
-        return this.User.create({username: 'akira'}).then((user) => {
+        return this.User.create({username: 'akira'}).then(user => {
           return user.updateAttributes({username: 'spider', mood: 'sad'});
-        }).then((user) => {
+        }).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('spider');
           expect(hookCalled).to.equal(3);

--- a/test/integration/hooks/upsert.test.js
+++ b/test/integration/hooks/upsert.test.js
@@ -78,7 +78,7 @@ if (Support.sequelize.dialect.supports.upserts) {
           let hookCalled = 0;
           const valuesOriginal = { mood: 'sad', username: 'leafninja' };
 
-          this.User.beforeUpsert((values) => {
+          this.User.beforeUpsert(values => {
             values.mood = 'happy';
             hookCalled++;
           });

--- a/test/integration/hooks/validate.test.js
+++ b/test/integration/hooks/validate.test.js
@@ -24,16 +24,16 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
   describe('#validate', () => {
     describe('#create', () => {
       it('should return the user', function() {
-        this.User.beforeValidate((user) => {
+        this.User.beforeValidate(user => {
           user.username = 'Bob';
           user.mood = 'happy';
         });
 
-        this.User.afterValidate((user) => {
+        this.User.afterValidate(user => {
           user.username = 'Toni';
         });
 
-        return this.User.create({mood: 'ecstatic'}).then((user) => {
+        return this.User.create({mood: 'ecstatic'}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(user.username).to.equal('Toni');
         });
@@ -44,7 +44,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('fields modified in hooks are saved', function() {
         const self = this;
 
-        this.User.afterValidate((user) => {
+        this.User.afterValidate(user => {
           //if username is defined and has more than 5 char
           user.username = user.username
                           ? user.username.length < 5 ? null : user.username
@@ -53,12 +53,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         });
 
-        this.User.beforeValidate((user) => {
+        this.User.beforeValidate(user => {
           user.mood = user.mood || 'neutral';
         });
 
 
-        return this.User.create({username: 'T', mood: 'neutral'}).then((user) => {
+        return this.User.create({username: 'T', mood: 'neutral'}).then(user => {
           expect(user.mood).to.equal('neutral');
           expect(user.username).to.equal('Samorost 3');
 
@@ -67,7 +67,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           user.username = 'Samorost Good One';
 
           return user.save();
-        }).then((uSaved) => {
+        }).then(uSaved => {
           expect(uSaved.mood).to.equal('sad');
           expect(uSaved.username).to.equal('Samorost Good One');
 
@@ -75,12 +75,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           uSaved.username = 'One';
 
           return uSaved.save();
-        }).then((uSaved) => {
+        }).then(uSaved => {
           //attributes were replaced by hooks ?
           expect(uSaved.mood).to.equal('sad');
           expect(uSaved.username).to.equal('Samorost 3');
           return self.User.findById(uSaved.id);
-        }).then((uFetched) => {
+        }).then(uFetched => {
           expect(uFetched.mood).to.equal('sad');
           expect(uFetched.username).to.equal('Samorost 3');
 
@@ -88,12 +88,12 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           uFetched.username = 'New Game is Needed';
 
           return uFetched.save();
-        }).then((uFetchedSaved) => {
+        }).then(uFetchedSaved => {
           expect(uFetchedSaved.mood).to.equal('neutral');
           expect(uFetchedSaved.username).to.equal('New Game is Needed');
 
           return self.User.findById(uFetchedSaved.id);
-        }).then((uFetched) => {
+        }).then(uFetched => {
           expect(uFetched.mood).to.equal('neutral');
           expect(uFetched.username).to.equal('New Game is Needed');
 
@@ -101,7 +101,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           uFetched.username = 'New';
           uFetched.mood = 'happy';
           return uFetched.save();
-        }).then((uFetchedSaved) => {
+        }).then(uFetchedSaved => {
           expect(uFetchedSaved.mood).to.equal('happy');
           expect(uFetchedSaved.username).to.equal('Samorost 3');
         });
@@ -110,7 +110,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
     describe('on error', () => {
       it('should emit an error from after hook', function() {
-        this.User.afterValidate((user) => {
+        this.User.afterValidate(user => {
           user.mood = 'ecstatic';
           throw new Error('Whoops! Changed user.mood!');
         });
@@ -133,7 +133,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         this.User.validationFailed(validationFailedHook);
 
-        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then((err) => {
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(err => {
           expect(err.name).to.equal('SequelizeValidationError');
         });
       });
@@ -143,7 +143,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
         this.User.validationFailed(validationFailedHook);
 
-        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then((err) => {
+        return expect(this.User.create({mood: 'happy'})).to.be.rejected.then(err => {
           expect(err.message).to.equal('Whoops!');
         });
       });

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -26,7 +26,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       }).then(() => {
         return User.find({
           include: [{model: Company, as: 'Employer'}]
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
         });
       });
@@ -42,7 +42,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       }).then(() => {
         return User.findOne({
           include: [Employer]
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
         });
       });
@@ -56,7 +56,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       return this.sequelize.sync({force: true}).then(() => {
         return Company.create({
           name: 'CyberCorp'
-        }).then((company) => {
+        }).then(company => {
           return User.create({
             employerId: company.get('id')
           });
@@ -66,7 +66,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           include: [
             {association: Employer, where: {name: 'CyberCorp'}}
           ]
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
         });
       });
@@ -82,7 +82,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         return Company.create().then(() => {
           return Company.find({
             include: [{model: Person, as: 'CEO'}]
-          }).then((company) => {
+          }).then(company => {
             expect(company).to.be.ok;
           });
         });
@@ -100,7 +100,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         return Company.find({
           include: [CEO]
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user).to.be.ok;
       });
     });
@@ -123,7 +123,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       }).then(() => {
         return Person.find({
           include: [Person.relation.Employer]
-        }).then((person) => {
+        }).then(person => {
           expect(person).to.be.ok;
           expect(person.employer).to.be.ok;
         });
@@ -138,13 +138,13 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       Task.belongsTo(User);
 
       return this.sequelize.sync({force: true}).then(() => {
-        return User.create().then((user) => {
+        return User.create().then(user => {
           return user.createTask();
         }).then(() => {
           return User.find({
             include: [Tasks]
           });
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
           expect(user.tasks).to.be.ok;
         });
@@ -159,7 +159,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       Task.belongsTo(User);
 
       return this.sequelize.sync({force: true}).then(() => {
-        return User.create().then((user) => {
+        return User.create().then(user => {
           return Promise.join(
             user.createTask({
               title: 'trivial'
@@ -174,7 +174,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               {association: Tasks, where: {title: 'trivial'}}
             ]
           });
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
           expect(user.tasks).to.be.ok;
           expect(user.tasks.length).to.equal(1);
@@ -190,13 +190,13 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       Group.belongsToMany(User, { through: 'UserGroup' });
 
       return this.sequelize.sync({force: true}).then(() => {
-        return User.create().then((user) => {
+        return User.create().then(user => {
           return user.createGroup();
         });
       }).then(() => {
         return User.find({
           include: [Groups]
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
           expect(user.groups).to.be.ok;
         });
@@ -216,12 +216,12 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           task: Task.create(),
           user: User.create(),
           group: Group.create()
-        }).then((props) => {
+        }).then(props => {
           return Promise.join(
             props.task.setUser(props.user),
             props.user.setGroup(props.group)
           ).return(props);
-        }).then((props) => {
+        }).then(props => {
           return Task.findOne({
             where: {
               id: props.task.id
@@ -231,7 +231,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                 {model: Group}
               ]}
             ]
-          }).then((task) => {
+          }).then(task => {
             expect(task.User).to.be.ok;
             expect(task.User.Group).to.be.ok;
           });
@@ -254,7 +254,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         }, {
           include: [User, Group]
         });
-      }).then((task) => {
+      }).then(task => {
         return Task.find({
           where: {
             id: task.id
@@ -264,7 +264,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             {model: Group}
           ]
         });
-      }).then((task) => {
+      }).then(task => {
         expect(task.User).to.be.ok;
         expect(task.Group).to.be.ok;
       });
@@ -286,7 +286,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         }, {
           include: [Task, Group]
         });
-      }).then((user) => {
+      }).then(user => {
         return Group.find({
           where: {
             id: user.Group.id
@@ -297,7 +297,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]}
           ]
         });
-      }).then((group) => {
+      }).then(group => {
         expect(group.User).to.be.ok;
         expect(group.User.Task).to.be.ok;
       });
@@ -324,7 +324,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         }, {
           include: [Task]
         });
-      }).then((user) => {
+      }).then(user => {
         return User.find({
           where: {
             id: user.id
@@ -335,11 +335,11 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]}
           ]
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user.Tasks).to.be.ok;
         expect(user.Tasks.length).to.equal(4);
 
-        user.Tasks.forEach((task) => {
+        user.Tasks.forEach(task => {
           expect(task.Project).to.be.ok;
         });
       });
@@ -361,7 +361,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         }, {
           include: [Worker, Task]
         });
-      }).then((project) => {
+      }).then(project => {
         return Worker.find({
           where: {
             id: project.Workers[0].id
@@ -372,7 +372,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]}
           ]
         });
-      }).then((worker) => {
+      }).then(worker => {
         expect(worker.Project).to.be.ok;
         expect(worker.Project.Tasks).to.be.ok;
         expect(worker.Project.Tasks.length).to.equal(4);
@@ -436,7 +436,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             [Product, 'id']
           ]
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user.Products.length).to.equal(4);
         expect(user.Products[0].Tags.length).to.equal(2);
         expect(user.Products[1].Tags.length).to.equal(1);
@@ -541,7 +541,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]}
           ]
         });
-      }).then((user) => {
+      }).then(user => {
         user.Memberships.sort(sortById);
         expect(user.Memberships.length).to.equal(2);
         expect(user.Memberships[0].Group.name).to.equal('Developers');
@@ -588,7 +588,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             {model: Project, attributes: ['title']}
           ]
         });
-      }).then((tasks) => {
+      }).then(tasks => {
         expect(tasks[0].title).to.equal('FooBar');
         expect(tasks[0].Project.title).to.equal('BarFoo');
 
@@ -608,7 +608,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
 
       return this.sequelize.sync({ force: true }).then(() => {
         return Post.create({});
-      }).then((post) => {
+      }).then(post => {
         return post.createPostComment({
           comment_title: 'WAT'
         });
@@ -635,7 +635,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             }
           ]
         });
-      }).then((posts) => {
+      }).then(posts => {
         expect(posts[0].PostComments[0].get('someProperty')).to.be.ok;
         expect(posts[0].PostComments[0].get('someProperty2')).to.be.ok;
         expect(posts[0].PostComments[0].get('commentTitle')).to.equal('WAT');
@@ -668,7 +668,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           },
           include: [{model: Group, as: 'OutsourcingCompanies'}]
         });
-      }).then((group) => {
+      }).then(group => {
         expect(group.OutsourcingCompanies).to.have.length(3);
       });
     });
@@ -699,7 +699,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           },
           include: [Group]
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user.dateField.getTime()).to.equal(Date.UTC(2014, 1, 20));
         expect(user.groups[0].dateField.getTime()).to.equal(Date.UTC(2014, 1, 20));
       });
@@ -747,7 +747,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             as: 'Members'
           }]
         });
-      }).then((groups) => {
+      }).then(groups => {
         expect(groups.length).to.equal(1);
         expect(groups[0].Members[0].name).to.equal('Member');
       });
@@ -796,7 +796,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         include: [
           {model: this.Item, where: Sequelize.and({ test: 'def' })}
         ]
-      }).then((result) => {
+      }).then(result => {
         expect(result.length).to.eql(1);
         expect(result[0].Item.test).to.eql('def');
       });
@@ -825,7 +825,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             }}
           ]
         });
-      }).then((result) => {
+      }).then(result => {
         expect(result.count).to.eql(1);
 
         expect(result.rows.length).to.eql(1);
@@ -848,7 +848,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
 
       return this.sequelize.sync({force: true}).then(() => {
         return Questionnaire.create();
-      }).then((questionnaire) => {
+      }).then(questionnaire => {
         return questionnaire.getQuestions({
           include: Answer
         });
@@ -880,7 +880,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           Employee.create({ name: 'Jill' }),
           Clearence.create({ level: 3 }),
           Clearence.create({ level: 5 })
-        ]).then((instances) => {
+        ]).then(instances => {
           return Promise.all([
             instances[0].addMembers([instances[2], instances[3]]),
             instances[1].addMembers([instances[4], instances[5]]),
@@ -905,7 +905,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           }
         ]
-      }).then((teams) => {
+      }).then(teams => {
         expect(teams).to.have.length(2);
       });
     });
@@ -923,7 +923,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           }
         ]
-      }).then((teams) => {
+      }).then(teams => {
         expect(teams).to.have.length(2);
       });
     });
@@ -942,7 +942,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           }
         ]
-      }).then((teams) => {
+      }).then(teams => {
         expect(teams).to.have.length(1);
       });
     });

--- a/test/integration/include/find.test.js
+++ b/test/integration/include/find.test.js
@@ -78,7 +78,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         force: true
       }).then(() => {
         return User.create();
-      }).then((user) => {
+      }).then(user => {
         return Task.bulkCreate([
           {userId: user.get('id'), deletedAt: new Date()},
           {userId: user.get('id'), deletedAt: new Date()},
@@ -90,7 +90,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             {model: Task, where: {deletedAt: null}, required: false}
           ]
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user).to.be.ok;
         expect(user.Tasks.length).to.equal(0);
       });
@@ -116,7 +116,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         force: true
       }).then(() => {
         return User.create();
-      }).then((user) => {
+      }).then(user => {
         return Task.bulkCreate([
           {userId: user.get('id'), searchString: 'one'},
           {userId: user.get('id'), searchString: 'two'}
@@ -127,7 +127,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             {model: Task, where: {searchString: 'one'} }
           ]
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user).to.be.ok;
         expect(user.Tasks.length).to.equal(1);
       });
@@ -165,7 +165,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           });
         })
-        .then((a) => {
+        .then(a => {
           expect(a).to.not.equal(null);
           expect(a.get('bs')).to.have.length(1);
         });
@@ -198,7 +198,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           });
         })
-        .then((a) => {
+        .then(a => {
           expect(a).to.not.equal(null);
           expect(a.get('bs')).to.deep.equal([]);
         });
@@ -240,7 +240,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           });
         })
-        .then((a) => {
+        .then(a => {
           expect(a).to.not.exist;
         });
     });
@@ -252,14 +252,14 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       Task.belongsTo(User, { foreignKey: 'user_name', targetKey: 'username'});
 
       return this.sequelize.sync({ force: true }).then(() => {
-        return User.create({ username: 'bob' }).then((newUser) => {
-          return Task.create({ title: 'some task' }).then((newTask) => {
+        return User.create({ username: 'bob' }).then(newUser => {
+          return Task.create({ title: 'some task' }).then(newTask => {
             return newTask.setUser(newUser).then(() => {
               return Task.find({
                 where: { title: 'some task' },
                 include: [ { model: User } ]
               })
-                .then((foundTask) => {
+                .then(foundTask => {
                   expect(foundTask).to.be.ok;
                   expect(foundTask.User.username).to.equal('bob');
                 });
@@ -299,7 +299,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               previousInstance,
               b;
 
-            singles.forEach((model) => {
+            singles.forEach(model => {
               const values = {};
 
               if (model.name === 'g') {
@@ -307,7 +307,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               }
 
               promise = promise.then(() => {
-                return model.create(values).then((instance) => {
+                return model.create(values).then(instance => {
                   if (previousInstance) {
                     return previousInstance['set'+ Sequelize.Utils.uppercaseFirst(model.name)](instance).then(() => {
                       previousInstance = instance;
@@ -346,7 +346,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                 ]}
               ]}
             ]
-          }).then((a) => {
+          }).then(a => {
             expect(a.b.c.d.e.f.g.h).to.be.ok;
           });
         });

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -116,13 +116,13 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]).then(() => {
               return Tag.findAll();
             })
-          }).then((results) => {
+          }).then(results => {
             const groups = results.groups,
               ranks = results.ranks,
               tags = results.tags,
               companies = results.companies;
 
-            return Promise.each([0, 1, 2, 3, 4], (i) => {
+            return Promise.each([0, 1, 2, 3, 4], i => {
               return Promise.props({
                 user: User.create(),
                 products: Product.bulkCreate([
@@ -134,7 +134,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                 ]).then(() => {
                   return Product.findAll();
                 })
-              }).then((results) => {
+              }).then(results => {
                 const user = results.user,
                   products = results.products,
                   groupMembers  = [
@@ -389,7 +389,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             return Tag.findAll();
           })
         ]).spread((groups, ranks, tags) => {
-          return Promise.each([0, 1, 2, 3, 4], (i) => {
+          return Promise.each([0, 1, 2, 3, 4], i => {
             return Promise.all([
               User.create(),
               Product.bulkCreate([
@@ -442,8 +442,8 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               order: [
                 ['id', 'ASC']
               ]
-            }).then((users) => {
-              users.forEach((user) => {
+            }).then(users => {
+              users.forEach(user => {
                 user.Memberships.sort(sortById);
 
                 expect(user.Memberships.length).to.equal(2);
@@ -505,9 +505,9 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               previousInstance,
               b;
 
-            singles.forEach((model) => {
+            singles.forEach(model => {
               promise = promise.then(() => {
-                return model.create({}).then((instance) => {
+                return model.create({}).then(instance => {
                   if (previousInstance) {
                     return previousInstance['set'+ Sequelize.Utils.uppercaseFirst(model.name)](instance).then(() => {
                       previousInstance = instance;
@@ -526,7 +526,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             return promise;
           })([B, C, D, E, F, G, H])
         ).spread((as, b) => {
-          return Promise.map(as, (a) => {
+          return Promise.map(as, a => {
             return a.setB(b);
           });
         }).then(() => {
@@ -546,10 +546,10 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                 ]}
               ]}
             ]
-          }).then((as) => {
+          }).then(as => {
             expect(as.length).to.be.ok;
 
-            as.forEach((a) => {
+            as.forEach(a => {
               expect(a.b.c.d.e.f.g.h).to.be.ok;
             });
           });
@@ -598,7 +598,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               previousInstance,
               b;
 
-            singles.forEach((model) => {
+            singles.forEach(model => {
               const values = {};
 
               if (model.name === 'g') {
@@ -606,7 +606,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               }
 
               promise = promise.then(() => {
-                return model.create(values).then((instance) => {
+                return model.create(values).then(instance => {
                   if (previousInstance) {
                     return previousInstance['set'+ Sequelize.Utils.uppercaseFirst(model.name)](instance).then(() => {
                       previousInstance = instance;
@@ -625,7 +625,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             return promise;
           })([B, C, D, E, F, G, H])
         ).spread((as, b) => {
-          return Promise.map(as, (a) => {
+          return Promise.map(as, a => {
             return a.setB(b);
           });
         }).then(() => {
@@ -647,10 +647,10 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                 ]}
               ]}
             ]
-          }).then((as) => {
+          }).then(as => {
             expect(as.length).to.be.ok;
 
-            as.forEach((a) => {
+            as.forEach(a => {
               expect(a.b.c.d.e.f.g.h).to.be.ok;
             });
           });
@@ -687,7 +687,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           ]).then(() => {
             return Order.findAll({order: ['id']});
           })
-        }).then((results) => {
+        }).then(results => {
           const user1 = results.users[0];
           const user2 = results.users[1];
           const user3 = results.users[2];
@@ -721,7 +721,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             'order': [
               [Order, 'position']
             ]
-          }).then((as) => {
+          }).then(as => {
             expect(as.length).to.eql(2);
 
             expect(as[0].itemA.test).to.eql('abc');
@@ -764,7 +764,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           ]).then(() => {
             return Tag.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.products[0].addTag(results.tags[0], { through: {priority: 1}}),
             results.products[0].addTag(results.tags[1], { through: {priority: 2}}),
@@ -782,7 +782,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               ['id', 'ASC'],
               [Tag, 'id', 'ASC']
             ]
-          }).then((products) => {
+          }).then(products => {
             expect(products[0].Tags[0].ProductTag.priority).to.equal(1);
             expect(products[0].Tags[1].ProductTag.priority).to.equal(2);
 
@@ -810,14 +810,14 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           users: User.bulkCreate([{}, {}, {}]).then(() => {
             return User.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return results.users[2].setGroup(results.groups[1]);
         }).then(() => {
           return User.findAll({
             include: [
               {model: Group, required: true}
             ]
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].Group).to.be.ok;
           });
@@ -844,7 +844,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           users: User.bulkCreate([{}, {}]).then(() => {
             return User.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[0].setGroup(results.groups[1]),
             results.users[1].setGroup(results.groups[0])
@@ -854,7 +854,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             include: [
               {model: Group, where: {name: 'A'}}
             ]
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].Group).to.be.ok;
             expect(users[0].Group.name).to.equal('A');
@@ -882,7 +882,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           users: User.bulkCreate([{}, {}]).then(() => {
             return User.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[0].setGroup(results.groups[1]),
              results.users[1].setGroup(results.groups[0])
@@ -892,8 +892,8 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             include: [
               {model: Group, required: true}
             ]
-          }).then((users) => {
-            users.forEach((user) => {
+          }).then(users => {
+            users.forEach(user => {
               expect(user.Group).to.be.ok;
             });
           });
@@ -915,8 +915,8 @@ describe(Support.getTestDialectTeaser('Include'), () => {
 
       // Sync
       return this.sequelize.sync({ force: true }).then(() => {
-        return Street.create({ active: true }).then((street) => {
-          return Address.create({ active: true, streetId: street.id }).then((address ) => {
+        return Street.create({ active: true }).then(street => {
+          return Address.create({ active: true, streetId: street.id }).then(address => {
             return User.create({ username: 'John', addressId: address.id }).then(() => {
               return User.find({
                 where: { username: 'John'},
@@ -930,7 +930,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                     model: Street
                   }]
                 }]
-              }).then((john) => {
+              }).then(john => {
                 expect(john.Address).to.be.ok;
                 expect(john.Address.Street).to.be.ok;
               });
@@ -966,11 +966,11 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           categories: Category.bulkCreate([{}, {}]).then(() => {
             return Category.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[0].setGroup(results.groups[1]),
             results.users[1].setGroup(results.groups[0]),
-            Promise.map(results.groups, (group) => {
+            Promise.map(results.groups, group => {
               return group.setCategories(results.categories);
             })
           );
@@ -982,9 +982,9 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               ]}
             ],
             limit: 1
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Group).to.be.ok;
               expect(user.Group.Categories).to.be.ok;
             });
@@ -1019,11 +1019,11 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           categories: Category.bulkCreate([{}, {}]).then(() => {
             return Category.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[0].setTeam(results.groups[1]),
             results.users[1].setTeam(results.groups[0]),
-            Promise.map(results.groups, (group) => {
+            Promise.map(results.groups, group => {
               return group.setTags(results.categories);
             })
           );
@@ -1035,9 +1035,9 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               ]}
             ],
             limit: 1
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Team).to.be.ok;
               expect(user.Team.Tags).to.be.ok;
             });
@@ -1072,11 +1072,11 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           categories: Category.bulkCreate([{}, {}]).then(() => {
             return Category.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[0].setGroup(results.groups[1]),
             results.users[1].setGroup(results.groups[0]),
-            Promise.map(results.groups, (group) => {
+            Promise.map(results.groups, group => {
               return group.setCategories(results.categories);
             })
           );
@@ -1088,9 +1088,9 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               ]}
             ],
             limit: 1
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Group).to.be.ok;
               expect(user.Group.Categories).to.be.ok;
             });
@@ -1118,7 +1118,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           users: User.bulkCreate([{}, {}]).then(() => {
             return User.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[1].setLeaderOf(results.projects[1]),
             results.users[0].setLeaderOf(results.projects[0])
@@ -1128,7 +1128,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             include: [
               {model: Project, as: 'LeaderOf', where: {title: 'Beta'}}
             ]
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].LeaderOf).to.be.ok;
             expect(users[0].LeaderOf.title).to.equal('Beta');
@@ -1167,7 +1167,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           ]).then(() => {
             return Tag.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.products[0].addTag(results.tags[0], {priority: 1}),
             results.products[0].addTag(results.tags[1], {priority: 2}),
@@ -1181,7 +1181,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             include: [
               {model: Tag, where: {name: 'C'}}
             ]
-          }).then((products) => {
+          }).then(products => {
             expect(products.length).to.equal(1);
             expect(products[0].Tags.length).to.equal(1);
           });
@@ -1258,7 +1258,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             return Tag.findAll();
           })
         ]).spread((groups, ranks, tags) => {
-          return Promise.each([0, 1, 2, 3, 4], (i) => {
+          return Promise.each([0, 1, 2, 3, 4], i => {
             return Promise.props({
               user: User.create({name: 'FooBarzz'}),
               products: Product.bulkCreate([
@@ -1267,7 +1267,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               ]).then(() => {
                 return Product.findAll();
               })
-            }).then((results) => {
+            }).then(results => {
               return Promise.join(
                 GroupMember.bulkCreate([
                   {UserId: results.user.id, GroupId: groups[0].id, RankId: ranks[0].id},
@@ -1318,8 +1318,8 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             order: [
               ['id', 'ASC']
             ]
-          }).then((users) => {
-            users.forEach((user) => {
+          }).then(users => {
+            users.forEach(user => {
               expect(user.Memberships.length).to.equal(1);
               expect(user.Memberships[0].Rank.name).to.equal('Admin');
               expect(user.Products.length).to.equal(1);
@@ -1349,7 +1349,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           users: User.bulkCreate([{}, {}, {}, {}]).then(() => {
             return User.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[0].setGroup(results.groups[0]),
             results.users[1].setGroup(results.groups[0]),
@@ -1362,10 +1362,10 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               {model: Group, where: {name: 'A'}}
             ],
             limit: 2
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(2);
 
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Group.name).to.equal('A');
             });
           });
@@ -1387,10 +1387,10 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           order: [
             [self.sequelize.col(self.models.Product.name + '.id'), 'ASC']
           ]
-        }).then((products) => {
+        }).then(products => {
           expect(products.length).to.equal(3);
 
-          products.forEach((product) => {
+          products.forEach(product => {
             expect(product.Company.name).to.equal('NYSE');
             expect(product.Tags.length).to.be.ok;
             expect(product.Prices.length).to.be.ok;
@@ -1415,7 +1415,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         return parent.addChild1(child).then(() => {
           return parent;
         });
-      }).then((parent) => {
+      }).then(parent => {
         return Child1.find({
           include: [
             {
@@ -1438,10 +1438,10 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           include: [
             {model: self.models.Tag, through: {attributes: []}, required: true}
           ]
-        }).then((products) => {
-          products.forEach((product) => {
+        }).then(products => {
+          products.forEach(product => {
             expect(product.Tags.length).to.be.ok;
-            product.Tags.forEach((tag) => {
+            product.Tags.forEach(tag => {
               expect(tag.get().productTags).not.to.be.ok;
             });
           });
@@ -1465,7 +1465,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               required: true
             }
           ]
-        }).then((products) => {
+        }).then(products => {
           expect(products).have.length(1);
         });
       });
@@ -1488,7 +1488,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             }
           ],
           limit: 5
-        }).then((products) => {
+        }).then(products => {
           expect(products).have.length(1);
         });
       });
@@ -1555,9 +1555,9 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                   model: Album
                 }
               ]
-            }).then((members) => {
+            }).then(members => {
               expect(members.length).to.equal(20);
-              members.forEach((member) => {
+              members.forEach(member => {
                 expect(member.get('id')).not.to.be.ok;
                 expect(member.Albums.length).to.equal(1);
               });
@@ -1582,14 +1582,14 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           order: [
             ['id', 'ASC']
           ]
-        }).then((products) => {
+        }).then(products => {
           expect(products.length).to.equal(6);
 
-          products.forEach((product) => {
+          products.forEach(product => {
             expect(product.Tags.length).to.be.ok;
             expect(product.Prices.length).to.be.ok;
 
-            product.Prices.forEach((price) => {
+            product.Prices.forEach(price => {
               expect(price.value).to.be.above(5);
             });
           });
@@ -1610,14 +1610,14 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           order: [
             ['id', 'ASC']
           ]
-        }).then((products) => {
+        }).then(products => {
           expect(products.length).to.equal(10);
 
-          products.forEach((product) => {
+          products.forEach(product => {
             expect(product.Tags.length).to.be.ok;
             expect(product.Prices.length).to.be.ok;
 
-            product.Tags.forEach((tag) => {
+            product.Tags.forEach(tag => {
               expect(['A', 'B', 'C']).to.include(tag.name);
             });
           });
@@ -1637,15 +1637,15 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       Group.belongsToMany(User, {through: 'group_user'});
 
       return this.sequelize.sync().then(() => {
-        return User.create({ dateField: Date.UTC(2014, 1, 20) }).then((user) => {
-          return Group.create({ dateField: Date.UTC(2014, 1, 20) }).then((group) => {
+        return User.create({ dateField: Date.UTC(2014, 1, 20) }).then(user => {
+          return Group.create({ dateField: Date.UTC(2014, 1, 20) }).then(group => {
             return user.addGroup(group).then(() => {
               return User.findAll({
                 where: {
                   id: user.id
                 },
                 include: [Group]
-              }).then((users) => {
+              }).then(users => {
                 expect(users[0].dateField.getTime()).to.equal(Date.UTC(2014, 1, 20));
                 expect(users[0].groups[0].dateField.getTime()).to.equal(Date.UTC(2014, 1, 20));
               });
@@ -1677,7 +1677,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           });
         })
-        .then((as) => {
+        .then(as => {
           expect(as.length).to.equal(1);
           expect(as[0].get('bs')).deep.equal([]);
         });
@@ -1703,8 +1703,8 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           Post.create({'public': true}),
           Post.create({'public': true}),
           Post.create({'public': true})
-        ).then((posts) => {
-          return Promise.map(posts.slice(1, 3), (post) => {
+        ).then(posts => {
+          return Promise.map(posts.slice(1, 3), post => {
             return post.createCategory({slug: 'food'});
           });
         }).then(() => {
@@ -1721,7 +1721,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                 }
               }
             ]
-          }).then((posts) => {
+          }).then(posts => {
             expect(posts.length).to.equal(2);
           });
         });
@@ -1860,7 +1860,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               ['lastName', 'DESC']
             ],
             limit: 5
-          }).then((users) => {
+          }).then(users => {
             expect(users[0].lastName).to.equal('Albertsen');
             expect(users[0].Company.rank).to.equal(1);
 
@@ -1907,7 +1907,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             'Post.id'
           ]
         });
-      }).then((posts) => {
+      }).then(posts => {
         expect(posts.length).to.equal(1);
 
         const post = posts[0];
@@ -1949,7 +1949,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           ],
           raw: true
         });
-      }).then((posts) => {
+      }).then(posts => {
         expect(posts.length).to.equal(1);
 
         const post = posts[0];

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -113,7 +113,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
                 }
               }],
               limit: 5
-            }).then((result ) => {
+            }).then(result => {
               expect(result.count).to.be.equal(2);
               expect(result.rows.length).to.be.equal(2);
             });
@@ -141,7 +141,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         return Project.sync({force: true});
       }).then(() => {
         return Promise.all([User.create(), Project.create(), Project.create(), Project.create()]);
-      }).then((results) => {
+      }).then(results => {
         const user = results[0];
         userId = user.id;
         return user.setProjects([results[1], results[2], results[3]]);
@@ -151,7 +151,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           include: [Project],
           distinct: true
         });
-      }).then((result) => {
+      }).then(result => {
         expect(result.rows.length).to.equal(1);
         expect(result.rows[0].Projects.length).to.equal(3);
         expect(result.count).to.equal(1);
@@ -181,11 +181,11 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           return Foo.findAll({
             include: [{ model: Bar, required: true }],
             limit: 2
-          }).then((items) => {
+          }).then(items => {
             expect(items.length).to.equal(2);
           });
         });
-      }).then((result) => {
+      }).then(result => {
         expect(result.count).to.equal(4);
 
         // The first two of those should be returned due to the limit (Foo
@@ -213,7 +213,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           limit: 1,
           distinct: true
         });
-      }).then((result) => {
+      }).then(result => {
         // There should be 2 instances matching the query (Instances 1 and 2), see the findAll statement
         expect(result.count).to.equal(2);
 
@@ -289,7 +289,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             ]
           });
         });
-      }).then((result) => {
+      }).then(result => {
         expect(result.count).to.equal(2);
         expect(result.rows.length).to.equal(1);
       });
@@ -340,7 +340,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             }
           ]
         });
-      }).then((result) => {
+      }).then(result => {
         expect(result.count).to.equal(2);
         expect(result.rows.length).to.equal(1);
       });

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -123,7 +123,7 @@ describe(Support.getTestDialectTeaser('Paranoid'), () => {
       return X.findAll({
         include: [Y]
       }).get(0);
-    }).then((x) => {
+    }).then(x => {
       expect(x.ys).to.have.length(0);
     });
   });

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -120,7 +120,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
                   Tag.findAll()
                 ]);
               }).spread((groups, companies, ranks, tags) => {
-                return Promise.each([0, 1, 2, 3, 4], (i) => {
+                return Promise.each([0, 1, 2, 3, 4], i => {
                   return Promise.all([
                     AccUser.create(),
                     Product.bulkCreate([
@@ -262,7 +262,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
                 return Tag.findAll();
               })
             ]).spread((groups, ranks, tags) => {
-              return Promise.each([0, 1, 2, 3, 4], (i) => {
+              return Promise.each([0, 1, 2, 3, 4], i => {
                 return Promise.all([
                   AccUser.create(),
                   Product.bulkCreate([
@@ -316,8 +316,8 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
                 order: [
                   [AccUser.rawAttributes.id, 'ASC']
                 ]
-              }).then((users) => {
-                users.forEach((user) => {
+              }).then(users => {
+                users.forEach(user => {
                   expect(user.Memberships).to.be.ok;
                   user.Memberships.sort(sortById);
 
@@ -378,8 +378,8 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           {}, {}, {}, {}, {}, {}, {}, {}
         ]).then(() => {
           let previousInstance;
-          return Promise.each(singles, (model) => {
-            return model.create({}).then((instance) => {
+          return Promise.each(singles, model => {
+            return model.create({}).then(instance => {
               if (previousInstance) {
                 return previousInstance['set'+ Sequelize.Utils.uppercaseFirst(model.name)](instance).then(() => {
                   previousInstance = instance;
@@ -391,9 +391,9 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           });
         }).then(() => {
           return A.findAll();
-        }).then((as) => {
+        }).then(as => {
           const promises = [];
-          as.forEach((a) => {
+          as.forEach(a => {
             promises.push(a.setB(b));
           });
           return Promise.all(promises);
@@ -414,9 +414,9 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
                 ]}
               ]}
             ]
-          }).then((as) => {
+          }).then(as => {
             expect(as.length).to.be.ok;
-            as.forEach((a) => {
+            as.forEach(a => {
               expect(a.b.c.d.e.f.g.h).to.be.ok;
             });
           });
@@ -474,7 +474,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             'order': [
               [Order, 'position']
             ]
-          }).then((as) => {
+          }).then(as => {
             expect(as.length).to.eql(2);
             expect(as[0].itemA.test).to.eql('abc');
             expect(as[1].itemA.test).to.eql('abc');
@@ -534,7 +534,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
               ['id', 'ASC'],
               [Tag, 'id', 'ASC']
             ]
-          }).then((products) => {
+          }).then(products => {
             expect(products[0].Tags[0].ProductTag.priority).to.equal(1);
             expect(products[0].Tags[1].ProductTag.priority).to.equal(2);
             expect(products[1].Tags[0].ProductTag.priority).to.equal(1);
@@ -568,7 +568,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             include: [
               {model: Group, required: true}
             ]
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].Group).to.be.ok;
           });
@@ -606,7 +606,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             include: [
               {model: Group, where: {name: 'A'}}
             ]
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].Group).to.be.ok;
             expect(users[0].Group.name).to.equal('A');
@@ -645,8 +645,8 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             include: [
               {model: Group, required: true}
             ]
-          }).then((users) => {
-            users.forEach((user) => {
+          }).then(users => {
+            users.forEach(user => {
               expect(user.Group).to.be.ok;
             });
           });
@@ -685,7 +685,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             users[0].setGroup(groups[1]),
             users[1].setGroup(groups[0])
           ];
-          groups.forEach((group) => {
+          groups.forEach(group => {
             promises.push(group.setCategories(categories));
           });
           return Promise.all(promises);
@@ -697,9 +697,9 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
               ]}
             ],
             limit: 1
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Group).to.be.ok;
               expect(user.Group.Categories).to.be.ok;
             });
@@ -739,7 +739,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             users[0].setTeam(groups[1]),
             users[1].setTeam(groups[0])
           ];
-          groups.forEach((group) => {
+          groups.forEach(group => {
             promises.push(group.setTags(categories));
           });
           return Promise.all(promises);
@@ -751,9 +751,9 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
               ]}
             ],
             limit: 1
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Team).to.be.ok;
               expect(user.Team.Tags).to.be.ok;
             });
@@ -793,7 +793,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             users[0].setGroup(groups[1]),
             users[1].setGroup(groups[0])
           ];
-          groups.forEach((group) => {
+          groups.forEach(group => {
             promises.push(group.setCategories(categories));
           });
           return Promise.all(promises);
@@ -805,9 +805,9 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
               ]}
             ],
             limit: 1
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Group).to.be.ok;
               expect(user.Group.Categories).to.be.ok;
             });
@@ -846,7 +846,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             include: [
               {model: Project, as: 'LeaderOf', where: {title: 'Beta'}}
             ]
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].LeaderOf).to.be.ok;
             expect(users[0].LeaderOf.title).to.equal('Beta');
@@ -900,7 +900,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             include: [
               {model: Tag, where: {name: 'C'}}
             ]
-          }).then((products) => {
+          }).then(products => {
             expect(products.length).to.equal(1);
             expect(products[0].Tags.length).to.equal(1);
           });
@@ -977,7 +977,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             Tag.findAll()
           ]);
         }).spread((groups, ranks, tags) => {
-          return Promise.resolve([0, 1, 2, 3, 4]).each((i) => {
+          return Promise.resolve([0, 1, 2, 3, 4]).each(i => {
             return Promise.all([
               User.create({name: 'FooBarzz'}),
               Product.bulkCreate([
@@ -1035,8 +1035,8 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
             order: [
               ['id', 'ASC']
             ]
-          }).then((users) => {
-            users.forEach((user) => {
+          }).then(users => {
+            users.forEach(user => {
               expect(user.Memberships.length).to.equal(1);
               expect(user.Memberships[0].Rank.name).to.equal('Admin');
               expect(user.Products.length).to.equal(1);
@@ -1066,7 +1066,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           users: User.bulkCreate([{}, {}, {}, {}]).then(() => {
             return User.findAll();
           })
-        }).then((results) => {
+        }).then(results => {
           return Promise.join(
             results.users[1].setGroup(results.groups[0]),
             results.users[2].setGroup(results.groups[0]),
@@ -1079,10 +1079,10 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
               {model: Group, where: {name: 'A'}}
             ],
             limit: 2
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(2);
 
-            users.forEach((user) => {
+            users.forEach(user => {
               expect(user.Group.name).to.equal('A');
             });
           });
@@ -1104,10 +1104,10 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           order: [
             ['id', 'ASC']
           ]
-        }).then((products) => {
+        }).then(products => {
           expect(products.length).to.equal(3);
 
-          products.forEach((product) => {
+          products.forEach(product => {
             expect(product.Company.name).to.equal('NYSE');
             expect(product.Tags.length).to.be.ok;
             expect(product.Prices.length).to.be.ok;
@@ -1131,14 +1131,14 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           order: [
             ['id', 'ASC']
           ]
-        }).then((products) => {
+        }).then(products => {
           expect(products.length).to.equal(6);
 
-          products.forEach((product) => {
+          products.forEach(product => {
             expect(product.Tags.length).to.be.ok;
             expect(product.Prices.length).to.be.ok;
 
-            product.Prices.forEach((price) => {
+            product.Prices.forEach(price => {
               expect(price.value).to.be.above(5);
             });
           });
@@ -1159,14 +1159,14 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           order: [
             ['id', 'ASC']
           ]
-        }).then((products) => {
+        }).then(products => {
           expect(products.length).to.equal(10);
 
-          products.forEach((product) => {
+          products.forEach(product => {
             expect(product.Tags.length).to.be.ok;
             expect(product.Prices.length).to.be.ok;
 
-            product.Tags.forEach((tag) => {
+            product.Tags.forEach(tag => {
               expect(['A', 'B', 'C']).to.include(tag.name);
             });
           });
@@ -1186,15 +1186,15 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
       Group.belongsToMany(User, {through: 'group_user'});
 
       return this.sequelize.sync().then(() => {
-        return User.create({ dateField: Date.UTC(2014, 1, 20) }).then((user) => {
-          return Group.create({ dateField: Date.UTC(2014, 1, 20) }).then((group) => {
+        return User.create({ dateField: Date.UTC(2014, 1, 20) }).then(user => {
+          return Group.create({ dateField: Date.UTC(2014, 1, 20) }).then(group => {
             return user.addGroup(group).then(() => {
               return User.findAll({
                 where: {
                   id: user.id
                 },
                 include: [Group]
-              }).then((users) => {
+              }).then(users => {
                 if (dialect === 'sqlite') {
                   expect(new Date(users[0].dateField).getTime()).to.equal(Date.UTC(2014, 1, 20));
                   expect(new Date(users[0].groups[0].dateField).getTime()).to.equal(Date.UTC(2014, 1, 20));

--- a/test/integration/include/seperate.test.js
+++ b/test/integration/include/seperate.test.js
@@ -50,7 +50,7 @@ if (current.dialect.supports.groupedLimit) {
               ],
               logging: sqlSpy
             });
-          }).then((users) => {
+          }).then(users => {
             expect(users[0].get('tasks')).to.be.ok;
             expect(users[0].get('tasks').length).to.equal(3);
             expect(users[1].get('tasks')).to.be.ok;
@@ -94,7 +94,7 @@ if (current.dialect.supports.groupedLimit) {
               ],
               logging: sqlSpy
             });
-          }).then((users) => {
+          }).then(users => {
             expect(users[0].get('tasks')).to.be.ok;
             expect(users[0].get('tasks').length).to.equal(3);
             expect(sqlSpy).to.have.been.calledTwice;
@@ -166,7 +166,7 @@ if (current.dialect.supports.groupedLimit) {
               ],
               logging: sqlSpy
             });
-          }).then((users) => {
+          }).then(users => {
             expect(users[0].get('tasks')).to.be.ok;
             expect(users[0].get('tasks').length).to.equal(2);
             expect(users[1].get('tasks')).to.be.ok;
@@ -225,7 +225,7 @@ if (current.dialect.supports.groupedLimit) {
               ],
               logging: sqlSpy
             });
-          }).then((users) => {
+          }).then(users => {
             expect(users[0].get('company').get('tasks')).to.be.ok;
             expect(users[0].get('company').get('tasks').length).to.equal(3);
             expect(users[1].get('company').get('tasks')).to.be.ok;
@@ -282,7 +282,7 @@ if (current.dialect.supports.groupedLimit) {
               ],
               logging: sqlSpy
             });
-          }).then((companies) => {
+          }).then(companies => {
             expect(sqlSpy).to.have.been.calledTwice;
 
             expect(companies[0].users[0].tasks[0].project).to.be.ok;
@@ -352,7 +352,7 @@ if (current.dialect.supports.groupedLimit) {
               ],
               logging: sqlSpy
             });
-          }).then((users) => {
+          }).then(users => {
             const u1projects = users[0].get('projects');
 
             expect(u1projects).to.be.ok;
@@ -361,8 +361,8 @@ if (current.dialect.supports.groupedLimit) {
             expect(u1projects.length).to.equal(2);
 
             // WTB ES2015 syntax ...
-            expect(_.find(u1projects, (p) => { return p.id === 1; }).get('tasks').length).to.equal(3);
-            expect(_.find(u1projects, (p) => { return p.id === 2; }).get('tasks').length).to.equal(1);
+            expect(_.find(u1projects, p => { return p.id === 1; }).get('tasks').length).to.equal(3);
+            expect(_.find(u1projects, p => { return p.id === 2; }).get('tasks').length).to.equal(1);
 
             expect(users[1].get('projects')).to.be.ok;
             expect(users[1].get('projects')[0].get('tasks')).to.be.ok;
@@ -415,7 +415,7 @@ if (current.dialect.supports.groupedLimit) {
                 order: [
                   ['id', 'ASC']
                 ]
-              }).then((result) => {
+              }).then(result => {
                 expect(result[0].tasks.length).to.equal(2);
                 expect(result[0].tasks[0].title).to.equal('b');
                 expect(result[0].tasks[1].title).to.equal('d');

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -61,8 +61,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       const bio = dialect + "'\"\n", // Need to add the dialect here so in case of failure I know what DB it failed for
         self = this;
 
-      return this.User.create({ username: bio }).then((u1) => {
-        return self.User.findById(u1.id).then((u2) => {
+      return this.User.create({ username: bio }).then(u1 => {
+        return self.User.findById(u1.id).then(u2 => {
           expect(u2.username).to.equal(bio);
         });
       });
@@ -77,13 +77,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('returns false for saved objects', function() {
-      return this.User.build({ username: 'user' }).save().then((user) => {
+      return this.User.build({ username: 'user' }).save().then(user => {
         expect(user.isNewRecord).to.not.be.ok;
       });
     });
 
     it('returns false for created objects', function() {
-      return this.User.create({ username: 'user' }).then((user) => {
+      return this.User.create({ username: 'user' }).then(user => {
         expect(user.isNewRecord).to.not.be.ok;
       });
     });
@@ -91,8 +91,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('returns false for objects found by find method', function() {
       const self = this;
       return this.User.create({ username: 'user' }).then(() => {
-        return self.User.create({ username: 'user' }).then((user) => {
-          return self.User.findById(user.id).then((user) => {
+        return self.User.create({ username: 'user' }).then(user => {
+          return self.User.findById(user.id).then(user => {
             expect(user.isNewRecord).to.not.be.ok;
           });
         });
@@ -108,8 +108,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       }
 
       return this.User.bulkCreate(users).then(() => {
-        return self.User.findAll().then((users) => {
-          users.forEach((u) => {
+        return self.User.findAll().then(users => {
+          users.forEach(u => {
             expect(u.isNewRecord).to.not.be.ok;
           });
         });
@@ -124,15 +124,15 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { number: Support.Sequelize.INTEGER });
 
           return User.sync({ force: true }).then(() => {
-            return User.create({ number: 1 }).then((user) => {
-              return sequelize.transaction().then((t) => {
+            return User.create({ number: 1 }).then(user => {
+              return sequelize.transaction().then(t => {
                 return user.increment('number', { by: 2, transaction: t }).then(() => {
-                  return User.findAll().then((users1) => {
-                    return User.findAll({ transaction: t }).then((users2) => {
+                  return User.findAll().then(users1 => {
+                    return User.findAll({ transaction: t }).then(users2 => {
                       expect(users1[0].number).to.equal(1);
                       expect(users2[0].number).to.equal(3);
                       return t.rollback();
@@ -148,7 +148,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     if (current.dialect.supports.returnValues.returning) {
       it('supports returning', function() {
-        return this.User.findById(1).then((user1) => {
+        return this.User.findById(1).then(user1 => {
           return user1.increment('aNumber', { by: 2 }).then(() => {
             expect(user1.aNumber).to.be.equal(2);
           });
@@ -158,9 +158,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('supports where conditions', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.increment(['aNumber'], { by: 2, where: { bNumber: 1 } }).then(() => {
-          return self.User.findById(1).then((user3) => {
+          return self.User.findById(1).then(user3 => {
             expect(user3.aNumber).to.be.equal(0);
           });
         });
@@ -169,9 +169,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with array', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.increment(['aNumber'], { by: 2 }).then(() => {
-          return self.User.findById(1).then((user3) => {
+          return self.User.findById(1).then(user3 => {
             expect(user3.aNumber).to.be.equal(2);
           });
         });
@@ -180,9 +180,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with single field', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.increment('aNumber', { by: 2 }).then(() => {
-          return self.User.findById(1).then((user3) => {
+          return self.User.findById(1).then(user3 => {
             expect(user3.aNumber).to.be.equal(2);
           });
         });
@@ -191,9 +191,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with single field and no value', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.increment('aNumber').then(() => {
-          return self.User.findById(1).then((user2) => {
+          return self.User.findById(1).then(user2 => {
             expect(user2.aNumber).to.be.equal(1);
           });
         });
@@ -202,14 +202,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('should still work right with other concurrent updates', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         // Select the user again (simulating a concurrent query)
-        return self.User.findById(1).then((user2) => {
+        return self.User.findById(1).then(user2 => {
           return user2.updateAttributes({
             aNumber: user2.aNumber + 1
           }).then(() => {
             return user1.increment(['aNumber'], { by: 2 }).then(() => {
-              return self.User.findById(1).then((user5) => {
+              return self.User.findById(1).then(user5 => {
                 expect(user5.aNumber).to.be.equal(3);
               });
             });
@@ -220,13 +220,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('should still work right with other concurrent increments', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return self.sequelize.Promise.all([
           user1.increment(['aNumber'], { by: 2 }),
           user1.increment(['aNumber'], { by: 2 }),
           user1.increment(['aNumber'], { by: 2 })
         ]).then(() => {
-          return self.User.findById(1).then((user2) => {
+          return self.User.findById(1).then(user2 => {
             expect(user2.aNumber).to.equal(6);
           });
         });
@@ -235,9 +235,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with key value pair', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.increment({ 'aNumber': 1, 'bNumber': 2 }).then(() => {
-          return self.User.findById(1).then((user3) => {
+          return self.User.findById(1).then(user3 => {
             expect(user3.aNumber).to.be.equal(1);
             expect(user3.bNumber).to.be.equal(2);
           });
@@ -288,15 +288,15 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { number: Support.Sequelize.INTEGER });
 
           return User.sync({ force: true }).then(() => {
-            return User.create({ number: 3 }).then((user) => {
-              return sequelize.transaction().then((t) => {
+            return User.create({ number: 3 }).then(user => {
+              return sequelize.transaction().then(t => {
                 return user.decrement('number', { by: 2, transaction: t }).then(() => {
-                  return User.findAll().then((users1) => {
-                    return User.findAll({ transaction: t }).then((users2) => {
+                  return User.findAll().then(users1 => {
+                    return User.findAll({ transaction: t }).then(users2 => {
                       expect(users1[0].number).to.equal(3);
                       expect(users2[0].number).to.equal(1);
                       return t.rollback();
@@ -312,9 +312,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with array', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.decrement(['aNumber'], { by: 2 }).then(() => {
-          return self.User.findById(1).then((user3) => {
+          return self.User.findById(1).then(user3 => {
             expect(user3.aNumber).to.be.equal(-2);
           });
         });
@@ -323,9 +323,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with single field', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.decrement('aNumber', { by: 2 }).then(() => {
-          return self.User.findById(1).then((user3) => {
+          return self.User.findById(1).then(user3 => {
             expect(user3.aNumber).to.be.equal(-2);
           });
         });
@@ -334,9 +334,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with single field and no value', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.decrement('aNumber').then(() => {
-          return self.User.findById(1).then((user2) => {
+          return self.User.findById(1).then(user2 => {
             expect(user2.aNumber).to.be.equal(-1);
           });
         });
@@ -345,14 +345,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('should still work right with other concurrent updates', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         // Select the user again (simulating a concurrent query)
-        return self.User.findById(1).then((user2) => {
+        return self.User.findById(1).then(user2 => {
           return user2.updateAttributes({
             aNumber: user2.aNumber + 1
           }).then(() => {
             return user1.decrement(['aNumber'], { by: 2 }).then(() => {
-              return self.User.findById(1).then((user5) => {
+              return self.User.findById(1).then(user5 => {
                 expect(user5.aNumber).to.be.equal(-1);
               });
             });
@@ -363,13 +363,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('should still work right with other concurrent increments', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return self.sequelize.Promise.all([
           user1.decrement(['aNumber'], { by: 2 }),
           user1.decrement(['aNumber'], { by: 2 }),
           user1.decrement(['aNumber'], { by: 2 })
         ]).then(() => {
-          return self.User.findById(1).then((user2) => {
+          return self.User.findById(1).then(user2 => {
             expect(user2.aNumber).to.equal(-6);
           });
         });
@@ -378,9 +378,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('with key value pair', function() {
       const self = this;
-      return this.User.findById(1).then((user1) => {
+      return this.User.findById(1).then(user1 => {
         return user1.decrement({ 'aNumber': 1, 'bNumber': 2}).then(() => {
-          return self.User.findById(1).then((user3) => {
+          return self.User.findById(1).then(user3 => {
             expect(user3.aNumber).to.be.equal(-1);
             expect(user3.bNumber).to.be.equal(-2);
           });
@@ -426,16 +426,16 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
   describe('reload', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return sequelize.transaction().then((t) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return sequelize.transaction().then(t => {
                 return User.update({ username: 'bar' }, {where: {username: 'foo'}, transaction: t }).then(() => {
-                  return user.reload().then((user) => {
+                  return user.reload().then(user => {
                     expect(user.username).to.equal('foo');
-                    return user.reload({ transaction: t }).then((user) => {
+                    return user.reload({ transaction: t }).then(user => {
                       expect(user.username).to.equal('bar');
                       return t.rollback();
                     });
@@ -449,9 +449,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     }
 
     it('should return a reference to the same DAO instead of creating a new one', function() {
-      return this.User.create({ username: 'John Doe' }).then((originalUser) => {
+      return this.User.create({ username: 'John Doe' }).then(originalUser => {
         return originalUser.updateAttributes({ username: 'Doe John' }).then(() => {
-          return originalUser.reload().then((updatedUser) => {
+          return originalUser.reload().then(updatedUser => {
             expect(originalUser === updatedUser).to.be.true;
           });
         });
@@ -460,12 +460,12 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('should update the values on all references to the DAO', function() {
       const self = this;
-      return this.User.create({ username: 'John Doe' }).then((originalUser) => {
-        return self.User.findById(originalUser.id).then((updater) => {
+      return this.User.create({ username: 'John Doe' }).then(originalUser => {
+        return self.User.findById(originalUser.id).then(updater => {
           return updater.updateAttributes({ username: 'Doe John' }).then(() => {
             // We used a different reference when calling updateAttributes, so originalUser is now out of sync
             expect(originalUser.username).to.equal('John Doe');
-            return originalUser.reload().then((updatedUser) => {
+            return originalUser.reload().then(updatedUser => {
               expect(originalUser.username).to.equal('Doe John');
               expect(updatedUser.username).to.equal('Doe John');
             });
@@ -486,11 +486,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             id: user.get('id')
           }
         });
-      }).then((user) => {
+      }).then(user => {
         return user.reload({
           attributes: ['bNumber']
         });
-      }).then((user) => {
+      }).then(user => {
         expect(user.get('aNumber')).to.equal(1);
         expect(user.get('bNumber')).to.equal(2);
       });
@@ -504,7 +504,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         // Wait for a second, so updatedAt will actually be different
         this.clock.tick(1000);
         return this.User.findById(originalUser.id);
-      }).then((updater) => {
+      }).then(updater => {
         return updater.updateAttributes({username: 'Doe John'});
       }).then(function(updatedUser) {
         this.updatedUser = updatedUser;
@@ -524,18 +524,18 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return Book.sync({force: true}).then(() => {
         return Page.sync({force: true}).then(() => {
-          return Book.create({ title: 'A very old book' }).then((book) => {
-            return Page.create({ content: 'om nom nom' }).then((page) => {
+          return Book.create({ title: 'A very old book' }).then(book => {
+            return Page.create({ content: 'om nom nom' }).then(page => {
               return book.setPages([page]).then(() => {
                 return Book.findOne({
                   where: { id: book.id },
                   include: [Page]
-                }).then((leBook) => {
-                  return page.updateAttributes({ content: 'something totally different' }).then((page) => {
+                }).then(leBook => {
+                  return page.updateAttributes({ content: 'something totally different' }).then(page => {
                     expect(leBook.Pages.length).to.equal(1);
                     expect(leBook.Pages[0].content).to.equal('om nom nom');
                     expect(page.content).to.equal('something totally different');
-                    return leBook.reload().then((leBook) => {
+                    return leBook.reload().then(leBook => {
                       expect(leBook.Pages.length).to.equal(1);
                       expect(leBook.Pages[0].content).to.equal('something totally different');
                       expect(page.content).to.equal('something totally different');
@@ -558,16 +558,16 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return Book.sync({force: true}).then(() => {
         return Page.sync({force: true}).then(() => {
-          return Book.create({ title: 'A very old book' }).then((book) => {
-            return Page.create().then((page) => {
+          return Book.create({ title: 'A very old book' }).then(book => {
+            return Page.create().then(page => {
               return book.setPages([page]).then(() => {
                 return Book.findOne({
                   where: { id: book.id }
-                }).then((leBook) => {
+                }).then(leBook => {
                   const oldOptions = leBook._options;
                   return leBook.reload({
                     include: [Page]
-                  }).then((leBook) => {
+                  }).then(leBook => {
                     expect(oldOptions).not.to.equal(leBook._options);
                     expect(leBook._options.include.length).to.equal(1);
                     expect(leBook.Pages.length).to.equal(1);
@@ -582,7 +582,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('should return an error when reload fails', function() {
-      return this.User.create({ username: 'John Doe' }).then((user) => {
+      return this.User.create({ username: 'John Doe' }).then(user => {
         return user.destroy().then(() => {
           return expect(user.reload()).to.be.rejectedWith(
             Sequelize.InstanceError,
@@ -606,16 +606,16 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'the player'
           }
         }, {include: [Player]});
-      }).then((shoe) => {
+      }).then(shoe => {
         return Player.findOne({
           where: { id: shoe.Player.id },
           include: [Shoe]
-        }).then((lePlayer) => {
+        }).then(lePlayer => {
           expect(lePlayer.Shoe).not.to.be.null;
           return lePlayer.Shoe.destroy().return(lePlayer);
-        }).then((lePlayer) => {
+        }).then(lePlayer => {
           return lePlayer.reload();
-        }).then((lePlayer) => {
+        }).then(lePlayer => {
           expect(lePlayer.Shoe).to.be.null;
         });
       });
@@ -637,18 +637,18 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'the player2'
           }]
         }, {include: [Player]});
-      }).then((team) => {
+      }).then(team => {
         return Team.findOne({
           where: { id: team.id },
           include: [Player]
-        }).then((leTeam) => {
+        }).then(leTeam => {
           expect(leTeam.Players).not.to.be.empty;
           return leTeam.Players[1].destroy().then(() => {
             return leTeam.Players[0].destroy();
           }).return(leTeam);
-        }).then((leTeam) => {
+        }).then(leTeam => {
           return leTeam.reload();
-        }).then((leTeam) => {
+        }).then(leTeam => {
           expect(leTeam.Players).to.be.empty;
         });
       });
@@ -671,16 +671,16 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'the player2'
           }]
         }, {include: [Player]});
-      }).then((team) => {
+      }).then(team => {
         return Team.findOne({
           where: { id: team.id },
           include: [Player]
-        }).then((leTeam) => {
+        }).then(leTeam => {
           expect(leTeam.Players).to.have.length(2);
           return leTeam.Players[0].destroy().return(leTeam);
-        }).then((leTeam) => {
+        }).then(leTeam => {
           return leTeam.reload();
-        }).then((leTeam) => {
+        }).then(leTeam => {
           expect(leTeam.Players).to.have.length(1);
         });
       });
@@ -740,7 +740,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       it('should be just "null" and not Date with Invalid Date', function() {
         const self = this;
         return this.User.build({ username: 'a user'}).save().then(() => {
-          return self.User.findOne({where: {username: 'a user'}}).then((user) => {
+          return self.User.findOne({where: {username: 'a user'}}).then(user => {
             expect(user.dateAllowNullTrue).to.be.null;
           });
         });
@@ -750,7 +750,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         const self = this;
         const date = new Date();
         return this.User.build({ username: 'a user', dateAllowNullTrue: date}).save().then(() => {
-          return self.User.findOne({where: {username: 'a user'}}).then((user) => {
+          return self.User.findOne({where: {username: 'a user'}}).then(user => {
             expect(user.dateAllowNullTrue.toString()).to.equal(date.toString());
           });
         });
@@ -770,7 +770,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
                 username: 'a user'
               }
             })
-          .then((user) => {
+          .then(user => {
             expect(user.isSuperUser).to.be.false;
           });
           });
@@ -789,7 +789,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
                 username: 'a user'
               }
             })
-          .then((user) => {
+          .then(user => {
             expect(user.isSuperUser).to.be.true;
           });
           });
@@ -808,7 +808,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
                 username: 'a user'
               }
             })
-          .then((user) => {
+          .then(user => {
             expect(user.isSuperUser).to.be.true;
           });
           });
@@ -827,7 +827,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
               username: 'a user'
             }
           })
-        .then((user) => {
+        .then(user => {
           expect(user.isSuperUser).to.be.true;
         });
         });
@@ -844,7 +844,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         .then(() => {
           callCount += 1;
         })
-        .catch((err) => {
+        .catch(err => {
           expect(callCount).to.equal(0);
           expect(err).to.exist;
           expect(err.message).to.exist;
@@ -855,14 +855,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
   describe('complete', () => {
     it('gets triggered if an error occurs', function() {
-      return this.User.findOne({ where: ['asdasdasd'] }).catch((err) => {
+      return this.User.findOne({ where: ['asdasdasd'] }).catch(err => {
         expect(err).to.exist;
         expect(err.message).to.exist;
       });
     });
 
     it('gets triggered if everything was ok', function() {
-      return this.User.count().then((result) => {
+      return this.User.count().then(result => {
         expect(result).to.exist;
       });
     });
@@ -871,13 +871,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
   describe('save', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING });
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.build({ username: 'foo' }).save({ transaction: t }).then(() => {
-                return User.count().then((count1) => {
-                  return User.count({ transaction: t }).then((count2) => {
+                return User.count().then(count1 => {
+                  return User.count({ transaction: t }).then(count2 => {
                     expect(count1).to.equal(0);
                     expect(count2).to.equal(1);
                     return t.rollback();
@@ -897,13 +897,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       return this.User.create({
         username: 'foo',
         touchedAt: new Date()
-      }).then((user) => {
+      }).then(user => {
         user.username = 'fizz';
         user.touchedAt = date;
 
         return user.save({fields: ['username']}).then(() => {
           // re-select user
-          return self.User.findById(user.id).then((user2) => {
+          return self.User.findById(user.id).then(user2 => {
             // name should have changed
             expect(user2.username).to.equal('fizz');
             // bio should be unchanged
@@ -925,14 +925,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           length: 1,
           width: 2,
           height: 3
-        }).then((box) => {
+        }).then(box => {
           return box.update({
             length: 4,
             width: 5,
             height: 6
           });
         }).then(() => {
-          return Box.findOne({}).then((box) => {
+          return Box.findOne({}).then(box => {
             expect(box.get('length')).to.equal(4);
             expect(box.get('width')).to.equal(5);
             expect(box.get('height')).to.equal(6);
@@ -958,7 +958,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           email: DataTypes.STRING
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'B');
         });
 
@@ -967,14 +967,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'A'
-          }).then((user) => {
+          }).then(user => {
             return user.set({
               name: 'B',
               bio: 'B'
             }).save();
           }).then(() => {
             return User.findOne({});
-          }).then((user) => {
+          }).then(user => {
             expect(user.get('name')).to.equal('B');
             expect(user.get('bio')).to.equal('B');
             expect(user.get('email')).to.equal('B');
@@ -989,7 +989,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           email: DataTypes.STRING
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'C');
         });
 
@@ -998,7 +998,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'A'
-          }).then((user) => {
+          }).then(user => {
             return user.set({
               name: 'B',
               bio: 'B',
@@ -1006,7 +1006,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             }).save();
           }).then(() => {
             return User.findOne({});
-          }).then((user) => {
+          }).then(user => {
             expect(user.get('name')).to.equal('B');
             expect(user.get('bio')).to.equal('B');
             expect(user.get('email')).to.equal('C');
@@ -1026,7 +1026,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           }
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'B');
         });
 
@@ -1035,12 +1035,12 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'valid.email@gmail.com'
-          }).then((user) => {
+          }).then(user => {
             return expect(user.set({
               name: 'B'
             }).save()).to.be.rejectedWith(Sequelize.ValidationError);
           }).then(() => {
-            return User.findOne({}).then((user) => {
+            return User.findOne({}).then(user => {
               expect(user.get('email')).to.equal('valid.email@gmail.com');
             });
           });
@@ -1059,7 +1059,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           }
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'B');
         });
 
@@ -1068,13 +1068,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'valid.email@gmail.com'
-          }).then((user) => {
+          }).then(user => {
             return expect(user.set({
               name: 'B',
               email: 'still.valid.email@gmail.com'
             }).save()).to.be.rejectedWith(Sequelize.ValidationError);
           }).then(() => {
-            return User.findOne({}).then((user) => {
+            return User.findOne({}).then(user => {
               expect(user.get('email')).to.equal('valid.email@gmail.com');
             });
           });
@@ -1090,10 +1090,10 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           touchedAt: new Date(1984, 8, 23)
         });
 
-      return User.findAll().then((users) => {
+      return User.findAll().then(users => {
         expect(users).to.have.length(0);
         return user.save().then(() => {
-          return User.findAll().then((users) => {
+          return User.findAll().then(users => {
             expect(users).to.have.length(1);
             expect(users[0].username).to.equal(username);
             expect(users[0].touchedAt).to.be.instanceof(Date);
@@ -1117,15 +1117,15 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           });
 
       return User2.sync().then(() => {
-        return User2.create({id: 0, username}).then((user) => {
+        return User2.create({id: 0, username}).then(user => {
           expect(user).to.be.ok;
           expect(user.id).to.equal(0);
           expect(user.username).to.equal(username);
-          return User2.findById(0).then((user) => {
+          return User2.findById(0).then(user => {
             expect(user).to.be.ok;
             expect(user.id).to.equal(0);
             expect(user.username).to.equal(username);
-            return user.updateAttributes({username: newUsername}).then((user) => {
+            return user.updateAttributes({username: newUsername}).then(user => {
               expect(user).to.be.ok;
               expect(user.id).to.equal(0);
               expect(user.username).to.equal(newUsername);
@@ -1167,7 +1167,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return this.User.bulkCreate(data).bind(this).then(function() {
         return this.User.findAll();
-      }).then((users) => {
+      }).then(users => {
         updatedAtPaul = users[0].updatedAt;
         updatedAtPeter = users[1].updatedAt;
       })
@@ -1179,7 +1179,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         );
       }).then(() => {
         return self.User.findAll();
-      }).then((users) => {
+      }).then(users => {
         expect(users[0].updatedAt).to.equalTime(updatedAtPeter);
         expect(users[1].updatedAt).to.equalTime(updatedAtPaul);
       });
@@ -1198,12 +1198,12 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       it('does not update timestamps', function() {
         const self = this;
         return self.User.create({ username: 'John' }).then(() => {
-          return self.User.findOne({ where: { username: 'John' } }).then((user) => {
+          return self.User.findOne({ where: { username: 'John' } }).then(user => {
             const updatedAt = user.updatedAt;
             self.clock.tick(2000);
-            return user.save().then((newlySavedUser) => {
+            return user.save().then(newlySavedUser => {
               expect(newlySavedUser.updatedAt).to.equalTime(updatedAt);
-              return self.User.findOne({ where: { username: 'John' } }).then((newlySavedUser) => {
+              return self.User.findOne({ where: { username: 'John' } }).then(newlySavedUser => {
                 expect(newlySavedUser.updatedAt).to.equalTime(updatedAt);
               });
             });
@@ -1222,7 +1222,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           timestamps: false
         });
         return User.sync({force: true}).then(() =>
-          User.create({ name: 'John', bio: 'swag 1' }).then((user) => user.update({ bio: 'swag 2' }).should.be.fulfilled)
+          User.create({ name: 'John', bio: 'swag 1' }).then(user => user.update({ bio: 'swag 2' }).should.be.fulfilled)
         );
       });
     });
@@ -1232,11 +1232,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return this.User.create({
         aNumber: 42
-      }).then((user) => {
+      }).then(user => {
         user.bNumber = self.sequelize.col('aNumber');
         user.username = self.sequelize.fn('upper', 'sequelize');
         return user.save().then(() => {
-          return self.User.findById(user.id).then((user2) => {
+          return self.User.findById(user.id).then(user2 => {
             expect(user2.username).to.equal('SEQUELIZE');
             expect(user2.bNumber).to.equal(42);
           });
@@ -1251,7 +1251,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           updatedAt: DataTypes.DATE
         }, { timestamps: false });
         return User2.sync().then(() => {
-          return User2.create({ username: 'john doe' }).then((johnDoe) => {
+          return User2.create({ username: 'john doe' }).then(johnDoe => {
             // sqlite and mysql return undefined, whereas postgres returns null
             expect([undefined, null].indexOf(johnDoe.updatedAt)).not.to.be.equal(-1);
           });
@@ -1269,7 +1269,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         }, { updatedAt: false });
 
         return User2.sync().then(() => {
-          return User2.create({ username: 'john doe' }).then((johnDoe) => {
+          return User2.create({ username: 'john doe' }).then(johnDoe => {
             expect(johnDoe.updatedAt).to.be.undefined;
             expect(now).to.be.beforeTime(johnDoe.createdAt);
           });
@@ -1285,7 +1285,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         }, { createdAt: false });
 
         return User2.sync().then(() => {
-          return User2.create({ username: 'john doe' }).then((johnDoe) => {
+          return User2.create({ username: 'john doe' }).then(johnDoe => {
             expect(johnDoe.createdAt).to.be.undefined;
             expect(now).to.be.beforeTime(johnDoe.updatedAt);
           });
@@ -1306,7 +1306,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         }, { timestamps: true });
 
         return User2.sync().then(() => {
-          return User2.create({ username: 'john doe' }).then((johnDoe) => {
+          return User2.create({ username: 'john doe' }).then(johnDoe => {
             expect(johnDoe.createdAt).to.be.an.instanceof(Date);
             expect( ! isNaN(johnDoe.createdAt.valueOf()) ).to.be.ok;
             expect(johnDoe.createdAt).to.equalTime(johnDoe.updatedAt);
@@ -1316,7 +1316,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('should fail a validation upon creating', function() {
-      return this.User.create({aNumber: 0, validateTest: 'hello'}).catch((err) => {
+      return this.User.create({aNumber: 0, validateTest: 'hello'}).catch(err => {
         expect(err).to.exist;
         expect(err).to.be.instanceof(Object);
         expect(err.get('validateTest')).to.be.instanceof(Array);
@@ -1326,7 +1326,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('should fail a validation upon creating with hooks false', function() {
-      return this.User.create({aNumber: 0, validateTest: 'hello'}, {hooks: false}).catch((err) => {
+      return this.User.create({aNumber: 0, validateTest: 'hello'}, {hooks: false}).catch(err => {
         expect(err).to.exist;
         expect(err).to.be.instanceof(Object);
         expect(err.get('validateTest')).to.be.instanceof(Array);
@@ -1337,7 +1337,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('should fail a validation upon building', function() {
       return this.User.build({aNumber: 0, validateCustom: 'aaaaaaaaaaaaaaaaaaaaaaaaaa'}).save()
-      .catch((err) => {
+      .catch(err => {
         expect(err).to.exist;
         expect(err).to.be.instanceof(Object);
         expect(err.get('validateCustom')).to.exist;
@@ -1348,8 +1348,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('should fail a validation when updating', function() {
-      return this.User.create({aNumber: 0}).then((user) => {
-        return user.updateAttributes({validateTest: 'hello'}).catch((err) => {
+      return this.User.create({aNumber: 0}).then(user => {
+        return user.updateAttributes({validateTest: 'hello'}).catch(err => {
           expect(err).to.exist;
           expect(err).to.be.instanceof(Object);
           expect(err.get('validateTest')).to.exist;
@@ -1363,7 +1363,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('takes zero into account', function() {
       return this.User.build({ aNumber: 0 }).save({
         fields: ['aNumber']
-      }).then((user) => {
+      }).then(user => {
         expect(user.aNumber).to.equal(0);
       });
     });
@@ -1375,8 +1375,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         aRandomId: { type: DataTypes.INTEGER }
       });
       return HistoryLog.sync().then(() => {
-        return HistoryLog.create({ someText: 'Some random text', aNumber: 3, aRandomId: 5 }).then((log) => {
-          return log.updateAttributes({ aNumber: 5 }).then((newLog) => {
+        return HistoryLog.create({ someText: 'Some random text', aNumber: 3, aRandomId: 5 }).then(log => {
+          return log.updateAttributes({ aNumber: 5 }).then(newLog => {
             expect(newLog.aNumber).to.equal(5);
           });
         });
@@ -1406,18 +1406,18 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       it('saves one object that has a collection of eagerly loaded objects', function() {
         const self = this;
-        return this.UserEager.create({ username: 'joe', age: 1 }).then((user) => {
-          return self.ProjectEager.create({ title: 'project-joe1', overdue_days: 0 }).then((project1) => {
-            return self.ProjectEager.create({ title: 'project-joe2', overdue_days: 0 }).then((project2) => {
+        return this.UserEager.create({ username: 'joe', age: 1 }).then(user => {
+          return self.ProjectEager.create({ title: 'project-joe1', overdue_days: 0 }).then(project1 => {
+            return self.ProjectEager.create({ title: 'project-joe2', overdue_days: 0 }).then(project2 => {
               return user.setProjects([project1, project2]).then(() => {
-                return self.UserEager.findOne({where: {age: 1}, include: [{model: self.ProjectEager, as: 'Projects'}]}).then((user) => {
+                return self.UserEager.findOne({where: {age: 1}, include: [{model: self.ProjectEager, as: 'Projects'}]}).then(user => {
                   expect(user.username).to.equal('joe');
                   expect(user.age).to.equal(1);
                   expect(user.Projects).to.exist;
                   expect(user.Projects.length).to.equal(2);
 
                   user.age = user.age + 1; // happy birthday joe
-                  return user.save().then((user) => {
+                  return user.save().then(user => {
                     expect(user.username).to.equal('joe');
                     expect(user.age).to.equal(2);
                     expect(user.Projects).to.exist;
@@ -1432,15 +1432,15 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       it('saves many objects that each a have collection of eagerly loaded objects', function() {
         const self = this;
-        return this.UserEager.create({ username: 'bart', age: 20 }).then((bart) => {
-          return self.UserEager.create({ username: 'lisa', age: 20 }).then((lisa) => {
-            return self.ProjectEager.create({ title: 'detention1', overdue_days: 0 }).then((detention1) => {
-              return self.ProjectEager.create({ title: 'detention2', overdue_days: 0 }).then((detention2) => {
-                return self.ProjectEager.create({ title: 'exam1', overdue_days: 0 }).then((exam1) => {
-                  return self.ProjectEager.create({ title: 'exam2', overdue_days: 0 }).then((exam2) => {
+        return this.UserEager.create({ username: 'bart', age: 20 }).then(bart => {
+          return self.UserEager.create({ username: 'lisa', age: 20 }).then(lisa => {
+            return self.ProjectEager.create({ title: 'detention1', overdue_days: 0 }).then(detention1 => {
+              return self.ProjectEager.create({ title: 'detention2', overdue_days: 0 }).then(detention2 => {
+                return self.ProjectEager.create({ title: 'exam1', overdue_days: 0 }).then(exam1 => {
+                  return self.ProjectEager.create({ title: 'exam2', overdue_days: 0 }).then(exam2 => {
                     return bart.setProjects([detention1, detention2]).then(() => {
                       return lisa.setProjects([exam1, exam2]).then(() => {
-                        return self.UserEager.findAll({where: {age: 20}, order: [['username', 'ASC']], include: [{model: self.ProjectEager, as: 'Projects'}]}).then((simpsons) => {
+                        return self.UserEager.findAll({where: {age: 20}, order: [['username', 'ASC']], include: [{model: self.ProjectEager, as: 'Projects'}]}).then(simpsons => {
                           expect(simpsons.length).to.equal(2);
 
                           const _bart = simpsons[0];
@@ -1453,13 +1453,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
                           _bart.age = _bart.age + 1; // happy birthday bart - off to Moe's
 
-                          return _bart.save().then((savedbart) => {
+                          return _bart.save().then(savedbart => {
                             expect(savedbart.username).to.equal('bart');
                             expect(savedbart.age).to.equal(21);
 
                             _lisa.username = 'lsimpson';
 
-                            return _lisa.save().then((savedlisa) => {
+                            return _lisa.save().then(savedlisa => {
                               expect(savedlisa.username).to.equal('lsimpson');
                               expect(savedlisa.age).to.equal(20);
                             });
@@ -1477,11 +1477,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       it('saves many objects that each has one eagerly loaded object (to which they belong)', function() {
         const self = this;
-        return this.UserEager.create({ username: 'poobah', age: 18 }).then((user) => {
-          return self.ProjectEager.create({ title: 'homework', overdue_days: 10 }).then((homework) => {
-            return self.ProjectEager.create({ title: 'party', overdue_days: 2 }).then((party) => {
+        return this.UserEager.create({ username: 'poobah', age: 18 }).then(user => {
+          return self.ProjectEager.create({ title: 'homework', overdue_days: 10 }).then(homework => {
+            return self.ProjectEager.create({ title: 'party', overdue_days: 2 }).then(party => {
               return user.setProjects([homework, party]).then(() => {
-                return self.ProjectEager.findAll({include: [{model: self.UserEager, as: 'Poobah'}]}).then((projects) => {
+                return self.ProjectEager.findAll({include: [{model: self.UserEager, as: 'Poobah'}]}).then(projects => {
                   expect(projects.length).to.equal(2);
                   expect(projects[0].Poobah).to.exist;
                   expect(projects[1].Poobah).to.exist;
@@ -1495,7 +1495,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
                   return projects[0].save().then(() => {
                     return projects[1].save().then(() => {
-                      return self.ProjectEager.findAll({where: {title: 'partymore', overdue_days: 0}, include: [{model: self.UserEager, as: 'Poobah'}]}).then((savedprojects) => {
+                      return self.ProjectEager.findAll({where: {title: 'partymore', overdue_days: 0}, include: [{model: self.UserEager, as: 'Poobah'}]}).then(savedprojects => {
                         expect(savedprojects.length).to.equal(2);
                         expect(savedprojects[0].Poobah).to.exist;
                         expect(savedprojects[1].Poobah).to.exist;
@@ -1532,7 +1532,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       return this.User.sync({ force: true }).then(() => {
         return self.Project.sync({ force: true }).then(() => {
           return self.User.create({ username: 'fnord', age: 1, isAdmin: true })
-            .then((user) => {
+            .then(user => {
               udo = user;
             });
         });
@@ -1543,7 +1543,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       // @thanpolas rethink this test, it doesn't make sense, a relation has
       // to be created first in the beforeEach().
       return this.User.findOne({id: udo.id})
-        .then((user) => {
+        .then(user => {
           user.NiceProjectId = 1;
           expect(user.NiceProjectId).to.equal(1);
         });
@@ -1572,7 +1572,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it("dont return instance that isn't defined", function() {
       const self = this;
       return self.Project.create({ lovelyUserId: null })
-        .then((project) => {
+        .then(project => {
           return self.Project.findOne({
             where: {
               id: project.id
@@ -1582,7 +1582,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             ]
           });
         })
-        .then((project) => {
+        .then(project => {
           const json = project.toJSON();
           expect(json.LovelyUser).to.be.equal(null);
         });
@@ -1591,7 +1591,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it("dont return instances that aren't defined", function() {
       const self = this;
       return self.User.create({ username: 'cuss' })
-        .then((user) => {
+        .then(user => {
           return self.User.findOne({
             where: {
               id: user.id
@@ -1601,7 +1601,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             ]
           });
         })
-        .then((user) => {
+        .then(user => {
           expect(user.Projects).to.be.instanceof(Array);
           expect(user.Projects).to.be.length(0);
         });
@@ -1624,16 +1624,16 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('includes the eagerly loaded associations', function() {
       const self = this;
-      return this.User.create({ username: 'fnord', age: 1, isAdmin: true }).then((user) => {
-        return self.Project.create({ title: 'fnord' }).then((project) => {
+      return this.User.create({ username: 'fnord', age: 1, isAdmin: true }).then(user => {
+        return self.Project.create({ title: 'fnord' }).then(project => {
           return user.setProjects([project]).then(() => {
-            return self.User.findAll({include: [{ model: self.Project, as: 'Projects' }]}).then((users) => {
+            return self.User.findAll({include: [{ model: self.Project, as: 'Projects' }]}).then(users => {
               const _user = users[0];
 
               expect(_user.Projects).to.exist;
               expect(JSON.parse(JSON.stringify(_user)).Projects).to.exist;
 
-              return self.Project.findAll({include: [{ model: self.User, as: 'LovelyUser' }]}).then((projects) => {
+              return self.Project.findAll({include: [{ model: self.User, as: 'LovelyUser' }]}).then(projects => {
                 const _project = projects[0];
 
                 expect(_project.LovelyUser).to.exist;
@@ -1662,14 +1662,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         .then(() => {
           return self.ParanoidUser.findAll();
         })
-        .then((users) => {
+        .then(users => {
           expect(users).to.have.length(1);
           return users[0].destroy();
         })
         .then(() => {
           return self.ParanoidUser.findAll();
         })
-        .then((users) => {
+        .then(users => {
           expect(users).to.have.length(0);
         });
     });
@@ -1684,7 +1684,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             })
           });
         })
-        .then((users) => {
+        .then(users => {
           expect(users).to.have.length(1);
           return users[0].destroy();
         })
@@ -1695,7 +1695,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             })
           });
         })
-        .then((users) => {
+        .then(users => {
           expect(users).to.have.length(0);
         });
     });
@@ -1710,7 +1710,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             })
           });
         })
-        .then((users) => {
+        .then(users => {
           expect(users).to.have.length(1);
           return users[0].destroy();
         })
@@ -1721,7 +1721,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             })
           });
         })
-        .then((users) => {
+        .then(users => {
           expect(users).to.have.length(0);
         });
     });
@@ -1733,7 +1733,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         .then(() => {
           return self.User.findAll({
             where: { username: "user'name" }
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].username).to.equal("user'name");
           });
@@ -1747,7 +1747,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         .then(() => {
           return self.User.findAll({
             where: { username: "user''name" }
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].username).to.equal("user''name");
           });
@@ -1757,7 +1757,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('returns the timestamps if no attributes have been specified', function() {
       const self = this;
       return this.User.create({ username: 'fnord' }).then(() => {
-        return self.User.findAll().then((users) => {
+        return self.User.findAll().then(users => {
           expect(users[0].createdAt).to.exist;
         });
       });
@@ -1766,7 +1766,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('does not return the timestamps if the username attribute has been specified', function() {
       const self = this;
       return this.User.create({ username: 'fnord' }).then(() => {
-        return self.User.findAll({ attributes: ['username'] }).then((users) => {
+        return self.User.findAll({ attributes: ['username'] }).then(users => {
           expect(users[0].createdAt).not.to.exist;
           expect(users[0].username).to.exist;
         });
@@ -1776,7 +1776,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('creates the deletedAt property, when defining paranoid as true', function() {
       const self = this;
       return this.ParanoidUser.create({ username: 'fnord' }).then(() => {
-        return self.ParanoidUser.findAll().then((users) => {
+        return self.ParanoidUser.findAll().then(users => {
           expect(users[0].deletedAt).to.be.null;
         });
       });
@@ -1793,7 +1793,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return UserDestroy.sync().then(() => {
         return UserDestroy.create({newId: '123ABC', email: 'hello'}).then(() => {
-          return UserDestroy.findOne({where: {email: 'hello'}}).then((user) => {
+          return UserDestroy.findOne({where: {email: 'hello'}}).then(user => {
             return user.destroy();
           });
         });
@@ -1803,11 +1803,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('sets deletedAt property to a specific date when deleting an instance', function() {
       const self = this;
       return this.ParanoidUser.create({ username: 'fnord' }).then(() => {
-        return self.ParanoidUser.findAll().then((users) => {
+        return self.ParanoidUser.findAll().then(users => {
           return users[0].destroy().then(() => {
             expect(users[0].deletedAt.getMonth).to.exist;
 
-            return users[0].reload({ paranoid: false }).then((user) => {
+            return users[0].reload({ paranoid: false }).then(user => {
               expect(user.deletedAt.getMonth).to.exist;
             });
           });
@@ -1818,8 +1818,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('keeps the deletedAt-attribute with value null, when running updateAttributes', function() {
       const self = this;
       return this.ParanoidUser.create({ username: 'fnord' }).then(() => {
-        return self.ParanoidUser.findAll().then((users) => {
-          return users[0].updateAttributes({username: 'newFnord'}).then((user) => {
+        return self.ParanoidUser.findAll().then(users => {
+          return users[0].updateAttributes({username: 'newFnord'}).then(user => {
             expect(user.deletedAt).not.to.exist;
           });
         });
@@ -1829,9 +1829,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('keeps the deletedAt-attribute with value null, when updating associations', function() {
       const self = this;
       return this.ParanoidUser.create({ username: 'fnord' }).then(() => {
-        return self.ParanoidUser.findAll().then((users) => {
-          return self.ParanoidUser.create({ username: 'linkedFnord' }).then((linkedUser) => {
-            return users[0].setParanoidUser(linkedUser).then((user) => {
+        return self.ParanoidUser.findAll().then(users => {
+          return self.ParanoidUser.create({ username: 'linkedFnord' }).then(linkedUser => {
+            return users[0].setParanoidUser(linkedUser).then(user => {
               expect(user.deletedAt).not.to.exist;
             });
           });
@@ -1843,9 +1843,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       const self = this;
       return this.User.create({ username: 'fnord' }).then(() => {
         const query = { where: { username: 'fnord' }};
-        return self.User.findAll(query).then((users) => {
+        return self.User.findAll(query).then(users => {
           expect(users[0].username).to.equal('fnord');
-          return self.User.findAll(query).then((users) => {
+          return self.User.findAll(query).then(users => {
             expect(users[0].username).to.equal('fnord');
           });
         });
@@ -1858,9 +1858,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       const self = this;
       return this.User.create({ username: 'fnord' }).then(() => {
         const query = { where: { username: 'fnord' }};
-        return self.User.findOne(query).then((user) => {
+        return self.User.findOne(query).then(user => {
           expect(user.username).to.equal('fnord');
-          return self.User.findOne(query).then((user) => {
+          return self.User.findOne(query).then(user => {
             expect(user.username).to.equal('fnord');
           });
         });
@@ -1876,7 +1876,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return Setting.sync({ force: true }).then(() => {
         return Setting.create({ setting_key: 'test', bool_value: null, bool_value2: undefined }).then(() => {
-          return Setting.findOne({ where: { setting_key: 'test' } }).then((setting) => {
+          return Setting.findOne({ where: { setting_key: 'test' } }).then(setting => {
             expect(setting.bool_value).to.equal(null);
             expect(setting.bool_value2).to.equal(null);
             expect(setting.bool_value3).to.equal(null);
@@ -1889,8 +1889,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
   describe('equals', () => {
     it('can compare records with Date field', function() {
       const self = this;
-      return this.User.create({ username: 'fnord' }).then((user1) => {
-        return self.User.findOne({ where: { username: 'fnord' }}).then((user2) => {
+      return this.User.create({ username: 'fnord' }).then(user1 => {
+        return self.User.findOne({ where: { username: 'fnord' }}).then(user2 => {
           expect(user1.equals(user2)).to.be.true;
         });
       });
@@ -1914,11 +1914,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return this.UserAssociationEqual.sync({force: true}).then(() => {
         return self.ProjectAssociationEqual.sync({force: true}).then(() => {
-          return self.UserAssociationEqual.create({ username: 'jimhalpert' }).then((user1) => {
-            return self.ProjectAssociationEqual.create({ title: 'A Cool Project'}).then((project1) => {
+          return self.UserAssociationEqual.create({ username: 'jimhalpert' }).then(user1 => {
+            return self.ProjectAssociationEqual.create({ title: 'A Cool Project'}).then(project1 => {
               return user1.setProjects([project1]).then(() => {
-                return self.UserAssociationEqual.findOne({ where: { username: 'jimhalpert' }, include: [{model: self.ProjectAssociationEqual, as: 'Projects'}] }).then((user2) => {
-                  return self.UserAssociationEqual.create({ username: 'pambeesly' }).then((user3) => {
+                return self.UserAssociationEqual.findOne({ where: { username: 'jimhalpert' }, include: [{model: self.ProjectAssociationEqual, as: 'Projects'}] }).then(user2 => {
+                  return self.UserAssociationEqual.create({ username: 'pambeesly' }).then(user3 => {
                     expect(user1.get('Projects')).to.not.exist;
                     expect(user2.get('Projects')).to.exist;
                     expect(user1.equals(user2)).to.be.true;
@@ -1951,15 +1951,15 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
   describe('destroy', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return sequelize.transaction().then((t) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return sequelize.transaction().then(t => {
                 return user.destroy({ transaction: t }).then(() => {
-                  return User.count().then((count1) => {
-                    return User.count({ transaction: t }).then((count2) => {
+                  return User.count().then(count1 => {
+                    return User.count({ transaction: t }).then(count2 => {
                       expect(count1).to.equal(1);
                       expect(count2).to.equal(0);
                       return t.rollback();
@@ -1980,7 +1980,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       }, { paranoid: true });
 
       return UserDestroy.sync({ force: true }).then(() => {
-        return UserDestroy.create({name: 'hallo', bio: 'welt'}).then((user) => {
+        return UserDestroy.create({name: 'hallo', bio: 'welt'}).then(user => {
           return user.destroy().then(() => {
             return user.reload({ paranoid: false }).then(() => {
               const deletedAt = user.deletedAt;
@@ -2003,11 +2003,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       return UserDestroy.sync({ force: true }).then(() => {
-        return UserDestroy.create({name: 'hallo', bio: 'welt'}).then((u) => {
-          return UserDestroy.findAll().then((users) => {
+        return UserDestroy.create({name: 'hallo', bio: 'welt'}).then(u => {
+          return UserDestroy.findAll().then(users => {
             expect(users.length).to.equal(1);
             return u.destroy().then(() => {
-              return UserDestroy.findAll().then((users) => {
+              return UserDestroy.findAll().then(users => {
                 expect(users.length).to.equal(0);
               });
             });
@@ -2023,8 +2023,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       return UserDelete.sync({ force: true }).then(() => {
-        return UserDelete.create({name: 'hallo', bio: 'welt'}).then((u) => {
-          return UserDelete.findAll().then((users) => {
+        return UserDelete.create({name: 'hallo', bio: 'welt'}).then(u => {
+          return UserDelete.findAll().then(users => {
             expect(users.length).to.equal(1);
             return u.destroy({
               logging(sql) {
@@ -2052,8 +2052,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
       return MultiPrimary.sync({ force: true }).then(() => {
         return MultiPrimary.create({ bilibili: 'bl', guruguru: 'gu' }).then(() => {
-          return MultiPrimary.create({ bilibili: 'bl', guruguru: 'ru' }).then((m2) => {
-            return MultiPrimary.findAll().then((ms) => {
+          return MultiPrimary.create({ bilibili: 'bl', guruguru: 'ru' }).then(m2 => {
+            return MultiPrimary.findAll().then(ms => {
               expect(ms.length).to.equal(2);
               return m2.destroy({
                 logging(sql) {
@@ -2063,7 +2063,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
                   expect(sql.indexOf('bl')).to.be.above(-1);
                 }
               }).then(() => {
-                return MultiPrimary.findAll().then((ms) => {
+                return MultiPrimary.findAll().then(ms => {
                   expect(ms.length).to.equal(1);
                   expect(ms[0].bilibili).to.equal('bl');
                   expect(ms[0].guruguru).to.equal('gu');
@@ -2078,7 +2078,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
   describe('restore', () => {
     it('returns an error if the model is not paranoid', function() {
-      return this.User.create({username: 'Peter', secretValue: '42'}).then((user) => {
+      return this.User.create({username: 'Peter', secretValue: '42'}).then(user => {
         expect(() => {user.restore();}).to.throw(Error, 'Model is not paranoid');
       });
     });
@@ -2101,13 +2101,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         return ParanoidUser.bulkCreate(data);
       }).then(() => {
         return ParanoidUser.findOne({where: {secretValue: '42'}});
-      }).then((user) => {
+      }).then(user => {
         return user.destroy().then(() => {
           return user.restore();
         });
       }).then(() => {
         return ParanoidUser.findOne({where: {secretValue: '42'}});
-      }).then((user) => {
+      }).then(user => {
         expect(user).to.be.ok;
         expect(user.username).to.equal('Peter');
       });

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -23,11 +23,11 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       });
 
       return User.sync({ force: true }).then(() => {
-        return User.create({ username: 'bob', email: 'hello@world.com' }).then((user) => {
+        return User.create({ username: 'bob', email: 'hello@world.com' }).then(user => {
           return User
             .update({ username: 'toni' }, { where: {id: user.id }})
             .then(() => {
-              return User.findById(1).then((user) => {
+              return User.findById(1).then(user => {
                 expect(user.username).to.equal('toni');
               });
             });
@@ -47,8 +47,8 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       });
 
       return Model.sync({ force: true }).then(() => {
-        return Model.create({name: 'World'}).then((model) => {
-          return model.updateAttributes({name: ''}).catch((err) => {
+        return Model.create({name: 'World'}).then(model => {
+          return model.updateAttributes({name: ''}).catch(err => {
             expect(err).to.be.an.instanceOf(Error);
             expect(err.get('name')[0].message).to.equal('Validation notEmpty on name failed');
           });
@@ -69,7 +69,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
       return Model.sync({ force: true }).then(() => {
         return Model.create({name: 'World'}).then(() => {
-          return Model.update({name: ''}, {where: {id: 1}}).catch((err) => {
+          return Model.update({name: ''}, {where: {id: 1}}).catch(err => {
             expect(err).to.be.an.instanceOf(Error);
             expect(err.get('name')[0].message).to.equal('Validation notEmpty on name failed');
           });
@@ -88,13 +88,13 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       return Model.sync({ force: true })
         .then(() => {
           return Model.create(records[0]);
-        }).then((instance) => {
+        }).then(instance => {
           expect(instance).to.be.ok;
           return Model.create(records[1]);
-        }).then((instance) => {
+        }).then(instance => {
           expect(instance).to.be.ok;
           return expect(Model.update(records[0], { where: { id: instance.id } })).to.be.rejected;
-        }).then((err) => {
+        }).then(err => {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.errors).to.have.length(1);
           expect(err.errors[0].path).to.include('uniqueName');
@@ -116,13 +116,13 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       return Model.sync({ force: true })
         .then(() => {
           return Model.create(records[0]);
-        }).then((instance) => {
+        }).then(instance => {
           expect(instance).to.be.ok;
           return Model.create(records[1]);
-        }).then((instance) => {
+        }).then(instance => {
           expect(instance).to.be.ok;
           return expect(Model.update(records[0], { where: { id: instance.id } })).to.be.rejected;
-        }).then((err) => {
+        }).then(err => {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.errors).to.have.length(1);
           expect(err.errors[0].path).to.include('uniqueName');
@@ -149,17 +149,17 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       return Model.sync({ force: true })
         .then(() => {
           return Model.create(records[0]);
-        }).then((instance) => {
+        }).then(instance => {
           expect(instance).to.be.ok;
           return expect(Model.create(records[1])).to.be.rejected;
-        }).then((err) => {
+        }).then(err => {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.errors).to.have.length(1);
           expect(err.errors[0].path).to.include('uniqueName1');
           expect(err.errors[0].message).to.equal('custom unique error message 1');
 
           return expect(Model.create(records[2])).to.be.rejected;
-        }).then((err) => {
+        }).then(err => {
           expect(err).to.be.an.instanceOf(Error);
           expect(err.errors).to.have.length(1);
           expect(err.errors[0].path).to.include('uniqueName2');
@@ -198,18 +198,18 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       });
 
       it('correctly throws an error using create method ', function() {
-        return this.Project.create({name: 'nope'}).catch((err) => {
+        return this.Project.create({name: 'nope'}).catch(err => {
           expect(err).to.have.ownProperty('name');
         });
       });
 
       it('correctly validates using create method ', function() {
         const self = this;
-        return this.Project.create({}).then((project) => {
-          return self.Task.create({something: 1}).then((task) => {
-            return project.setTask(task).then((task) => {
+        return this.Project.create({}).then(project => {
+          return self.Task.create({something: 1}).then(task => {
+            return project.setTask(task).then(task => {
               expect(task.ProjectId).to.not.be.null;
-              return task.setProject(project).then((project) => {
+              return task.setProject(project).then(project => {
                 expect(project.ProjectId).to.not.be.null;
               });
             });
@@ -232,7 +232,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         });
 
         return User.sync({ force: true }).then(() => {
-          return User.create({id: 'helloworld'}).catch((err) => {
+          return User.create({id: 'helloworld'}).catch(err => {
             expect(err).to.be.an.instanceOf(Error);
             expect(err.get('id')[0].message).to.equal('Validation isInt on id failed');
           });
@@ -252,7 +252,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         });
 
         return User.sync({ force: true }).then(() => {
-          return User.create({username: 'helloworldhelloworld'}).catch((err) => {
+          return User.create({username: 'helloworldhelloworld'}).catch(err => {
             expect(err).to.be.an.instanceOf(Error);
             expect(err.get('username')[0].message).to.equal('Username must be an integer!');
           });
@@ -276,7 +276,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         });
 
         it('should emit an error when we try to enter in a string for the id key with validation arguments', function() {
-          return this.User.create({id: 'helloworld'}).catch((err) => {
+          return this.User.create({id: 'helloworld'}).catch(err => {
             expect(err).to.be.an.instanceOf(Error);
             expect(err.get('id')[0].message).to.equal('ID must be an integer!');
           });
@@ -285,14 +285,14 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         it('should emit an error when we try to enter in a string for an auto increment key through .build().validate()', function() {
           const user = this.User.build({id: 'helloworld'});
 
-          return expect(user.validate()).to.be.rejected.then((err) => {
+          return expect(user.validate()).to.be.rejected.then(err => {
             expect(err.get('id')[0].message).to.equal('ID must be an integer!');
           });
         });
 
         it('should emit an error when we try to .save()', function() {
           const user = this.User.build({id: 'helloworld'});
-          return user.save().catch((err) => {
+          return user.save().catch(err => {
             expect(err).to.be.an.instanceOf(Error);
             expect(err.get('id')[0].message).to.equal('ID must be an integer!');
           });
@@ -337,7 +337,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       });
 
       it('produce 3 errors', function() {
-        return this.Project.create({}).catch((err) => {
+        return this.Project.create({}).catch(err => {
           expect(err).to.be.an.instanceOf(Error);
           delete err.stack; // longStackTraces
           expect(err.errors).to.have.length(3);
@@ -364,7 +364,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     const failingUser = User.build({ name: '3' });
 
-    return expect(failingUser.validate()).to.be.rejected.then((error) => {
+    return expect(failingUser.validate()).to.be.rejected.then(error => {
       expect(error).to.be.an.instanceOf(Error);
       expect(error.get('name')[0].message).to.equal("name should equal '2'");
 
@@ -392,7 +392,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       });
 
     return User.sync().then(() => {
-      return expect(User.build({ name: 'error' }).validate()).to.be.rejected.then((error) => {
+      return expect(User.build({ name: 'error' }).validate()).to.be.rejected.then(error => {
         expect(error).to.be.instanceof(self.sequelize.ValidationError);
         expect(error.get('name')[0].message).to.equal('Invalid username');
 
@@ -416,7 +416,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       .build({ age: -1 })
       .validate())
       .to.be.rejected
-      .then((error) => {
+      .then(error => {
         expect(error.get('age')[0].message).to.equal('must be positive');
       });
   });
@@ -445,7 +445,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       .build({ field1: null, field2: null })
       .validate())
       .to.be.rejected
-      .then((error) => {
+      .then(error => {
         expect(error.get('xnor')[0].message).to.equal('xnor failed');
 
         return expect(Foo
@@ -485,7 +485,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     const failingBar = Bar.build({ field: 'value3' });
 
-    return expect(failingBar.validate()).to.be.rejected.then((errors) => {
+    return expect(failingBar.validate()).to.be.rejected.then(errors => {
       expect(errors.get('field')).to.have.length(1);
       expect(errors.get('field')[0].message).to.equal('Validation isIn on field failed');
     });
@@ -520,10 +520,10 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     });
 
     return User.sync({force: true}).then(() => {
-      return User.create({ name: 'RedCat' }).then((user) => {
+      return User.create({ name: 'RedCat' }).then(user => {
         expect(user.getDataValue('name')).to.equal('RedCat');
         user.setDataValue('name', 'YellowCat');
-        return expect(user.save()).to.be.rejected.then((errors) => {
+        return expect(user.save()).to.be.rejected.then(errors => {
           expect(errors.get('name')[0].message).to.eql('Validation isImmutable on name failed');
         });
       });
@@ -655,7 +655,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       expect(User.build({
         password: 'short',
         salt: '42'
-      }).validate()).to.be.rejected.then((errors) => {
+      }).validate()).to.be.rejected.then(errors => {
         expect(errors.get('password')[0].message).to.equal('Please choose a longer password');
       }),
       expect(User.build({
@@ -666,7 +666,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   });
 
   it('allows me to add custom validation functions to validator.js', function() {
-    this.sequelize.Validator.extend('isExactly7Characters', (val) => {
+    this.sequelize.Validator.extend('isExactly7Characters', val => {
       return val.length === 7;
     });
 
@@ -685,7 +685,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       return expect(User.build({
         name: 'a'
       }).validate()).to.be.rejected;
-    }).then((errors) => {
+    }).then(errors => {
       expect(errors.get('name')[0].message).to.equal('Validation isExactly7Characters on name failed');
     });
   });

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -64,15 +64,15 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return User.create({ username: 'foo' }).then((user) => {
-              return sequelize.transaction().then((t) => {
+            return User.create({ username: 'foo' }).then(user => {
+              return sequelize.transaction().then(t => {
                 return user.update({ username: 'bar' }, { transaction: t }).then(() => {
-                  return User.findAll().then((users1) => {
-                    return User.findAll({ transaction: t }).then((users2) => {
+                  return User.findAll().then(users1 => {
+                    return User.findAll({ transaction: t }).then(users2 => {
                       expect(users1[0].username).to.equal('foo');
                       expect(users2[0].username).to.equal('bar');
                       return t.rollback();
@@ -99,11 +99,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           email: 'email'
         }, {
           fields: ['name', 'email']
-        }).then((user) => {
+        }).then(user => {
           return user.update({bio: 'swag'});
-        }).then((user) => {
+        }).then(user => {
           return user.reload();
-        }).then((user) => {
+        }).then(user => {
           expect(user.get('name')).to.equal('snafu');
           expect(user.get('email')).to.equal('email');
           expect(user.get('bio')).to.equal('swag');
@@ -126,14 +126,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           email: 'email'
         }, {
           fields: ['name', 'email']
-        }).then((user) => {
+        }).then(user => {
           return user.update({
             name: 'snafu',
             email: 'email'
           });
-        }).then((user) => {
+        }).then(user => {
           return user.reload();
-        }).then((user) => {
+        }).then(user => {
           expect(user.get('name')).to.equal('snafu');
           expect(user.get('email')).to.equal('email');
         });
@@ -158,9 +158,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           return User.create({
             name: 'snafu',
             email: 'email'
-          }).then((user) => {
+          }).then(user => {
             return user.reload();
-          }).then((user) => {
+          }).then(user => {
             expect(user.get('name')).to.equal('snafu');
             expect(user.get('email')).to.equal('email');
             const testDate = new Date();
@@ -209,7 +209,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           email: DataTypes.STRING
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'B');
         });
 
@@ -218,14 +218,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'A'
-          }).then((user) => {
+          }).then(user => {
             return user.update({
               name: 'B',
               bio: 'B'
             });
           }).then(() => {
             return User.findOne({});
-          }).then((user) => {
+          }).then(user => {
             expect(user.get('name')).to.equal('B');
             expect(user.get('bio')).to.equal('B');
             expect(user.get('email')).to.equal('B');
@@ -240,7 +240,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           email: DataTypes.STRING
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'C');
         });
 
@@ -249,7 +249,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'A'
-          }).then((user) => {
+          }).then(user => {
             return user.update({
               name: 'B',
               bio: 'B',
@@ -257,7 +257,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             });
           }).then(() => {
             return User.findOne({});
-          }).then((user) => {
+          }).then(user => {
             expect(user.get('name')).to.equal('B');
             expect(user.get('bio')).to.equal('B');
             expect(user.get('email')).to.equal('C');
@@ -277,7 +277,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           }
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'B');
         });
 
@@ -286,12 +286,12 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'valid.email@gmail.com'
-          }).then((user) => {
+          }).then(user => {
             return expect(user.update({
               name: 'B'
             })).to.be.rejectedWith(Sequelize.ValidationError);
           }).then(() => {
-            return User.findOne({}).then((user) => {
+            return User.findOne({}).then(user => {
               expect(user.get('email')).to.equal('valid.email@gmail.com');
             });
           });
@@ -310,7 +310,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           }
         });
 
-        User.beforeUpdate((instance) => {
+        User.beforeUpdate(instance => {
           instance.set('email', 'B');
         });
 
@@ -319,13 +319,13 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
             name: 'A',
             bio: 'A',
             email: 'valid.email@gmail.com'
-          }).then((user) => {
+          }).then(user => {
             return expect(user.update({
               name: 'B',
               email: 'still.valid.email@gmail.com'
             })).to.be.rejectedWith(Sequelize.ValidationError);
           }).then(() => {
-            return User.findOne({}).then((user) => {
+            return User.findOne({}).then(user => {
               expect(user.get('email')).to.equal('valid.email@gmail.com');
             });
           });
@@ -344,14 +344,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         return User.create({
           name: 'snafu',
           email: 'email'
-        }).then((user) => {
+        }).then(user => {
           return user.update({
             bio: 'heyo',
             email: 'heho'
           }, {
             fields: ['bio']
           });
-        }).then((user) => {
+        }).then(user => {
           expect(user.get('name')).to.equal('snafu');
           expect(user.get('email')).to.equal('email');
           expect(user.get('bio')).to.equal('heyo');
@@ -360,17 +360,17 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('updates attributes in the database', function() {
-      return this.User.create({ username: 'user' }).then((user) => {
+      return this.User.create({ username: 'user' }).then(user => {
         expect(user.username).to.equal('user');
-        return user.update({ username: 'person' }).then((user) => {
+        return user.update({ username: 'person' }).then(user => {
           expect(user.username).to.equal('person');
         });
       });
     });
 
     it('ignores unknown attributes', function() {
-      return this.User.create({ username: 'user' }).then((user) => {
-        return user.update({ username: 'person', foo: 'bar'}).then((user) => {
+      return this.User.create({ username: 'user' }).then(user => {
+        return user.update({ username: 'person', foo: 'bar'}).then(user => {
           expect(user.username).to.equal('person');
           expect(user.foo).not.to.exist;
         });
@@ -399,7 +399,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           name: 'foobar',
           createdAt: new Date(2000, 1, 1),
           identifier: 'another identifier'
-        }).then((user) => {
+        }).then(user => {
           expect(new Date(user.createdAt)).to.equalDate(new Date(oldCreatedAt));
           expect(new Date(user.updatedAt)).to.not.equalTime(new Date(oldUpdatedAt));
           expect(user.identifier).to.equal(oldIdentifier);
@@ -417,22 +417,22 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       return Download.sync().then(() => {
         return Download.create({
           startedAt: new Date()
-        }).then((download) => {
+        }).then(download => {
           expect(download.startedAt instanceof Date).to.be.true;
           expect(download.canceledAt).to.not.be.ok;
           expect(download.finishedAt).to.not.be.ok;
 
           return download.update({
             canceledAt: new Date()
-          }).then((download) => {
+          }).then(download => {
             expect(download.startedAt instanceof Date).to.be.true;
             expect(download.canceledAt instanceof Date).to.be.true;
             expect(download.finishedAt).to.not.be.ok;
 
             return Download.findAll({
               where: {finishedAt: null}
-            }).then((downloads) => {
-              downloads.forEach((download) => {
+            }).then(downloads => {
+              downloads.forEach(download => {
                 expect(download.startedAt instanceof Date).to.be.true;
                 expect(download.canceledAt instanceof Date).to.be.true;
                 expect(download.finishedAt).to.not.be.ok;
@@ -446,7 +446,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('should support logging', function() {
       const spy = sinon.spy();
 
-      return this.User.create({}).then((user) => {
+      return this.User.create({}).then(user => {
         return user.update({username: 'yolo'}, {logging: spy}).then(() => {
           expect(spy.called).to.be.ok;
         });

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -117,7 +117,7 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
           }, {timestamps: false});
 
         return User.sync({ force: true }).then(() => {
-          return User.create({}).then((user) => {
+          return User.create({}).then(user => {
             // Create the user first to set the proper default values. PG does not support column references in insert,
             // so we must create a record with the right value for always_false, then reference it in an update
             let now = dialect === 'sqlite' ? self.sequelize.fn('', self.sequelize.fn('datetime', 'now')) : self.sequelize.fn('NOW');
@@ -313,7 +313,7 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
           });
           expect(contact.get('tags')).to.deep.equal(['yes', 'no']);
 
-          return contact.save().then((me) => {
+          return contact.save().then(me => {
             expect(me.get('tags')).to.deep.equal(['yes', 'no']);
           });
         });
@@ -439,7 +439,7 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
         });
 
         return User.sync().then(() => {
-          return User.create({name: 'Jan Meier'}).then((user) => {
+          return User.create({name: 'Jan Meier'}).then(user => {
             expect(user.changed('name')).to.be.false;
             expect(user.changed()).not.to.be.ok;
           });
@@ -485,7 +485,7 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
         });
         let changed;
 
-        User.afterUpdate((instance) => {
+        User.afterUpdate(instance => {
           changed = instance.changed();
           return;
         });
@@ -494,11 +494,11 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
           return User.create({
             name: 'Ford Prefect'
           });
-        }).then((user) => {
+        }).then(user => {
           return user.update({
             name: 'Arthur Dent'
           });
-        }).then((user) => {
+        }).then(user => {
           expect(changed).to.be.ok;
           expect(changed.length).to.be.ok;
           expect(changed.indexOf('name') > -1).to.be.ok;

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -120,15 +120,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       }, { timestamps: true });
 
       return UserTable.sync({ force: true }).then(() => {
-        return UserTable.create({aNumber: 5}).then((user) => {
+        return UserTable.create({aNumber: 5}).then(user => {
           return UserTable.bulkCreate([
             {aNumber: 10},
             {aNumber: 12}
           ]).then(() => {
-            return UserTable.findAll({where: {aNumber: { gte: 10 }}}).then((users) => {
+            return UserTable.findAll({where: {aNumber: { gte: 10 }}}).then(users => {
               expect(moment(user.createdAt).format('YYYY-MM-DD')).to.equal('2012-01-01');
               expect(moment(user.updatedAt).format('YYYY-MM-DD')).to.equal('2012-01-02');
-              users.forEach((u) => {
+              users.forEach(u => {
                 expect(moment(u.createdAt).format('YYYY-MM-DD')).to.equal('2012-01-01');
                 expect(moment(u.updatedAt).format('YYYY-MM-DD')).to.equal('2012-01-02');
               });
@@ -148,8 +148,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       }, { timestamps: true });
 
       return UserTable.sync({ force: true }).then(() => {
-        return UserTable.create().then((user) => {
-          return UserTable.create().then((user2) => {
+        return UserTable.create().then(user => {
+          return UserTable.create().then(user2 => {
             expect(user.aNumber).to.equal(5);
             expect(user2.aNumber).to.equal(5);
             expect(defaultFunction.callCount).to.equal(2);
@@ -170,7 +170,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       return UserTable.sync({force: true}).then(() => {
-        return UserTable.create({aNumber: 4}).then((user) => {
+        return UserTable.create({aNumber: 4}).then(user => {
           expect(user.updatedOn).to.exist;
           expect(user.dateCreated).to.exist;
           return user.destroy().then(() => {
@@ -196,12 +196,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return UpdatingUser.sync({force: true}).then(() => {
         return UpdatingUser.create({
           name: 'heyo'
-        }).then((user) => {
+        }).then(user => {
           expect(user.createdAt).not.to.exist;
           expect(user.false).not.to.exist; //  because, you know we might accidentally add a field named 'false'
 
           user.name = 'heho';
-          return user.save().then((user) => {
+          return user.save().then(user => {
             expect(user.updatedAt).not.to.exist;
             return user.destroy().then(() => {
               return user.reload({ paranoid: false }).then(() => {
@@ -228,7 +228,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
       return Task.sync({force: true}).then(() => {
-        return Task.build().save().then((record) => {
+        return Task.build().save().then(record => {
           expect(record.title).to.be.a('string');
           expect(record.title).to.equal('');
           expect(titleSetter.notCalled).to.be.ok; // The setter method should not be invoked for default values
@@ -246,7 +246,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return UserTable.sync({force: true}).then(() => {
         return UserTable.create({aNumber: 30}).then(() => {
-          return UserTable.count().then((c) => {
+          return UserTable.count().then(c => {
             expect(c).to.equal(1);
           });
         });
@@ -261,7 +261,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         bCol: { type: Sequelize.STRING, unique: 'a_and_b' }
       });
 
-      return User.sync({ force: true, logging: _.after(2, _.once((sql) => {
+      return User.sync({ force: true, logging: _.after(2, _.once(sql => {
         if (dialect === 'mssql') {
           expect(sql).to.match(/CONSTRAINT\s*([`"\[]?user_and_email[`"\]]?)?\s*UNIQUE\s*\([`"\[]?username[`"\]]?, [`"\[]?email[`"\]]?\)/);
           expect(sql).to.match(/CONSTRAINT\s*([`"\[]?a_and_b[`"\]]?)?\s*UNIQUE\s*\([`"\[]?aCol[`"\]]?, [`"\[]?bCol[`"\]]?\)/);
@@ -277,7 +277,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         userName: { type: Sequelize.STRING, unique: 'user_name_unique', field: 'user_name' }
       });
       return User.sync({ force: true }).bind(this).then(function() {
-        return this.sequelize.queryInterface.showIndex(User.tableName).then((indexes) => {
+        return this.sequelize.queryInterface.showIndex(User.tableName).then(indexes => {
           let idxUnique;
           if (dialect === 'sqlite') {
             expect(indexes).to.have.length(1);
@@ -321,7 +321,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return self.sequelize.Promise.all([
           User.create({username: 'tobi', email: 'tobi@tobi.me'}),
           User.create({username: 'tobi', email: 'tobi@tobi.me'})]);
-      }).catch (self.sequelize.UniqueConstraintError, (err) => {
+      }).catch (self.sequelize.UniqueConstraintError, err => {
         expect(err.message).to.equal('User and email must be unique');
       });
     });
@@ -354,7 +354,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return self.sequelize.Promise.all([
           User.create({user_id: 1, email: 'tobi@tobi.me'}),
           User.create({user_id: 1, email: 'tobi@tobi.me'})]);
-      }).catch (self.sequelize.UniqueConstraintError, (err) => {
+      }).catch (self.sequelize.UniqueConstraintError, err => {
         expect(err.message).to.equal('User and email must be unique');
       });
     });
@@ -471,7 +471,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   describe('build', () => {
     it("doesn't create database entries", function() {
       this.User.build({ username: 'John Wayne' });
-      return this.User.findAll().then((users) => {
+      return this.User.findAll().then(users => {
         expect(users).to.have.length(0);
       });
     });
@@ -677,12 +677,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   describe('findOne', () => {
     if (current.dialect.supports.transactions) {
       it('supports the transaction option in the first parameter', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING, foo: Sequelize.STRING });
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
-                return User.findOne({ where: { username: 'foo' }, transaction: t }).then((user) => {
+                return User.findOne({ where: { username: 'foo' }, transaction: t }).then(user => {
                   expect(user).to.not.be.null;
                   return t.rollback();
                 });
@@ -703,7 +703,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         .then(() => {
           return User.findOne({ where: [] });
         })
-        .then((u) => {
+        .then(u => {
           expect(u.username).to.equal('A fancy name');
         });
     });
@@ -713,24 +713,24 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING, foo: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
                 return User.findOrInitialize({
                   where: {username: 'foo'}
-                }).spread((user1) => {
+                }).spread(user1 => {
                   return User.findOrInitialize({
                     where: {username: 'foo'},
                     transaction: t
-                  }).spread((user2) => {
+                  }).spread(user2 => {
                     return User.findOrInitialize({
                       where: {username: 'foo'},
                       defaults: { foo: 'asd' },
                       transaction: t
-                    }).spread((user3) => {
+                    }).spread(user3 => {
                       expect(user1.isNewRecord).to.be.true;
                       expect(user2.isNewRecord).to.be.false;
                       expect(user3.isNewRecord).to.be.false;
@@ -749,7 +749,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('with a single find field', function() {
         const self = this;
 
-        return this.User.create({ username: 'Username' }).then((user) => {
+        return this.User.create({ username: 'Username' }).then(user => {
           return self.User.findOrInitialize({
             where: { username: user.username }
           }).spread((_user, initialized) => {
@@ -763,7 +763,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('with multiple find fields', function() {
         const self = this;
 
-        return this.User.create({ username: 'Username', data: 'data' }).then((user) => {
+        return this.User.create({ username: 'Username', data: 'data' }).then(user => {
           return self.User.findOrInitialize({ where: {
             username: user.username,
             data: user.data
@@ -806,7 +806,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return User.update();
       }).then(() => {
         throw new Error('Update should throw an error if no where clause is given.');
-      }, (err) => {
+      }, err => {
         expect(err).to.be.an.instanceof(Error);
         expect(err.message).to.equal('Missing where attribute in the options parameter passed to update.');
       });
@@ -814,15 +814,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
             return User.create({ username: 'foo' }).then(() => {
-              return sequelize.transaction().then((t) => {
+              return sequelize.transaction().then(t => {
                 return User.update({ username: 'bar' }, {where: {username: 'foo'}, transaction: t }).then(() => {
-                  return User.findAll().then((users1) => {
-                    return User.findAll({ transaction: t }).then((users2) => {
+                  return User.findAll().then(users1 => {
+                    return User.findAll({ transaction: t }).then(users2 => {
                       expect(users1[0].username).to.equal('foo');
                       expect(users2[0].username).to.equal('bar');
                       return t.rollback();
@@ -846,7 +846,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       let test = false;
       return User.sync({ force: true }).then(() => {
-        return User.create({username: 'Peter', secretValue: '42'}).then((user) => {
+        return User.create({username: 'Peter', secretValue: '42'}).then(user => {
           return user.updateAttributes({ secretValue: '43' }, {
             fields: ['secretValue'], logging(sql) {
               test = true;
@@ -872,7 +872,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
       let test = false;
       return User.sync({ force: true }).then(() => {
-        return User.create({ name: 'meg', bio: 'none' }).then((u) => {
+        return User.create({ name: 'meg', bio: 'none' }).then(u => {
           expect(u).to.exist;
           return u.updateAttributes({name: 'brian'}, {
             logging(sql) {
@@ -895,10 +895,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.User.bulkCreate(data).then(() => {
         return self.User.update({username: 'Bill'}, {where: {secretValue: '42'}}).then(() => {
-          return self.User.findAll({order: ['id']}).then((users) => {
+          return self.User.findAll({order: ['id']}).then(users => {
             expect(users.length).to.equal(3);
 
-            users.forEach((user) => {
+            users.forEach(user => {
               if (user.secretValue === '42') {
                 expect(user.username).to.equal('Bill');
               } else {
@@ -917,7 +917,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.User.bulkCreate(data).then(() => {
         return self.User.update({username: 'Bill', secretValue: '43'}, {where: {secretValue: '42'}, fields: ['username']}).then(() => {
-          return self.User.findAll({order: ['id']}).then((users) => {
+          return self.User.findAll({order: ['id']}).then(users => {
             expect(users.length).to.equal(1);
 
             const user = users[0];
@@ -934,7 +934,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         username: 'John'
       }).then(() => {
         return self.User.update({username: self.sequelize.cast('1', dialect === 'mssql' ? 'nvarchar' : 'char')}, {where: {username: 'John'}}).then(() => {
-          return self.User.findAll().then((users) => {
+          return self.User.findAll().then(users => {
             expect(users[0].username).to.equal('1');
           });
         });
@@ -948,7 +948,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         username: 'John'
       }).then(() => {
         return self.User.update({username: self.sequelize.fn('upper', self.sequelize.col('username'))}, {where: {username: 'John'}}).then(() => {
-          return self.User.findAll().then((users) => {
+          return self.User.findAll().then(users => {
             expect(users[0].username).to.equal('JOHN');
           });
         });
@@ -974,7 +974,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       }).then(() => {
         return User.findAll();
-      }).spread((user) => {
+      }).spread(user => {
         expect(user.username).to.equal('kurt');
       });
     });
@@ -1010,7 +1010,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       }).then(() => {
         return User.findAll();
-      }).spread((user) => {
+      }).spread(user => {
         expect(user.illness_pain).to.be.equal(5);
       });
     });
@@ -1045,7 +1045,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       }).then(() => {
         return User.findAll();
-      }).spread((user) => {
+      }).spread(user => {
         expect(user.illness_pain).to.be.equal(10);
       });
     });
@@ -1053,13 +1053,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should properly set data when individualHooks are true', function() {
       const self = this;
 
-      self.User.beforeUpdate((instance) => {
+      self.User.beforeUpdate(instance => {
         instance.set('intVal', 1);
       });
 
-      return self.User.create({ username: 'Peter' }).then((user) => {
+      return self.User.create({ username: 'Peter' }).then(user => {
         return self.User.update({ data: 'test' }, { where: { id: user.id }, individualHooks: true }).then(() => {
-          return self.User.findById(user.id).then((userUpdated) => {
+          return self.User.findById(user.id).then(userUpdated => {
             expect(userUpdated.intVal).to.be.equal(1);
           });
         });
@@ -1101,10 +1101,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Bob', secretValue: '43' }];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.update({username: 'Bill'}, {where: {secretValue: '42'}}).spread((affectedRows) => {
+        return self.User.update({username: 'Bill'}, {where: {secretValue: '42'}}).spread(affectedRows => {
           expect(affectedRows).to.equal(2);
         }).then(() => {
-          return self.User.update({username: 'Bill'}, {where: {secretValue: '44'}}).spread((affectedRows) => {
+          return self.User.update({username: 'Bill'}, {where: {secretValue: '44'}}).spread(affectedRows => {
             expect(affectedRows).to.equal(0);
           });
         });
@@ -1140,7 +1140,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                     { username: 'Peter', secretValue: '42' }];
 
         return this.User.bulkCreate(data).then(() => {
-          return self.User.update({secretValue: '43'}, {where: {username: 'Peter'}, limit: 1}).spread((affectedRows) => {
+          return self.User.update({secretValue: '43'}, {where: {username: 'Peter'}, limit: 1}).spread(affectedRows => {
             expect(affectedRows).to.equal(1);
           });
         });
@@ -1189,7 +1189,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return User.destroy();
       }).then(() => {
         throw new Error('Destroy should throw an error if no where clause is given.');
-      }, (err) => {
+      }, err => {
         expect(err).to.be.an.instanceof(Error);
         expect(err.message).to.equal('Missing where or truncate attribute in the options parameter of model.destroy.');
       });
@@ -1206,28 +1206,28 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return User.bulkCreate(data);
       }).then(() => {
         return User.destroy({ where: {} });
-      }).then((affectedRows) => {
+      }).then(affectedRows => {
         expect(affectedRows).to.equal(2);
         return User.findAll();
-      }).then((users) => {
+      }).then(users => {
         expect(users).to.have.length(0);
       });
     });
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
             return User.create({ username: 'foo' }).then(() => {
-              return sequelize.transaction().then((t) => {
+              return sequelize.transaction().then(t => {
                 return User.destroy({
                   where: {},
                   transaction: t
                 }).then(() => {
-                  return User.count().then((count1) => {
-                    return User.count({ transaction: t }).then((count2) => {
+                  return User.count().then(count1 => {
+                    return User.count({ transaction: t }).then(count2 => {
                       expect(count1).to.equal(1);
                       expect(count2).to.equal(0);
                       return t.rollback();
@@ -1250,7 +1250,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return this.User.bulkCreate(data).then(() => {
         return self.User.destroy({where: {secretValue: '42'}})
           .then(() => {
-            return self.User.findAll({order: ['id']}).then((users) => {
+            return self.User.findAll({order: ['id']}).then(users => {
               expect(users.length).to.equal(1);
               expect(users[0].username).to.equal('Bob');
             });
@@ -1279,7 +1279,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
         });
       }).then(() => {
-        return Log.findAll().then((logs) => {
+        return Log.findAll().then(logs => {
           expect(logs.length).to.equal(0);
         });
       });
@@ -1305,7 +1305,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       }).then(() => {
         return UserProject.findAll();
-      }).then((userProjects) => {
+      }).then(userProjects => {
         expect(userProjects.length).to.equal(0);
       });
     });
@@ -1333,7 +1333,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return ParanoidUser.destroy({where: {secretValue: '42'}});
       }).then(() => {
         return ParanoidUser.findAll({order: ['id']});
-      }).then((users) => {
+      }).then(users => {
         expect(users.length).to.equal(1);
         expect(users[0].username).to.equal('Bob');
 
@@ -1359,7 +1359,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           { username: 'Tobi', secretValue: '42' },
           { username: 'Max', secretValue: '42' }
         ]).then(() => {
-          return User.findById(1).then((user) => {
+          return User.findById(1).then(user => {
             return user.destroy().then(() => {
               return user.reload({ paranoid: false }).then(() => {
                 const deletedAt = user.deletedAt;
@@ -1388,13 +1388,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             {username: 'Tobi'},
             {username: 'Max'}
           ]).then(() => {
-            return User.findById(1).then((user) => {
+            return User.findById(1).then(user => {
               return user.destroy().then(() => {
-                return User.findById(1).then((user) => {
+                return User.findById(1).then(user => {
                   expect(user).to.be.null;
-                  return User.count().then((cnt) => {
+                  return User.count().then(cnt => {
                     expect(cnt).to.equal(2);
-                    return User.findAll().then((users) => {
+                    return User.findAll().then(users => {
                       expect(users).to.have.length(2);
                     });
                   });
@@ -1421,13 +1421,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ]);
           })
           .then(() => { return User.findById(1); })
-          .then((user) => { return user.destroy(); })
+          .then(user => { return user.destroy(); })
           .then(() => { return User.find({ where: 1, paranoid: false }); })
-          .then((user) => {
+          .then(user => {
             expect(user).to.exist;
             return User.findById(1);
           })
-          .then((user) => {
+          .then(user => {
             expect(user).to.be.null;
             return [User.count(), User.count({ paranoid: false })];
           })
@@ -1454,7 +1454,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return User.sync({ force: true })
           .then(() => { return Pet.sync({ force: true }); })
           .then(() => { return User.create({ username: 'Joe' }); })
-          .then((_user) => {
+          .then(_user => {
             user = _user;
             return Pet.bulkCreate([
               { name: 'Fido', UserId: user.id },
@@ -1462,7 +1462,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ]);
           })
           .then(() => { return Pet.findById(1); })
-          .then((pet) => { return pet.destroy(); })
+          .then(pet => { return pet.destroy(); })
           .then(() => {
             return [
               User.find({ where: {id: user.id}, include: Pet }),
@@ -1495,27 +1495,27 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]);
       }).then(() => {
         return User.find({where: {username: 'Bob'}});
-      }).then((user) => {
+      }).then(user => {
         return user.destroy({force: true});
       }).then(() => {
         return expect(User.find({where: {username: 'Bob'}})).to.eventually.be.null;
       }).then(() => {
         return User.find({where: {username: 'Tobi'}});
-      }).then((tobi) => {
+      }).then(tobi => {
         return tobi.destroy();
       }).then(() => {
         return self.sequelize.query('SELECT * FROM paranoidusers WHERE username=\'Tobi\'', { plain: true});
-      }).then((result) => {
+      }).then(result => {
         expect(result.username).to.equal('Tobi');
         return User.destroy({where: {username: 'Tony'}});
       }).then(() => {
         return self.sequelize.query('SELECT * FROM paranoidusers WHERE username=\'Tony\'', { plain: true});
-      }).then((result) => {
+      }).then(result => {
         expect(result.username).to.equal('Tony');
         return User.destroy({where: {username: ['Tony', 'Max']}, force: true});
       }).then(() => {
         return self.sequelize.query('SELECT * FROM paranoidusers', {raw: true});
-      }).spread((users) => {
+      }).spread(users => {
         expect(users).to.have.length(1);
         expect(users[0].username).to.equal('Tobi');
       });
@@ -1528,11 +1528,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Bob', secretValue: '43' }];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.destroy({where: {secretValue: '42'}}).then((affectedRows) => {
+        return self.User.destroy({where: {secretValue: '42'}}).then(affectedRows => {
           expect(affectedRows).to.equal(2);
         });
       }).then(() => {
-        return self.User.destroy({where: {secretValue: '44'}}).then((affectedRows) => {
+        return self.User.destroy({where: {secretValue: '44'}}).then(affectedRows => {
           expect(affectedRows).to.equal(0);
         });
       });
@@ -1549,7 +1549,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return prefixUser.sync({ force: true }).then(() => {
           return prefixUser.bulkCreate(data).then(() => {
             return prefixUser.destroy({where: {secretValue: '42'}}).then(() => {
-              return prefixUser.findAll({order: ['id']}).then((users) => {
+              return prefixUser.findAll({order: ['id']}).then(users => {
                 expect(users.length).to.equal(1);
                 expect(users[0].username).to.equal('Bob');
               });
@@ -1598,7 +1598,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return ParanoidUser.restore({where: {secretValue: '42'}});
       }).then(() => {
         return ParanoidUser.find({where: {secretValue: '42'}});
-      }).then((user) => {
+      }).then(user => {
         expect(user).to.be.ok;
         expect(user.username).to.equal('Peter');
       });
@@ -1607,7 +1607,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
   describe('equals', () => {
     it('correctly determines equality of objects', function() {
-      return this.User.create({username: 'hallo', data: 'welt'}).then((u) => {
+      return this.User.create({username: 'hallo', data: 'welt'}).then(u => {
         expect(u.equals(u)).to.be.ok;
       });
     });
@@ -1623,7 +1623,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return userKeys.sync({ force: true }).then(() => {
-          return userKeys.create({foo: '1', bar: '2', name: 'hallo', bio: 'welt'}).then((u) => {
+          return userKeys.create({foo: '1', bar: '2', name: 'hallo', bio: 'welt'}).then(u => {
             expect(u.equals(u)).to.be.ok;
           });
         });
@@ -1646,13 +1646,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('determines equality if one is matching', function() {
-        return this.userKey.create({foo: '1', bar: '2', name: 'hallo', bio: 'welt'}).then((u) => {
+        return this.userKey.create({foo: '1', bar: '2', name: 'hallo', bio: 'welt'}).then(u => {
           expect(u.equalsOneOf([u, {a: 1}])).to.be.ok;
         });
       });
 
       it("doesn't determine equality if none is matching", function() {
-        return this.userKey.create({foo: '1', bar: '2', name: 'hallo', bio: 'welt'}).then((u) => {
+        return this.userKey.create({foo: '1', bar: '2', name: 'hallo', bio: 'welt'}).then(u => {
           expect(u.equalsOneOf([{b: 2}, {a: 1}])).to.not.be.ok;
         });
       });
@@ -1662,14 +1662,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   describe('count', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
-                return User.count().then((count1) => {
-                  return User.count({ transaction: t }).then((count2) => {
+                return User.count().then(count1 => {
+                  return User.count({ transaction: t }).then(count2 => {
                     expect(count1).to.equal(0);
                     expect(count2).to.equal(1);
                     return t.rollback();
@@ -1685,7 +1685,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('counts all created objects', function() {
       const self = this;
       return this.User.bulkCreate([{username: 'user1'}, {username: 'user2'}]).then(() => {
-        return self.User.count().then((count) => {
+        return self.User.count().then(count => {
           expect(count).to.equal(2);
         });
       });
@@ -1701,7 +1701,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return self.User.count({
           attributes: ['data'],
           group: ['data']
-        }).then((count) => {
+        }).then(count => {
           expect(count.length).to.equal(2);
         });
       });
@@ -1772,7 +1772,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const self = this;
       return this.User.create({username: 'user1'}).then(() => {
         return self.User.create({username: 'foo'}).then(() => {
-          return self.User.count({where: {username: {$like: '%us%'}}}).then((count) => {
+          return self.User.count({where: {username: {$like: '%us%'}}}).then(count => {
             expect(count).to.equal(1);
           });
         });
@@ -1786,7 +1786,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return Post.sync({ force: true })
         .then(() => PostComment.sync({ force: true }))
         .then(() => Post.create({}))
-        .then((post) => PostComment.bulkCreate([{ PostId: post.id }, { PostId: post.id }]))
+        .then(post => PostComment.bulkCreate([{ PostId: post.id }, { PostId: post.id }]))
         .then(() => Promise.join(
             Post.count({ distinct: false, include: [{ model: PostComment, required: false }] }),
             Post.count({ distinct: true, include: [{ model: PostComment, required: false }] }),
@@ -1817,14 +1817,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { age: Sequelize.INTEGER });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.bulkCreate([{ age: 2 }, { age: 5 }, { age: 3 }], { transaction: t }).then(() => {
-                return User.min('age').then((min1) => {
-                  return User.min('age', { transaction: t }).then((min2) => {
+                return User.min('age').then(min1 => {
+                  return User.min('age', { transaction: t }).then(min2 => {
                     expect(min1).to.be.not.ok;
                     expect(min2).to.equal(2);
                     return t.rollback();
@@ -1840,7 +1840,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should return the min value', function() {
       const self = this;
       return this.UserWithAge.bulkCreate([{age: 3}, { age: 2 }]).then(() => {
-        return self.UserWithAge.min('age').then((min) => {
+        return self.UserWithAge.min('age').then(min => {
           expect(min).to.equal(2);
         });
       });
@@ -1862,7 +1862,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow decimals in min', function() {
       const self = this;
       return this.UserWithDec.bulkCreate([{value: 5.5}, {value: 3.5}]).then(() => {
-        return self.UserWithDec.min('value').then((min) => {
+        return self.UserWithDec.min('value').then(min => {
           expect(min).to.equal(3.5);
         });
       });
@@ -1871,7 +1871,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow strings in min', function() {
       const self = this;
       return this.User.bulkCreate([{username: 'bbb'}, {username: 'yyy'}]).then(() => {
-        return self.User.min('username').then((min) => {
+        return self.User.min('username').then(min => {
           expect(min).to.equal('bbb');
         });
       });
@@ -1880,7 +1880,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow dates in min', function() {
       const self = this;
       return this.User.bulkCreate([{theDate: new Date(2000, 1, 1)}, {theDate: new Date(1990, 1, 1)}]).then(() => {
-        return self.User.min('theDate').then((min) => {
+        return self.User.min('theDate').then(min => {
           expect(min).to.be.a('Date');
           expect(new Date(1990, 1, 1)).to.equalDate(min);
         });
@@ -1907,14 +1907,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { age: Sequelize.INTEGER });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.bulkCreate([{ age: 2 }, { age: 5 }, { age: 3 }], { transaction: t }).then(() => {
-                return User.max('age').then((min1) => {
-                  return User.max('age', { transaction: t }).then((min2) => {
+                return User.max('age').then(min1 => {
+                  return User.max('age', { transaction: t }).then(min2 => {
                     expect(min1).to.be.not.ok;
                     expect(min2).to.equal(5);
                     return t.rollback();
@@ -1930,7 +1930,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should return the max value for a field named the same as an SQL reserved keyword', function() {
       const self = this;
       return this.UserWithAge.bulkCreate([{age: 2, order: 3}, {age: 3, order: 5}]).then(() => {
-        return self.UserWithAge.max('order').then((max) => {
+        return self.UserWithAge.max('order').then(max => {
           expect(max).to.equal(5);
         });
       });
@@ -1939,7 +1939,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should return the max value', function() {
       const self = this;
       return self.UserWithAge.bulkCreate([{age: 2}, {age: 3}]).then(() => {
-        return self.UserWithAge.max('age').then((max) => {
+        return self.UserWithAge.max('age').then(max => {
           expect(max).to.equal(3);
         });
       });
@@ -1948,7 +1948,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow decimals in max', function() {
       const self = this;
       return this.UserWithDec.bulkCreate([{value: 3.5}, {value: 5.5}]).then(() => {
-        return self.UserWithDec.max('value').then((max) => {
+        return self.UserWithDec.max('value').then(max => {
           expect(max).to.equal(5.5);
         });
       });
@@ -1960,7 +1960,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         {theDate: new Date(2013, 11, 31)},
         {theDate: new Date(2000, 1, 1)}
       ]).then(() => {
-        return self.User.max('theDate').then((max) => {
+        return self.User.max('theDate').then(max => {
           expect(max).to.be.a('Date');
           expect(max).to.equalDate(new Date(2013, 11, 31));
         });
@@ -1970,7 +1970,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow strings in max', function() {
       const self = this;
       return this.User.bulkCreate([{username: 'aaa'}, {username: 'zzz'}]).then(() => {
-        return self.User.max('username').then((max) => {
+        return self.User.max('username').then(max => {
           expect(max).to.equal('zzz');
         });
       });
@@ -2024,7 +2024,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should return the sum of the values for a field named the same as an SQL reserved keyword', function() {
       const self = this;
       return this.UserWithAge.bulkCreate([{age: 2, order: 3}, {age: 3, order: 5}]).then(() => {
-        return self.UserWithAge.sum('order').then((sum) => {
+        return self.UserWithAge.sum('order').then(sum => {
           expect(sum).to.equal(8);
         });
       });
@@ -2033,7 +2033,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should return the sum of a field in various records', function() {
       const self = this;
       return self.UserWithAge.bulkCreate([{age: 2}, {age: 3}]).then(() => {
-        return self.UserWithAge.sum('age').then((sum) => {
+        return self.UserWithAge.sum('age').then(sum => {
           expect(sum).to.equal(5);
         });
       });
@@ -2042,7 +2042,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow decimals in sum', function() {
       const self = this;
       return this.UserWithDec.bulkCreate([{value: 3.5}, {value: 5.25}]).then(() => {
-        return self.UserWithDec.sum('value').then((sum) => {
+        return self.UserWithDec.sum('value').then(sum => {
           expect(sum).to.equal(8.75);
         });
       });
@@ -2053,7 +2053,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       const self = this;
       return self.UserWithAge.bulkCreate([{age: 2, gender: 'male'}, {age: 3, gender: 'female'}]).then(() => {
-        return self.UserWithAge.sum('age', options).then((sum) => {
+        return self.UserWithAge.sum('age', options).then(sum => {
           expect(sum).to.equal(2);
         });
       });
@@ -2099,7 +2099,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return self.sequelize.dropAllSchemas().then(() => {
         return self.sequelize.createSchema('schema_test').then(() => {
           return self.sequelize.createSchema('special').then(() => {
-            return self.UserSpecial.schema('special').sync({force: true}).then((UserSpecialSync) => {
+            return self.UserSpecial.schema('special').sync({force: true}).then(UserSpecialSync => {
               self.UserSpecialSync = UserSpecialSync;
             });
           });
@@ -2112,7 +2112,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('should be able to list schemas', function() {
-      return this.sequelize.showAllSchemas().then((schemas) => {
+      return this.sequelize.showAllSchemas().then(schemas => {
         expect(schemas).to.be.instanceof(Array);
 
         // FIXME: reenable when schema support is properly added
@@ -2130,8 +2130,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         let test = 0;
         const UserSpecialUnderscore = this.sequelize.define('UserSpecialUnderscore', {age: Sequelize.INTEGER}, {schema: 'hello', schemaDelimiter: '_'});
         const UserSpecialDblUnderscore = this.sequelize.define('UserSpecialDblUnderscore', {age: Sequelize.INTEGER});
-        return UserSpecialUnderscore.sync({force: true}).then((User) => {
-          return UserSpecialDblUnderscore.schema('hello', '__').sync({force: true}).then((DblUser) => {
+        return UserSpecialUnderscore.sync({force: true}).then(User => {
+          return UserSpecialDblUnderscore.schema('hello', '__').sync({force: true}).then(DblUser => {
             return DblUser.create({age: 3}, {
               logging(sql) {
                 expect(sql).to.exist;
@@ -2170,7 +2170,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 count++;
               }
             }
-          }).then((table) => {
+          }).then(table => {
             if (dialect === 'postgres') {
               expect(table.id.defaultValue).to.not.contain('special');
               count++;
@@ -2183,7 +2183,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   count++;
                 }
               }
-            }).then((table) => {
+            }).then(table => {
               if (dialect === 'postgres') {
                 expect(table.id.defaultValue).to.contain('special');
                 count++;
@@ -2213,7 +2213,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       const run = function() {
         return UserPub.sync({ force: true }).then(() => {
-          return ItemPub.sync({ force: true, logging: _.after(2, _.once((sql) => {
+          return ItemPub.sync({ force: true, logging: _.after(2, _.once(sql => {
             if (dialect === 'postgres') {
               expect(sql).to.match(/REFERENCES\s+"prefix"\."UserPubs" \("id"\)/);
             } else if (dialect === 'mssql') {
@@ -2240,7 +2240,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should be able to create and update records under any valid schematic', function() {
       const self = this;
       let logged = 0;
-      return self.UserPublic.sync({ force: true }).then((UserPublicSync) => {
+      return self.UserPublic.sync({ force: true }).then(UserPublicSync => {
         return UserPublicSync.create({age: 3}, {
           logging(UserPublic) {
             logged++;
@@ -2272,7 +2272,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 expect(UserSpecial.indexOf('INSERT INTO `special.UserSpecials`')).to.be.above(-1);
               }
             }
-          }).then((UserSpecial) => {
+          }).then(UserSpecial => {
             return UserSpecial.updateAttributes({age: 5}, {
               logging(user) {
                 logged++;
@@ -2318,7 +2318,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       Post.belongsTo(this.Author);
 
       // The posts table gets dropped in the before filter.
-      return Post.sync({logging: _.once((sql) => {
+      return Post.sync({logging: _.once(sql => {
         if (dialect === 'postgres') {
           expect(sql).to.match(/"authorId" INTEGER REFERENCES "authors" \("id"\)/);
         } else if (dialect === 'mysql') {
@@ -2343,7 +2343,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       Post.belongsTo(this.Author);
 
       // The posts table gets dropped in the before filter.
-      return Post.sync({logging: _.once((sql) => {
+      return Post.sync({logging: _.once(sql => {
         if (dialect === 'postgres') {
           expect(sql).to.match(/"authorId" INTEGER REFERENCES "authors" \("id"\)/);
         } else if (dialect === 'mysql') {
@@ -2377,7 +2377,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         }
 
         return;
-      }).catch ((err) => {
+      }).catch (err => {
         if (dialect === 'mysql') {
           // MySQL 5.7 or above doesn't support POINT EMPTY
           if (dialect === 'mysql' && semver.gte(current.options.databaseVersion, '5.6.0')) {
@@ -2429,7 +2429,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to take a buffer as parameter to a BLOB field', function() {
         return this.BlobUser.create({
           data: new Buffer('Sequelize')
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
         });
       });
@@ -2438,8 +2438,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const self = this;
         return this.BlobUser.create({
           data: new Buffer('Sequelize')
-        }).then((user) => {
-          return self.BlobUser.findById(user.id).then((user) => {
+        }).then(user => {
+          return self.BlobUser.findById(user.id).then(user => {
             expect(user.data).to.be.an.instanceOf(Buffer);
             expect(user.data.toString()).to.have.string('Sequelize');
           });
@@ -2450,8 +2450,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const self = this;
         return this.BlobUser.create({
           // create a null column
-        }).then((user) => {
-          return self.BlobUser.findById(user.id).then((user) => {
+        }).then(user => {
+          return self.BlobUser.findById(user.id).then(user => {
             expect(user.data).to.be.null;
           });
         });
@@ -2468,7 +2468,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should be able to take a string as parameter to a BLOB field', function() {
           return this.BlobUser.create({
             data: 'Sequelize'
-          }).then((user) => {
+          }).then(user => {
             expect(user).to.be.ok;
           });
         });
@@ -2477,8 +2477,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const self = this;
           return this.BlobUser.create({
             data: 'Sequelize'
-          }).then((user) => {
-            return self.BlobUser.findById(user.id).then((user) => {
+          }).then(user => {
+            return self.BlobUser.findById(user.id).then(user => {
               expect(user.data).to.be.an.instanceOf(Buffer);
               expect(user.data.toString()).to.have.string('Sequelize');
             });
@@ -2512,8 +2512,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }, {
             title: 'empire'
           }]).then(() => {
-            return self.User.findAll().then((users) => {
-              return self.Project.findAll().then((projects) => {
+            return self.User.findAll().then(users => {
+              return self.Project.findAll().then(projects => {
                 const leia = users[0],
                   luke = users[1],
                   vader = users[2],
@@ -2540,7 +2540,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           this.sequelize.and({ id: [1, 2, 3] })
         ]
       })
-        .then((res) => {
+        .then(res => {
           expect(res).to.have.length(2);
         });
     });
@@ -2557,7 +2557,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         include: [
           {model: this.Project}
         ]
-      }).then((users) => {
+      }).then(users => {
         expect(users.length).to.be.equal(1);
         expect(users[0].username).to.be.equal('luke');
       });
@@ -2574,7 +2574,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         include: [
           {model: this.Project}
         ]
-      }).then((users) => {
+      }).then(users => {
         expect(users.length).to.be.equal(1);
         expect(users[0].username).to.be.equal('leia');
       });
@@ -2591,7 +2591,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           )
         ]
       })
-        .then((res) => {
+        .then(res => {
           expect(res).to.have.length(2);
         });
     });
@@ -2602,10 +2602,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('supports multiple async transactions', function() {
       this.timeout(90000);
       const self = this;
-      return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+      return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
         const User = sequelize.define('User', { username: Sequelize.STRING });
         const testAsync = function() {
-          return sequelize.transaction().then((t) => {
+          return sequelize.transaction().then(t => {
             return User.create({
               username: 'foo'
             }, {
@@ -2615,7 +2615,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 where: {
                   username: 'foo'
                 }
-              }).then((users) => {
+              }).then(users => {
                 expect(users).to.have.length(0);
               });
             }).then(() => {
@@ -2624,13 +2624,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   username: 'foo'
                 },
                 transaction: t
-              }).then((users) => {
+              }).then(users => {
                 expect(users).to.have.length(1);
               });
             }).then(() => {
               return t;
             });
-          }).then((t) => {
+          }).then(t => {
             return t.rollback();
           });
         };
@@ -2639,7 +2639,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           for (let i = 0; i < 1000; i++) {
             tasks.push(testAsync.bind(this));
           }
-          return self.sequelize.Promise.resolve(tasks).map((entry) => {
+          return self.sequelize.Promise.resolve(tasks).map(entry => {
             return entry();
           }, {
             // Needs to be one less than ??? else the non transaction query won't ever get a connection
@@ -2657,7 +2657,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         str: { type: Sequelize.STRING, unique: true }
       });
 
-      return uniqueTrue.sync({force: true, logging: _.after(2, _.once((s) => {
+      return uniqueTrue.sync({force: true, logging: _.after(2, _.once(s => {
         expect(s).to.match(/UNIQUE/);
       }))});
     });
@@ -2668,7 +2668,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         str: { type: Sequelize.STRING, unique: false }
       });
 
-      return uniqueFalse.sync({force: true, logging: _.after(2, _.once((s) => {
+      return uniqueFalse.sync({force: true, logging: _.after(2, _.once(s => {
         expect(s).not.to.match(/UNIQUE/);
       }))});
     });
@@ -2679,7 +2679,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         str: { type: Sequelize.STRING }
       });
 
-      return uniqueUnset.sync({force: true, logging: _.after(2, _.once((s) => {
+      return uniqueUnset.sync({force: true, logging: _.after(2, _.once(s => {
         expect(s).not.to.match(/UNIQUE/);
       }))});
     });

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -54,7 +54,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return student.addCourse(course, { through: {score: 98, test_value: 1000}});
           }).then(() => {
             expect(self.callCount).to.equal(1);
-            return self.Score.find({ where: { StudentId: 1, CourseId: 100 } }).then((score) => {
+            return self.Score.find({ where: { StudentId: 1, CourseId: 100 } }).then(score => {
               expect(score.test_value).to.equal(1001);
             });
           })

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -174,14 +174,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return this
               .ModelUnderTest
               .describe()
-              .then((fields) => {
+              .then(fields => {
                 expect(fields.identifier).to.include({ allowNull: false });
               });
           });
         });
 
         it('should support instance.destroy()', function() {
-          return this.User.create().then((user) => {
+          return this.User.create().then(user => {
             return user.destroy();
           });
         });
@@ -206,32 +206,32 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('bulkCreate should work', function() {
-          return this.Comment.findAll().then((comments) => {
+          return this.Comment.findAll().then(comments => {
             expect(comments[0].notes).to.equal('Number one');
             expect(comments[1].notes).to.equal('Number two');
           });
         });
 
         it('find with where should work', function() {
-          return this.Comment.findAll({ where: { notes: 'Number one' }}).then((comments) => {
+          return this.Comment.findAll({ where: { notes: 'Number one' }}).then(comments => {
             expect(comments).to.have.length(1);
             expect(comments[0].notes).to.equal('Number one');
           });
         });
 
         it('reload should work', function() {
-          return this.Comment.findById(1).then((comment) => {
+          return this.Comment.findById(1).then(comment => {
             return comment.reload();
           });
         });
 
         it('save should work', function() {
-          return this.Comment.create({ notes: 'my note' }).then((comment) => {
+          return this.Comment.create({ notes: 'my note' }).then(comment => {
             comment.notes = 'new note';
             return comment.save();
-          }).then((comment) => {
+          }).then(comment => {
             return comment.reload();
-          }).then((comment) => {
+          }).then(comment => {
             expect(comment.notes).to.equal('new note');
           });
         });
@@ -275,7 +275,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return self.User.find({
             limit: 1
           });
-        }).then((user) => {
+        }).then(user => {
           expect(user.get('name')).to.equal('Foobar');
           return user.updateAttributes({
             name: 'Barfoo'
@@ -284,7 +284,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return self.User.find({
             limit: 1
           });
-        }).then((user) => {
+        }).then(user => {
           expect(user.get('name')).to.equal('Barfoo');
         });
       });
@@ -306,7 +306,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             where: {
               strField: 'bar'
             }
-          }).then((entity) => {
+          }).then(entity => {
             expect(entity).to.be.ok;
             expect(entity.get('strField')).to.equal('bar');
           });
@@ -336,7 +336,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return Model.sync({force: true}).then(() => {
-          return Model.create({title: 'test'}).then((data) => {
+          return Model.create({title: 'test'}).then(data => {
             expect(data.get('test_title')).to.be.an('undefined');
             expect(data.get('test_id')).to.be.an('undefined');
           });
@@ -346,7 +346,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should make the aliased auto incremented primary key available after create', function() {
         return this.User.create({
           name: 'Barfoo'
-        }).then((user) => {
+        }).then(user => {
           expect(user.get('id')).to.be.ok;
         });
       });
@@ -356,11 +356,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return this.User.create({
           name: 'Barfoo'
-        }).then((user) => {
+        }).then(user => {
           return user.createTask({
             title: 'DatDo'
           });
-        }).then((task) => {
+        }).then(task => {
           return task.createComment({
             text: 'Comment'
           });
@@ -372,7 +372,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ],
             where: {title: 'DatDo'}
           });
-        }).then((task) => {
+        }).then(task => {
           expect(task.get('title')).to.equal('DatDo');
           expect(task.get('comments')[0].get('text')).to.equal('Comment');
           expect(task.get('user')).to.be.ok;
@@ -384,11 +384,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return this.User.create({
           name: 'Foobar'
-        }).then((user) => {
+        }).then(user => {
           return user.createTask({
             title: 'DoDat'
           });
-        }).then((task) => {
+        }).then(task => {
           return task.createComment({
             text: 'Comment'
           });
@@ -400,8 +400,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               ]}
             ]
           });
-        }).then((users) => {
-          users.forEach((user) => {
+        }).then(users => {
+          users.forEach(user => {
             expect(user.get('name')).to.be.ok;
             expect(user.get('tasks')[0].get('title')).to.equal('DoDat');
             expect(user.get('tasks')[0].get('comments')).to.be.ok;
@@ -410,7 +410,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should work with increment', function() {
-        return this.User.create().then((user) => {
+        return this.User.create().then(user => {
           return user.increment('taskCount');
         });
       });
@@ -426,7 +426,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               name: 'Foobar'
             }
           });
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
         });
       });
@@ -444,7 +444,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               name: 'Lollerskates'
             })
           });
-        }).then((user) => {
+        }).then(user => {
           expect(user).to.be.ok;
         });
       });
@@ -459,8 +459,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           name: 'Cde'
         }]).then(() => {
           return self.User.findAll();
-        }).then((users) => {
-          users.forEach((user) => {
+        }).then(users => {
+          users.forEach(user => {
             expect(['Abc', 'Bcd', 'Cde'].indexOf(user.get('name')) !== -1).to.be.true;
           });
         });
@@ -491,7 +491,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             attributes: findAttributes
           });
 
-        }).then((tests) => {
+        }).then(tests => {
           expect(tests[0].get('someProperty')).to.be.ok;
           expect(tests[0].get('someProperty2')).to.be.ok;
         });
@@ -511,7 +511,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         .then(() => {
           return this.User.find({ where: { name: 'test user' } });
         })
-        .then((user) => {
+        .then(user => {
           expect(user.name).to.equal('test user');
         });
       });
@@ -525,7 +525,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return self.Comment.find({
             limit: 1
           });
-        }).then((comment) => {
+        }).then(comment => {
           expect(comment.get('notes')).to.equal('Foobar');
           return comment.updateAttributes({
             notes: 'Barfoo'
@@ -534,7 +534,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return self.Comment.find({
             limit: 1
           });
-        }).then((comment) => {
+        }).then(comment => {
           expect(comment.get('notes')).to.equal('Barfoo');
         });
       });
@@ -573,14 +573,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           .then(() => {
             return User.create();
           })
-          .then((user) => {
+          .then(user => {
             return user.destroy();
           })
           .then(function() {
             this.clock.tick(1000);
             return User.findAll();
           })
-          .then((users) => {
+          .then(users => {
             expect(users.length).to.equal(0);
           });
       });
@@ -597,10 +597,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return User.sync({force: true}).then(() => {
-          return User.create().then((user) => {
+          return User.create().then(user => {
             return User.destroy({where: {id: user.get('id')}});
           }).then(() => {
-            return User.findAll().then((users) => {
+            return User.findAll().then(users => {
               expect(users.length).to.equal(0);
             });
           });

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -61,7 +61,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('should be ignored in table creation', function() {
-          return this.sequelize.getQueryInterface().describeTable(this.User.tableName).then((fields) => {
+          return this.sequelize.getQueryInterface().describeTable(this.User.tableName).then(fields => {
             expect(Object.keys(fields).length).to.equal(2);
           });
         });
@@ -106,7 +106,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
 
             return Post.find({ attributes: ['id', 'text', Sequelize.literal(boolQuery)] });
-          }).then((post) => {
+          }).then(post => {
             expect(post.get('someBoolean')).to.be.ok;
             expect(post.get().someBoolean).to.be.ok;
           });
@@ -115,7 +115,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should be ignored in create and updateAttributes', function() {
           return this.User.create({
             field1: 'something'
-          }).then((user) => {
+          }).then(user => {
             // We already verified that the virtual is not added to the table definition, so if this succeeds, were good
 
             expect(user.virtualWithDefault).to.equal('cake');
@@ -125,7 +125,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }, {
               fields: ['storage']
             });
-          }).then((user) => {
+          }).then(user => {
             expect(user.virtualWithDefault).to.equal('cake');
             expect(user.storage).to.equal('something else');
           });
@@ -139,7 +139,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             logging: this.sqlAssert
           }).then(() => {
             return self.User.findAll();
-          }).then((users) => {
+          }).then(users => {
             expect(users[0].storage).to.equal('something');
           });
         });

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -29,7 +29,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         {username: 'boo2'}
       ]).then(() => {
         return self.User.findOne();
-      }).then((user) => {
+      }).then(user => {
         return user.createProject({
           name: 'project1'
         });
@@ -62,7 +62,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           group: ['createdAt']
         })
       )
-      .then((users) => {
+      .then(users => {
         expect(users.length).to.be.eql(2);
 
         // have attributes
@@ -87,20 +87,20 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           order: ['age']
         })
       )
-      .then((result) => {
+      .then(result => {
         expect(parseInt(result[0].count)).to.be.eql(2);
         return this.User.count({
           where: { username: 'fire' }
         });
       })
-      .then((count) => {
+      .then(count => {
         expect(count).to.be.eql(0);
         return this.User.count({
           where: { username: 'fire' },
           group: 'age'
         });
       })
-      .then((count) => {
+      .then(count => {
         expect(count).to.be.eql([]);
       });
     });
@@ -119,14 +119,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           col: 'username'
         })
       )
-      .then((count) => {
+      .then(count => {
         expect(parseInt(count)).to.be.eql(3);
         return this.User.count({
           col: 'age',
           distinct: true
         });
       })
-      .then((count) => {
+      .then(count => {
         expect(parseInt(count)).to.be.eql(2);
       });
     });
@@ -139,11 +139,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           '$Projects.name$': 'project1'
         }
       };
-      return this.User.count(queryObject).then((count) => {
+      return this.User.count(queryObject).then(count => {
         expect(parseInt(count)).to.be.eql(1);
         queryObject.where['$Projects.name$'] = 'project2';
         return this.User.count(queryObject);
-      }).then((count) => {
+      }).then(count => {
         expect(parseInt(count)).to.be.eql(0);
       });
     });
@@ -161,14 +161,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           distinct: true,
           include: [this.Project]
         })
-      ).then((count) => {
+      ).then(count => {
         expect(parseInt(count)).to.be.eql(3);
         return this.User.count({
           col: 'age',
           distinct: true,
           include: [this.Project]
         });
-      }).then((count) => expect(parseInt(count)).to.be.eql(2));
+      }).then(count => expect(parseInt(count)).to.be.eql(2));
     });
 
   });

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -42,7 +42,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
         const self = this;
-        return this.sequelize.transaction().then((t) => {
+        return this.sequelize.transaction().then(t => {
           return self.User.findOrCreate({
             where: {
               username: 'Username'
@@ -52,10 +52,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             },
             transaction: t
           }).then(() => {
-            return self.User.count().then((count) => {
+            return self.User.count().then(count => {
               expect(count).to.equal(0);
               return t.commit().then(() => {
-                return self.User.count().then((count) => {
+                return self.User.count().then(count => {
                   expect(count).to.equal(1);
                 });
               });
@@ -66,7 +66,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('supports more than one models per transaction', function() {
         const self = this;
-        return this.sequelize.transaction().then((t) => {
+        return this.sequelize.transaction().then(t => {
           return self.User.findOrCreate({ where: { username: 'Username'}, defaults: { data: 'some data' }, transaction: t }).then(() => {
             return self.Account.findOrCreate({ where: { accountName: 'accountName'}, transaction: t}).then(() => {
               return t.commit();
@@ -143,7 +143,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return User.sync({force: true}).then(() => {
-          return Promise.map(_.range(50), (i) => {
+          return Promise.map(_.range(50), i => {
             return User.findOrCreate({
               where: {
                 email: 'unique.email.'+i+'@sequelizejs.com',
@@ -167,7 +167,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return User.sync({force: true}).then(() => {
-          return Promise.map(_.range(50), (i) => {
+          return Promise.map(_.range(50), i => {
             return User.findOrCreate({
               where: {
                 email: 'unique.email.'+i+'@sequelizejs.com',
@@ -175,7 +175,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               }
             });
           }).then(() => {
-            return Promise.map(_.range(50), (i) => {
+            return Promise.map(_.range(50), i => {
               return User.findOrCreate({
                 where: {
                   email: 'unique.email.'+i+'@sequelizejs.com',
@@ -262,7 +262,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           username: 'Username'
         };
 
-      return this.User.create(data).then((user) => {
+      return this.User.create(data).then(user => {
         return self.User.findOrCreate({ where: {
           username: user.username
         }}).spread((_user, created) => {
@@ -280,7 +280,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           data: 'ThisIsData'
         };
 
-      return this.User.create(data).then((user) => {
+      return this.User.create(data).then(user => {
         return self.User.findOrCreate({where: data}).spread((_user, created) => {
           expect(_user.id).to.equal(user.id);
           expect(_user.username).to.equal('Username');
@@ -300,13 +300,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return self.User.findOrCreate({
         where: data,
         defaults: {}
-      }).spread((user) => {
+      }).spread(user => {
         expect(user.dataValues.sequelize_caught_exception).to.be.undefined;
       }).then(() => {
         return self.User.findOrCreate({
           where: data,
           defaults: {}
-        }).spread((user) => {
+        }).spread(user => {
           expect(user.dataValues.sequelize_caught_exception).to.be.undefined;
         });
       });
@@ -352,7 +352,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
           })
               .timeout(1000)
-              .catch (Promise.TimeoutError, (e) => {
+              .catch (Promise.TimeoutError, e => {
                 throw new Error(e);
               })
               .catch (Sequelize.ValidationError, () => {
@@ -458,7 +458,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               }
             }).then(() => {
               throw new Error('I should have ben rejected');
-            }).catch((err) => {
+            }).catch(err => {
               expect(err instanceof Sequelize.UniqueConstraintError).to.be.ok;
               expect(err.fields).to.be.ok;
             }),
@@ -471,7 +471,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               }
             }).then(() => {
               throw new Error('I should have ben rejected');
-            }).catch((err) => {
+            }).catch(err => {
               expect(err instanceof Sequelize.UniqueConstraintError).to.be.ok;
               expect(err.fields).to.be.ok;
             })
@@ -517,7 +517,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             thirdInstance = third[0],
             thirdCreated = third[1];
 
-          expect([firstCreated, secondCreated, thirdCreated].filter((value) => {
+          expect([firstCreated, secondCreated, thirdCreated].filter(value => {
             return value;
           }).length).to.equal(1);
 
@@ -547,7 +547,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       return this.sequelize.sync({force: true}).then(() => {
-        return User.create({}).then((user) => {
+        return User.create({}).then(user => {
           expect(user).to.be.ok;
           expect(user.id).to.be.ok;
         });
@@ -570,7 +570,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return User.create({email: 'hello@sequelize.com'}).then(() => {
           return User.create({email: 'hello@sequelize.com'}).then(() => {
             assert(false);
-          }).catch((err) => {
+          }).catch(err => {
             expect(err).to.be.ok;
             expect(err).to.be.an.instanceof(Error);
           });
@@ -595,8 +595,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         );
       }).then(() => {
         return Log.findAll();
-      }).then((logs) => {
-        logs.forEach((log) => {
+      }).then(logs => {
+        logs.forEach(log => {
           expect(log.get('id')).not.to.be.ok;
         });
       });
@@ -618,7 +618,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           updatedAt
         }, {
           silent: true
-        }).then((user) => {
+        }).then(user => {
           expect(createdAt.getTime()).to.equal(user.get('createdAt').getTime());
           expect(updatedAt.getTime()).to.equal(user.get('updatedAt').getTime());
 
@@ -628,7 +628,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 ne: null
               }
             }
-          }).then((user) => {
+          }).then(user => {
             expect(createdAt.getTime()).to.equal(user.get('createdAt').getTime());
             expect(updatedAt.getTime()).to.equal(user.get('updatedAt').getTime());
           });
@@ -662,7 +662,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       return this.sequelize.sync({force: true}).then(() => {
-        return User.create({}).then((user) => {
+        return User.create({}).then(user => {
           expect(user).to.be.ok;
           expect(user.created_time).to.be.ok;
           expect(user.updated_time).to.be.ok;
@@ -680,7 +680,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       return this.sequelize.sync({force: true}).then(() => {
-        return User.create({}).then((user) => {
+        return User.create({}).then(user => {
           expect(user).to.be.ok;
           expect(user.createdAt).to.be.ok;
           expect(user.updatedAt).to.be.ok;
@@ -694,12 +694,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
         const self = this;
-        return this.sequelize.transaction().then((t) => {
+        return this.sequelize.transaction().then(t => {
           return self.User.create({ username: 'user' }, { transaction: t }).then(() => {
-            return self.User.count().then((count) => {
+            return self.User.count().then(count => {
               expect(count).to.equal(0);
               return t.commit().then(() => {
-                return self.User.count().then((count) => {
+                return self.User.count().then(count => {
                   expect(count).to.equal(1);
                 });
               });
@@ -715,7 +715,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const User = this.sequelize.define('user', {});
 
           return User.sync({force: true}).then(() => {
-            return User.create({}, {returning: true}).then((user) => {
+            return User.create({}, {returning: true}).then(user => {
               expect(user.get('id')).to.be.ok;
               expect(user.get('id')).to.equal(1);
             });
@@ -733,7 +733,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
 
           return User.sync({force: true}).then(() => {
-            return User.create({}, {returning: true}).then((user) => {
+            return User.create({}, {returning: true}).then(user => {
               expect(user.get('maId')).to.be.ok;
               expect(user.get('maId')).to.equal(1);
             });
@@ -754,8 +754,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(sql).to.match(new RegExp("CAST\\(N?'1' AS " + type.toUpperCase() + '\\)'));
           match = true;
         }
-      }).then((user) => {
-        return self.User.findById(user.id).then((user) => {
+      }).then(user => {
+        return self.User.findById(user.id).then(user => {
           expect(user.intVal).to.equal(1);
           expect(match).to.equal(true);
         });
@@ -782,8 +782,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
           match = true;
         }
-      }).then((user) => {
-        return self.User.findById(user.id).then((user) => {
+      }).then(user => {
+        return self.User.findById(user.id).then(user => {
           expect(user.intVal).to.equal(-1);
           expect(match).to.equal(true);
         });
@@ -795,8 +795,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.User.create({
         intVal: this.sequelize.literal('CAST(1-2 AS ' + (dialect === 'mysql' ? 'SIGNED' : 'INTEGER') + ')')
-      }).then((user) => {
-        return self.User.findById(user.id).then((user) => {
+      }).then(user => {
+        return self.User.findById(user.id).then(user => {
           expect(user.intVal).to.equal(-1);
         });
       });
@@ -806,8 +806,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const self = this;
       return this.User.create({
         secretValue: this.sequelize.fn('upper', 'sequelize')
-      }).then((user) => {
-        return self.User.findById(user.id).then((user) => {
+      }).then(user => {
+        return self.User.findById(user.id).then(user => {
           expect(user.secretValue).to.equal('SEQUELIZE');
         });
       });
@@ -820,7 +820,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.sequelize.sync({force: true}).then(() => {
         return Monkey.create();
-      }).then((monkey) => {
+      }).then(monkey => {
         expect(monkey.get('monkeyId')).to.be.ok;
       });
     });
@@ -839,7 +839,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
 
           return userWithDefaults.sync({force: true}).then(() => {
-            return userWithDefaults.create({}).then((user) => {
+            return userWithDefaults.create({}).then(user => {
               // uuid validation regex taken from http://stackoverflow.com/a/13653180/800016
               expect(user.uuid).to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
             });
@@ -856,8 +856,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return userWithDefaults.sync({force: true}).then(() => {
-          return userWithDefaults.create({}).then((user) => {
-            return userWithDefaults.findById(user.id).then((user) => {
+          return userWithDefaults.create({}).then(user => {
+            return userWithDefaults.findById(user.id).then(user => {
               const now = new Date(),
                 pad = function(number) {
                   if (number > 9) {
@@ -914,7 +914,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       let test = false;
 
       return User.sync({force: true}).then(() => {
-        return User.create({myvals: [1, 2, 3, 4], mystr: ['One', 'Two', 'Three', 'Four']}).then((user) => {
+        return User.create({myvals: [1, 2, 3, 4], mystr: ['One', 'Two', 'Three', 'Four']}).then(user => {
           user.myvals = [];
           user.mystr = [];
           return user.save({
@@ -938,7 +938,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return User.sync({ force: true }).then(() => {
         return User.create({ username: 'foo' }).then(() => {
-          return User.create({ username: 'foo' }).catch(self.sequelize.UniqueConstraintError, (err) => {
+          return User.create({ username: 'foo' }).catch(self.sequelize.UniqueConstraintError, err => {
             expect(err).to.be.ok;
           });
         });
@@ -954,7 +954,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       this.sequelize.options.omitNull = false;
 
       return UserNull.sync({ force: true }).then(() => {
-        return UserNull.create({ username: 'foo2', smth: null }).catch((err) => {
+        return UserNull.create({ username: 'foo2', smth: null }).catch(err => {
           expect(err).to.exist;
           expect(err.get('smth')[0].path).to.equal('smth');
           if (dialect === 'mysql') {
@@ -981,7 +981,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return UserNull.sync({ force: true }).then(() => {
         return UserNull.create({ username: 'foo', smth: 'foo' }).then(() => {
-          return UserNull.create({ username: 'foo', smth: 'bar' }).catch (self.sequelize.UniqueConstraintError, (err) => {
+          return UserNull.create({ username: 'foo', smth: 'bar' }).catch (self.sequelize.UniqueConstraintError, err => {
             expect(err).to.be.ok;
           });
         });
@@ -996,11 +996,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       this.sequelize.options.omitNull = false;
 
       return StringIsNullOrUrl.sync({ force: true }).then(() => {
-        return StringIsNullOrUrl.create({ str: null }).then((str1) => {
+        return StringIsNullOrUrl.create({ str: null }).then(str1 => {
           expect(str1.str).to.be.null;
-          return StringIsNullOrUrl.create({ str: 'http://sequelizejs.org' }).then((str2) => {
+          return StringIsNullOrUrl.create({ str: 'http://sequelizejs.org' }).then(str2 => {
             expect(str2.str).to.equal('http://sequelizejs.org');
-            return StringIsNullOrUrl.create({ str: '' }).catch((err) => {
+            return StringIsNullOrUrl.create({ str: '' }).catch(err => {
               expect(err).to.exist;
               expect(err.get('str')[0].message).to.match(/Validation isURL on str failed/);
             });
@@ -1030,7 +1030,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       return User.sync({ force: true }).then(() => {
-        return User.create({ big: '9223372036854775807' }).then((user) => {
+        return User.create({ big: '9223372036854775807' }).then(user => {
           expect(user.big).to.be.equal('9223372036854775807');
         });
       });
@@ -1042,9 +1042,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       return User.sync({ force: true }).then(() => {
-        return User.create({}).then((user) => {
+        return User.create({}).then(user => {
           expect(user.userid).to.equal(1);
-          return User.create({}).then((user) => {
+          return User.create({}).then(user => {
             expect(user.userid).to.equal(2);
           });
         });
@@ -1062,7 +1062,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return User.sync({ force: true }).then(() => {
         return User
           .create({ name: 'John Doe', options })
-          .then((user) => {
+          .then(user => {
             expect(user.options).to.equal(options);
           });
       });
@@ -1093,8 +1093,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const self = this,
         data = { username: 'Peter', secretValue: '42' };
 
-      return this.User.create(data, { fields: ['username'] }).then((user) => {
-        return self.User.findById(user.id).then((_user) => {
+      return this.User.create(data, { fields: ['username'] }).then(user => {
+        return self.User.findById(user.id).then(_user => {
           expect(_user.username).to.equal(data.username);
           expect(_user.secretValue).not.to.equal(data.secretValue);
           expect(_user.secretValue).to.equal(null);
@@ -1106,8 +1106,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const self = this,
         data = { username: 'Peter', secretValue: '42' };
 
-      return this.User.create(data).then((user) => {
-        return self.User.findById(user.id).then((_user) => {
+      return this.User.create(data).then(user => {
+        return self.User.findById(user.id).then(_user => {
           expect(_user.username).to.equal(data.username);
           expect(_user.secretValue).to.equal(data.secretValue);
         });
@@ -1129,13 +1129,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
 
-      books.forEach((b) => {
+      books.forEach(b => {
         sync.push(b.sync({ force: true }));
       });
 
       return Promise.all(sync).then(() => {
         books.forEach((b, index) => {
-          promises.push(b.create(data).then((book) => {
+          promises.push(b.create(data).then(book => {
             expect(book.title).to.equal(data.title);
             expect(book.author).to.equal(data.author);
             expect(books[index].rawAttributes.id.type instanceof dataTypes[index]).to.be.ok;
@@ -1149,9 +1149,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const quote = "single'quote",
         self = this;
 
-      return this.User.create({ data: quote }).then((user) => {
+      return this.User.create({ data: quote }).then(user => {
         expect(user.data).to.equal(quote);
-        return self.User.find({where: { id: user.id }}).then((user) => {
+        return self.User.find({where: { id: user.id }}).then(user => {
           expect(user.data).to.equal(quote);
         });
       });
@@ -1161,9 +1161,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const quote = 'double"quote',
         self = this;
 
-      return this.User.create({ data: quote }).then((user) => {
+      return this.User.create({ data: quote }).then(user => {
         expect(user.data).to.equal(quote);
-        return self.User.find({where: { id: user.id }}).then((user) => {
+        return self.User.find({where: { id: user.id }}).then(user => {
           expect(user.data).to.equal(quote);
         });
       });
@@ -1173,25 +1173,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const json = JSON.stringify({ key: 'value' }),
         self = this;
 
-      return this.User.create({ data: json }).then((user) => {
+      return this.User.create({ data: json }).then(user => {
         expect(user.data).to.equal(json);
-        return self.User.find({where: { id: user.id }}).then((user) => {
+        return self.User.find({where: { id: user.id }}).then(user => {
           expect(user.data).to.equal(json);
         });
       });
     });
 
     it('stores the current date in createdAt', function() {
-      return this.User.create({ username: 'foo' }).then((user) => {
+      return this.User.create({ username: 'foo' }).then(user => {
         expect(parseInt(+user.createdAt / 5000, 10)).to.be.closeTo(parseInt(+new Date() / 5000, 10), 1.5);
       });
     });
 
     it('allows setting custom IDs', function() {
       const self = this;
-      return this.User.create({ id: 42 }).then((user) => {
+      return this.User.create({ id: 42 }).then(user => {
         expect(user.id).to.equal(42);
-        return self.User.findById(42).then((user) => {
+        return self.User.findById(42).then(user => {
           expect(user).to.exist;
         });
       });
@@ -1200,7 +1200,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow blank creates (with timestamps: false)', function() {
       const Worker = this.sequelize.define('Worker', {}, {timestamps: false});
       return Worker.sync().then(() => {
-        return Worker.create({}, {fields: []}).then((worker) => {
+        return Worker.create({}, {fields: []}).then(worker => {
           expect(worker).to.be.ok;
         });
       });
@@ -1209,7 +1209,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow truly blank creates', function() {
       const Worker = this.sequelize.define('Worker', {}, {timestamps: false});
       return Worker.sync().then(() => {
-        return Worker.create({}, {fields: []}).then((worker) => {
+        return Worker.create({}, {fields: []}).then(worker => {
           expect(worker).to.be.ok;
         });
       });
@@ -1231,10 +1231,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           email: 'yolo@bear.com'
         }, {
           fields: ['name']
-        }).then((user) => {
+        }).then(user => {
           expect(user.name).to.be.ok;
           expect(user.email).not.to.be.ok;
-          return User.findById(user.id).then((user) => {
+          return User.findById(user.id).then(user => {
             expect(user.name).to.be.ok;
             expect(user.email).not.to.be.ok;
           });
@@ -1272,8 +1272,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
 
         return Item.sync({ force: true }).then(() => {
-          return Item.create({ state: 'available' }).then((_item) => {
-            return Item.find({ where: { state: 'available' }}).then((item) => {
+          return Item.create({ state: 'available' }).then(_item => {
+            return Item.find({ where: { state: 'available' }}).then(item => {
               expect(item.id).to.equal(_item.id);
             });
           });
@@ -1290,7 +1290,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return Enum.sync({ force: true }).then(() => {
-          return Enum.create({state: null}).then((_enum) => {
+          return Enum.create({state: null}).then(_enum => {
             expect(_enum.state).to.be.null;
           });
         });
@@ -1395,11 +1395,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return User.bulkCreate([{ username: 'foo' }, { username: 'bar' }], { transaction });
           })
           .then(() => User.count())
-          .then((count) => {
+          .then(count => {
             count1 = count;
             return User.count({ transaction });
           })
-          .then((count2) => {
+          .then(count2 => {
             expect(count1).to.equal(0);
             expect(count2).to.equal(2);
             return transaction.rollback();
@@ -1433,8 +1433,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 ne: null
               }
             }
-          }).then((users) => {
-            users.forEach((user) => {
+          }).then(users => {
+            users.forEach(user => {
               expect(createdAt.getTime()).to.equal(user.get('createdAt').getTime());
               expect(updatedAt.getTime()).to.equal(user.get('updatedAt').getTime());
             });
@@ -1485,7 +1485,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   {username: 'Steve', uniqueName: '3'}];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.findAll({where: {username: 'Paul'}}).then((users) => {
+        return self.User.findAll({where: {username: 'Paul'}}).then(users => {
           expect(users.length).to.equal(1);
           expect(users[0].username).to.equal('Paul');
           expect(users[0].secretValue).to.be.null;
@@ -1499,7 +1499,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Paul', secretValue: '23', uniqueName: '2'}];
 
       return this.User.bulkCreate(data, { fields: ['username', 'uniqueName'] }).then(() => {
-        return self.User.findAll({order: ['id']}).then((users) => {
+        return self.User.findAll({order: ['id']}).then(users => {
           expect(users.length).to.equal(2);
           expect(users[0].username).to.equal('Peter');
           expect(users[0].secretValue).to.be.null;
@@ -1515,7 +1515,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Paul', secretValue: '23', uniqueName: '2'}];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.findAll({order: ['id']}).then((users) => {
+        return self.User.findAll({order: ['id']}).then(users => {
           expect(users.length).to.equal(2);
           expect(users[0].username).to.equal('Peter');
           expect(users[0].secretValue).to.equal('42');
@@ -1531,9 +1531,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Paul', secretValue: '23', uniqueName: '2'}];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.findAll({order: ['id']}).then((users) => {
+        return self.User.findAll({order: ['id']}).then(users => {
           expect(users.length).to.equal(2);
-          users.forEach((user) => {
+          users.forEach(user => {
             expect(user.isNewRecord).to.equal(false);
           });
         });
@@ -1547,7 +1547,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Paul', data: quote, uniqueName: '2'}];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.findAll({order: ['id']}).then((users) => {
+        return self.User.findAll({order: ['id']}).then(users => {
           expect(users.length).to.equal(2);
           expect(users[0].username).to.equal('Peter');
           expect(users[0].data).to.equal(quote);
@@ -1564,7 +1564,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Paul', data: quote, uniqueName: '2'}];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.findAll({order: ['id']}).then((users) => {
+        return self.User.findAll({order: ['id']}).then(users => {
           expect(users.length).to.equal(2);
           expect(users[0].username).to.equal('Peter');
           expect(users[0].data).to.equal(quote);
@@ -1581,7 +1581,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Paul', data: json, uniqueName: '2'}];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.findAll({order: ['id']}).then((users) => {
+        return self.User.findAll({order: ['id']}).then(users => {
           expect(users.length).to.equal(2);
           expect(users[0].username).to.equal('Peter');
           expect(users[0].data).to.equal(json);
@@ -1607,7 +1607,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   { username: 'Paul', uniqueName: '2'}];
 
       return this.User.bulkCreate(data).then(() => {
-        return self.User.findAll({order: ['id']}).then((users) => {
+        return self.User.findAll({order: ['id']}).then(users => {
           expect(users.length).to.equal(2);
           expect(users[0].username).to.equal('Peter');
           expect(parseInt(+users[0].createdAt / 5000, 10)).to.be.closeTo(parseInt(+new Date() / 5000, 10), 1.5);
@@ -1636,7 +1636,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           {name: 'foo', code: '123'},
           {code: '1234'},
           {name: 'bar', code: '1'}
-        ], { validate: true }).catch((errors) => {
+        ], { validate: true }).catch(errors => {
           expect(errors).to.be.instanceof(Promise.AggregateError);
           expect(errors).to.have.length(2);
           expect(errors[0].record.code).to.equal('1234');
@@ -1675,7 +1675,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow blank arrays (return immediatly)', function() {
       const Worker = this.sequelize.define('Worker', {});
       return Worker.sync().then(() => {
-        return Worker.bulkCreate([]).then((workers) => {
+        return Worker.bulkCreate([]).then(workers => {
           expect(workers).to.be.ok;
           expect(workers.length).to.equal(0);
         });
@@ -1685,7 +1685,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should allow blank creates (with timestamps: false)', function() {
       const Worker = this.sequelize.define('Worker', {}, {timestamps: false});
       return Worker.sync().then(() => {
-        return Worker.bulkCreate([{}, {}]).then((workers) => {
+        return Worker.bulkCreate([{}, {}]).then(workers => {
           expect(workers).to.be.ok;
         });
       });
@@ -1698,7 +1698,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           {id: 5},
           {id: 10}
         ]).then(() => {
-          return Worker.findAll({order: [['id', 'ASC']]}).then((workers) => {
+          return Worker.findAll({order: [['id', 'ASC']]}).then(workers => {
             expect(workers[0].id).to.equal(5);
             expect(workers[1].id).to.equal(10);
           });
@@ -1736,7 +1736,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'] }).then(() => {
           data.push({ uniqueName: 'Michael', secretValue: '26' });
           return self.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'], ignoreDuplicates: true }).then(() => {
-            return self.User.findAll({order: ['id']}).then((users) => {
+            return self.User.findAll({order: ['id']}).then(users => {
               expect(users.length).to.equal(3);
               expect(users[0].uniqueName).to.equal('Peter');
               expect(users[0].secretValue).to.equal('42');
@@ -1757,7 +1757,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'] }).then(() => {
           data.push({ uniqueName: 'Michael', secretValue: '26' });
 
-          return self.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'], ignoreDuplicates: true }).catch((err) => {
+          return self.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'], ignoreDuplicates: true }).catch(err => {
             if (dialect === 'mssql') {
               expect(err.message).to.match(/mssql does not support the \'ignoreDuplicates\' option./);
             } else {
@@ -1778,7 +1778,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               {},
               {},
               {}
-            ], {returning: true}).then((users) => {
+            ], {returning: true}).then(users => {
               expect(users.length).to.be.ok;
               users.forEach((user, i) => {
                 expect(user.get('id')).to.be.ok;
@@ -1803,7 +1803,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               {},
               {},
               {}
-            ], {returning: true}).then((users) => {
+            ], {returning: true}).then(users => {
               expect(users.length).to.be.ok;
               users.forEach((user, i) => {
                 expect(user.get('maId')).to.be.ok;
@@ -1825,7 +1825,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return Item.sync({ force: true }).then(() => {
           return Item.bulkCreate([{state: 'in_cart', name: 'A'}, { state: 'available', name: 'B'}]).then(() => {
-            return Item.find({ where: { state: 'available' }}).then((item) => {
+            return Item.find({ where: { state: 'available' }}).then(item => {
               expect(item.name).to.equal('B');
             });
           });
@@ -1854,14 +1854,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const M2 = { id: 2, name: 'Dwitiya Maya', secret: 'You are on list #2'};
 
       return Maya.sync({ force: true }).then(() => Maya.create(M1))
-      .then((m) => {
+      .then(m => {
         expect(m.createdAt).to.be.ok;
         expect(m.id).to.be.eql(M1.id);
         expect(m.name).to.be.eql(M1.name);
         expect(m.secret).to.be.eql(M1.secret);
 
         return Maya.bulkCreate([M2]);
-      }).spread((m) => {
+      }).spread(m => {
 
         // only attributes are returned, no fields are mixed
         expect(m.createdAt).to.be.ok;
@@ -1883,7 +1883,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const M1 = {};
 
       return Maya.sync({ force: true }).then(() => Maya.create(M1, {returning: true}))
-      .then((m) => {
+      .then(m => {
         expect(m.id).to.be.eql(1);
       });
     });
@@ -1895,7 +1895,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const M2 = {};
 
       return Maya.sync({ force: true }).then(() => Maya.bulkCreate([M1, M2], {returning: true}))
-      .then((ms) => {
+      .then(ms => {
         expect(ms[0].id).to.be.eql(1);
         expect(ms[1].id).to.be.eql(2);
       });

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -44,14 +44,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               model: User,
               myOption: 'option'
             }]
-          }).then((savedProduct) => {
+          }).then(savedProduct => {
             expect(savedProduct.isIncludeCreatedOnAfterCreate).to.be.true;
             expect(savedProduct.User.createOptions.myOption).to.be.equal('option');
             expect(savedProduct.User.createOptions.parentRecord).to.be.equal(savedProduct);
             return Product.findOne({
               where: { id: savedProduct.id },
               include: [ User ]
-            }).then((persistedProduct) => {
+            }).then(persistedProduct => {
               expect(persistedProduct.User).to.be.ok;
               expect(persistedProduct.User.first_name).to.be.equal('Mick');
               expect(persistedProduct.User.last_name).to.be.equal('Broadstone');
@@ -80,11 +80,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
           }, {
             include: [ Creator ]
-          }).then((savedProduct) => {
+          }).then(savedProduct => {
             return Product.findOne({
               where: { id: savedProduct.id },
               include: [ Creator ]
-            }).then((persistedProduct) => {
+            }).then(persistedProduct => {
               expect(persistedProduct.creator).to.be.ok;
               expect(persistedProduct.creator.first_name).to.be.equal('Matt');
               expect(persistedProduct.creator.last_name).to.be.equal('Hansen');
@@ -100,7 +100,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           hooks: {
             afterCreate(product) {
               product.areIncludesCreatedOnAfterCreate = product.Tags &&
-                product.Tags.every((tag) => {
+                product.Tags.every(tag => {
                   return !!tag.id;
                 });
             }
@@ -131,7 +131,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               model: Tag,
               myOption: 'option'
             }]
-          }).then((savedProduct) => {
+          }).then(savedProduct => {
             expect(savedProduct.areIncludesCreatedOnAfterCreate).to.be.true;
             expect(savedProduct.Tags[0].createOptions.myOption).to.be.equal('option');
             expect(savedProduct.Tags[0].createOptions.parentRecord).to.be.equal(savedProduct);
@@ -140,7 +140,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return Product.find({
               where: { id: savedProduct.id },
               include: [ Tag ]
-            }).then((persistedProduct) => {
+            }).then(persistedProduct => {
               expect(persistedProduct.Tags).to.be.ok;
               expect(persistedProduct.Tags.length).to.equal(2);
             });
@@ -168,11 +168,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ]
           }, {
             include: [ Categories ]
-          }).then((savedProduct) => {
+          }).then(savedProduct => {
             return Product.find({
               where: { id: savedProduct.id },
               include: [ Categories ]
-            }).then((persistedProduct) => {
+            }).then(persistedProduct => {
               expect(persistedProduct.categories).to.be.ok;
               expect(persistedProduct.categories.length).to.equal(2);
             });
@@ -199,11 +199,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
           }, {
             include: [ Task ]
-          }).then((savedUser) => {
+          }).then(savedUser => {
             return User.find({
               where: { id: savedUser.id },
               include: [ Task ]
-            }).then((persistedUser) => {
+            }).then(persistedUser => {
               expect(persistedUser.Task).to.be.ok;
             });
           });
@@ -230,11 +230,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
           }, {
             include: [ Job ]
-          }).then((savedUser) => {
+          }).then(savedUser => {
             return User.find({
               where: { id: savedUser.id },
               include: [ Job ]
-            }).then((persistedUser) => {
+            }).then(persistedUser => {
               expect(persistedUser.job).to.be.ok;
             });
           });
@@ -248,7 +248,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           hooks: {
             afterCreate(user) {
               user.areIncludesCreatedOnAfterCreate = user.Tasks &&
-                user.Tasks.every((task) => {
+                user.Tasks.every(task => {
                   return !!task.id;
                 });
             }
@@ -281,7 +281,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               model: Task,
               myOption: 'option'
             }]
-          }).then((savedUser) => {
+          }).then(savedUser => {
             expect(savedUser.areIncludesCreatedOnAfterCreate).to.be.true;
             expect(savedUser.Tasks[0].createOptions.myOption).to.be.equal('option');
             expect(savedUser.Tasks[0].createOptions.parentRecord).to.be.equal(savedUser);
@@ -290,7 +290,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return User.find({
               where: { id: savedUser.id },
               include: [ Task ]
-            }).then((persistedUser) => {
+            }).then(persistedUser => {
               expect(persistedUser.Tasks).to.be.ok;
               expect(persistedUser.Tasks.length).to.equal(2);
             });
@@ -378,18 +378,18 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }]
           }
           );
-        }).then((savedPost) => {
+        }).then(savedPost => {
           // The saved post should include the two tags
           expect(savedPost.tags.length).to.equal(2);
           // The saved post should be able to retrieve the two tags
           // using the convenience accessor methods
           return savedPost.getTags();
-        }).then((savedTags) => {
+        }).then(savedTags => {
           // All nested tags should be returned
           expect(savedTags.length).to.equal(2);
         }).then(() => {
           return ItemTag.findAll();
-        }).then((itemTags) => {
+        }).then(itemTags => {
           // Two "through" models should be created
           expect(itemTags.length).to.equal(2);
           // And their polymorphic field should be correctly set to 'post'
@@ -420,11 +420,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ]
           }, {
             include: [ Jobs ]
-          }).then((savedUser) => {
+          }).then(savedUser => {
             return User.find({
               where: { id: savedUser.id },
               include: [ Jobs ]
-            }).then((persistedUser) => {
+            }).then(persistedUser => {
               expect(persistedUser.jobs).to.be.ok;
               expect(persistedUser.jobs.length).to.equal(2);
             });

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -29,19 +29,19 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   describe('find', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
                 return User.findOne({
                   where: { username: 'foo' }
-                }).then((user1) => {
+                }).then(user1 => {
                   return User.findOne({
                     where: { username: 'foo' },
                     transaction: t
-                  }).then((user2) => {
+                  }).then(user2 => {
                     expect(user1).to.be.null;
                     expect(user2).to.not.be.null;
                     return t.rollback();
@@ -57,7 +57,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     describe('general / basic function', () => {
       beforeEach(function() {
         const self = this;
-        return this.User.create({username: 'barfooz'}).then((user) => {
+        return this.User.create({username: 'barfooz'}).then(user => {
           self.UserPrimary = self.sequelize.define('UserPrimary', {
             specialkey: {
               type: DataTypes.STRING,
@@ -100,7 +100,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ]);
           }).then(() => {
             return bitUser.findAll();
-          }).then((bitUsers) => {
+          }).then(bitUsers => {
             expect(bitUsers[0].bool).not.to.be.ok;
             expect(bitUsers[1].bool).to.be.ok;
           });
@@ -121,14 +121,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('doesn\'t throw an error when entering in a non integer value for a specified primary field', function() {
-        return this.UserPrimary.findById('a string').then((user) => {
+        return this.UserPrimary.findById('a string').then(user => {
           expect(user.specialkey).to.equal('a string');
         });
       });
 
       it('returns a single dao', function() {
         const self = this;
-        return this.User.findById(this.user.id).then((user) => {
+        return this.User.findById(this.user.id).then(user => {
           expect(Array.isArray(user)).to.not.be.ok;
           expect(user.id).to.equal(self.user.id);
           expect(user.id).to.equal(1);
@@ -137,7 +137,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('returns a single dao given a string id', function() {
         const self = this;
-        return this.User.findById(this.user.id + '').then((user) => {
+        return this.User.findById(this.user.id + '').then(user => {
           expect(Array.isArray(user)).to.not.be.ok;
           expect(user.id).to.equal(self.user.id);
           expect(user.id).to.equal(1);
@@ -148,7 +148,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.User.findOne({
           where: { id: 1 },
           attributes: ['id', ['username', 'name']]
-        }).then((user) => {
+        }).then(user => {
           expect(user.dataValues.name).to.equal('barfooz');
         });
       });
@@ -166,8 +166,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         return UserWithBoolean.sync({force: true}).then(() => {
-          return UserWithBoolean.create({ active: true }).then((user) => {
-            return UserWithBoolean.findOne({ where: { id: user.id }, attributes: ['id'] }).then((user) => {
+          return UserWithBoolean.create({ active: true }).then(user => {
+            return UserWithBoolean.findOne({ where: { id: user.id }, attributes: ['id'] }).then(user => {
               expect(user.active).not.to.exist;
             });
           });
@@ -175,13 +175,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('finds a specific user via where option', function() {
-        return this.User.findOne({ where: { username: 'barfooz' } }).then((user) => {
+        return this.User.findOne({ where: { username: 'barfooz' } }).then(user => {
           expect(user.username).to.equal('barfooz');
         });
       });
 
       it('doesn\'t find a user if conditions are not matching', function() {
-        return this.User.findOne({ where: { username: 'foo' } }).then((user) => {
+        return this.User.findOne({ where: { username: 'foo' } }).then(user => {
           expect(user).to.be.null;
         });
       });
@@ -201,7 +201,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('ignores passed limit option', function() {
-        return this.User.findOne({ limit: 10 }).then((user) => {
+        return this.User.findOne({ limit: 10 }).then(user => {
           // it returns an object instead of an array
           expect(Array.isArray(user)).to.not.be.ok;
           expect(user.dataValues.hasOwnProperty('username')).to.be.ok;
@@ -219,9 +219,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return UserPrimary.create({
             identifier: 'an identifier',
             name: 'John'
-          }).then((u) => {
+          }).then(u => {
             expect(u.id).not.to.exist;
-            return UserPrimary.findById('an identifier').then((u2) => {
+            return UserPrimary.findById('an identifier').then(u2 => {
               expect(u2.identifier).to.equal('an identifier');
               expect(u2.name).to.equal('John');
             });
@@ -241,7 +241,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             id: 'a string based id',
             name: 'Johnno'
           }).then(() => {
-            return UserPrimary.findById('a string based id').then((u2) => {
+            return UserPrimary.findById('a string based id').then(u2 => {
               expect(u2.id).to.equal('a string based id');
               expect(u2.name).to.equal('Johnno');
             });
@@ -258,13 +258,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         let count = 0;
 
         return this.User.bulkCreate([{username: 'jack'}, {username: 'jack'}]).then(() => {
-          return self.sequelize.Promise.map(permutations, (perm) => {
+          return self.sequelize.Promise.map(permutations, perm => {
             return self.User.findById(perm, {
               logging(s) {
                 expect(s.indexOf(0)).not.to.equal(-1);
                 count++;
               }
-            }).then((user) => {
+            }).then(user => {
               expect(user).to.be.null;
             });
           });
@@ -281,7 +281,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return User.sync({ force: true }).then(() => {
           return User.create({Login: 'foo'}).then(() => {
-            return User.findById(1).then((user) => {
+            return User.findById(1).then(user => {
               expect(user).to.exist;
               expect(user.ID).to.equal(1);
             });
@@ -298,8 +298,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         this.init = function(callback) {
           return self.sequelize.sync({ force: true }).then(() => {
-            return self.Worker.create({ name: 'worker' }).then((worker) => {
-              return self.Task.create({ title: 'homework' }).then((task) => {
+            return self.Worker.create({ name: 'worker' }).then(worker => {
+              return self.Task.create({ title: 'homework' }).then(task => {
                 self.worker = worker;
                 self.task = task;
                 return callback();
@@ -313,14 +313,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         describe('generic', () => {
           it('throws an error about unexpected input if include contains a non-object', function() {
             const self = this;
-            return self.Worker.findOne({ include: [1] }).catch ((err) => {
+            return self.Worker.findOne({ include: [1] }).catch (err => {
               expect(err.message).to.equal('Include unexpected. Element has to be either a Model, an Association or an object.');
             });
           });
 
           it('throws an error if included DaoFactory is not associated', function() {
             const self = this;
-            return self.Worker.findOne({ include: [self.Task] }).catch ((err) => {
+            return self.Worker.findOne({ include: [self.Task] }).catch (err => {
               expect(err.message).to.equal('Task is not associated to Worker!');
             });
           });
@@ -333,7 +333,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 return self.Task.findOne({
                   where: { title: 'homework' },
                   include: [self.Worker]
-                }).then((task) => {
+                }).then(task => {
                   expect(task).to.exist;
                   expect(task.Worker).to.exist;
                   expect(task.Worker.name).to.equal('worker');
@@ -352,9 +352,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           return self.Domain.sync({ force: true }).then(() => {
             return self.Environment.sync({ force: true }).then(() => {
-              return self.Domain.create({ ip: '192.168.0.1' }).then((privateIp) => {
-                return self.Domain.create({ ip: '91.65.189.19' }).then((publicIp) => {
-                  return self.Environment.create({ name: 'environment' }).then((env) => {
+              return self.Domain.create({ ip: '192.168.0.1' }).then(privateIp => {
+                return self.Domain.create({ ip: '91.65.189.19' }).then(publicIp => {
+                  return self.Environment.create({ name: 'environment' }).then(env => {
                     return env.setPrivateDomain(privateIp).then(() => {
                       return env.setPublicDomain(publicIp).then(() => {
                         return self.Environment.findOne({
@@ -363,7 +363,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                             { model: self.Domain, as: 'PrivateDomain' },
                             { model: self.Domain, as: 'PublicDomain' }
                           ]
-                        }).then((environment) => {
+                        }).then(environment => {
                           expect(environment).to.exist;
                           expect(environment.PrivateDomain).to.exist;
                           expect(environment.PrivateDomain.ip).to.equal('192.168.0.1');
@@ -403,7 +403,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                     username: 'someone'
                   },
                   include: [self.Group]
-                }).then((someUser) => {
+                }).then(someUser => {
                   expect(someUser).to.exist;
                   expect(someUser.username).to.equal('someone');
                   expect(someUser.GroupPKeagerbelong.name).to.equal('people');
@@ -429,7 +429,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           Message.belongsTo(User, { foreignKey: 'user_id' });
 
           return this.sequelize.sync({ force: true }).then(() => {
-            return User.create({username: 'test_testerson'}).then((user) => {
+            return User.create({username: 'test_testerson'}).then(user => {
               return Message.create({user_id: user.id, message: 'hi there!'}).then(() => {
                 return Message.create({user_id: user.id, message: 'a second message'}).then(() => {
                   return Message.findAll({
@@ -439,7 +439,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                       'message'
                     ],
                     include: [{ model: User, attributes: ['username'] }]
-                  }).then((messages) => {
+                  }).then(messages => {
                     expect(messages.length).to.equal(2);
 
                     expect(messages[0].message).to.equal('hi there!');
@@ -481,7 +481,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if included DaoFactory is not associated', function() {
           const self = this;
-          return self.Task.findOne({ include: [self.Worker] }).catch ((err) => {
+          return self.Task.findOne({ include: [self.Worker] }).catch (err => {
             expect(err.message).to.equal('Worker is not associated to Task!');
           });
         });
@@ -490,7 +490,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findOne({
             where: { name: 'worker' },
             include: [this.Task]
-          }).then((worker) => {
+          }).then(worker => {
             expect(worker).to.exist;
             expect(worker.Task).to.exist;
             expect(worker.Task.title).to.equal('homework');
@@ -521,7 +521,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                     name: 'people'
                   },
                   include: [self.User]
-                }).then((someGroup) => {
+                }).then(someGroup => {
                   expect(someGroup).to.exist;
                   expect(someGroup.name).to.equal('people');
                   expect(someGroup.UserPKeagerone.username).to.equal('someone');
@@ -535,7 +535,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       describe('hasOne with alias', () => {
         it('throws an error if included DaoFactory is not referenced by alias', function() {
           const self = this;
-          return self.Worker.findOne({ include: [self.Task] }).catch ((err) => {
+          return self.Worker.findOne({ include: [self.Task] }).catch (err => {
             expect(err.message).to.equal('Task is not associated to Worker!');
           });
         });
@@ -552,7 +552,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           it(`throws an error indicating an incorrect alias was entered if an association
               and alias exist but the alias doesn't match`, function() {
             const self = this;
-            return self.Worker.findOne({ include: [{ model: self.Task, as: 'Work' }] }).catch ((err) => {
+            return self.Worker.findOne({ include: [{ model: self.Task, as: 'Work' }] }).catch (err => {
               expect(err.message).to.equal('Task is associated to Worker using an alias. You\'ve included an alias (Work), but it does not match the alias defined in your association.');
             });
           });
@@ -561,7 +561,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return this.Worker.findOne({
               where: { name: 'worker' },
               include: [{ model: this.Task, as: 'ToDo' }]
-            }).then((worker) => {
+            }).then(worker => {
               expect(worker).to.exist;
               expect(worker.ToDo).to.exist;
               expect(worker.ToDo.title).to.equal('homework');
@@ -572,7 +572,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return this.Worker.findOne({
               where: { name: 'worker' },
               include: [{ model: this.Task, as: 'ToDo' }]
-            }).then((worker) => {
+            }).then(worker => {
               expect(worker.ToDo.title).to.equal('homework');
             });
           });
@@ -604,7 +604,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if included DaoFactory is not associated', function() {
           const self = this;
-          return self.Task.findOne({ include: [self.Worker] }).catch ((err) => {
+          return self.Task.findOne({ include: [self.Worker] }).catch (err => {
             expect(err.message).to.equal('Worker is not associated to Task!');
           });
         });
@@ -613,7 +613,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findOne({
             where: { name: 'worker' },
             include: [this.Task]
-          }).then((worker) => {
+          }).then(worker => {
             expect(worker).to.exist;
             expect(worker.Tasks).to.exist;
             expect(worker.Tasks[0].title).to.equal('homework');
@@ -631,10 +631,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Contact.hasMany(self.PhoneNumber);
 
           return self.sequelize.sync({ force: true }).then(() => {
-            return self.Contact.create({ name: 'Boris' }).then((someContact) => {
-              return self.Photo.create({ img: 'img.jpg' }).then((somePhoto) => {
-                return self.PhoneNumber.create({ phone: '000000' }).then((somePhone1) => {
-                  return self.PhoneNumber.create({ phone: '111111' }).then((somePhone2) => {
+            return self.Contact.create({ name: 'Boris' }).then(someContact => {
+              return self.Photo.create({ img: 'img.jpg' }).then(somePhoto => {
+                return self.PhoneNumber.create({ phone: '000000' }).then(somePhone1 => {
+                  return self.PhoneNumber.create({ phone: '111111' }).then(somePhone2 => {
                     return someContact.setPhotos([somePhoto]).then(() => {
                       return someContact.setPhoneNumbers([somePhone1, somePhone2]).then(() => {
                         return self.Contact.findOne({
@@ -642,7 +642,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                             name: 'Boris'
                           },
                           include: [self.PhoneNumber, { model: self.Photo, as: 'Photos' }]
-                        }).then((fetchedContact) => {
+                        }).then(fetchedContact => {
                           expect(fetchedContact).to.exist;
                           expect(fetchedContact.Photos.length).to.equal(1);
                           expect(fetchedContact.PhoneNumbers.length).to.equal(2);
@@ -674,15 +674,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.User.belongsToMany(self.Group, {through: 'group_user'});
 
           return self.sequelize.sync({ force: true }).then(() => {
-            return self.User.create({ username: 'someone' }).then((someUser) => {
-              return self.Group.create({ name: 'people' }).then((someGroup) => {
+            return self.User.create({ username: 'someone' }).then(someUser => {
+              return self.Group.create({ name: 'people' }).then(someGroup => {
                 return someUser.setGroupPKeagerones([someGroup]).then(() => {
                   return self.User.findOne({
                     where: {
                       username: 'someone'
                     },
                     include: [self.Group]
-                  }).then((someUser) => {
+                  }).then(someUser => {
                     expect(someUser).to.exist;
                     expect(someUser.username).to.equal('someone');
                     expect(someUser.GroupPKeagerones[0].name).to.equal('people');
@@ -697,7 +697,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       describe('hasMany with alias', () => {
         it('throws an error if included DaoFactory is not referenced by alias', function() {
           const self = this;
-          return self.Worker.findOne({ include: [self.Task] }).catch ((err) => {
+          return self.Worker.findOne({ include: [self.Task] }).catch (err => {
             expect(err.message).to.equal('Task is not associated to Worker!');
           });
         });
@@ -714,7 +714,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           it(`throws an error indicating an incorrect alias was entered if an association
               and alias exist but the alias doesn't match`, function() {
             const self = this;
-            return self.Worker.findOne({ include: [{ model: self.Task, as: 'Work' }] }).catch ((err) => {
+            return self.Worker.findOne({ include: [{ model: self.Task, as: 'Work' }] }).catch (err => {
               expect(err.message).to.equal('Task is associated to Worker using an alias. You\'ve included an alias (Work), but it does not match the alias defined in your association.');
             });
           });
@@ -723,7 +723,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return this.Worker.findOne({
               where: { name: 'worker' },
               include: [{ model: this.Task, as: 'ToDos' }]
-            }).then((worker) => {
+            }).then(worker => {
               expect(worker).to.exist;
               expect(worker.ToDos).to.exist;
               expect(worker.ToDos[0].title).to.equal('homework');
@@ -734,7 +734,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return this.Worker.findOne({
               where: { name: 'worker' },
               include: [{ model: this.Task, as: 'ToDos' }]
-            }).then((worker) => {
+            }).then(worker => {
               expect(worker.ToDos[0].title).to.equal('homework');
             });
           });
@@ -804,11 +804,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                     include: [
                       {model: self.Product, as: 'products'}
                     ]
-                  }).then((tag) => {
+                  }).then(tag => {
                     expect(tag).to.exist;
                     expect(tag.products.length).to.equal(2);
                   }),
-                  tags[1].getProducts().then((products) => {
+                  tags[1].getProducts().then(products => {
                     expect(products.length).to.equal(3);
                   }),
                   self.Product.findOne({
@@ -818,11 +818,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                     include: [
                       {model: self.Tag, as: 'tags'}
                     ]
-                  }).then((product) => {
+                  }).then(product => {
                     expect(product).to.exist;
                     expect(product.tags.length).to.equal(2);
                   }),
-                  products[1].getTags().then((tags) => {
+                  products[1].getTags().then(tags => {
                     expect(tags.length).to.equal(1);
                   })
                 ]);
@@ -898,28 +898,28 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     describe('queryOptions', () => {
       beforeEach(function() {
         const self = this;
-        return this.User.create({username: 'barfooz'}).then((user) => {
+        return this.User.create({username: 'barfooz'}).then(user => {
           self.user = user;
         });
       });
 
       it('should return a DAO when queryOptions are not set', function() {
         const self = this;
-        return this.User.findOne({ where: { username: 'barfooz'}}).then((user) => {
+        return this.User.findOne({ where: { username: 'barfooz'}}).then(user => {
           expect(user).to.be.instanceOf(self.User);
         });
       });
 
       it('should return a DAO when raw is false', function() {
         const self = this;
-        return this.User.findOne({ where: { username: 'barfooz'}, raw: false }).then((user) => {
+        return this.User.findOne({ where: { username: 'barfooz'}, raw: false }).then(user => {
           expect(user).to.be.instanceOf(self.User);
         });
       });
 
       it('should return raw data when raw is true', function() {
         const self = this;
-        return this.User.findOne({ where: { username: 'barfooz'}, raw: true }).then((user) => {
+        return this.User.findOne({ where: { username: 'barfooz'}, raw: true }).then(user => {
           expect(user).to.not.be.instanceOf(self.User);
           expect(user).to.be.instanceOf(Object);
         });
@@ -1010,11 +1010,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]);
       }).then(() => {
         return User.find({ where: {username: 'Tobi'} });
-      }).then((tobi) => {
+      }).then(tobi => {
         expect(tobi).not.to.be.null;
       }).then(() => {
         return User.findAll();
-      }).then((users) => {
+      }).then(users => {
         expect(users.length).to.be.eql(3);
       });
     });

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -30,15 +30,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   describe('findAll', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
-                return User.findAll({ where: {username: 'foo'} }).then((users1) => {
-                  return User.findAll({ transaction: t }).then((users2) => {
-                    return User.findAll({ where: {username: 'foo'}, transaction: t }).then((users3) => {
+                return User.findAll({ where: {username: 'foo'} }).then(users1 => {
+                  return User.findAll({ transaction: t }).then(users2 => {
+                    return User.findAll({ where: {username: 'foo'}, transaction: t }).then(users3 => {
                       expect(users1.length).to.equal(0);
                       expect(users2.length).to.equal(1);
                       expect(users3.length).to.equal(1);
@@ -68,7 +68,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           where: {
             username: ['boo', 'boo2']
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(2);
         });
       });
@@ -86,7 +86,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           where: {
             binary: [this.buf, this.buf]
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(1);
           expect(users[0].binary).to.be.an.instanceof.string;
           expect(users[0].username).to.equal('boo2');
@@ -100,7 +100,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               like: '%2'
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.be.an.instanceof(Array);
           expect(users).to.have.length(1);
           expect(users[0].username).to.equal('boo2');
@@ -115,7 +115,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               nlike: '%2'
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.be.an.instanceof(Array);
           expect(users).to.have.length(1);
           expect(users[0].username).to.equal('boo');
@@ -131,7 +131,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 ilike: '%2'
               }
             }
-          }).then((users) => {
+          }).then(users => {
             expect(users).to.be.an.instanceof(Array);
             expect(users).to.have.length(1);
             expect(users[0].username).to.equal('boo2');
@@ -146,7 +146,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 notilike: '%2'
               }
             }
-          }).then((users) => {
+          }).then(users => {
             expect(users).to.be.an.instanceof(Array);
             expect(users).to.have.length(1);
             expect(users[0].username).to.equal('boo');
@@ -162,7 +162,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               '..': ['2013-01-02', '2013-01-11']
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo2');
           expect(users[0].intVal).to.equal(10);
         });
@@ -175,7 +175,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               '!..': [8, 10]
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo');
           expect(users[0].intVal).to.equal(5);
         });
@@ -188,10 +188,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           {username: 'boo5', aBool: false},
           {username: 'boo6', aBool: true}
         ]).then(() => {
-          return User.findAll({where: {aBool: false}}).then((users) => {
+          return User.findAll({where: {aBool: false}}).then(users => {
             expect(users).to.have.length(1);
             expect(users[0].username).to.equal('boo5');
-            return User.findAll({where: {aBool: true}}).then((_users) => {
+            return User.findAll({where: {aBool: true}}).then(_users => {
               expect(_users).to.have.length(1);
               expect(_users[0].username).to.equal('boo6');
             });
@@ -218,14 +218,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 {isActive: true},
                 {isActive: false}
               ]).then(() => {
-                return User.findById(1).then((user) => {
-                  return Passports.findById(1).then((passport) => {
+                return User.findById(1).then(user => {
+                  return Passports.findById(1).then(passport => {
                     return user.setPassports([passport]).then(() => {
-                      return User.findById(2).then((_user) => {
-                        return Passports.findById(2).then((_passport) => {
+                      return User.findById(2).then(_user => {
+                        return Passports.findById(2).then(_passport => {
                           return _user.setPassports([_passport]).then(() => {
-                            return _user.getPassports({where: {isActive: false}}).then((theFalsePassport) => {
-                              return user.getPassports({where: {isActive: true}}).then((theTruePassport) => {
+                            return _user.getPassports({where: {isActive: false}}).then(theFalsePassport => {
+                              return user.getPassports({where: {isActive: true}}).then(theTruePassport => {
                                 expect(theFalsePassport).to.have.length(1);
                                 expect(theFalsePassport[0].isActive).to.be.false;
                                 expect(theTruePassport).to.have.length(1);
@@ -268,14 +268,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               {id: buf1},
               {id: buf2}
             ]).then(() => {
-              return User.findById(1).then((user) => {
-                return Binary.findById(buf1).then((binary) => {
+              return User.findById(1).then(user => {
+                return Binary.findById(buf1).then(binary => {
                   return user.setBinary(binary).then(() => {
-                    return User.findById(2).then((_user) => {
-                      return Binary.findById(buf2).then((_binary) => {
+                    return User.findById(2).then(_user => {
+                      return Binary.findById(buf2).then(_binary => {
                         return _user.setBinary(_binary).then(() => {
-                          return _user.getBinary().then((_binaryRetrieved) => {
-                            return user.getBinary().then((binaryRetrieved) => {
+                          return _user.getBinary().then(_binaryRetrieved => {
+                            return user.getBinary().then(binaryRetrieved => {
                               expect(binaryRetrieved.id).to.be.an.instanceof.string;
                               expect(_binaryRetrieved.id).to.be.an.instanceof.string;
                               expect(binaryRetrieved.id).to.have.length(16);
@@ -302,7 +302,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               between: ['2013-01-02', '2013-01-11']
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo2');
           expect(users[0].intVal).to.equal(10);
         });
@@ -316,7 +316,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             },
             intVal: 10
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo2');
           expect(users[0].intVal).to.equal(10);
         });
@@ -329,7 +329,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               nbetween: [8, 10]
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo');
           expect(users[0].intVal).to.equal(5);
         });
@@ -343,7 +343,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               nbetween: ['2013-01-04', '2013-01-20']
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo');
           expect(users[0].intVal).to.equal(5);
         });
@@ -357,7 +357,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               nbetween: [new Date('2013-01-04'), new Date('2013-01-20')]
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo');
           expect(users[0].intVal).to.equal(5);
         });
@@ -370,7 +370,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               gte: new Date('2013-01-09')
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo2');
           expect(users[0].intVal).to.equal(10);
         });
@@ -383,7 +383,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               gte: 6
             }
           }
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('boo2');
           expect(user.intVal).to.equal(10);
         });
@@ -396,7 +396,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               gt: 5
             }
           }
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('boo2');
           expect(user.intVal).to.equal(10);
         });
@@ -409,7 +409,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               lte: 5
             }
           }
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('boo');
           expect(user.intVal).to.equal(5);
         });
@@ -422,7 +422,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               lt: 6
             }
           }
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('boo');
           expect(user.intVal).to.equal(5);
         });
@@ -436,7 +436,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               gt: 4
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo');
           expect(users[0].intVal).to.equal(5);
         });
@@ -449,7 +449,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               ne: 10
             }
           }
-        }).then((user) => {
+        }).then(user => {
           expect(user.username).to.equal('boo');
           expect(user.intVal).to.equal(5);
         });
@@ -462,7 +462,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               lte: 10
             }
           }
-        }).then((users) => {
+        }).then(users => {
           expect(users[0].username).to.equal('boo');
           expect(users[0].intVal).to.equal(5);
           expect(users[1].username).to.equal('boo2');
@@ -487,8 +487,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           return self.Worker.sync({ force: true }).then(() => {
             return self.Task.sync({ force: true }).then(() => {
-              return self.Worker.create({ name: 'worker' }).then((worker) => {
-                return self.Task.create({ title: 'homework' }).then((task) => {
+              return self.Worker.create({ name: 'worker' }).then(worker => {
+                return self.Task.create({ title: 'homework' }).then(task => {
                   self.worker = worker;
                   self.task = task;
                   return self.task.setWorker(self.worker);
@@ -500,14 +500,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error about unexpected input if include contains a non-object', function() {
           const self = this;
-          return self.Worker.findAll({ include: [1] }).catch ((err) => {
+          return self.Worker.findAll({ include: [1] }).catch (err => {
             expect(err.message).to.equal('Include unexpected. Element has to be either a Model, an Association or an object.');
           });
         });
 
         it('throws an error if included DaoFactory is not associated', function() {
           const self = this;
-          return self.Worker.findAll({ include: [self.Task] }).catch ((err) => {
+          return self.Worker.findAll({ include: [self.Task] }).catch (err => {
             expect(err.message).to.equal('TaskBelongsTo is not associated to Worker!');
           });
         });
@@ -516,7 +516,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Task.findAll({
             where: { title: 'homework' },
             include: [this.Worker]
-          }).then((tasks) => {
+          }).then(tasks => {
             expect(tasks).to.exist;
             expect(tasks[0].Worker).to.exist;
             expect(tasks[0].Worker.name).to.equal('worker');
@@ -529,7 +529,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             include: [this.Worker],
             limit: 1,
             order: [['title', 'DESC']]
-          }).then((tasks) => {
+          }).then(tasks => {
             expect(tasks).to.exist;
             expect(tasks[0].Worker).to.exist;
             expect(tasks[0].Worker.name).to.equal('worker');
@@ -545,8 +545,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Worker.hasOne(self.Task);
           return self.Worker.sync({ force: true }).then(() => {
             return self.Task.sync({ force: true }).then(() => {
-              return self.Worker.create({ name: 'worker' }).then((worker) => {
-                return self.Task.create({ title: 'homework' }).then((task) => {
+              return self.Worker.create({ name: 'worker' }).then(worker => {
+                return self.Task.create({ title: 'homework' }).then(task => {
                   self.worker = worker;
                   self.task = task;
                   return self.worker.setTaskHasOne(self.task);
@@ -558,7 +558,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if included DaoFactory is not associated', function() {
           const self = this;
-          return self.Task.findAll({ include: [self.Worker] }).catch ((err) => {
+          return self.Task.findAll({ include: [self.Worker] }).catch (err => {
             expect(err.message).to.equal('Worker is not associated to TaskHasOne!');
           });
         });
@@ -567,7 +567,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findAll({
             where: { name: 'worker' },
             include: [this.Task]
-          }).then((workers) => {
+          }).then(workers => {
             expect(workers).to.exist;
             expect(workers[0].TaskHasOne).to.exist;
             expect(workers[0].TaskHasOne.title).to.equal('homework');
@@ -583,8 +583,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Worker.hasOne(self.Task, { as: 'ToDo' });
           return self.Worker.sync({ force: true }).then(() => {
             return self.Task.sync({ force: true }).then(() => {
-              return self.Worker.create({ name: 'worker' }).then((worker) => {
-                return self.Task.create({ title: 'homework' }).then((task) => {
+              return self.Worker.create({ name: 'worker' }).then(worker => {
+                return self.Task.create({ title: 'homework' }).then(task => {
                   self.worker = worker;
                   self.task = task;
                   return self.worker.setToDo(self.task);
@@ -596,7 +596,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if included DaoFactory is not referenced by alias', function() {
           const self = this;
-          return self.Worker.findAll({ include: [self.Task] }).catch ((err) => {
+          return self.Worker.findAll({ include: [self.Task] }).catch (err => {
             expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
             'You must use the \'as\' keyword to specify the alias within your include statement.');
           });
@@ -604,7 +604,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if alias is not associated', function() {
           const self = this;
-          return self.Worker.findAll({ include: [{ model: self.Task, as: 'Work' }] }).catch ((err) => {
+          return self.Worker.findAll({ include: [{ model: self.Task, as: 'Work' }] }).catch (err => {
             expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
             'You\'ve included an alias (Work), but it does not match the alias defined in your association.');
           });
@@ -614,7 +614,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findAll({
             where: { name: 'worker' },
             include: [{ model: this.Task, as: 'ToDo' }]
-          }).then((workers) => {
+          }).then(workers => {
             expect(workers).to.exist;
             expect(workers[0].ToDo).to.exist;
             expect(workers[0].ToDo.title).to.equal('homework');
@@ -625,7 +625,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findAll({
             where: { name: 'worker' },
             include: [{ model: this.Task, as: 'ToDo' }]
-          }).then((workers) => {
+          }).then(workers => {
             expect(workers[0].ToDo.title).to.equal('homework');
           });
         });
@@ -639,8 +639,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Worker.hasMany(self.Task);
           return self.Worker.sync({ force: true }).then(() => {
             return self.Task.sync({ force: true }).then(() => {
-              return self.Worker.create({ name: 'worker' }).then((worker) => {
-                return self.Task.create({ title: 'homework' }).then((task) => {
+              return self.Worker.create({ name: 'worker' }).then(worker => {
+                return self.Task.create({ title: 'homework' }).then(task => {
                   self.worker = worker;
                   self.task = task;
                   return self.worker.setTasks([self.task]);
@@ -652,7 +652,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if included DaoFactory is not associated', function() {
           const self = this;
-          return self.Task.findAll({ include: [self.Worker] }).catch ((err) => {
+          return self.Task.findAll({ include: [self.Worker] }).catch (err => {
             expect(err.message).to.equal('worker is not associated to task!');
           });
         });
@@ -661,7 +661,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findAll({
             where: { name: 'worker' },
             include: [this.Task]
-          }).then((workers) => {
+          }).then(workers => {
             expect(workers).to.exist;
             expect(workers[0].tasks).to.exist;
             expect(workers[0].tasks[0].title).to.equal('homework');
@@ -677,8 +677,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Worker.hasMany(self.Task, { as: 'ToDos' });
           return self.Worker.sync({ force: true }).then(() => {
             return self.Task.sync({ force: true }).then(() => {
-              return self.Worker.create({ name: 'worker' }).then((worker) => {
-                return self.Task.create({ title: 'homework' }).then((task) => {
+              return self.Worker.create({ name: 'worker' }).then(worker => {
+                return self.Task.create({ title: 'homework' }).then(task => {
                   self.worker = worker;
                   self.task = task;
                   return self.worker.setToDos([self.task]);
@@ -690,7 +690,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if included DaoFactory is not referenced by alias', function() {
           const self = this;
-          return self.Worker.findAll({ include: [self.Task] }).catch ((err) => {
+          return self.Worker.findAll({ include: [self.Task] }).catch (err => {
             expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
             'You must use the \'as\' keyword to specify the alias within your include statement.');
           });
@@ -698,7 +698,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('throws an error if alias is not associated', function() {
           const self = this;
-          return self.Worker.findAll({ include: [{ model: self.Task, as: 'Work' }] }).catch ((err) => {
+          return self.Worker.findAll({ include: [{ model: self.Task, as: 'Work' }] }).catch (err => {
             expect(err.message).to.equal('Task is associated to Worker using an alias. ' +
             'You\'ve included an alias (Work), but it does not match the alias defined in your association.');
           });
@@ -708,7 +708,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findAll({
             where: { name: 'worker' },
             include: [{ model: this.Task, as: 'ToDos' }]
-          }).then((workers) => {
+          }).then(workers => {
             expect(workers).to.exist;
             expect(workers[0].ToDos).to.exist;
             expect(workers[0].ToDos[0].title).to.equal('homework');
@@ -719,7 +719,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Worker.findAll({
             where: { name: 'worker' },
             include: [{ model: this.Task, as: 'ToDos' }]
-          }).then((workers) => {
+          }).then(workers => {
             expect(workers[0].ToDos[0].title).to.equal('homework');
           });
         });
@@ -728,15 +728,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       describe('queryOptions', () => {
         beforeEach(function() {
           const self = this;
-          return this.User.create({username: 'barfooz'}).then((user) => {
+          return this.User.create({username: 'barfooz'}).then(user => {
             self.user = user;
           });
         });
 
         it('should return a DAO when queryOptions are not set', function() {
           const self = this;
-          return this.User.findAll({ where: { username: 'barfooz'}}).then((users) => {
-            users.forEach((user) => {
+          return this.User.findAll({ where: { username: 'barfooz'}}).then(users => {
+            users.forEach(user => {
               expect(user).to.be.instanceOf(self.User);
             });
           });
@@ -744,8 +744,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('should return a DAO when raw is false', function() {
           const self = this;
-          return this.User.findAll({ where: { username: 'barfooz'}, raw: false }).then((users) => {
-            users.forEach((user) => {
+          return this.User.findAll({ where: { username: 'barfooz'}, raw: false }).then(users => {
+            users.forEach(user => {
               expect(user).to.be.instanceOf(self.User);
             });
           });
@@ -753,8 +753,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('should return raw data when raw is true', function() {
           const self = this;
-          return this.User.findAll({ where: { username: 'barfooz'}, raw: true }).then((users) => {
-            users.forEach((user) => {
+          return this.User.findAll({ where: { username: 'barfooz'}, raw: true }).then(users => {
+            users.forEach(user => {
               expect(user).to.not.be.instanceOf(self.User);
               expect(users[0]).to.be.instanceOf(Object);
             });
@@ -786,7 +786,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               england: self.Country.create({ name: 'England' }),
               coal: self.Industry.create({ name: 'Coal' }),
               bob: self.Person.create({ name: 'Bob', lastName: 'Becket' })
-            }).then((r) => {
+            }).then(r => {
               _.forEach(r, (item, itemName) => {
                 self[itemName] = item;
               });
@@ -801,7 +801,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('includes all associations', function() {
-          return this.Country.findAll({ include: [{ all: true }] }).then((countries) => {
+          return this.Country.findAll({ include: [{ all: true }] }).then(countries => {
             expect(countries).to.exist;
             expect(countries[0]).to.exist;
             expect(countries[0].continent).to.exist;
@@ -812,7 +812,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('includes specific type of association', function() {
-          return this.Country.findAll({ include: [{ all: 'BelongsTo' }] }).then((countries) => {
+          return this.Country.findAll({ include: [{ all: 'BelongsTo' }] }).then(countries => {
             expect(countries).to.exist;
             expect(countries[0]).to.exist;
             expect(countries[0].continent).to.exist;
@@ -823,7 +823,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('utilises specified attributes', function() {
-          return this.Country.findAll({ include: [{ all: 'HasMany', attributes: ['name'] }] }).then((countries) => {
+          return this.Country.findAll({ include: [{ all: 'HasMany', attributes: ['name'] }] }).then(countries => {
             expect(countries).to.exist;
             expect(countries[0]).to.exist;
             expect(countries[0].people).to.exist;
@@ -838,7 +838,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('is over-ruled by specified include', function() {
-          return this.Country.findAll({ include: [{ all: true }, { model: this.Continent, attributes: ['id'] }] }).then((countries) => {
+          return this.Country.findAll({ include: [{ all: true }, { model: this.Continent, attributes: ['id'] }] }).then(countries => {
             expect(countries).to.exist;
             expect(countries[0]).to.exist;
             expect(countries[0].continent).to.exist;
@@ -847,7 +847,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('includes all nested associations', function() {
-          return this.Continent.findAll({ include: [{ all: true, nested: true }] }).then((continents) => {
+          return this.Continent.findAll({ include: [{ all: true, nested: true }] }).then(continents => {
             expect(continents).to.exist;
             expect(continents[0]).to.exist;
             expect(continents[0].countries).to.exist;
@@ -904,9 +904,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               where: { age: { $gte : 29 } },
               attributes: []
             }]
-          }).then((kingdoms) => {
+          }).then(kingdoms => {
             expect(kingdoms.length).to.be.eql(2);
-            kingdoms.forEach((kingdom) => {
+            kingdoms.forEach(kingdom => {
               // include.attributes:[] , model doesn't exists
               expect(kingdom.Animals).to.not.exist;
             });
@@ -922,9 +922,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 attributes: []
               }
             }]
-          }).then((kingdoms) => {
+          }).then(kingdoms => {
             expect(kingdoms.length).to.be.eql(2);
-            kingdoms.forEach((kingdom) => {
+            kingdoms.forEach(kingdom => {
               expect(kingdom.Animals).to.exist; // include model exists
               expect(kingdom.Animals[0].AnimalKingdom).to.not.exist; // through doesn't exists
             });
@@ -941,9 +941,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 attributes: ['mutation']
               }
             }]
-          }).then((kingdoms) => {
+          }).then(kingdoms => {
             expect(kingdoms.length).to.be.eql(2);
-            kingdoms.forEach((kingdom) => {
+            kingdoms.forEach(kingdom => {
               // include.attributes: [], model doesn't exists
               expect(kingdom.Animals).to.not.exist;
             });
@@ -980,7 +980,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               fred: self.Person.create({ name: 'Fred', lastName: 'Able' }),
               pierre: self.Person.create({ name: 'Pierre', lastName: 'Paris' }),
               kim: self.Person.create({ name: 'Kim', lastName: 'Z' })
-            }).then((r) => {
+            }).then(r => {
               _.forEach(r, (item, itemName) => {
                 self[itemName] = item;
               });
@@ -1006,10 +1006,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts simply', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'Asia'], ['DESC', 'Europe']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'Asia'], ['DESC', 'Europe']], params => {
             return self.Continent.findAll({
               order: [['name', params[0]]]
-            }).then((continents) => {
+            }).then(continents => {
               expect(continents).to.exist;
               expect(continents[0]).to.exist;
               expect(continents[0].name).to.equal(params[1]);
@@ -1019,11 +1019,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts by 1st degree association', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'Europe', 'England'], ['DESC', 'Asia', 'Korea']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'Europe', 'England'], ['DESC', 'Asia', 'Korea']], params => {
             return self.Continent.findAll({
               include: [self.Country],
               order: [[self.Country, 'name', params[0]]]
-            }).then((continents) => {
+            }).then(continents => {
               expect(continents).to.exist;
               expect(continents[0]).to.exist;
               expect(continents[0].name).to.equal(params[1]);
@@ -1036,11 +1036,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts by 2nd degree association', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'Europe', 'England', 'Fred'], ['DESC', 'Asia', 'Korea', 'Kim']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'Europe', 'England', 'Fred'], ['DESC', 'Asia', 'Korea', 'Kim']], params => {
             return self.Continent.findAll({
               include: [{ model: self.Country, include: [self.Person] }],
               order: [[self.Country, self.Person, 'lastName', params[0]]]
-            }).then((continents) => {
+            }).then(continents => {
               expect(continents).to.exist;
               expect(continents[0]).to.exist;
               expect(continents[0].name).to.equal(params[1]);
@@ -1056,11 +1056,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts by 2nd degree association with alias', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'Europe', 'France', 'Fred'], ['DESC', 'Europe', 'England', 'Kim']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'Europe', 'France', 'Fred'], ['DESC', 'Europe', 'England', 'Kim']], params => {
             return self.Continent.findAll({
               include: [{ model: self.Country, include: [self.Person, {model: self.Person, as: 'residents' }] }],
               order: [[self.Country, {model: self.Person, as: 'residents' }, 'lastName', params[0]]]
-            }).then((continents) => {
+            }).then(continents => {
               expect(continents).to.exist;
               expect(continents[0]).to.exist;
               expect(continents[0].name).to.equal(params[1]);
@@ -1076,12 +1076,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts by 2nd degree association with alias while using limit', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'Europe', 'France', 'Fred'], ['DESC', 'Europe', 'England', 'Kim']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'Europe', 'France', 'Fred'], ['DESC', 'Europe', 'England', 'Kim']], params => {
             return self.Continent.findAll({
               include: [{ model: self.Country, include: [self.Person, {model: self.Person, as: 'residents' }] }],
               order: [[{ model: self.Country }, {model: self.Person, as: 'residents' }, 'lastName', params[0]]],
               limit: 3
-            }).then((continents) => {
+            }).then(continents => {
               expect(continents).to.exist;
               expect(continents[0]).to.exist;
               expect(continents[0].name).to.equal(params[1]);
@@ -1115,7 +1115,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               energy: self.Industry.create({ name: 'Energy' }),
               media: self.Industry.create({ name: 'Media' }),
               tech: self.Industry.create({ name: 'Tech' })
-            }).then((r) => {
+            }).then(r => {
               _.forEach(r, (item, itemName) => {
                 self[itemName] = item;
               });
@@ -1132,11 +1132,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts by 1st degree association', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'England', 'Energy'], ['DESC', 'Korea', 'Tech']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'England', 'Energy'], ['DESC', 'Korea', 'Tech']], params => {
             return self.Country.findAll({
               include: [self.Industry],
               order: [[self.Industry, 'name', params[0]]]
-            }).then((countries) => {
+            }).then(countries => {
               expect(countries).to.exist;
               expect(countries[0]).to.exist;
               expect(countries[0].name).to.equal(params[1]);
@@ -1149,14 +1149,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts by 1st degree association while using limit', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'England', 'Energy'], ['DESC', 'Korea', 'Tech']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'England', 'Energy'], ['DESC', 'Korea', 'Tech']], params => {
             return self.Country.findAll({
               include: [self.Industry],
               order: [
                 [self.Industry, 'name', params[0]]
               ],
               limit: 3
-            }).then((countries) => {
+            }).then(countries => {
               expect(countries).to.exist;
               expect(countries[0]).to.exist;
               expect(countries[0].name).to.equal(params[1]);
@@ -1169,11 +1169,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         it('sorts by through table attribute', function() {
           const self = this;
-          return this.sequelize.Promise.map([['ASC', 'England', 'Energy'], ['DESC', 'France', 'Media']], (params) => {
+          return this.sequelize.Promise.map([['ASC', 'England', 'Energy'], ['DESC', 'France', 'Media']], params => {
             return self.Country.findAll({
               include: [self.Industry],
               order: [[self.Industry, self.IndustryCountry, 'numYears', params[0]]]
-            }).then((countries) => {
+            }).then(countries => {
               expect(countries).to.exist;
               expect(countries[0]).to.exist;
               expect(countries[0].name).to.equal(params[1]);
@@ -1189,36 +1189,36 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     describe('normal findAll', () => {
       beforeEach(function() {
         const self = this;
-        return this.User.create({username: 'user', data: 'foobar', theDate: moment().toDate()}).then((user) => {
-          return self.User.create({username: 'user2', data: 'bar', theDate: moment().toDate()}).then((user2) => {
+        return this.User.create({username: 'user', data: 'foobar', theDate: moment().toDate()}).then(user => {
+          return self.User.create({username: 'user2', data: 'bar', theDate: moment().toDate()}).then(user2 => {
             self.users = [user].concat(user2);
           });
         });
       });
 
       it('finds all entries', function() {
-        return this.User.findAll().then((users) => {
+        return this.User.findAll().then(users => {
           expect(users.length).to.equal(2);
         });
       });
 
       it('can also handle object notation', function() {
         const self = this;
-        return this.User.findAll({where: {id: this.users[1].id}}).then((users) => {
+        return this.User.findAll({where: {id: this.users[1].id}}).then(users => {
           expect(users.length).to.equal(1);
           expect(users[0].id).to.equal(self.users[1].id);
         });
       });
 
       it('sorts the results via id in ascending order', function() {
-        return this.User.findAll().then((users) => {
+        return this.User.findAll().then(users => {
           expect(users.length).to.equal(2);
           expect(users[0].id).to.be.below(users[1].id);
         });
       });
 
       it('sorts the results via id in descending order', function() {
-        return this.User.findAll({ order: [['id', 'DESC']] }).then((users) => {
+        return this.User.findAll({ order: [['id', 'DESC']] }).then(users => {
           expect(users[0].id).to.be.above(users[1].id);
         });
       });
@@ -1226,7 +1226,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('sorts the results via a date column', function() {
         const self = this;
         return self.User.create({username: 'user3', data: 'bar', theDate: moment().add(2, 'hours').toDate()}).then(() => {
-          return self.User.findAll({ order: [['theDate', 'DESC']] }).then((users) => {
+          return self.User.findAll({ order: [['theDate', 'DESC']] }).then(users => {
             expect(users[0].id).to.be.above(users[2].id);
           });
         });
@@ -1235,7 +1235,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('handles offset and limit', function() {
         const self = this;
         return this.User.bulkCreate([{username: 'bobby'}, {username: 'tables'}]).then(() => {
-          return self.User.findAll({ limit: 2, offset: 2 }).then((users) => {
+          return self.User.findAll({ limit: 2, offset: 2 }).then(users => {
             expect(users.length).to.equal(2);
             expect(users[0].id).to.equal(3);
           });
@@ -1250,7 +1250,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return User.sync({ force: true }).then(() => {
           return User.create({Login: 'foo'}).then(() => {
-            return User.findAll({ where: { ID: 1 } }).then((user) => {
+            return User.findAll({ where: { ID: 1 } }).then(user => {
               expect(user).to.be.instanceof(Array);
               expect(user).to.have.length(1);
             });
@@ -1286,8 +1286,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return User.create().then(() => {
           return User.findAll({
             attributes: ['active']
-          }).then((users) => {
-            users.forEach((user) => {
+          }).then(users => {
+            users.forEach(user => {
               expect(user.get('createdAt')).to.be.ok;
               expect(user.get('active')).to.equal(true);
             });
@@ -1305,7 +1305,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         {username: 'user2', data: 'bar'},
         {username: 'bobby', data: 'foo'}
       ]).then(() => {
-        return self.User.findAll().then((users) => {
+        return self.User.findAll().then(users => {
           self.users = users;
         });
       });
@@ -1313,14 +1313,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
-                return User.findAndCountAll().then((info1) => {
-                  return User.findAndCountAll({ transaction: t }).then((info2) => {
+                return User.findAndCountAll().then(info1 => {
+                  return User.findAndCountAll({ transaction: t }).then(info2 => {
                     expect(info1.count).to.equal(0);
                     expect(info2.count).to.equal(1);
                     return t.rollback();
@@ -1334,7 +1334,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     }
 
     it('handles where clause {only}', function() {
-      return this.User.findAndCountAll({where: {id: {$ne: this.users[0].id}}}).then((info) => {
+      return this.User.findAndCountAll({where: {id: {$ne: this.users[0].id}}}).then(info => {
         expect(info.count).to.equal(2);
         expect(Array.isArray(info.rows)).to.be.ok;
         expect(info.rows.length).to.equal(2);
@@ -1342,7 +1342,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('handles where clause with ordering {only}', function() {
-      return this.User.findAndCountAll({where: {id: {$ne: this.users[0].id}}, order: [['id', 'ASC']]}).then((info) => {
+      return this.User.findAndCountAll({where: {id: {$ne: this.users[0].id}}, order: [['id', 'ASC']]}).then(info => {
         expect(info.count).to.equal(2);
         expect(Array.isArray(info.rows)).to.be.ok;
         expect(info.rows.length).to.equal(2);
@@ -1350,7 +1350,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('handles offset', function() {
-      return this.User.findAndCountAll({offset: 1}).then((info) => {
+      return this.User.findAndCountAll({offset: 1}).then(info => {
         expect(info.count).to.equal(3);
         expect(Array.isArray(info.rows)).to.be.ok;
         expect(info.rows.length).to.equal(2);
@@ -1358,7 +1358,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('handles limit', function() {
-      return this.User.findAndCountAll({limit: 1}).then((info) => {
+      return this.User.findAndCountAll({limit: 1}).then(info => {
         expect(info.count).to.equal(3);
         expect(Array.isArray(info.rows)).to.be.ok;
         expect(info.rows.length).to.equal(1);
@@ -1366,7 +1366,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('handles offset and limit', function() {
-      return this.User.findAndCountAll({offset: 1, limit: 1}).then((info) => {
+      return this.User.findAndCountAll({offset: 1, limit: 1}).then(info => {
         expect(info.count).to.equal(3);
         expect(Array.isArray(info.rows)).to.be.ok;
         expect(info.rows.length).to.equal(1);
@@ -1389,10 +1389,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.sequelize.sync().then(() => {
         // Add some data
-        return Citizen.create({ name: 'Alice' }).then((alice) => {
-          return Citizen.create({ name: 'Bob' }).then((bob) => {
+        return Citizen.create({ name: 'Alice' }).then(alice => {
+          return Citizen.create({ name: 'Bob' }).then(bob => {
             return Election.create({ name: 'Some election' }).then(() => {
-              return Election.create({ name: 'Some other election' }).then((election) => {
+              return Election.create({ name: 'Some other election' }).then(election => {
                 return election.setCitizen(alice).then(() => {
                   return election.setVoters([alice, bob]).then(() => {
                     const criteria = {
@@ -1406,7 +1406,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                         { model: Citizen, as: 'Voters' } // Election voters
                       ]
                     };
-                    return Election.findAndCountAll(criteria).then((elections) => {
+                    return Election.findAndCountAll(criteria).then(elections => {
                       expect(elections.count).to.equal(1);
                       expect(elections.rows.length).to.equal(0);
                     });
@@ -1420,7 +1420,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('handles attributes', function() {
-      return this.User.findAndCountAll({where: {id: {$ne: this.users[0].id}}, attributes: ['data']}).then((info) => {
+      return this.User.findAndCountAll({where: {id: {$ne: this.users[0].id}}, attributes: ['data']}).then(info => {
         expect(info.count).to.equal(2);
         expect(Array.isArray(info.rows)).to.be.ok;
         expect(info.rows.length).to.equal(2);
@@ -1440,14 +1440,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Sequelize.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((t) => {
+            return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
-                return User.findAll().then((users1) => {
-                  return User.findAll({ transaction: t }).then((users2) => {
+                return User.findAll().then(users1 => {
+                  return User.findAll({ transaction: t }).then(users2 => {
                     expect(users1.length).to.equal(0);
                     expect(users2.length).to.equal(1);
                     return t.rollback();
@@ -1461,7 +1461,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     }
 
     it('should return all users', function() {
-      return this.User.findAll().then((users) => {
+      return this.User.findAll().then(users => {
         expect(users.length).to.equal(2);
       });
     });

--- a/test/integration/model/findAll/group.test.js
+++ b/test/integration/model/findAll/group.test.js
@@ -46,7 +46,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ],
             group: [ 'Post.id' ]
           });
-        }).then((posts) => {
+        }).then(posts => {
           expect(parseInt(posts[0].get('comment_count'))).to.be.equal(3);
           expect(parseInt(posts[1].get('comment_count'))).to.be.equal(2);
         });

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -26,9 +26,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           it('should work with order: literal()', function() {
             return this.User.findAll({
               order: this.sequelize.literal('email = ' + this.sequelize.escape('test@sequelizejs.com'))
-            }).then((users) => {
+            }).then(users => {
               expect(users.length).to.equal(1);
-              users.forEach((user) => {
+              users.forEach(user => {
                 expect(user.get('email')).to.be.ok;
               });
             });
@@ -37,9 +37,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           it('should work with order: [literal()]', function() {
             return this.User.findAll({
               order: [this.sequelize.literal('email = ' + this.sequelize.escape('test@sequelizejs.com'))]
-            }).then((users) => {
+            }).then(users => {
               expect(users.length).to.equal(1);
-              users.forEach((user) => {
+              users.forEach(user => {
                 expect(user.get('email')).to.be.ok;
               });
             });
@@ -50,9 +50,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               order: [
                 [this.sequelize.literal('email = ' + this.sequelize.escape('test@sequelizejs.com'))]
               ]
-            }).then((users) => {
+            }).then(users => {
               expect(users.length).to.equal(1);
-              users.forEach((user) => {
+              users.forEach(user => {
                 expect(user.get('email')).to.be.ok;
               });
             });

--- a/test/integration/model/geography.test.js
+++ b/test/integration/model/geography.test.js
@@ -27,7 +27,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return Pub.sync({ force: true }).then(() => {
           return Pub.create({location: point});
-        }).then((pub) => {
+        }).then(pub => {
           expect(pub).not.to.be.null;
           expect(pub.location).to.be.deep.eql(point);
         });
@@ -37,7 +37,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const User = this.User;
         const point = { type: 'Point', coordinates: [39.807222, -76.984722]};
 
-        return User.create({username: 'username', geography: point }).then((newUser) => {
+        return User.create({username: 'username', geography: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geography).to.be.deep.eql(point);
         });
@@ -53,7 +53,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geography: point2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geography).to.be.deep.eql(point2);
         });
       });
@@ -73,7 +73,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const User = this.User;
         const point = { type: 'Point', coordinates: [39.807222, -76.984722]};
 
-        return User.create({username: 'username', geography: point }).then((newUser) => {
+        return User.create({username: 'username', geography: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geography).to.be.deep.eql(point);
         });
@@ -89,7 +89,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geography: point2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geography).to.be.deep.eql(point2);
         });
       });
@@ -109,7 +109,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const User = this.User;
         const point = { type: 'LineString', 'coordinates': [ [100.0, 0.0], [101.0, 1.0] ] };
 
-        return User.create({username: 'username', geography: point }).then((newUser) => {
+        return User.create({username: 'username', geography: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geography).to.be.deep.eql(point);
         });
@@ -125,7 +125,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geography: point2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geography).to.be.deep.eql(point2);
         });
       });
@@ -148,7 +148,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                [100.0, 1.0], [100.0, 0.0] ]
         ]};
 
-        return User.create({username: 'username', geography: point }).then((newUser) => {
+        return User.create({username: 'username', geography: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geography).to.be.deep.eql(point);
         });
@@ -170,7 +170,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geography: polygon2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geography).to.be.deep.eql(polygon2);
         });
       });

--- a/test/integration/model/geometry.test.js
+++ b/test/integration/model/geometry.test.js
@@ -29,7 +29,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return Pub.sync({ force: true }).then(() => {
           return Pub.create({location: point});
-        }).then((pub) => {
+        }).then(pub => {
           expect(pub).not.to.be.null;
           expect(pub.location).to.be.deep.eql(point);
         });
@@ -39,7 +39,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const User = this.User;
         const point = { type: 'Point', coordinates: [39.807222, -76.984722]};
 
-        return User.create({username: 'username', geometry: point }).then((newUser) => {
+        return User.create({username: 'username', geometry: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geometry).to.be.deep.eql(point);
         });
@@ -55,7 +55,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geometry: point2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geometry).to.be.deep.eql(point2);
         });
       });
@@ -75,7 +75,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const User = this.User;
         const point = { type: 'Point', coordinates: [39.807222, -76.984722]};
 
-        return User.create({username: 'username', geometry: point }).then((newUser) => {
+        return User.create({username: 'username', geometry: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geometry).to.be.deep.eql(point);
         });
@@ -91,7 +91,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geometry: point2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geometry).to.be.deep.eql(point2);
         });
       });
@@ -111,7 +111,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const User = this.User;
         const point = { type: 'LineString', 'coordinates': [ [100.0, 0.0], [101.0, 1.0] ] };
 
-        return User.create({username: 'username', geometry: point }).then((newUser) => {
+        return User.create({username: 'username', geometry: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geometry).to.be.deep.eql(point);
         });
@@ -127,7 +127,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geometry: point2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geometry).to.be.deep.eql(point2);
         });
       });
@@ -150,7 +150,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                [100.0, 1.0], [100.0, 0.0] ]
         ]};
 
-        return User.create({username: 'username', geometry: point }).then((newUser) => {
+        return User.create({username: 'username', geometry: point }).then(newUser => {
           expect(newUser).not.to.be.null;
           expect(newUser.geometry).to.be.deep.eql(point);
         });
@@ -172,7 +172,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.update({geometry: polygon2}, {where: {username: props.username}});
         }).then(() => {
           return User.findOne({where: {username: props.username}});
-        }).then((user) => {
+        }).then(user => {
           expect(user.geometry).to.be.deep.eql(polygon2);
         });
       });

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -578,7 +578,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         });
 
-        it('should query an instance with JSONB data and order while trying to inject', function () {
+        it('should query an instance with JSONB data and order while trying to inject', function() {
           return this.Event.create({
             data: {
               name: {

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -35,24 +35,24 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return Account.sync({force: true})
         .then(() => Account.create({ ownerId: 12 }))
         .then(() => Account.count())
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(1);
           return Account.destroy({ where: { ownerId: 12 }})
-          .then((result) => {
+          .then(result => {
             expect(result).to.be.equal(1);
           });
         })
         .then(() => Account.count())
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(0);
           return Account.count({ paranoid: false });
         })
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(1);
           return Account.restore({ where: { ownerId: 12 }});
         })
         .then(() => Account.count())
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(1);
         });
     });
@@ -83,21 +83,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return Account.sync({force: true})
         .then(() => Account.create({ ownerId: 12 }))
         .then(() => Account.count())
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(1);
           return Account.destroy({ where: { ownerId: 12 }});
         })
         .then(() => Account.count())
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(0);
           return Account.count({ paranoid: false });
         })
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(1);
           return Account.restore({ where: { ownerId: 12 }});
         })
         .then(() => Account.count())
-        .then((count) => {
+        .then(count => {
           expect(count).to.be.equal(1);
         });
     });

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -82,15 +82,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return self.RestaurantOne.findOne({
               where: {foo: 'one'}
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('one');
             restaurantId = obj.id;
             return self.RestaurantOne.findById(restaurantId);
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('one');
-            return self.RestaurantTwo.findOne({where: {foo: 'one'}}).then((RestaurantObj) => {
+            return self.RestaurantTwo.findOne({where: {foo: 'one'}}).then(RestaurantObj => {
               expect(RestaurantObj).to.be.null;
             });
           });
@@ -107,15 +107,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return self.RestaurantTwo.findOne({
               where: {foo: 'two'}
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('two');
             restaurantId = obj.id;
             return self.RestaurantTwo.findById(restaurantId);
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('two');
-            return self.RestaurantOne.findOne({where: {foo: 'two'}}).then((RestaurantObj) => {
+            return self.RestaurantOne.findOne({where: {foo: 'two'}}).then(RestaurantObj => {
               expect(RestaurantObj).to.be.null;
             });
           });
@@ -145,59 +145,59 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return restaurauntModel.save();
             }).then(() => {
               return self.RestaurantOne.findAll();
-            }).then((restaurantsOne) => {
+            }).then(restaurantsOne => {
               expect(restaurantsOne).to.not.be.null;
               expect(restaurantsOne.length).to.equal(2);
-              restaurantsOne.forEach((restaurant) => {
+              restaurantsOne.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('one');
               });
               return self.RestaurantOne.findAndCountAll();
-            }).then((restaurantsOne) => {
+            }).then(restaurantsOne => {
               expect(restaurantsOne).to.not.be.null;
               expect(restaurantsOne.rows.length).to.equal(2);
               expect(restaurantsOne.count).to.equal(2);
-              restaurantsOne.rows.forEach((restaurant) => {
+              restaurantsOne.rows.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('one');
               });
               return self.RestaurantOne.findAll({
                 where: {bar: {$like: '%.1'}}
               });
-            }).then((restaurantsOne) => {
+            }).then(restaurantsOne => {
               expect(restaurantsOne).to.not.be.null;
               expect(restaurantsOne.length).to.equal(1);
-              restaurantsOne.forEach((restaurant) => {
+              restaurantsOne.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('one');
               });
               return self.RestaurantOne.count();
-            }).then((count) => {
+            }).then(count => {
               expect(count).to.not.be.null;
               expect(count).to.equal(2);
               return self.RestaurantTwo.findAll();
-            }).then((restaurantsTwo) => {
+            }).then(restaurantsTwo => {
               expect(restaurantsTwo).to.not.be.null;
               expect(restaurantsTwo.length).to.equal(3);
-              restaurantsTwo.forEach((restaurant) => {
+              restaurantsTwo.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('two');
               });
               return self.RestaurantTwo.findAndCountAll();
-            }).then((restaurantsTwo) => {
+            }).then(restaurantsTwo => {
               expect(restaurantsTwo).to.not.be.null;
               expect(restaurantsTwo.rows.length).to.equal(3);
               expect(restaurantsTwo.count).to.equal(3);
-              restaurantsTwo.rows.forEach((restaurant) => {
+              restaurantsTwo.rows.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('two');
               });
               return self.RestaurantTwo.findAll({
                 where: {bar: {$like: '%.3'}}
               });
-            }).then((restaurantsTwo) => {
+            }).then(restaurantsTwo => {
               expect(restaurantsTwo).to.not.be.null;
               expect(restaurantsTwo.length).to.equal(1);
-              restaurantsTwo.forEach((restaurant) => {
+              restaurantsTwo.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('two');
               });
               return self.RestaurantTwo.count();
-            }).then((count) => {
+            }).then(count => {
               expect(count).to.not.be.null;
               expect(count).to.equal(3);
             });
@@ -211,14 +211,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return Location.sync({force: true})
             .then(() => {
               return Location.create({name: 'HQ'}).then(() => {
-                return Location.findOne({where: {name: 'HQ'}}).then((obj) => {
+                return Location.findOne({where: {name: 'HQ'}}).then(obj => {
                   expect(obj).to.not.be.null;
                   expect(obj.name).to.equal('HQ');
                   locationId = obj.id;
                 });
               });
             })
-            .catch((err) => {
+            .catch(err => {
               expect(err).to.be.null;
             });
         });
@@ -235,7 +235,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: self.Location, as: 'location'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('one');
             expect(obj.location).to.not.be.null;
@@ -264,7 +264,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return self.RestaurantOne.findOne({
               where: {foo: 'one'}
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('one');
             restaurantId = obj.id;
@@ -279,13 +279,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: self.EmployeeOne, as: 'employees'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.employees).to.not.be.null;
             expect(obj.employees.length).to.equal(1);
             expect(obj.employees[0].last_name).to.equal('one');
             return obj.getEmployees({schema:SCHEMA_ONE});
-          }).then((employees) => {
+          }).then(employees => {
             expect(employees.length).to.equal(1);
             expect(employees[0].last_name).to.equal('one');
             return self.EmployeeOne.findOne({
@@ -293,12 +293,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: self.RestaurantOne, as: 'restaurant'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.restaurant).to.not.be.null;
             expect(obj.restaurant.foo).to.equal('one');
             return obj.getRestaurant({schema:SCHEMA_ONE});
-          }).then((restaurant) => {
+          }).then(restaurant => {
             expect(restaurant).to.not.be.null;
             expect(restaurant.foo).to.equal('one');
           });
@@ -315,7 +315,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return self.RestaurantTwo.findOne({
               where: {foo: 'two'}
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('two');
             restaurantId = obj.id;
@@ -330,13 +330,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: self.Employee.schema(SCHEMA_TWO), as: 'employees'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.employees).to.not.be.null;
             expect(obj.employees.length).to.equal(1);
             expect(obj.employees[0].last_name).to.equal('two');
             return obj.getEmployees({schema:SCHEMA_TWO});
-          }).then((employees) => {
+          }).then(employees => {
             expect(employees.length).to.equal(1);
             expect(employees[0].last_name).to.equal('two');
             return self.Employee.schema(SCHEMA_TWO).findOne({
@@ -344,12 +344,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: self.RestaurantTwo, as: 'restaurant'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.restaurant).to.not.be.null;
             expect(obj.restaurant.foo).to.equal('two');
             return obj.getRestaurant({schema:SCHEMA_TWO});
-          }).then((restaurant) => {
+          }).then(restaurant => {
             expect(restaurant).to.not.be.null;
             expect(restaurant.foo).to.equal('two');
           });
@@ -371,17 +371,17 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return restaurauntModelSchema1.save();
             }).then(() => {
               return Restaurant.schema(SCHEMA_ONE).findAll();
-            }).then((restaurantsOne) => {
+            }).then(restaurantsOne => {
               expect(restaurantsOne).to.not.be.null;
               expect(restaurantsOne.length).to.equal(2);
-              restaurantsOne.forEach((restaurant) => {
+              restaurantsOne.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('one');
               });
               return Restaurant.schema(SCHEMA_TWO).findAll();
-            }).then((restaurantsTwo) => {
+            }).then(restaurantsTwo => {
               expect(restaurantsTwo).to.not.be.null;
               expect(restaurantsTwo.length).to.equal(1);
-              restaurantsTwo.forEach((restaurant) => {
+              restaurantsTwo.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('two');
               });
             });

--- a/test/integration/model/scope.test.js
+++ b/test/integration/model/scope.test.js
@@ -42,7 +42,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('should be able to merge attributes as array', function() {
       return this.ScopeMe.scope('lowAccess', 'withName').findOne()
-              .then((record) => {
+              .then(record => {
                 expect(record.other_value).to.exist;
                 expect(record.username).to.exist;
                 expect(record.access_level).to.exist;

--- a/test/integration/model/scope/aggregate.test.js
+++ b/test/integration/model/scope/aggregate.test.js
@@ -60,7 +60,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.ScopeMe.bulkCreate(records);
         }).then(() => {
           return this.ScopeMe.findAll();
-        }).then((records) => {
+        }).then(records => {
           return Promise.all([
             records[0].createChild({
               priority: 1

--- a/test/integration/model/scope/associations.test.js
+++ b/test/integration/model/scope/associations.test.js
@@ -126,7 +126,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should apply default scope when including an associations', function() {
           return this.Company.findAll({
             include: [this.UserAssociation]
-          }).get(0).then((company) => {
+          }).get(0).then(company => {
             expect(company.users).to.have.length(2);
           });
         });
@@ -134,7 +134,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should apply default scope when including a model', function() {
           return this.Company.findAll({
             include: [{ model: this.ScopeMe, as: 'users'}]
-          }).get(0).then((company) => {
+          }).get(0).then(company => {
             expect(company.users).to.have.length(2);
           });
         });
@@ -142,7 +142,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should be able to include a scoped model', function() {
           return this.Company.findAll({
             include: [{ model: this.ScopeMe.scope('isTony'), as: 'users'}]
-          }).get(0).then((company) => {
+          }).get(0).then(company => {
             expect(company.users).to.have.length(1);
             expect(company.users[0].get('username')).to.equal('tony');
           });
@@ -161,9 +161,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         describe('it should be able to unscope', () => {
           it('hasMany', function() {
-            return this.Company.findById(1).then((company) => {
+            return this.Company.findById(1).then(company => {
               return company.getUsers({ scope: false});
-            }).then((users) => {
+            }).then(users => {
               expect(users).to.have.length(4);
             });
           });
@@ -174,25 +174,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               userId: 1
             }).bind(this).then(function() {
               return this.ScopeMe.findById(1);
-            }).then((user) => {
+            }).then(user => {
               return user.getProfile({ scope: false });
-            }).then((profile) => {
+            }).then(profile => {
               expect(profile).to.be.ok;
             });
           });
 
           it('belongsTo', function() {
-            return this.ScopeMe.unscoped().find({ where: { username: 'bob' }}).then((user) => {
+            return this.ScopeMe.unscoped().find({ where: { username: 'bob' }}).then(user => {
               return user.getCompany({ scope: false });
-            }).then((company) => {
+            }).then(company => {
               expect(company).to.be.ok;
             });
           });
 
           it('belongsToMany', function() {
-            return this.Project.findAll().get(0).then((p) => {
+            return this.Project.findAll().get(0).then(p => {
               return p.getCompanies({ scope: false});
-            }).then((companies) => {
+            }).then(companies => {
               expect(companies).to.have.length(2);
             });
           });
@@ -200,9 +200,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         describe('it should apply default scope', () => {
           it('hasMany', function() {
-            return this.Company.findById(1).then((company) => {
+            return this.Company.findById(1).then(company => {
               return company.getUsers();
-            }).then((users) => {
+            }).then(users => {
               expect(users).to.have.length(2);
             });
           });
@@ -213,25 +213,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               userId: 1
             }).bind(this).then(function() {
               return this.ScopeMe.findById(1);
-            }).then((user) => {
+            }).then(user => {
               return user.getProfile();
-            }).then((profile) => {
+            }).then(profile => {
               expect(profile).not.to.be.ok;
             });
           });
 
           it('belongsTo', function() {
-            return this.ScopeMe.unscoped().find({ where: { username: 'bob' }}).then((user) => {
+            return this.ScopeMe.unscoped().find({ where: { username: 'bob' }}).then(user => {
               return user.getCompany();
-            }).then((company) => {
+            }).then(company => {
               expect(company).not.to.be.ok;
             });
           });
 
           it('belongsToMany', function() {
-            return this.Project.findAll().get(0).then((p) => {
+            return this.Project.findAll().get(0).then(p => {
               return p.getCompanies();
-            }).then((companies) => {
+            }).then(companies => {
               expect(companies).to.have.length(1);
               expect(companies[0].get('active')).to.be.ok;
             });
@@ -240,9 +240,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         describe('it should be able to apply another scope', () => {
           it('hasMany', function() {
-            return this.Company.findById(1).then((company) => {
+            return this.Company.findById(1).then(company => {
               return company.getUsers({ scope: 'isTony'});
-            }).then((users) => {
+            }).then(users => {
               expect(users).to.have.length(1);
               expect(users[0].get('username')).to.equal('tony');
             });
@@ -254,25 +254,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               userId: 1
             }).bind(this).then(function() {
               return this.ScopeMe.findById(1);
-            }).then((user) => {
+            }).then(user => {
               return user.getProfile({ scope: 'notActive' });
-            }).then((profile) => {
+            }).then(profile => {
               expect(profile).not.to.be.ok;
             });
           });
 
           it('belongsTo', function() {
-            return this.ScopeMe.unscoped().find({ where: { username: 'bob' }}).then((user) => {
+            return this.ScopeMe.unscoped().find({ where: { username: 'bob' }}).then(user => {
               return user.getCompany({ scope: 'notActive' });
-            }).then((company) => {
+            }).then(company => {
               expect(company).to.be.ok;
             });
           });
 
           it('belongsToMany', function() {
-            return this.Project.findAll().get(0).then((p) => {
+            return this.Project.findAll().get(0).then(p => {
               return p.getCompanies({ scope: 'reversed' });
-            }).then((companies) => {
+            }).then(companies => {
               expect(companies).to.have.length(2);
               expect(companies[0].id).to.equal(2);
               expect(companies[1].id).to.equal(1);
@@ -297,7 +297,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('should apply scope conditions', function() {
-          return this.ScopeMe.scope('includeActiveProjects').findOne({ where: { id: 1 }}).then((user) => {
+          return this.ScopeMe.scope('includeActiveProjects').findOne({ where: { id: 1 }}).then(user => {
             expect(user.company.projects).to.have.length(1);
           });
         });

--- a/test/integration/model/scope/count.test.js
+++ b/test/integration/model/scope/count.test.js
@@ -61,7 +61,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.ScopeMe.bulkCreate(records);
         }).then(() => {
           return this.ScopeMe.findAll();
-        }).then((records) => {
+        }).then(records => {
           return Promise.all([
             records[0].createChild({
               priority: 1

--- a/test/integration/model/scope/destroy.test.js
+++ b/test/integration/model/scope/destroy.test.js
@@ -47,7 +47,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should apply defaultScope', function() {
         return this.ScopeMe.destroy({ where: {}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll();
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(2);
           expect(users[0].get('username')).to.equal('tony');
           expect(users[1].get('username')).to.equal('fred');
@@ -57,7 +57,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to override default scope', function() {
         return this.ScopeMe.destroy({ where: { access_level: { lt: 5 }}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll();
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(2);
           expect(users[0].get('username')).to.equal('tobi');
           expect(users[1].get('username')).to.equal('dan');
@@ -73,7 +73,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to apply other scopes', function() {
         return this.ScopeMe.scope('lowAccess').destroy({ where: {}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll();
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(1);
           expect(users[0].get('username')).to.equal('tobi');
         });
@@ -82,7 +82,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to merge scopes with where', function() {
         return this.ScopeMe.scope('lowAccess').destroy({ where: { username: 'dan'}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll();
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(3);
           expect(users[0].get('username')).to.equal('tony');
           expect(users[1].get('username')).to.equal('tobi');

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -57,14 +57,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('should be able use where in scope', function() {
-      return this.ScopeMe.scope({where: { parent_id: 2 }}).findAll().then((users) => {
+      return this.ScopeMe.scope({where: { parent_id: 2 }}).findAll().then(users => {
         expect(users).to.have.length(1);
         expect(users[0].username).to.equal('tobi');
       });
     });
 
     it('should be able to combine scope and findAll where clauses', function() {
-      return this.ScopeMe.scope({where: { parent_id: 1 }}).findAll({ where: {access_level: 3}}).then((users) => {
+      return this.ScopeMe.scope({where: { parent_id: 1 }}).findAll({ where: {access_level: 3}}).then(users => {
         expect(users).to.have.length(2);
         expect(['tony', 'fred'].indexOf(users[0].username) !== -1).to.be.true;
         expect(['tony', 'fred'].indexOf(users[1].username) !== -1).to.be.true;
@@ -72,7 +72,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('should be able to use a defaultScope if declared', function() {
-      return this.ScopeMe.all().then((users) => {
+      return this.ScopeMe.all().then(users => {
         expect(users).to.have.length(2);
         expect([10, 5].indexOf(users[0].access_level) !== -1).to.be.true;
         expect([10, 5].indexOf(users[1].access_level) !== -1).to.be.true;
@@ -82,7 +82,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('should be able to handle $and in scopes', function() {
-      return this.ScopeMe.scope('andScope').findAll().then((users) => {
+      return this.ScopeMe.scope('andScope').findAll().then(users => {
         expect(users).to.have.length(1);
         expect(users[0].username).to.equal('tony');
       });
@@ -94,7 +94,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(users).to.have.length(1);
 
           return this.ScopeMe.findAll();
-        }).then((users) => {
+        }).then(users => {
           // This should not have other_value: 10
           expect(users).to.have.length(2);
         });
@@ -106,7 +106,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(users).to.have.length(1);
 
           return this.ScopeMe.scope('highValue').findAll();
-        }).then((users) => {
+        }).then(users => {
           // This should not have other_value: 10
           expect(users).to.have.length(2);
         });
@@ -114,7 +114,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('should have no problem performing findOrCreate', function() {
-      return this.ScopeMe.findOrCreate({ where: {username: 'fake'}}).spread((user) => {
+      return this.ScopeMe.findOrCreate({ where: {username: 'fake'}}).spread(user => {
         expect(user.username).to.equal('fake');
       });
     });

--- a/test/integration/model/scope/findAndCount.test.js
+++ b/test/integration/model/scope/findAndCount.test.js
@@ -51,7 +51,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should apply defaultScope', function() {
-        return this.ScopeMe.findAndCount().then((result) => {
+        return this.ScopeMe.findAndCount().then(result => {
           expect(result.count).to.equal(2);
           expect(result.rows.length).to.equal(2);
         });
@@ -59,7 +59,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('should be able to override default scope', function() {
         return this.ScopeMe.findAndCount({ where: { access_level: { gt: 5 }}})
-          .then((result) => {
+          .then(result => {
             expect(result.count).to.equal(1);
             expect(result.rows.length).to.equal(1);
           });
@@ -67,7 +67,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('should be able to unscope', function() {
         return this.ScopeMe.unscoped().findAndCount({ limit: 1 })
-          .then((result) => {
+          .then(result => {
             expect(result.count).to.equal(4);
             expect(result.rows.length).to.equal(1);
           });
@@ -75,21 +75,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('should be able to apply other scopes', function() {
         return this.ScopeMe.scope('lowAccess').findAndCount()
-          .then((result) => {
+          .then(result => {
             expect(result.count).to.equal(3);
           });
       });
 
       it('should be able to merge scopes with where', function() {
         return this.ScopeMe.scope('lowAccess')
-          .findAndCount({ where: { username: 'dan'}}).then((result) => {
+          .findAndCount({ where: { username: 'dan'}}).then(result => {
             expect(result.count).to.equal(1);
           });
       });
 
       it('should ignore the order option if it is found within the scope', function() {
         return this.ScopeMe.scope('withOrder').findAndCount()
-          .then((result) => {
+          .then(result => {
             expect(result.count).to.equal(4);
           });
       });

--- a/test/integration/model/scope/update.test.js
+++ b/test/integration/model/scope/update.test.js
@@ -48,7 +48,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should apply defaultScope', function() {
         return this.ScopeMe.update({ username: 'ruben' }, { where: {}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll({ where: { username: 'ruben' }});
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(2);
           expect(users[0].get('email')).to.equal('tobi@fakeemail.com');
           expect(users[1].get('email')).to.equal('dan@sequelizejs.com');
@@ -58,7 +58,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to override default scope', function() {
         return this.ScopeMe.update({ username: 'ruben' }, { where: { access_level: { lt: 5 }}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll({ where: { username: 'ruben' }});
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(2);
           expect(users[0].get('email')).to.equal('tony@sequelizejs.com');
           expect(users[1].get('email')).to.equal('fred@foobar.com');
@@ -68,8 +68,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to unscope destroy', function() {
         return this.ScopeMe.unscoped().update({ username: 'ruben' }, { where: {}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll();
-        }).then((rubens) => {
-          expect(_.every(rubens, (r) => {
+        }).then(rubens => {
+          expect(_.every(rubens, r => {
             return r.get('username') === 'ruben';
           })).to.be.true;
         });
@@ -78,7 +78,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to apply other scopes', function() {
         return this.ScopeMe.scope('lowAccess').update({ username: 'ruben' }, { where: {}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll({ where: { username: { $ne: 'ruben' }}});
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(1);
           expect(users[0].get('email')).to.equal('tobi@fakeemail.com');
         });
@@ -87,7 +87,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to merge scopes with where', function() {
         return this.ScopeMe.scope('lowAccess').update({ username: 'ruben' }, { where: { username: 'dan'}}).bind(this).then(function() {
           return this.ScopeMe.unscoped().findAll({ where: { username: 'ruben' }});
-        }).then((users) => {
+        }).then(users => {
           expect(users).to.have.length(1);
           expect(users[0].get('email')).to.equal('dan@sequelizejs.com');
         });

--- a/test/integration/model/searchPath.test.js
+++ b/test/integration/model/searchPath.test.js
@@ -59,7 +59,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return Restaurant.sync({force: true, searchPath: SEARCH_PATH_ONE});
         }).then(() => {
           return Restaurant.sync({force: true, searchPath: SEARCH_PATH_TWO});
-        }).catch((err) => {
+        }).catch(err => {
           expect(err).to.be.null;
         });
       });
@@ -83,12 +83,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return Restaurant.findOne({
                 where: {foo: 'one'}, searchPath: SEARCH_PATH_ONE
               });
-            }).then((obj) => {
+            }).then(obj => {
               expect(obj).to.not.be.null;
               expect(obj.foo).to.equal('one');
               restaurantId = obj.id;
               return Restaurant.findById(restaurantId, {searchPath: SEARCH_PATH_ONE});
-            }).then((obj) => {
+            }).then(obj => {
               expect(obj).to.not.be.null;
               expect(obj.foo).to.equal('one');
             });
@@ -99,7 +99,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           return Restaurant.create({
             foo: 'test'
-          }, {searchPath: SEARCH_PATH_TWO}).catch((err) => {
+          }, {searchPath: SEARCH_PATH_TWO}).catch(err => {
             expect(err).to.not.be.null;
           });
         });
@@ -116,12 +116,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return Restaurant.findOne({
                 where: {foo: 'two'}, searchPath: SEARCH_PATH_TWO
               });
-            }).then((obj) => {
+            }).then(obj => {
               expect(obj).to.not.be.null;
               expect(obj.foo).to.equal('two');
               restaurantId = obj.id;
               return Restaurant.findById(restaurantId, {searchPath: SEARCH_PATH_TWO});
-            }).then((obj) => {
+            }).then(obj => {
               expect(obj).to.not.be.null;
               expect(obj.foo).to.equal('two');
             });
@@ -131,7 +131,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should fail to find schema_one object in schema_two', function() {
           const Restaurant = this.Restaurant;
 
-          return Restaurant.findOne({where: {foo: 'one'}, searchPath: SEARCH_PATH_TWO}).then((RestaurantObj) => {
+          return Restaurant.findOne({where: {foo: 'one'}, searchPath: SEARCH_PATH_TWO}).then(RestaurantObj => {
             expect(RestaurantObj).to.be.null;
           });
         });
@@ -139,7 +139,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should fail to find schema_two object in schema_one', function() {
           const Restaurant = this.Restaurant;
 
-          return Restaurant.findOne({where: {foo: 'two'}, searchPath: SEARCH_PATH_ONE}).then((RestaurantObj) => {
+          return Restaurant.findOne({where: {foo: 'two'}, searchPath: SEARCH_PATH_ONE}).then(RestaurantObj => {
             expect(RestaurantObj).to.be.null;
           });
         });
@@ -166,33 +166,33 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return restaurauntModel.save({searchPath: SEARCH_PATH_TWO});
             }).then(() => {
               return Restaurant.findAll({searchPath: SEARCH_PATH_ONE});
-            }).then((restaurantsOne) => {
+            }).then(restaurantsOne => {
               expect(restaurantsOne).to.not.be.null;
               expect(restaurantsOne.length).to.equal(2);
-              restaurantsOne.forEach((restaurant) => {
+              restaurantsOne.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('one');
               });
               return Restaurant.findAndCountAll({searchPath: SEARCH_PATH_ONE});
-            }).then((restaurantsOne) => {
+            }).then(restaurantsOne => {
               expect(restaurantsOne).to.not.be.null;
               expect(restaurantsOne.rows.length).to.equal(2);
               expect(restaurantsOne.count).to.equal(2);
-              restaurantsOne.rows.forEach((restaurant) => {
+              restaurantsOne.rows.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('one');
               });
               return Restaurant.findAll({searchPath: SEARCH_PATH_TWO});
-            }).then((restaurantsTwo) => {
+            }).then(restaurantsTwo => {
               expect(restaurantsTwo).to.not.be.null;
               expect(restaurantsTwo.length).to.equal(3);
-              restaurantsTwo.forEach((restaurant) => {
+              restaurantsTwo.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('two');
               });
               return Restaurant.findAndCountAll({searchPath: SEARCH_PATH_TWO});
-            }).then((restaurantsTwo) => {
+            }).then(restaurantsTwo => {
               expect(restaurantsTwo).to.not.be.null;
               expect(restaurantsTwo.rows.length).to.equal(3);
               expect(restaurantsTwo.count).to.equal(3);
-              restaurantsTwo.rows.forEach((restaurant) => {
+              restaurantsTwo.rows.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('two');
               });
             });
@@ -222,28 +222,28 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               where: {bar: {$like: 'one%'}},
               searchPath: SEARCH_PATH_ONE
             });
-          }).then((restaurantsOne) => {
+          }).then(restaurantsOne => {
             expect(restaurantsOne).to.not.be.null;
             expect(restaurantsOne.length).to.equal(2);
-            restaurantsOne.forEach((restaurant) => {
+            restaurantsOne.forEach(restaurant => {
               expect(restaurant.bar).to.contain('one');
             });
             return Restaurant.count({searchPath: SEARCH_PATH_ONE});
-          }).then((count) => {
+          }).then(count => {
             expect(count).to.not.be.null;
             expect(count).to.equal(2);
             return Restaurant.findAll({
               where: {bar: {$like: 'two%'}},
               searchPath: SEARCH_PATH_TWO
             });
-          }).then((restaurantsTwo) => {
+          }).then(restaurantsTwo => {
             expect(restaurantsTwo).to.not.be.null;
             expect(restaurantsTwo.length).to.equal(3);
-            restaurantsTwo.forEach((restaurant) => {
+            restaurantsTwo.forEach(restaurant => {
               expect(restaurant.bar).to.contain('two');
             });
             return Restaurant.count({searchPath: SEARCH_PATH_TWO});
-          }).then((count) => {
+          }).then(count => {
             expect(count).to.not.be.null;
             expect(count).to.equal(3);
           });
@@ -258,14 +258,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return Location.sync({force: true})
             .then(() => {
               return Location.create({name: 'HQ'}).then(() => {
-                return Location.findOne({where: {name: 'HQ'}}).then((obj) => {
+                return Location.findOne({where: {name: 'HQ'}}).then(obj => {
                   expect(obj).to.not.be.null;
                   expect(obj.name).to.equal('HQ');
                   locationId = obj.id;
                 });
               });
             })
-            .catch((err) => {
+            .catch(err => {
               expect(err).to.be.null;
             });
         });
@@ -283,7 +283,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: Location, as: 'location'
               }], searchPath: SEARCH_PATH_ONE
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('one');
             expect(obj.location).to.not.be.null;
@@ -305,7 +305,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: Location, as: 'location'
               }], searchPath: SEARCH_PATH_TWO
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('two');
             expect(obj.location).to.not.be.null;
@@ -322,7 +322,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             .then(() => {
               return Employee.sync({force: true, searchPath: SEARCH_PATH_TWO});
             })
-            .catch((err) => {
+            .catch(err => {
               expect(err).to.be.null;
             });
         });
@@ -338,7 +338,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return Restaurant.findOne({
               where: {foo: 'one'}, searchPath: SEARCH_PATH_ONE
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('one');
             restaurantId = obj.id;
@@ -353,13 +353,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: Employee, as: 'employees'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.employees).to.not.be.null;
             expect(obj.employees.length).to.equal(1);
             expect(obj.employees[0].last_name).to.equal('one');
             return obj.getEmployees({searchPath: SEARCH_PATH_ONE});
-          }).then((employees) => {
+          }).then(employees => {
             expect(employees.length).to.equal(1);
             expect(employees[0].last_name).to.equal('one');
             return Employee.findOne({
@@ -367,12 +367,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: Restaurant, as: 'restaurant'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.restaurant).to.not.be.null;
             expect(obj.restaurant.foo).to.equal('one');
             return obj.getRestaurant({searchPath: SEARCH_PATH_ONE});
-          }).then((restaurant) => {
+          }).then(restaurant => {
             expect(restaurant).to.not.be.null;
             expect(restaurant.foo).to.equal('one');
           });
@@ -390,7 +390,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return Restaurant.findOne({
               where: {foo: 'two'}, searchPath: SEARCH_PATH_TWO
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.foo).to.equal('two');
             restaurantId = obj.id;
@@ -405,13 +405,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: Employee, as: 'employees'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.employees).to.not.be.null;
             expect(obj.employees.length).to.equal(1);
             expect(obj.employees[0].last_name).to.equal('two');
             return obj.getEmployees({searchPath: SEARCH_PATH_TWO});
-          }).then((employees) => {
+          }).then(employees => {
             expect(employees.length).to.equal(1);
             expect(employees[0].last_name).to.equal('two');
             return Employee.findOne({
@@ -419,12 +419,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 model: Restaurant, as: 'restaurant'
               }]
             });
-          }).then((obj) => {
+          }).then(obj => {
             expect(obj).to.not.be.null;
             expect(obj.restaurant).to.not.be.null;
             expect(obj.restaurant.foo).to.equal('two');
             return obj.getRestaurant({searchPath: SEARCH_PATH_TWO});
-          }).then((restaurant) => {
+          }).then(restaurant => {
             expect(restaurant).to.not.be.null;
             expect(restaurant.foo).to.equal('two');
           });
@@ -446,17 +446,17 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return restaurauntModelSchema1.save({searchPath: SEARCH_PATH_ONE});
             }).then(() => {
               return Restaurant.findAll({searchPath: SEARCH_PATH_ONE});
-            }).then((restaurantsOne) => {
+            }).then(restaurantsOne => {
               expect(restaurantsOne).to.not.be.null;
               expect(restaurantsOne.length).to.equal(2);
-              restaurantsOne.forEach((restaurant) => {
+              restaurantsOne.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('one');
               });
               return Restaurant.findAll({searchPath: SEARCH_PATH_TWO});
-            }).then((restaurantsTwo) => {
+            }).then(restaurantsTwo => {
               expect(restaurantsTwo).to.not.be.null;
               expect(restaurantsTwo.length).to.equal(1);
-              restaurantsTwo.forEach((restaurant) => {
+              restaurantsTwo.forEach(restaurant => {
                 expect(restaurant.bar).to.contain('two');
               });
             });

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -74,7 +74,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           return this.User.findById(42);
-        }).then((user) => {
+        }).then(user => {
           expect(user.createdAt).to.be.ok;
           expect(user.username).to.equal('doe');
           expect(user.updatedAt).to.be.afterTime(user.createdAt);
@@ -99,7 +99,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           return this.User.find({ where: { foo: 'baz', bar: 19 }});
-        }).then((user) => {
+        }).then(user => {
           expect(user.createdAt).to.be.ok;
           expect(user.username).to.equal('doe');
           expect(user.updatedAt).to.be.afterTime(user.createdAt);
@@ -158,7 +158,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           this.clock.tick(1000);
           // Update the first one
           return User.upsert({ a: 'a', b: 'b', username: 'doe' });
-        }).then((created) => {
+        }).then(created => {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
           } else {
@@ -166,13 +166,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           return User.find({ where: { a: 'a', b: 'b' }});
-        }).then((user1) => {
+        }).then(user1 => {
           expect(user1.createdAt).to.be.ok;
           expect(user1.username).to.equal('doe');
           expect(user1.updatedAt).to.be.afterTime(user1.createdAt);
 
           return User.find({ where: { a: 'a', b: 'a' }});
-        }).then((user2) => {
+        }).then(user2 => {
           // The second one should not be updated
           expect(user2.createdAt).to.be.ok;
           expect(user2.username).to.equal('curt');
@@ -212,7 +212,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           return this.User.findById(42);
-        }).then((user) => {
+        }).then(user => {
           expect(user.createdAt).to.be.ok;
           expect(user.username).to.equal('doe');
           expect(user.blob.toString()).to.equal('andrea');
@@ -237,7 +237,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           return this.User.findById(42);
-        }).then((user) => {
+        }).then(user => {
           expect(user.baz).to.equal('oof');
         });
       });
@@ -261,7 +261,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
 
           return this.ModelWithFieldPK.findOne({ where: { userId: 42 } });
-        }).then((instance) => {
+        }).then(instance => {
           expect(instance.foo).to.equal('second');
         });
       });
@@ -284,7 +284,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(created).not.to.be.ok;
           }
           return this.User.findById(42);
-        }).then((user) => {
+        }).then(user => {
           expect(user.createdAt).to.be.ok;
           expect(user.username).to.equal('doe');
           expect(user.foo).to.equal('MIXEDCASE2');
@@ -304,7 +304,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.User.upsert({ id: 42, username: 'doe'});
         }).then(function() {
           return this.User.findById(42);
-        }).then((user) => {
+        }).then(user => {
           expect(user.updatedAt).to.be.gt(originalUpdatedAt);
           expect(user.createdAt).to.deep.equal(originalCreatedAt);
           clock.restore();
@@ -322,7 +322,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.User.upsert({ id: 42, username: 'doe'});
         }).then(function() {
           return this.User.findById(42);
-        }).then((user) => {
+        }).then(user => {
           // 'username' was updated
           expect(user.username).to.equal('doe');
           // 'baz' should still be 'new baz value' since it was not updated
@@ -335,7 +335,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.User.findById(42);
         }).then(function(user) {
           return this.User.upsert({ id: user.id, username: user.username });
-        }).then((created) => {
+        }).then(created => {
           if (dialect === 'sqlite') {
             expect(created).to.be.undefined;
           } else {
@@ -364,7 +364,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const clock = sinon.useFakeTimers();
         return User.sync({ force: true }).bind(this).then(() => {
           return User.upsert({ username: 'user1', email: 'user1@domain.ext', city: 'City' })
-            .then((created) => {
+            .then(created => {
               if (dialect === 'sqlite') {
                 expect(created).to.be.undefined;
               } else {
@@ -372,7 +372,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               }
               clock.tick(1000);
               return User.upsert({ username: 'user1', email: 'user1@domain.ext', city: 'New City' });
-            }).then((created) => {
+            }).then(created => {
               if (dialect === 'sqlite') {
                 expect(created).to.be.undefined;
               } else {
@@ -381,7 +381,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               clock.tick(1000);
               return User.findOne({ where: { username: 'user1', email: 'user1@domain.ext' }});
             })
-            .then((user) => {
+            .then(user => {
               expect(user.createdAt).to.be.ok;
               expect(user.city).to.equal('New City');
               expect(user.updatedAt).to.be.afterTime(user.createdAt);

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -34,7 +34,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         })
         .then(() => this.queryInterface.renameTable('myTestTable', 'myTestTableNew'))
         .then(() => this.queryInterface.showAllTables())
-        .then((tableNames) => {
+        .then(tableNames => {
           if (dialect === 'mssql') {
             tableNames = _.map(tableNames, 'tableName');
           }
@@ -49,16 +49,16 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       const filterMSSQLDefault = tableNames => tableNames.filter(t => t.tableName !== 'spt_values');
       const self = this;
       return this.queryInterface.dropAllTables().then(() => {
-        return self.queryInterface.showAllTables().then((tableNames) => {
+        return self.queryInterface.showAllTables().then(tableNames => {
           // MSSQL include spt_values table which is system defined, hence cant be dropped
           tableNames = filterMSSQLDefault(tableNames);
           expect(tableNames).to.be.empty;
           return self.queryInterface.createTable('table', { name: DataTypes.STRING }).then(() => {
-            return self.queryInterface.showAllTables().then((tableNames) => {
+            return self.queryInterface.showAllTables().then(tableNames => {
               tableNames = filterMSSQLDefault(tableNames);
               expect(tableNames).to.have.length(1);
               return self.queryInterface.dropAllTables().then(() => {
-                return self.queryInterface.showAllTables().then((tableNames) => {
+                return self.queryInterface.showAllTables().then(tableNames => {
                   // MSSQL include spt_values table which is system defined, hence cant be dropped
                   tableNames = filterMSSQLDefault(tableNames);
                   expect(tableNames).to.be.empty;
@@ -76,7 +76,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         name: DataTypes.STRING
       }).then(() => {
         return self.queryInterface.dropAllTables({skip: ['skipme']}).then(() => {
-          return self.queryInterface.showAllTables().then((tableNames) => {
+          return self.queryInterface.showAllTables().then(tableNames => {
             if (dialect === 'mssql' /* current.dialect.supports.schemas */) {
               tableNames = _.map(tableNames, 'tableName');
             }
@@ -102,12 +102,12 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     it('adds, reads and removes an index to the table', function() {
       const self = this;
       return this.queryInterface.addIndex('Group', ['username', 'isAdmin']).then(() => {
-        return self.queryInterface.showIndex('Group').then((indexes) => {
-          let indexColumns = _.uniq(indexes.map((index) => { return index.name; }));
+        return self.queryInterface.showIndex('Group').then(indexes => {
+          let indexColumns = _.uniq(indexes.map(index => { return index.name; }));
           expect(indexColumns).to.include('group_username_is_admin');
           return self.queryInterface.removeIndex('Group', ['username', 'isAdmin']).then(() => {
-            return self.queryInterface.showIndex('Group').then((indexes) => {
-              indexColumns = _.uniq(indexes.map((index) => { return index.name; }));
+            return self.queryInterface.showIndex('Group').then(indexes => {
+              indexColumns = _.uniq(indexes.map(index => { return index.name; }));
               expect(indexColumns).to.be.empty;
             });
           });
@@ -136,7 +136,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           return self.queryInterface.showIndex({
             schema: 'schema',
             tableName: 'table'
-          }).then((indexes) => {
+          }).then(indexes => {
             expect(indexes.length).to.eq(1);
           });
         });
@@ -162,7 +162,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       }, { freezeTableName: true });
 
       return Users.sync({ force: true }).then(() => {
-        return self.queryInterface.describeTable('_Users').then((metadata) => {
+        return self.queryInterface.describeTable('_Users').then(metadata => {
           const id = metadata.id;
           const username = metadata.username;
           const city = metadata.city;
@@ -244,12 +244,12 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       }, { freezeTableName: true });
 
       return Country.sync({ force: true }).then(() => {
-        return self.queryInterface.describeTable('_Country').then((metacountry) => {
+        return self.queryInterface.describeTable('_Country').then(metacountry => {
           expect(metacountry.code.primaryKey).to.eql(true);
           expect(metacountry.name.primaryKey).to.eql(false);
 
           return Alumni.sync({ force: true }).then(() => {
-            return self.queryInterface.describeTable('_Alumni').then((metalumni) => {
+            return self.queryInterface.describeTable('_Alumni').then(metalumni => {
               expect(metalumni.year.primaryKey).to.eql(true);
               expect(metalumni.num.primaryKey).to.eql(true);
               expect(metalumni.username.primaryKey).to.eql(false);
@@ -274,7 +274,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           autoIncrement: true
         }
       }).bind(this).then(function() {
-        return this.queryInterface.insert(null, 'TableWithPK', {}, {raw: true, returning: true, plain: true}).then((results) => {
+        return this.queryInterface.insert(null, 'TableWithPK', {}, {raw: true, returning: true, plain: true}).then(results => {
           const response = _.head(results);
           expect(response.table_id || typeof response !== 'object' && response).to.be.ok;
         });
@@ -343,7 +343,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         return self.queryInterface.renameColumn('_Users', 'username', 'pseudo');
       }).bind(this).then(function() {
         return this.queryInterface.describeTable('_Users');
-      }).then((table) => {
+      }).then(table => {
         expect(table).to.have.property('pseudo');
         expect(table).to.not.have.property('username');
       });
@@ -369,7 +369,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           schema: 'archive',
           tableName: 'Users'
         });
-      }).then((table) => {
+      }).then(table => {
         expect(table).to.have.property('pseudo');
         expect(table).to.not.have.property('username');
       });
@@ -388,7 +388,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         return self.queryInterface.renameColumn('_Users', 'username', 'pseudo');
       }).bind(this).then(function() {
         return this.queryInterface.describeTable('_Users');
-      }).then((table) => {
+      }).then(table => {
         expect(table).to.have.property('pseudo');
         expect(table).to.not.have.property('username');
       });
@@ -408,7 +408,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         return self.queryInterface.renameColumn('_Users', 'active', 'enabled');
       }).bind(this).then(function() {
         return this.queryInterface.describeTable('_Users');
-      }).then((table) => {
+      }).then(table => {
         expect(table).to.have.property('enabled');
         expect(table).to.not.have.property('active');
       });
@@ -429,7 +429,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         return self.queryInterface.renameColumn('Fruit', 'fruitId', 'fruit_id');
       }).bind(this).then(function() {
         return this.queryInterface.describeTable('Fruit');
-      }).then((table) => {
+      }).then(table => {
         expect(table).to.have.property('fruit_id');
         expect(table).to.not.have.property('fruitId');
       });
@@ -474,7 +474,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             tableName: 'users',
             schema: 'archive'
           });
-        }).then((table) => {
+        }).then(table => {
           if (dialect === 'postgres' || dialect === 'postgres-native') {
             expect(table.currency.type).to.equal('DOUBLE PRECISION');
           } else {
@@ -503,7 +503,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         return this.queryInterface.describeTable({
           tableName: 'users'
         });
-      }).then((table) => {
+      }).then(table => {
         if (dialect === 'postgres' || dialect === 'postgres-native') {
           expect(table.currency.type).to.equal('DOUBLE PRECISION');
         } else {
@@ -623,7 +623,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         });
       }).then(function() {
         return this.queryInterface.describeTable('users');
-      }).then((table) => {
+      }).then(table => {
         expect(table).to.have.property('level_id');
       });
     });
@@ -649,7 +649,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             tableName: 'users',
             schema: 'archive'
           });
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.have.property('level_id');
         });
       });
@@ -696,7 +696,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       it('should be able to remove a column with a default value', function() {
         return this.queryInterface.removeColumn('users', 'firstName').bind(this).then(function() {
           return this.queryInterface.describeTable('users');
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.not.have.property('firstName');
         });
       });
@@ -704,7 +704,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       it('should be able to remove a column without default value', function() {
         return this.queryInterface.removeColumn('users', 'lastName').bind(this).then(function() {
           return this.queryInterface.describeTable('users');
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.not.have.property('lastName');
         });
       });
@@ -712,7 +712,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       it('should be able to remove a column with a foreign key constraint', function() {
         return this.queryInterface.removeColumn('users', 'manager').bind(this).then(function() {
           return this.queryInterface.describeTable('users');
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.not.have.property('manager');
         });
       });
@@ -725,7 +725,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           return this.queryInterface.removeColumn('users', 'id');
         }).then(function() {
           return this.queryInterface.describeTable('users');
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.not.have.property('id');
         });
       });
@@ -765,7 +765,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             tableName: 'users',
             schema: 'archive'
           });
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.not.have.property('firstName');
         });
       });
@@ -780,7 +780,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             tableName: 'users',
             schema: 'archive'
           });
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.not.have.property('lastName');
         });
       });
@@ -794,7 +794,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             tableName: 'users',
             schema: 'archive'
           });
-        }).then((table) => {
+        }).then(table => {
           expect(table).to.not.have.property('id');
         });
       });
@@ -847,7 +847,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     it('should get a list of foreign keys for the table', function() {
       const sql = this.queryInterface.QueryGenerator.getForeignKeysQuery('hosts', this.sequelize.config.database);
       const self = this;
-      return this.sequelize.query(sql, {type: this.sequelize.QueryTypes.FOREIGNKEYS}).then((fks) => {
+      return this.sequelize.query(sql, {type: this.sequelize.QueryTypes.FOREIGNKEYS}).then(fks => {
         expect(fks).to.have.length(3);
         const keys = Object.keys(fks[0]),
           keys2 = Object.keys(fks[1]),
@@ -865,13 +865,13 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           console.log('This test doesn\'t support ' + dialect);
         }
         return fks;
-      }).then((fks) => {
+      }).then(fks => {
         if (dialect === 'mysql') {
           return self.sequelize.query(
               self.queryInterface.QueryGenerator.getForeignKeyQuery('hosts', 'admin'),
               {}
             )
-            .spread((fk) => {
+            .spread(fk => {
               expect(fks[0]).to.deep.eql(fk[0]);
             });
         }

--- a/test/integration/replication.test.js
+++ b/test/integration/replication.test.js
@@ -67,14 +67,14 @@ describe(Support.getTestDialectTeaser('Replication'), function() {
   });
 
   it('should run read-only transactions on the replica', () => {
-    return this.sequelize.transaction({readOnly: true}, (transaction) => {
+    return this.sequelize.transaction({readOnly: true}, transaction => {
       return this.User.findAll({transaction});
     })
     .then(expectReadCalls);
   });
 
   it('should run non-read-only transactions on the primary', () => {
-    return this.sequelize.transaction((transaction) => {
+    return this.sequelize.transaction(transaction => {
       return this.User.findAll({transaction});
     })
     .then(expectWriteCalls);

--- a/test/integration/schema.test.js
+++ b/test/integration/schema.test.js
@@ -25,22 +25,22 @@ describe(Support.getTestDialectTeaser('Schema'), () => {
   });
 
   it('supports increment', function() {
-    return this.User.create({ aNumber: 1 }).then((user) => {
+    return this.User.create({ aNumber: 1 }).then(user => {
       return user.increment('aNumber', { by: 3 });
-    }).then((result) => {
+    }).then(result => {
       return result.reload();
-    }).then((user) => {
+    }).then(user => {
       expect(user).to.be.ok;
       expect(user.aNumber).to.be.equal(4);
     });
   });
 
   it('supports decrement', function() {
-    return this.User.create({ aNumber: 10 }).then((user) => {
+    return this.User.create({ aNumber: 10 }).then(user => {
       return user.decrement('aNumber', { by: 3 });
-    }).then((result) => {
+    }).then(result => {
       return result.reload();
-    }).then((user) => {
+    }).then(user => {
       expect(user).to.be.ok;
       expect(user.aNumber).to.be.equal(7);
     });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -100,7 +100,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           return this
             .sequelizeWithInvalidConnection
             .authenticate()
-            .catch((err) => {
+            .catch(err => {
               expect(err).to.not.be.null;
             });
         });
@@ -109,7 +109,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           return this
             .sequelizeWithInvalidConnection
             .authenticate()
-            .catch((err) => {
+            .catch(err => {
               expect(
                 err instanceof RangeError ||
                 err instanceof Sequelize.ConnectionError
@@ -121,7 +121,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           return this
             .sequelizeWithInvalidConnection
             .authenticate()
-            .catch((err) => {
+            .catch(err => {
               expect(
                 err.message.match(/connect ECONNREFUSED/) ||
                 err.message.match(/invalid port number/) ||
@@ -141,7 +141,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           return this
             .sequelizeWithInvalidCredentials
             .authenticate()
-            .catch((err) => {
+            .catch(err => {
               expect(err).to.not.be.null;
             });
         });
@@ -150,7 +150,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           return this
             .sequelizeWithInvalidCredentials
             .authenticate()
-            .catch((err) => {
+            .catch(err => {
               expect(err).to.be.instanceof(Sequelize.Error);
             });
         });
@@ -166,7 +166,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
               }
             }
           }).authenticate()
-            .catch((err) => {
+            .catch(err => {
               expect(err).to.not.be.null;
             });
         });
@@ -332,8 +332,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       const self = this;
       return self.sequelize.query(this.insertQuery).then(() => {
         return self.sequelize.query('select * from ' + qq(self.User.tableName) + '');
-      }).spread((users) => {
-        expect(users.map((u) => { return u.username; })).to.include('john');
+      }).spread(users => {
+        expect(users.map(u => { return u.username; })).to.include('john');
       });
     });
 
@@ -344,8 +344,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       seq.options.quoteIdentifiers = false;
       return seq.query(this.insertQuery).then(() => {
         return seq.query('select * from ' + qq(self.User.tableName) + '');
-      }).spread((users) => {
-        expect(users.map((u) => { return u.username; })).to.include('john');
+      }).spread(users => {
+        expect(users.map(u => { return u.username; })).to.include('john');
       });
     });
 
@@ -355,7 +355,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         return self.sequelize.query(self.insertQuery);
       }).then(() => {
         return self.sequelize.query('select username as ' + qq('user.username') + ' from ' + qq(self.User.tableName) + '');
-      }).spread(( users) => {
+      }).spread(users => {
         expect(users).to.deep.equal([{'user.username': 'john'}]);
       });
     });
@@ -366,8 +366,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         return self.sequelize.query(self.insertQuery);
       }).then(() => {
         return self.sequelize.query('select username as ' + qq('user.username') + ' from ' + qq(self.User.tableName) + '', { raw: true, nest: true });
-      }).then((users) => {
-        expect(users.map((u) => { return u.user; })).to.deep.equal([{'username': 'john'}]);
+      }).then(users => {
+        expect(users.map(u => { return u.user; })).to.deep.equal([{'username': 'john'}]);
       });
     });
 
@@ -379,8 +379,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             return self.sequelize.query(
               'CREATE PROCEDURE foo()\nSELECT * FROM ' + self.User.tableName + ';'
             ).then(() => {
-              return self.sequelize.query('CALL foo()').then((users) => {
-                expect(users.map((u) => { return u.username; })).to.include('john');
+              return self.sequelize.query('CALL foo()').then(users => {
+                expect(users.map(u => { return u.username; })).to.include('john');
               });
             });
           });
@@ -406,7 +406,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           model: this.User,
           mapToModel: true
         });
-      }).then((users) => {
+      }).then(users => {
         expect(users[0].emailAddress).to.be.equal('john@gmail.com');
       });
     });
@@ -417,7 +417,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           type: 'SELECT',
           fieldMap: {username: 'userName', email_address: 'email'}
         });
-      }).then((users) => {
+      }).then(users => {
         expect(users[0].userName).to.be.equal('john');
         expect(users[0].email).to.be.equal('john@gmail.com');
       });
@@ -470,7 +470,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         logging(s) {
           logSql = s;
         }
-      }).then((result) => {
+      }).then(result => {
         const res = result[0] || {};
         res.date = res.date && new Date(res.date);
         res.boolean = res.boolean && true;
@@ -506,7 +506,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
     it('uses properties `query` and `values` if query is tagged', function() {
       let logSql;
-      return this.sequelize.query({ query: 'select ? as foo, ? as bar', values: [1, 2] }, { type: this.sequelize.QueryTypes.SELECT, logging(s) { logSql = s; } }).then((result) => {
+      return this.sequelize.query({ query: 'select ? as foo, ? as bar', values: [1, 2] }, { type: this.sequelize.QueryTypes.SELECT, logging(s) { logSql = s; } }).then(result => {
         expect(result).to.deep.equal([{ foo: 1, bar: 2 }]);
         expect(logSql.indexOf('?')).to.equal(-1);
       });
@@ -515,7 +515,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     it('uses properties `query` and `bind` if query is tagged', function() {
       const typeCast = dialect === 'postgres' ? '::int' : '';
       let logSql;
-      return this.sequelize.query({ query: 'select $1'+typeCast+' as foo, $2'+typeCast+' as bar', bind: [1, 2] }, { type: this.sequelize.QueryTypes.SELECT, logging(s) { logSql = s; } }).then((result) => {
+      return this.sequelize.query({ query: 'select $1'+typeCast+' as foo, $2'+typeCast+' as bar', bind: [1, 2] }, { type: this.sequelize.QueryTypes.SELECT, logging(s) { logSql = s; } }).then(result => {
         expect(result).to.deep.equal([{ foo: 1, bar: 2 }]);
         if (dialect === 'postgres' || dialect === 'sqlite') {
           expect(logSql.indexOf('$1')).to.be.above(-1);
@@ -535,13 +535,13 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       const tickChar = dialect === 'postgres' || dialect === 'mssql' ? '"' : '`',
         sql = 'select 1 as ' + Sequelize.Utils.addTicks('foo.bar.baz', tickChar);
 
-      return this.sequelize.query(sql, { raw: true, nest: true }).then((result) => {
+      return this.sequelize.query(sql, { raw: true, nest: true }).then(result => {
         expect(result).to.deep.equal([{ foo: { bar: { baz: 1 } } }]);
       });
     });
 
     it('replaces token with the passed array', function() {
-      return this.sequelize.query('select ? as foo, ? as bar', { type: this.sequelize.QueryTypes.SELECT, replacements: [1, 2] }).then((result) => {
+      return this.sequelize.query('select ? as foo, ? as bar', { type: this.sequelize.QueryTypes.SELECT, replacements: [1, 2] }).then(result => {
         expect(result).to.deep.equal([{ foo: 1, bar: 2 }]);
       });
     });
@@ -594,7 +594,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     it('binds token with the passed array', function() {
       const typeCast = dialect === 'postgres' ? '::int' : '';
       let logSql;
-      return this.sequelize.query('select $1'+typeCast+' as foo, $2'+typeCast+' as bar', { type: this.sequelize.QueryTypes.SELECT, bind: [1, 2], logging(s) { logSql = s; } }).then((result) => {
+      return this.sequelize.query('select $1'+typeCast+' as foo, $2'+typeCast+' as bar', { type: this.sequelize.QueryTypes.SELECT, bind: [1, 2], logging(s) { logSql = s; } }).then(result => {
         expect(result).to.deep.equal([{ foo: 1, bar: 2 }]);
         if (dialect === 'postgres' || dialect === 'sqlite') {
           expect(logSql.indexOf('$1')).to.be.above(-1);
@@ -605,7 +605,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     it('binds named parameters with the passed object', function() {
       const typeCast = dialect === 'postgres' ? '::int' : '';
       let logSql;
-      return this.sequelize.query('select $one'+typeCast+' as foo, $two'+typeCast+' as bar', { raw: true, bind: { one: 1, two: 2 }, logging(s) { logSql = s; } }).then((result) => {
+      return this.sequelize.query('select $one'+typeCast+' as foo, $two'+typeCast+' as bar', { raw: true, bind: { one: 1, two: 2 }, logging(s) { logSql = s; } }).then(result => {
         expect(result[0]).to.deep.equal([{ foo: 1, bar: 2 }]);
         if (dialect === 'postgres') {
           expect(logSql.indexOf('$1')).to.be.above(-1);
@@ -619,7 +619,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     it('binds named parameters with the passed object using the same key twice', function() {
       const typeCast = dialect === 'postgres' ? '::int' : '';
       let logSql;
-      return this.sequelize.query('select $one'+typeCast+' as foo, $two'+typeCast+' as bar, $one'+typeCast+' as baz', { raw: true, bind: { one: 1, two: 2 }, logging(s) { logSql = s; } }).then((result) => {
+      return this.sequelize.query('select $one'+typeCast+' as foo, $two'+typeCast+' as bar, $one'+typeCast+' as baz', { raw: true, bind: { one: 1, two: 2 }, logging(s) { logSql = s; } }).then(result => {
         expect(result[0]).to.deep.equal([{ foo: 1, bar: 2, baz: 1 }]);
         if (dialect === 'postgres') {
           expect(logSql.indexOf('$1')).to.be.above(-1);
@@ -631,7 +631,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
     it('binds named parameters with the passed object having a null property', function() {
       const typeCast = dialect === 'postgres' ? '::int' : '';
-      return this.sequelize.query('select $one'+typeCast+' as foo, $two'+typeCast+' as bar', { raw: true, bind: { one: 1, two: null }}).then((result) => {
+      return this.sequelize.query('select $one'+typeCast+' as foo, $two'+typeCast+' as bar', { raw: true, bind: { one: 1, two: null }}).then(result => {
         expect(result[0]).to.deep.equal([{ foo: 1, bar: null }]);
       });
     });
@@ -639,7 +639,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     it('binds named parameters array handles escaped $$', function() {
       const typeCast = dialect === 'postgres' ? '::int' : '';
       let logSql;
-      return this.sequelize.query('select $1'+typeCast+' as foo, \'$$ / $$1\' as bar', { raw: true, bind: [1 ], logging(s) { logSql = s; } }).then((result) => {
+      return this.sequelize.query('select $1'+typeCast+' as foo, \'$$ / $$1\' as bar', { raw: true, bind: [1 ], logging(s) { logSql = s; } }).then(result => {
         expect(result[0]).to.deep.equal([{ foo: 1, bar: '$ / $1' }]);
         if (dialect === 'postgres' || dialect === 'sqlite') {
           expect(logSql.indexOf('$1')).to.be.above(-1);
@@ -649,14 +649,14 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
     it('binds named parameters object handles escaped $$', function() {
       const typeCast = dialect === 'postgres' ? '::int' : '';
-      return this.sequelize.query('select $one'+typeCast+' as foo, \'$$ / $$one\' as bar', { raw: true, bind: { one: 1 } }).then((result) => {
+      return this.sequelize.query('select $one'+typeCast+' as foo, \'$$ / $$one\' as bar', { raw: true, bind: { one: 1 } }).then(result => {
         expect(result[0]).to.deep.equal([{ foo: 1, bar: '$ / $one' }]);
       });
     });
 
     if (dialect === 'postgres' || dialect === 'sqlite' || dialect === 'mssql') {
       it ('does not improperly escape arrays of strings bound to named parameters', function() {
-        return this.sequelize.query('select :stringArray as foo', { raw: true, replacements: { stringArray: [ '"string"' ] } }).then((result) => {
+        return this.sequelize.query('select :stringArray as foo', { raw: true, replacements: { stringArray: [ '"string"' ] } }).then(result => {
           expect(result[0]).to.deep.equal([{ foo: '"string"' }]);
         });
       });
@@ -720,7 +720,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         datetime = 'GETDATE()';
       }
 
-      return this.sequelize.query('SELECT ' + datetime + ' AS t').spread((result) => {
+      return this.sequelize.query('SELECT ' + datetime + ' AS t').spread(result => {
         expect(moment(result[0].t).isValid()).to.be.true;
       });
     });
@@ -897,7 +897,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       const self = this,
         Photo = this.sequelize.define('Foto', { name: DataTypes.STRING }, { tableName: 'photos' });
       return Photo.sync({ force: true }).then(() => {
-        return self.sequelize.getQueryInterface().showAllTables().then((tableNames) => {
+        return self.sequelize.getQueryInterface().showAllTables().then(tableNames => {
           if (dialect === 'mssql' /* current.dialect.supports.schemas */) {
             tableNames = _.map(tableNames, 'tableName');
           }
@@ -927,7 +927,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         return this.sequelize.truncate().then(() => {
           return Project.findAll({});
         });
-      }).then((projects) => {
+      }).then(projects => {
         expect(projects).to.exist;
         expect(projects).to.have.length(0);
       });
@@ -942,7 +942,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       return Project.sync({ force: true }).then(() => {
         return Task.sync({ force: true }).then(() => {
           return Project.create({title: 'bla'}).then(() => {
-            return Task.create({title: 'bla'}).then((task) => {
+            return Task.create({title: 'bla'}).then(task => {
               expect(task).to.exist;
               expect(task.title).to.equal('bla');
             });
@@ -964,7 +964,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
         const User2 = this.sequelizeWithInvalidCredentials.define('User', { name: DataTypes.STRING, bio: DataTypes.TEXT });
 
-        return User2.sync().catch((err) => {
+        return User2.sync().catch(err => {
           if (dialect === 'postgres' || dialect === 'postgres-native') {
             assert([
               'fe_sendauth: no password supplied',
@@ -988,7 +988,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         sequelize.define('Project', {title: Sequelize.STRING});
         sequelize.define('Task', {title: Sequelize.STRING});
 
-        return sequelize.sync({force: true}).catch((err) => {
+        return sequelize.sync({force: true}).catch(err => {
           expect(err).to.be.ok;
         });
       });
@@ -1002,7 +1002,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         sequelize.define('Project', {title: Sequelize.STRING});
         sequelize.define('Task', {title: Sequelize.STRING});
 
-        return sequelize.sync({force: true}).catch((err) => {
+        return sequelize.sync({force: true}).catch(err => {
           expect(err).to.be.ok;
         });
       });
@@ -1017,7 +1017,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         sequelize.define('Project', {title: Sequelize.STRING});
         sequelize.define('Task', {title: Sequelize.STRING});
 
-        return sequelize.sync({force: true}).catch((err) => {
+        return sequelize.sync({force: true}).catch(err => {
           expect(err).to.be.ok;
         });
       });
@@ -1027,7 +1027,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           authorID: { type: Sequelize.BIGINT, allowNull: false, references: { model: 'User', key: 'id' } }
         });
 
-        return this.sequelize.sync().catch((error) => {
+        return this.sequelize.sync().catch(error => {
           assert.ok(error);
         });
       });
@@ -1062,7 +1062,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
       it('return the sequelize instance after syncing', function() {
         const self = this;
-        return this.sequelize.sync().then((sequelize) => {
+        return this.sequelize.sync().then(sequelize => {
           expect(sequelize).to.deep.equal(self.sequelize);
         });
       });
@@ -1077,7 +1077,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           paranoid: false
         });
 
-        return block.sync().then((result) => {
+        return block.sync().then(result => {
           expect(result).to.deep.equal(block);
         });
       });
@@ -1159,7 +1159,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     [
       { type: DataTypes.ENUM, values: ['scheduled', 'active', 'finished']},
       DataTypes.ENUM('scheduled', 'active', 'finished')
-    ].forEach((status) => {
+    ].forEach(status => {
       describe('enum', () => {
         beforeEach(function() {
           this.sequelize = Support.createSequelizeInstance({
@@ -1180,7 +1180,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         });
 
         it('correctly stores values', function() {
-          return this.Review.create({ status: 'active' }).then((review) => {
+          return this.Review.create({ status: 'active' }).then(review => {
             expect(review.status).to.equal('active');
           });
         });
@@ -1188,14 +1188,14 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         it('correctly loads values', function() {
           const self = this;
           return this.Review.create({ status: 'active' }).then(() => {
-            return self.Review.findAll().then((reviews) => {
+            return self.Review.findAll().then(reviews => {
               expect(reviews[0].status).to.equal('active');
             });
           });
         });
 
         it("doesn't save an instance if value is not in the range of enums", function() {
-          return this.Review.create({status: 'fnord'}).catch((err) => {
+          return this.Review.create({status: 'fnord'}).catch(err => {
             expect(err).to.be.instanceOf(Error);
             expect(err.message).to.equal('"fnord" is not a valid choice in ["scheduled","active","finished"]');
           });
@@ -1208,13 +1208,13 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         { id: { type: DataTypes.BIGINT, primaryKey: true } },
         { id: { type: DataTypes.STRING, allowNull: true, primaryKey: true } },
         { id: { type: DataTypes.BIGINT, allowNull: false, primaryKey: true, autoIncrement: true } }
-      ].forEach((customAttributes) => {
+      ].forEach(customAttributes => {
 
         it('should be able to override options on the default attributes', function() {
           const Picture = this.sequelize.define('picture', _.cloneDeep(customAttributes));
           return Picture.sync({ force: true }).then(() => {
-            Object.keys(customAttributes).forEach((attribute) => {
-              Object.keys(customAttributes[attribute]).forEach((option) => {
+            Object.keys(customAttributes).forEach(attribute => {
+              Object.keys(customAttributes[attribute]).forEach(option => {
                 const optionValue = customAttributes[attribute][option];
                 if (typeof optionValue === 'function' && optionValue() instanceof DataTypes.ABSTRACT) {
                   expect(Picture.rawAttributes[attribute][option] instanceof optionValue).to.be.ok;
@@ -1234,7 +1234,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         beforeEach(function() {
           const self = this;
 
-          return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+          return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
             self.sequelizeWithTransaction = sequelize;
           });
         });
@@ -1244,13 +1244,13 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         });
 
         it('passes a transaction object to the callback', function() {
-          return this.sequelizeWithTransaction.transaction().then((t) => {
+          return this.sequelizeWithTransaction.transaction().then(t => {
             expect(t).to.be.instanceOf(Transaction);
           });
         });
 
         it('allows me to define a callback on the result', function() {
-          return this.sequelizeWithTransaction.transaction().then((t) => {
+          return this.sequelizeWithTransaction.transaction().then(t => {
             return t.commit();
           });
         });
@@ -1263,7 +1263,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             const count = function(transaction) {
               const sql = self.sequelizeWithTransaction.getQueryInterface().QueryGenerator.selectQuery('TransactionTests', { attributes: [['count(*)', 'cnt']] });
 
-              return self.sequelizeWithTransaction.query(sql, { plain: true, transaction }).then((result) => {
+              return self.sequelizeWithTransaction.query(sql, { plain: true, transaction }).then(result => {
                 return result.cnt;
               });
             };
@@ -1291,7 +1291,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             const count = function(transaction) {
               const sql = self.sequelizeWithTransaction.getQueryInterface().QueryGenerator.selectQuery('TransactionTests', { attributes: [['count(*)', 'cnt']] });
 
-              return self.sequelizeWithTransaction.query(sql, { plain: true, transaction }).then((result) => {
+              return self.sequelizeWithTransaction.query(sql, { plain: true, transaction }).then(result => {
                 return parseInt(result.cnt, 10);
               });
             };
@@ -1330,12 +1330,12 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           const User = this.sequelizeWithTransaction.define('Users', { username: DataTypes.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return self.sequelizeWithTransaction.transaction().then((t1) => {
-              return User.create({ username: 'foo' }, { transaction: t1 }).then((user) => {
-                return self.sequelizeWithTransaction.transaction({ transaction: t1 }).then((t2) => {
+            return self.sequelizeWithTransaction.transaction().then(t1 => {
+              return User.create({ username: 'foo' }, { transaction: t1 }).then(user => {
+                return self.sequelizeWithTransaction.transaction({ transaction: t1 }).then(t2 => {
                   return user.updateAttributes({ username: 'bar' }, { transaction: t2 }).then(() => {
                     return t2.commit().then(() => {
-                      return user.reload({ transaction: t1 }).then((newUser) => {
+                      return user.reload({ transaction: t1 }).then(newUser => {
                         expect(newUser.username).to.equal('bar');
                         return t1.commit();
                       });
@@ -1415,12 +1415,12 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           const User = this.sequelizeWithTransaction.define('Users', { username: DataTypes.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return self.sequelizeWithTransaction.transaction().then((t1) => {
-              return User.create({ username: 'foo' }, { transaction: t1 }).then((user) => {
-                return self.sequelizeWithTransaction.transaction({ transaction: t1 }).then((t2) => {
+            return self.sequelizeWithTransaction.transaction().then(t1 => {
+              return User.create({ username: 'foo' }, { transaction: t1 }).then(user => {
+                return self.sequelizeWithTransaction.transaction({ transaction: t1 }).then(t2 => {
                   return user.updateAttributes({ username: 'bar' }, { transaction: t2 }).then(() => {
                     return t2.rollback().then(() => {
-                      return user.reload({ transaction: t1 }).then((newUser) => {
+                      return user.reload({ transaction: t1 }).then(newUser => {
                         expect(newUser.username).to.equal('foo');
                         return t1.commit();
                       });
@@ -1437,12 +1437,12 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           const User = this.sequelizeWithTransaction.define('Users', { username: DataTypes.STRING });
 
           return User.sync({ force: true }).then(() => {
-            return self.sequelizeWithTransaction.transaction().then((t1) => {
-              return User.create({ username: 'foo' }, { transaction: t1 }).then((user) => {
-                return self.sequelizeWithTransaction.transaction({ transaction: t1 }).then((t2) => {
+            return self.sequelizeWithTransaction.transaction().then(t1 => {
+              return User.create({ username: 'foo' }, { transaction: t1 }).then(user => {
+                return self.sequelizeWithTransaction.transaction({ transaction: t1 }).then(t2 => {
                   return user.updateAttributes({ username: 'bar' }, { transaction: t2 }).then(() => {
                     return t1.rollback().then(() => {
-                      return User.findAll().then((users) => {
+                      return User.findAll().then(users => {
                         expect(users.length).to.equal(0);
                       });
                     });
@@ -1458,7 +1458,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
   describe('databaseVersion', () => {
     it('should database/dialect version', function() {
-      return this.sequelize.databaseVersion().then((version) => {
+      return this.sequelize.databaseVersion().then(version => {
         expect(typeof version).to.equal('string');
         expect(version).to.be.ok;
       });
@@ -1480,39 +1480,39 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       return this.sequelize.sync({force: true}).bind(this).then(() => {
-        return User.create({username: 'user1'}).then((user) => {
+        return User.create({username: 'user1'}).then(user => {
           expect(Number(user.deletedAt)).to.equal(epoch);
           return User.findOne({
             where: {
               username: 'user1'
             }
-          }).then((user) => {
+          }).then(user => {
             expect(user).to.exist;
             expect(Number(user.deletedAt)).to.equal(epoch);
             return user.destroy();
-          }).then((destroyedUser) => {
+          }).then(destroyedUser => {
             expect(destroyedUser.deletedAt).to.exist;
             expect(Number(destroyedUser.deletedAt)).not.to.equal(epoch);
             return User.findById(destroyedUser.id, { paranoid: false });
-          }).then((fetchedDestroyedUser) => {
+          }).then(fetchedDestroyedUser => {
             expect(fetchedDestroyedUser.deletedAt).to.exist;
             expect(Number(fetchedDestroyedUser.deletedAt)).not.to.equal(epoch);
             return fetchedDestroyedUser.restore();
-          }).then((restoredUser) => {
+          }).then(restoredUser => {
             expect(Number(restoredUser.deletedAt)).to.equal(epoch);
             return User.destroy({where: {
               username: 'user1'
             }});
           }).then(() => {
             return User.count();
-          }).then((count) => {
+          }).then(count => {
             expect(count).to.equal(0);
             return User.restore();
           }).then(() => {
             return User.findAll();
-          }).then((nonDeletedUsers) => {
+          }).then(nonDeletedUsers => {
             expect(nonDeletedUsers.length).to.equal(1);
-            nonDeletedUsers.forEach((u) => {
+            nonDeletedUsers.forEach(u => {
               expect(Number(u.deletedAt)).to.equal(epoch);
             });
           });

--- a/test/integration/sequelize.transaction.test.js
+++ b/test/integration/sequelize.transaction.test.js
@@ -24,7 +24,7 @@ if (current.dialect.supports.transactions) {
         let called = false;
         return this
         .sequelize
-        .transaction().then((t) => {
+        .transaction().then(t => {
           return t.commit().then(() => {
             called = 1;
           });
@@ -38,7 +38,7 @@ if (current.dialect.supports.transactions) {
         let called = false;
         return this
         .sequelize
-        .transaction().then((t) => {
+        .transaction().then(t => {
           return t.rollback().then(() => {
             called = 1;
           });
@@ -86,7 +86,7 @@ if (current.dialect.supports.transactions) {
             });
           }).then(function() {
             return this.User.all();
-          }).then((users) => {
+          }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].name).to.equal('foo');
           });
@@ -96,14 +96,14 @@ if (current.dialect.supports.transactions) {
 
     describe('complex long running example', () => {
       it('works with promise syntax', function() {
-        return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
           const Test = sequelize.define('Test', {
             id: { type: Support.Sequelize.INTEGER, primaryKey: true, autoIncrement: true},
             name: { type: Support.Sequelize.STRING }
           });
 
           return sequelize.sync({ force: true }).then(() => {
-            return sequelize.transaction().then((transaction) => {
+            return sequelize.transaction().then(transaction => {
               expect(transaction).to.be.instanceOf(Transaction);
 
               return Test
@@ -113,7 +113,7 @@ if (current.dialect.supports.transactions) {
                   return transaction
                     .commit()
                     .then(() => { return Test.count(); })
-                    .then((count) => {
+                    .then(count => {
                       expect(count).to.equal(1);
                     });
                 });
@@ -129,7 +129,7 @@ if (current.dialect.supports.transactions) {
         beforeEach(function() {
           const self = this;
 
-          return Support.prepareTransactionTest(this.sequelize).then((sequelize) => {
+          return Support.prepareTransactionTest(this.sequelize).then(sequelize => {
             self.sequelize = sequelize;
 
             self.Model = sequelize.define('Model', {
@@ -145,11 +145,11 @@ if (current.dialect.supports.transactions) {
         it('triggers the error event for the second transactions', function() {
           const self = this;
 
-          return this.sequelize.transaction().then((t1) => {
-            return self.sequelize.transaction().then((t2) => {
+          return this.sequelize.transaction().then(t1 => {
+            return self.sequelize.transaction().then(t2 => {
               return self.Model.create({ name: 'omnom' }, { transaction: t1 }).then(() => {
                 return Promise.all([
-                  self.Model.create({ name: 'omnom' }, { transaction: t2 }).catch((err) => {
+                  self.Model.create({ name: 'omnom' }, { transaction: t2 }).catch(err => {
                     expect(err).to.be.ok;
                     return t2.rollback();
                   }),

--- a/test/integration/sequelize/deferrable.test.js
+++ b/test/integration/sequelize/deferrable.test.js
@@ -46,10 +46,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         return User.sync({ force: true }).bind(this).then(() => {
           return Task.sync({ force: true });
         }).then(function() {
-          return this.sequelize.transaction(transactionOptions, (t) => {
+          return this.sequelize.transaction(transactionOptions, t => {
             return Task
               .create({ title: 'a task', user_id: -1 }, { transaction: t })
-              .then((task) => {
+              .then(task => {
                 return [task, User.create({}, { transaction: t })];
               })
               .spread((task, user) => {
@@ -71,7 +71,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       it('allows the violation of the foreign key constraint if the transaction is deferred', function() {
         return this
           .run(Sequelize.Deferrable.INITIALLY_IMMEDIATE)
-          .then((task) => {
+          .then(task => {
             expect(task.title).to.equal('a task');
             expect(task.user_id).to.equal(1);
           });
@@ -91,7 +91,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             deferrable: Sequelize.Deferrable.SET_DEFERRED([taskTableName + '_user_id_fkey']),
             taskTableName
           })
-          .then((task) => {
+          .then(task => {
             expect(task.title).to.equal('a task');
             expect(task.user_id).to.equal(1);
           });
@@ -102,7 +102,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       it('allows the violation of the foreign key constraint', function() {
         return this
           .run(Sequelize.Deferrable.INITIALLY_DEFERRED)
-          .then((task) => {
+          .then(task => {
             expect(task.title).to.equal('a task');
             expect(task.user_id).to.equal(1);
           });

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -62,7 +62,7 @@ if (dialect !== 'sqlite') {
 
         return this.sequelize.sync({ force: true }).bind(this).then(() => {
           return TimezonedUser.create({});
-        }).then((timezonedUser) => {
+        }).then(timezonedUser => {
           return Promise.all([
             NormalUser.findById(timezonedUser.id),
             TimezonedUser.findById(timezonedUser.id)

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -61,7 +61,7 @@ if (current.dialect.supports.transactions) {
 
       it('supports automatically rolling back with a thrown error', function() {
         let t;
-        return expect(this.sequelize.transaction((transaction) => {
+        return expect(this.sequelize.transaction(transaction => {
           t = transaction;
           throw new Error('Yolo');
         })).to.eventually.be.rejected.then(() => {
@@ -71,7 +71,7 @@ if (current.dialect.supports.transactions) {
 
       it('supports automatically rolling back with a rejection', function() {
         let t;
-        return expect(this.sequelize.transaction((transaction) => {
+        return expect(this.sequelize.transaction(transaction => {
           t = transaction;
           return Promise.reject(new Error('Swag'));
         })).to.eventually.be.rejected.then(() => {
@@ -90,7 +90,7 @@ if (current.dialect.supports.transactions) {
             }),
             self = this,
             transTest = function(val) {
-              return self.sequelize.transaction({isolationLevel: 'SERIALIZABLE'}, (t) => {
+              return self.sequelize.transaction({isolationLevel: 'SERIALIZABLE'}, t => {
                 return SumSumSum.sum('value', {transaction: t}).then(() => {
                   return SumSumSum.create({value: -val}, {transaction: t});
                 });
@@ -116,14 +116,14 @@ if (current.dialect.supports.transactions) {
 
     it('does not allow queries after commit', function() {
       const self = this;
-      return this.sequelize.transaction().then((t) => {
+      return this.sequelize.transaction().then(t => {
         return self.sequelize.query('SELECT 1+1', {transaction: t, raw: true}).then(() => {
           return t.commit();
         }).then(() => {
           return self.sequelize.query('SELECT 1+1', {transaction: t, raw: true});
         });
       }).throw(new Error('Expected error not thrown'))
-    .catch ((err) => {
+    .catch (err => {
       expect (err.message).to.match(/commit has been called on this transaction\([^)]+\), you can no longer use it\. \(The rejected query is attached as the 'sql' property of this error\)/);
       expect (err.sql).to.equal('SELECT 1+1');
     });
@@ -132,13 +132,13 @@ if (current.dialect.supports.transactions) {
     it('does not allow queries immediatly after commit call', function() {
       const self = this;
       return expect(
-      this.sequelize.transaction().then((t) => {
+      this.sequelize.transaction().then(t => {
         return self.sequelize.query('SELECT 1+1', {transaction: t, raw: true}).then(() => {
           return Promise.join(
             expect(t.commit()).to.eventually.be.fulfilled,
             self.sequelize.query('SELECT 1+1', {transaction: t, raw: true})
               .throw(new Error('Expected error not thrown'))
-              .catch ((err) => {
+              .catch (err => {
                 expect (err.message).to.match(/commit has been called on this transaction\([^)]+\), you can no longer use it\. \(The rejected query is attached as the 'sql' property of this error\)/);
                 expect (err.sql).to.equal('SELECT 1+1');
               })
@@ -151,7 +151,7 @@ if (current.dialect.supports.transactions) {
     it('does not allow queries after rollback', function() {
       const self = this;
       return expect(
-      this.sequelize.transaction().then((t) => {
+      this.sequelize.transaction().then(t => {
         return self.sequelize.query('SELECT 1+1', {transaction: t, raw: true}).then(() => {
           return t.rollback();
         }).then(() => {
@@ -164,12 +164,12 @@ if (current.dialect.supports.transactions) {
     it('does not allow queries immediatly after rollback call', function() {
       const self = this;
       return expect(
-      this.sequelize.transaction().then((t) => {
+      this.sequelize.transaction().then(t => {
         return Promise.join(
           expect(t.rollback()).to.eventually.be.fulfilled,
           self.sequelize.query('SELECT 1+1', {transaction: t, raw: true})
             .throw(new Error('Expected error not thrown'))
-            .catch ((err) => {
+            .catch (err => {
               expect (err.message).to.match(/rollback has been called on this transaction\([^)]+\), you can no longer use it\. \(The rejected query is attached as the 'sql' property of this error\)/);
               expect (err.sql).to.equal('SELECT 1+1');
             })
@@ -181,7 +181,7 @@ if (current.dialect.supports.transactions) {
     it('does not allow commits after commit', function() {
       const self = this;
       return expect(
-      self.sequelize.transaction().then((t) => {
+      self.sequelize.transaction().then(t => {
         return t.commit().then(() => {
           return t.commit();
         });
@@ -191,7 +191,7 @@ if (current.dialect.supports.transactions) {
 
     it('does not allow commits after rollback', function() {
       const self = this;
-      return expect(self.sequelize.transaction().then((t) => {
+      return expect(self.sequelize.transaction().then(t => {
         return t.rollback().then(() => {
           return t.commit();
         });
@@ -200,7 +200,7 @@ if (current.dialect.supports.transactions) {
 
     it('does not allow rollbacks after commit', function() {
       const self = this;
-      return expect(self.sequelize.transaction().then((t) => {
+      return expect(self.sequelize.transaction().then(t => {
         return t.commit().then(() => {
           return t.rollback();
         });
@@ -209,7 +209,7 @@ if (current.dialect.supports.transactions) {
 
     it('does not allow rollbacks after rollback', function() {
       const self = this;
-      return expect(self.sequelize.transaction().then((t) => {
+      return expect(self.sequelize.transaction().then(t => {
         return t.rollback().then(() => {
           return t.rollback();
         });
@@ -257,20 +257,20 @@ if (current.dialect.supports.transactions) {
           });
         let persistentTransaction;
 
-        return sequelize.transaction().then((t) => {
+        return sequelize.transaction().then(t => {
           return sequelize.sync({ transaction:t }).then(( ) => {
             return t;
           });
-        }).then((t) => {
+        }).then(t => {
           return User.create({}, {transaction:t}).then(( ) => {
             return t.commit();
           });
         }).then(() => {
-          return sequelize.transaction().then((t) => {
+          return sequelize.transaction().then(t => {
             persistentTransaction = t;
           });
         }).then(() => {
-          return User.findAll({transaction: persistentTransaction}).then((users) => {
+          return User.findAll({transaction: persistentTransaction}).then(users => {
             expect(users.length).to.equal(1);
             return persistentTransaction.commit();
           });
@@ -289,7 +289,7 @@ if (current.dialect.supports.transactions) {
           });
         });
 
-        Object.keys(Transaction.TYPES).forEach((key) => {
+        Object.keys(Transaction.TYPES).forEach(key => {
           it('should allow specification of ' + key + ' type', function() {
             return this.sequelize.transaction({
               type: key
@@ -307,18 +307,18 @@ if (current.dialect.supports.transactions) {
 
     if (dialect === 'sqlite') {
       it('automatically retries on SQLITE_BUSY failure', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { username: Support.Sequelize.STRING });
           return User.sync({ force: true }).then(() => {
             const newTransactionFunc = function() {
-              return sequelize.transaction({type: Support.Sequelize.Transaction.TYPES.EXCLUSIVE}).then((t) => {
+              return sequelize.transaction({type: Support.Sequelize.Transaction.TYPES.EXCLUSIVE}).then(t => {
                 return User.create({}, {transaction:t}).then(( ) => {
                   return t.commit();
                 });
               });
             };
             return Promise.join(newTransactionFunc(), newTransactionFunc()).then(() => {
-              return User.findAll().then((users) => {
+              return User.findAll().then(users => {
                 expect(users.length).to.equal(2);
               });
             });
@@ -327,11 +327,11 @@ if (current.dialect.supports.transactions) {
       });
 
       it('fails with SQLITE_BUSY when retry.match is changed', function() {
-        return Support.prepareTransactionTest(this.sequelize).bind({}).then((sequelize) => {
+        return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
           const User = sequelize.define('User', { id: {type: Support.Sequelize.INTEGER, primaryKey: true}, username: Support.Sequelize.STRING });
           return User.sync({ force: true }).then(() => {
             const newTransactionFunc = function() {
-              return sequelize.transaction({type: Support.Sequelize.Transaction.TYPES.EXCLUSIVE, retry: {match: ['NO_MATCH']}}).then((t) => {
+              return sequelize.transaction({type: Support.Sequelize.Transaction.TYPES.EXCLUSIVE, retry: {match: ['NO_MATCH']}}).then(t => {
               // introduce delay to force the busy state race condition to fail
                 return Promise.delay(1000).then(() => {
                   return User.create({id: null, username: 'test ' + t.id}, {transaction:t}).then(() => {
@@ -361,17 +361,17 @@ if (current.dialect.supports.transactions) {
           return this.sequelize.sync({ force: true }).then(() => {
             return User.create({ username: 'jan'});
           }).then(() => {
-            return self.sequelize.transaction().then((t1) => {
+            return self.sequelize.transaction().then(t1 => {
               return User.find({
                 where: {
                   username: 'jan'
                 },
                 lock: t1.LOCK.UPDATE,
                 transaction: t1
-              }).then((t1Jan) => {
+              }).then(t1Jan => {
                 return self.sequelize.transaction({
                   isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED
-                }).then((t2) => {
+                }).then(t2 => {
                   return Promise.join(
                   User.find({
                     where: {
@@ -418,7 +418,7 @@ if (current.dialect.supports.transactions) {
           (john, task1) => {
             return john.setTasks([task1]);
           }).then(() => {
-            return self.sequelize.transaction((t1) => {
+            return self.sequelize.transaction(t1 => {
 
               if (current.dialect.supports.lockOuterJoinFailure) {
 
@@ -465,7 +465,7 @@ if (current.dialect.supports.transactions) {
             (john, task1) => {
               return john.setTasks([task1]);
             }).then(() => {
-              return self.sequelize.transaction((t1) => {
+              return self.sequelize.transaction(t1 => {
                 return User.find({
                   where: {
                     username: 'John'
@@ -476,9 +476,9 @@ if (current.dialect.supports.transactions) {
                     of: User
                   },
                   transaction: t1
-                }).then((t1John) => {
+                }).then(t1John => {
                   // should not be blocked by the lock of the other transaction
-                  return self.sequelize.transaction((t2) => {
+                  return self.sequelize.transaction(t2 => {
                     return Task.update({
                       active: true
                     }, {
@@ -512,15 +512,15 @@ if (current.dialect.supports.transactions) {
             return this.sequelize.sync({ force: true }).then(() => {
               return User.create({ username: 'jan'});
             }).then(() => {
-              return self.sequelize.transaction().then((t1) => {
+              return self.sequelize.transaction().then(t1 => {
                 return User.find({
                   where: {
                     username: 'jan'
                   },
                   lock: t1.LOCK.NO_KEY_UPDATE,
                   transaction: t1
-                }).then((t1Jan) => {
-                  return self.sequelize.transaction().then((t2) => {
+                }).then(t1Jan => {
+                  return self.sequelize.transaction().then(t2 => {
                     return Promise.join(
                     User.find({
                       where: {
@@ -564,24 +564,24 @@ if (current.dialect.supports.transactions) {
           return this.sequelize.sync({ force: true }).then(() => {
             return User.create({ username: 'jan'});
           }).then(() => {
-            return self.sequelize.transaction().then((t1) => {
+            return self.sequelize.transaction().then(t1 => {
               return User.find({
                 where: {
                   username: 'jan'
                 },
                 lock: t1.LOCK.SHARE,
                 transaction: t1
-              }).then((t1Jan) => {
+              }).then(t1Jan => {
                 return self.sequelize.transaction({
                   isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED
-                }).then((t2) => {
+                }).then(t2 => {
                   return Promise.join(
                   User.find({
                     where: {
                       username: 'jan'
                     },
                     transaction: t2
-                  }).then((t2Jan) => {
+                  }).then(t2Jan => {
                     t2FindSpy();
                     return t2Jan.updateAttributes({
                       awesome: false

--- a/test/integration/trigger.test.js
+++ b/test/integration/trigger.test.js
@@ -48,7 +48,7 @@ if (current.dialect.supports.tmpTableTrigger) {
       it('should return output rows after instance update', () => {
         return User.create({
           username: 'triggertest'
-        }).then((user) => {
+        }).then(user => {
           user.username = 'usernamechanged';
           return user.save();
         })
@@ -60,7 +60,7 @@ if (current.dialect.supports.tmpTableTrigger) {
       it('should return output rows after Model update', () => {
         return User.create({
           username: 'triggertest'
-        }).then((user) => {
+        }).then(user => {
           return User.update({
             username: 'usernamechanged'
           }, {
@@ -77,7 +77,7 @@ if (current.dialect.supports.tmpTableTrigger) {
       it('should successfully delete with a trigger on the table', () => {
         return User.create({
           username: 'triggertest'
-        }).then((user) => {
+        }).then(user => {
           return user.destroy();
         }).then(() => {
           return expect(User.find({username: 'triggertest'})).to.eventually.be.null;

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -271,7 +271,7 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
               }
             }, type)), 'count-engines-wings']
           ]
-        }).spread((airplane) => {
+        }).spread(airplane => {
           expect(parseInt(airplane.get('count'))).to.equal(3);
           expect(parseInt(airplane.get('count-engines'))).to.equal(1);
           expect(parseInt(airplane.get('count-engines-wings'))).to.equal(2);
@@ -296,7 +296,7 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
               }
             }), 'count-engines-wings']
           ]
-        }).spread((airplane) => {
+        }).spread(airplane => {
           expect(parseInt(airplane.get('count'))).to.equal(3);
           expect(parseInt(airplane.get('count-engines'))).to.equal(1);
           expect(parseInt(airplane.get('count-engines-wings'))).to.equal(2);

--- a/test/integration/vectors.test.js
+++ b/test/integration/vectors.test.js
@@ -18,10 +18,10 @@ describe(Support.getTestDialectTeaser('Vectors'), () => {
     return Student.sync({force: true}).then(() => {
       return Student.create({
         name: 'Robert\\\'); DROP TABLE "students"; --'
-      }).then((result) => {
+      }).then(result => {
         expect(result.get('name')).to.equal('Robert\\\'); DROP TABLE "students"; --');
         return Student.findAll();
-      }).then((result) => {
+      }).then(result => {
         expect(result[0].name).to.equal('Robert\\\'); DROP TABLE "students"; --');
       });
     });

--- a/test/support.js
+++ b/test/support.js
@@ -18,11 +18,11 @@ chai.config.includeStack = true;
 chai.should();
 
 // Make sure errors get thrown when testing
-process.on('uncaughtException', (e) => {
+process.on('uncaughtException', e => {
   console.error('An unhandled exception occured:');
   throw e;
 });
-Sequelize.Promise.onPossiblyUnhandledRejection((e) => {
+Sequelize.Promise.onPossiblyUnhandledRejection(e => {
   console.error('An unhandled rejection occured:');
   throw e;
 });
@@ -59,7 +59,7 @@ const Support = {
     if (dialect === 'sqlite') {
       const p = path.join(__dirname, 'tmp', 'db.sqlite');
 
-      return new Sequelize.Promise((resolve) => {
+      return new Sequelize.Promise(resolve => {
         // We cannot promisify exists, since exists does not follow node callback convention - first argument is a boolean, not an error / null
         if (fs.existsSync(p)) {
           resolve(Sequelize.Promise.promisify(fs.unlink)(p));
@@ -140,7 +140,7 @@ const Support = {
   },
 
   getSupportedDialects() {
-    return fs.readdirSync(__dirname + '/../lib/dialects').filter((file) => {
+    return fs.readdirSync(__dirname + '/../lib/dialects').filter(file => {
       return file.indexOf('.js') === -1 && file.indexOf('abstract') === -1;
     });
   },

--- a/test/supportShim.js
+++ b/test/supportShim.js
@@ -21,8 +21,8 @@ module.exports = function(Sequelize) {
   });
 
   // Shim Model static methods to then shim getter/setter methods
-  ['hasOne', 'belongsTo', 'hasMany', 'belongsToMany'].forEach((type) => {
-    shimMethod(Sequelize.Model, type, (original) => {
+  ['hasOne', 'belongsTo', 'hasMany', 'belongsToMany'].forEach(type => {
+    shimMethod(Sequelize.Model, type, original => {
       return function() {
         const model = this,
           association = original.apply(this, arguments);
@@ -129,7 +129,7 @@ module.exports = function(Sequelize) {
   function shim(obj, name, index, conform, debugName) {
     index--;
 
-    shimMethod(obj, name, (original) => {
+    shimMethod(obj, name, original => {
       const sequelizeProto = obj === Sequelize.prototype;
 
       return function() {
@@ -283,7 +283,7 @@ module.exports = function(Sequelize) {
  * @returns {Object} - `obj` input
  */
 function forOwn(obj, fn) {
-  Object.getOwnPropertyNames(obj).forEach((key) => {
+  Object.getOwnPropertyNames(obj).forEach(key => {
     if (Object.getOwnPropertyDescriptor(obj, key).hasOwnProperty('value')) fn(obj[key], key, obj);
   });
   return obj;
@@ -311,7 +311,7 @@ function getFunctionCode(fn) {
  * @returns {Array} - Array of names of `method`'s arguments
  */
 function getFunctionArguments(tree) {
-  return tree.body[0].params.map((param) => {return param.name;});
+  return tree.body[0].params.map(param => {return param.name;});
 }
 
 /**
@@ -348,7 +348,7 @@ function getArgumentsConformFn(method, args, hints, tree) {
  * @returns {Object} - Clone of options
  */
 function cloneOptions(options) {
-  return _.cloneDeepWith(options, (value) => {
+  return _.cloneDeepWith(options, value => {
     if (typeof value === 'object' && !_.isPlainObject(value)) return value;
   });
 }

--- a/test/unit/associations/has-many.test.js
+++ b/test/unit/associations/has-many.test.js
@@ -139,7 +139,7 @@ describe(Support.getTestDialectTeaser('hasMany'), () => {
       expect(findAll).to.have.been.calledOnce;
       expect(findAll.firstCall.args[0].where).to.deep.equal(where);
 
-      return actual.then((results) => {
+      return actual.then(results => {
         expect(results).to.be.an('array');
         expect(results.length).to.equal(2);
       }).finally(() => {
@@ -178,7 +178,7 @@ describe(Support.getTestDialectTeaser('hasMany'), () => {
       expect(findAll).to.have.been.calledOnce;
       expect(findAll.firstCall.args[0].where).to.deep.equal(where);
 
-      return actual.then((result) => {
+      return actual.then(result => {
         expect(result).to.be.an('object');
         expect(Object.keys(result)).to.deep.equal([idA, idB, idC]);
 

--- a/test/unit/connection-manager.test.js
+++ b/test/unit/connection-manager.test.js
@@ -44,7 +44,7 @@ describe('connection manager', () => {
       const username = Math.random().toString(),
         password = Math.random().toString();
 
-      this.sequelize.beforeConnect((config) => {
+      this.sequelize.beforeConnect(config => {
         config.username = username;
         config.password = password;
         return config;

--- a/test/unit/dialects/mssql/resource-lock.test.js
+++ b/test/unit/dialects/mssql/resource-lock.test.js
@@ -15,19 +15,19 @@ describe('[MSSQL Specific] ResourceLock', () => {
     }
 
     return Promise.all([
-      Promise.using(lock.lock(), (resource) => {
+      Promise.using(lock.lock(), resource => {
         validateResource(resource);
         assert.equal(last, 0);
         last = 1;
 
         return Promise.delay(15);
       }),
-      Promise.using(lock.lock(), (resource) => {
+      Promise.using(lock.lock(), resource => {
         validateResource(resource);
         assert.equal(last, 1);
         last = 2;
       }),
-      Promise.using(lock.lock(), (resource) => {
+      Promise.using(lock.lock(), resource => {
         validateResource(resource);
         assert.equal(last, 2);
         last = 3;
@@ -46,7 +46,7 @@ describe('[MSSQL Specific] ResourceLock', () => {
     }
 
     return Promise.all([
-      Promise.using(lock.lock(), (resource) => {
+      Promise.using(lock.lock(), resource => {
         validateResource(resource);
 
         throw new Error('unexpected error');

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -544,7 +544,7 @@ if (dialect === 'mysql') {
 
     _.each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
-        tests.forEach((test) => {
+        tests.forEach(test => {
           const title = test.title || 'MySQL correctly returns ' + test.expectation + ' for ' + JSON.stringify(test.arguments);
           it(title, function() {
             // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -886,7 +886,7 @@ if (dialect.match(/^postgres/)) {
           QueryGenerator.options.quoteIdentifiers = true;
         });
 
-        tests.forEach((test) => {
+        tests.forEach(test => {
           const title = test.title || 'Postgres correctly returns ' + test.expectation + ' for ' + JSON.stringify(test.arguments);
           it(title, function() {
             // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -507,7 +507,7 @@ if (dialect === 'sqlite') {
 
     _.each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
-        tests.forEach((test) => {
+        tests.forEach(test => {
           const title = test.title || 'SQLite correctly returns ' + test.expectation + ' for ' + JSON.stringify(test.arguments);
           it(title, function() {
             // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -15,7 +15,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
   describe('arguments', () => {
     it('hooks can modify passed arguments', function() {
-      this.Model.addHook('beforeCreate', (options) => {
+      this.Model.addHook('beforeCreate', options => {
         options.answer = 41;
       });
 

--- a/test/unit/instance-validator.test.js
+++ b/test/unit/instance-validator.test.js
@@ -100,7 +100,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         const validationFailedHook = sinon.stub().returns(Promise.resolve());
         this.User.validationFailed(validationFailedHook);
 
-        return expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected.then((err) => {
+        return expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected.then(err => {
           expect(err.name).to.equal('SequelizeValidationError');
         });
       });
@@ -111,7 +111,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         const validationFailedHook = sinon.stub().throws(new Error('validation failed hook error'));
         this.User.validationFailed(validationFailedHook);
 
-        return expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected.then((err) => {
+        return expect(failingInstanceValidator._validateAndRunHooks()).to.be.rejected.then(err => {
           expect(err.message).to.equal('validation failed hook error');
         });
       });

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -197,7 +197,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
           const failingUser = UserFail.build({ name: failingValue });
 
-          return expect(failingUser.validate()).to.be.rejected.then((_errors) => {
+          return expect(failingUser.validate()).to.be.rejected.then(_errors => {
             expect(_errors.get('name')[0].message).to.equal(message);
             expect(_errors.get('name')[0].value).to.equal(failingValue);
           });
@@ -273,7 +273,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     before(function() {
       this.stub = sinon.stub(current, 'query', () => {
-        return new Promise((resolve) => {
+        return new Promise(resolve => {
           resolve([User.build({}), 1]);
         });
       });

--- a/test/unit/sql/change-column.test.js
+++ b/test/unit/sql/change-column.test.js
@@ -25,7 +25,7 @@ if (current.dialect.name !== 'sqlite') {
 
       before(function() {
 
-        this.stub = sinon.stub(current, 'query', (sql) => {
+        this.stub = sinon.stub(current, 'query', sql => {
           return Promise.resolve(sql);
         });
       });
@@ -42,7 +42,7 @@ if (current.dialect.name !== 'sqlite') {
         return current.getQueryInterface().changeColumn(Model.getTableName(), 'level_id', {
           type: DataTypes.FLOAT,
           allowNull: false
-        }).then((sql) => {
+        }).then(sql => {
           expectsql(sql, {
             mssql: 'ALTER TABLE [users] ALTER COLUMN [level_id] FLOAT NOT NULL;',
             mysql: 'ALTER TABLE `users` CHANGE `level_id` `level_id` FLOAT NOT NULL;',
@@ -60,7 +60,7 @@ if (current.dialect.name !== 'sqlite') {
           },
           onUpdate: 'cascade',
           onDelete: 'cascade'
-        }).then((sql) => {
+        }).then(sql => {
           expectsql(sql, {
             mssql: 'ALTER TABLE [users] ADD CONSTRAINT [level_id_foreign_idx] FOREIGN KEY ([level_id]) REFERENCES [level] ([id]) ON DELETE CASCADE;',
             mysql: 'ALTER TABLE `users` ADD CONSTRAINT `users_level_id_foreign_idx` FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',


### PR DESCRIPTION
This comes up a lot in PRs. Arrow functions with a single argument do not need to specify the parenthesis, so they shouldn't. Example:
```js
[1, 2, 3].map(x => x * 2)
// looks a lot cleaner than
[1, 2, 3].map((x) => x * 2)
```
Just like you wouldn't for example wrap every assignment expression in an extra set of parenthesis:
```ts
const x = (y + 1);
```
you shouldn't do it for arrow functions if it's not needed.

Just added the rule and ran `eslint --fix`