### PR TITLE
Fix alter option Fixes #537

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -297,20 +297,30 @@ const QueryGenerator = {
         definition += ' USING (' + this.quoteIdentifier(attributeName) + '::' + this.pgEnumName(tableName, attributeName) + ')';
       }
 
-      if (definition.match(/UNIQUE;*$/)) {
-        definition = definition.replace(/UNIQUE;*$/, '');
+      attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
+        tableName: this.quoteTable(tableName),
+        query: 'DROP CONSTRAINT IF EXISTS ' + this.quoteIdentifier(tableName + '_' + attributeName + '_key')
+      });
 
+      if (definition.match(/UNIQUE;*$/)) {
         attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
           tableName: this.quoteTable(tableName),
-          query: 'ADD CONSTRAINT ' + this.quoteIdentifier(attributeName + '_unique_idx') + ' UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
+          query: 'ADD UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
         });
+        definition = definition.replace(/UNIQUE;*$/, '');
       }
+
+      attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
+        tableName: this.quoteTable(tableName),
+        query: 'DROP CONSTRAINT IF EXISTS ' + this.quoteIdentifier(tableName + '_' + attributeName + '_fkey')
+      });
 
       if (definition.match(/REFERENCES/)) {
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
         attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
           tableName: this.quoteTable(tableName),
-          query: 'ADD CONSTRAINT ' + this.quoteIdentifier(attributeName + '_foreign_idx') + ' FOREIGN KEY (' + this.quoteIdentifier(attributeName) + ') ' + definition
+          query: 'ADD CONSTRAINT ' + this.quoteIdentifier(tableName + '_' + attributeName + '_fkey')
+            + ' FOREIGN KEY (' + this.quoteIdentifier(attributeName) + ') ' + definition
         });
       } else {
         attrSql += Utils._.template(query)({

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -255,7 +255,9 @@ const QueryGenerator = {
     return `ALTER TABLE ${quotedTableName} DROP COLUMN ${quotedAttributeName};`;
   },
 
-  changeColumnQuery(tableName, attributes) {
+  changeColumnQuery(tableName, attributes, constraints) {
+    constraints = constraints || {};
+    const tableDetails = this.extractTableDetails(tableName);
     const query = 'ALTER TABLE <%= tableName %> ALTER COLUMN <%= query %>;';
     const sql = [];
 
@@ -297,31 +299,43 @@ const QueryGenerator = {
         definition += ' USING (' + this.quoteIdentifier(attributeName) + '::' + this.pgEnumName(tableName, attributeName) + ')';
       }
 
-      attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
-        tableName: this.quoteTable(tableName),
-        query: 'DROP CONSTRAINT IF EXISTS ' + this.quoteIdentifier(tableName + '_' + attributeName + '_key')
+      const uniqueConstraintName = tableDetails.tableName + '_' + attributeName + '_key';
+      const uniqueConstraint = Utils._.find(constraints, constraint => {
+        return constraint.constraintName === uniqueConstraintName;
       });
 
       if (definition.match(/UNIQUE;*$/)) {
-        attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
-          tableName: this.quoteTable(tableName),
-          query: 'ADD UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
-        });
+        if (!uniqueConstraint) {
+          attrSql += Utils._.template(query.replace('ALTER COLUMN ', ''))({
+            tableName: this.quoteTable(tableName),
+            query: 'ADD CONSTRAINT ' + this.quoteIdentifier(uniqueConstraintName)
+              + ' UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
+          });
+        }
         definition = definition.replace(/UNIQUE;*$/, '');
+      } else if (!definition.match(/REFERENCES/)) {
+        if (uniqueConstraint) {
+          attrSql += Utils._.template(query.replace('ALTER COLUMN ', ''))({
+            tableName: this.quoteTable(tableName),
+            query: 'DROP CONSTRAINT ' + this.quoteIdentifier(uniqueConstraintName)
+          });
+        }
       }
 
-      attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
-        tableName: this.quoteTable(tableName),
-        query: 'DROP CONSTRAINT IF EXISTS ' + this.quoteIdentifier(tableName + '_' + attributeName + '_fkey')
+      const foreignKeyConstraintName = tableDetails.tableName + '_' + attributeName + '_fkey';
+      const foreignKeyConstraint = Utils._.find(constraints, constraint => {
+        return constraint.constraintName === foreignKeyConstraintName;
       });
 
       if (definition.match(/REFERENCES/)) {
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
-        attrSql += Utils._.template(query.replace('ALTER COLUMN', ''))({
-          tableName: this.quoteTable(tableName),
-          query: 'ADD CONSTRAINT ' + this.quoteIdentifier(tableName + '_' + attributeName + '_fkey')
-            + ' FOREIGN KEY (' + this.quoteIdentifier(attributeName) + ') ' + definition
-        });
+        if (!foreignKeyConstraint) {
+          attrSql += Utils._.template(query.replace('ALTER COLUMN ', ''))({
+            tableName: this.quoteTable(tableName),
+            query: 'ADD CONSTRAINT ' + this.quoteIdentifier(foreignKeyConstraintName)
+              + ' FOREIGN KEY (' + this.quoteIdentifier(attributeName) + ') ' + definition
+          });
+        }
       } else {
         attrSql += Utils._.template(query)({
           tableName: this.quoteTable(tableName),
@@ -451,9 +465,10 @@ const QueryGenerator = {
       'GROUP BY i.relname, ix.indexrelid, ix.indisprimary, ix.indisunique, ix.indkey ORDER BY i.relname;';
   },
 
-  showConstraintsQuery(tableName) {
+  showConstraintsQuery(tableName, constraintName) {
+    const tableDetails = this.extractTableDetails(tableName);
     //Postgres converts camelCased alias to lowercase unless quoted
-    return [
+    let sql = [
       'SELECT constraint_catalog AS "constraintCatalog",',
       'constraint_schema AS "constraintSchema",',
       'constraint_name AS "constraintName",',
@@ -464,8 +479,14 @@ const QueryGenerator = {
       'is_deferrable AS "isDeferrable",',
       'initially_deferred AS "initiallyDeferred"',
       'from INFORMATION_SCHEMA.table_constraints',
-      `WHERE table_name='${tableName}';`
+      `WHERE table_name=${this.escape(tableDetails.tableName)}`,
+      `AND table_schema=${this.escape(tableDetails.schema)}`
     ].join(' ');
+
+    if (constraintName) {
+      sql += ` AND constraint_name=${this.escape(constraintName)}`;
+    }
+    return sql + ';';
   },
 
   removeIndexQuery(tableName, indexNameOrAttributes) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1116,16 +1116,20 @@ class Model {
         return this.QueryInterface.describeTable(this.getTableName(options))
           .then(columns => {
             const changes = []; // array of promises to run
-            _.each(attributes, (columnDesc, columnName) => {
-              if (!columns[columnName]) {
-                changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), columnName, attributes[columnName]));
+            _.each(attributes, columnDesc => {
+              if (!columns[columnDesc.field]) {
+                changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), columnDesc.field, columnDesc));
               }
             });
             _.each(columns, (columnDesc, columnName) => {
-              if (!attributes[columnName]) {
+              const columnAttributes = _.find(attributes, value => {
+                return value.field === columnName;
+              });
+
+              if (!columnAttributes) {
                 changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
-              } else if (!attributes[columnName].primaryKey) {
-                changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnName, attributes[columnName]));
+              } else if (!columnAttributes.primaryKey) {
+                changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnAttributes.field, columnAttributes));
               }
             });
             return changes.reduce((p, fn) => p.then(fn), Promise.resolve());

--- a/lib/model.js
+++ b/lib/model.js
@@ -1126,9 +1126,11 @@ class Model {
                 return value.field === columnName;
               });
 
-              if (!columnAttributes) {
+              if (options.dropColumn && !columnAttributes) {
                 changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
-              } else if (!columnAttributes.primaryKey) {
+              }
+
+              if (columnAttributes && !columnAttributes.primaryKey) {
                 changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnAttributes.field, columnAttributes));
               }
             });

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -363,10 +363,12 @@ class QueryInterface {
       // sqlite needs some special treatment as it cannot change a column
       return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes, options);
     } else {
-      const query = this.QueryGenerator.attributesToSQL(attributes);
-      const sql = this.QueryGenerator.changeColumnQuery(tableName, query);
+      return this.showConstraint(tableName).then(constraints => {
+        const query = this.QueryGenerator.attributesToSQL(attributes);
+        const sql = this.QueryGenerator.changeColumnQuery(tableName, query, constraints);
 
-      return this.sequelize.query(sql, options);
+        return this.sequelize.query(sql, options);
+      });
     }
   }
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -647,7 +647,8 @@ class Sequelize {
    * @param {String} [options.schema='public'] The schema that the tables should be created in. This can be overriden for each table in sequelize.define
    * @param  {String} [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param {Boolean} [options.hooks=true] If hooks is true then beforeSync, afterSync, beforBulkSync, afterBulkSync hooks will be called
-   * @param {Boolean} [options.alter=false] Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
+   * @param {Boolean} [options.alter=false] Alters tables to fit models. Not recommended for production use
+   * @param {Boolean} [options.dropColumn=false] Drops column in datatase when options.alter is true, i.e. drops database columns not present in model
    * @return {Promise}
    */
   sync(options) {

--- a/test/unit/sql/change-column.test.js
+++ b/test/unit/sql/change-column.test.js
@@ -64,7 +64,7 @@ if (current.dialect.name !== 'sqlite') {
           expectsql(sql, {
             mssql: 'ALTER TABLE [users] ADD CONSTRAINT [level_id_foreign_idx] FOREIGN KEY ([level_id]) REFERENCES [level] ([id]) ON DELETE CASCADE;',
             mysql: 'ALTER TABLE `users` ADD CONSTRAINT `users_level_id_foreign_idx` FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
-            postgres: 'ALTER TABLE "users"  ADD CONSTRAINT "level_id_foreign_idx" FOREIGN KEY ("level_id") REFERENCES "level" ("id") ON DELETE CASCADE ON UPDATE CASCADE;'
+            postgres: 'ALTER TABLE "users" ADD CONSTRAINT "users_level_id_fkey" FOREIGN KEY ("level_id") REFERENCES "level" ("id") ON DELETE CASCADE ON UPDATE CASCADE;'
           });
         });
       });

