### PR TITLE
fix(datatypes): don't stringify range bounds when infinite (fixes: #8…

### DIFF
--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -422,7 +422,10 @@ module.exports = BaseTypes => {
         this.toCastType();
     }
     const valuesStringified = values.map(value => {
-      if (this.options.subtype.stringify) {
+      if (_.includes([null, -Infinity, Infinity], value)) {
+        // Pass through "unbounded" bounds unchanged
+        return value;
+      } else if (this.options.subtype.stringify) {
         return this.options.subtype.stringify(value, options);
       } else {
         return options.escape(value);

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -103,6 +103,78 @@ if (dialect.match(/^postgres/)) {
         expect(Range.stringify(new Date(Date.UTC(2000, 1, 1)), { timezone: '+02:00' })).to.equal('\'2000-02-01 02:00:00.000 +02:00\'::timestamptz');
       });
 
+      describe('with null range bounds', () => {
+        const infiniteRange = [null, null];
+        const infiniteRangeSQL = "'[,)'";
+
+        it('should stringify integer range to infinite range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.INTEGER);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify bigint range to infinite range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.BIGINT);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify numeric range to infinite range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DECIMAL);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify dateonly ranges appropriately', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DATEONLY);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should be stringified to appropriate unbounded postgres range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DATEONLY);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify date values with appropriate casting', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DATE);
+          expect(Range.stringify(infiniteRange, { timezone: '+02:00' })).to.equal(infiniteRangeSQL);
+        });
+
+      });
+
+      describe('with infinite range bounds', () => {
+        const infiniteRange = [-Infinity, Infinity];
+        const infiniteRangeSQL = "'[-infinity,infinity)'";
+
+        it('should stringify integer range to infinite range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.INTEGER);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify bigint range to infinite range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.BIGINT);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify numeric range to infinite range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DECIMAL);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify dateonly ranges appropriately', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DATEONLY);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should be stringified to appropriate unbounded postgres range', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DATEONLY);
+          expect(Range.stringify(infiniteRange)).to.equal(infiniteRangeSQL);
+        });
+
+        it('should stringify date values with appropriate casting', () => {
+          const Range = new DataTypes.postgres.RANGE(DataTypes.DATE);
+          expect(Range.stringify(infiniteRange, { timezone: '+02:00' })).to.equal(infiniteRangeSQL);
+        });
+
+      });
+
     });
 
     describe('parse', () => {

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -673,6 +673,28 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           postgres: "\"Timeline\".\"range\" <@ '[\"2000-02-01 00:00:00.000 +00:00\",\"2000-03-01 00:00:00.000 +00:00\")'"
         });
 
+        testsql('unboundedRange', {
+          $contains: [new Date(Date.UTC(2000, 1, 1)), null]
+        }, {
+          field: {
+            type: new DataTypes.postgres.RANGE(DataTypes.DATE)
+          },
+          prefix: 'Timeline'
+        }, {
+          postgres: "\"Timeline\".\"unboundedRange\" @> '[\"2000-02-01 00:00:00.000 +00:00\",)'"
+        });
+
+        testsql('unboundedRange', {
+          $contains: [-Infinity, Infinity]
+        }, {
+          field: {
+            type: new DataTypes.postgres.RANGE(DataTypes.DATE)
+          },
+          prefix: 'Timeline'
+        }, {
+          postgres: "\"Timeline\".\"unboundedRange\" @> '[-infinity,infinity)'"
+        });
+
         testsql('reservedSeats', {
           $overlap: [1, 4]
         }, {


### PR DESCRIPTION
…192)

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [YES] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [YES] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [YES] Have you added new tests to prevent regressions?
- [N/A] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [YES] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Fix range bound processing logic in `RANGE.prototype.stringify` to pass through range bounds of `null` or `-Infinity`/`Infinity` unchanged (ie. dont' pass these values to the range subtype's stringify function). This allows `RANGE.stringify` to correctly identify these as infinite bounds and format the range SQL output correctly.
Fixes: #8192