### PR TITLE
Fixed missing captureStackTrace for errors. (closes #7770)

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -24,6 +24,7 @@ class SequelizeScopeError extends BaseError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeScopeError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.SequelizeScopeError = SequelizeScopeError;
@@ -56,6 +57,7 @@ class ValidationError extends BaseError {
     } else if (this.errors.length > 0 && this.errors[0].message) {
       this.message = this.errors.map(err => err.type + ': ' + err.message).join(',\n');
     }
+    Error.captureStackTrace(this, this.constructor);
   }
 
   /**
@@ -100,6 +102,7 @@ class OptimisticLockError extends BaseError {
      * @type {object}
      */
     this.where = options.where;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.OptimisticLockError = OptimisticLockError;
@@ -124,6 +127,7 @@ class DatabaseError extends BaseError {
      * @type {string}
      */
     this.sql = parent.sql;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.DatabaseError = DatabaseError;
@@ -135,6 +139,7 @@ class TimeoutError extends DatabaseError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeTimeoutError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.TimeoutError = TimeoutError;
@@ -157,6 +162,7 @@ class UniqueConstraintError extends ValidationError {
     this.parent = options.parent;
     this.original = options.parent;
     this.sql = options.parent.sql;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.UniqueConstraintError = UniqueConstraintError;
@@ -177,6 +183,7 @@ class ForeignKeyConstraintError extends DatabaseError {
     this.table = options.table;
     this.value = options.value;
     this.index = options.index;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.ForeignKeyConstraintError = ForeignKeyConstraintError;
@@ -196,6 +203,7 @@ class ExclusionConstraintError extends DatabaseError {
     this.constraint = options.constraint;
     this.fields = options.fields;
     this.table = options.table;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.ExclusionConstraintError = ExclusionConstraintError;
@@ -209,6 +217,7 @@ class UnknownConstraintError extends DatabaseError {
     super(parent);
     this.name = 'SequelizeUnknownConstraintError';
     this.message = message || 'The specified constraint does not exist';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.UnknownConstraintError = UnknownConstraintError;
@@ -228,6 +237,7 @@ class ValidationErrorItem {
     this.type = type || null;
     this.path = path || null;
     this.value = value !== undefined ? value : null;
+    //This doesn't need captureStackTrace because its not a subclass of Error
   }
 }
 exports.ValidationErrorItem = ValidationErrorItem;
@@ -245,6 +255,7 @@ class ConnectionError extends BaseError {
      */
     this.parent = parent;
     this.original = parent;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.ConnectionError = ConnectionError;
@@ -256,6 +267,7 @@ class ConnectionRefusedError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeConnectionRefusedError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.ConnectionRefusedError = ConnectionRefusedError;
@@ -267,6 +279,7 @@ class AccessDeniedError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeAccessDeniedError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.AccessDeniedError = AccessDeniedError;
@@ -278,6 +291,7 @@ class HostNotFoundError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeHostNotFoundError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.HostNotFoundError = HostNotFoundError;
@@ -289,6 +303,7 @@ class HostNotReachableError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeHostNotReachableError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.HostNotReachableError = HostNotReachableError;
@@ -300,6 +315,7 @@ class InvalidConnectionError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeInvalidConnectionError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.InvalidConnectionError = InvalidConnectionError;
@@ -311,6 +327,7 @@ class ConnectionTimedOutError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeConnectionTimedOutError';
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.ConnectionTimedOutError = ConnectionTimedOutError;
@@ -323,6 +340,7 @@ class InstanceError extends BaseError {
     super(message);
     this.name = 'SequelizeInstanceError';
     this.message = message;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.InstanceError = InstanceError;
@@ -335,6 +353,7 @@ class EmptyResultError extends BaseError {
     super(message);
     this.name = 'SequelizeEmptyResultError';
     this.message = message;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.EmptyResultError = EmptyResultError;
@@ -347,6 +366,7 @@ class EagerLoadingError extends BaseError {
     super(message);
     this.name = 'SequelizeEagerLoadingError';
     this.message = message;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.EagerLoadingError = EagerLoadingError;
@@ -359,6 +379,7 @@ class AssociationError extends BaseError {
     super(message);
     this.name = 'SequelizeAssociationError';
     this.message = message;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.AssociationError = AssociationError;
@@ -370,6 +391,7 @@ class QueryError extends BaseError {
     super(message);
     this.name = 'SequelizeQueryError';
     this.message = message;
+    Error.captureStackTrace(this, this.constructor);
   }
 }
 exports.QueryError = QueryError;

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -4,19 +4,52 @@ const errors = require('../../lib/errors');
 const expect = require('chai').expect;
 
 describe('errors', () => {
-  it('should maintain stack trace', () => {
-    function throwError() {
-      throw new errors.ValidationError('this is a message');
-    }
-    let err;
-    try {
-      throwError();
-    } catch (error) {
-      err = error;
-    }
-    expect(err).to.exist;
-    const stackParts = err.stack.split('\n');
-    expect(stackParts[0]).to.equal('SequelizeValidationError: this is a message');
-    expect(stackParts[1]).to.match(/^    at throwError \(.*errors.test.js:\d+:\d+\)$/);
+  it('should maintain stack trace with message', () => {
+    const errorsWithMessage = [
+      'BaseError', 'ValidationError', 'UnknownConstraintError', 'InstanceError', 
+      'EmptyResultError', 'EagerLoadingError', 'AssociationError', 'QueryError'
+    ];
+
+    errorsWithMessage.forEach(errorName => {
+      function throwError() {
+        throw new errors[errorName]('this is a message');
+      }
+      let err;
+      try {
+        throwError();
+      } catch (error) {
+        err = error;
+      }
+      expect(err).to.exist;
+      const stackParts = err.stack.split('\n');
+      const fullErrorName = 'Sequelize' + errorName;
+      expect(stackParts[0]).to.equal(fullErrorName + ': this is a message');
+      expect(stackParts[1]).to.match(/^    at throwError \(.*errors.test.js:\d+:\d+\)$/);
+    });    
+  });
+
+  it('should maintain stack trace without message', () => {
+    const errorsWithoutMessage = [
+      'ConnectionError', 'ConnectionRefusedError', 'ConnectionTimedOutError',
+      'AccessDeniedError', 'HostNotFoundError', 'HostNotReachableError', 'InvalidConnectionError'
+    ];
+
+    errorsWithoutMessage.forEach(errorName => {
+      function throwError() {
+        throw new errors[errorName](null);
+      }
+      let err;
+      try {
+        throwError();
+      } catch (error) {
+        err = error;
+      }
+      expect(err).to.exist;
+      const stackParts = err.stack.split('\n');
+
+      const fullErrorName = 'Sequelize' + errorName;
+      expect(stackParts[0]).to.equal(fullErrorName);
+      expect(stackParts[1]).to.match(/^    at throwError \(.*errors.test.js:\d+:\d+\)$/);
+    });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

This fixes stacktraces of custom errors that subclass `BaseError` not having their error name in the stacktrace (issue #7770). I've also added unit tests to all the custom errors to check if the stacktrace contains the error name.
