### PR TITLE
Remove documentation regarding column comments

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -49,9 +49,6 @@ const Foo = sequelize.define('foo', {
  // autoIncrement can be used to create auto_incrementing integer columns
  incrementMe: { type: Sequelize.INTEGER, autoIncrement: true },
 
- // Comments can be specified for each field for MySQL and PG
- hasComment: { type: Sequelize.INTEGER, comment: "I'm a comment!" },
-
  // You can specify a custom field name via the "field" attribute:
  fieldWithUnderscores: { type: Sequelize.STRING, field: "field_with_underscores" },
 


### PR DESCRIPTION
Column comments are not a currently supported feature and should not possess documentation references.

Documentation should be readded when the feature is supported once again; until then, the documentation is inaccurate and misleading to users.