### PR TITLE
Tiny markdown change to fix esdoc formatting

### DIFF
--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -97,6 +97,7 @@ The success handler will always receive an object with two properties:
 
 * `count` - an integer, total number records matching the where clause
 * `rows` - an array of objects, the records matching the where clause, within the limit and offset range
+
 ```js
 Project
   .findAndCountAll({


### PR DESCRIPTION
Added a new line between the list and code block in `findAndCountAll` section, so the esdoc markdown parser does not break the page.

This is how it looks now:
![bad](https://user-images.githubusercontent.com/920747/31321204-7fa3d0a0-ac71-11e7-92f1-4e816290ceec.png)

http://docs.sequelizejs.com/manual/tutorial/models-usage.html#-findandcountall-search-for-multiple-elements-in-the-database-returns-both-data-and-total-count