### PR TITLE
fix: sqlite find out deleteAt items problem

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -76,8 +76,9 @@ class Model {
     const deletedAtAttribute = model.rawAttributes[deletedAtCol];
     const deletedAtObject = {};
     let deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
+    const now = Utils.now(this.sequelize.options.dialect);
 
-    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gt: model.sequelize.literal('CURRENT_TIMESTAMP'), $eq: null } };
+    deletedAtDefaultValue = deletedAtDefaultValue || { $or: { $gt: now, $eq: null } };
 
     deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 


### PR DESCRIPTION
sqlite 1s 内可以查询已经删除的数据
`deleted_at` > CURRENT_TIMESTAMP 
`deleted_at` > 2017-08-26 16:36:19

`deleted_at` > now
`deleted_at` > 2017-08-26 16:36:19.836 +00:00

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
