### PR TITLE
Mssql PrependN flag

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -901,7 +901,7 @@ const QueryGenerator = {
 
           if (field.type.stringify) {
             // Users shouldn't have to worry about these args - just give them a function that takes a single arg
-            const simpleEscape = _.partialRight(SqlString.escape, this.options.timezone, this.dialect);
+            const simpleEscape = _.partialRight(SqlString.escape, this.options.timezone, this.dialect, undefined, field.prependN);
 
             value = field.type.stringify(value, { escape: simpleEscape, field, timezone: this.options.timezone });
 

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -3,8 +3,13 @@
 const dataTypes = require('./data-types');
 const _ = require('lodash');
 
-function escape(val, timeZone, dialect, format) {
+function escape(val, timeZone, dialect, format, prependNFlag) {
   let prependN = false;
+
+  if(prependNFlag === undefined) {
+    prependNFlag = true; 
+  }
+
   if (val === undefined || val === null) {
     return 'NULL';
   }
@@ -22,7 +27,7 @@ function escape(val, timeZone, dialect, format) {
     case 'string':
     // In mssql, prepend N to all quoted vals which are originally a string (for
     // unicode compatibility)
-      prependN = dialect === 'mssql';
+      prependN = dialect === 'mssql' & prependNFlag;
       break;
   }
 


### PR DESCRIPTION
I understand that in #5039 string literals are prefix with N for mssql to convert it into nvarchar for querying in mssql. However, there may be performance issues under high load as SQL server uses high CPU when searching with nvarchar strings due to unicode comparison logic. 

In circumstances like searching by reference id, it is not required to pass in unicode string to the database, so I thought it will be flexible for users to choose whether to prefix the field with N for mssql.

**Change Description**
In abstract/query-generator.js escape function, the field.prependN value is passed into the sql-string escape function. 

In sql-string.js escape function, the additional parameter prependNFlag value, together with the dialect value will determine whether to prefix the string with N for mssql. 

In model.js, users have to put prependN option if they do not want to prefix the field with N. For example:
   ReferenceID: {
      type: DataTypes.STRING(100),
      allowNull: false,
      prependN: false
    },
    Name: {
      type: DataTypes.STRING(256),
      allowNull: true
    },
