### PR TITLE
Added _scopeName property in instance

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -842,6 +842,7 @@ class Model {
     this._findAutoIncrementAttribute();
 
     this._scope = this.options.defaultScope;
+    this._scopeNames = ['defaultScope'];
 
     if (_.isPlainObject(this._scope)) {
       this._conformOptions(this._scope, this);
@@ -1327,6 +1328,7 @@ class Model {
     Object.defineProperty(self, 'name', {value: this.name});
 
     self._scope = {};
+    self._scopeNames = [];
     self.scoped = true;
 
     if (!option) {
@@ -1375,6 +1377,8 @@ class Model {
 
           return objectValue ? objectValue : sourceValue;
         });
+
+        self._scopeNames.push(scopeName ? scopeName : 'defaultScope');
       } else {
         throw new sequelizeErrors.SequelizeScopeError('Invalid scope ' + scopeName + ' called.');
       }

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -181,6 +181,18 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    it('should be able to check default scope name', () => {
+      expect(Company._scopeNames).to.include('defaultScope');
+    });
+
+    it('should be able to check custom scope name', () => {
+      expect(Company.scope('users')._scopeNames).to.include('users');
+    });
+
+    it('should be able to check multiple custom scope names', () => {
+      expect(Company.scope('users', 'projects')._scopeNames).to.include.members(['users', 'projects']);
+    });
+
     it('should be able to merge two scoped includes', () => {
       expect(Company.scope('users', 'projects')._scope).to.deep.equal({
         include: [


### PR DESCRIPTION
*The name of the used scope is now stored in a instance property "_scopeNames" which contains the list of all scope used in the query

Resolves #7433 

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Property `_scopeNames` is added to the instance, this is useful when in need to check for the used scope in hooks, this holds a lists of all used scopes. If `scope()` was not called then `_scopeNames` holds `defaultScope` as the only item in the list.