### PR TITLE
fix(query-generator): add parentheses to queries when using ALL with LIKE

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2304,8 +2304,11 @@ const QueryGenerator = {
       if (escapeValue) {
         value = this.escape(value, field, escapeOptions);
 
-        //if ANY is used with like, add parentheses to generate correct query
-        if (escapeOptions.acceptStrings && comparator.indexOf('ANY') > comparator.indexOf('LIKE')) {
+        // if ANY or ALL is used with like, add parentheses to generate correct query
+        if (escapeOptions.acceptStrings && (
+          comparator.indexOf('ANY') > comparator.indexOf('LIKE') ||
+          comparator.indexOf('ALL') > comparator.indexOf('LIKE')
+        )) {
           value = '(' + value + ')';
         }
       } else if (escapeOptions.acceptRegExp) {

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -603,11 +603,35 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
 
           testsql('userId', {
+            $like: {
+              $all: ['foo', 'bar', 'baz']
+            }
+          }, {
+            postgres: "\"userId\" LIKE ALL (ARRAY['foo','bar','baz'])"
+          });
+
+          testsql('userId', {
+            $iLike: {
+              $all: ['foo', 'bar', 'baz']
+            }
+          }, {
+            postgres: "\"userId\" ILIKE ALL (ARRAY['foo','bar','baz'])"
+          });
+
+          testsql('userId', {
+            $notLike: {
+              $all: ['foo', 'bar', 'baz']
+            }
+          }, {
+            postgres: "\"userId\" NOT LIKE ALL (ARRAY['foo','bar','baz'])"
+          });
+
+          testsql('userId', {
             $notILike: {
               $all: ['foo', 'bar', 'baz']
             }
           }, {
-            postgres: "\"userId\" NOT ILIKE ALL ARRAY['foo','bar','baz']"
+            postgres: "\"userId\" NOT ILIKE ALL (ARRAY['foo','bar','baz'])"
           });
         });
       });


### PR DESCRIPTION
fixed an issue with LIKE/ILIKE when used with the ALL keyword.
it already worked fine for the ANY keyword, but was missing the parentheses when I tried with ALL.
extended the tests a bit to cover all LIKE/ILIKE/NOT combinations.