### PR TITLE
fix<handleSelectQuery>: obey the options.raw

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -296,13 +296,13 @@ class AbstractQuery {
         includeMap: this.options.includeMap,
         includeValidated: true,
         attributes: this.options.originalAttributes || this.options.attributes,
-        raw: true
+        raw: this.options.raw
       });
     // Regular queries
     } else {
       result = this.model.bulkBuild(results, {
         isNewRecord: false,
-        raw: true,
+        raw: this.options.raw,
         attributes: this.options.attributes
       });
     }


### PR DESCRIPTION
When calling Model.find, the option raw is ignored in the latest release. When someone extends the data types or override _sanitize of datatype. options.raw always passing false so that raw data is returned and never create a proper object.

This is because AbstractQuery class override the raw option when calling BulkCreate. I think it should follow the option.

This PR is to fix this bug, please review.