### PR TITLE
Fix null check for DATEONLY

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -394,7 +394,7 @@ DATEONLY.prototype._stringify = function _stringify(date) {
 };
 
 DATEONLY.prototype._sanitize = function _sanitize(value, options) {
-  if (!options || options && !options.raw) {
+  if ((!options || options && !options.raw) && !!value) {
     return moment(value).format('YYYY-MM-DD');
   }
 

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -730,6 +730,8 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         return this.task.getUsers();
       }).then(_users => {
         expect(_users).to.have.length(0);
+      }).finally(() => {
+        this.sequelize.options.omitNull = false;
       });
     });
 

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -488,6 +488,33 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
       });
   });
 
+  it('should return set DATEONLY field to NULL correctly', function() {
+    const Model = this.sequelize.define('user', {
+      stamp: Sequelize.DATEONLY
+    });
+    const testDate = moment().format('YYYY-MM-DD');
+
+    return Model.sync({ force: true})
+      .then(() => Model.create({ stamp: testDate }))
+      .then(record => {
+        expect(typeof record.stamp).to.be.eql('string');
+        expect(record.stamp).to.be.eql(testDate);
+
+        return Model.findById(record.id);
+      }).then(record => {
+        expect(typeof record.stamp).to.be.eql('string');
+        expect(record.stamp).to.be.eql(testDate);
+
+        return record.update({
+          stamp: null
+        });
+      }).then(record => {
+        return record.reload();
+      }).then(record => {
+        expect(record.stamp).to.be.eql(null);
+      });
+  });
+
   it('should be able to cast buffer as boolean', function() {
     const ByteModel = this.sequelize.define('Model', {
       byteToBool: this.sequelize.Sequelize.BLOB


### PR DESCRIPTION
Fixes comment mentioned [here](https://github.com/sequelize/sequelize/pull/8357/files#r141506197)

`DATEONLY` fields were sanitized wrong when being `NULL`.