### PR TITLE
docs: add link to CONTRIBUTING.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ _Please make sure to review and check all of these items:_
 - [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
 - [ ] Have you added new tests to prevent regressions?
 - [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
-- [ ] Did you follow the commit message conventions explained in CONTRIBUTING.md?
+- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?
 
 <!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->
 


### PR DESCRIPTION
So users can click on it for reference

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in CONTRIBUTING.md?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
