### PR TITLE
ConnectionManager.close not closing database connection completely 

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # Next
 - [ADDED] `Model.increment`, to increment multiple rows at a time [#7394](https://github.com/sequelize/sequelize/pull/7394)
+- [FIXED] calling `.close` on Sequelize db instance does not properly close the connection socket [#7751](https://github.com/sequelize/sequelize/issues/7751)
 
 # 4.0.0 (final)
 - [ADDED] Add `isSoftDeleted` helper method to model instance [#7408](https://github.com/sequelize/sequelize/issues/7408)

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -61,7 +61,7 @@ class ConnectionManager {
       return Promise.resolve();
     }
 
-    return this.pool.drain(() => {
+    return this.pool.drain().then(() => {
       debug('connection drain due to process exit');
       return this.pool.clear();
     });

--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -146,4 +146,23 @@ describe('Connection Manager', () => {
       });
   });
 
+  it('should clear the pool after draining it', () => {
+    const options = {
+      replication: null
+    };
+    const sequelize = Support.createSequelizeInstance(options);
+    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+
+    connectionManager.initPools();
+
+    const poolDrainSpy = sandbox.spy(connectionManager.pool, 'drain');
+    const poolClearSpy = sandbox.spy(connectionManager.pool, 'clear');
+
+    return connectionManager.close().then(() => {
+      expect(poolDrainSpy.calledOnce).to.be.true;
+      expect(poolClearSpy.calledOnce).to.be.true;
+    });
+
+  });
+
 });


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? 
- [X] Have you added an entry under `Future` in the changelog?

### Description of change

closes https://github.com/sequelize/sequelize/issues/7751

As mentioned in https://github.com/sequelize/sequelize/issues/7751, db.close() was not doing what it was supposed to.  It looks like during the `generic-pool` library upgrade the pool.drain() implementation was changed from taking a callback to returning a promise (https://github.com/coopernurse/node-pool/blob/master/lib/Pool.js#L481), but the sequelize code was not updated.  Because of that, the function being passed as a callback was never being called.  Adding a `.then` with the same function seems to fix the problem.

I didn't go looking for other `generic-pool` callbacks that may have this same issue.

I'm also not quite sure of the best way to test this change, some insight would be appreciated.