### PR TITLE
fix(connection-manager): only use close to shutdown

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -43,10 +43,6 @@ class ConnectionManager {
       Promise
     });
 
-    process.on('beforeExit', () => {
-      this._onProcessExit.call(this);
-    });
-
     this.initPools();
   }
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Fixes https://github.com/sequelize/sequelize/issues/8781
Closes https://github.com/sequelize/sequelize/issues/8780 

`beforeExit` by design can be called multiple times and even prevent process shutdown from empty event loop. In Sequelize case it was used to drain generic-pool which for some reason will repeat beforeExit process in series. (Using high memory in some cases)

Users should use `close` to shutdown pool and process should auto exit due to empty REPL