### PR TITLE
fixed #7735, sqlite memory url no longer works

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -74,6 +74,7 @@
 - [REMOVED] Removes support for interpretation of raw properties and values in the where object. [#7568](https://github.com/sequelize/sequelize/issues/7568)
 - [FIXED] Upsert now updates all changed fields by default
 - [ADDED] Support for paths for sqlite databases via connection strings [#4721](https://github.com/sequelize/sequelize/issues/4721)
+- [FIXED] `sqlite://:memory:` no longer works [#7735](https://github.com/sequelize/sequelize/issues/7735)
 
 ## BC breaks:
 - Model.validate instance method now runs validation hooks by default. Previously you needed to pass { hooks: true }. You can override this behavior by passing { hooks: false }

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -111,7 +111,7 @@ class Sequelize {
       options.dialect = urlParts.protocol.replace(/:$/, '');
       options.host = urlParts.hostname;
 
-      if (options.dialect === 'sqlite' && urlParts.pathname) {
+      if (options.dialect === 'sqlite' && urlParts.pathname && urlParts.pathname.indexOf('/:memory') !== 0) {
         const path = Path.join(options.host, urlParts.pathname);
         options.storage = options.storage || path;
       }

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -92,6 +92,16 @@ describe('Sequelize', () => {
           expect(options.dialect).to.equal('sqlite');
           expect(options.storage).to.equal('/completely/different/path.db');
         });
+
+        it('should be able to use :memory:', () => {
+          const sequelize = new Sequelize('sqlite://:memory:');
+          const options = sequelize.options;
+          expect(options.dialect).to.equal('sqlite');
+
+          // empty host is treated as :memory:
+          expect(options.host).to.equal('');
+          expect(options.storage).to.equal(undefined);
+        });
       }
     });
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

### Description of change

Closes  #7735 