### PR TITLE
fix(sequelize/query): release connection after retry

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -529,11 +529,12 @@ class Sequelize {
     }).then(connection => {
       const query = new this.dialect.Query(connection, this, options);
 
-      return retry(() => query.run(sql, bindParameters).finally(() => {
-        if (!options.transaction) {
-          return this.connectionManager.releaseConnection(connection);
-        }
-      }), Utils._.extend(this.options.retry, options.retry || {}));
+      return retry(() => query.run(sql, bindParameters), Utils._.extend(this.options.retry, options.retry || {}))
+        .finally(() => {
+          if (!options.transaction) {
+            return this.connectionManager.releaseConnection(connection);
+          }
+        });
     }).finally(() => {
       if (this.test._trackRunningQueries) {
         this.test._runningQueries--;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -528,8 +528,9 @@ class Sequelize {
       return options.transaction ? options.transaction.connection : this.connectionManager.getConnection(options);
     }).then(connection => {
       const query = new this.dialect.Query(connection, this, options);
+      const retryOptions = Utils._.extend(this.options.retry, options.retry || {});
 
-      return retry(() => query.run(sql, bindParameters), Utils._.extend(this.options.retry, options.retry || {}))
+      return retry(() => query.run(sql, bindParameters), retryOptions)
         .finally(() => {
           if (!options.transaction) {
             return this.connectionManager.releaseConnection(connection);

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -728,26 +728,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
     });
 
-    it('connection should be released only once when retry fails', function() {
-      const spy = this.sequelize.connectionManager.releaseConnection = sinon.spy(this.sequelize.connectionManager.releaseConnection);
-      return this.sequelize.query('THIS IS A WRONG SQL', {
-        retry: {
-          max: 2,
-          // retry for all errors
-          match: null
-        }
-      }).catch(err => {
-        // If the connection is released multiple times,
-        // than an Error(not Sequelize BaseError) will be raised by generic-pool.
-        // If the connection is released only once,
-        // then a DatabaseError which inherits Sequelize BaseError will be raised,
-        // because this is a wrong sql.
-        expect(err).to.be.an.instanceof(this.sequelize.Error);
-      }).finally(() => {
-        expect(spy).to.have.been.calledOnce;
-      });
-    });
-
     if (Support.getTestDialect() === 'postgres') {
       it('replaces named parameters with the passed object and ignores casts', function() {
         return expect(this.sequelize.query('select :one as foo, :two as bar, \'1000\'::integer as baz', { raw: true, replacements: { one: 1, two: 2 } }).get(0))

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -728,7 +728,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
     });
 
-    it('connections should be released only once', function() {
+    it('connection should be released only once when retry fails', function() {
+      const spy = this.sequelize.connectionManager.releaseConnection = sinon.spy(this.sequelize.connectionManager.releaseConnection);
       return this.sequelize.query('THIS IS A WRONG SQL', {
         retry: {
           max: 2,
@@ -742,6 +743,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         // then a DatabaseError which inherits Sequelize BaseError will be raised,
         // because this is a wrong sql.
         expect(err).to.be.an.instanceof(this.sequelize.Error);
+      }).finally(() => {
+        expect(spy).to.have.been.calledOnce;
       });
     });
 

--- a/test/unit/query.test.js
+++ b/test/unit/query.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const chai = require('chai'),
+  sinon = require('sinon'),
+  expect = chai.expect,
+  Support = require(__dirname + '/support'),
+  Sequelize = Support.Sequelize,
+  Promise = Sequelize.Promise,
+  current = Support.sequelize;
+
+describe('sequelize.query', () => {
+  it('connection should be released only once when retry fails', () => {
+    const getConnectionStub = sinon.stub(current.connectionManager, 'getConnection', () => {
+      return Promise.resolve({});
+    });
+    const releaseConnectionStub = sinon.stub(current.connectionManager, 'releaseConnection', () => {
+      return Promise.resolve();
+    });
+    const queryStub = sinon.stub(current.dialect.Query.prototype, 'run', () => {
+      return Promise.reject(new Error('wrong sql'));
+    });
+    return current.query('THIS IS A WRONG SQL', {
+      retry: {
+        max: 2,
+        // retry for all errors
+        match: null
+      }
+    })
+      .catch(() => {})
+      .finally(() => {
+        expect(releaseConnectionStub).have.been.calledOnce;
+        queryStub.restore();
+        getConnectionStub.restore();
+        releaseConnectionStub.restore();
+      });
+  });
+});


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Connections should be release after retry rather than being released after every query.
It will cause `'Resource not currently part of this pool'` error if it's released after every query.

In v3, sequelize use `coopernurse/node-pool@2.4.8` which won't raise a error if a connection is released multiple times. See here [https://github.com/coopernurse/node-pool/blob/v2.4/lib/generic-pool.js#L420](https://github.com/coopernurse/node-pool/blob/v2.4/lib/generic-pool.js#L420)

But in v4, sequelize use new version of `coopernurse/node-pool` which will return a rejected promise if a connection is released multiple times. See here [https://github.com/coopernurse/node-pool/blob/master/lib/Pool.js#L422](https://github.com/coopernurse/node-pool/blob/master/lib/Pool.js#L422).

Because of this error, if you are using retry, you will get `'Resource not currently part of this pool'` when got every sql error. You can not get a normal sql error which shows you what is wrong.
