### PR TITLE
 fix(mssql): dateonly value should be treated as utc when parsing

### DIFF
--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -145,7 +145,7 @@ module.exports = BaseTypes => {
   inherits(DATEONLY, BaseTypes.DATEONLY);
 
   DATEONLY.parse = function(value) {
-    return moment(value).format('YYYY-MM-DD');
+    return moment.utc(value).format('YYYY-MM-DD');
   };
 
   function INTEGER(length) {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -478,8 +478,10 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     const Model = this.sequelize.define('user', {
       stamp: Sequelize.DATEONLY
     });
+
     const testDate = moment().format('YYYY-MM-DD');
     const newDate = new Date();
+    const dateOnly = moment(newDate).format('YYYY-MM-DD');
 
     return Model.sync({ force: true})
       .then(() => Model.create({ stamp: testDate }))
@@ -508,7 +510,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
         return record.reload();
       }).then(record => {
         expect(typeof record.stamp).to.be.eql('string');
-        expect(new Date(record.stamp)).to.equalDate(newDate);
+        expect(record.stamp).to.equal(dateOnly);
       });
   });
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
MSSQL date only fields are being parsed to local date only strings. This is incorrect behavior because a date only string is only useful as it is. The problem is that `tedious` returns a Date object created with the date only value from the database (which it really shouldn't do). When formatting this Date object into a string using `moment`, the local time is used to determine the result:

```
let dbValue = '2017-12-15';
let tdsValue = new Date(dbValue);
// Date object as UTC time: 2017-12-15 00:00:00
// Assuming EST, Date object as local time: 2017-12-14 19:00:00 -0500
moment(tdsValue).format('YYYY-MM-DD'); // Outputs: 2017-12-14
```

We can fix this by changing the date mode:

```
moment.utc(tdsValue).format('YYYY-MM-DD'); // Outputs: 2017-12-15
```

This creates a `moment` object in UTC mode which uses the UTC time when it produces a date only string.