### PR TITLE
docs(DataTypes): correct type of TEXT's parameter

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -790,7 +790,7 @@ for (const helper of Object.keys(helpers)) {
  *
  * @property {function(length=255: integer)} STRING A variable length string
  * @property {function(length=255: integer)} CHAR A fixed length string.
- * @property {function([length]: string)} TEXT An unlimited length text column. Available lengths: `tiny`, `medium`, `long`
+ * @property {function(length: string)} TEXT An unlimited length text column. Available lengths: `tiny`, `medium`, `long`
  * @property {function(length: integer)} TINYINT A 8 bit integer.
  * @property {function(length: integer)} SMALLINT A 16 bit integer.
  * @property {function(length: integer)} MEDIUMINT A 24 bit integer.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

### Description of change

remove brackets of `length` parameter, which may mislead users to pass an array as the parameter at the very first time.