### PR TITLE
Link directly to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@
 
 Sequelize is a promise-based Node.js ORM for Postgres, MySQL, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.
 
-[Stable (v4) documentation](http://docs.sequelizejs.com)
+### Version 4 (stable)
 
-[v3 documentation](https://sequelize.readthedocs.io/en/v3/)
+- [Guides](http://docs.sequelizejs.com)
+- [API documentation](http://docs.sequelizejs.com/identifiers.html)
+
+### Version 3
+
+- [documentation](https://sequelize.readthedocs.io/en/v3/)
 
 ## Installation
 


### PR DESCRIPTION
Make it clearer there is both a "Guides" and "API docs". The small "Reference" link isn't super obvious to a newcomer (like myself). I find I always scan a readme for "API docs" and this PR will make that clearer and quicker for new users.