### PR TITLE
chore(issues): add probot/stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,24 @@
+
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+
+# Label to use when marking an issue as stale
+staleLabel: stale
+
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs.
+  If this is still an issue, just leave a comment 🙂
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
This adds https://github.com/probot/stale.

After 60 days of silence on an issue, it will post a friendly comment on it asking whether it is still valid as it has not received activity in a long time.

If no further activity occurs in the following 7 days, it will be automatically closed.

We have 886 open issues, more than any of us could ever go through. Lets make the Sequelize issue tracker manageable again.