### PR TITLE
Fix pg v7 regressions

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -8,6 +8,38 @@ const Promise = require('../../promise');
 const sequelizeErrors = require('../../errors.js');
 const _ = require('lodash');
 
+function squashResults(results) {
+  if (!Array.isArray(results)) {
+    return results;
+  }
+
+  let rowCount = 0;
+  let rows = [];
+  let fields = [];
+
+  for (const result of results) {
+    if (!Number.isNaN(result.rowCount)) {
+      rowCount += result.rowCount;
+    }
+
+    if (result.fields.length > 0 && fields.length === 0) {
+      fields = result.fields;
+    }
+
+    if (result.rows.length > 0) {
+      rows = rows.concat(result.rows);
+    }
+  }
+
+  const last = results[results.length - 1];
+
+  return Object.assign({}, last, {
+    rows,
+    fields,
+    rowCount: rowCount === 0 ? NaN : rowCount,
+  });
+}
+
 class Query extends AbstractQuery {
   constructor(client, sequelize, options) {
     super();
@@ -95,8 +127,9 @@ class Query extends AbstractQuery {
         return queryResult;
       })
       .then(queryResult => {
-        const rows = queryResult.rows;
-        const rowCount = queryResult.rowCount;
+        const squashed = squashResults(queryResult);
+        const rows = squashed.rows;
+        const rowCount = squashed.rowCount;
         const isTableNameQuery = sql.indexOf('SELECT table_name FROM information_schema.tables') === 0;
         const isRelNameQuery = sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0;
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "lcov-result-merger": "^1.2.0",
     "mocha": "^3.0.2",
     "mysql2": "^1.2.0",
-    "pg": "^6.1.0",
+    "pg": "^7.0.0",
     "pg-hstore": "^2.3.2",
     "pg-native": "^1.10.0",
     "pg-types": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "mysql2": "^1.2.0",
     "pg": "^7.0.0",
     "pg-hstore": "^2.3.2",
-    "pg-native": "^1.10.0",
+    "pg-native": "^2.0.0",
     "pg-types": "^1.11.0",
     "rimraf": "^2.5.4",
     "semantic-release": "^6.3.6",


### PR DESCRIPTION
This hacks around #7998.

I wrote a function which squashes the results returned by pg. except for when raw query doesn't have a type. In that case it returns whatever returned by pg (I don't think we should change this behavior).

This is a temporary fix until we come up with a solution that satisfies every use-case. Might require architectural changes. Since other dialects support multiple statements too.

Until then this fixes #7998