### PR TITLE
feat(query): introduce alias substitution

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -709,7 +709,7 @@ const QueryGenerator = {
     potentially also be used for other places where we want to be able to call SQL functions (e.g. as default values)
    @private
   */
-  quote(collection, parent, connector) {
+  quote(collection, parent, connector, queryOptions) {
     // init
     const validOrderOptions = [
       'ASC',
@@ -827,14 +827,29 @@ const QueryGenerator = {
       const tableNames = [];
       let item;
       let i = 0;
+      let currentRef = queryOptions;
 
       for (i = 0; i < collectionLength - 1; i++) {
         item = collection[i];
         if (typeof item === 'string' || item._modelAttribute || item instanceof Utils.SequelizeMethod) {
           break;
         } else if (item instanceof Association) {
-          tableNames[i] = item.as;
+          if (queryOptions.substitution) {
+            if (Array.isArray(currentRef.include)) {
+              const includeIndex = currentRef.include.findIndex(include => include.as === item.as);
+
+              if (includeIndex !== -1) {
+                currentRef = currentRef.include[includeIndex];
+              }
+            }
+          } else {
+            tableNames[i] = item.as;
+          }
         }
+      }
+
+      if (queryOptions.substitution) {
+        tableNames.push(currentRef.substituteAs);
       }
 
       // start building sql
@@ -987,11 +1002,11 @@ const QueryGenerator = {
     }
 
     if (options.include) {
-      for (const include of options.include) {
+      for (const [ordinal, include] of options.include.entries()) {
         if (include.separate) {
           continue;
         }
-        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo);
+        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo, options.substitution ? { parent: '', child: `${ordinal}` } : undefined);
 
         subJoinQueries = subJoinQueries.concat(joinQueries.subQuery);
         mainJoinQueries = mainJoinQueries.concat(joinQueries.mainQuery);
@@ -1083,6 +1098,7 @@ const QueryGenerator = {
             attributes: options.attributes,
             limit: options.groupedLimit.limit,
             order: groupedLimitOrder,
+            substitution: false,
             where,
             include,
             model
@@ -1208,7 +1224,7 @@ const QueryGenerator = {
       let addTable = true;
 
       if (attr instanceof Utils.SequelizeMethod) {
-        return this.handleSequelizeMethod(attr);
+        return this.handleSequelizeMethod(attr, undefined, undefined, options);
       }
       if (Array.isArray(attr)) {
         if (attr.length !== 2) {
@@ -1217,7 +1233,7 @@ const QueryGenerator = {
         attr = attr.slice();
 
         if (attr[0] instanceof Utils.SequelizeMethod) {
-          attr[0] = this.handleSequelizeMethod(attr[0]);
+          attr[0] = this.handleSequelizeMethod(attr[0], undefined, undefined, options);
           addTable = false;
         } else if (attr[0].indexOf('(') === -1 && attr[0].indexOf(')') === -1) {
           attr[0] = this.quoteIdentifier(attr[0]);
@@ -1234,7 +1250,7 @@ const QueryGenerator = {
     });
   },
 
-  generateInclude(include, parentTableName, topLevelInfo) {
+  generateInclude(include, parentTableName, topLevelInfo, substitution) {
     const association = include.association;
     const joinQueries = {
       mainQuery: [],
@@ -1255,14 +1271,20 @@ const QueryGenerator = {
 
     topLevelInfo.options.keysEscaped = true;
 
-    if (topLevelInfo.names.name !== parentTableName.externalAs && topLevelInfo.names.as !== parentTableName.externalAs) {
-      includeAs.internalAs = `${parentTableName.internalAs}->${include.as}`;
+    if (substitution) {
+      include.substituteAs = `T${substitution.child}`;
+      includeAs.internalAs = `T${substitution.child}`;
       includeAs.externalAs = `${parentTableName.externalAs}.${include.as}`;
+    } else {
+      if (topLevelInfo.names.name !== parentTableName.externalAs && topLevelInfo.names.as !== parentTableName.externalAs) {
+        includeAs.internalAs = `${parentTableName.internalAs}->${include.as}`;
+        includeAs.externalAs = `${parentTableName.externalAs}.${include.as}`;
+      }
     }
 
     // includeIgnoreAttributes is used by aggregate functions
     if (topLevelInfo.options.includeIgnoreAttributes !== false) {
-      const includeAttributes = include.attributes.map(attr => {
+      const includeAttributes = include.attributes.map((attr, idx) => {
         let attrAs = attr;
         let verbatim = false;
 
@@ -1275,7 +1297,7 @@ const QueryGenerator = {
             verbatim = true;
           }
 
-          attr = attr.map(attr => attr instanceof Utils.SequelizeMethod ? this.handleSequelizeMethod(attr) : attr);
+          attr = attr.map(attr => attr instanceof Utils.SequelizeMethod ? this.handleSequelizeMethod(attr, undefined, undefined, include.parent) : attr);
 
           attrAs = attr[1];
           attr = attr[0];
@@ -1294,7 +1316,11 @@ const QueryGenerator = {
         } else {
           prefix = `${this.quoteIdentifier(includeAs.internalAs)}.${this.quoteIdentifier(attr)}`;
         }
-        return `${prefix} AS ${this.quoteIdentifier(`${includeAs.externalAs}.${attrAs}`, true)}`;
+        if (substitution) {
+          return `${prefix} AS ${this.quoteIdentifier(`${substitution.child}.${idx}`, true)}`;
+        } else {
+          return `${prefix} AS ${this.quoteIdentifier(`${includeAs.externalAs}.${attrAs}`, true)}`;
+        }
       });
       if (include.subQuery && topLevelInfo.subQuery) {
         for (const attr of includeAttributes) {
@@ -1309,7 +1335,7 @@ const QueryGenerator = {
 
     //through
     if (include.through) {
-      joinQuery = this.generateThroughJoin(include, includeAs, parentTableName.internalAs, topLevelInfo);
+      joinQuery = this.generateThroughJoin(include, includeAs, parentTableName.internalAs, topLevelInfo, substitution);
     } else {
       if (topLevelInfo.subQuery && include.subQueryFilter) {
         const associationWhere = {};
@@ -1348,7 +1374,7 @@ const QueryGenerator = {
           topLevelInfo.options.where = { $and: [topLevelInfo.options.where, subQueryWhere] };
         }
       }
-      joinQuery = this.generateJoin(include, topLevelInfo);
+      joinQuery = this.generateJoin(include, topLevelInfo, includeAs.internalAs, substitution);
     }
 
     // handle possible new attributes created in join
@@ -1361,12 +1387,12 @@ const QueryGenerator = {
     }
 
     if (include.include) {
-      for (const childInclude of include.include) {
+      for (const [ordinal, childInclude] of include.include.entries()) {
         if (childInclude.separate || childInclude._pseudo) {
           continue;
         }
 
-        const childJoinQueries = this.generateInclude(childInclude, includeAs, topLevelInfo);
+        const childJoinQueries = this.generateInclude(childInclude, includeAs, topLevelInfo, substitution ? { parent: substitution.child, child: `${substitution.child}.${ordinal}` } : undefined);
 
         if (include.required === false && childInclude.required === true) {
           requiredMismatch = true;
@@ -1416,7 +1442,7 @@ const QueryGenerator = {
     };
   },
 
-  generateJoin(include, topLevelInfo) {
+  generateJoin(include, topLevelInfo, alias, substitution) {
     const association = include.association;
     const parent = include.parent;
     const parentIsTop = !!parent && !include.parent.association && include.parent.model.name === topLevelInfo.options.model.name;
@@ -1439,16 +1465,21 @@ const QueryGenerator = {
       association.identifierField;
     let asRight = include.as;
 
-    while (($parent = $parent && $parent.parent || include.parent) && $parent.association) {
-      if (asLeft) {
-        asLeft = `${$parent.as}->${asLeft}`;
-      } else {
-        asLeft = $parent.as;
+    if (substitution) {
+      asLeft = substitution.parent ? `T${substitution.parent}` : parent.as || parent.model.name;
+      asRight = alias;
+    } else {
+      while (($parent = $parent && $parent.parent || include.parent) && $parent.association) {
+        if (asLeft) {
+          asLeft = `${$parent.as}->${asLeft}`;
+        } else {
+          asLeft = $parent.as;
+        }
       }
-    }
 
-    if (!asLeft) asLeft = parent.as || parent.model.name;
-    else asRight = `${asLeft}->${asRight}`;
+      if (!asLeft) asLeft = parent.as || parent.model.name;
+      else asRight = `${asLeft}->${asRight}`;
+    }
 
     let joinOn = `${this.quoteTable(asLeft)}.${this.quoteIdentifier(fieldLeft)}`;
 
@@ -1457,7 +1488,19 @@ const QueryGenerator = {
         // The main model attributes is not aliased to a prefix
         joinOn = `${this.quoteTable(parent.as || parent.model.name)}.${this.quoteIdentifier(attrLeft)}`;
       } else {
-        joinOn = this.quoteIdentifier(`${asLeft.replace(/->/g, '.')}.${attrLeft}`);
+        const parentAttributeIndex = include.parent.attributes.findIndex(attr => {
+          if (Array.isArray(attr) && attr.length === 2) {
+            return attr[1] === attrLeft;
+          } else {
+            return attr === attrLeft;
+          }
+        });
+
+        if (substitution) {
+          joinOn = this.quoteIdentifier(`${substitution.parent}.${parentAttributeIndex}`);
+        } else {
+          joinOn = this.quoteIdentifier(`${asLeft.replace(/->/g, '.')}.${attrLeft}`);
+        }
       }
     }
 
@@ -1495,15 +1538,15 @@ const QueryGenerator = {
     };
   },
 
-  generateThroughJoin(include, includeAs, parentTableName, topLevelInfo) {
+  generateThroughJoin(include, includeAs, parentTableName, topLevelInfo, substitution) {
     const through = include.through;
     const throughTable = through.model.getTableName();
-    const throughAs = `${includeAs.internalAs}->${through.as}`;
-    const externalThroughAs = `${includeAs.externalAs}.${through.as}`;
-    const throughAttributes = through.attributes.map(attr =>
+    const throughAs = substitution ? 'J' + includeAs.internalAs : `${includeAs.internalAs}->${through.as}`;
+    const externalThroughAs = substitution ? 'J' + substitution.child : `${includeAs.externalAs}.${through.as}`;
+    const throughAttributes = through.attributes.map((attr, idx) =>
       this.quoteIdentifier(throughAs) + '.' + this.quoteIdentifier(Array.isArray(attr) ? attr[0] : attr)
       + ' AS '
-      + this.quoteIdentifier(externalThroughAs + '.' + (Array.isArray(attr) ? attr[1] : attr))
+      + (substitution ? this.quoteIdentifier(externalThroughAs + '.' + idx) : this.quoteIdentifier(externalThroughAs + '.' + (Array.isArray(attr) ? attr[1] : attr)))
     );
     const association = include.association;
     const parentIsTop = !include.parent.association && include.parent.model.name === topLevelInfo.options.model.name;
@@ -1528,6 +1571,10 @@ const QueryGenerator = {
     let throughWhere;
     let targetWhere;
 
+    if (substitution) {
+      through.substituteAs = throughAs;
+    }
+
     if (topLevelInfo.options.includeIgnoreAttributes !== false) {
       // Through includes are always hasMany, so we need to add the attributes to the mainAttributes no matter what (Real join will never be executed in subquery)
       for (const attr of throughAttributes) {
@@ -1547,7 +1594,19 @@ const QueryGenerator = {
     // Used by both join and subquery where
     // If parent include was in a subquery need to join on the aliased attribute
     if (topLevelInfo.subQuery && !include.subQuery && include.parent.subQuery && !parentIsTop) {
-      sourceJoinOn = `${this.quoteIdentifier(`${tableSource}.${attrSource}`)} = `;
+      const parentAttributeIndex = include.parent.attributes.findIndex(attr => {
+        if (Array.isArray(attr) && attr.length === 2) {
+          return attr[1] === attrSource;
+        } else {
+          return attr === attrSource;
+        }
+      });
+
+      if (substitution) {
+        sourceJoinOn = `${this.quoteIdentifier(`${substitution.parent}.${parentAttributeIndex}`)} = `;
+      } else {
+        sourceJoinOn = `${this.quoteIdentifier(`${tableSource}.${attrSource}`)} = `;
+      }
     } else {
       sourceJoinOn = `${this.quoteTable(tableSource)}.${this.quoteIdentifier(attrSource)} = `;
     }
@@ -1679,9 +1738,9 @@ const QueryGenerator = {
           && !(typeof order[0].model === 'function' && order[0].model.prototype instanceof Model)
           && !(typeof order[0] === 'string' && model && model.associations !== undefined && model.associations[order[0]])
         ) {
-          subQueryOrder.push(this.quote(order, model, '->'));
+          subQueryOrder.push(this.quote(order, model, '->', options));
         } else {
-          mainQueryOrder.push(this.quote(order, model, '->'));
+          mainQueryOrder.push(this.quote(order, model, '->', options));
         }
       }
     } else if (options.order instanceof Utils.SequelizeMethod) {
@@ -1896,6 +1955,31 @@ const QueryGenerator = {
         }
       } else if (smth.col.indexOf('*') === 0) {
         return '*';
+      }
+
+      const splittedAttr = smth.col.split('.');
+      if (splittedAttr.length >= 2 && options && options.substitution) {
+        let substituteTables = [];
+        let currentRef = options;
+
+        for (let i = 0; i < splittedAttr.length - 1; i++) {
+          if (!Array.isArray(currentRef.include)) {
+            substituteTables = null;
+            break;
+          }
+          const includeIndex = currentRef.include.findIndex(include => include.association.as === splittedAttr[i]);
+          if (includeIndex === -1) {
+            substituteTables = null;
+            break;
+          }
+          substituteTables.push(includeIndex);
+          currentRef = currentRef.include[includeIndex];
+        }
+
+        if (substituteTables && substituteTables.length > 0) {
+          const subName = 'T' + substituteTables.join('.');
+          return this.quote(`${subName}.${splittedAttr[splittedAttr.length - 1]}`);
+        }
       }
       return this.quote(smth.col, factory);
     } else {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1002,11 +1002,12 @@ const QueryGenerator = {
     }
 
     if (options.include) {
-      for (const [ordinal, include] of options.include.entries()) {
+      for (const element of options.include.entries()) {
+        const include = element[1];
         if (include.separate) {
           continue;
         }
-        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo, options.substitution ? { parent: '', child: `${ordinal}` } : undefined);
+        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo, options.substitution ? { parent: '', child: `${element[0]}` } : undefined);
 
         subJoinQueries = subJoinQueries.concat(joinQueries.subQuery);
         mainJoinQueries = mainJoinQueries.concat(joinQueries.mainQuery);
@@ -1387,12 +1388,13 @@ const QueryGenerator = {
     }
 
     if (include.include) {
-      for (const [ordinal, childInclude] of include.include.entries()) {
+      for (const element of include.include.entries()) {
+        const childInclude = element[1];
         if (childInclude.separate || childInclude._pseudo) {
           continue;
         }
 
-        const childJoinQueries = this.generateInclude(childInclude, includeAs, topLevelInfo, substitution ? { parent: substitution.child, child: `${substitution.child}.${ordinal}` } : undefined);
+        const childJoinQueries = this.generateInclude(childInclude, includeAs, topLevelInfo, substitution ? { parent: substitution.child, child: `${substitution.child}.${element[0]}` } : undefined);
 
         if (include.required === false && childInclude.required === true) {
           requiredMismatch = true;

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -248,8 +248,55 @@ class AbstractQuery {
     return this.options.type === QueryTypes.UPDATE;
   }
 
+  generateSubstitutionMapping(obj, prefix) {
+    const map = {};
+
+    if (!prefix) {
+      prefix = { substitute: '', original: '' };
+    }
+
+    //for (const [idx, includeName] of obj.includeNames.entries()) {
+    //  const relation = obj.includeMap[includeName];
+    for (const [idx, relation] of obj.include.entries()) {
+      const includeName = relation.as;
+
+      for (const [attrIdx, attrName] of relation.attributes.entries()) {
+        map[`${prefix.substitute}${idx}.${attrIdx}`] = `${prefix.original}${includeName}.${Array.isArray(attrName) ? attrName[1] : attrName}`;
+      }
+
+      if (relation.through) {
+        for (const [throughAttrIdx, throughAttrName] of relation.through.attributes.entries()) {
+          map[`J${prefix.substitute}${idx}.${throughAttrIdx}`] = `${prefix.original}${includeName}.${relation.through.as}.${Array.isArray(throughAttrName) ? throughAttrName[1] : throughAttrName}`;
+        }
+      }
+
+      if (relation.includeNames) {
+        Object.assign(map, this.generateSubstitutionMapping(relation, {
+          substitute: `${prefix.substitute}${idx}.`,
+          original: `${prefix.original}${includeName}.`
+        }));
+      }
+    }
+
+    return map;
+  }
+
   handleSelectQuery(results) {
     let result = null;
+    // Map attribute names if substitution is active
+    if (this.options.include) {
+      const substitutionMap = this.generateSubstitutionMapping(this.options);
+
+      results = Utils._.map(results, result => {
+        for (const key of Object.keys(substitutionMap)) {
+          if (result[key] !== undefined) {
+            result[substitutionMap[key]] = result[key];
+            delete result[key];
+          }
+        }
+        return result;
+      });
+    }
     // Map raw fields to names if a mapping is provided
     if (this.options.fieldMap) {
       const fieldMap = this.options.fieldMap;

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -284,7 +284,7 @@ class AbstractQuery {
   handleSelectQuery(results) {
     let result = null;
     // Map attribute names if substitution is active
-    if (this.options.include) {
+    if (this.options.substitution && this.options.include) {
       const substitutionMap = this.generateSubstitutionMapping(this.options);
 
       results = Utils._.map(results, result => {

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -255,25 +255,26 @@ class AbstractQuery {
       prefix = { substitute: '', original: '' };
     }
 
-    //for (const [idx, includeName] of obj.includeNames.entries()) {
-    //  const relation = obj.includeMap[includeName];
-    for (const [idx, relation] of obj.include.entries()) {
-      const includeName = relation.as;
+    for (const include of obj.include.entries()) {
+      const idx = include[0];
+      const relation = include[1];
 
-      for (const [attrIdx, attrName] of relation.attributes.entries()) {
-        map[`${prefix.substitute}${idx}.${attrIdx}`] = `${prefix.original}${includeName}.${Array.isArray(attrName) ? attrName[1] : attrName}`;
+      for (const attr of relation.attributes.entries()) {
+        const attrName = attr[1];
+        map[`${prefix.substitute}${idx}.${attr[0]}`] = `${prefix.original}${relation.as}.${Array.isArray(attrName) ? attrName[1] : attrName}`;
       }
 
       if (relation.through) {
-        for (const [throughAttrIdx, throughAttrName] of relation.through.attributes.entries()) {
-          map[`J${prefix.substitute}${idx}.${throughAttrIdx}`] = `${prefix.original}${includeName}.${relation.through.as}.${Array.isArray(throughAttrName) ? throughAttrName[1] : throughAttrName}`;
+        for (const throughAttr of relation.through.attributes.entries()) {
+          const throughAttrName = throughAttr[1];
+          map[`J${prefix.substitute}${idx}.${throughAttr[0]}`] = `${prefix.original}${relation.as}.${relation.through.as}.${Array.isArray(throughAttrName) ? throughAttrName[1] : throughAttrName}`;
         }
       }
 
       if (relation.includeNames) {
         Object.assign(map, this.generateSubstitutionMapping(relation, {
           substitute: `${prefix.substitute}${idx}.`,
-          original: `${prefix.original}${includeName}.`
+          original: `${prefix.original}${relation.as}.`
         }));
       }
     }
@@ -286,15 +287,13 @@ class AbstractQuery {
     // Map attribute names if substitution is active
     if (this.options.substitution && this.options.include) {
       const substitutionMap = this.generateSubstitutionMapping(this.options);
-
+      
       results = Utils._.map(results, result => {
-        for (const key of Object.keys(substitutionMap)) {
-          if (result[key] !== undefined) {
-            result[substitutionMap[key]] = result[key];
-            delete result[key];
-          }
-        }
-        return result;
+        const row = {};
+        Object.keys(result).forEach(key => {
+          row[substitutionMap[key] || key] = result[key];
+        });
+        return row;
       });
     }
     // Map raw fields to names if a mapping is provided

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1008,7 +1008,8 @@ class QueryInterface {
     options = Utils.cloneDeep(options);
     options.type = QueryTypes.SELECT;
     options.model = model;
-    options.substitution = options.substitution === undefined ? true : options.substitution;
+    options.substitution = this.QueryGenerator.dialect === 'sqlite' ? false : 
+      (options.substitution === undefined ? true : options.substitution);
 
     return this.sequelize.query(
       this.QueryGenerator.selectQuery(tableName, options, model),

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1008,6 +1008,7 @@ class QueryInterface {
     options = Utils.cloneDeep(options);
     options.type = QueryTypes.SELECT;
     options.model = model;
+    options.substitution = options.substitution === undefined ? true : options.substitution;
 
     return this.sequelize.query(
       this.QueryGenerator.selectQuery(tableName, options, model),

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -2555,6 +2555,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should not fail with an include', function() {
       return this.User.findAll({
         where: this.sequelize.literal(this.sequelize.queryInterface.QueryGenerator.quoteIdentifiers('Projects.title') + ' = ' + this.sequelize.queryInterface.QueryGenerator.escape('republic')),
+        substitution: false,
         include: [
           {model: this.Project}
         ]


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This is an attempt to fix #2084
The feature basically introduces an ordinal-based (deep) alias substitution for column names as well as table aliases for all includes within a query.
It allows more complex use cases/queries with sequelize and postgresql by avoiding to hit the 63 character limit for identifiers that soon.

Let me know what you think about the approach. If you are okay with it, I will update the PR to:
1) make substitution option default to false (currently true in order to show full compliance with the test suite)
2) implement substitution-specific tests to cover 100% of the added lines
3) update doc