### PR TITLE
4.4.0 breaks pg connection initialization

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -153,10 +153,9 @@ class ConnectionManager extends AbstractConnectionManager {
         query += 'SELECT typname, oid, typarray FROM pg_type WHERE typtype = \'b\' AND typname IN (\'hstore\', \'geometry\', \'geography\')';
       }
 
-      return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(result => {
-        if (Array.isArray(result)) {
-          result = result.pop();
-        }
+      return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(results => {
+        const result = Array.isArray(results) ? results.pop() : results;
+        
         for (const row of result.rows) {
           let type;
           if (row.typname === 'geometry') {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -8,6 +8,7 @@ const sequelizeErrors = require('../../errors');
 const semver = require('semver');
 const dataTypes = require('../../data-types');
 const moment = require('moment-timezone');
+const _ = require('lodash');
 
 class ConnectionManager extends AbstractConnectionManager {
   constructor(dialect, sequelize) {
@@ -154,6 +155,9 @@ class ConnectionManager extends AbstractConnectionManager {
       }
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(result => {
+        if (_.isArray(result)) {
+          result = result.pop();
+        }
         for (const row of result.rows) {
           let type;
           if (row.typname === 'geometry') {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -8,7 +8,6 @@ const sequelizeErrors = require('../../errors');
 const semver = require('semver');
 const dataTypes = require('../../data-types');
 const moment = require('moment-timezone');
-const _ = require('lodash');
 
 class ConnectionManager extends AbstractConnectionManager {
   constructor(dialect, sequelize) {
@@ -155,7 +154,7 @@ class ConnectionManager extends AbstractConnectionManager {
       }
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(result => {
-        if (_.isArray(result)) {
+        if (Array.isArray(result)) {
           result = result.pop();
         }
         for (const row of result.rows) {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
In case the initial query contains multiple statements in the [postgres connection manager](https://github.com/sequelize/sequelize/blob/master/lib/dialects/postgres/connection-manager.js#L156), the result will be an array which is not being handled here. Since we are only interested in the rows from the very last statement, we can skip the rest.

This fixes #7985