### PR TITLE
feat(scopes): allow scope `group`s to be concatenated

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1349,7 +1349,7 @@ class Model {
         _.assignWith(self._scope, scope, (objectValue, sourceValue, key) => {
           if (key === 'where') {
             return Array.isArray(sourceValue) ? sourceValue : _.assign(objectValue || {}, sourceValue);
-          } else if (['attributes', 'include'].indexOf(key) >= 0 && Array.isArray(objectValue) && Array.isArray(sourceValue)) {
+          } else if (['attributes', 'include', 'group'].indexOf(key) >= 0 && Array.isArray(objectValue) && Array.isArray(sourceValue)) {
             return objectValue.concat(sourceValue);
           }
 

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -226,7 +226,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should concatenate scope groups', () => {
       expect(Company.scope('groupByCompanyId', 'groupByProjectId')._scope).to.deep.equal({
         group: ['company.id', 'project.id'],
-        include: [{ model: Project }],
+        include: [{ model: Project }]
       });
     });
   });

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -41,6 +41,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     projects: {
       include: [Project]
     },
+    groupByCompanyId: {
+      group: ['company.id']
+    },
+    groupByProjectId: {
+      group: ['project.id'],
+      include: [Project]
+    },
     noArgs() {
       // This does not make much sense, since it does not actually need to be in a function,
       // In reality it could be used to do for example new Date or random in the scope - but we want it deterministic
@@ -214,6 +221,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(() => {
         Company.scope('doesntexist');
       }).to.throw('Invalid scope doesntexist called.');
+    });
+
+    it('should concatenate scope groups', () => {
+      expect(Company.scope('groupByCompanyId', 'groupByProjectId')._scope).to.deep.equal({
+        group: ['company.id', 'project.id'],
+        include: [{ model: Project }],
+      });
     });
   });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Add 'group' to items to be concatenated when combining scopes. Work based on @Mijago's fork.
Closes #6690 