### PR TITLE
fix(abstract/connection-manager): acquire call never finishes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,7 @@ env:
     - SEQ_PG_PORT=8998
 
 before_script:
-  # mount ramdisk
-  - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then sudo mkdir /mnt/sequelize-ramdisk; fi"
-  - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then sudo mount -t ramfs tmpfs /mnt/sequelize-ramdisk; fi"
-  # setup docker
+   # setup docker
   - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then docker-compose up -d ${POSTGRES_VER} ${MYSQL_VER}; fi"
   - "if [ $MYSQL_VER ]; then docker run --link ${MYSQL_VER}:db -e CHECK_PORT=3306 -e CHECK_HOST=db --net sequelize_default giorgos/takis; fi"
   - "if [ $POSTGRES_VER ]; then docker run --link ${POSTGRES_VER}:db -e CHECK_PORT=5432 -e CHECK_HOST=db --net sequelize_default giorgos/takis; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ env:
     - SEQ_PG_PORT=8998
 
 before_script:
+  # mount ramdisk
+  - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then sudo mkdir /mnt/sequelize-ramdisk; fi"
+  - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then sudo mount -t ramfs tmpfs /mnt/sequelize-ramdisk; fi"
    # setup docker
   - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then docker-compose up -d ${POSTGRES_VER} ${MYSQL_VER}; fi"
   - "if [ $MYSQL_VER ]; then docker run --link ${MYSQL_VER}:db -e CHECK_PORT=3306 -e CHECK_HOST=db --net sequelize_default giorgos/takis; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_script:
   # mount ramdisk
   - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then sudo mkdir /mnt/sequelize-ramdisk; fi"
   - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then sudo mount -t ramfs tmpfs /mnt/sequelize-ramdisk; fi"
-   # setup docker
+  # setup docker
   - "if [ $POSTGRES_VER ] || [ $MYSQL_VER ]; then docker-compose up -d ${POSTGRES_VER} ${MYSQL_VER}; fi"
   - "if [ $MYSQL_VER ]; then docker run --link ${MYSQL_VER}:db -e CHECK_PORT=3306 -e CHECK_HOST=db --net sequelize_default giorgos/takis; fi"
   - "if [ $POSTGRES_VER ]; then docker run --link ${POSTGRES_VER}:db -e CHECK_PORT=5432 -e CHECK_HOST=db --net sequelize_default giorgos/takis; fi"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       POSTGRES_USER: sequelize_test
       POSTGRES_PASSWORD: sequelize_test
       POSTGRES_DB: sequelize_test
-    volumes:
-      - /mnt/sequelize-ramdisk:/var/lib/postgresql/data
     ports:
       - "127.0.0.1:8998:5432"
     container_name: postgres-95
@@ -34,8 +32,6 @@ services:
       MYSQL_DATABASE: sequelize_test
       MYSQL_USER: sequelize_test
       MYSQL_PASSWORD: sequelize_test
-    volumes:
-      - /mnt/sequelize-ramdisk:/var/lib/mysql
     ports:
       - "127.0.0.1:8999:3306"
     container_name: mysql-57

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     links:
      - mysql-57
      - postgres-95
+     - mssql
     volumes:
       - .:/sequelize
     environment:
@@ -20,6 +21,8 @@ services:
       POSTGRES_USER: sequelize_test
       POSTGRES_PASSWORD: sequelize_test
       POSTGRES_DB: sequelize_test
+    volumes:
+      - /mnt/sequelize-ramdisk:/var/lib/postgresql/data
     ports:
       - "127.0.0.1:8998:5432"
     container_name: postgres-95
@@ -32,6 +35,18 @@ services:
       MYSQL_DATABASE: sequelize_test
       MYSQL_USER: sequelize_test
       MYSQL_PASSWORD: sequelize_test
+    volumes:
+      - /mnt/sequelize-ramdisk:/var/lib/mysql
     ports:
       - "127.0.0.1:8999:3306"
     container_name: mysql-57
+
+  # MSSQL
+  mssql:
+    image: microsoft/mssql-server-linux:latest
+    environment:
+      ACCEPT_EULA: "Y"
+      SA_PASSWORD: yourStrong(!)Password
+    ports:
+      - "127.0.0.1:8997:1433"
+    container_name: mssql

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -261,17 +261,13 @@ class ConnectionManager {
    * @param {Object|Error} mayBeConnection Object which can be either connection or error
    */
   _determineConnection(mayBeConnection) {
-    return new Promise((resolve, reject) => {
-      if (mayBeConnection instanceof Error) {
-        return this.pool.destroy(mayBeConnection)
-          .then(() => { reject(mayBeConnection); })
-          .catch(/Resource not currently part of this pool/, () => {
-            reject(mayBeConnection);
-          });
-      }
+    if (mayBeConnection instanceof Error) {
+      return Promise.resolve(this.pool.destroy(mayBeConnection))
+        .catch(/Resource not currently part of this pool/, () => {})
+        .then(() => { throw mayBeConnection; });
+    }
 
-      return resolve(mayBeConnection);
-    });
+    return Promise.resolve(mayBeConnection);
   }
 
   _connect(config) {

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -44,8 +44,8 @@ class ConnectionManager {
     }) ;
 
     // Save a reference to the bound version so we can remove it with removeListener
-    this.onProcessExit = this.onProcessExit.bind(this);
-    process.on('exit', this.onProcessExit);
+    this._onProcessExit = this._onProcessExit.bind(this);
+    process.on('exit', this._onProcessExit);
 
     this.initPools();
   }
