### PR TITLE
docs(change): Remove default for dialect

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -64,7 +64,7 @@ class Sequelize {
    * @param {String}   [options.username=null] The username which is used to authenticate against the database.
    * @param {String}   [options.password=null] The password which is used to authenticate against the database.
    * @param {String}   [options.database=null] The name of the database
-   * @param {String}   [options.dialect='mysql'] The dialect of the database you are connecting to. One of mysql, postgres, sqlite and mssql.
+   * @param {String}   [options.dialect] The dialect of the database you are connecting to. One of mysql, postgres, sqlite and mssql.
    * @param {String}   [options.dialectModulePath=null] If specified, load the dialect library from this path. For example, if you want to use pg.js instead of pg when connecting to a pg database, you should specify 'pg.js' here
    * @param {Object}   [options.dialectOptions] An object of additional options, which are passed directly to the connection library
    * @param {String}   [options.storage] Only used by sqlite. Defaults to ':memory:'


### PR DESCRIPTION
The default has been removed in v4. Updating the docs to match the signature.

Closes #7958 