### PR TITLE
fix abstract/connection-manager.js pool configuration problem

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -152,6 +152,10 @@ Sequelize uses a pool to manage connections to your replicas. The default option
   max: 10,
   min: 0,
   idle: 1000
+  idle: 10000,
+  acquire: 10000,
+  evict: 60000,
+  handleDisconnects: true		  
 }
 ```
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -13,6 +13,8 @@ const defaultPoolingConfig = {
   min: 0,
   idle: 10000,
   acquire: 10000,
+  autostart:true,
+  evict: 60000,
   handleDisconnects: true
 };
 
@@ -112,6 +114,7 @@ class ConnectionManager {
         autostart: true,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
+        evictionRunIntervalMillis: config.pool.evict,
         softIdleTimeoutMillis: config.pool.idle
       });
 
@@ -196,9 +199,11 @@ class ConnectionManager {
         max: config.pool.max,
         min: config.pool.min,
         testOnBorrow: true,
-        autostart: false,
+        autostart: true,
         acquireTimeoutMillis: config.pool.acquire,
-        idleTimeoutMillis: config.pool.idle
+        idleTimeoutMillis: config.pool.idle,
+        evictionRunIntervalMillis: config.pool.evict,
+        softIdleTimeoutMillis: config.pool.idle
       }),
       write: Pooling.createPool({
         create: () => new Promise(resolve => {
@@ -222,9 +227,11 @@ class ConnectionManager {
         max: config.pool.max,
         min: config.pool.min,
         testOnBorrow: true,
-        autostart: false,
+        autostart: true,
         acquireTimeoutMillis: config.pool.acquire,
-        idleTimeoutMillis: config.pool.idle
+        idleTimeoutMillis: config.pool.idle,
+        evictionRunIntervalMillis: config.pool.evict,
+        softIdleTimeoutMillis: config.pool.idle
       })
     };
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -109,9 +109,10 @@ class ConnectionManager {
         max: config.pool.max,
         min: config.pool.min,
         testOnBorrow: true,
-        autostart: false,
+        autostart: true,
         acquireTimeoutMillis: config.pool.acquire,
-        idleTimeoutMillis: config.pool.idle
+        idleTimeoutMillis: config.pool.idle,
+        softIdleTimeoutMillis:config.pool.idle
       });
 
       this.pool.on('factoryCreateError', error => {

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -112,7 +112,7 @@ class ConnectionManager {
         autostart: true,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        softIdleTimeoutMillis:config.pool.idle
+        softIdleTimeoutMillis: config.pool.idle
       });
 
       this.pool.on('factoryCreateError', error => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions? no test needed
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? *no changes to public APIs*
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

As described in issue [#7882](https://github.com/sequelize/sequelize/issues/7882) , current [pool confiuration](https://github.com/sequelize/sequelize/blob/master/lib/dialects/abstract/connection-manager.js#L112) in `/lib/dialects/abstract/connection-manager.js` initPool method sets `autostart` to false when no replication is configured, which causes generic-pool `_scheduleEvictorRun` check routine [never gets invoked](https://github.com/coopernurse/node-pool/blob/master/lib/Pool.js#L119). As a result idle connections never get evicted even if the database server's already closed the connection.
To fix that problem, simply set `autostart` option to true and the evict check routine gets scheduled.
As documented in node-pool, the `softIdleTimeoutMillis`(default to -1 ) is checked before `idleTimeoutMillis`, so if `softIdleTimeoutMillis` is not set, the connection will be considered stale no matter what `idleTimeoutMillis` is