### PR TITLE
fix(abstract/querygenerator): remove duplicated order expression on outer query

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1680,8 +1680,9 @@ const QueryGenerator = {
           && !(typeof order[0] === 'string' && model && model.associations !== undefined && model.associations[order[0]])
         ) {
           subQueryOrder.push(this.quote(order, model, '->'));
+        } else {
+          mainQueryOrder.push(this.quote(order, model, '->'));
         }
-        mainQueryOrder.push(this.quote(order, model, '->'));
       }
     } else if (options.order instanceof Utils.SequelizeMethod) {
       const sql = this.quote(options.order, model, '->');

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -295,7 +295,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +
                        'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC' +
                        sql.addLimitAndOffset({ limit: 30, offset:10, order: [['`user`.`last_name`', 'ASC']]}) +
-                   ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;'
+                   ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id];'
       });
 
       const nestedInclude = Model._validateIncludedElements({


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

There is a bug https://github.com/sequelize/sequelize/issues/8275 and it may be fixed by just removing part of SQL statement that looks like redundant (at list for me)

The point of change is that now `order` statement is applying to both main query and sub query. It looks like there is no need for second `order`ing. Also this would also fix a mentioned bug