### PR TITLE
fix issue: Eviction doesn't happen when autostart=false

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -110,7 +110,7 @@ class ConnectionManager {
         max: config.pool.max,
         min: config.pool.min,
         testOnBorrow: true,
-        autostart: false,
+        autostart: true,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
         evictionRunIntervalMillis: config.pool.evict
@@ -197,7 +197,7 @@ class ConnectionManager {
         max: config.pool.max,
         min: config.pool.min,
         testOnBorrow: true,
-        autostart: false,
+        autostart: true,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
         evictionRunIntervalMillis: config.pool.evict


### PR DESCRIPTION

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
config pool.evict not work when autostart=false
https://github.com/coopernurse/node-pool/issues/174
