### PR TITLE
Pick keepAlive dialectOption

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -76,7 +76,10 @@ class ConnectionManager extends AbstractConnectionManager {
           // !! DONT SET THIS TO TRUE !!
           // (unless you know what you're doing)
           // see [http://www.postgresql.org/message-id/flat/bc9549a50706040852u27633f41ib1e6b09f8339d845@mail.gmail.com#bc9549a50706040852u27633f41ib1e6b09f8339d845@mail.gmail.com]
-          'binary'
+          'binary',
+          // This should help with backends incorrectly considering idle clients to be dead and prematurely disconnecting them.
+          // this feature has been added in pg module v6.0.0, check pg/CHANGELOG.md
+          'keepAlive'
         ]));
     }
 
@@ -149,7 +152,7 @@ class ConnectionManager extends AbstractConnectionManager {
       if (dataTypes.HSTORE.types.postgres.oids.length === 0 && supportedVersion) {
         query += 'SELECT typname, oid, typarray FROM pg_type WHERE typtype = \'b\' AND typname IN (\'hstore\', \'geometry\', \'geography\')';
       }
-      
+
       return new Promise((resolve, reject) => {
         connection.query(query)
           .on('error', err => reject(err))


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [yes] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [yes] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [NA] Have you added new tests to prevent regressions?
- [No] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [Yes] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change 

<!-- Please provide a description of the change here. -->
Closes #7896

idle connections were getting prematurely dropped/closed by the backend, in order to avoid this problem the underlying pg module introduced 'keepAlive' option in its v6.0.0 which was missing from the sequelize library, this PR allows the user to set the 'keepAlive' option through the dialectOptions