### PR TITLE
feat(updateOnDuplicate): Add 'preserveValuesOnNull' option to bulkIns…

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -250,6 +250,9 @@ const QueryGenerator = {
       onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + options.updateOnDuplicate.map(attr => {
         const field = rawAttributes && rawAttributes[attr] && rawAttributes[attr].field || attr;
         const key = this.quoteIdentifier(field);
+        if (options.preserveValuesOnNull && options.preserveValuesOnNull.indexOf(attr) !== -1) {
+          return key + '=IF(VALUES(' + key +') IS NOT NULL, VALUES(' + key +'), ' + key +')';
+        }
         return key + '=VALUES(' + key + ')';
       }).join(',');
     }

--- a/lib/model.js
+++ b/lib/model.js
@@ -829,7 +829,7 @@ class Model {
     }
     this._hasReadOnlyAttributes = this._readOnlyAttributes && this._readOnlyAttributes.length;
     this._isReadOnlyAttribute = Utils._.memoize(key => this._hasReadOnlyAttributes && this._readOnlyAttributes.indexOf(key) !== -1);
-    
+
     this._addDefaultAttributes();
     this.refreshAttributes();
     this._findAutoIncrementAttribute();
@@ -847,7 +847,7 @@ class Model {
     });
 
     this.options.indexes = this.options.indexes.map(this._conformIndex);
-    
+
     this.sequelize.modelManager.addModel(this);
     this.sequelize.runHooks('afterDefine', this);
 
@@ -2243,6 +2243,7 @@ class Model {
    * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {Boolean}      [options.returning=false] Append RETURNING * to get back auto generated values (Postgres only)
    * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {Array}        [options.preserveValuesOnNull]   Fields to preserve current values if row key already exists (on duplicate key update) and the value in the record is NULL? (only supported by mysql). By default, no fields are preserved.
    *
    * @return {Promise<Array<Model>>}
    */
@@ -2255,7 +2256,7 @@ class Model {
       validate: false,
       hooks: true,
       individualHooks: false,
-      ignoreDuplicates: false
+      ignoreDuplicates: false,
     }, options || {});
 
     options.fields = options.fields || Object.keys(this.tableAttributes);
@@ -2267,6 +2268,9 @@ class Model {
     if (options.updateOnDuplicate && dialect !== 'mysql') {
       return Promise.reject(new Error(dialect + ' does not support the \'updateOnDuplicate\' option.'));
     }
+    if (options.preserveValuesOnNull && dialect !== 'mysql') {
+      return Promise.reject(new Error(dialect + ' does not support the \'preserveValuesOnNull\' option.'));
+    }
 
     if (options.updateOnDuplicate) {
       // By default, all attributes except 'createdAt' can be updated
@@ -2275,6 +2279,15 @@ class Model {
         updatableFields = Utils._.intersection(updatableFields, options.updateOnDuplicate);
       }
       options.updateOnDuplicate = updatableFields;
+    }
+
+    if (options.preserveValuesOnNull) {
+      // By default, all attributes except 'updatedAt' can be preserved
+      let preservableFields = Utils._.pull(Object.keys(this.tableAttributes), 'updatedAt');
+      if (Utils._.isArray(options.preserveValuesOnNull) && !Utils._.isEmpty(options.preserveValuesOnNull)) {
+        preservableFields = Utils._.intersection(preservableFields, options.preserveValuesOnNull);
+      }
+      options.preserveValuesOnNull = preservableFields;
     }
 
     options.model = this;

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -479,6 +479,9 @@ if (dialect === 'mysql') {
         }, {
           arguments: ['myTable', [{name: 'foo'}, {name: 'bar'}], {updateOnDuplicate: ['name']}],
           expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON DUPLICATE KEY UPDATE `name`=VALUES(`name`);"
+        }, {
+          arguments: ['myTable', [{name: 'foo'}, {name: 'bar'}], {updateOnDuplicate: ['name'], preserveValuesOnNull: ['name']}],
+          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON DUPLICATE KEY UPDATE `name`=IF(VALUES(`name`) IS NOT NULL, VALUES(`name`), `name`);"
         }
       ],
 

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -116,5 +116,40 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           mysql:'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);'
         });
     });
+
+    it('bulk create with preserveValuesOnNull', () => {
+      // Skip mssql for now, it seems broken
+      if (Support.getTestDialect() === 'mssql') {
+        return;
+      }
+
+      const User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name'
+        },
+        password: {
+          type: DataTypes.STRING,
+          field: 'pass_word'
+        },
+        createdAt: {
+          type: DataTypes.DATE,
+          field: 'created_at'
+        },
+        updatedAt: {
+          type: DataTypes.DATE,
+          field: 'updated_at'
+        }
+      }, {
+        timestamps:true
+      });
+
+      expectsql(sql.bulkInsertQuery(User.tableName, [{ user_name: 'testuser', pass_word: '12345' }], { updateOnDuplicate: ['username', 'password', 'createdAt'], preserveValuesOnNull: ['username', 'password', 'createdAt'] }, User.rawAttributes),
+        {
+          default:'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
+          postgres:'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\');',
+          mysql:'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=IF(VALUES(`user_name`) IS NOT NULL, VALUES(`user_name`), `user_name`),`pass_word`=IF(VALUES(`pass_word`) IS NOT NULL, VALUES(`pass_word`), `pass_word`),`created_at`=IF(VALUES(`created_at`) IS NOT NULL, VALUES(`created_at`), `created_at`);'
+        });
+    });
   });
 });


### PR DESCRIPTION
…ert to prevent NULLing of data during updateOnDuplicate (#8237)

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does your issue contain a link to existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Have you added an entry under `Future` in the changelog?

_NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._

### Description of change

Added preserveValuesOnNull option for bulkInsert to prevent NULLing of existing data when the database has more data than the record used for update.

Resolves [#7462](https://github.com/sequelize/sequelize/issues/8237)