### PR TITLE
fix: pooling fails to handle disconnection

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -266,8 +266,21 @@ class ConnectionManager {
     }
 
     return promise.then(() => {
-      const connectionPromise = this.pool.acquire(options.priority, options.type, options.useMaster);
-      return this._watchPoolError(connectionPromise).tap(() => { debug('connection acquired'); });
+      return Promise.race([
+        this.pool.acquire(options.priority, options.type, options.useMaster),
+        new Promise((resolve, reject) =>
+        timers.setTimeout(() => {
+          if (this.poolError) {
+            reject(this.poolError);
+          }
+        }, 0))
+      ])
+      .tap(() => { debug('connection acquired'); })
+      .catch(e => {
+        e = this.poolError || e;
+        this.poolError = null;
+        throw e;
+      });
     });
   }
 
@@ -290,31 +303,6 @@ class ConnectionManager {
   _validate(connection) {
     if (!this.dialect.connectionManager.validate) return true;
     return this.dialect.connectionManager.validate(connection);
-  }
-
-  _watchPoolError(acquirePromise) {
-    return new Promise((resolve, reject) => {
-      if (acquirePromise.isFulfilled()) {
-        this.poolError = null;
-        return resolve(acquirePromise.value());
-      }
-
-      if (acquirePromise.isRejected()) {
-        this.poolError = null;
-        return reject(acquirePromise.reason());
-      }
-
-      if (this.poolError) {
-        acquirePromise.cancel();
-        const error = this.poolError;
-        this.poolError = null;
-        return reject(error);
-      }
-
-      timers.setTimeout(() => {
-        resolve(this._watchPoolError(acquirePromise));
-      }, 0);
-    });
   }
 }
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -6,6 +6,7 @@ const _ = require('lodash');
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('pool');
 const semver = require('semver');
