### PR TITLE
fix(query): incorrect arguments passed to SQLString.escape

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -44,7 +44,7 @@ class AbstractQuery {
       } else {
         replacementFunc = (match, key, values, timeZone, dialect) => {
           if (values[key] !== undefined) {
-            return SqlString.escape(values[key], false, timeZone, dialect);
+            return SqlString.escape(values[key], timeZone, dialect);
           }
           return undefined;
         };


### PR DESCRIPTION
SqlString.escape() has three arguments but query.js called it with four, resulting in runtime error.


- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

Sorry, but  'no' for all questions, this is obvious typo fix from github Edit function. 