### PR TITLE
Minor typos

### DIFF
--- a/docs/associations.md
+++ b/docs/associations.md
@@ -811,7 +811,7 @@ return Product.create({
 
 ### Creating elements of a "HasMany" or "BelongsToMany" association
 
-Let's introduce the ability to associate a project with many tags. Setting up the models could look like:
+Let's introduce the ability to associate a product with many tags. Setting up the models could look like:
 
 ```js
 const Tag = this.sequelize.define('tag', {
@@ -822,7 +822,7 @@ Product.hasMany(Tag);
 // Also works for `belongsToMany`.
 ```
 
-Now we can create a project with multiple tags in the following way:
+Now we can create a product with multiple tags in the following way:
 
 ```js
 Product.create({


### PR DESCRIPTION
### Description of change

_Documentation change only_

Should reference products instead of projects in "Creating elements of a "HasMany" or "BelongsToMany" association" section.