### PR TITLE
fix(errors): spurious Bluebird warnings

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -11,7 +11,6 @@ class BaseError extends Error {
   constructor(message) {
     super(message);
     this.name = 'SequelizeBaseError';
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }
@@ -86,7 +85,6 @@ class OptimisticLockError extends BaseError {
     options.message = options.message || 'Attempting to update a stale model instance: ' + options.modelName;
     super(options);
     this.name = 'SequelizeOptimisticLockError';
-    this.message = options.message;
     /**
      * The name of the model on which the update was attempted
      * @type {string}
@@ -156,7 +154,6 @@ class UniqueConstraintError extends ValidationError {
     super(options.message, options.errors);
 
     this.name = 'SequelizeUniqueConstraintError';
-    this.message = options.message;
     this.errors = options.errors;
     this.fields = options.fields;
     this.parent = options.parent;
@@ -200,7 +197,7 @@ class ExclusionConstraintError extends DatabaseError {
     super(options.parent);
     this.name = 'SequelizeExclusionConstraintError';
 
-    this.message = options.message || options.parent.message;
+    this.message = options.message || options.parent.message || '';
     this.constraint = options.constraint;
     this.fields = options.fields;
     this.table = options.table;
@@ -340,7 +337,6 @@ class InstanceError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeInstanceError';
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }
@@ -353,7 +349,6 @@ class EmptyResultError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeEmptyResultError';
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }
@@ -366,7 +361,6 @@ class EagerLoadingError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeEagerLoadingError';
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }
@@ -379,7 +373,6 @@ class AssociationError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeAssociationError';
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }
@@ -391,7 +384,6 @@ class QueryError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeQueryError';
-    this.message = message;
     Error.captureStackTrace(this, this.constructor);
   }
 }


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions? **N/A, unless you think it's worth it**
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **N/A shouldn't modify any API**
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

The way Sequelize instantiates some of its Error subclasses confuses Bluebird into thinking that Promises are rejected with non-Error objects, so you get warnings when running with `BLUEBIRD_DEBUG` enabled.

See https://github.com/petkaantonov/bluebird/issues/990
