### PR TITLE
FEAT get used scope name in hooks

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1373,6 +1373,8 @@ class Model {
       }
     }
 
+    self._scopeName = scopeName;
+
     return self;
   }
 

--- a/test/integration/model/scope.test.js
+++ b/test/integration/model/scope.test.js
@@ -48,5 +48,18 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 expect(record.access_level).to.exist;
               });
     });
+
+    it('should expose _scopeName in hooks', function () {
+      let scopeName;
+
+      this.ScopeMe.afterFind(function () {
+        scopeName = this._scopeName;
+      });
+
+      return this.ScopeMe.scope('withName').findOne().then(record => {
+        expect(record).to.exist;
+        expect(scopeName).to.equal('withName');
+      });
+    });
   });
 });

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -291,6 +291,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    it('should expose _scopeName', () => {
+      Company.addScope('namedScope', {});
+
+      expect(Company.scope('namedScope')._scopeName).to.equal('namedScope');
+    });
   });
 
   describe('_injectScope', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
This PR exposes _scopeName on _this_ object in hooks when using named scopes as described by @sushantdhiman in #7433. 

It's unclear to me if this is considered an API addition, so not sure if/where this should be documented but happy to do so if desired.  Just let me know where would be appropriate.
