### PR TITLE
fix(DATE type) Error:"date.indexOf is not a function"

### DIFF
--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -42,7 +42,7 @@ module.exports = BaseTypes => {
   inherits(DATE, BaseTypes.DATE);
 
   DATE.parse = function parse(date, options) {
-    if (date.indexOf('+') === -1) {
+    if (typeof date === 'string' && date.indexOf('+') === -1) {
       // For backwards compat. Dates inserted by sequelize < 2.0dev12 will not have a timestamp set
       return new Date(date + options.timezone);
     } else {


### PR DESCRIPTION
Fix issue of "TypeError: date.indexOf is not a function" in some cases.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
