### PR TITLE
feat(sqlite/query-generator): sqlite delete supporting limit via rowid

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -288,12 +288,25 @@ const QueryGenerator = {
     options = options || {};
     _.defaults(options, this.options);
 
-    let whereClause = this.getWhereConditions(where, null, model, options);
-    if (whereClause) {
-      whereClause = ' WHERE ' + whereClause;
+    if (options.truncate === true) {
+      // Truncate does not allow LIMIT and WHERE
+      return `DELETE FROM ${this.quoteTable(tableName)}`;
     }
 
-    return `DELETE FROM ${this.quoteTable(tableName)}${whereClause}`;
+    if (_.isUndefined(options.limit)) {
+      options.limit = 1;
+    }
+
+    let whereClause = this.getWhereConditions(where, null, model, options);
+    if (whereClause) {
+      whereClause = `WHERE ${whereClause}`;
+    }
+
+    if (options.limit) {
+      whereClause = `WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${whereClause} LIMIT ${this.escape(options.limit)})`;
+    }
+
+    return `DELETE FROM ${this.quoteTable(tableName)} ${whereClause}`;
   },
 
   attributesToSQL(attributes) {

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -86,6 +86,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           ), {
             default:  "DELETE FROM [public.test_users] WHERE `name` = 'foo'",
             postgres: 'DELETE FROM "public"."test_users" WHERE "name" = \'foo\'',
+            sqlite:   "DELETE FROM `public.test_users` WHERE `name` = 'foo'",
             mssql:    "DELETE FROM [public].[test_users] WHERE [name] = N'foo'; SELECT @@ROWCOUNT AS AFFECTEDROWS;"
           }
         );
@@ -108,7 +109,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             User
           ), {
             postgres: 'DELETE FROM "public"."test_users" WHERE "id" IN (SELECT "id" FROM "public"."test_users" WHERE "name" = \'foo\'\';DROP TABLE mySchema.myTable;\' LIMIT 10)',
-            sqlite:   "DELETE FROM `public.test_users` WHERE `name` = 'foo'';DROP TABLE mySchema.myTable;'",
+            sqlite:   "DELETE FROM `public.test_users` WHERE rowid IN (SELECT rowid FROM `public.test_users` WHERE `name` = \'foo\'\';DROP TABLE mySchema.myTable;\' LIMIT 10)",
             mssql:    "DELETE TOP(10) FROM [public].[test_users] WHERE [name] = N'foo'';DROP TABLE mySchema.myTable;'; SELECT @@ROWCOUNT AS AFFECTEDROWS;",
             default:  "DELETE FROM [public.test_users] WHERE `name` = 'foo\\';DROP TABLE mySchema.myTable;' LIMIT 10"
           }
@@ -139,7 +140,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         return expectsql(
           query, {
             postgres: new Error('Cannot LIMIT delete without a model.'),
-            sqlite:   "DELETE FROM `public.test_users` WHERE `name` = 'foo'';DROP TABLE mySchema.myTable;'",
+            sqlite:   "DELETE FROM `public.test_users` WHERE rowid IN (SELECT rowid FROM `public.test_users` WHERE `name` = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)",
             mssql:    "DELETE TOP(10) FROM [public].[test_users] WHERE [name] = N'foo'';DROP TABLE mySchema.myTable;'; SELECT @@ROWCOUNT AS AFFECTEDROWS;",
             default:  "DELETE FROM [public.test_users] WHERE `name` = 'foo\\';DROP TABLE mySchema.myTable;' LIMIT 10"
           }
@@ -173,7 +174,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             User
           ), {
             postgres: 'DELETE FROM "test_user" WHERE "test_user_id" IN (SELECT "test_user_id" FROM "test_user" WHERE "test_user_id" = 100 LIMIT 1)',
-            sqlite:   'DELETE FROM `test_user` WHERE `test_user_id` = 100',
+            sqlite:   'DELETE FROM `test_user` WHERE rowid IN (SELECT rowid FROM `test_user` WHERE `test_user_id` = 100 LIMIT 1)',
             mssql:    'DELETE TOP(1) FROM [test_user] WHERE [test_user_id] = 100; SELECT @@ROWCOUNT AS AFFECTEDROWS;',
             default:  'DELETE FROM [test_user] WHERE [test_user_id] = 100 LIMIT 1'
           }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

By default SQLite is compiled with `SQLITE_ENABLE_UPDATE_DELETE_LIMIT` off. That means the `DELETE` statements would not support an optional `LIMIT` clause. By using `DELETE ... WHERE rowid IN (SELECT rowid FROM ... WHERE ... LIMIT n)` instead it can provide support in environments without such feature.

(This is a companion PR to #8450.)