### PR TITLE
Evict stale connections

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -149,9 +149,12 @@ Sequelize uses a pool to manage connections to your replicas. The default option
 
 ```js
 {
-  max: 10,
+  max: 5,
   min: 0,
-  idle: 1000
+  idle: 10000,
+  acquire: 10000,
+  evict: 60000,
+  handleDisconnects: true  
 }
 ```
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -13,6 +13,7 @@ const defaultPoolingConfig = {
   min: 0,
   idle: 10000,
   acquire: 10000,
+  evict: 60000,
   handleDisconnects: true
 };
 
@@ -111,7 +112,8 @@ class ConnectionManager {
         testOnBorrow: true,
         autostart: false,
         acquireTimeoutMillis: config.pool.acquire,
-        idleTimeoutMillis: config.pool.idle
+        idleTimeoutMillis: config.pool.idle,
+        
       });
 
       this.pool.on('factoryCreateError', error => {
@@ -223,7 +225,8 @@ class ConnectionManager {
         testOnBorrow: true,
         autostart: false,
         acquireTimeoutMillis: config.pool.acquire,
-        idleTimeoutMillis: config.pool.idle
+        idleTimeoutMillis: config.pool.idle,
+        evictionRunIntervalMillis: config.pool.evict
       })
     };
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -113,7 +113,7 @@ class ConnectionManager {
         autostart: false,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        
+        evictionRunIntervalMillis: config.pool.evict
       });
 
       this.pool.on('factoryCreateError', error => {
@@ -199,7 +199,8 @@ class ConnectionManager {
         testOnBorrow: true,
         autostart: false,
         acquireTimeoutMillis: config.pool.acquire,
-        idleTimeoutMillis: config.pool.idle
+        idleTimeoutMillis: config.pool.idle,
+        evictionRunIntervalMillis: config.pool.evict
       }),
       write: Pooling.createPool({
         create: () => new Promise(resolve => {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -85,7 +85,7 @@ class Sequelize {
    * @param {Integer}  [options.pool.idle] The maximum time, in milliseconds, that a connection can be idle before being released
    * @param {Integer}  [options.pool.acquire] The maximum time, in milliseconds, that pool will try to get connection before throwing error
    * @param {Function} [options.pool.validate] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
-   * @param {Integer}  [options.pool.evict] The time interval, in milliseconds, between evicting stale connections. The default value is 0, which disables this feature.
+   * @param {Integer}  [options.pool.evict] The time interval, in milliseconds, for evicting stale connections. The default value is 0, which disables this feature.
    * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.  WARNING: Setting this to false may expose vulnerabilities and is not reccomended!
    * @param {String}   [options.transactionType='DEFERRED'] Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
    * @param {String}   [options.isolationLevel] Set the default transaction isolation level. See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options.

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -85,6 +85,7 @@ class Sequelize {
    * @param {Integer}  [options.pool.idle] The maximum time, in milliseconds, that a connection can be idle before being released
    * @param {Integer}  [options.pool.acquire] The maximum time, in milliseconds, that pool will try to get connection before throwing error
    * @param {Function} [options.pool.validate] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
+   * @param {Integer}  [options.pool.evict] The time interval, in milliseconds, between evicting stale connections. The default value is 0, which disables this feature.
    * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.  WARNING: Setting this to false may expose vulnerabilities and is not reccomended!
    * @param {String}   [options.transactionType='DEFERRED'] Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
    * @param {String}   [options.isolationLevel] Set the default transaction isolation level. See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options.


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Adding a new option to `defaultPoolingConfig` for overiding the default _evictionRunIntervalMillis_ when instantiating connection pools using `node-pool`. You can see how evictions are never ran if this setting remains 0 https://github.com/coopernurse/node-pool/blob/master/lib/Pool.js#L351

This PR is a bandaid for several recent "open" issues: https://github.com/sequelize/sequelize/issues/7884 and https://github.com/sequelize/sequelize/issues/7882 and possibly https://github.com/sequelize/sequelize/issues/7616
