### PR TITLE
perf: dont keep bounded reference of connection manager

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -43,7 +43,7 @@ class ConnectionManager {
       Promise
     });
 
-    process.on('exit', () => {
+    process.on('beforeExit', () => {
       this._onProcessExit.call(this);
     });
 
@@ -85,9 +85,6 @@ class ConnectionManager {
    * @return {Promise}
    */
   close() {
-    // Remove the listener, so all references to this instance can be garbage collected.
-    process.removeListener('exit', this._onProcessExit);
-
     // Mark close of pool
     this.getConnection = function getConnection() {
       return Promise.reject(new Error('ConnectionManager.getConnection was called after the connection manager was closed!'));

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -43,9 +43,9 @@ class ConnectionManager {
       Promise
     });
 
-    // Save a reference to the bound version so we can remove it with removeListener
-    this._onProcessExit = this._onProcessExit.bind(this);
-    process.on('exit', this._onProcessExit);
+    process.on('exit', () => {
+      this._onProcessExit.call(this);
+    });
 
     this.initPools();
   }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Actual a memory management improvement, now Sequelize will consume less RAM. I noticed connection manager reference is not released. There are still more issues but I just got time to track this one over last weekend