### PR TITLE
feat(sqlite/query-generator): sqlite update queries now support limit via rowid

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -277,7 +277,11 @@ const QueryGenerator = {
       values.push(this.quoteIdentifier(key) + '=' + this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE' }));
     }
 
-    return `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} ${this.whereQuery(where, options)}`;
+    if (options.limit) {
+      return `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${this.whereQuery(where, options)} LIMIT ${this.escape(options.limit)})`;
+    } else {
+      return `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} ${this.whereQuery(where, options)}`;
+    }
   },
 
   deleteQuery(tableName, where, options, model) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -2590,7 +2590,7 @@ class Model {
    * @param  {Boolean}      [options.sideEffects=true] Whether or not to update the side effects of any virtual setters.
    * @param  {Boolean}      [options.individualHooks=false] Run before / after update hooks?. If true, this will execute a SELECT followed by individual UPDATEs. A select is needed, because the row data needs to be passed to the hooks
    * @param  {Boolean}      [options.returning=false]       Return the affected rows (only for postgres)
-   * @param  {Number}       [options.limit]                 How many rows to update (only for mysql and mariadb, implemented as TOP(n) for MSSQL)
+   * @param  {Number}       [options.limit]                 How many rows to update (only for mysql and mariadb, implemented as TOP(n) for MSSQL; for sqlite it is supported only when rowid is present)
    * @param  {Function}     [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param  {Boolean}      [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {Transaction}  [options.transaction] Transaction to run query under

--- a/test/unit/sql/update.test.js
+++ b/test/unit/sql/update.test.js
@@ -49,6 +49,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }), {
         mssql: "UPDATE TOP(1) [Users] SET [username]=N'new.username' OUTPUT INSERTED.* WHERE [username] = N'username'",
         mysql: "UPDATE `Users` SET `username`='new.username' WHERE `username` = 'username' LIMIT 1",
+        sqlite: "UPDATE `Users` SET `username`='new.username' WHERE rowid IN (SELECT rowid FROM `Users` WHERE `username` = 'username' LIMIT 1)",
         default: "UPDATE [Users] SET [username]='new.username' WHERE [username] = 'username'"
       });
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

By default SQLite is compiled with `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` off. That means the `UPDATE` statements would not support an optional `LIMIT` clause. By using `UPDATE ... WHERE rowid IN (SELECT rowid FROM ... WHERE ... LIMIT n)` instead it can provide support in environments without such feature.
