### PR TITLE
refs #7680 remove unreachable break in switch

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -329,8 +329,6 @@ class Query extends AbstractQuery {
             parent: err
           });
         }
-
-        break;
       case '23P01':
         match = errDetail.match(/Key \((.*?)\)=\((.*?)\)/);
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Remove unreachable break in switch, as described in https://github.com/sequelize/sequelize/issues/7680
This `break` is unreachable because `return` exists in both `if` and `else`.
