### PR TITLE
feat(cls-hooked): Add a test for cls-hooked

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "cls-bluebird": "^2.0.1",
+    "cls-hooked": "4.2.2",
     "debug": "^3.0.0",
     "depd": "^1.1.0",
     "dottie": "^2.0.0",

--- a/test/integration/cls-hooked/.eslintrc.json
+++ b/test/integration/cls-hooked/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+    "parserOptions": {
+        "ecmaVersion": 2017
+    }
+}

--- a/test/integration/cls-hooked/cls-hooked.test.js
+++ b/test/integration/cls-hooked/cls-hooked.test.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const chai      = require('chai'),
+  expect    = chai.expect,
+  Support   = require('../support'),
+  Sequelize = Support.Sequelize,
+  Promise   = Sequelize.Promise,
+  cls       = require('cls-hooked'),
+  current = Support.sequelize,
+  semver = require('semver'),
+  isNode8 = semver.satisfies(process.version, '>= 8');
+
+if (current.dialect.supports.transactions && isNode8) {
+  describe(Support.getTestDialectTeaser('cls-hooked'), () => {
+    before(function() {
+      this.thenOriginal = Promise.prototype.then;
+      Sequelize.useCLS(cls.createNamespace('sequelize'));
+    });
+
+    after(() => {
+      delete Sequelize._cls;
+    });
+
+    let sequelize, ns, User;
+    beforeEach(async function() {
+      sequelize = await Support.prepareTransactionTest(this.sequelize);
+      ns = cls.getNamespace('sequelize');
+      User = sequelize.define('user', {
+        name: Sequelize.STRING
+      });
+      await sequelize.sync({ force: true });
+    });
+
+    describe('context', () => {
+      it('does not use continuation storage on manually managed transactions', () => {
+        return Sequelize._clsRun(async() => {
+          const transaction = await sequelize.transaction();
+          expect(ns.get('transaction')).to.be.undefined;
+          await transaction.rollback();
+        });
+      });
+
+      it('supports several concurrent transactions', async() => {
+        const [t1id, t2id] = await Promise.all([
+          sequelize.transaction(async() => {
+            const _t1id = ns.get('transaction').id;
+            return await Promise.resolve(_t1id);
+          }),
+          sequelize.transaction(async() => {
+            const _t2id = ns.get('transaction').id;
+            return await Promise.resolve(_t2id);
+          })
+        ]);
+        expect(t1id).to.be.ok;
+        expect(t2id).to.be.ok;
+        expect(t1id).not.to.equal(t2id);
+      });
+
+      it('supports nested promise chains', async() => {
+        await sequelize.transaction(async() => {
+          const tid = ns.get('transaction').id;
+          expect(tid).to.be.ok;
+
+          await User.findAll().then(() => {
+            expect(ns.get('transaction').id).to.equal(tid);
+          });
+          expect(ns.get('transaction').id).to.equal(tid);
+        });
+      });
+
+      it('does not leak variables to the outer scope', async() => {
+        // This is a little tricky. We want to check the values in the outer scope, when the transaction has been successfully set up, but before it has been comitted.
+        // We can't just call another function from inside that transaction, since that would transfer the context to that function - exactly what we are trying to prevent;
+
+        let transactionSetup = false,
+          transactionEnded = false;
+
+        sequelize.transaction(async() => {
+          transactionSetup = true;
+
+          await Promise.delay(500).then(() => {
+            expect(ns.get('transaction')).to.be.ok;
+            transactionEnded = true;
+          });
+        });
+
+        await new Promise(resolve => {
+          // Wait for the transaction to be setup
+          const interval = setInterval(() => {
+            if (transactionSetup) {
+              clearInterval(interval);
+              resolve();
+            }
+          }, 200);
+        });
+        expect(transactionEnded).not.to.be.ok;
+
+        expect(ns.get('transaction')).not.to.be.ok;
+
+        // Just to make sure it didn't change between our last check and the assertion
+        expect(transactionEnded).not.to.be.ok;
+      });
+
+      it('does not leak variables to the following promise chain', async() => {
+        await sequelize.transaction(() => {
+          return Promise.resolve();
+        });
+        expect(ns.get('transaction')).not.to.be.ok;
+      });
+
+      it('does not leak outside findOrCreate', async() => {
+        await User.findOrCreate({
+          where: {
+            name: 'Kafka'
+          },
+          logging(sql) {
+            if (/default/.test(sql)) {
+              throw new Error('The transaction was not properly assigned');
+            }
+          }
+        });
+        await User.findAll();
+      });
+    });
+
+    describe('sequelize.query integration', () => {
+      it('automagically uses the transaction in all calls', async() => {
+        await sequelize.transaction(async() => {
+          await User.create({ name: 'bob' });
+          await Promise.all([
+            expect(User.findAll({ transaction: null })).to.eventually.have.length(0),
+            expect(User.findAll({})).to.eventually.have.length(1)
+          ]);
+        });
+      });
+    });
+
+    it('bluebird patch is applied', function() {
+      expect(Promise.prototype.then).to.be.a('function');
+      expect(this.thenOriginal).to.be.a('function');
+      expect(Promise.prototype.then).not.to.equal(this.thenOriginal);
+    });
+
+    it('CLS namespace is stored in Sequelize._cls', () => {
+      expect(Sequelize._cls).to.equal(ns);
+    });
+  });
+}


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? **please see below**
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Hi @janmeier. Following our discussion at #8430 ([comment link][clink]), I added a test for [cls-hooked][cls-hooked]. Looks like it already works seamlessly since the API is the same as the original [CLS][cls] library.

