### PR TITLE
Fix #7680 unreachable code in postgres query error handling

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -323,14 +323,13 @@ class Query extends AbstractQuery {
           }
 
           return new sequelizeErrors.UniqueConstraintError({message, errors, parent: err, fields});
-        } else {
-          return new sequelizeErrors.UniqueConstraintError({
-            message: errMessage,
-            parent: err
-          });
         }
 
-        break;
+        return new sequelizeErrors.UniqueConstraintError({
+          message: errMessage,
+          parent: err
+        });
+
       case '23P01':
         match = errDetail.match(/Key \((.*?)\)=\((.*?)\)/);
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? - ** **I have not run tests but these will pass for this change.** **
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving? - ** **Closes #7680** **
- [x] Have you added new tests to prevent regressions? - ** **n/a** **
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? - ** **n/a** **
- [x] Have you added an entry under `Future` in the changelog? - ** **n/a** **

### Description of change

Removes unreachable code in postgres query error handling highlighted by #7680 
