### PR TITLE
fix(query): include non-aliased order by attributes in sub query (#8551)

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1013,6 +1013,16 @@ const QueryGenerator = {
     }
 
     if (subQuery) {
+      // We need to make sure the order by attributes are available to the parent query in non-aliased form
+      if (Array.isArray(options.order)) {
+        options.order.forEach(order => {
+          if (Array.isArray(order)) {
+            order = order[0];
+          }
+
+          attributes.subQuery.push(this.quote([order], model, '->'));
+        });
+      }
       subQueryItems.push(this.selectFromTableFragment(options, mainTable.model, attributes.subQuery, mainTable.quotedName, mainTable.as));
       subQueryItems.push(subJoinQueries.join(''));
     } else {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] ~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~ **N/A**
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

Fixes #8551, by ensuring the non-aliased names of the `ORDER BY` columns are included when using subqueries.

It's 2 AM so haven't added tests yet 😪 , but I can do so afterwards if the change is significant if that makes sense.

**Edit:** Looks like it's failing on the CI tests over a duplicated column. I can probably add some logic that prevents adding the column if it's already present.