### PR TITLE
code updates

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -725,6 +725,25 @@ const QueryGenerator = {
     });
   },
 
+  getCheckConstraintQuery(tableName, attributeName) {
+    const sql = 'SELECT name FROM SYS.CHECK_CONSTRAINTS ' +
+      "WHERE PARENT_OBJECT_ID = OBJECT_ID('<%= table %>', 'U') " +
+      "AND PARENT_COLUMN_ID = (SELECT column_id FROM sys.columns WHERE NAME = ('<%= column %>') " +
+      "AND object_id = OBJECT_ID('<%= table %>', 'U'));";
+    return Utils._.template(sql)({
+      table: this.quoteTable(tableName),
+      column: attributeName
+    });
+  },
+
+  dropCheckConstraintQuery(tableName, constraintName) {
+    const sql = 'ALTER TABLE <%= table %> DROP CONSTRAINT <%= constraint %>;';
+    return Utils._.template(sql)({
+      table: this.quoteTable(tableName),
+      constraint: this.quoteIdentifier(constraintName)
+    });
+  },
+
   setAutocommitQuery() {
     return '';
   },

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -58,6 +58,18 @@ const removeColumn = function(tableName, attributeName, options) {
       return this.sequelize.query(dropConstraintSql, options);
     })
     .then(() => {
+      //Check if the current column has a Check constraint (ENUMS)
+      const checkConstraintSql = this.QueryGenerator.getCheckConstraintQuery(tableName, attributeName);
+      return this.sequelize.query(checkConstraintSql, options);
+    })
+    .spread(result => {
+      if (!result.length) {
+        return;
+      }
+      const dropCheckConstraintSql = this.QueryGenerator.dropCheckConstraintQuery(tableName, result[0].name);
+      return this.sequelize.query(dropCheckConstraintSql, options);
+    })
+    .then(() => {
       const removeSql = this.QueryGenerator.removeColumnQuery(tableName, attributeName);
       return this.sequelize.query(removeSql, options);
     });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? no: on master, npm install would give an error and so would npm run test and npm run test-mssql. I did test this with a simple code (same as in bug report https://github.com/sequelize/sequelize/issues/8312)
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? yes
- [x] Have you added new tests to prevent regressions? no
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? No need
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md? NO

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Closes #8312 
In order to fix issue #8312 , I had to include in the `removeColumn` wrapper a step to remove any CHECK constraints on the column. CHECK constraints are added on `ENUM` columns (created as `VARCHAR`) and prevent the column to be dropped similarly to default value constraints.
I added in `lib/dialects/mssql/query-generator.js` two methods:
* `getCheckConstraintQuery` (line 728)
* `dropCheckConstraintQuery` (line 739)
and in `lib/dialects/mssql/query-interface.js` I added the necessary steps to check the constraints and drop them in the same way as the other constraints are.
<!-- Please provide a description of the change here. -->
