### PR TITLE
improve error messaging

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const dataTypes = require('./data-types');
+const util = require('util');
 const _ = require('lodash');
 
 function escape(val, timeZone, dialect, format) {
@@ -47,7 +48,7 @@ function escape(val, timeZone, dialect, format) {
   }
 
   if (!val.replace) {
-    throw new Error('Invalid value ' + val);
+    throw new Error('Invalid value ' + util.inspect(val));
   }
 
   if (dialect === 'postgres' || dialect === 'sqlite' || dialect === 'mssql') {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Currently any error message on an invalid query is worthless, for example:

```
Error: Invalid value [object Object]
    at Object.escape (/Users/contra/Projects/staeco/node_modules/sequelize/lib/sql-string.js:50:11)
    at Object.escape (/Users/contra/Projects/staeco/node_modules/sequelize/lib/dialects/abstract/query-generator.js:919:22)
    at Object._whereParseSingleValueObject (/Users/contra/Projects/staeco/node_modules/sequelize/lib/dialects/abstract/query-generator.js:2374:41)
```

With this fix, the object is actually included in the message:

```
Error: Invalid value { a: 123 }
    at Object.escape (/Users/contra/Projects/staeco/node_modules/sequelize/lib/sql-string.js:50:11)
    at Object.escape (/Users/contra/Projects/staeco/node_modules/sequelize/lib/dialects/abstract/query-generator.js:919:22)
    at Object._whereParseSingleValueObject (/Users/contra/Projects/staeco/node_modules/sequelize/lib/dialects/abstract/query-generator.js:2374:41)
```

Maintainers - If there is any issue with the PR feel free to do it yourselves, it will probably be faster than the process of fixing the PR. No need to spend weeks of back-and-forth over one line of code.