### PR TITLE
fix(hooks): removeHook should only remove the specified hook

### DIFF
--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -182,9 +182,10 @@ const Hooks = {
       this.options.hooks[type] = this.options.hooks[type].filter(hook => {
         if (isReference && typeof hook === 'function') {
           return hook !== name; // check if same method
-        } else {
-          return typeof hook === 'object' && hook.name !== name;
+        } else if (!isReference && typeof hook === 'object') {
+          return hook.name !== name;
         }
+        return true;
       });
     }
 

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -209,6 +209,39 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         expect(hook2).not.to.have.been.called;
       });
     });
+
+    it('should not remove other hooks', function() {
+      const hook1 = sinon.spy(),
+        hook2 = sinon.spy(),
+        hook3 = sinon.spy(),
+        hook4 = sinon.spy();
+
+      this.Model.addHook('beforeCreate', hook1);
+      this.Model.addHook('beforeCreate', 'myHook', hook2);
+      this.Model.beforeCreate('myHook2', hook3);
+      this.Model.beforeCreate(hook4);
+
+      return this.Model.runHooks('beforeCreate').bind(this).then(function() {
+        expect(hook1).to.have.been.calledOnce;
+        expect(hook2).to.have.been.calledOnce;
+        expect(hook3).to.have.been.calledOnce;
+        expect(hook4).to.have.been.calledOnce;
+
+        hook1.reset();
+        hook2.reset();
+        hook3.reset();
+        hook4.reset();
+
+        this.Model.removeHook('beforeCreate', 'myHook');
+
+        return this.Model.runHooks('beforeCreate');
+      }).then(() => {
+        expect(hook1).to.have.been.calledOnce;
+        expect(hook2).not.to.have.been.called;
+        expect(hook3).to.have.been.calledOnce;
+        expect(hook4).to.have.been.calledOnce;
+      });
+    });
   });
 
   describe('#addHook', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ x ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ x ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ x ] Have you added new tests to prevent regressions?
- [ N/A ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ x ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Bugfix: `removeHook` removes hooks that you want to keep, if some hooks are named and some are not named.

Steps to reproduce:

1. Add an unnamed `beforeCreate` hook. `Model.addHook('beforeCreate', (…) => {…});`
2. Add a named `beforeCreate` hook to the same Model. `Model.addHook('beforeCreate', 'myNamedHook', (…) => {…});`
3. Remove the named hook. `Model.removeHook('beforeCreate', 'myNamedHook');`

Expected results:

The `myNamedHook` should be removed, and the unnamed hook should still be attached to the Model.

Actual results:

Both hooks are removed.

This PR corrects the problem.
