### PR TITLE
docs(migration): mention old connection pooling conf keys no longer s…

### DIFF
--- a/docs/upgrade-to-v4.md
+++ b/docs/upgrade-to-v4.md
@@ -9,6 +9,25 @@ Sequelize V4 is a major release and it introduces new features and breaking chan
 - Removed MariaDB dialect. This was just a thin wrapper around MySQL, so using `dialect: 'mysql'` instead should work with no further changes
 - Removed default `REPEATABLE_READ` transaction isolation. The isolation level now defaults to that of the database. Explicitly pass the required isolation level when initiating the transaction.
 - Removed support for `pool: false`. To use a single connection, set `pool.max` to 1.
+- Removed support for old connection pooling configuration keys. Instead of
+  ```js
+  pool: {
+    maxIdleTime: 30000,
+    minConnections: 20,
+    maxConnections: 30
+  }
+  ```
+
+  use
+
+  ```js
+  pool: {
+    idle: 30000,
+    min: 20,
+    max: 30
+  }
+  ```
+
 - (MySQL) BIGINT now gets converted to string when number is too big
 - Removed support for referencesKey, use a references object
   ```js


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Document that the old connection pooling conf. keys are no longer supported

Closes https://github.com/sequelize/sequelize/issues/8723