### PR TITLE
MsSQL empty results array patch

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -299,7 +299,16 @@ const QueryGenerator = {
     if (this._dialect.supports.returnValues) {
       if (this._dialect.supports.returnValues.output) {
         // we always need this for mssql
-        outputFragment = ' OUTPUT INSERTED.*';
+        if(_.isArray(options.includes) && !_.isEmpty(options.includes)){
+          outputFragment = ' OUTPUT ';
+          let outputColumns = [];
+          for(const key in options.includes){
+            outputColumns.push(`INSERTED.${options.includes[key]}`);
+          }
+          outputFragment += outputColumns.join(',');
+        } else {
+          outputFragment = ' OUTPUT INSERTED.*';
+        }
 
         //To capture output rows when there is a trigger on MSSQL DB
         if (attributes && options.hasTrigger && this._dialect.supports.tmpTableTrigger) {

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -382,6 +382,8 @@ class Query extends AbstractQuery {
         this.model.rawAttributes[autoIncrementField].field !== undefined)
         autoIncrementFieldAlias = this.model.rawAttributes[autoIncrementField].field;
 
+      if(_.isEmpty(results))
+        results = undefined;
       id = id || results && results[0][this.getInsertIdField()];
       id = id || metaData && metaData[this.getInsertIdField()];
       id = id || results && results[0][autoIncrementField];


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Improves the flexibility of queries when specifying a custom Primary Key for mssql. If the results array is empty on creation, the array is set to "undefined" so the code doesn't break when the default 'id' key is queried on the empty set and the defined key is used instead.
