### PR TITLE
 pass dialect for now with milliseconds - issue 8460

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -988,7 +988,7 @@ class Model {
       }
 
       if (definition.hasOwnProperty('defaultValue')) {
-        this._defaultValues[name] = _.partial(Utils.toDefaultValue, definition.defaultValue);
+        this._defaultValues[name] = _.partial(Utils.toDefaultValue, definition.defaultValue, this.sequelize.options.dialect);
       }
 
       if (definition.hasOwnProperty('unique') && definition.unique) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -299,7 +299,7 @@ function removeCommentsFromFunctionString(s) {
 }
 exports.removeCommentsFromFunctionString = removeCommentsFromFunctionString;
 
-function toDefaultValue(value) {
+function toDefaultValue(value, dialect) {
   if (typeof value === 'function') {
     const tmp = value();
     if (tmp instanceof DataTypes.ABSTRACT) {
@@ -312,7 +312,7 @@ function toDefaultValue(value) {
   } else if (value instanceof DataTypes.UUIDV4) {
     return uuid.v4();
   } else if (value instanceof DataTypes.NOW) {
-    return now();
+    return now(dialect);
   } else if (_.isPlainObject(value) || _.isArray(value)) {
     return _.clone(value);
   } else {


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

fix issue #4539 / #8460 

Minimum changes included.  You might want to change everywhere else that model.js uses Utils.toDefaultValue also - or make a helper in model and use that, similar to _getDefaultTimestamp. These changes are working for me on create() with postgres.