### PR TITLE
fix sqlstring bug: if save json string ,may cause bug

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -9,6 +9,9 @@ function escape(val, timeZone, dialect, format) {
   if (val === undefined || val === null) {
     return 'NULL';
   }
+  if(typeof val === "object"){
+    val = JSON.stringify(val);
+  }
   switch (typeof val) {
     case 'boolean':
     // SQLite doesn't have true/false support. MySQL aliases true/false to 1/0


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ok ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ no ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ no ] Have you added new tests to prevent regressions?
- [ no ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ no ] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
if save json string ,sqlstring may cause bug in "typeof val" switch case which pass "val" a object, so i add a "if" change before the "typeof val switch case" .
<!-- Please provide a description of the change here. -->
