### PR TITLE
fix(query_generator.js): fixes duplicate unique index

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -78,6 +78,9 @@ const QueryGenerator = {
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1]);
           foreignKeys[attr] = match[2];
+        } else if (_.includes(dataType, 'UNIQUE')) {
+          dataType = dataType.replace(/UNIQUE/, '');
+          attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
         } else {
           attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
         }

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -59,7 +59,7 @@ const QueryGenerator = {
 
     for (const attr in attributes) {
       if (attributes.hasOwnProperty(attr)) {
-        const dataType = attributes[attr];
+        let dataType = attributes[attr];
         let match;
 
         if (_.includes(dataType, 'PRIMARY KEY')) {

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -79,7 +79,7 @@ const QueryGenerator = {
           attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1]);
           foreignKeys[attr] = match[2];
         } else if (_.includes(dataType, 'UNIQUE')) {
-          dataType = dataType.replace(/UNIQUE/, '');
+          dataType = dataType.replace(/UNIQUE/, '').trim();
           attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
         } else {
           attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -61,7 +61,7 @@ const QueryGenerator = {
           attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1]);
           foreignKeys[attr] = match[2];
         } else if (_.includes(dataType, 'UNIQUE')) {
-          dataType = dataType.replace(/UNIQUE/, '');
+          dataType = dataType.replace(/UNIQUE/, '').trim();
           attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
         } else {
           attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -41,7 +41,7 @@ const QueryGenerator = {
 
     for (const attr in attributes) {
       if (attributes.hasOwnProperty(attr)) {
-        const dataType = attributes[attr];
+        let dataType = attributes[attr];
         let match;
 
         if (_.includes(dataType, 'PRIMARY KEY')) {
@@ -60,6 +60,9 @@ const QueryGenerator = {
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1]);
           foreignKeys[attr] = match[2];
+        } else if (_.includes(dataType, 'UNIQUE')) {
+          dataType = dataType.replace(/UNIQUE/, '');
+          attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
         } else {
           attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
         }

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -60,7 +60,12 @@ const QueryGenerator = {
         attributes[attr] = attributes[attr].substring(0, i);
       }
 
-      const dataType = this.dataTypeMapping(tableName, attr, attributes[attr]);
+      let dataType = this.dataTypeMapping(tableName, attr, attributes[attr]);
+      const containsUniqueConstraint =  _.includes(dataType, 'UNIQUE');
+
+      if (containsUniqueConstraint) {
+        dataType = dataType.replace(/UNIQUE/, '');
+      }
       attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
     }
 

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -64,7 +64,7 @@ const QueryGenerator = {
       const containsUniqueConstraint =  _.includes(dataType, 'UNIQUE');
 
       if (containsUniqueConstraint) {
-        dataType = dataType.replace(/UNIQUE/, '');
+        dataType = dataType.replace(/UNIQUE/, '').trim();
       }
       attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
     }

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -42,7 +42,7 @@ const QueryGenerator = {
         }
 
         if (containsUniqueConstraint) {
-          dataType = dataType.replace(/UNIQUE/, '');
+          dataType = dataType.replace(/UNIQUE/, '').trim();
         }
 
         let dataTypeString = dataType;

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -35,9 +35,14 @@ const QueryGenerator = {
       if (attributes.hasOwnProperty(attr)) {
         let dataType = attributes[attr];
         const containsAutoIncrement = _.includes(dataType, 'AUTOINCREMENT');
+        const containsUniqueConstraint =  _.includes(dataType, 'UNIQUE');
 
         if (containsAutoIncrement) {
           dataType = dataType.replace(/BIGINT/, 'INTEGER');
+        }
+
+        if (containsUniqueConstraint) {
+          dataType = dataType.replace(/UNIQUE/, '');
         }
 
         let dataTypeString = dataType;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1010,7 +1010,6 @@ class Model {
         idx.msg = idx.msg || definition.unique.msg || null;
         idx.name = idxName || false;
         idx.column = name;
-
         this.options.uniqueKeys[idxName] = idx;
       }
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -117,6 +117,10 @@ if (dialect === 'mysql') {
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=MyISAM;'
         },
         {
+          arguments: ['myTable', {title: 'VARCHAR(255) UNIQUE', name: 'VARCHAR(255)'}, {engine: 'MyISAM'}],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=MyISAM;'
+        },
+        {
           arguments: ['myTable', {title: 'VARCHAR(255)', name: 'VARCHAR(255)'}, {charset: 'utf8', collate: 'utf8_unicode_ci'}],
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE utf8_unicode_ci;'
         },

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -135,6 +135,10 @@ if (dialect.match(/^postgres/)) {
           expectation: 'CREATE TABLE IF NOT EXISTS \"myTable\" (\"title\" VARCHAR(255), \"name\" VARCHAR(255));'
         },
         {
+          arguments: ['myTable', {title: 'VARCHAR(255) UNIQUE', name: 'VARCHAR(255)'}],
+          expectation: 'CREATE TABLE IF NOT EXISTS \"myTable\" (\"title\" VARCHAR(255), \"name\" VARCHAR(255));'
+        },
+        {
           arguments: ['myTable', {data: current.normalizeDataType(DataTypes.BLOB).toSql()}],
           expectation: 'CREATE TABLE IF NOT EXISTS \"myTable\" (\"data\" BYTEA);'
         },

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -122,6 +122,10 @@ if (dialect === 'sqlite') {
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255));'
         },
         {
+          arguments: ['myTable', {title: 'VARCHAR(255) UNIQUE', name: 'VARCHAR(255)'}],
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR(255), `name` VARCHAR(255));'
+        },
+        {
           arguments: ['myTable', {title: 'VARCHAR BINARY(255)', number: 'INTEGER(5) UNSIGNED PRIMARY KEY '}], // length and unsigned are not allowed on primary key
           expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`title` VARCHAR BINARY(255), `number` INTEGER PRIMARY KEY);'
         },


### PR DESCRIPTION

#6134 

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Removes the unique index from the dataType script, thus not causing the duplicate indexes to be
created
<!-- Please provide a description of the change here. -->
