### PR TITLE
fix(model): handle Symbol-only where clauses

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -83,7 +83,7 @@ class Model {
 
     deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 
-    if (Utils.whereIsEmpty(options.where)) {
+    if (Utils.isWhereEmpty(options.where)) {
       options.where = deletedAtObject;
     } else {
       options.where = { [Op.and]: [deletedAtObject, options.where] };

--- a/lib/model.js
+++ b/lib/model.js
@@ -83,7 +83,7 @@ class Model {
 
     deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 
-    if (_.isEmpty(options.where)) {
+    if (Utils.whereIsEmpty(options.where)) {
       options.where = deletedAtObject;
     } else {
       options.where = { [Op.and]: [deletedAtObject, options.where] };

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -849,7 +849,7 @@ class QueryInterface {
 
     options = _.clone(options);
 
-    if (!_.isEmpty(where)) {
+    if (!Utils.whereIsEmpty(where)) {
       wheres.push(where);
     }
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -849,7 +849,7 @@ class QueryInterface {
 
     options = _.clone(options);
 
-    if (!Utils.whereIsEmpty(where)) {
+    if (!Utils.isWhereEmpty(where)) {
       wheres.push(where);
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -574,7 +574,7 @@ exports.mapIsolationLevelStringToTedious = (isolationLevel, tedious) => {
  * @private
  */
 function getOperators(obj) {
-  return _.intersection(Object.getOwnPropertySymbols(obj), operatorsArray);
+  return _.intersection(Object.getOwnPropertySymbols(obj || {}), operatorsArray);
 }
 exports.getOperators = getOperators;
 
@@ -599,3 +599,9 @@ function getComplexSize(obj) {
   return Array.isArray(obj) ? obj.length : getComplexKeys(obj).length;
 }
 exports.getComplexSize = getComplexSize;
+
+// Returns true if a where clause is empty
+function whereIsEmpty(obj) {
+  return _.isEmpty(obj) && getOperators(obj).length === 0;
+}
+exports.whereIsEmpty = whereIsEmpty;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -600,8 +600,14 @@ function getComplexSize(obj) {
 }
 exports.getComplexSize = getComplexSize;
 
-// Returns true if a where clause is empty
-function whereIsEmpty(obj) {
+/**
+ * Returns true if a where clause is empty, even with Symbols
+ *
+ * @param  {Object} obj
+ * @return {Boolean}
+ * @private
+ */
+function isWhereEmpty(obj) {
   return _.isEmpty(obj) && getOperators(obj).length === 0;
 }
-exports.whereIsEmpty = whereIsEmpty;
+exports.isWhereEmpty = isWhereEmpty;

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -708,6 +708,29 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(u.username).to.equal('A fancy name');
         });
     });
+
+    // https://github.com/sequelize/sequelize/issues/8406
+    it('should work if model is paranoid and only operator in where clause is a Symbol', function() {
+      const User = this.sequelize.define('User', { username: Sequelize.STRING }, { paranoid: true } );
+
+      return User.sync({ force: true})
+        .then(() => {
+          return User.create({ username: 'foo' });
+        })
+        .then(() => {
+          return User.findOne({
+            where: {
+              [Sequelize.Op.or]: [
+                { username: 'bar' },
+                { username: 'baz' }
+              ]
+            }
+          });
+        })
+        .then(user => {
+          expect(user).to.not.be.ok;
+        });
+    });
   });
 
   describe('findOrInitialize', () => {


### PR DESCRIPTION
Closes #8406

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **N/A**
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Fixes paranoid clauses where the `where` only has symbols. See https://github.com/sequelize/sequelize/issues/8406.

I'll also work on adding more tests so we can completely close https://github.com/sequelize/sequelize/issues/8423, but this is ready to merge if we want a quick fix for #8406, which is kind of a big issue for a lot of users.
