### PR TITLE
add support for federated mysql engine

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -23,10 +23,11 @@ const QueryGenerator = {
     options = Utils._.extend({
       engine: 'InnoDB',
       charset: null,
-      rowFormat: null
+      rowFormat: null,
+      connection: null
     }, options || {});
 
-    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %><%= rowFormat %>';
+    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= connection %><%= initialAutoIncrement %><%= rowFormat %>';
     const primaryKeys = [];
     const foreignKeys = {};
     const attrStr = [];
@@ -66,7 +67,8 @@ const QueryGenerator = {
       charset: options.charset ? ' DEFAULT CHARSET=' + options.charset : '',
       collation: options.collate ? ' COLLATE ' + options.collate : '',
       rowFormat: options.rowFormat ? ' ROW_FORMAT=' + options.rowFormat : '',
-      initialAutoIncrement: options.initialAutoIncrement ? ' AUTO_INCREMENT=' + options.initialAutoIncrement : ''
+      initialAutoIncrement: options.initialAutoIncrement ? ' AUTO_INCREMENT=' + options.initialAutoIncrement : '',
+      connection: options.connection ? ' CONNECTION=\'' + options.connection + '\'' : ''
     };
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -141,6 +141,10 @@ if (dialect === 'mysql') {
         {
           arguments: ['myTable', {id: 'INTEGER auto_increment PRIMARY KEY'}, {initialAutoIncrement: 1000001}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER auto_increment , PRIMARY KEY (`id`)) ENGINE=InnoDB AUTO_INCREMENT=1000001;'
+        },
+        {
+          arguments: ['myTable', {id: 'INTEGER auto_increment PRIMARY KEY'}, { 'engine': 'FEDERATED', connection: 'mysql://user:password@localhost:3306/main/myTable' }],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER auto_increment , PRIMARY KEY (`id`)) ENGINE=FEDERATED CONNECTION=\'mysql://user:password@localhost:3306/main/myTable\';'
         }
       ],
 


### PR DESCRIPTION
Are you open to adding support for federated tables in MySQL? I am moving some legacy system to Node.js that is using federated tables so support for this would be great.

Thanks

