### PR TITLE
fix(order): Fix the sorting on a primary key with includes for MSSQL dialect

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -846,9 +846,16 @@ const QueryGenerator = {
     }
 
     if (options.limit || options.offset) {
-      if (!options.order || options.include && !orders.subQueryOrder.length) {
-        fragment += options.order && !isSubQuery ? ', ' : ' ORDER BY ';
-        fragment += this.quoteTable(options.tableAs || model.name) + '.' + this.quoteIdentifier(model.primaryKeyField);
+      if (!options.order)  {
+        fragment += ' ORDER BY ' + this.quoteTable(options.tableAs || model.name) + '.' + this.quoteIdentifier(model.primaryKeyField);
+      } else if (options.include && !orders.subQueryOrder.length) {
+        const orderFieldNames = Utils._.map(options.order, (order) => order[0]);
+        const primaryKeyFieldAlreadyPresent = Utils._.includes(orderFieldNames, model.primaryKeyField);
+
+        if (!primaryKeyFieldAlreadyPresent) {
+          fragment += options.order && !isSubQuery ? ', ' : ' ORDER BY ';
+          fragment += this.quoteTable(options.tableAs || model.name) + '.' + this.quoteIdentifier(model.primaryKeyField);
+        }
       }
 
       if (options.offset || options.limit) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Fix this issue: https://github.com/sequelize/sequelize/issues/7851
Developers receive this error: `SequelizeBaseError: A column has been specified more than once in the order by list. Columns in the order by list must be unique.`

If they try to order their results on a `findAll` call with the primary key set in the `order` option value and have also the `include` option set with at least one value.

This fix prevent the issue by checking if the primary key is already defined by the developer.
The change is restricted in the MSSQL code.