### PR TITLE
Default to aliases for 'createdAt', 'updatedAt', and 'deletedAt' in options

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
 # Future
+- [ADDED] Allow `updatedAt`, `createdAt`, and `deletedAt` to reference field name via alias.
 - [ADDED] Add `isSoftDeleted` helper method to model instance [#7408](https://github.com/sequelize/sequelize/issues/7408)
 - [FIXED] Map isolation level strings to tedious isolation level [MSSQL] [#7296](https://github.com/sequelize/sequelize/issues/7296)
 - [ADDED] `addConstraint`, `removeConstraint`, `showConstraint` [#7108](https://github.com/sequelize/sequelize/pull/7108)

--- a/lib/model.js
+++ b/lib/model.js
@@ -801,13 +801,28 @@ class Model {
     this._timestampAttributes = {};
     if (this.options.timestamps) {
       if (this.options.createdAt !== false) {
-        this._timestampAttributes.createdAt = this.options.createdAt || Utils.underscoredIf('createdAt', this.options.underscored);
+        if (this.attributes[this.options.createdAt]) {
+          this._timestampAttributes.createdAt = this.attributes[this.options.createdAt].field;
+        }
+        else {
+          this._timestampAttributes.createdAt = this.options.createdAt || Utils.underscoredIf('createdAt', this.options.underscored);
+        }
       }
       if (this.options.updatedAt !== false) {
-        this._timestampAttributes.updatedAt = this.options.updatedAt || Utils.underscoredIf('updatedAt', this.options.underscored);
+        if (this.attributes[this.options.updatedAt]) {
+          this._timestampAttributes.updatedAt = this.attributes[this.options.updatedAt].field;
+        }
+        else {
+          this._timestampAttributes.updatedAt = this.options.updatedAt || Utils.underscoredIf('updatedAt', this.options.underscored);
+        }
       }
       if (this.options.paranoid && this.options.deletedAt !== false) {
-        this._timestampAttributes.deletedAt = this.options.deletedAt || Utils.underscoredIf('deletedAt', this.options.underscored);
+        if (this.attributes[this.options.deletedAt]) {
+          this._timestampAttributes.deletedAt = this.attributes[this.options.deletedAt].field;
+        }
+        else {
+          this._timestampAttributes.deletedAt = this.options.deletedAt || Utils.underscoredIf('deletedAt', this.options.underscored);
+        }
       }
     }
     if (this.options.version) {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -670,6 +670,42 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    t('works with custom timestamps which alias an existing field', function() {
+      const User = this.sequelize.define('User', {
+        username: DataTypes.STRING,
+        date_of_birth: DataTypes.DATE,
+        email: DataTypes.STRING,
+        password: DataTypes.STRING,
+        createdTime: {
+          type: DataTypes.DATE,
+          allowNull: true,
+          defaultValue: DataTypes.NOW,
+          field: 'created_time'
+        },
+        updatedTime: {
+          type: DataTypes.DATE,
+          allowNull: true,
+          defaultValue: DataTypes.NOW,
+          field: 'updated_time'
+        }
+      }, {
+        createdAt: 'createdTime',
+        updatedAt: 'updatedTime',
+        tableName: 'users',
+        underscored: true,
+        freezeTableName: true,
+        force: false
+      });
+
+      return this.sequelize.sync({force: true}).then(() => {
+        return User.create({}).then(user => {
+          expect(user).to.be.ok;
+          expect(user.created_time).to.be.ok;
+          expect(user.updated_time).to.be.ok;
+        });
+      });
+    });
+
     it('works with custom timestamps and underscored', function() {
       const User = this.sequelize.define('User', {
 

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -670,7 +670,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
-    t('works with custom timestamps which alias an existing field', function() {
+    it('works with custom timestamps which alias an existing field', function() {
       const User = this.sequelize.define('User', {
         username: DataTypes.STRING,
         date_of_birth: DataTypes.DATE,


### PR DESCRIPTION
### Description of change

We are currently using `sequelize-auto` to generate the majority of our DB models.  Our generated models are frequently created with aliases to `createdAt`, `updatedAt`, etc in the model options field (as we have them with a different name).  This has been causing us problems.

We are, however, a dozen or so minor versions behind so please let me know if this is actually fixed somewhere else and I can begin updating our services.
