### PR TITLE
fix(connection): fixing mssql reconnect bug

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -2,6 +2,7 @@
 
 const Pooling = require('generic-pool');
 const Promise = require('../../promise');
+const retry = require('retry-as-promised');
 const _ = require('lodash');
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('pool');
@@ -13,7 +14,8 @@ const defaultPoolingConfig = {
   min: 0,
   idle: 10000,
   acquire: 10000,
-  handleDisconnects: true
+  handleDisconnects: true,
+  connectRetries: 5
 };
 
 class ConnectionManager {
@@ -24,7 +26,6 @@ class ConnectionManager {
     this.config = config;
     this.dialect = dialect;
     this.versionPromise = null;
-    this.poolError = null;
     this.dialectName = this.sequelize.options.dialect;
 
     if (config.pool === false) {
@@ -84,19 +85,14 @@ class ConnectionManager {
 
     if (!config.replication) {
       this.pool = Pooling.createPool({
-        create: () => new Promise(resolve => {
-          this
-            ._connect(config)
-            .tap(() => {
-              this.poolError = null;
-            })
-            .then(resolve)
-            .catch(e => {
-              // dont throw otherwise pool will release _dispense call
-              // which will call _connect even if error is fatal
-              // https://github.com/coopernurse/node-pool/issues/161
-              this.poolError = e;
-            });
+        create: () => new Promise((resolve, reject) => {
+          retry(() => this._connect(config), {
+            max: config.connectRetries
+          })
+          .then(resolve)
+          .catch(e => {
+            reject(e);
+          });
         }),
         destroy: connection => {
           return this._disconnect(connection).tap(() => {
@@ -112,10 +108,6 @@ class ConnectionManager {
         autostart: false,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle
-      });
-
-      this.pool.on('factoryCreateError', error => {
-        this.poolError = error;
       });
 
       debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
@@ -173,17 +165,17 @@ class ConnectionManager {
       read: Pooling.createPool({
         create: () => {
           const nextRead = reads++ % config.replication.read.length; // round robin config
-          return new Promise(resolve => {
-            this
-              ._connect(config.replication.read[nextRead])
-              .tap(connection => {
-                connection.queryType = 'read';
-                this.poolError = null;
-                resolve(connection);
-              })
-              .catch(e => {
-                this.poolError = e;
-              });
+          return new Promise((resolve, reject) => {
+            retry(() => this._connect(config.replication.read[nextRead]), {
+              max: config.connectRetries
+            })
+            .then(connection => {
+              connection.queryType = 'read';
+              resolve(connection);
+            })
+            .catch(e => {
+              reject(e);
+            });
           });
         },
         destroy: connection => {
@@ -200,17 +192,17 @@ class ConnectionManager {
         idleTimeoutMillis: config.pool.idle
       }),
       write: Pooling.createPool({
-        create: () => new Promise(resolve => {
-          this
-            ._connect(config.replication.write)
-            .then(connection => {
-              connection.queryType = 'write';
-              this.poolError = null;
-              return resolve(connection);
-            })
-            .catch(e => {
-              this.poolError = e;
-            });
+        create: () => new Promise((resolve, reject) => {
+          retry(() => this._connect(config.replication.write), {
+            max: config.connectRetries
+          })
+          .then(connection => {
+            connection.queryType = 'write';
+            resolve(connection);
+          })
+          .catch(e => {
+            reject(e);
+          });
         }),
         destroy: connection => {
           return this._disconnect(connection);
@@ -226,14 +218,6 @@ class ConnectionManager {
         idleTimeoutMillis: config.pool.idle
       })
     };
-
-    this.pool.read.on('factoryCreateError', error => {
-      this.poolError = error;
-    });
-
-    this.pool.write.on('factoryCreateError', error => {
-      this.poolError = error;
-    });
   }
 
   getConnection(options) {
@@ -265,23 +249,9 @@ class ConnectionManager {
       promise = Promise.resolve();
     }
 
-    return promise.then(() => {
-      return Promise.race([
-        this.pool.acquire(options.priority, options.type, options.useMaster),
-        new Promise((resolve, reject) =>
-          timers.setTimeout(() => {
-            if (this.poolError) {
-              reject(this.poolError);
-            }
-          }, 0))
-      ])
-        .tap(() => { debug('connection acquired'); })
-        .catch(e => {
-          e = this.poolError || e;
-          this.poolError = null;
-          throw e;
-        });
-    });
+    return promise.then(() =>
+      this.pool.acquire(options.priority, options.type, options.useMaster)
+    );
   }
 
   releaseConnection(connection) {

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -86,15 +86,11 @@ class ConnectionManager {
 
     if (!config.replication) {
       this.pool = Pooling.createPool({
-        create: () => new Promise((resolve, reject) => {
+        create: () =>
           retry(() => this._connect(config), {
             max: config.pool.connectRetries
           })
-            .then(resolve)
-            .catch(e => {
-              reject(e);
-            });
-        }),
+        ,
         destroy: connection => {
           return this._disconnect(connection).tap(() => {
             debug('connection destroy');
@@ -170,18 +166,12 @@ class ConnectionManager {
       read: Pooling.createPool({
         create: () => {
           const nextRead = reads++ % config.replication.read.length; // round robin config
-          return new Promise((resolve, reject) => {
-            retry(() => this._connect(config.replication.read[nextRead]), {
-              max: config.pool.connectRetries
-            })
-              .then(connection => {
-                connection.queryType = 'read';
-                resolve(connection);
-              })
-              .catch(e => {
-                reject(e);
-              });
-          });
+          return retry(() => this._connect(config.replication.read[nextRead]), {
+            max: config.pool.connectRetries
+          })
+            .tap(connection => {
+              connection.queryType = 'read';
+            });
         },
         destroy: connection => {
           return this._disconnect(connection);
@@ -197,18 +187,14 @@ class ConnectionManager {
         idleTimeoutMillis: config.pool.idle
       }),
       write: Pooling.createPool({
-        create: () => new Promise((resolve, reject) => {
+        create: () =>
           retry(() => this._connect(config.replication.write), {
             max: config.pool.connectRetries
           })
-            .then(connection => {
+            .tap(connection => {
               connection.queryType = 'write';
-              resolve(connection);
             })
-            .catch(e => {
-              reject(e);
-            });
-        }),
+        ,
         destroy: connection => {
           return this._disconnect(connection);
         },

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -7,7 +7,6 @@ const _ = require('lodash');
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('pool');
 const semver = require('semver');
-const timers = require('timers');
 
 const defaultPoolingConfig = {
   max: 5,
@@ -89,10 +88,10 @@ class ConnectionManager {
           retry(() => this._connect(config), {
             max: config.connectRetries
           })
-          .then(resolve)
-          .catch(e => {
-            reject(e);
-          });
+            .then(resolve)
+            .catch(e => {
+              reject(e);
+            });
         }),
         destroy: connection => {
           return this._disconnect(connection).tap(() => {
@@ -169,13 +168,13 @@ class ConnectionManager {
             retry(() => this._connect(config.replication.read[nextRead]), {
               max: config.connectRetries
             })
-            .then(connection => {
-              connection.queryType = 'read';
-              resolve(connection);
-            })
-            .catch(e => {
-              reject(e);
-            });
+              .then(connection => {
+                connection.queryType = 'read';
+                resolve(connection);
+              })
+              .catch(e => {
+                reject(e);
+              });
           });
         },
         destroy: connection => {
@@ -196,13 +195,13 @@ class ConnectionManager {
           retry(() => this._connect(config.replication.write), {
             max: config.connectRetries
           })
-          .then(connection => {
-            connection.queryType = 'write';
-            resolve(connection);
-          })
-          .catch(e => {
-            reject(e);
-          });
+            .then(connection => {
+              connection.queryType = 'write';
+              resolve(connection);
+            })
+            .catch(e => {
+              reject(e);
+            });
         }),
         destroy: connection => {
           return this._disconnect(connection);

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -18,11 +18,6 @@ const defaultPoolingConfig = {
   connectRetries: 5
 };
 
-function isCriticalError(e) {
-  return e.name === 'SequelizeAccessDeniedError' ||
-    e.parent instanceof RangeError
-}
-
 class ConnectionManager {
   constructor(dialect, sequelize) {
     const config = _.cloneDeep(sequelize.config);
@@ -284,7 +279,7 @@ class ConnectionManager {
           e = this.poolError || e;
           this.poolError = null;
           throw e;
-        })
+        });
     });
   }
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -2,11 +2,12 @@
 
 const Pooling = require('generic-pool');
 const Promise = require('../../promise');
-const retry = require('retry-as-promised');
 const _ = require('lodash');
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('pool');
 const semver = require('semver');
+const timers = require('timers');
+const retry = require('retry-as-promised');
 
 const defaultPoolingConfig = {
   max: 5,
@@ -17,6 +18,11 @@ const defaultPoolingConfig = {
   connectRetries: 5
 };
 
+function isCriticalError(e) {
+  return e.name === 'SequelizeAccessDeniedError' ||
+    e.parent instanceof RangeError
+}
+
 class ConnectionManager {
   constructor(dialect, sequelize) {
     const config = _.cloneDeep(sequelize.config);
@@ -25,6 +31,7 @@ class ConnectionManager {
     this.config = config;
     this.dialect = dialect;
     this.versionPromise = null;
+    this.poolError = null;
     this.dialectName = this.sequelize.options.dialect;
 
     if (config.pool === false) {
@@ -107,6 +114,10 @@ class ConnectionManager {
         autostart: false,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle
+      });
+
+      this.pool.on('factoryCreateError', error => {
+        this.poolError = error;
       });
 
       debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
@@ -217,6 +228,14 @@ class ConnectionManager {
         idleTimeoutMillis: config.pool.idle
       })
     };
+
+    this.pool.read.on('factoryCreateError', error => {
+      this.poolError = error;
+    });
+
+    this.pool.write.on('factoryCreateError', error => {
+      this.poolError = error;
+    });
   }
 
   getConnection(options) {
@@ -248,9 +267,25 @@ class ConnectionManager {
       promise = Promise.resolve();
     }
 
-    return promise.then(() =>
-      this.pool.acquire(options.priority, options.type, options.useMaster)
-    );
+    return promise.then(() => {
+      return new Promise((resolve, reject) => {
+        timers.setTimeout(() => {
+          if (this.poolError) {
+            reject(this.poolError);
+          } else {
+            this.pool.acquire(options.priority, options.type, options.useMaster)
+              .then(resolve)
+              .catch(reject);
+          }
+        }, 0);
+      })
+        .tap(() => { debug('connection acquired'); })
+        .catch(e => {
+          e = this.poolError || e;
+          this.poolError = null;
+          throw e;
+        })
+    });
   }
 
   releaseConnection(connection) {

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -88,7 +88,7 @@ class ConnectionManager {
       this.pool = Pooling.createPool({
         create: () => new Promise((resolve, reject) => {
           retry(() => this._connect(config), {
-            max: config.connectRetries
+            max: config.pool.connectRetries
           })
             .then(resolve)
             .catch(e => {
@@ -172,7 +172,7 @@ class ConnectionManager {
           const nextRead = reads++ % config.replication.read.length; // round robin config
           return new Promise((resolve, reject) => {
             retry(() => this._connect(config.replication.read[nextRead]), {
-              max: config.connectRetries
+              max: config.pool.connectRetries
             })
               .then(connection => {
                 connection.queryType = 'read';
@@ -199,7 +199,7 @@ class ConnectionManager {
       write: Pooling.createPool({
         create: () => new Promise((resolve, reject) => {
           retry(() => this._connect(config.replication.write), {
-            max: config.connectRetries
+            max: config.pool.connectRetries
           })
             .then(connection => {
               connection.queryType = 'write';

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -69,9 +69,18 @@ class ConnectionManager extends AbstractConnectionManager {
 
       const connection = new this.lib.Connection(connectionConfig);
       const connectionLock = new ResourceLock(connection);
+      let connected = false;
       connection.lib = this.lib;
 
+      connection.on('end', err => {
+        if (!connected) {
+          reject(new sequelizeErrors.ConnectionError("Error connecting to the database"));
+        }
+      });
+
       connection.on('connect', err => {
+        connected = true;
+
         if (!err) {
           debug('connection acquired');
           resolve(connectionLock);
@@ -111,9 +120,9 @@ class ConnectionManager extends AbstractConnectionManager {
             break;
         }
       });
-      
+
       if (config.dialectOptions && config.dialectOptions.debug) {
-        connection.on('debug', debugTedious);        
+        connection.on('debug', debugTedious);
       }
 
       if (config.pool.handleDisconnects) {

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -72,9 +72,9 @@ class ConnectionManager extends AbstractConnectionManager {
       let connected = false;
       connection.lib = this.lib;
 
-      connection.on('end', err => {
+      connection.on('end', () => {
         if (!connected) {
-          reject(new sequelizeErrors.ConnectionError("Error connecting to the database"));
+          reject(new sequelizeErrors.ConnectionError('Error connecting to the database'));
         }
       });
 

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -155,6 +155,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(results => {
         const result = Array.isArray(results) ? results.pop() : results;
+
         for (const row of result.rows) {
           let type;
           if (row.typname === 'geometry') {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -155,7 +155,6 @@ class ConnectionManager extends AbstractConnectionManager {
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(results => {
         const result = Array.isArray(results) ? results.pop() : results;
-
         for (const row of result.rows) {
           let type;
           if (row.typname === 'geometry') {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -110,20 +110,17 @@ class ConnectionManager extends AbstractConnectionManager {
           } else {
             reject(new sequelizeErrors.ConnectionError(err));
           }
-          connection.end();
           return;
         }
         responded = true;
         debug('connection acquired');
         resolve(connection);
       });
-      
 
       // If we didn't ever hear from the client.connect() callback the connection timeout, node-postgres does not treat this as an error since no active query was ever emitted
       connection.on('end', () => {
         debug('connection timeout');
         if (!responded) {
-          connection._invalid = true;
           reject(new sequelizeErrors.ConnectionTimedOutError(new Error('Connection timed out')));
         }
       });

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -117,6 +117,7 @@ class ConnectionManager extends AbstractConnectionManager {
         debug('connection acquired');
         resolve(connection);
       });
+      
 
       // If we didn't ever hear from the client.connect() callback the connection timeout, node-postgres does not treat this as an error since no active query was ever emitted
       connection.on('end', () => {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -121,6 +121,7 @@ class ConnectionManager extends AbstractConnectionManager {
       connection.on('end', () => {
         debug('connection timeout');
         if (!responded) {
+          connection._invalid = true;
           reject(new sequelizeErrors.ConnectionTimedOutError(new Error('Connection timed out')));
         }
       });
@@ -155,7 +156,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(results => {
         const result = Array.isArray(results) ? results.pop() : results;
-        
+
         for (const row of result.rows) {
           let type;
           if (row.typname === 'geometry') {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -110,6 +110,7 @@ class ConnectionManager extends AbstractConnectionManager {
           } else {
             reject(new sequelizeErrors.ConnectionError(err));
           }
+          connection.end();
           return;
         }
         responded = true;

--- a/test/unit/dialects/mssql/connection-manager.js
+++ b/test/unit/dialects/mssql/connection-manager.js
@@ -5,8 +5,7 @@ const chai = require('chai'),
   Sequelize = require(__dirname + '/../../../../index'),
   tedious = require('tedious'),
   sinon = require('sinon'),
-  connectionStub = sinon.stub(tedious, 'Connection'),
-  sequelizeErrors = require('../../../../lib/errors');
+  connectionStub = sinon.stub(tedious, 'Connection');
 
 let endCb = null;
 
@@ -51,14 +50,14 @@ describe('[MSSQL] Connection Manager', () => {
     });
 
   it('connectionManager._connect() should reject if end was called and connect was not',
-    (done) => {
+    done => {
       instance.dialect.connectionManager._connect(config)
         .catch(err => {
-          expect(err.name).to.equal('SequelizeConnectionError')
-          done()
-        })
+          expect(err.name).to.equal('SequelizeConnectionError');
+          done();
+        });
       setTimeout(() => {
-        endCb()
+        endCb();
       }, 1000);
     });
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Original Issue:
https://github.com/sequelize/sequelize/issues/8014

There is currently a bug where if you restart a mssql database,
sequelize will lock the pool resources.  Once those are locked, all
future requests to .acquire will throw a ResourceRequest timed out
error.  This commit wraps all the connect logic in a retry to prevent an
inifite loop of trying to connect, and also watchins for an 'end' event
in the mssql adapter to properly reject the promise if 'end' is sent
before 'connect' is fired.
