### PR TITLE
fix(sequelize/constructor): queryInterface was initialized on first use

### DIFF
--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -27,7 +27,7 @@ function addForeignKeyConstraints(newAttribute, source, target, options, key) {
     if (primaryKeys.length === 1) {
       if (source._schema) {
         newAttribute.references = {
-          model: source.sequelize.queryInterface.QueryGenerator.addSchema({
+          model: source.sequelize.getQueryInterface().QueryGenerator.addSchema({
             tableName: source.tableName,
             _schema: source._schema,
             _schemaDelimiter: source._schemaDelimiter

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -57,7 +57,7 @@ class Query extends AbstractQuery {
     this.sql = sql;
 
     if (!Utils._.isEmpty(this.options.searchPath)) {
-      this.sql = this.sequelize.queryInterface.QueryGenerator.setSearchPath(this.options.searchPath) + sql;
+      this.sql = this.sequelize.getQueryInterface().QueryGenerator.setSearchPath(this.options.searchPath) + sql;
     }
 
     const query = parameters && parameters.length
@@ -129,7 +129,7 @@ class Query extends AbstractQuery {
             // Map column index in table to column name
             const columns = _.zipObject(
               row.column_indexes,
-              this.sequelize.queryInterface.QueryGenerator.fromArray(row.column_names)
+              this.sequelize.getQueryInterface().QueryGenerator.fromArray(row.column_names)
             );
             delete row.column_indexes;
             delete row.column_names;
@@ -203,7 +203,7 @@ class Query extends AbstractQuery {
               type: row.Type.toUpperCase(),
               allowNull: row.Null === 'YES',
               defaultValue: row.Default,
-              special: row.special ? this.sequelize.queryInterface.QueryGenerator.fromArray(row.special) : [],
+              special: row.special ? this.sequelize.getQueryInterface().QueryGenerator.fromArray(row.special) : [],
               primaryKey: row.Constraint === 'PRIMARY KEY'
             };
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -224,9 +224,11 @@ class Sequelize {
       default:
         throw new Error('The dialect ' + this.getDialect() + ' is not supported. Supported dialects: mssql, mysql, postgres, and sqlite.');
     }
-    this.dialect = new Dialect(this);
 
+    this.dialect = new Dialect(this);
     this.dialect.QueryGenerator.typeValidation = options.typeValidation;
+
+    this.queryInterface = new QueryInterface(this);
 
     /**
      * Models are stored here under the name given to `sequelize.define`


### PR DESCRIPTION
Closes #8173

It seems `sequelize.queryInterface` was being set on first call to `sequelize.getQueryInterface()`.

Now https://github.com/sequelize/sequelize/pull/8160 cleaned up some old code, it also cleaned up `findAutoIncrementField` from `QueryGenerator`, thus model doesn't need to call it anymore.

Which exposed this issue, now `queryInterface` was not being initialized until very first query call or use of `getQueryInterface()` in code.

This PR will fix it