@@ -62,7 +62,13 @@ class ConnectionManager {
     });
   }
 
-  onProcessExit() {
+  /**
+   * Handler which executes on process exit or connection manager shutdown
+   *
+   * @private
+   * @return {Promise}
+   */
+  _onProcessExit() {
     if (!this.pool) {
       return Promise.resolve();
     }
@@ -73,18 +79,27 @@ class ConnectionManager {
     });
   }
 
+  /**
+   * Drain the pool and close it permanently
+   *
+   * @return {Promise}
+   */
   close() {
     // Remove the listener, so all references to this instance can be garbage collected.
-    process.removeListener('exit', this.onProcessExit);
+    process.removeListener('exit', this._onProcessExit);
 
     // Mark close of pool
     this.getConnection = function getConnection() {
       return Promise.reject(new Error('ConnectionManager.getConnection was called after the connection manager was closed!'));
     };
 
-    return this.onProcessExit();
+    return this._onProcessExit();
   }
 
+  /**
+   * Initialize connection pool. By default pool autostart is set to false, so no connection will be
+   * be created unless `pool.acquire` is called.
+   */
   initPools() {
     const config = this.config;
 
@@ -217,6 +232,17 @@ class ConnectionManager {
     debug(`pool created with max/min: ${config.pool.max}/${config.pool.min}, with replication`);
   }
 
+  /**
+   * Get connection from pool. It set database version if its not already set.
+   * Call pool.acquire to get a connection
+   *
+   * @param {Object}   [options]                 Pool options
+   * @param {Integer}  [options.priority]        Set priority for this call. Read more at https://github.com/coopernurse/node-pool#priority-queueing
+   * @param {String}   [options.type]            Set which replica to use. Available options are `read` and `write`
+   * @param {Boolean}  [options.useMaster=false] Force master or write replica to get connection from
+   *
+   * @return {Promise<Connection>}
+   */
   getConnection(options) {
     options = options || {};
 
@@ -255,6 +281,13 @@ class ConnectionManager {
     });
   }
 
