### PR TITLE
feat(postgres): returning option for arithmetic queries (#8727)

### DIFF
--- a/docs/associations.md
+++ b/docs/associations.md
@@ -103,7 +103,7 @@ Project.hasOne(User, { foreignKey: 'initiator_id' })
 */
  
 Project.hasOne(User, { as: 'Initiator' })
-// Now you will get Project#getInitiator and Project#setInitiator
+// Now you will get Project.getInitiator and Project.setInitiator
  
 // Or let's define some self references
 const Person = sequelize.define('person', { /* ... */})
@@ -116,8 +116,8 @@ Person.hasOne(Person, {as: 'Father', foreignKey: 'DadId'})
 // this will add the attribute DadId to Person
  
 // In both cases you will be able to do:
-Person#setFather
-Person#getFather
+Person.setFather
+Person.getFather
  
 // If you need to join a table twice you can double join the same table
 Team.hasOne(Game, {as: 'HomeTeam', foreignKey : 'homeTeamId'});
@@ -191,8 +191,7 @@ const Project = sequelize.define('project', {/* ... */})
 Project.hasMany(User, {as: 'Workers'})
 ```
 
-This will add the attribute `projectId` or `project_id` to User. Instances of Project will get the accessors `getWorkers` and `setWorkers`. We could just leave it the way it is and let it be a one-way association.
-But we want more! Let's define it the other way around by creating a many to many association in the next section:
+This will add the attribute `projectId` or `project_id` to User. Instances of Project will get the accessors `getWorkers` and `setWorkers`. 
 
 Sometimes you may need to associate records on different columns, you may use `sourceKey` option:
 
@@ -205,6 +204,7 @@ Country.hasMany(City, {foreignKey: 'countryCode', sourceKey: 'isoCode'});
 City.belongsTo(Country, {foreignKey: 'countryCode', targetKey: 'isoCode'});
 ```
 
+So far we dealt with a one-way association. But we want more! Let's define it the other way around by creating a many to many association in the next section.
 
 ## Belongs-To-Many associations
 

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -300,7 +300,10 @@ First of all you can define a field and the value you want to add to it&period;
 ```js
 User.findById(1).then(user => {
   return user.increment('my-integer-field', {by: 2})
-}).then(/* ... */)
+}).then(user => {
+  // Postgres will return the updated user by default (unless disabled by setting { returning: false })
+  // In other dialects, you'll want to call user.reload() to get the updated instance...
+})
 ```
 
 Second&comma; you can define multiple fields and the value you want to add to them&period;
@@ -331,7 +334,10 @@ First of all you can define a field and the value you want to add to it&period;
 ```js
 User.findById(1).then(user => {
   return user.decrement('my-integer-field', {by: 2})
-}).then(/* ... */)
+}).then(user => {
+  // Postgres will return the updated user by default (unless disabled by setting { returning: false })
+  // In other dialects, you'll want to call user.reload() to get the updated instance...
+})
 ```
 
 Second&comma; you can define multiple fields and the value you want to add to them&period;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -389,7 +389,7 @@ const QueryGenerator = {
   */
   arithmeticQuery(operator, tableName, attrValueHash, where, options, attributes) {
     options = options || {};
-    _.defaults(options, this.options, { returning: true });
+    _.defaults(options, { returning: true });
 
     attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull);
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -388,13 +388,16 @@ const QueryGenerator = {
    @private
   */
   arithmeticQuery(operator, tableName, attrValueHash, where, options, attributes) {
+    options = options || {};
+    _.defaults(options, this.options, { returning: true });
+
     attrValueHash = Utils.removeNullValuesFromHash(attrValueHash, this.options.omitNull);
 
     const values = [];
     let query = 'UPDATE <%= table %> SET <%= values %><%= output %> <%= where %>';
     let outputFragment;
 
-    if (this._dialect.supports.returnValues) {
+    if (this._dialect.supports.returnValues && options.returning) {
       if (this._dialect.supports.returnValues.returning) {
         options.mapToModel = true;
         query += ' RETURNING *';

--- a/lib/model.js
+++ b/lib/model.js
@@ -3899,7 +3899,7 @@ class Model {
    * ```sql
    * SET column = column + X
    * ```
-   * query. To get the correct value after an increment into the Instance you should do a reload.
+   * query. The updated instance will be returned by default in Postgres. However, in other dialects, you will need to do a reload to get the new values.
    *
    *```js
   * instance.increment('number') // increment number by 1
@@ -3916,6 +3916,7 @@ class Model {
   * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
   * @param {Transaction} [options.transaction]
   * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+  * @param {Boolean} [options.returning=true] Append RETURNING * to get back auto generated values (Postgres only)
   *
   * @return {Promise<this>}
   * @since 4.0.0
@@ -3935,7 +3936,7 @@ class Model {
    * ```sql
    * SET column = column - X
    * ```
-   * query. To get the correct value after an decrement into the Instance you should do a reload.
+   * query. The updated instance will be returned by default in Postgres. However, in other dialects, you will need to do a reload to get the new values.
    *
    * ```js
    * instance.decrement('number') // decrement number by 1
@@ -3952,6 +3953,7 @@ class Model {
    * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {Transaction} [options.transaction]
    * @param  {String}       [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {Boolean} [options.returning=true] Append RETURNING * to get back auto generated values (Postgres only)
    *
    * @return {Promise}
    */

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -156,6 +156,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         return this.User.findById(1).then(user1 => {
           return user1.increment('aNumber', { by: 2 }).then(() => {
             expect(user1.aNumber).to.be.equal(2);
+            return user1.increment('bNumber', { by: 2, returning: false }).then(user3 => {
+              expect(user3.bNumber).to.be.equal(0);
+            });
           });
         });
       });
@@ -323,6 +326,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         return this.User.findById(1).then(user1 => {
           return user1.decrement('aNumber', { by: 2 }).then(() => {
             expect(user1.aNumber).to.be.equal(-2);
+            return user1.decrement('bNumber', { by: 2, returning: false }).then(user3 => {
+              expect(user3.bNumber).to.be.equal(0);
+            });
           });
         });
       });

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -26,6 +26,11 @@ if (dialect.match(/^postgres/)) {
           expectation: 'UPDATE "myTable" SET "foo"="foo"+ \'bar\' WHERE "bar" = \'biz\' RETURNING *'
         },
         {
+          title: 'Should use the plus operator without returning clause',
+          arguments: ['+', 'myTable', { foo: 'bar' }, {}, { returning: false }],
+          expectation: 'UPDATE "myTable" SET "foo"="foo"+ \'bar\' '
+        },
+        {
           title: 'Should use the minus operator',
           arguments: ['-', 'myTable', { foo: 'bar' }, {}, {}],
           expectation: 'UPDATE "myTable" SET "foo"="foo"- \'bar\'  RETURNING *'
@@ -39,6 +44,11 @@ if (dialect.match(/^postgres/)) {
           title: 'Should use the minus operator with where clause',
           arguments: ['-', 'myTable', { foo: 'bar' }, { bar: 'biz'}, {}],
           expectation: 'UPDATE "myTable" SET "foo"="foo"- \'bar\' WHERE "bar" = \'biz\' RETURNING *'
+        },
+        {
+          title: 'Should use the minus operator without returning clause',
+          arguments: ['-', 'myTable', { foo: 'bar' }, {}, { returning: false }],
+          expectation: 'UPDATE "myTable" SET "foo"="foo"- \'bar\' '
         }
       ],
       attributesToSQL: [


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Add handling for a `returning` option in arithmetic queries (`increment` and `decrement`). Defaults to `true` to maintain expected behavior.

Closes #8727