### PR TITLE
fix(model): do not mark a column as changed if a custom setter sets it to the same value

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3247,7 +3247,8 @@ class Model {
       // If not raw, and there's a custom setter
       if (!options.raw && this._customSetters[key]) {
         this._customSetters[key].call(this, value, key);
-        if (!Utils.isPrimitive(value) && value !== null || value !== originalValue) {
+        const newValue = this.dataValues[key];
+        if (!Utils.isPrimitive(newValue) && newValue !== null || newValue !== originalValue) {
           this._previousDataValues[key] = originalValue;
           this.changed(key, true);
         }

--- a/lib/model.js
+++ b/lib/model.js
@@ -3247,6 +3247,8 @@ class Model {
       // If not raw, and there's a custom setter
       if (!options.raw && this._customSetters[key]) {
         this._customSetters[key].call(this, value, key);
+        // custom setter should have changed value, get that changed value
+        // TODO: v5 make setters return new value instead of changing internal store
         const newValue = this.dataValues[key];
         if (!Utils.isPrimitive(newValue) && newValue !== null || newValue !== originalValue) {
           this._previousDataValues[key] = originalValue;

--- a/test/unit/instance/set.test.js
+++ b/test/unit/instance/set.test.js
@@ -80,7 +80,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     describe('custom setter', () => {
       before(function() {
         this.stubCreate = sinon.stub(current.getQueryInterface(), 'insert', instance => {
-          return Promise.resolve([ instance, 1]);
+          return Promise.resolve([instance, 1]);
         });
       });
 

--- a/test/unit/instance/set.test.js
+++ b/test/unit/instance/set.test.js
@@ -4,7 +4,9 @@ const chai = require('chai'),
   expect = chai.expect,
   Support   = require(__dirname + '/../support'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
-  current   = Support.sequelize;
+  current   = Support.sequelize,
+  Promise = current.Promise,
+  sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
   describe('set', () => {
@@ -73,6 +75,54 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       user.set('date', new Date());
       expect(user.get('date')).to.be.an.instanceof(Date);
       expect(user.get('date')).not.to.be.NaN;
+    });
+
+    describe('custom setter', () => {
+      before(function() {
+        this.stubCreate = sinon.stub(current.getQueryInterface(), 'insert', (instance) => {
+          return Promise.resolve([ instance, 1]);
+        });
+      });
+
+      after(function() {
+        this.stubCreate.restore();
+      });
+
+      const User = current.define('User', {
+        phoneNumber: {
+          type: DataTypes.STRING,
+          set (val) {
+            if (typeof value === 'string') {
+              val = val.replace(/^\+/, '00').replace(/\(0\)|[\s+\/.\-\(\)]/g, '');
+            }
+            this.setDataValue('phoneNumber', val.split(' ').reverse().join(' '));
+          }
+        }
+      });
+
+      it('does not set field to changed if field is set to the same value with custom setter', () => {
+        const user = User.build({
+          phoneNumber: 'hello world'
+        });
+        return user.save().then(() => {
+          expect(user.changed('phoneNumber')).to.be.false;
+
+          user.set('phoneNumber', 'hello world');
+          expect(user.changed('phoneNumber')).to.be.false;
+        });
+      });
+
+      it('sets field to changed if field is set to the another value with custom setter', () => {
+        const user = User.build({
+          phoneNumber: 'hello world'
+        });
+        return user.save().then(() => {
+          expect(user.changed('phoneNumber')).to.be.false;
+
+          user.set('phoneNumber', 'goodbye world');
+          expect(user.changed('phoneNumber')).to.be.true;
+        });
+      });
     });
   });
 });

--- a/test/unit/instance/set.test.js
+++ b/test/unit/instance/set.test.js
@@ -92,34 +92,36 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         phoneNumber: {
           type: DataTypes.STRING,
           set (val) {
-            if (typeof value === 'string') {
+            if (typeof val === 'string') {
+              // Canonicalize phone number
               val = val.replace(/^\+/, '00').replace(/\(0\)|[\s+\/.\-\(\)]/g, '');
+              console.log('val', val);
             }
-            this.setDataValue('phoneNumber', val.split(' ').reverse().join(' '));
+            this.setDataValue('phoneNumber', val);
           }
         }
       });
 
       it('does not set field to changed if field is set to the same value with custom setter', () => {
         const user = User.build({
-          phoneNumber: 'hello world'
+          phoneNumber: '+1 234 567'
         });
         return user.save().then(() => {
           expect(user.changed('phoneNumber')).to.be.false;
 
-          user.set('phoneNumber', 'hello world');
+          user.set('phoneNumber', '+1 (0) 234567'); // Canonical equivalent of existing phone number
           expect(user.changed('phoneNumber')).to.be.false;
         });
       });
 
       it('sets field to changed if field is set to the another value with custom setter', () => {
         const user = User.build({
-          phoneNumber: 'hello world'
+          phoneNumber: '+1 234 567'
         });
         return user.save().then(() => {
           expect(user.changed('phoneNumber')).to.be.false;
 
-          user.set('phoneNumber', 'goodbye world');
+          user.set('phoneNumber', '+1 (0) 765432'); // Canonical non-equivalent of existing phone number
           expect(user.changed('phoneNumber')).to.be.true;
         });
       });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

lint is not Windows-friendly - gives many "Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style" warnings
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Some models can define a custom setter to modify the value that is set. For determining whether a column is changed, the original value needs to be compared with the value that is really set, not with the value that was input and modified.