### PR TITLE
fix #7968 - mssql bind support - add support for array in bind parame…

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -151,7 +151,15 @@ class Query extends AbstractQuery {
         return seen[key];
       }
       if (values[key] !== undefined) {
-        i = i + 1;
+        i++;
+        if (Array.isArray(values[key])) {
+          return values[key].map((value, index) => {
+            const currentKey = key + '_' + index;
+            bindParam[currentKey] = value;
+            seen[currentKey] = '$' + currentKey;
+            return '@' + currentKey;
+          }).join(',');
+        }
         bindParam[key] = values[key];
         seen[key] = '$' + i;
         return '@' + key;

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -527,6 +527,16 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
     });
 
+    it('array in `bind` property working', function() {
+      let logSql;
+      return this.sequelize.query({query: 'select $prop', bind: {prop: [1]}}, {type: this.sequelize.QueryTypes.SELECT, logging(s) { logSql = s; }}).then(result => {
+        expect(result).to.deep.equal([{'': 1}]);
+        if (dialect === 'mssql') {
+          expect(logSql.indexOf('@prop_0')).to.be.above(-1);
+        }
+      });
+    });
+
     it('dot separated attributes when doing a raw query without nest', function() {
       const tickChar = dialect === 'postgres' || dialect === 'mssql' ? '"' : '`',
         sql = 'select 1 as ' + Sequelize.Utils.addTicks('foo.bar.baz', tickChar);

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -527,15 +527,15 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
     });
 
-    it('array in `bind` property working', function() {
-      let logSql;
-      return this.sequelize.query({query: 'select $prop', bind: {prop: [1]}}, {type: this.sequelize.QueryTypes.SELECT, logging(s) { logSql = s; }}).then(result => {
-        expect(result).to.deep.equal([{'': 1}]);
-        if (dialect === 'mssql') {
+    if (dialect === 'mssql') {
+      it('array in `bind` property working', function () {
+        let logSql;
+        return this.sequelize.query({query: 'select $prop', bind: {prop: [1]}}, {type: this.sequelize.QueryTypes.SELECT, logging(s) {logSql = s;}}).then(result => {
+          expect(result).to.deep.equal([{'': 1}]);
           expect(logSql.indexOf('@prop_0')).to.be.above(-1);
-        }
+        });
       });
-    });
+    }
 
     it('dot separated attributes when doing a raw query without nest', function() {
       const tickChar = dialect === 'postgres' || dialect === 'mssql' ? '"' : '`',


### PR DESCRIPTION
fix #7968 - mssql bind support - add support for array in bind parameters.
@renaudholcombe can you please review this commit?