### PR TITLE
fix(mssql): improper parameter binding sql generation

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -144,16 +144,9 @@ class Query extends AbstractQuery {
 
   static formatBindParameters(sql, values, dialect) {
     const bindParam = {};
-    let i = 0;
-    const seen = {};
     const replacementFunc = (match, key, values) => {
-      if (seen[key] !== undefined) {
-        return seen[key];
-      }
       if (values[key] !== undefined) {
-        i = i + 1;
         bindParam[key] = values[key];
-        seen[key] = '$' + i;
         return '@' + key;
       }
       return undefined;

--- a/test/unit/dialects/mssql/connection-manager.test.js
+++ b/test/unit/dialects/mssql/connection-manager.test.js
@@ -9,36 +9,36 @@ const chai = require('chai'),
   sinon = require('sinon'),
   connectionStub = sinon.stub(tedious, 'Connection');
 
-if (dialect !== 'mssql') { return; }
-
 connectionStub.returns({on() {}});
 
-describe('[MSSQL Specific] Connection Manager', () => {
-  let instance,
-    config;
-  beforeEach(() => {
-    config = {
-      dialect: 'mssql',
-      database: 'none',
-      username: 'none',
-      password: 'none',
-      host: 'localhost',
-      port: 2433,
-      pool: {},
-      dialectOptions: {
-        domain: 'TEST.COM'
-      }
-    };
-    instance = new Sequelize(config.database
-      , config.username
-      , config.password
-      , config);
-  });
-
-  it('connectionManager._connect() Does not delete `domain` from config.dialectOptions',
-    () => {
-      expect(config.dialectOptions.domain).to.equal('TEST.COM');
-      instance.dialect.connectionManager._connect(config);
-      expect(config.dialectOptions.domain).to.equal('TEST.COM');
+if (dialect === 'mssql') {
+  describe('[MSSQL Specific] Connection Manager', () => {
+    let instance,
+      config;
+    beforeEach(() => {
+      config = {
+        dialect: 'mssql',
+        database: 'none',
+        username: 'none',
+        password: 'none',
+        host: 'localhost',
+        port: 2433,
+        pool: {},
+        dialectOptions: {
+          domain: 'TEST.COM'
+        }
+      };
+      instance = new Sequelize(config.database
+        , config.username
+        , config.password
+        , config);
     });
-});
+
+    it('connectionManager._connect() Does not delete `domain` from config.dialectOptions',
+      () => {
+        expect(config.dialectOptions.domain).to.equal('TEST.COM');
+        instance.dialect.connectionManager._connect(config);
+        expect(config.dialectOptions.domain).to.equal('TEST.COM');
+      });
+  });
+}

--- a/test/unit/dialects/mssql/connection-manager.test.js
+++ b/test/unit/dialects/mssql/connection-manager.test.js
@@ -9,7 +9,7 @@ const chai = require('chai'),
 
 connectionStub.returns({on() {}});
 
-describe('[MSSQL] Connection Manager', () => {
+describe('[MSSQL Specific] Connection Manager', () => {
   let instance,
     config;
   beforeEach(() => {

--- a/test/unit/dialects/mssql/connection-manager.test.js
+++ b/test/unit/dialects/mssql/connection-manager.test.js
@@ -3,9 +3,13 @@
 const chai = require('chai'),
   expect = chai.expect,
   Sequelize = require(__dirname + '/../../../../index'),
+  Support = require(__dirname + '/../../support'),
+  dialect = Support.getTestDialect(),
   tedious = require('tedious'),
   sinon = require('sinon'),
   connectionStub = sinon.stub(tedious, 'Connection');
+
+if (dialect !== 'mssql') { return; }
 
 connectionStub.returns({on() {}});
 

--- a/test/unit/dialects/mssql/query.js
+++ b/test/unit/dialects/mssql/query.js
@@ -12,7 +12,7 @@ const connectionStub = { beginTransaction: () => {}, lib: tedious };
 
 let sandbox, query;
 
-describe('[MSSQL]', () => {
+describe('[MSSQL] Query', () => {
   describe('beginTransaction', () => {
     beforeEach(() => {
       sandbox = sinon.sandbox.create();
@@ -38,6 +38,30 @@ describe('[MSSQL]', () => {
 
     afterEach(() => {
       sandbox.restore();
+    });
+  });
+
+  describe('formatBindParameters', () => {
+    it('should convert Sequelize named binding format to MSSQL format', () => {
+      const sql = 'select $one as a, $two as b, $one as c, $three as d, $one as e';
+      const values = { one: 1, two: 2, three: 3 };
+
+      const expected = 'select @one as a, @two as b, @one as c, @three as d, @one as e';
+
+      const result = Query.formatBindParameters(sql, values, 'mssql');
+      expect(result[0]).to.be.a('string');
+      expect(result[0]).to.equal(expected);
+    });
+
+    it('should convert Sequelize numbered binding format to MSSQL format', () => {
+      const sql = 'select $1 as a, $2 as b, $1 as c, $3 as d, $1 as e';
+      const values = [1, 2, 3];
+
+      const expected = 'select @0 as a, @1 as b, @0 as c, @2 as d, @0 as e';
+
+      const result = Query.formatBindParameters(sql, values, 'mssql');
+      expect(result[0]).to.be.a('string');
+      expect(result[0]).to.equal(expected);
     });
   });
 });

--- a/test/unit/dialects/mssql/query.test.js
+++ b/test/unit/dialects/mssql/query.test.js
@@ -11,60 +11,60 @@ const tedious = require('tedious');
 const tediousIsolationLevel = tedious.ISOLATION_LEVEL;
 const connectionStub = { beginTransaction: () => {}, lib: tedious };
 
-if (dialect !== 'mssql') { return; }
-
 let sandbox, query;
 
-describe('[MSSQL Specific] Query', () => {
-  describe('beginTransaction', () => {
-    beforeEach(() => {
-      sandbox = sinon.sandbox.create();
-      const options = {
-        transaction: { name: 'transactionName' },
-        isolationLevel: 'REPEATABLE_READ',
-        logging: false
-      };
-      sandbox.stub(connectionStub, 'beginTransaction').callsFake(cb => {
-        cb();
-      });
-      query = new Query(connectionStub, sequelize, options);
-    });
-
-    it('should call beginTransaction with correct arguments', () => {
-      return query._run(connectionStub, 'BEGIN TRANSACTION')
-        .then(() => {
-          expect(connectionStub.beginTransaction.called).to.equal(true);
-          expect(connectionStub.beginTransaction.args[0][1]).to.equal('transactionName');
-          expect(connectionStub.beginTransaction.args[0][2]).to.equal(tediousIsolationLevel.REPEATABLE_READ);
+if (dialect === 'mssql') {
+  describe('[MSSQL Specific] Query', () => {
+    describe('beginTransaction', () => {
+      beforeEach(() => {
+        sandbox = sinon.sandbox.create();
+        const options = {
+          transaction: { name: 'transactionName' },
+          isolationLevel: 'REPEATABLE_READ',
+          logging: false
+        };
+        sandbox.stub(connectionStub, 'beginTransaction').callsFake(cb => {
+          cb();
         });
+        query = new Query(connectionStub, sequelize, options);
+      });
+
+      it('should call beginTransaction with correct arguments', () => {
+        return query._run(connectionStub, 'BEGIN TRANSACTION')
+          .then(() => {
+            expect(connectionStub.beginTransaction.called).to.equal(true);
+            expect(connectionStub.beginTransaction.args[0][1]).to.equal('transactionName');
+            expect(connectionStub.beginTransaction.args[0][2]).to.equal(tediousIsolationLevel.REPEATABLE_READ);
+          });
+      });
+
+      afterEach(() => {
+        sandbox.restore();
+      });
     });
 
-    afterEach(() => {
-      sandbox.restore();
+    describe('formatBindParameters', () => {
+      it('should convert Sequelize named binding format to MSSQL format', () => {
+        const sql = 'select $one as a, $two as b, $one as c, $three as d, $one as e';
+        const values = { one: 1, two: 2, three: 3 };
+
+        const expected = 'select @one as a, @two as b, @one as c, @three as d, @one as e';
+
+        const result = Query.formatBindParameters(sql, values, dialect);
+        expect(result[0]).to.be.a('string');
+        expect(result[0]).to.equal(expected);
+      });
+
+      it('should convert Sequelize numbered binding format to MSSQL format', () => {
+        const sql = 'select $1 as a, $2 as b, $1 as c, $3 as d, $1 as e';
+        const values = [1, 2, 3];
+
+        const expected = 'select @0 as a, @1 as b, @0 as c, @2 as d, @0 as e';
+
+        const result = Query.formatBindParameters(sql, values, dialect);
+        expect(result[0]).to.be.a('string');
+        expect(result[0]).to.equal(expected);
+      });
     });
   });
-
-  describe('formatBindParameters', () => {
-    it('should convert Sequelize named binding format to MSSQL format', () => {
-      const sql = 'select $one as a, $two as b, $one as c, $three as d, $one as e';
-      const values = { one: 1, two: 2, three: 3 };
-
-      const expected = 'select @one as a, @two as b, @one as c, @three as d, @one as e';
-
-      const result = Query.formatBindParameters(sql, values, dialect);
-      expect(result[0]).to.be.a('string');
-      expect(result[0]).to.equal(expected);
-    });
-
-    it('should convert Sequelize numbered binding format to MSSQL format', () => {
-      const sql = 'select $1 as a, $2 as b, $1 as c, $3 as d, $1 as e';
-      const values = [1, 2, 3];
-
-      const expected = 'select @0 as a, @1 as b, @0 as c, @2 as d, @0 as e';
-
-      const result = Query.formatBindParameters(sql, values, dialect);
-      expect(result[0]).to.be.a('string');
-      expect(result[0]).to.equal(expected);
-    });
-  });
-});
+}

--- a/test/unit/dialects/mssql/query.test.js
+++ b/test/unit/dialects/mssql/query.test.js
@@ -12,7 +12,7 @@ const connectionStub = { beginTransaction: () => {}, lib: tedious };
 
 let sandbox, query;
 
-describe('[MSSQL] Query', () => {
+describe('[MSSQL Specific] Query', () => {
   describe('beginTransaction', () => {
     beforeEach(() => {
       sandbox = sinon.sandbox.create();

--- a/test/unit/dialects/mssql/query.test.js
+++ b/test/unit/dialects/mssql/query.test.js
@@ -2,13 +2,16 @@
 
 const path = require('path');
 const Query = require(path.resolve('./lib/dialects/mssql/query.js'));
-const Support = require(path.resolve('./test/support'));
+const Support = require(__dirname + '/../../support');
+const dialect = Support.getTestDialect();
 const sequelize = Support.sequelize;
 const sinon = require('sinon');
 const expect = require('chai').expect;
 const tedious = require('tedious');
 const tediousIsolationLevel = tedious.ISOLATION_LEVEL;
 const connectionStub = { beginTransaction: () => {}, lib: tedious };
+
+if (dialect !== 'mssql') { return; }
 
 let sandbox, query;
 
@@ -48,7 +51,7 @@ describe('[MSSQL Specific] Query', () => {
 
       const expected = 'select @one as a, @two as b, @one as c, @three as d, @one as e';
 
-      const result = Query.formatBindParameters(sql, values, 'mssql');
+      const result = Query.formatBindParameters(sql, values, dialect);
       expect(result[0]).to.be.a('string');
       expect(result[0]).to.equal(expected);
     });
@@ -59,7 +62,7 @@ describe('[MSSQL Specific] Query', () => {
 
       const expected = 'select @0 as a, @1 as b, @0 as c, @2 as d, @0 as e';
 
-      const result = Query.formatBindParameters(sql, values, 'mssql');
+      const result = Query.formatBindParameters(sql, values, dialect);
       expect(result[0]).to.be.a('string');
       expect(result[0]).to.equal(expected);
     });

--- a/test/unit/dialects/mssql/resource-lock.test.js
+++ b/test/unit/dialects/mssql/resource-lock.test.js
@@ -2,7 +2,11 @@
 
 const ResourceLock = require('../../../../lib/dialects/mssql/resource-lock'),
   Promise = require('../../../../lib/promise'),
-  assert = require('assert');
+  assert = require('assert'),
+  Support = require(__dirname + '/../../support'),
+  dialect = Support.getTestDialect();
+
+if (dialect !== 'mssql') { return; }
 
 describe('[MSSQL Specific] ResourceLock', () => {
   it('should process requests serially', () => {

--- a/test/unit/dialects/mssql/resource-lock.test.js
+++ b/test/unit/dialects/mssql/resource-lock.test.js
@@ -6,63 +6,63 @@ const ResourceLock = require('../../../../lib/dialects/mssql/resource-lock'),
   Support = require(__dirname + '/../../support'),
   dialect = Support.getTestDialect();
 
-if (dialect !== 'mssql') { return; }
+if (dialect === 'mssql') {
+  describe('[MSSQL Specific] ResourceLock', () => {
+    it('should process requests serially', () => {
+      const expected = {};
+      const lock = new ResourceLock(expected);
+      let last = 0;
 
-describe('[MSSQL Specific] ResourceLock', () => {
-  it('should process requests serially', () => {
-    const expected = {};
-    const lock = new ResourceLock(expected);
-    let last = 0;
+      function validateResource(actual) {
+        assert.equal(actual, expected);
+      }
 
-    function validateResource(actual) {
-      assert.equal(actual, expected);
-    }
+      return Promise.all([
+        Promise.using(lock.lock(), resource => {
+          validateResource(resource);
+          assert.equal(last, 0);
+          last = 1;
 
-    return Promise.all([
-      Promise.using(lock.lock(), resource => {
-        validateResource(resource);
-        assert.equal(last, 0);
-        last = 1;
+          return Promise.delay(15);
+        }),
+        Promise.using(lock.lock(), resource => {
+          validateResource(resource);
+          assert.equal(last, 1);
+          last = 2;
+        }),
+        Promise.using(lock.lock(), resource => {
+          validateResource(resource);
+          assert.equal(last, 2);
+          last = 3;
 
-        return Promise.delay(15);
-      }),
-      Promise.using(lock.lock(), resource => {
-        validateResource(resource);
-        assert.equal(last, 1);
-        last = 2;
-      }),
-      Promise.using(lock.lock(), resource => {
-        validateResource(resource);
-        assert.equal(last, 2);
-        last = 3;
+          return Promise.delay(5);
+        })
+      ]);
+    });
 
-        return Promise.delay(5);
-      })
-    ]);
+    it('should still return resource after failure', () => {
+      const expected = {};
+      const lock = new ResourceLock(expected);
+
+      function validateResource(actual) {
+        assert.equal(actual, expected);
+      }
+
+      return Promise.all([
+        Promise.using(lock.lock(), resource => {
+          validateResource(resource);
+
+          throw new Error('unexpected error');
+        }).catch(() => {}),
+        Promise.using(lock.lock(), validateResource)
+      ]);
+    });
+
+    it('should be able to.lock resource without waiting on lock', () => {
+      const expected = {};
+      const lock = new ResourceLock(expected);
+
+      assert.equal(lock.unwrap(), expected);
+    });
   });
-
-  it('should still return resource after failure', () => {
-    const expected = {};
-    const lock = new ResourceLock(expected);
-
-    function validateResource(actual) {
-      assert.equal(actual, expected);
-    }
-
-    return Promise.all([
-      Promise.using(lock.lock(), resource => {
-        validateResource(resource);
-
-        throw new Error('unexpected error');
-      }).catch(() => {}),
-      Promise.using(lock.lock(), validateResource)
-    ]);
-  });
-
-  it('should be able to.lock resource without waiting on lock', () => {
-    const expected = {};
-    const lock = new ResourceLock(expected);
-
-    assert.equal(lock.unwrap(), expected);
-  });
-});
+}


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Parameters are not properly converting to their MSSQL counterparts beyond the first occurrence of each name. For example:

`select $one as foo, $two as bar, $one as baz`

Becomes:

`select @one as foo, @two as bar, $1 as baz`

This pull request fixes the conversion by removing code that does not apply to the MSSQL dialect.