### PR TITLE
fix(findOrCreate): TypeError when default attribute unknown

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2102,7 +2102,9 @@ class Model {
         const flattenedWhere = Utils.flattenObjectDeep(options.where);
         const flattenedWhereKeys = _.map(_.keys(flattenedWhere), name => _.last(_.split(name, '.')));
         const whereFields = flattenedWhereKeys.map(name => _.get(this.rawAttributes, `${name}.field`, name));
-        const defaultFields = options.defaults && Object.keys(options.defaults).map(name => this.rawAttributes[name].field || name);
+        const defaultFields = options.defaults && Object.keys(options.defaults)
+          .filter(name => this.rawAttributes[name])
+          .map(name => this.rawAttributes[name].field || name);
 
         if (defaultFields) {
           if (!_.intersection(Object.keys(err.fields), whereFields).length && _.intersection(Object.keys(err.fields), defaultFields).length) {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -104,6 +104,35 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    it('should error correctly when defaults contain a unique key and a non-existent field', function() {
+      const User = this.sequelize.define('user', {
+        objectId: {
+          type: DataTypes.STRING,
+          unique: true
+        },
+        username: {
+          type: DataTypes.STRING,
+          unique: true
+        }
+      });
+
+      return User.sync({force: true}).then(() => {
+        return User.create({
+          username: 'gottlieb'
+        });
+      }).then(() => {
+        return expect(User.findOrCreate({
+          where: {
+            objectId: 'asdasdasd'
+          },
+          defaults: {
+            username: 'gottlieb',
+            foo: 'bar' // field that's not a defined attribute
+          }
+        })).to.eventually.be.rejectedWith(Sequelize.UniqueConstraintError);
+      });
+    });
+
     it('should error correctly when defaults contain a unique key and the where clause is complex', function() {
       const User = this.sequelize.define('user', {
         objectId: {


### PR DESCRIPTION
Closes #8492

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **N/A**
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Fix for #8492: don't crash when passed an unknown attribute in `defaults` when `findOrCreate` returns a `UniqueConstraintError`.
