### PR TITLE
fix(abstract/querygenerator): correctly name indexes that live in custom schemas

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -424,6 +424,11 @@ const QueryGenerator = {
   },
 
   nameIndexes(indexes, rawTablename) {
+    if (typeof rawTablename === 'object') {
+      // don't include schema in the index name
+      rawTablename = rawTablename.tableName;
+    }
+
     return _.map(indexes, index => {
       if (!index.hasOwnProperty('name')) {
         const onlyAttributeNames = index.fields.map(field => typeof field === 'string' ? field : field.name || field.attribute);

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -138,6 +138,8 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             tableName: 'table'
           }).then(indexes => {
             expect(indexes.length).to.eq(1);
+            const index = indexes[0];
+            expect(index.name).to.eq('table_name_is_admin');
           });
         });
       });


### PR DESCRIPTION
Previously, `queryInterface.addIndex({schema: 'foo', tableName: 'bar'}, ['baz'])` would create an index named `[object_object]_baz`.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->
