### PR TITLE
fix(unittest): Refactor tests to not use Sinon Syntactic Sugar

### DIFF
--- a/test/unit/instance-validator.test.js
+++ b/test/unit/instance-validator.test.js
@@ -87,7 +87,9 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     it('should run beforeValidate hook but not afterValidate hook when _validate is unsuccessful', () => {
       const failingInstanceValidator = new InstanceValidator(this.User.build());
-      sinon.stub(failingInstanceValidator, '_validate').returns(Promise.reject());
+      sinon.stub(failingInstanceValidator, '_validate', () => {
+        return Promise.reject();
+      });
       const beforeValidate = sinon.spy();
       const afterValidate = sinon.spy();
       this.User.beforeValidate(beforeValidate);
@@ -110,7 +112,9 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     describe('validatedFailed hook', () => {
       it('should call validationFailed hook when validation fails', () => {
         const failingInstanceValidator = new InstanceValidator(this.User.build());
-        sinon.stub(failingInstanceValidator, '_validate').returns(Promise.reject());
+        sinon.stub(failingInstanceValidator, '_validate', () => {
+          return Promise.reject();
+        });
         const validationFailedHook = sinon.spy();
         this.User.validationFailed(validationFailedHook);
 
@@ -121,7 +125,9 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
       it('should not replace the validation error in validationFailed hook by default', () => {
         const failingInstanceValidator = new InstanceValidator(this.User.build());
-        sinon.stub(failingInstanceValidator, '_validate').returns(Promise.reject(new SequelizeValidationError()));
+        sinon.stub(failingInstanceValidator, '_validate', () => {
+          return Promise.reject(new SequelizeValidationError());
+        });
         const validationFailedHook = sinon.stub().returns(Promise.resolve());
         this.User.validationFailed(validationFailedHook);
 
@@ -132,7 +138,9 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
       it('should replace the validation error if validationFailed hook creates a new error', () => {
         const failingInstanceValidator = new InstanceValidator(this.User.build());
-        sinon.stub(failingInstanceValidator, '_validate').returns(Promise.reject(new SequelizeValidationError()));
+        sinon.stub(failingInstanceValidator, '_validate', () => {
+          return Promise.reject(new SequelizeValidationError());
+        });
         const validationFailedHook = sinon.stub().throws(new Error('validation failed hook error'));
         this.User.validationFailed(validationFailedHook);
 

--- a/test/unit/model/find-create-find.test.js
+++ b/test/unit/model/find-create-find.test.js
@@ -52,7 +52,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         where = {prop: Math.random().toString()},
         findSpy = this.sinon.stub(Model, 'findOne');
 
-      this.sinon.stub(Model, 'create').returns(Promise.reject(new UniqueConstraintError()));
+      this.sinon.stub(Model, 'create', () => {
+        return Promise.reject(new UniqueConstraintError());
+      });
 
       findSpy.onFirstCall().returns(Promise.resolve(null));
       findSpy.onSecondCall().returns(Promise.resolve(result));


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change
Using the the pattern `sinon.stub(...).returns(Promise.reject(...))` would cause occasional
"Unhandled Rejection" messages from the Bluebird unhandled rejection handler. The pattern has been
removed in favor of a replacement function.

See a discussion of the issue [here](https://github.com/petkaantonov/bluebird/issues/313).
