### PR TITLE
Fix that nasty undefined $parent bug for real

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -70,7 +70,8 @@
 - [FIXED] Update or soft delete breaks when querying on `JSON/JSONB` [#7376](https://github.com/sequelize/sequelize/issues/7376) [#7400](https://github.com/sequelize/sequelize/issues/7400) [#7444](https://github.com/sequelize/sequelize/issues/7444)
 - [ADDED] Support for JSON attributes in orders and groups. [#7564](https://github.com/sequelize/sequelize/issues/7564)
 - [REMOVED] Removes support for interpretation of raw properties and values in the where object. [#7568](https://github.com/sequelize/sequelize/issues/7568)
-- [FIXED] Upsert now updates all changed fields by default
+- [FIXED] Upsert now updates all changed fields by default [#7523](https://github.com/sequelize/sequelize/pull/7523)
+- [FIXED] Support more edge-cases of using attribute:[] in include or through
 
 ## BC breaks:
 - Model.validate instance method now runs validation hooks by default. Previously you needed to pass { hooks: true }. You can override this behavior by passing { hooks: false }

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -588,15 +588,15 @@ class AbstractQuery {
                 $parent = resultMap[parentHash];
                 $lastKeyPrefix = lastKeyPrefix(prevKey);
 
-                if (includeMap[prevKey].association.isSingleAssociation) {
-                  if ($parent) {
+                if ($parent) {
+                  if (includeMap[prevKey].association.isSingleAssociation) {
                     $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+                  } else {
+                    if (!$parent[$lastKeyPrefix]) {
+                      $parent[$lastKeyPrefix] = [];
+                    }
+                    $parent[$lastKeyPrefix].push(resultMap[itemHash] = values);
                   }
-                } else {
-                  if (!$parent[$lastKeyPrefix]) {
-                    $parent[$lastKeyPrefix] = [];
-                  }
-                  $parent[$lastKeyPrefix].push(resultMap[itemHash] = values);
                 }
               }
             }
@@ -677,15 +677,15 @@ class AbstractQuery {
             $parent = resultMap[parentHash];
             $lastKeyPrefix = lastKeyPrefix(prevKey);
 
-            if (includeMap[prevKey].association.isSingleAssociation) {
-              if ($parent) {
+            if ($parent) {
+              if (includeMap[prevKey].association.isSingleAssociation) {
                 $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
+              } else {
+                if (!$parent[$lastKeyPrefix]) {
+                  $parent[$lastKeyPrefix] = [];
+                }
+                $parent[$lastKeyPrefix].push(resultMap[itemHash] = values);
               }
-            } else {
-              if (!$parent[$lastKeyPrefix]) {
-                $parent[$lastKeyPrefix] = [];
-              }
-              $parent[$lastKeyPrefix].push(resultMap[itemHash] = values);
             }
           }
         }


### PR DESCRIPTION
Hi,

PR [#6297](https://github.com/sequelize/sequelize/pull/6297) fixed a bunch of bugs appearing when using `attribute: []` in `include` or `through`. For some reason, the author of the patch didn't check for the existence of `$parent` at the right place in the code, and the bug was still present for a few edge-cases.

I'm not sure exactly how my code is different from the test-cases provided in PR #6297, but this patch fixes the undefined $parent errors I encountered.

If the test case is mandatory, I can try to spend some additional time on reducing my code to see why things went wrong for me.
