### PR TITLE
Added 'field' parameter to this.escape call for '$in' query building (Fixes #8261)

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2221,7 +2221,7 @@ const QueryGenerator = {
       if ((value.$in || value.$notIn) instanceof Utils.Literal) {
         value = (value.$in || value.$notIn).val;
       } else if ((value.$in || value.$notIn).length) {
-        value = '('+(value.$in || value.$notIn).map(item => this.escape(item)).join(', ')+')';
+        value = '('+(value.$in || value.$notIn).map(item => this.escape(item, field)).join(', ')+')';
       } else {
         if (value.$in) {
           value = '(NULL)';


### PR DESCRIPTION
Added 'field' parameter to this.escape call for '$in' query building (Closes #8261)

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

See #8261 
