### PR TITLE
Fix small typo in models-usage.md

### DIFF
--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -598,7 +598,7 @@ To move the where conditions from an included model from the `ON` condition to t
 User.findAll({
     where: {
         '$Instruments.name$': { $iLike: '%ooth%' }
-    }
+    },
     include: [{
         model: Tool,
         as: 'Instruments'


### PR DESCRIPTION
The original code I found in the docs was:
```
User.findAll({
    where: {
        '$Instruments.name$': { $iLike: '%ooth%' }
    }
    include: [{
        model: Tool,
        as: 'Instruments'
    }]
})
```

This code does not have a comma between the key `include` and the key `where`. People who would copy/paste this code would get an error. So a comma was added.