### PR TITLE
fix(query-interface): add ability to pass options from createFunction() call

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1122,6 +1122,35 @@ class QueryInterface {
     }
   }
 
+  /**
+   * Create SQL function
+   *
+   * ```js
+   * queryInterface.createFunction(
+   *   'someFunction',
+   *   [
+   *     {type: 'integer', name: 'param', direction: 'IN'}
+   *   ],
+   *   'integer',
+   *   'plpgsql',
+   *   'RETURN param + 1;',
+   *   [
+   *     'IMMUTABLE',
+   *     'LEAKPROOF'
+   *   ]
+   * );
+   * ```
+   *
+   * @param {String} functionName Name of SQL function to create
+   * @param {Array}  params       List of parameters declared for SQL function
+   * @param {String} returnType   SQL type of function returned value
+   * @param {String} language     The name of the language that the function is implemented in
+   * @param {String} body         Source code of function
+   * @param {Array}  optionsArray Extra-options for creation
+   * @param {Object} [options]
+   *
+   * @return {Promise}
+   */
   createFunction(functionName, params, returnType, language, body, optionsArray, options) {
     const sql = this.QueryGenerator.createFunction(functionName, params, returnType, language, body, optionsArray);
     options = options || {};
@@ -1133,6 +1162,25 @@ class QueryInterface {
     }
   }
 
+  /**
+   * Drop SQL function
+   *
+   * ```js
+   * queryInterface.dropFunction(
+   *   'someFunction',
+   *   [
+   *     {type: 'varchar', name: 'param1', direction: 'IN'},
+   *     {type: 'integer', name: 'param2', direction: 'INOUT'}
+   *   ]
+   * );
+   * ```
+   *
+   * @param {String} functionName Name of SQL function to drop
+   * @param {Array}  params       List of parameters declared for SQL function
+   * @param {Object} [options]
+   *
+   * @return {Promise}
+   */
   dropFunction(functionName, params, options) {
     const sql = this.QueryGenerator.dropFunction(functionName, params);
     options = options || {};
@@ -1144,6 +1192,27 @@ class QueryInterface {
     }
   }
 
+  /**
+   * Rename SQL function
+   *
+   * ```js
+   * queryInterface.renameFunction(
+   *   'fooFunction',
+   *   [
+   *     {type: 'varchar', name: 'param1', direction: 'IN'},
+   *     {type: 'integer', name: 'param2', direction: 'INOUT'}
+   *   ],
+   *   'barFunction'
+   * );
+   * ```
+   *
+   * @param {String} oldFunctionName
+   * @param {Array}  params           List of parameters declared for SQL function
+   * @param {String} newFunctionName
+   * @param {Object} [options]
+   *
+   * @return {Promise}
+   */
   renameFunction(oldFunctionName, params, newFunctionName, options) {
     const sql = this.QueryGenerator.renameFunction(oldFunctionName, params, newFunctionName);
     options = options || {};

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1122,8 +1122,8 @@ class QueryInterface {
     }
   }
 
-  createFunction(functionName, params, returnType, language, body, options) {
-    const sql = this.QueryGenerator.createFunction(functionName, params, returnType, language, body, options);
+  createFunction(functionName, params, returnType, language, body, optionsArray, options) {
+    const sql = this.QueryGenerator.createFunction(functionName, params, returnType, language, body, optionsArray);
     options = options || {};
 
     if (sql) {


### PR DESCRIPTION
Closes #8741

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

queryInterface.createFunction() does not support ability to pass options to sequelize.query().
I extended signature of this function similar to createTrigger() approach - separate extended SQL function description options with options that passed to sequelize.query().
