### PR TITLE
Check for null value in setDataValue

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3081,7 +3081,7 @@ class Model {
    */
   setDataValue(key, value) {
     const originalValue = this._previousDataValues[key];
-    if (!Utils.isPrimitive(value) || value !== originalValue) {
+    if ((!Utils.isPrimitive(value) && value !== null) || value !== originalValue) {
       this.changed(key, true);
     }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This prevent key to be marked as changed if `value` and `originalValue` are both `null` when calling `setDataValue`.
