### PR TITLE
fix(postgres/date): upserts with Infinity

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2188,6 +2188,7 @@ class Model {
     options = _.extend({
       hooks: true
     }, Utils.cloneDeep(options || {}));
+    options.model = this;
 
     const createdAtAttr = this._timestampAttributes.createdAt;
     const updatedAtAttr = this._timestampAttributes.updatedAt;


### PR DESCRIPTION
Closes #8396

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **N/A**
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Similar to #8383, but for upserts. Sequelize wasn't serializing attributes in the WHERE clause on the UPDATE branch.