--- a/test/unit/sql/show-constraints.test.js
+++ b/test/unit/sql/show-constraints.test.js
@@ -10,7 +10,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     it('naming', () => {
       expectsql(sql.showConstraintsQuery('myTable'), {
         mssql: "EXEC sp_helpconstraint @objname = N'[myTable]';",
-        postgres: 'SELECT constraint_catalog AS "constraintCatalog", constraint_schema AS "constraintSchema", constraint_name AS "constraintName", table_catalog AS "tableCatalog", table_schema AS "tableSchema", table_name AS "tableName", constraint_type AS "constraintType", is_deferrable AS "isDeferrable", initially_deferred AS "initiallyDeferred" from INFORMATION_SCHEMA.table_constraints WHERE table_name=\'myTable\';',
+        postgres: 'SELECT constraint_catalog AS "constraintCatalog", constraint_schema AS "constraintSchema", constraint_name AS "constraintName", table_catalog AS "tableCatalog", table_schema AS "tableSchema", table_name AS "tableName", constraint_type AS "constraintType", is_deferrable AS "isDeferrable", initially_deferred AS "initiallyDeferred" from INFORMATION_SCHEMA.table_constraints WHERE table_name=\'myTable\' AND table_schema=\'public\';',
         mysql: "SELECT CONSTRAINT_CATALOG AS constraintCatalog, CONSTRAINT_NAME AS constraintName, CONSTRAINT_SCHEMA AS constraintSchema, CONSTRAINT_TYPE AS constraintType, TABLE_NAME AS tableName, TABLE_SCHEMA AS tableSchema from INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE table_name='myTable';",
         default: "SELECT sql FROM sqlite_master WHERE tbl_name='myTable';"
       });
@@ -19,7 +19,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     it('should add constraint_name to where clause if passed in case of mysql', () => {
       expectsql(sql.showConstraintsQuery('myTable', 'myConstraintName'), {
         mssql: "EXEC sp_helpconstraint @objname = N'[myTable]';",
-        postgres: 'SELECT constraint_catalog AS "constraintCatalog", constraint_schema AS "constraintSchema", constraint_name AS "constraintName", table_catalog AS "tableCatalog", table_schema AS "tableSchema", table_name AS "tableName", constraint_type AS "constraintType", is_deferrable AS "isDeferrable", initially_deferred AS "initiallyDeferred" from INFORMATION_SCHEMA.table_constraints WHERE table_name=\'myTable\';',
+        postgres: 'SELECT constraint_catalog AS "constraintCatalog", constraint_schema AS "constraintSchema", constraint_name AS "constraintName", table_catalog AS "tableCatalog", table_schema AS "tableSchema", table_name AS "tableName", constraint_type AS "constraintType", is_deferrable AS "isDeferrable", initially_deferred AS "initiallyDeferred" from INFORMATION_SCHEMA.table_constraints WHERE table_name=\'myTable\' AND table_schema=\'public\' AND constraint_name=\'myConstraintName\';',
         mysql: "SELECT CONSTRAINT_CATALOG AS constraintCatalog, CONSTRAINT_NAME AS constraintName, CONSTRAINT_SCHEMA AS constraintSchema, CONSTRAINT_TYPE AS constraintType, TABLE_NAME AS tableName, TABLE_SCHEMA AS tableSchema from INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE table_name='myTable' AND constraint_name = 'myConstraintName';",
         default: "SELECT sql FROM sqlite_master WHERE tbl_name='myTable' AND sql LIKE '%myConstraintName%';"
       });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

### Description of change

This patch improves on the changes that were done for the alter option for model sync. #537 #7230  
- It fixes the column/model name mapping (i.e. for example model = createdAt and DB = created_at).
- Removes the default dropping of database columns for any column not present in the model and adds an additional option 'dropColumn' to support it.
- Checks constraints (for postgres) to ensure valid alter of unique columns + addition of foreign keys
- Fixes showConstraintQuery for postgres (was ignoring schema as part of table name)
- Fixes alter option
