### PR TITLE
docs(migration): document mysql2 DECIMAL type incompatibility (#8713)

### DIFF
--- a/docs/upgrade-to-v4.md
+++ b/docs/upgrade-to-v4.md
@@ -10,6 +10,13 @@ Sequelize V4 is a major release and it introduces new features and breaking chan
 - Removed default `REPEATABLE_READ` transaction isolation. The isolation level now defaults to that of the database. Explicitly pass the required isolation level when initiating the transaction.
 - Removed support for `pool: false`. To use a single connection, set `pool.max` to 1.
 - (MySQL) BIGINT now gets converted to string when number is too big
+- (MySQL) `DECIMAL` and `NEWDECIMAL` types now returned as String unless
+  ```js
+  dialectOptions: {
+    decimalNumbers: true
+  }
+  ```
+  is specified.
 - Removed support for referencesKey, use a references object
   ```js
   references: {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Closes https://github.com/sequelize/sequelize/issues/8713