### PR TITLE
fix(sync): drop foreign key constraint before re-adding it to prevent…

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -10,6 +10,7 @@ const Transaction = require('./transaction');
 const Promise = require('./promise');
 const QueryTypes = require('./query-types');
 const Op = require('./operators');
+const UnknownConstraintError = require('./errors').UnknownConstraintError;
 
 /**
  * The interface that Sequelize uses to talk to all databases
@@ -558,9 +559,21 @@ class QueryInterface {
       return SQLiteQueryInterface.changeColumn.call(this, tableName, attributes, options);
     } else {
       const query = this.QueryGenerator.attributesToSQL(attributes);
+
+      let resultingPromise = Promise.resolve();
+
+      if (query[attributeName].match(/REFERENCES/)) {
+        resultingPromise = resultingPromise
+          .then(() => this.removeConstraint(tableName, tableName + '_' + attributeName + '_foreign_idx'))
+          .catch(e => {
+            if (!(e instanceof UnknownConstraintError)) {
+              throw e;
+            }
+          });
+      }
       const sql = this.QueryGenerator.changeColumnQuery(tableName, query);
 
-      return this.sequelize.query(sql, options);
+      return resultingPromise.then(() => this.sequelize.query(sql, options));
     }
   }
 


### PR DESCRIPTION
… duplicate errors

Currently, when I create two tables that have a relation, and I use `sync({alter: true})` on an existing database with the foreign key constraints already in place, the sync fails with a "duplicate key" error.

### Description of change

Before changing a column, I check whether the new column definition includes a `REFERENCES` clause. If so, just to be sure, I try removing the foreign key constraint before changing the column, ignoring failures due to the constraint actually not existing (because it might be the first time we introduce this foreign key). Now `changeColumn` can create a new foreign key constraint.

The new test fails on master and passes on my fork.