### PR TITLE
fix(transactions): don't set transaction on continuation storage when…

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -962,7 +962,7 @@ class Sequelize {
 
     const transaction = new Transaction(this, options);
 
-    if (!autoCallback) return transaction.prepareEnvironment().return(transaction);
+    if (!autoCallback) return transaction.prepareEnvironment(false).return(transaction);
 
     // autoCallback provided
     return Sequelize._clsRun(() => {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -99,7 +99,7 @@ class Transaction {
       });
   }
 
-  prepareEnvironment() {
+  prepareEnvironment(useCLS = true) {
     let connectionPromise;
 
     if (this.parent) {
@@ -125,7 +125,7 @@ class Transaction {
         throw setupErr;
       }))
       .tap(() => {
-        if (this.sequelize.constructor._cls) {
+        if (useCLS && this.sequelize.constructor._cls) {
           this.sequelize.constructor._cls.set('transaction', this);
         }
         return null;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -99,8 +99,12 @@ class Transaction {
       });
   }
 
-  prepareEnvironment(useCLS = true) {
+  prepareEnvironment(useCLS) {
     let connectionPromise;
+
+    if (typeof useCLS === 'undefined') {
+      useCLS = true;
+    }
 
     if (this.parent) {
       connectionPromise = Utils.Promise.resolve(this.parent.connection);

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -33,6 +33,18 @@ if (current.dialect.supports.transactions) {
     });
 
     describe('context', () => {
+      it('does not use continuation storage on manually managed transactions', function() {
+        const self = this;
+
+        return Sequelize._clsRun(() => {
+          return this.sequelize.transaction()
+          .then(transaction => {
+            console.error(self.ns.get('transaction'));
+            expect(self.ns.get('transaction')).to.be.undefined;
+          });
+        });
+      });
+
       it('supports several concurrent transactions', function() {
         let t1id, t2id;
         const self = this;

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -37,9 +37,7 @@ if (current.dialect.supports.transactions) {
         const self = this;
 
         return Sequelize._clsRun(() => {
-          return this.sequelize.transaction()
-          .then(transaction => {
-            console.error(self.ns.get('transaction'));
+          return this.sequelize.transaction().then(() => {
             expect(self.ns.get('transaction')).to.be.undefined;
           });
         });

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -37,8 +37,9 @@ if (current.dialect.supports.transactions) {
         const self = this;
 
         return Sequelize._clsRun(() => {
-          return this.sequelize.transaction().then(() => {
+          return this.sequelize.transaction().then(transaction => {
             expect(self.ns.get('transaction')).to.be.undefined;
+            return transaction.rollback();
           });
         });
       });


### PR DESCRIPTION
… manually managed

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This patch prevents Sequelize from adding a transaction to the continuation storage namespace when the transaction is manually managed.  Traditionally `Transaction#prepareEnvironment` would unconditionally set the transaction on the continuation storage, but is sunk immediately because manual transactions are never run under `Sequelize._clsRun`.  

Has associated test.  Closes #8429.