+const timers = require('timers');
 
 const defaultPoolingConfig = {
   max: 5,
@@ -290,23 +291,32 @@ class ConnectionManager {
 
   _acquire(options) {
     const connectionPromise = this.pool.acquire(options.priority, options.type, options.useMaster);
+    return this._watchPoolError(connectionPromise).tap(() => { debug('connection acquired'); });
+  }
 
-    return Promise.delay(0)
-      .then(() => {
-        if (connectionPromise.isRejected()) {
-          this.poolError = null;
-          return Promise.reject(connectionPromise.reason());
-        }
+  _watchPoolError(acquirePromise) {
+    return new Promise((resolve, reject) => {
+      if (acquirePromise.isFulfilled()) {
+        this.poolError = null;
+        return resolve(acquirePromise.value());
+      }
 
-        if (this.poolError) {
-          connectionPromise.cancel();
-          const error = this.poolError;
-          this.poolError = null;
-          return Promise.reject(error);
-        }
+      if (acquirePromise.isRejected()) {
+        this.poolError = null;
+        return reject(acquirePromise.reason());
+      }
 
-        return connectionPromise;
-      });
+      if (this.poolError) {
+        acquirePromise.cancel();
+        const error = this.poolError;
+        this.poolError = null;
+        return reject(error);
+      }
+
+      timers.setTimeout(() => {
+        resolve(this._watchPoolError(acquirePromise));
+      }, 0);
+    });
   }
 }
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -264,16 +264,7 @@ class ConnectionManager {
       promise = Promise.resolve();
     }
 
-    return promise.then(() => Promise.race([
-      this.pool.acquire(options.priority, options.type, options.useMaster)
-        .tap(() => {
-          debug('connection acquired');
-          this.poolError = null;
-        }),
-      this._watchPoolErrors()
-    ])).catch(e => {
-      throw this.poolError || e;
-    });
+    return promise.then(() => this._acquire(options));
   }
 
   releaseConnection(connection) {
@@ -297,9 +288,25 @@ class ConnectionManager {
     return this.dialect.connectionManager.validate(connection);
   }
 
-  _watchPoolErrors() {
-    return Promise.delay(this.config.pool.acquire)
-      .then(() => this.poolError ? Promise.reject(null) : this._watchPoolErrors());
+  _acquire(options) {
+    const connectionPromise = this.pool.acquire(options.priority, options.type, options.useMaster);
+
+    return Promise.delay(0)
+      .then(() => {
+        if (connectionPromise.isRejected()) {
+          this.poolError = null;
+          return Promise.reject(connectionPromise.reason());
+        }
+
+        if (this.poolError) {
+          connectionPromise.cancel();
+          const error = this.poolError;
+          this.poolError = null;
+          return Promise.reject(error);
+        }
+
+        return connectionPromise;
+      });
   }
 }
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -265,7 +265,10 @@ class ConnectionManager {
       promise = Promise.resolve();
     }
 
-    return promise.then(() => this._acquire(options));
+    return promise.then(() => {
+      const connectionPromise = this.pool.acquire(options.priority, options.type, options.useMaster);
+      return this._watchPoolError(connectionPromise).tap(() => { debug('connection acquired'); });
+    });
   }
 
   releaseConnection(connection) {
@@ -287,11 +290,6 @@ class ConnectionManager {
   _validate(connection) {
     if (!this.dialect.connectionManager.validate) return true;
     return this.dialect.connectionManager.validate(connection);
-  }
-
-  _acquire(options) {
-    const connectionPromise = this.pool.acquire(options.priority, options.type, options.useMaster);
-    return this._watchPoolError(connectionPromise).tap(() => { debug('connection acquired'); });
   }
 
   _watchPoolError(acquirePromise) {

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -6,7 +6,6 @@ const _ = require('lodash');
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('pool');
 const semver = require('semver');
-const timers = require('timers');
 
 const defaultPoolingConfig = {
   max: 5,
@@ -265,31 +264,16 @@ class ConnectionManager {
       promise = Promise.resolve();
     }
 
-    return promise.then(() =>
-      new Promise((resolve, reject) => {
-        const connectionPromise = this.pool.acquire(options.priority, options.type, options.useMaster);
-        const connectionTimer = timers.setInterval(() => {
-          let evictTimer = false;
-
-          if (connectionPromise.isFulfilled()) {
-            resolve(connectionPromise);
-            debug('connection acquire');
-            evictTimer = true;
-          } else if (this.poolError) {
-            reject(this.poolError);
-            this.poolError = null;
-            evictTimer = true;
-          } else if (connectionPromise.isRejected()) {
-            connectionPromise.catch(reject);
-            evictTimer = true;
-          }
-
-          if (evictTimer) {
-            timers.clearInterval(connectionTimer);
-          }
-        }, 0);
-      })
-    );
+    return promise.then(() => Promise.race([
+      this.pool.acquire(options.priority, options.type, options.useMaster)
+        .tap(() => {
+          debug('connection acquired');
+          this.poolError = null;
+        }),
+      this._watchPoolErrors()
+    ])).catch(e => {
+      throw this.poolError || e;
+    });
   }
 
   releaseConnection(connection) {
@@ -311,6 +295,11 @@ class ConnectionManager {
   _validate(connection) {
     if (!this.dialect.connectionManager.validate) return true;
     return this.dialect.connectionManager.validate(connection);
+  }
+
+  _watchPoolErrors() {
+    return Promise.delay(this.config.pool.acquire)
+      .then(() => this.poolError ? Promise.reject(null) : this._watchPoolErrors());
   }
 }
 

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -92,77 +92,69 @@ class ConnectionManager extends AbstractConnectionManager {
       const connection = this.lib.createConnection(connectionConfig);
 
       const errorHandler = e => {
-          // clean up connect event if there is error
+        // clean up connect event if there is error
         connection.removeListener('connect', connectHandler);
+
+        if (config.pool.handleDisconnects) {
+          debug(`connection error ${e.code}`);
+
+          switch (e.code) {
+            case 'PROTOCOL_CONNECTION_LOST':
+              return;
+            default:
+          }
+        }
+
+        connection.removeListener('error', errorHandler);
         reject(e);
       };
 
       const connectHandler = () => {
+        if (!config.pool.handleDisconnects) {
           // clean up error event if connected
-        connection.removeListener('error', errorHandler);
+          connection.removeListener('error', errorHandler);
+        }
         resolve(connection);
       };
 
-      connection.once('error', errorHandler);
+      connection.on('error', errorHandler);
       connection.once('connect', connectHandler);
     })
-      .then(connection => {
-
-        if (config.pool.handleDisconnects) {
-          // Connection to the MySQL server is usually
-          // lost due to either server restart, or a
-          // connection idle timeout (the wait_timeout
-          // server variable configures this)
-          //
-          // See [stackoverflow answer](http://stackoverflow.com/questions/20210522/nodejs-mysql-error-connection-lost-the-server-closed-the-connection)
-          connection.on('error', err => {
-            if (err.code === 'PROTOCOL_CONNECTION_LOST') {
-              // Remove it from read/write pool
-              this.pool.destroy(connection);
-            }
-            debug(`connection error ${err.code}`);
-          });
-        }
-
-        debug('connection acquired');
-        return connection;
-      })
-      .then(connection => {
-        return new Utils.Promise((resolve, reject) => {
-          // set timezone for this connection
-          // but named timezone are not directly supported in mysql, so get its offset first
-          let tzOffset = this.sequelize.options.timezone;
-          tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
-
-          connection.query(`SET time_zone = '${tzOffset}'`, err => {
-            if (err) { reject(err); } else { resolve(connection); }
-          });
+    .tap (() => { debug('connection acquired'); })
+    .then(connection => {
+      return new Utils.Promise((resolve, reject) => {
+        // set timezone for this connection
+        // but named timezone are not directly supported in mysql, so get its offset first
+        let tzOffset = this.sequelize.options.timezone;
+        tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
+        connection.query(`SET time_zone = '${tzOffset}'`, err => {
+          if (err) { reject(err); } else { resolve(connection); }
         });
-      })
-      .catch(err => {
-        if (err.code) {
-          switch (err.code) {
-            case 'ECONNREFUSED':
-              throw new SequelizeErrors.ConnectionRefusedError(err);
-            case 'ER_ACCESS_DENIED_ERROR':
-              throw new SequelizeErrors.AccessDeniedError(err);
-            case 'ENOTFOUND':
-              throw new SequelizeErrors.HostNotFoundError(err);
-            case 'EHOSTUNREACH':
-              throw new SequelizeErrors.HostNotReachableError(err);
-            case 'EINVAL':
-              throw new SequelizeErrors.InvalidConnectionError(err);
-            default:
-              throw new SequelizeErrors.ConnectionError(err);
-          }
-        } else {
-          throw new SequelizeErrors.ConnectionError(err);
-        }
       });
+    })
+    .catch(err => {
+      if (err.code) {
+        switch (err.code) {
+          case 'ECONNREFUSED':
+            throw new SequelizeErrors.ConnectionRefusedError(err);
+          case 'ER_ACCESS_DENIED_ERROR':
+            throw new SequelizeErrors.AccessDeniedError(err);
+          case 'ENOTFOUND':
+            throw new SequelizeErrors.HostNotFoundError(err);
+          case 'EHOSTUNREACH':
+            throw new SequelizeErrors.HostNotReachableError(err);
+          case 'EINVAL':
+            throw new SequelizeErrors.InvalidConnectionError(err);
+          default:
+            throw new SequelizeErrors.ConnectionError(err);
+        }
+      } else {
+        throw new SequelizeErrors.ConnectionError(err);
+      }
+    });
   }
 
   disconnect(connection) {
-
     // Dont disconnect connections with CLOSED state
     if (connection._closing) {
       debug('connection tried to disconnect but was already at CLOSED state');

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -98,10 +98,8 @@ class ConnectionManager extends AbstractConnectionManager {
         if (config.pool.handleDisconnects) {
           debug(`connection error ${e.code}`);
 
-          switch (e.code) {
-            case 'PROTOCOL_CONNECTION_LOST':
-              return;
-            default:
+          if (e.code === 'PROTOCOL_CONNECTION_LOST') {
+            return;
           }
         }
 
@@ -133,23 +131,19 @@ class ConnectionManager extends AbstractConnectionManager {
       });
     })
     .catch(err => {
-      if (err.code) {
-        switch (err.code) {
-          case 'ECONNREFUSED':
-            throw new SequelizeErrors.ConnectionRefusedError(err);
-          case 'ER_ACCESS_DENIED_ERROR':
-            throw new SequelizeErrors.AccessDeniedError(err);
-          case 'ENOTFOUND':
-            throw new SequelizeErrors.HostNotFoundError(err);
-          case 'EHOSTUNREACH':
-            throw new SequelizeErrors.HostNotReachableError(err);
-          case 'EINVAL':
-            throw new SequelizeErrors.InvalidConnectionError(err);
-          default:
-            throw new SequelizeErrors.ConnectionError(err);
-        }
-      } else {
-        throw new SequelizeErrors.ConnectionError(err);
+      switch (err.code) {
+        case 'ECONNREFUSED':
+          throw new SequelizeErrors.ConnectionRefusedError(err);
+        case 'ER_ACCESS_DENIED_ERROR':
+          throw new SequelizeErrors.AccessDeniedError(err);
+        case 'ENOTFOUND':
+          throw new SequelizeErrors.HostNotFoundError(err);
+        case 'EHOSTUNREACH':
+          throw new SequelizeErrors.HostNotReachableError(err);
+        case 'EINVAL':
+          throw new SequelizeErrors.InvalidConnectionError(err);
+        default:
+          throw new SequelizeErrors.ConnectionError(err);
       }
     });
   }

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -76,7 +76,7 @@ if (dialect === 'mysql') {
         });
     });
 
-    it('should work with handleDisconnects', () => {
+    it('should work with handleDisconnects before release', () => {
       const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
       const cm = sequelize.connectionManager;
       let conn;
@@ -87,8 +87,8 @@ if (dialect === 'mysql') {
         .then(connection => {
           // Save current connection
           conn = connection;
-          // simulate a unexpected end
-          connection.close();
+          // simulate a unexpected end from MySQL2
+          conn.stream.emit('end');
         })
         .then(() => cm.releaseConnection(conn))
         .then(() => {
@@ -116,6 +116,34 @@ if (dialect === 'mysql') {
         }))
         // https://github.com/sequelize/sequelize/issues/7184
         .spread(affectedCount => affectedCount.should.equal(1));
+    });
+
+    it('should work with handleDisconnects', () => {
+      const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
+      const cm = sequelize.connectionManager;
+      let conn;
+
+      return sequelize
+        .sync()
+        .then(() => cm.getConnection())
+        .then(connection => {
+          // Save current connection
+          conn = connection;
+          return cm.releaseConnection(conn);
+        })
+        .then(() => {
+          // simulate a unexpected end from MySQL2 AFTER releasing the connection
+          conn.stream.emit('end');
+
+          // Get next available connection
+          return cm.getConnection();
+        })
+        .then(connection => {
+          // Old threadId should be different from current new one
+          expect(conn.threadId).to.not.be.equal(connection.threadId);
+          expect(cm.validate(conn)).to.not.be.ok;
+          return cm.releaseConnection(connection);
+        });
     });
   });
 }

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -8,7 +8,6 @@ const chai = require('chai'),
   Promise = require('bluebird');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
-
   before(function() {
     this.clock = sinon.useFakeTimers();
   });


### PR DESCRIPTION
Continuation of ideas from https://github.com/sequelize/sequelize/pull/7626 

**Notable changes**
- No destroy from pool (Same as #7626) when handling disconnects
- No timers for watching eventual pool errors
- Wont crash when ETIMEOUT error occurs eventually

```js
'use strict';

/*
 * Copy this file to ./sscce.js
 * Add code from issue
 * npm run sscce-{dialect}
 */

const Sequelize = require('./index');
// const sequelize = require('./test/support').createSequelizeInstance();


let dbConfig = {
  username: 'sequelize_test',
  password: 'sequelize_test',
  port: '8999',
  dialect: 'mysql',
  syncOnAssociation: false,
  host: '127.0.0.1',
  seederStorage: 'sequelize',
  pool: {
    min: 1,
    max: 5,
    acquire:  10000,
  },
  dialectOptions: {
    connectTimeout: 10000
  }
}

let pool = new Sequelize(dbConfig.database, dbConfig.username, dbConfig.password, dbConfig);

setInterval(() =>
  pool.query("SELECT SLEEP(1);").catch((e) => {
    console.log('Got an exception!', e)
  })
  , 2000
)

```