### PR TITLE
feat(dialects): Changed dialectModulePath option to accept either a string or an object

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -18,7 +18,11 @@ class ConnectionManager extends AbstractConnectionManager {
     this.sequelize.config.port = this.sequelize.config.port || 1433;
     try {
       if (sequelize.config.dialectModulePath) {
-        this.lib = require(sequelize.config.dialectModulePath);
+        if (Utils._.isObject(sequelize.config.dialectModulePath)) {
+          this.lib = sequelize.config.dialectModulePath;
+        } else {
+          this.lib = require(sequelize.config.dialectModulePath);
+        }
       } else {
         this.lib = require('tedious');
       }
@@ -111,9 +115,9 @@ class ConnectionManager extends AbstractConnectionManager {
             break;
         }
       });
-      
+
       if (config.dialectOptions && config.dialectOptions.debug) {
-        connection.on('debug', debugTedious);        
+        connection.on('debug', debugTedious);
       }
 
       if (config.pool.handleDisconnects) {

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -28,7 +28,11 @@ class ConnectionManager extends AbstractConnectionManager {
     this.sequelize.config.port = this.sequelize.config.port || 3306;
     try {
       if (sequelize.config.dialectModulePath) {
-        this.lib = require(sequelize.config.dialectModulePath);
+        if (Utils._.isObject(sequelize.config.dialectModulePath)) {
+          this.lib = sequelize.config.dialectModulePath;
+        } else {
+          this.lib = require(sequelize.config.dialectModulePath);
+        }
       } else {
         this.lib = require('mysql2');
       }

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -18,7 +18,11 @@ class ConnectionManager extends AbstractConnectionManager {
     try {
       let pgLib;
       if (sequelize.config.dialectModulePath) {
-        pgLib = require(sequelize.config.dialectModulePath);
+        if (Utils._.isObject(sequelize.config.dialectModulePath)) {
+          pgLib = sequelize.config.dialectModulePath;
+        } else {
+          pgLib = require(sequelize.config.dialectModulePath);
+        }
       } else {
         pgLib = require('pg');
       }
@@ -155,7 +159,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(results => {
         const result = Array.isArray(results) ? results.pop() : results;
-        
+
         for (const row of result.rows) {
           let type;
           if (row.typname === 'geometry') {

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -22,7 +22,11 @@ class ConnectionManager extends AbstractConnectionManager {
 
     try {
       if (sequelize.config.dialectModulePath) {
-        this.lib = require(sequelize.config.dialectModulePath).verbose();
+        if (Utils._.isObject(sequelize.config.dialectModulePath)) {
+          this.lib = sequelize.config.dialectModulePath.verbose();
+        } else {
+          this.lib = require(sequelize.config.dialectModulePath).verbose();
+        }
       } else {
         this.lib = require('sqlite3').verbose();
       }

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -65,7 +65,7 @@ class Sequelize {
    * @param {String}   [options.password=null] The password which is used to authenticate against the database.
    * @param {String}   [options.database=null] The name of the database
    * @param {String}   [options.dialect] The dialect of the database you are connecting to. One of mysql, postgres, sqlite and mssql.
-   * @param {String}   [options.dialectModulePath=null] If specified, load the dialect library from this path. For example, if you want to use pg.js instead of pg when connecting to a pg database, you should specify 'pg.js' here
+   * @param {(String|Object)}   [options.dialectModulePath=null] If specified, load the dialect library from this path. For example, if you want to use pg.js instead of pg when connecting to a pg database, you should specify 'pg.js' here. You can also require the dialect module yourself if it's in a location where Sequelize doesn't look.
    * @param {Object}   [options.dialectOptions] An object of additional options, which are passed directly to the connection library
    * @param {String}   [options.storage] Only used by sqlite. Defaults to ':memory:'
    * @param {String}   [options.protocol='tcp'] The protocol of the relational database.


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

See my previous issue: #7354

The solution i proposed in the issue didn't work as well as I expected and would have constituted a breaking change.

This new solution modifies the dialectModulePath dialect option so that it now also accepts an object if the user wants to require the module himself. This solution would allow for using require.main.require() without breaking any existing functionality.

As I couldn't find any tests for dialectModulePath and this is a fairly small change I didn't add any tests, but I'm open to it if requested.

I don't think the property name (dialectModulePath) is apt but I felt that it was better to modify it instead of adding a new property(ex. dialectModule) to avoid any possible conflicts if a user specifies both a dialectModulePath as a string and  dialectModule as an object. A alternative solution would have been to deprecate dialectModulePath in favor of dialectModule and check for both until next major version.