+  /**
+   * Release a pooled connection so it can be utilized by other connection requests
+   *
+   * @param {Connection} connection
+   *
+   * @return {Promise}
+   */
   releaseConnection(connection) {
     return this.pool.release(connection)
       .tap(() => { debug('connection released'); })
@@ -266,6 +299,8 @@ class ConnectionManager {
    * Why we need to do this https://github.com/sequelize/sequelize/pull/8330
    *
    * @param {Object|Error} mayBeConnection Object which can be either connection or error
+   *
+   * @retun {Promise<Connection>}
    */
   _determineConnection(mayBeConnection) {
     if (mayBeConnection instanceof Error) {
@@ -277,16 +312,37 @@ class ConnectionManager {
     return Promise.resolve(mayBeConnection);
   }
 
+  /**
+   * Call dialect library to get connection
+   *
+   * @param {*} config Connection config
+   * @private
+   * @return {Promise<Connection>}
+   */
   _connect(config) {
     return this.sequelize.runHooks('beforeConnect', config)
       .then(() => this.dialect.connectionManager.connect(config))
       .then(connection => this.sequelize.runHooks('afterConnect', connection, config).return(connection));
   }
 
+  /**
+   * Call dialect library to disconnect a connection
+   *
+   * @param {Connection} connection
+   * @private
+   * @return {Promise}
+   */
   _disconnect(connection) {
     return this.dialect.connectionManager.disconnect(connection);
   }
 
+  /**
+   * Determine if a connection is still valid or not
+   *
+   * @param {Connection} connection
+   *
+   * @return {Boolean}
+   */
   _validate(connection) {
     if (!this.dialect.connectionManager.validate) {
       return true;

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -271,24 +271,26 @@ class ConnectionManager {
   }
 
   _connect(config) {
-    return new Promise(resolve => {
-      this.sequelize.runHooks('beforeConnect', config)
-        .then(() => this.dialect.connectionManager.connect(config))
-        .then(connection => this.sequelize.runHooks('afterConnect', connection, config).return(connection))
-        .then(connection => resolve(connection))
-        .catch(e => { resolve(e); });
-    });
+    return this.sequelize.runHooks('beforeConnect', config)
+      .then(() => this.dialect.connectionManager.connect(config))
+      .then(connection => this.sequelize.runHooks('afterConnect', connection, config).return(connection))
+      .catch(error => { return error; });
   }
 
   _disconnect(connection) {
     // hacky, _determineConnection could send Error instance for disconnection
-    if (connection instanceof Error) return Promise.resolve();
+    if (connection instanceof Error) {
+      return Promise.resolve();
+    }
 
     return this.dialect.connectionManager.disconnect(connection);
   }
 
   _validate(connection) {
-    if (!this.dialect.connectionManager.validate) return true;
+    if (!this.dialect.connectionManager.validate) {
+      return true;
+    }
+
     return this.dialect.connectionManager.validate(connection);
   }
 }

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -6,7 +6,6 @@ const _ = require('lodash');
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('pool');
 const semver = require('semver');
-const timers = require('timers');
 
 const defaultPoolingConfig = {
   max: 5,
@@ -17,6 +16,14 @@ const defaultPoolingConfig = {
   handleDisconnects: true
 };
 
+/**
+ * Abstract Connection Manager
+ *
+ * Connection manager which handles pool, replication and determining database versions
+ * Works with generic-pool to maintain connection pool
+ *
+ * @private
+ */
 class ConnectionManager {
   constructor(dialect, sequelize) {
     const config = _.cloneDeep(sequelize.config);
@@ -25,7 +32,6 @@ class ConnectionManager {
     this.config = config;
     this.dialect = dialect;
     this.versionPromise = null;
-    this.poolError = null;
     this.dialectName = this.sequelize.options.dialect;
 
     if (config.pool === false) {
@@ -39,7 +45,6 @@ class ConnectionManager {
 
     // Save a reference to the bound version so we can remove it with removeListener
     this.onProcessExit = this.onProcessExit.bind(this);
-
     process.on('exit', this.onProcessExit);
 
     this.initPools();
@@ -85,20 +90,7 @@ class ConnectionManager {
 
     if (!config.replication) {
       this.pool = Pooling.createPool({
-        create: () => new Promise(resolve => {
-          this
-            ._connect(config)
-            .tap(() => {
-              this.poolError = null;
-            })
-            .then(resolve)
-            .catch(e => {
-              // dont throw otherwise pool will release _dispense call
-              // which will call _connect even if error is fatal
-              // https://github.com/coopernurse/node-pool/issues/161
-              this.poolError = e;
-            });
-        }),
+        create: () => this._connect(config),
         destroy: connection => {
           return this._disconnect(connection).tap(() => {
             debug('connection destroy');
@@ -107,20 +99,17 @@ class ConnectionManager {
         validate: config.pool.validate
       }, {
         Promise: config.pool.Promise,
-        max: config.pool.max,
-        min: config.pool.min,
         testOnBorrow: true,
         autostart: false,
+        max: config.pool.max,
+        min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
         evictionRunIntervalMillis: config.pool.evict
       });
 
-      this.pool.on('factoryCreateError', error => {
-        this.poolError = error;
-      });
+      debug(`pool created with max/min: ${config.pool.max}/${config.pool.min}, no replication`);
 
-      debug(`pool created max/min: ${config.pool.max}/${config.pool.min} with no replication`);
       return;
     }
 
@@ -150,9 +139,11 @@ class ConnectionManager {
       acquire: (priority, queryType, useMaster) => {
         useMaster = _.isUndefined(useMaster) ? false : useMaster;
         if (queryType === 'SELECT' && !useMaster) {
-          return this.pool.read.acquire(priority);
+          return this.pool.read.acquire(priority)
+            .then(mayBeConnection => this._determineConnection(mayBeConnection));
         } else {
-          return this.pool.write.acquire(priority);
+          return this.pool.write.acquire(priority)
+            .then(mayBeConnection => this._determineConnection(mayBeConnection));
         }
       },
       destroy: connection => {
@@ -175,69 +166,47 @@ class ConnectionManager {
       read: Pooling.createPool({
         create: () => {
           const nextRead = reads++ % config.replication.read.length; // round robin config
-          return new Promise(resolve => {
-            this
-              ._connect(config.replication.read[nextRead])
-              .tap(connection => {
-                connection.queryType = 'read';
-                this.poolError = null;
-                resolve(connection);
-              })
-              .catch(e => {
-                this.poolError = e;
-              });
-          });
+          return this
+            ._connect(config.replication.read[nextRead])
+            .tap(connection => {
+              connection.queryType = 'read';
+            });
         },
-        destroy: connection => {
-          return this._disconnect(connection);
-        },
+        destroy: connection => this._disconnect(connection),
         validate: config.pool.validate
       }, {
         Promise: config.pool.Promise,
-        max: config.pool.max,
-        min: config.pool.min,
         testOnBorrow: true,
         autostart: false,
+        max: config.pool.max,
+        min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
         evictionRunIntervalMillis: config.pool.evict
       }),
       write: Pooling.createPool({
-        create: () => new Promise(resolve => {
-          this
+        create: () => {
+          return this
             ._connect(config.replication.write)
-            .then(connection => {
+            .tap(connection => {
               connection.queryType = 'write';
-              this.poolError = null;
-              return resolve(connection);
-            })
-            .catch(e => {
-              this.poolError = e;
             });
-        }),
-        destroy: connection => {
-          return this._disconnect(connection);
         },
+        destroy: connection => this._disconnect(connection),
         validate: config.pool.validate
       }, {
         Promise: config.pool.Promise,
-        max: config.pool.max,
-        min: config.pool.min,
         testOnBorrow: true,
         autostart: false,
+        max: config.pool.max,
+        min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
         evictionRunIntervalMillis: config.pool.evict
       })
     };
 
-    this.pool.read.on('factoryCreateError', error => {
-      this.poolError = error;
-    });
-
-    this.pool.write.on('factoryCreateError', error => {
-      this.poolError = error;
-    });
+    debug(`pool created with max/min: ${config.pool.max}/${config.pool.min}, with replication`);
   }
 
   getConnection(options) {
@@ -248,56 +217,65 @@ class ConnectionManager {
       if (this.versionPromise) {
         promise = this.versionPromise;
       } else {
-        promise = this.versionPromise = this._connect(this.config.replication.write || this.config).then(connection => {
-          const _options = {};
-          _options.transaction = {connection}; // Cheat .query to use our private connection
-          _options.logging = () => {};
-          _options.logging.__testLoggingFn = true;
+        promise = this.versionPromise = this._connect(this.config.replication.write || this.config)
+          .then(mayBeConnection => this._determineConnection(mayBeConnection))
+          .then(connection => {
+            const _options = {};
 
-          return this.sequelize.databaseVersion(_options).then(version => {
-            this.sequelize.options.databaseVersion = semver.valid(version) ? version : this.defaultVersion;
+            _options.transaction = {connection}; // Cheat .query to use our private connection
+            _options.logging = () => {};
+            _options.logging.__testLoggingFn = true;
+
+            return this.sequelize.databaseVersion(_options).then(version => {
+              this.sequelize.options.databaseVersion = semver.valid(version) ? version : this.defaultVersion;
+              this.versionPromise = null;
+
+              return this._disconnect(connection);
+            });
+          }).catch(err => {
             this.versionPromise = null;
-
-            return this._disconnect(connection);
+            throw err;
           });
-        }).catch(err => {
-          this.versionPromise = null;
-          throw err;
-        });
       }
     } else {
       promise = Promise.resolve();
     }
 
     return promise.then(() => {
-      return Promise.race([
-        this.pool.acquire(options.priority, options.type, options.useMaster),
-        new Promise((resolve, reject) =>
-          timers.setTimeout(() => {
-            if (this.poolError) {
-              reject(this.poolError);
-            }
-          }, 0))
-      ])
-        .tap(() => { debug('connection acquired'); })
-        .catch(e => {
-          e = this.poolError || e;
-          this.poolError = null;
-          throw e;
-        });
+      return this.pool.acquire(options.priority, options.type, options.useMaster)
+        .then(mayBeConnection => this._determineConnection(mayBeConnection))
+        .tap(() => { debug('connection acquired'); });
     });
   }
 
   releaseConnection(connection) {
-    return this.pool.release(connection).tap(() => {
-      debug('connection released');
+    return this.pool.release(connection)
+      .tap(() => { debug('connection released'); })
+      .catch(/Resource not currently part of this pool/, () => { });
+  }
+
+  _determineConnection(mayBeConnection) {
+    return new Promise((resolve, reject) => {
+      if (mayBeConnection instanceof Error) {
+        return this.pool.destroy(mayBeConnection)
+          .then(() => { reject(mayBeConnection); })
+          .catch(/Resource not currently part of this pool/, () => {
+            reject(mayBeConnection);
+          });
+      }
+
+      return resolve(mayBeConnection);
     });
   }
 
   _connect(config) {
-    return this.sequelize.runHooks('beforeConnect', config)
-      .then(() => this.dialect.connectionManager.connect(config))
-      .then(connection => this.sequelize.runHooks('afterConnect', connection, config).return(connection));
+    return new Promise(resolve => {
+      this.sequelize.runHooks('beforeConnect', config)
+        .then(() => this.dialect.connectionManager.connect(config))
+        .then(connection => this.sequelize.runHooks('afterConnect', connection, config).return(connection))
+        .then(connection => resolve(connection))
+        .catch(e => { resolve(e); });
+    });
   }
 
   _disconnect(connection) {

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -38,7 +38,7 @@ class ConnectionManager {
       throw new Error('Support for pool:false was removed in v4.0');
     }
 
-    this.config.pool =_.defaults(config.pool || {}, defaultPoolingConfig, {
+    this.config.pool = _.defaults(config.pool || {}, defaultPoolingConfig, {
       validate: this._validate.bind(this),
       Promise
     }) ;

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -19,7 +19,7 @@ const defaultPoolingConfig = {
 /**
  * Abstract Connection Manager
  *
- * Connection manager which handles pool, replication and determining database versions
+ * Connection manager which handles pool, replication and determining database version
  * Works with generic-pool to maintain connection pool
  *
  * @private
@@ -254,6 +254,12 @@ class ConnectionManager {
       .catch(/Resource not currently part of this pool/, () => {});
   }
 
+  /**
+   * Check if something acquired by pool is indeed a connection but not an Error instance
+   * Why we need to do this https://github.com/sequelize/sequelize/pull/8330
+   *
+   * @param {Object|Error} mayBeConnection Object which can be either connection or error
+   */
   _determineConnection(mayBeConnection) {
     return new Promise((resolve, reject) => {
       if (mayBeConnection instanceof Error) {
@@ -279,6 +285,9 @@ class ConnectionManager {
   }
 
   _disconnect(connection) {
+    // hacky, _determineConnection could send Error instance for disconnection
+    if (connection instanceof Error) return Promise.resolve();
+
     return this.dialect.connectionManager.disconnect(connection);
   }
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -105,7 +105,7 @@ class ConnectionManager {
 
     if (!config.replication) {
       this.pool = Pooling.createPool({
-        create: () => this._connect(config).catch(err => err ),
+        create: () => this._connect(config).catch(err => err),
         destroy: mayBeConnection => {
           if (mayBeConnection instanceof Error) {
             return Promise.resolve();

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -38,10 +38,10 @@ class ConnectionManager {
       throw new Error('Support for pool:false was removed in v4.0');
     }
 
-    this.config.pool = _.defaults(config.pool || {}, defaultPoolingConfig, {
+    config.pool = _.defaults(config.pool || {}, defaultPoolingConfig, {
       validate: this._validate.bind(this),
       Promise
-    }) ;
+    });
 
     // Save a reference to the bound version so we can remove it with removeListener
     this._onProcessExit = this._onProcessExit.bind(this);

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -12,7 +12,7 @@ const defaultPoolingConfig = {
   min: 0,
   idle: 10000,
   acquire: 10000,
-  evict: 60000,
+  evict: 10000,
   handleDisconnects: true
 };
 
@@ -38,7 +38,7 @@ class ConnectionManager {
       throw new Error('Support for pool:false was removed in v4.0');
     }
 
-    config.pool =_.defaults(config.pool || {}, defaultPoolingConfig, {
+    this.config.pool =_.defaults(config.pool || {}, defaultPoolingConfig, {
       validate: this._validate.bind(this),
       Promise
     }) ;
@@ -90,11 +90,14 @@ class ConnectionManager {
 
     if (!config.replication) {
       this.pool = Pooling.createPool({
-        create: () => this._connect(config),
-        destroy: connection => {
-          return this._disconnect(connection).tap(() => {
-            debug('connection destroy');
-          });
+        create: () => this._connect(config).catch(err => err ),
+        destroy: mayBeConnection => {
+          if (mayBeConnection instanceof Error) {
+            return Promise.resolve();
+          }
+
+          return this._disconnect(mayBeConnection)
+            .tap(() => { debug('connection destroy'); });
         },
         validate: config.pool.validate
       }, {
@@ -146,16 +149,19 @@ class ConnectionManager {
             .then(mayBeConnection => this._determineConnection(mayBeConnection));
         }
       },
-      destroy: connection => {
-        debug('connection destroy');
-        return this.pool[connection.queryType].destroy(connection);
+      destroy: mayBeConnection => {
+        if (mayBeConnection instanceof Error) {
+          return Promise.resolve();
+        }
+
+        this.pool[mayBeConnection.queryType].destroy(mayBeConnection)
+          .tap(() => { debug('connection destroy'); });
       },
       clear: () => {
-        debug('all connection clear');
         return Promise.join(
           this.pool.read.clear(),
           this.pool.write.clear()
-        );
+        ).tap(() => { debug('all connection clear'); });
       },
       drain: () => {
         return Promise.join(
@@ -170,7 +176,8 @@ class ConnectionManager {
             ._connect(config.replication.read[nextRead])
             .tap(connection => {
               connection.queryType = 'read';
-            });
+            })
+            .catch(err => err);
         },
         destroy: connection => this._disconnect(connection),
         validate: config.pool.validate
@@ -190,7 +197,8 @@ class ConnectionManager {
             ._connect(config.replication.write)
             .tap(connection => {
               connection.queryType = 'write';
-            });
+            })
+            .catch(err => err);
         },
         destroy: connection => this._disconnect(connection),
         validate: config.pool.validate
@@ -218,7 +226,6 @@ class ConnectionManager {
         promise = this.versionPromise;
       } else {
         promise = this.versionPromise = this._connect(this.config.replication.write || this.config)
-          .then(mayBeConnection => this._determineConnection(mayBeConnection))
           .then(connection => {
             const _options = {};
 
@@ -273,16 +280,10 @@ class ConnectionManager {
   _connect(config) {
     return this.sequelize.runHooks('beforeConnect', config)
       .then(() => this.dialect.connectionManager.connect(config))
-      .then(connection => this.sequelize.runHooks('afterConnect', connection, config).return(connection))
-      .catch(error => { return error; });
+      .then(connection => this.sequelize.runHooks('afterConnect', connection, config).return(connection));
   }
 
   _disconnect(connection) {
-    // hacky, _determineConnection could send Error instance for disconnection
-    if (connection instanceof Error) {
-      return Promise.resolve();
-    }
-
     return this.dialect.connectionManager.disconnect(connection);
   }
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -251,7 +251,7 @@ class ConnectionManager {
   releaseConnection(connection) {
     return this.pool.release(connection)
       .tap(() => { debug('connection released'); })
-      .catch(/Resource not currently part of this pool/, () => { });
+      .catch(/Resource not currently part of this pool/, () => {});
   }
 
   _determineConnection(mayBeConnection) {

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -111,9 +111,9 @@ class ConnectionManager extends AbstractConnectionManager {
             break;
         }
       });
-      
+
       if (config.dialectOptions && config.dialectOptions.debug) {
-        connection.on('debug', debugTedious);        
+        connection.on('debug', debugTedious);
       }
 
       if (config.pool.handleDisconnects) {
@@ -121,7 +121,8 @@ class ConnectionManager extends AbstractConnectionManager {
           switch (err.code) {
             case 'ESOCKET':
             case 'ECONNRESET':
-              this.pool.destroy(connectionLock);
+              this.pool.destroy(connectionLock)
+                .catch(/Resource not currently part of this pool/, () => {});
           }
         });
       }

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -99,6 +99,8 @@ class ConnectionManager extends AbstractConnectionManager {
           debug(`connection error ${e.code}`);
 
           if (e.code === 'PROTOCOL_CONNECTION_LOST') {
+            this.pool.destroy(connection)
+              .catch(/Resource not currently part of this pool/, () => {});
             return;
           }
         }

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -35,7 +35,6 @@ class ConnectionManager extends AbstractConnectionManager {
 
   // Expose this as a method so that the parsing may be updated when the user has added additional, custom types
   _refreshTypeParser(dataType) {
-
     if (dataType.types.postgres.oids) {
       for (const oid of dataType.types.postgres.oids) {
         this.lib.types.setTypeParser(oid, value => dataType.parse(value, oid, this.lib.types.getTypeParser));
@@ -54,7 +53,6 @@ class ConnectionManager extends AbstractConnectionManager {
   }
 
   connect(config) {
-
     config.user = config.username;
     const connectionConfig = Utils._.pick(config, [
       'user', 'password', 'host', 'database', 'port'
@@ -155,7 +153,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
       return new Promise((resolve, reject) => connection.query(query, (error, result) => error ? reject(error) : resolve(result))).then(results => {
         const result = Array.isArray(results) ? results.pop() : results;
-        
+
         for (const row of result.rows) {
           let type;
           if (row.typname === 'geometry') {
@@ -174,6 +172,7 @@ class ConnectionManager extends AbstractConnectionManager {
       });
     });
   }
+
   disconnect(connection) {
     return new Promise(resolve => {
       connection.end();

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -315,7 +315,7 @@ class Sequelize {
    *
    * sequelize.models.modelName // The model will now be available in models under the name given to define
    */
-  define(modelName, attributes, options) { // testhint options:none
+  define(modelName, attributes, options) {
     options = options || {};
 
     options.modelName = modelName;
@@ -324,7 +324,6 @@ class Sequelize {
     const model = class extends Model {};
 
     model.init(attributes, options);
-
 
     return model;
   }
@@ -950,7 +949,6 @@ class Sequelize {
       autoCallback = options;
       options = undefined;
     }
-    // testhint argsConform.end
 
     const transaction = new Transaction(this, options);
 
@@ -1061,9 +1059,11 @@ class Sequelize {
    *
    * Normally this is done on process exit, so you only need to call this method if you are creating multiple instances, and want
    * to garbage collect some of them.
+   *
+   * @return {Promise}
    */
   close() {
-    this.connectionManager.close();
+    return this.connectionManager.close();
   }
 
   normalizeDataType(Type) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -82,12 +82,12 @@ class Sequelize {
    * @param {Object}   [options.pool] sequelize connection pool configuration
    * @param {Integer}  [options.pool.max=5] Maximum number of connection in pool
    * @param {Integer}  [options.pool.min=0] Minimum number of connection in pool
-   * @param {Integer}  [options.pool.idle=10000] The maximum time, in milliseconds, that a connection can be idle before being released
+   * @param {Integer}  [options.pool.idle=10000] The maximum time, in milliseconds, that a connection can be idle before being released. Use with combination of evict for proper working, for more details read https://github.com/coopernurse/node-pool/issues/178#issuecomment-327110870
    * @param {Integer}  [options.pool.acquire=10000] The maximum time, in milliseconds, that pool will try to get connection before throwing error
    * @param {Integer}  [options.pool.evict=10000] The time interval, in milliseconds, for evicting stale connections. Set it to 0 to disable this feature.
    * @param {Boolean}  [options.pool.handleDisconnects=true] Controls if pool should handle connection disconnect automatically without throwing errors
    * @param {Function} [options.pool.validate] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
-   * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.  WARNING: Setting this to false may expose vulnerabilities and is not reccomended!
+   * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.  WARNING: Setting this to false may expose vulnerabilities and is not recommended!
    * @param {String}   [options.transactionType='DEFERRED'] Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
    * @param {String}   [options.isolationLevel] Set the default transaction isolation level. See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options.
    * @param {Object}   [options.retry] Set of flags that control when a query is automatically retried.
@@ -376,7 +376,7 @@ class Sequelize {
     if (!this.importCache[path]) {
       let defineCall = arguments.length > 1 ? arguments[1] : require(path);
       if (typeof defineCall === 'object') {
-        // ES6 module compatability
+        // ES6 module compatibility
         defineCall = defineCall.default;
       }
       this.importCache[path] = defineCall(this, DataTypes);
@@ -654,8 +654,8 @@ class Sequelize {
    * @param {RegExp} [options.match] Match a regex against the database name before syncing, a safety check for cases where force: true is used in tests but not live code
    * @param {Boolean|function} [options.logging=console.log] A function that logs sql queries, or false for no logging
    * @param {String} [options.schema='public'] The schema that the tables should be created in. This can be overriden for each table in sequelize.define
-   * @param  {String} [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
-   * @param {Boolean} [options.hooks=true] If hooks is true then beforeSync, afterSync, beforBulkSync, afterBulkSync hooks will be called
+   * @param {String} [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {Boolean} [options.hooks=true] If hooks is true then beforeSync, afterSync, beforeBulkSync, afterBulkSync hooks will be called
    * @param {Boolean} [options.alter=false] Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
    * @return {Promise}
    */

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -84,7 +84,7 @@ class Sequelize {
    * @param {Integer}  [options.pool.min=0] Minimum number of connection in pool
    * @param {Integer}  [options.pool.idle=10000] The maximum time, in milliseconds, that a connection can be idle before being released
    * @param {Integer}  [options.pool.acquire=10000] The maximum time, in milliseconds, that pool will try to get connection before throwing error
-   * @param {Integer}  [options.pool.evict=60000] The time interval, in milliseconds, for evicting stale connections. Set it to 0 to disable this feature.
+   * @param {Integer}  [options.pool.evict=10000] The time interval, in milliseconds, for evicting stale connections. Set it to 0 to disable this feature.
    * @param {Boolean}  [options.pool.handleDisconnects=true] Controls if pool should handle connection disconnect automatically without throwing errors
    * @param {Function} [options.pool.validate] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
    * @param {Boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.  WARNING: Setting this to false may expose vulnerabilities and is not reccomended!

--- a/test/config/.docker.env
+++ b/test/config/.docker.env
@@ -5,3 +5,7 @@ SEQ_MYSQL_PW=sequelize_test
 SEQ_PG_PORT=8998
 SEQ_PG_USER=sequelize_test
 SEQ_PG_PW=sequelize_test
+SEQ_MSSQL_PORT=8997
+SEQ_MSSQL_DB=master
+SEQ_MSSQL_USER=sa
+SEQ_MSSQL_PW=yourStrong(!)Password

--- a/test/config/config.js
+++ b/test/config/config.js
@@ -26,7 +26,7 @@ module.exports = {
     database: process.env.SEQ_MSSQL_DB   || process.env.SEQ_DB   || 'sequelize_test',
     username: process.env.SEQ_MSSQL_USER || process.env.SEQ_USER || 'sequelize',
     password: process.env.SEQ_MSSQL_PW   || process.env.SEQ_PW   || 'nEGkLma26gXVHFUAHJxcmsrK',
-    host:     process.env.SEQ_MSSQL_HOST || process.env.SEQ_HOST || 'mssql.sequelizejs.com',
+    host:     process.env.SEQ_MSSQL_HOST || process.env.SEQ_HOST || '127.0.0.1',
     port:     process.env.SEQ_MSSQL_PORT || process.env.SEQ_PORT || 1433,
     dialectOptions: {
       // big insert queries need a while

--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -18,7 +18,6 @@ const poolEntry = {
 };
 
 describe('Connection Manager', () => {
-
   let sandbox;
 
   beforeEach(() => {
@@ -162,7 +161,6 @@ describe('Connection Manager', () => {
       expect(poolDrainSpy.calledOnce).to.be.true;
       expect(poolClearSpy.calledOnce).to.be.true;
     });
-
   });
 
 });

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -34,18 +34,20 @@ if (dialect === 'mysql') {
 
     it('accepts new queries after shutting down a connection', () => {
       // Create a sequelize instance with fast disconnecting connection
-      const sequelize = Support.createSequelizeInstance({ pool: { idle: 50, max: 1 }});
+      const sequelize = Support.createSequelizeInstance({ pool: { idle: 50, max: 1, evict: 10 }});
       const User = sequelize.define('User', { username: DataTypes.STRING });
 
       return User
         .sync({force: true})
-        .then(() => User.create({username: 'user1'}))
+        .then(() => User.create({ username: 'user1' }))
         .then(() => sequelize.Promise.delay(100))
         .then(() => {
-        // This query will be queued just after the `client.end` is executed and before its callback is called
+          expect(sequelize.connectionManager.pool.size).to.equal(0);
+          //This query will be queued just after the `client.end` is executed and before its callback is called
           return sequelize.query('SELECT COUNT(*) AS count FROM Users', { type: sequelize.QueryTypes.SELECT });
         })
         .then(count => {
+          expect(sequelize.connectionManager.pool.size).to.equal(1);
           expect(count[0].count).to.equal(1);
         });
     });
@@ -68,7 +70,7 @@ if (dialect === 'mysql') {
           return cm.getConnection();
         })
         .then(connection => {
-          // Old threadId should be different from current new one
+          // Old threadId should be same as current connection
           expect(conn.threadId).to.be.equal(connection.threadId);
           expect(cm.validate(conn)).to.be.ok;
 
@@ -77,7 +79,7 @@ if (dialect === 'mysql') {
     });
 
     it('should work with handleDisconnects before release', () => {
-      const sequelize = Support.createSequelizeInstance({pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
+      const sequelize = Support.createSequelizeInstance({pool: { max: 1, min: 1, handleDisconnects: true, idle: 5000 }});
       const cm = sequelize.connectionManager;
       let conn;
 
@@ -89,8 +91,9 @@ if (dialect === 'mysql') {
           conn = connection;
           // simulate a unexpected end from MySQL2
           conn.stream.emit('end');
+
+          return cm.releaseConnection(connection);
         })
-        .then(() => cm.releaseConnection(conn))
         .then(() => {
           // Get next available connection
           return cm.getConnection();
@@ -98,7 +101,9 @@ if (dialect === 'mysql') {
         .then(connection => {
           // Old threadId should be different from current new one
           expect(conn.threadId).to.not.be.equal(connection.threadId);
-          expect(cm.validate(conn)).to.not.be.ok;
+          expect(sequelize.connectionManager.pool.size).to.equal(1);
+          expect(cm.validate(conn)).to.be.not.ok;
+
           return cm.releaseConnection(connection);
         });
     });

--- a/test/integration/replication.test.js
+++ b/test/integration/replication.test.js
@@ -57,26 +57,22 @@ describe(Support.getTestDialectTeaser('Replication'), function() {
   it('should be able to make a write', () => {
     return this.User.create({
       firstName: Math.random().toString()
-    })
-      .then(expectWriteCalls);
+    }).then(expectWriteCalls);
   });
 
   it('should be able to make a read', () => {
-    return this.User.findAll()
-      .then(expectReadCalls);
+    return this.User.findAll().then(expectReadCalls);
   });
 
   it('should run read-only transactions on the replica', () => {
     return this.sequelize.transaction({readOnly: true}, transaction => {
       return this.User.findAll({transaction});
-    })
-      .then(expectReadCalls);
+    }).then(expectReadCalls);
   });
 
   it('should run non-read-only transactions on the primary', () => {
     return this.sequelize.transaction(transaction => {
       return this.User.findAll({transaction});
-    })
-      .then(expectWriteCalls);
+    }).then(expectWriteCalls);
   });
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

This is basically a hack but pooling library has given us no options. Pool acquire call
now resolves even if there is an error. We simply check if its an error instance or not
and reject accordingly.

Read more here https://github.com/sequelize/sequelize/issues/7884#issuecomment-330136439

`_determineConnection` method can be used to check if thing returned by pooling library is
actaully a connection or error

Closes #7884
Closes #7616
Closes #8014
Closes #8133
Closes #8322
Closes #8185
Closes #8098
Closes #8076
Closes #8014
