### PR TITLE
docs(globalStyling): fix pre tags text overflow

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -113,3 +113,7 @@ a[href^="file/lib/"] {
 .center {
   text-align: center;
 }
+
+pre {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
### Description of change

#### Issue: there is an overflow by the text inside the `pre` tags 

![](https://i.imgur.com/VIJ2ocq.png)

#### Solution: add `white-space: pre-wrap` would make the text break in the end of the `pre` .

![](https://i.imgur.com/Sbq3TDs.png)