### PR TITLE
Add feature issues to exempt issues for stale issues

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,6 +10,7 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
+  - feature
 
 # Label to use when marking an issue as stale
 staleLabel: stale


### PR DESCRIPTION
I'm not sure if this is desired or not, but I added the `feature` label to the exempt issues labels.  I did this because it seem to me that closing a PR due to inactivity alone isn't a great experience for the community. 

For example the streaming issue here #2454 that likely needs another issue completed to be finished #2325 are both marked as `stale` and were closed. 

From a user standpoint, and a person who wants both of those features, it's disappointing to see them get closed without explanation with each has a good amount of interest in the Sequelize community.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
