### PR TITLE
fix(model): ordering by renamed sub-query attribute

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1688,6 +1688,16 @@ const QueryGenerator = {
         ) {
           subQueryOrder.push(this.quote(order, model, '->'));
         }
+
+        if (subQuery) {
+          // Handle case where sub-query renames attribute we want to order by,
+          // see https://github.com/sequelize/sequelize/issues/8739
+          const subQueryAttribute = options.attributes.find(a => Array.isArray(a) && a[0] === order[0] && a[1]);
+          if (subQueryAttribute) {
+            order[0] = new Utils.Col(subQueryAttribute[1]);
+          }
+        }
+
         mainQueryOrder.push(this.quote(order, model, '->'));
       }
     } else if (options.order instanceof Utils.SequelizeMethod) {


### PR DESCRIPTION
Closes #8739

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **N/A**
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Use correct column name when ordering by an attribute projected from a sub-query. See #8739.
