### PR TITLE
fix(validations): prevent deprecation warning in isDate 

### DIFF
--- a/lib/utils/validator-extras.js
+++ b/lib/utils/validator-extras.js
@@ -93,8 +93,19 @@ validator.isNull = validator.isEmpty;
 
 // isDate removed in 7.0.0
 // https://github.com/chriso/validator.js/commit/095509fc707a4dc0e99f85131df1176ad6389fc9
-validator.isDate = function (dateString) {
-  return moment(dateString).isValid();
+validator.isDate = function(dateString) {
+  // avoid http://momentjs.com/guides/#/warnings/js-date/
+  // by doing a preliminary check on `dateString`
+  const parsed = Date.parse(dateString);
+  if (isNaN(parsed)) {
+    // fail if we can't parse it
+    return false;
+  } else {
+    // otherwise convert to ISO 8601 as moment prefers
+    // http://momentjs.com/docs/#/parsing/string/
+    const date = new Date(parsed);
+    return moment(date.toISOString()).isValid();
+  }
 };
 
 exports.validator = validator;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ✓ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ✓ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ✗ ] Have you added new tests to prevent regressions? (_no, but there's no longer a deprecation warning while running them_)
- [ ✗ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ✓ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Avoid a deprecation warning when calling `isDate` closes #8170 

**Tests before**

```
      ...
      ✓ correctly specifies an instance as valid using a value of "f47ac10b-58cc-4372-a567-0e02b2c3d479" for the validation "isUUID" (42ms)
Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged and will be removed in an upcoming major release. Please refer to http://momentjs.com/guides/#/warnings/js-date/ for more info.
Arguments:
[0] _isAMomentObject: true, _isUTC: false, _useUTC: false, _l: undefined, _i: not a date, _f: undefined, _strict: undefined, _locale: [object Object]
Error
    at Function.createFromInputFallback (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:320:94)
    at configFromString (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:2178:11)
    at configFromInput (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:2547:9)
    at prepareConfig (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:2530:9)
    at createFromConfig (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:2497:40)
    at createLocalOrUTC (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:2584:12)
    at createLocal (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:2588:12)
    at hooks (/Users/jfsiii/forks/sequelize/node_modules/moment/moment.js:16:25)
    at Object.validator.isDate (/Users/jfsiii/forks/sequelize/lib/utils/validator-extras.js:97:10)
    at Promise.try (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:279:37)
    at tryCatcher (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/util.js:16:23)
    at Function.Promise.attempt.Promise.try (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/method.js:39:29)
    at InstanceValidator._invokeBuiltinValidator (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:271:23)
    at Utils._.forIn (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:206:37)
    at /Users/jfsiii/forks/sequelize/node_modules/lodash/lodash.js:4944:15
    at Function.forIn (/Users/jfsiii/forks/sequelize/node_modules/lodash/lodash.js:12938:11)
    at InstanceValidator._builtinAttrValidate (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:188:13)
    at Utils._.forIn (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:140:51)
    at /Users/jfsiii/forks/sequelize/node_modules/lodash/lodash.js:4944:15
    at Function.forIn (/Users/jfsiii/forks/sequelize/node_modules/lodash/lodash.js:12938:11)
    at InstanceValidator._builtinValidators (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:127:13)
    at InstanceValidator._validate (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:74:13)
    at runHooks.then (/Users/jfsiii/forks/sequelize/lib/instance-validator.js:110:14)
    at /Users/jfsiii/forks/sequelize/node_modules/continuation-local-storage/context.js:84:17
    at tryCatcher (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/promise.js:512:31)
    at Promise._settlePromise (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/promise.js:569:18)
    at Promise._settlePromise0 (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/promise.js:614:10)
    at Promise._settlePromises (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/promise.js:693:18)
    at Async._drainQueue (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/async.js:133:16)
    at Async._drainQueues (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/async.js:143:10)
    at Immediate.Async.drainQueues (/Users/jfsiii/forks/sequelize/node_modules/bluebird/js/release/async.js:17:14)
    at runCallback (timers.js:781:20)
    at tryOnImmediate (timers.js:743:5)
    at processImmediate [as _immediateCallback] (timers.js:714:5)
      ✓ correctly specifies an instance as invalid using a value of "not a date" for the validation "isDate" (42ms)
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate"
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate" (59ms)
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate"
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate"
      ✓ correctly specifies an instance as invalid using a value of "2011-11-04" for the validation "isAfter"
      ...
```

**Tests after**
```
      ...
      ✓ correctly specifies an instance as valid using a value of "f47ac10b-58cc-4372-a567-0e02b2c3d479" for the validation "isUUID" (42ms)
      ✓ correctly specifies an instance as invalid using a value of "not a date" for the validation "isDate"
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate"
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate"
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate"
      ✓ correctly specifies an instance as valid using a value of "2011-02-04" for the validation "isDate" (43ms)
      ✓ correctly specifies an instance as invalid using a value of "2011-11-04" for the validation "isAfter"
      ...
```