### PR TITLE
Fix $contains escaping

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -41,7 +41,7 @@ function escape(val, timeZone, dialect, format) {
   if (Array.isArray(val)) {
     const partialEscape = _.partial(escape, _, timeZone, dialect, format);
     if (dialect === 'postgres' && !format) {
-      return dataTypes.ARRAY.prototype.stringify(val, {escape});
+      return dataTypes.ARRAY.prototype.stringify(val, {escape: partialEscape});
     }
     return val.map(partialEscape);
   }

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -414,6 +414,10 @@ if (dialect.match(/^postgres/)) {
           arguments: ['myTable', {where: { field: new Buffer('Sequelize')}}],
           expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" = E'\\\\x53657175656c697a65';",
           context: QueryGenerator
+        }, {
+          title: 'string in array should escape \' as \'\'',
+          arguments: ['myTable', {where: { aliases: {$contains: ['Queen\'s']} }}],
+          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"aliases\" @> ARRAY['Queen''s'];",
         },
 
         // Variants when quoteIdentifiers is false


### PR DESCRIPTION
### Pull Request check-list

- [x] `npm run test-pgsql` and `npm run lint` passed;
- [x] Tests added to prevent regressions.
- [x] No documentation update is needed.

### Description of change

This pull request closes #7950.

> **Issue**: Wrong escaping of text in array (`'` should escape as `''`, not `\'`).
>
> **Cause**: A context losing when passing options.
