### PR TITLE
Add relative and full path support for sqlite

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -73,6 +73,7 @@
 - [ADDED] Support for JSON attributes in orders and groups. [#7564](https://github.com/sequelize/sequelize/issues/7564)
 - [REMOVED] Removes support for interpretation of raw properties and values in the where object. [#7568](https://github.com/sequelize/sequelize/issues/7568)
 - [FIXED] Upsert now updates all changed fields by default
+- [ADDED] Support for paths for sqlite databases via connection strings [#4721](https://github.com/sequelize/sequelize/issues/4721)
 
 ## BC breaks:
 - Model.validate instance method now runs validation hooks by default. Previously you needed to pass { hooks: true }. You can override this behavior by passing { hooks: false }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -192,6 +192,13 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 })
 ```
 
+Or you can use a connection string as well with a path:
+
+```js
+const sequelize = new Sequelize('sqlite:/home/abs/path/dbname.db')
+const sequelize = new Sequelize('sqlite:relativePath/dbname.db')
+```
+
 ### PostgreSQL
 
 The library for PostgreSQL is`pg@~3.6.0` You'll just need to define the dialect:

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -108,13 +108,17 @@ class Sequelize {
 
       const urlParts = url.parse(arguments[0]);
 
-      // SQLite don't have DB in connection url
+      options.dialect = urlParts.protocol.replace(/:$/, '');
+      options.host = urlParts.hostname;
+
+      if (options.dialect === 'sqlite' && urlParts.pathname) {
+        const path = Path.join(options.host, urlParts.pathname);
+        options.storage = options.storage || path;
+      }
+
       if (urlParts.pathname) {
         config.database = urlParts.pathname.replace(/^\//, '');
       }
-
-      options.dialect = urlParts.protocol.replace(/:$/, '');
-      options.host = urlParts.hostname;
 
       if (urlParts.port) {
         options.port = urlParts.port;

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -69,27 +69,31 @@ describe('Sequelize', () => {
       expect(config.port).to.equal('9821');
     });
 
-    it('should accept relative paths for sqlite', () => {
-      const sequelize = new Sequelize('sqlite:subfolder/dbname.db');
-      const options = sequelize.options;
-      expect(options.dialect).to.equal('sqlite');
-      expect(options.storage).to.equal('subfolder/dbname.db');
-    });
+    describe('sqllite path inititalization', () =>{
+      const current   = Support.sequelize;
+      if (current.dialect.name === 'sqlite') {
+        it('should accept relative paths for sqlite', () => {
+          const sequelize = new Sequelize('sqlite:subfolder/dbname.db');
+          const options = sequelize.options;
+          expect(options.dialect).to.equal('sqlite');
+          expect(options.storage).to.equal('subfolder/dbname.db');
+        });
 
-    it('should accept absolute paths for sqlite', () => {
-      const sequelize = new Sequelize('sqlite:/home/abs/dbname.db');
-      const options = sequelize.options;
-      expect(options.dialect).to.equal('sqlite');
-      expect(options.storage).to.equal('/home/abs/dbname.db');
-    });
+        it('should accept absolute paths for sqlite', () => {
+          const sequelize = new Sequelize('sqlite:/home/abs/dbname.db');
+          const options = sequelize.options;
+          expect(options.dialect).to.equal('sqlite');
+          expect(options.storage).to.equal('/home/abs/dbname.db');
+        });
 
-    it('should prefer storage in options object', () => {
-      const sequelize = new Sequelize('sqlite:/home/abs/dbname.db', {storage: '/completely/different/path.db'});
-      const options = sequelize.options;
-      expect(options.dialect).to.equal('sqlite');
-      expect(options.storage).to.equal('/completely/different/path.db');
+        it('should prefer storage in options object', () => {
+          const sequelize = new Sequelize('sqlite:/home/abs/dbname.db', {storage: '/completely/different/path.db'});
+          const options = sequelize.options;
+          expect(options.dialect).to.equal('sqlite');
+          expect(options.storage).to.equal('/completely/different/path.db');
+        });
+      }
     });
-
 
     it('should work with no authentication options', () => {
       const sequelize = new Sequelize('mysql://example.com:9821/dbname');

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -69,6 +69,28 @@ describe('Sequelize', () => {
       expect(config.port).to.equal('9821');
     });
 
+    it('should accept relative paths for sqlite', () => {
+      const sequelize = new Sequelize('sqlite:subfolder/dbname.db');
+      const options = sequelize.options;
+      expect(options.dialect).to.equal('sqlite');
+      expect(options.storage).to.equal('subfolder/dbname.db');
+    });
+
+    it('should accept absolute paths for sqlite', () => {
+      const sequelize = new Sequelize('sqlite:/home/abs/dbname.db');
+      const options = sequelize.options;
+      expect(options.dialect).to.equal('sqlite');
+      expect(options.storage).to.equal('/home/abs/dbname.db');
+    });
+
+    it('should prefer storage in options object', () => {
+      const sequelize = new Sequelize('sqlite:/home/abs/dbname.db', {storage: '/completely/different/path.db'});
+      const options = sequelize.options;
+      expect(options.dialect).to.equal('sqlite');
+      expect(options.storage).to.equal('/completely/different/path.db');
+    });
+
+
     it('should work with no authentication options', () => {
       const sequelize = new Sequelize('mysql://example.com:9821/dbname');
       const config = sequelize.config;


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

If the dialect is 'sqlite', then we parse host+pathname as a file path.
sqlite documentation suggests that this is the right way to parse them:
https://sqlite.org/c3ref/open.html#urifilenameexamples

If the "storage" option is provided, then that wil take precedence.

Examples:
sqlite:subfolder/dbname.db => subfolder/dbname.db
sqlite:/home/abs/dbname.db => /home/abs/dbname.db

Closes #4721 
