### PR TITLE
fix(queryGenerator): fix error in createTrigger when is executed with…

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -713,11 +713,11 @@ const QueryGenerator = {
         'truncate': 'TRUNCATE'
       };
 
-      if (!Utils._.has(EVENT_MAP, fireKey)) {
+      if (!Utils._.has(EVENT_MAP, fireValue)) {
         throw new Error('parseTriggerEventSpec: undefined trigger event ' + fireKey);
       }
 
-      let eventSpec = EVENT_MAP[fireKey];
+      let eventSpec = EVENT_MAP[fireValue];
       if (eventSpec === 'UPDATE') {
         if (Utils._.isArray(fireValue) && fireValue.length > 0) {
           eventSpec += ' OF ' + fireValue.join(', ');

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -422,7 +422,7 @@ if (dialect.match(/^postgres/)) {
         }, {
           title: 'string in array should escape \' as \'\'',
           arguments: ['myTable', {where: { aliases: {$contains: ['Queen\'s']} }}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"aliases\" @> ARRAY['Queen''s'];",
+          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"aliases\" @> ARRAY['Queen''s'];"
         },
 
         // Variants when quoteIdentifiers is false
@@ -904,6 +904,25 @@ if (dialect.match(/^postgres/)) {
           expectation: 'ROLLBACK TO SAVEPOINT \"transaction-uid\";',
           context: {options: {quoteIdentifiers: true}}
         }
+      ],
+
+      createTrigger: [
+        {
+          arguments: ['myTable', 'myTrigger', 'after', ['insert'],  'myFunction', [], []],
+          expectation: 'CREATE TRIGGER myTrigger\n\tAFTER INSERT\n\tON myTable\n\t\n\tEXECUTE PROCEDURE myFunction();'
+        },
+        {
+          arguments: ['myTable', 'myTrigger', 'before', ['insert', 'update'],  'myFunction', [{name: 'bar', type: 'INTEGER'}], []],
+          expectation: 'CREATE TRIGGER myTrigger\n\tBEFORE INSERT OR UPDATE\n\tON myTable\n\t\n\tEXECUTE PROCEDURE myFunction(bar INTEGER);'
+        },
+        {
+          arguments: ['myTable', 'myTrigger', 'instead_of', ['insert', 'update'],  'myFunction', [], ['FOR EACH ROW']],
+          expectation: 'CREATE TRIGGER myTrigger\n\tINSTEAD OF INSERT OR UPDATE\n\tON myTable\n\t\n\tFOR EACH ROW\n\tEXECUTE PROCEDURE myFunction();'
+        },
+        {
+          arguments: ['myTable', 'myTrigger', 'after_constraint', ['insert', 'update'],  'myFunction', [{name: 'bar', type: 'INTEGER'}], ['FOR EACH ROW']],
+          expectation:'CREATE CONSTRAINT TRIGGER myTrigger\n\tAFTER INSERT OR UPDATE\n\tON myTable\n\t\n\tFOR EACH ROW\n\tEXECUTE PROCEDURE myFunction(bar INTEGER);'
+        }
       ]
     };
 
@@ -924,6 +943,7 @@ if (dialect.match(/^postgres/)) {
               if (_.isFunction(test.arguments[1])) test.arguments[1] = test.arguments[1](this.sequelize);
               if (_.isFunction(test.arguments[2])) test.arguments[2] = test.arguments[2](this.sequelize);
             }
+
             QueryGenerator.options = _.assign(context.options, { timezone: '+00:00' });
             QueryGenerator._dialect = this.sequelize.dialect;
             QueryGenerator.sequelize = this.sequelize;


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ X] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

_Fixed `Error: parseTriggerEventSpec: undefined trigger event 0` when the [QueryGenerator.createTrigger function](https://github.com/sequelize/sequelize/blob/master/lib/dialects/postgres/query-generator.js#L590) is executed in postgres dialect with correct args._

_Solution: modify the [expandTriggerEventSpec](https://github.com/sequelize/sequelize/blob/master/lib/dialects/postgres/query-generator.js#L716) function_

```javascript

 expandTriggerEventSpec(fireOnSpec) {
    if (Utils._.isEmpty(fireOnSpec)) {
      throw new Error('no table change events specified to trigger on');
    }

    return Utils._.map(fireOnSpec, (fireValue, fireKey) => {
      const EVENT_MAP = {
        'insert': 'INSERT',
        'update': 'UPDATE',
        'delete': 'DELETE',
        'truncate': 'TRUNCATE'
      };
       // Replace fireKey with fireValue
      if (!Utils._.has(EVENT_MAP, fireKey)) {
        throw new Error('parseTriggerEventSpec: undefined trigger event ' + fireKey);
      }

      let eventSpec = EVENT_MAP[fireKey];
      if (eventSpec === 'UPDATE') {
        if (Utils._.isArray(fireValue) && fireValue.length > 0) {
          eventSpec += ' OF ' + fireValue.join(', ');
        }
      }

      return eventSpec;
    }).join(' OR ');
  },
```
[By](https://github.com/sequelize/sequelize/blob/master/lib/dialects/postgres/query-generator.js#L716)

```javascript

expandTriggerEventSpec(fireOnSpec) {
    if (Utils._.isEmpty(fireOnSpec)) {
      throw new Error('no table change events specified to trigger on');
    }

    return Utils._.map(fireOnSpec, (fireValue, fireKey) => {
      const EVENT_MAP = {
        'insert': 'INSERT',
        'update': 'UPDATE',
        'delete': 'DELETE',
        'truncate': 'TRUNCATE'
      };

      if (!Utils._.has(EVENT_MAP, fireValue)) {
        throw new Error('parseTriggerEventSpec: undefined trigger event ' + fireKey);
      }

      let eventSpec = EVENT_MAP[fireValue];
      if (eventSpec === 'UPDATE') {
        if (Utils._.isArray(fireValue) && fireValue.length > 0) {
          eventSpec += ' OF ' + fireValue.join(', ');
        }
      }

      return eventSpec;
    }).join(' OR ');
  },

```

And added [unit test for postgres dialect](https://github.com/madoos/sequelize/blob/feature/fix-postgres-query-generator-createTrigger/test/unit/dialects/postgres/query-generator.test.js#L909)

```javascript

createTrigger: [
        {
          arguments: ['myTable', 'myTrigger', 'after', ['insert'],  'myFunction', [], []],
          expectation: 'CREATE TRIGGER myTrigger\n\tAFTER INSERT\n\tON myTable\n\t\n\tEXECUTE PROCEDURE myFunction();'
        },
        {
          arguments: ['myTable', 'myTrigger', 'before', ['insert', 'update'],  'myFunction', [{name: 'bar', type: 'INTEGER'}], []],
          expectation: 'CREATE TRIGGER myTrigger\n\tBEFORE INSERT OR UPDATE\n\tON myTable\n\t\n\tEXECUTE PROCEDURE myFunction(bar INTEGER);'
        },
        {
          arguments: ['myTable', 'myTrigger', 'instead_of', ['insert', 'update'],  'myFunction', [], ['FOR EACH ROW']],
          expectation: 'CREATE TRIGGER myTrigger\n\tINSTEAD OF INSERT OR UPDATE\n\tON myTable\n\t\n\tFOR EACH ROW\n\tEXECUTE PROCEDURE myFunction();'
        },
        {
          arguments: ['myTable', 'myTrigger', 'after_constraint', ['insert', 'update'],  'myFunction', [{name: 'bar', type: 'INTEGER'}], ['FOR EACH ROW']],
          expectation:'CREATE CONSTRAINT TRIGGER myTrigger\n\tAFTER INSERT OR UPDATE\n\tON myTable\n\t\n\tFOR EACH ROW\n\tEXECUTE PROCEDURE myFunction(bar INTEGER);'
        }
      ]


```