### PR TITLE
Fix documentation - redirection link in docs/models-definition.md 

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -728,7 +728,7 @@ sequelize.define('user', {}, {
 ```
 
 
-[0]: ./tutorial/models-definition.html#configuration
+[0]: /tutorial/models-definition.html#configuration
 [3]: https://github.com/chriso/validator.js
 [5]: /docs/final/misc#asynchronicity
 [6]: http://bluebirdjs.com/docs/api/spread.html

--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -728,7 +728,7 @@ sequelize.define('user', {}, {
 ```
 
 
-[0]: #configuration
+[0]: ./tutorial/models-definition.html#configuration
 [3]: https://github.com/chriso/validator.js
 [5]: /docs/final/misc#asynchronicity
 [6]: http://bluebirdjs.com/docs/api/spread.html


### PR DESCRIPTION
In models-definition the markdown code used to link to (#id) configuration on same page did not lead to the configuration id set up on same page but rather looked for #configuration with respect to the base set up (i.e. ../../  which results to main index). I have changed the documentation models-definition.md file so that it can direct user to #configuration id on the same page(i.e. models-definition)

### Description of change
When a user opens
http://docs.sequelizejs.com/manual/tutorial/models-definition.html
there are three links on the page that should redirect to 
http://docs.sequelizejs.com/manual/tutorial/models-definition.html#configuration
but they actually redirect to 
http://docs.sequelizejs.com/#configuration

In models-definition.md
i have changed the markdown link so that the redirection is done correctly.

Though the earlier link redirects well in the models-definition.md file when viewed on github but it doesnt work right on the website. This new link works fine when run from the .html formed in esdoc directory but doesnt work right on the models-definition.md file when viewed on github. I checked the other links already given in the file and they also do the same i.e. they work correct on website but not in the documentation file.