### PR TITLE
fix sqlite deleted records can be queried in the same second

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -78,7 +78,7 @@ class Model {
     const deletedAtObject = {};
     let deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gt: model.sequelize.literal('CURRENT_TIMESTAMP'), $eq: null } };
+    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gt: Utils.now(this.sequelize.options.dialect), $eq: null } };
 
     deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1466,7 +1466,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
-    it('should return only non deleted records', function() {
+    it('should return only non deleted records', () => {
       const Model = current.define('Test', {
         username: Sequelize.STRING
       }, { paranoid: true });

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1465,6 +1465,24 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(users.length).to.equal(2);
       });
     });
+
+    it('should return only non deleted records', function() {
+      const Model = current.define('Test', {
+        username: Sequelize.STRING
+      }, { paranoid: true });
+      return Model.sync({ force: true }).then(() => {
+        return Model.bulkCreate([
+          { username: 'Bob' },
+          { username: 'Tobi' }
+        ]);
+      }).then(() => {
+        return Model.destroy({ where: { username: 'Tobi' } });
+      }).then(() => {
+        return Model.findAll();
+      }).then(users => {
+        expect(users.length).to.be.eql(1);
+      });
+    });
   });
 
   it('should support logging', function() {


### PR DESCRIPTION
Deleted records can be queried in the same second. At least using sqlite.
That's because deletedAt value is set using javascript's "new Date", but select query uses CURRENT_TIMESTAMP. That may lead to unpredictable results depending on configuration of node and db environment.
I guess it's more correct to use Utils.now() helper inside the query.

https://github.com/sequelize/sequelize/issues/7952

It looks like it breaks MSSQL tests :(
I don't know the MSSQL details, but found a related issue: https://github.com/sequelize/sequelize/pull/7787