### PR TITLE
Fix transaction error on MSSQL

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -40,7 +40,7 @@ class Transaction {
     if (this.parent) {
       this.id = this.parent.id;
       this.parent.savepoints.push(this);
-      this.name = this.id + '-savepoint-' + this.parent.savepoints.length;
+      this.name = this.id + '-sp-' + this.parent.savepoints.length;
     } else {
       this.id = this.name = generateTransactionId();
     }


### PR DESCRIPTION
Transaction on MSSQL fails because the transaction identifier is greater than 32 bit. "-savepoint-" is appended to a 20 bit uuid whose length goes beyond 32 characters after 9 transaction. reducing this text to minimal characters like "sp" resolved the issues.

Related issues: #3950 #5959

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
