### PR TITLE
fix(model): unhandled rejection in findAndCount

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1857,21 +1857,13 @@ class Model {
       countOptions.attributes = undefined;
     }
 
-    const countQuery = this.count(countOptions);
-    const findQuery = this.findAll(options);
-
-    return countQuery.then(count => {
-      if (count === 0) {
-        return {
-          count: 0,
-          rows: []
-        };
-      }
-      return findQuery.then(results => ({
-        count: count || 0,
-        rows: results
-      }));
-    });
+    return Promise.all([
+      this.count(countOptions),
+      this.findAll(options)
+    ]).spread((count, rows) => ({
+      count,
+      rows
+    }));
   }
 
   /**

--- a/test/unit/model/findandcount.test.js
+++ b/test/unit/model/findandcount.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support = require(__dirname + '/../support'),
+  current = Support.sequelize,
+  sinon = require('sinon'),
+  DataTypes = require(__dirname + '/../../../lib/data-types'),
+  Promise = require('bluebird').getNewLibraryCopy();
+
+describe(Support.getTestDialectTeaser('Model'), () => {
+  describe('method findAndCount', () => {
+    describe('should handle promise rejection in findAndCount', () => {
+      before(() => {
+        this.oldFindAll = current.Model.findAll;
+        this.oldCount = current.Model.count;
+
+        current.Model.count = () => Promise.reject(new Error());
+        current.Model.findAll = () => Promise.reject(new Error());
+
+        this.stub = sinon.stub();
+
+        Promise.onPossiblyUnhandledRejection(() => {
+          this.stub();
+        });
+
+        this.User = current.define('User', {
+          username: DataTypes.STRING,
+          age: DataTypes.INTEGER
+        });
+      });
+
+      after(() => {
+        current.Model.findAll = this.oldFindAll;
+        current.Model.count = this.oldCount;
+      });
+
+      it('with errors in count and findAll both', () => {
+        return this.User.findAndCount({})
+          .catch(() => {
+            expect(this.stub.callCount).to.eql(0);
+          });
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Before my changes the findAndCount method of model could throw an unhandled rejection. This happens, for example, when I refer to a non-existent column. In this case, countQuery.catch is correctly handled, but the error from the findQuery becomes unhandled (both promises start to be executed in parallel).

Sorry, but I have not written any new tests, because the tests for findAndCount just missing.

For me it seems strange the previous logic:
`if (count === 0)` - useless `if` as for me
`count || 0` - count can be `undefinde` or `null`?

But I'm not sure that it's wrong. May be I made some mistakes in my correction?