The test is `test/integration/cls-hooked/cls-hooked.test.js`. I added it to a subfolder because I had to change ESLint's `parserOptions.ecmaVersion` to `2017` to be able to use `async / await` keywords.

### Warnings from CLS Hooked

> When running Nodejs version < 8, this module uses [AsyncWrap][async-wrap] which is an unsupported Nodejs API, so please consider the risk before using it.
>
> When running Nodejs version >= 8.2.1, this module uses the newer [async_hooks][async-hooks] API which is considered Experimental by Nodejs.

### Check for Node 8

I am not sure if this test will run in the CI script since I added a check for Node 8:

```javascript
const isNode8 = semver.satisfies(process.version, '>= 8');
if (current.dialect.supports.transactions && isNode8) {
```

My node version is `v8.7.0` and I ran the MySQL tests. My version of MySQL: `mysql  Ver 14.14 Distrib 5.7.19, for osx10.13 (x86_64) using  EditLine wrapper`.

### Failing Tests

I had 4 failing MySQL tests that seem unrelated to any changes I made, and seem related to my machine:

```bash
  1) [MYSQL] DataTypes should return YYYY-MM-DD format string for DATEONLY:
     AssertionError: expected Mon Oct 30 2017 to equal Tue Oct 31 2017

     ^ This could be because of timezone difference

  2) [MYSQL] QueryInterface removeColumn (without a schema) should be able to remove a column with primaryKey:
     SequelizeDatabaseError: Can't DROP 'books_ibfk_1'; check that column/key exists

  3) [MYSQL] QueryInterface constraints primary key should add, read & remove primary key constraint:
     SequelizeDatabaseError: Can't DROP 'books_ibfk_1'; check that column/key exists

  4) [MYSQL] QueryInterface constraints foreign key should add, read & remove foreign key constraint:
     SequelizeDatabaseError: Can't DROP 'books_ibfk_1'; check that column/key exists
```

Finally, if there is an interest in this, we should probably mention `cls-hooked` as an option in the [documentation][docs].

[async-wrap]: https://github.com/nodejs/node-eps/blob/async-wrap-ep/XXX-asyncwrap-api.md
[async-hooks]: https://github.com/nodejs/node/blob/master/doc/api/async_hooks.md
[clink]: https://github.com/sequelize/sequelize/pull/8430#issuecomment-340682663
[cls-hooked]: https://www.npmjs.com/package/cls-hooked
[cls]: https://github.com/othiym23/node-continuation-local-storage
[docs]: http://docs.sequelizejs.com/manual/tutorial/transactions.html#automatically-pass-transactions-to-all-queries