### PR TITLE
fix: fix an error cause use for of syntax in postgres connection

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -154,20 +154,24 @@ class ConnectionManager extends AbstractConnectionManager {
       }
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(result => {
-        for (const row of result.rows) {
-          let type;
-          if (row.typname === 'geometry') {
-            type = dataTypes.postgres.GEOMETRY;
-          } else if (row.typname === 'hstore') {
-            type = dataTypes.postgres.HSTORE;
-          } else if (row.typname === 'geography') {
-            type = dataTypes.postgres.GEOGRAPHY;
+        const rows = result.rows;
+        for (const attr in rows) {
+          if(rows.hasOwnProperty(attr)){
+            const row = rows[attr];
+            let type;
+            if (row.typname === 'geometry') {
+              type = dataTypes.postgres.GEOMETRY;
+            } else if (row.typname === 'hstore') {
+              type = dataTypes.postgres.HSTORE;
+            } else if (row.typname === 'geography') {
+              type = dataTypes.postgres.GEOGRAPHY;
+            }
+
+            type.types.postgres.oids.push(row.oid);
+            type.types.postgres.array_oids.push(row.typarray);
+
+            this._refreshTypeParser(type);
           }
-
-          type.types.postgres.oids.push(row.oid);
-          type.types.postgres.array_oids.push(row.typarray);
-
-          this._refreshTypeParser(type);
         }
       });
     });


### PR DESCRIPTION
before:
  Unable to connect to the database: TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined
after:
  Connect success

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

user **for in** instead of **for of** for avoid an error in ``lib/dialects/postgres/connection-manager.js``

### Scene reproduction

Here is the code

```javascript
// Or you can simply use a connection uri
const sequelize = new Sequelize('postgres://postgres:admin@localhost:5432/postgres');

sequelize
  .authenticate()
  .then(() => {
    console.log('Connection has been established successfully.');
  })
  .catch(err => {
    console.error('Unable to connect to the database:', err);
  });
```

Here is the complete stack

```bash
Unable to connect to the database: TypeError: Cannot read property 'Symbol(Symbol.iterator)' of undefined
    at Promise.then.result (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\sequelize\lib\dialects\postgres\connection-manager.js:157:31)
    at tryCatcher (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\util.js:16:23)
    at Promise._settlePromiseFromHandler (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\promise.js:512:31)
    at Promise._settlePromise (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\promise.js:569:18)
    at Promise._settlePromise0 (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\promise.js:614:10)
    at Promise._settlePromises (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\promise.js:693:18)
    at Async._drainQueue (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\async.js:133:16)
    at Async._drainQueues (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\async.js:143:10)
    at Immediate.Async.drainQueues (C:\Users\axetroy\gpm\yichui.net\axetroy\duomi-nodejs\node_modules\bluebird\js\release\async.js:17:14)
    at runCallback (timers.js:651:20)
    at tryOnImmediate (timers.js:624:5)
    at processImmediate [as _immediateCallback] (timers.js:596:5)
```