### PR TITLE
ci(deploy): use Travis' npm deploy provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,21 +43,35 @@ script:
   - npm run lint
   - "if [ $COVERAGE ]; then npm run cover && bash <(curl -s https://codecov.io/bash) -f coverage/lcov.info; else npm run test; fi"
 
-after_success:
-  - npm run semantic-release
-
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/
 
-deploy:
-  provider: surge
-  project: ./esdoc/
-  domain: docs.sequelizejs.com
-  skip_cleanup: true
-  on:
-    branch: master
-    node: 6
-
 before_deploy:
+  # Prepare package.json with version field
+  - semantic-release pre
+  # Generate docs
   - npm run docs
+
+deploy:
+  # Publish on npm
+  - provider: npm
+    email:
+      secure: GcRjqjzsRsyOOuOVbYiIjIHv5MgCJ07EgB6f5GPs4DTBqT56O7l2D25oh+0L9NHVMTYIoaNTFb7FJMGjVJXS0uqyrTG5yMngodEQcGN6H+Tfuf1d0HDYNhvg2/DhjVpIh8WdC5bkh46z9ngHmYEwxnzs3loRrxAbbmLgp1Ya8iI=
+    api_key:
+      secure: ESYSlYkz9AxWdA1aQoUyFA+RV6Sz4ACm+OzdfAmI/FCPt/Tr7s6C11amrJOoliEtyQC08C9/7SBDxv9+dEmPRdSrpaqC8Uk4NlxD+q4LHh5r3yracL1qsAJiQihl4J9zlc7RXR5GyFh7usGrdbo9k1dOZ3vsYCBxQz/mBJsfPqc=
+    skip_cleanup: true
+    on:
+      branch: master
+  # Deploy docs
+  - provider: surge
+    project: ./esdoc/
+    domain: docs.sequelizejs.com
+    skip_cleanup: true
+    on:
+      branch: master
+      node: 6
+
+after_deploy:
+  # Publish release notes on GitHub
+  - semantic-release post

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "sscce-mysql": "cross-env DIALECT=mysql npm run sscce",
     "sscce-postgres": "cross-env DIALECT=postgres npm run sscce",
     "sscce-sqlite": "cross-env DIALECT=sqlite npm run sscce",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
     "commitmsg": "validate-commit-msg"
   },
   "engines": {
@@ -146,5 +145,8 @@
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"
     }
+  },
+  "release": {
+    "verifyConditions": []
   }
 }


### PR DESCRIPTION
Closes #7983

I don't know if this works, the only way to find out is to merge.

There could be an issue with commits that don't trigger a release, e.g. `chore` or `docs` commits. The npm publish provider still tries to publish and fails with an error like "version already exists".