### PR TITLE
Resolve limit param not working with includes

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1170,7 +1170,7 @@ const QueryGenerator = {
     }
 
     // Add LIMIT, OFFSET to sub or main query
-    const limitOrder = this.addLimitAndOffset(options, model);
+    const limitOrder = this.addLimitAndOffset(options, mainTable.model);
     if (limitOrder && !options.groupedLimit) {
       mainQueryItems.push(limitOrder);
     }

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1170,13 +1170,9 @@ const QueryGenerator = {
     }
 
     // Add LIMIT, OFFSET to sub or main query
-    const limitOrder = this.addLimitAndOffset(options, mainTable.model);
+    const limitOrder = this.addLimitAndOffset(options, model);
     if (limitOrder && !options.groupedLimit) {
-      if (subQuery) {
-        subQueryItems.push(limitOrder);
-      } else {
-        mainQueryItems.push(limitOrder);
-      }
+      mainQueryItems.push(limitOrder);
     }
 
     if (subQuery) {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ Yes (Double Check on Your End)] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [Yes ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [No ] Have you added new tests to prevent regressions?
- [ No] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [Idk ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

There is an outstanding issue since at least march where a query that includes other tables incorrectly forms the final sql output and sets the limit param on the subquery instead of the main query which then results in inconsistent #'s of rows being returned. 

https://github.com/sequelize/sequelize/issues/7344