### PR TITLE
fix(instance): toJSON returns internal object, instead of a copy

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3995,9 +3995,11 @@ class Model {
    * @return {object}
    */
   toJSON() {
-    return this.get({
-      plain: true
-    });
+    return Utils._.clone(
+      this.get({
+        plain: true
+      })
+    );
   }
 
   /**

--- a/test/unit/instance/to-json.test.js
+++ b/test/unit/instance/to-json.test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support   = require(__dirname + '/../support'),
+  DataTypes = require(__dirname + '/../../../lib/data-types'),
+  current   = Support.sequelize;
+
+describe(Support.getTestDialectTeaser('Instance'), () => {
+  describe('toJSON', () => {
+    it('returns copy of json', () => {
+      const User = current.define('User', {
+        name: DataTypes.STRING
+      });
+      const user = User.build({ name: 'my-name' });
+      const json1 = user.toJSON();
+      expect(json1).to.have.property('name').and.be.equal('my-name');
+
+      // remove value from json and ensure it's not changed in the instance
+      delete json1.name;
+
+      const json2 = user.toJSON();
+      expect(json2).to.have.property('name').and.be.equal('my-name');
+    });
+  });
+});


### PR DESCRIPTION
Whenever `toJSON()` is used and returned result is modified, it breaks the internal state of the
instance

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?
