### PR TITLE
bugfix: removing unique contraint column (#8385)

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -342,6 +342,7 @@ const QueryGenerator = {
       + ' AND REFERENCED_COLUMN_NAME = ' + wrapSingleQuote(columnName)
       + ') OR (TABLE_NAME = ' + wrapSingleQuote(tableName)
       + ' AND COLUMN_NAME = ' + wrapSingleQuote(columnName)
+      + ' AND REFERENCED_TABLE_NAME IS NOT NULL'
       + ')';
   },
 

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -689,6 +689,10 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
               model: 'users',
               key:   'id'
             }
+          },
+          email: {
+            type: DataTypes.STRING,
+            unique: true
           }
         });
       });
@@ -730,6 +734,19 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         });
       });
 
+      // From MSSQL documentation on ALTER COLUMN:
+      //    The modified column cannot be any one of the following:
+      //      - Used in a CHECK or UNIQUE constraint.
+      // https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql#arguments
+      if (dialect !== 'mssql') {
+        it('should be able to remove a column with unique contraint', function() {
+          return this.queryInterface.removeColumn('users', 'email').bind(this).then(function() {
+            return this.queryInterface.describeTable('users');
+          }).then(table => {
+            expect(table).to.not.have.property('email');
+          });
+        });
+      }
     });
 
     describe('(with a schema)', () => {
@@ -750,6 +767,10 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             },
             lastName: {
               type: DataTypes.STRING
+            },
+            email: {
+              type: DataTypes.STRING,
+              unique: true
             }
           });
         });
@@ -798,6 +819,26 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           expect(table).to.not.have.property('id');
         });
       });
+
+      // From MSSQL documentation on ALTER COLUMN:
+      //    The modified column cannot be any one of the following:
+      //      - Used in a CHECK or UNIQUE constraint.
+      // https://docs.microsoft.com/en-us/sql/t-sql/statements/alter-table-transact-sql#arguments
+      if (dialect !== 'mssql') {
+        it('should be able to remove a column with unique contraint', function() {
+          return this.queryInterface.removeColumn({
+            tableName: 'users',
+            schema: 'archive'
+          }, 'email').bind(this).then(function() {
+            return this.queryInterface.describeTable({
+              tableName: 'users',
+              schema: 'archive'
+            });
+          }).then(table => {
+            expect(table).to.not.have.property('email');
+          });
+        });
+      }
     });
   });
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -554,6 +554,12 @@ if (dialect === 'mysql') {
           arguments: ['User', ['foo', 'bar']],
           expectation: 'DROP INDEX `user_foo_bar` ON `User`'
         }
+      ],
+      getForeignKeyQuery: [
+        {
+          arguments: ['User', 'email'],
+          expectation: "SELECT CONSTRAINT_NAME as constraint_name FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE (REFERENCED_TABLE_NAME = 'User' AND REFERENCED_COLUMN_NAME = 'email') OR (TABLE_NAME = 'User' AND COLUMN_NAME = 'email' AND REFERENCED_TABLE_NAME IS NOT NULL)"
+        }
       ]
     };
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Fixes issue I opened here https://github.com/sequelize/sequelize/issues/8385 about dropping unique contraint column.

Before removing a column, the mysql dialect checks that there's no foreign keys attached to it with this query:
```
SELECT CONSTRAINT_NAME as constraint_name FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE (REFERENCED_TABLE_NAME = 'users' AND REFERENCED_COLUMN_NAME = 'email') OR (TABLE_NAME = 'users' AND COLUMN_NAME = 'email')
```

It looks to me like [KEY_COLUMN_USAGE](https://dev.mysql.com/doc/refman/5.7/en/key-column-usage-table.html) table stores not just foreign keys but all constraints. In my failing case, `email` is unique and present in this table, so sequelize aborts the removeColumn.

The fix is to add an additional condition onto the check: ` AND REFERENCED_TABLE_NAME IS NOT NULL` which also verifies that the column is a foreign key, not some other kind of constraint.

I've got a failing unit test and a passing fix.