### PR TITLE
docs(hooks): some refinements of hooks declarations

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -102,7 +102,7 @@ Book.addHook('afterCreate', 'notifyUsers', (book, options) => {
 Book.removeHook('afterCreate', 'notifyUsers');
 ```
 
-You could have many hooks with the same name. If so they would all be removed on `.removeHook()` call.
+You can have many hooks with same name. Calling `.removeHook()` will remove all of them.
 
 ## Global / universal hooks
 Global hooks are hooks which are run for all models. They can define behaviours that you want for all your models, and are especially useful for plugins. They can be defined in two ways, which have slightly different semantics:

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -65,12 +65,12 @@ const User = sequelize.define('user', {
   }
 });
 
-// Method 2 via the .hook() method
+// Method 2 via the .hook() method (or it's alias .addHook() method)
 User.hook('beforeValidate', (user, options) => {
   user.mood = 'happy';
 });
 
-User.hook('afterValidate', (user, options) => {
+User.addHook('afterValidate', 'someCustomName', (user, options) => {
   return sequelize.Promise.reject(new Error("I'm afraid I can't let you do that!"));
 });
 
@@ -101,6 +101,8 @@ Book.addHook('afterCreate', 'notifyUsers', (book, options) => {
 
 Book.removeHook('afterCreate', 'notifyUsers');
 ```
+
+You could have many hooks with the same name. If so they would all be removed on `.removeHook()` call.
 
 ## Global / universal hooks
 Global hooks are hooks which are run for all models. They can define behaviours that you want for all your models, and are especially useful for plugins. They can be defined in two ways, which have slightly different semantics:


### PR DESCRIPTION
https://github.com/sequelize/sequelize/issues/7784
1. A note that `.addHook()` is an alias to `.hook()`
2. Add an example of hook declaration with name parameter
3. Add a note that there would be no conflict if multiple hooks would have the same name