### PR TITLE
underscore attributes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -17,6 +17,7 @@ const Hooks = require('./hooks');
 const associationsMixin = require('./associations/mixin');
 const defaultsOptions = { raw: true };
 const assert = require('assert');
+const inflection = require('inflection');
 
 /**
  * A Model represents a table in the database. Instances of this class represent a database row.
@@ -673,6 +674,7 @@ class Model {
    * @param {Boolean}                 [options.paranoid=false] Calling `destroy` will not delete the model, but instead set a `deletedAt` timestamp if this is true. Needs `timestamps=true` to work
    * @param {Boolean}                 [options.underscored=false] Converts all camelCased columns to underscored if true. Will not affect timestamp fields named explicitly by model options and will not affect fields with explicitly set `field` option
    * @param {Boolean}                 [options.underscoredAll=false] Converts camelCased model names to underscored table names if true. Will not change model name if freezeTableName is set to true
+   * @param {Boolean}                 [options.underscoreAttributes=false] Converts camelCased attributes to underscored on the database
    * @param {Boolean}                 [options.freezeTableName=false] If freezeTableName is true, sequelize will not try to alter the model name to get the table name. Otherwise, the model name will be pluralized
    * @param {Object}                  [options.name] An object with two attributes, `singular` and `plural`, which are used when this model is associated to others.
    * @param {String}                  [options.name.singular=Utils.singularize(modelName)]
@@ -737,6 +739,7 @@ class Model {
       freezeTableName: false,
       underscored: false,
       underscoredAll: false,
+      underscoreAttributes: false,
       paranoid: false,
       rejectOnEmpty: false,
       whereCollection: null,
@@ -781,7 +784,9 @@ class Model {
       }
     });
 
-    this.attributes = this.rawAttributes = _.mapValues(attributes, (attribute, name) => {
+    this.attributes = {}; 
+    
+    _.each(attributes, (attribute, name) => {
 
       attribute = this.sequelize.normalizeAttribute(attribute);
 
@@ -793,8 +798,10 @@ class Model {
         throw new Error('Unrecognized data type for field ' + name);
       }
 
-      return attribute;
+      this.attributes[this.options.underscoreAttributes ? inflection.underscore(name) : name] = attribute;
     });
+
+    this.rawAttributes = this.attributes;
 
     this.primaryKeys = {};
 

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -2,19 +2,23 @@
 
 const chai = require('chai'),
   expect = chai.expect,
-  Support   = require(__dirname + '/../support'),
+  Support = require(__dirname + '/../support'),
   DataTypes = require('../../../lib/data-types'),
-  current   = Support.sequelize;
+  current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('define', () => {
     it('should allow custom timestamps with underscored: true', () => {
-      const Model = current.define('User', {}, {
-        createdAt   : 'createdAt',
-        updatedAt   : 'updatedAt',
-        timestamps  : true,
-        underscored : true
-      });
+      const Model = current.define(
+        'User',
+        {},
+        {
+          createdAt: 'createdAt',
+          updatedAt: 'updatedAt',
+          timestamps: true,
+          underscored: true
+        }
+      );
 
       expect(Model.rawAttributes.createdAt).to.be.defined;
       expect(Model.rawAttributes.updatedAt).to.be.defined;
@@ -26,12 +30,22 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(Model.rawAttributes.updated_at).not.to.be.defined;
     });
 
+    it('should create attributes that are camelCase', () => {
+      const Model = current.define('User', { dueDate: DataTypes.DATE });
+
+      expect(Model.rawAttributes.dueDate).to.be.defined;
+
+      expect(Model.rawAttributes.due_date).not.to.be.defined;
+    });
+
     it('should throw when id is added but not marked as PK', () => {
       expect(() => {
         current.define('foo', {
           id: DataTypes.INTEGER
         });
-      }).to.throw("A column called 'id' was added to the attributes of 'foos' but not marked with 'primaryKey: true'");
+      }).to.throw(
+        "A column called 'id' was added to the attributes of 'foos' but not marked with 'primaryKey: true'"
+      );
 
       expect(() => {
         current.define('bar', {
@@ -39,7 +53,54 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             type: DataTypes.INTEGER
           }
         });
-      }).to.throw("A column called 'id' was added to the attributes of 'bars' but not marked with 'primaryKey: true'");
+      }).to.throw(
+        "A column called 'id' was added to the attributes of 'bars' but not marked with 'primaryKey: true'"
+      );
+    });
+  });
+
+  describe('define with underscoreAttributes option', () => {
+    it('should create underscored attributes with underscoreAttributes: true', () => {
+      const Model = current.define(
+        'User',
+        {
+          dueDate: DataTypes.DATE
+        },
+        {
+          underscoreAttributes: true
+        }
+      );
+
+      expect(Model.rawAttributes.due_date).to.be.defined;
+
+      expect(Model.rawAttributes.dueDate).not.to.be.defined;
+    });
+
+    it('should allow custom timestamps with underscored: true and underscoreAttributes: true', () => {
+      const Model = current.define(
+        'User',
+        {
+          dueDate: DataTypes.DATE
+        },
+        {
+          createdAt: 'createdAt',
+          updatedAt: 'updatedAt',
+          timestamps: true,
+          underscored: true,
+          underscoreAttributes: true
+        }
+      );
+
+      expect(Model.rawAttributes.createdAt).to.be.defined;
+      expect(Model.rawAttributes.updatedAt).to.be.defined;
+      expect(Model.rawAttributes.due_date).to.be.defined;
+
+      expect(Model._timestampAttributes.createdAt).to.equal('createdAt');
+      expect(Model._timestampAttributes.updatedAt).to.equal('updatedAt');
+
+      expect(Model.rawAttributes.created_at).not.to.be.defined;
+      expect(Model.rawAttributes.updated_at).not.to.be.defined;
+      expect(Model.rawAttributes.dueDate).not.to.be.defined;
     });
   });
 });


### PR DESCRIPTION
Fixes https://github.com/sequelize/sequelize/issues/6423

I think this might be a POC for allowing all fields be underscored by simply adding `underscoreAttributes` boolean to model definition options. 

I may need to write tests for get/set, please do advise! 
