### PR TITLE
fix: maintable.as should be quoted using  quoteIdentifier method

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -958,9 +958,9 @@ const QueryGenerator = {
 
     // resolve table name options
     if (options.tableAs) {
-      mainTable.as = this.quoteTable(options.tableAs);
+      mainTable.as = this.quoteIdentifier(options.tableAs);
     } else if (!Array.isArray(mainTable.name) && mainTable.model) {
-      mainTable.as = this.quoteTable(mainTable.model.name);
+      mainTable.as = this.quoteIdentifier(mainTable.model.name);
     }
 
     mainTable.quotedName = !Array.isArray(mainTable.name) ? this.quoteTable(mainTable.name) : tableName.map(t => {


### PR DESCRIPTION
fix: maintable.as is different from tablename.
should be quoted using  quoteIdentifier method

### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?

### Description of change

This PR is not for solving any bug or critical issues. It is for improving quality of code base.
Sequelize has  well organized code base and it is easy to customize it for complex application.

This is PR will a fix a minor deviation from the  existing code convention

This is the summary of change: 
while generating select query, we are quoting "tablename" part and "tablename.as" part using same function ( quoteTable function ).

But, tablename can have a schema part but the "tablename.as" part can not have schema. so that part should be quoted using quoteIdentifier method


