### PR TITLE
Fix subquery check required association exists

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1350,7 +1350,8 @@ var QueryGenerator = {
                   include.where || {}
                 ]
               },
-              limit: 1
+              limit: 1,
+              tableAs: as
             }, include.model);
 
             subQueryWhere = self.sequelize.asIs([
@@ -1770,7 +1771,7 @@ var QueryGenerator = {
         }
       }
     }
-    
+
     return joinType + this.quoteTable(tableRight, asRight) + ' ON ' + joinOn;
   },
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -405,7 +405,11 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         default: 'SELECT [User].*, [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM ' +
           '(SELECT [User].[name], [User].[age], [User].[id] AS [id] FROM [User] AS [User] ' +
           'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) LIMIT 1 ) IS NOT NULL) AS [User] ' +
-          'INNER JOIN [Post] AS [postaliasname] ON [Model].[id] = [postaliasname].[user_id];'
+          'INNER JOIN [Post] AS [postaliasname] ON [Model].[id] = [postaliasname].[user_id];',
+        mssql: 'SELECT [User].*, [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM ' +
+          '(SELECT [User].[name], [User].[age], [User].[id] AS [id] FROM [User] AS [User] ' +
+          'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) ORDER BY [id] OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY ) IS NOT NULL) AS [User] ' +
+          'INNER JOIN [Post] AS [postaliasname] ON [].[id] = [postaliasname].[user_id];'
       });
     });
   });

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -400,17 +400,18 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
             subQuery: true,
             required: true,
           }],
+          as: 'User',
         }).include,
         subQuery: true,
       }, User), {
         default: 'SELECT [User].*, [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM ' +
           '(SELECT [User].[name], [User].[age], [User].[id] AS [id] FROM [User] AS [User] ' +
           'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) LIMIT 1 ) IS NOT NULL) AS [User] ' +
-          'INNER JOIN [Post] AS [postaliasname] ON [Model].[id] = [postaliasname].[user_id];',
+          'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id];',
         mssql: 'SELECT [User].*, [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM ' +
           '(SELECT [User].[name], [User].[age], [User].[id] AS [id] FROM [User] AS [User] ' +
           'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) ORDER BY [id] OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY ) IS NOT NULL) AS [User] ' +
-          'INNER JOIN [Post] AS [postaliasname] ON [Model].[id] = [postaliasname].[user_id];'
+          'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id];'
       });
     });
   });

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -390,6 +390,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
       User.Posts = User.hasMany(Post, {foreignKey: 'user_id', as: 'postaliasname'});
 
       expectsql(sql.selectQuery('User', {
+        table: User.getTableName(),
         model: User,
         attributes: ['name', 'age'],
         include: Model.$validateIncludedElements({
@@ -409,7 +410,7 @@ suite(Support.getTestDialectTeaser('SQL'), function() {
         mssql: 'SELECT [User].*, [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM ' +
           '(SELECT [User].[name], [User].[age], [User].[id] AS [id] FROM [User] AS [User] ' +
           'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) ORDER BY [id] OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY ) IS NOT NULL) AS [User] ' +
-          'INNER JOIN [Post] AS [postaliasname] ON [].[id] = [postaliasname].[user_id];'
+          'INNER JOIN [Post] AS [postaliasname] ON [Model].[id] = [postaliasname].[user_id];'
       });
     });
   });


### PR DESCRIPTION
When checking the required association exists, it is not considered necessary the name of the alias table to work properly `WHERE`.