### PR TITLE
fix(mysql/json): properly quote JSON path to be valid ECMAScript name

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -461,7 +461,12 @@ const QueryGenerator = {
    * @private
    */
   jsonPathExtractionQuery(column, path) {
-    const paths = _.toPath(path);
+    /**
+     * Sub paths need to be quoted as ECMAScript identifiers
+     *
+     * https://bugs.mysql.com/bug.php?id=81896
+     */
+    const paths = _.toPath(path).map(subPath => Utils.addTicks(subPath, '"'));
     const pathStr = `${['$'].concat(paths).join('.')}`;
     const quotedColumn = this.isIdentifierQuoted(column) ? column : this.quoteIdentifier(column);
     return `(${quotedColumn}->>'${pathStr}')`;

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -423,6 +423,60 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         });
 
+        it('should be possible to query for nested fields with hyphens/dashes, #8718', function() {
+          return Promise.join(
+            this.Event.create({
+              data: {
+                name: {
+                  first: 'Homer',
+                  last: 'Simpson'
+                },
+                status_report: {
+                  'red-indicator': {
+                    'level$$level': true
+                  }
+                },
+                employment: 'Nuclear Safety Inspector'
+              }
+            }),
+            this.Event.create({
+              data: {
+                name: {
+                  first: 'Marge',
+                  last: 'Simpson'
+                },
+                employment: null
+              }
+            })
+          ).then(() => {
+            return this.Event.findAll({
+              where: {
+                data: {
+                  status_report: {
+                    'red-indicator': {
+                      'level$$level': true
+                    }
+                  }
+                }
+              }
+            }).then(events => {
+              expect(events.length).to.equal(1);
+              expect(events[0].get('data')).to.eql({
+                name: {
+                  first: 'Homer',
+                  last: 'Simpson'
+                },
+                status_report: {
+                  'red-indicator': {
+                    'level$$level': true
+                  }
+                },
+                employment: 'Nuclear Safety Inspector'
+              });
+            });
+          });
+        });
+
         it('should be possible to query multiple nested values', function() {
           return this.Event.create({
             data: {

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -102,15 +102,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
     });
 
-    if (current.dialect.supports.JSONB) {
-      describe('JSONB', () => {
+    if (current.dialect.supports.JSON) {
+      describe('JSON', () => {
         before(function() {
           this.Model = this.sequelize.define('Model', {
             name: {
               type: DataTypes.STRING
             },
             data: {
-              type: DataTypes.JSONB
+              type: DataTypes.JSON
             },
             deletedAt: {
               type: DataTypes.DATE,
@@ -128,7 +128,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return this.Model.sync({ force: true });
         });
 
-        it('should soft delete with JSONB condition', function() {
+        it('should soft delete with JSON condition', function() {
           return this.Model.bulkCreate([{
             name: 'One',
             data: {

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -792,7 +792,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           },
           prefix: 'User'
         }, {
-          mysql: "(`User`.`data`->>'$.nested.attribute') = 'value'",
+          mysql: "(`User`.`data`->>'$.\"nested\".\"attribute\"') = 'value'",
           postgres: "(\"User\".\"data\"#>>'{nested,attribute}') = 'value'",
           sqlite: "json_extract(`User`.`data`, '$.nested.attribute') = 'value'"
         });
@@ -806,7 +806,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "CAST((`data`->>'$.nested') AS DECIMAL) IN (1, 2)",
+          mysql: "CAST((`data`->>'$.\"nested\"') AS DECIMAL) IN (1, 2)",
           postgres: "CAST((\"data\"#>>'{nested}') AS DOUBLE PRECISION) IN (1, 2)",
           sqlite: "CAST(json_extract(`data`, '$.nested') AS DOUBLE PRECISION) IN (1, 2)"
         });
@@ -820,7 +820,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "CAST((`data`->>'$.nested') AS DECIMAL) BETWEEN 1 AND 2",
+          mysql: "CAST((`data`->>'$.\"nested\"') AS DECIMAL) BETWEEN 1 AND 2",
           postgres: "CAST((\"data\"#>>'{nested}') AS DOUBLE PRECISION) BETWEEN 1 AND 2",
           sqlite: "CAST(json_extract(`data`, '$.nested') AS DOUBLE PRECISION) BETWEEN 1 AND 2"
         });
@@ -838,7 +838,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           },
           prefix: current.literal(sql.quoteTable.call(current.dialect.QueryGenerator, {tableName: 'User'}))
         }, {
-          mysql: "((`User`.`data`->>'$.nested.attribute') = 'value' AND (`User`.`data`->>'$.nested.prop') != 'None')",
+          mysql: "((`User`.`data`->>'$.\"nested\".\"attribute\"') = 'value' AND (`User`.`data`->>'$.\"nested\".\"prop\"') != 'None')",
           postgres: "((\"User\".\"data\"#>>'{nested,attribute}') = 'value' AND (\"User\".\"data\"#>>'{nested,prop}') != 'None')",
           sqlite: "(json_extract(`User`.`data`, '$.nested.attribute') = 'value' AND json_extract(`User`.`data`, '$.nested.prop') != 'None')"
         });
@@ -856,7 +856,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           },
           prefix: 'User'
         }, {
-          mysql: "((`User`.`data`->>'$.name.last') = 'Simpson' AND (`User`.`data`->>'$.employment') != 'None')",
+          mysql: "((`User`.`data`->>'$.\"name\".\"last\"') = 'Simpson' AND (`User`.`data`->>'$.\"employment\"') != 'None')",
           postgres: "((\"User\".\"data\"#>>'{name,last}') = 'Simpson' AND (\"User\".\"data\"#>>'{employment}') != 'None')",
           sqlite: "(json_extract(`User`.`data`, '$.name.last') = 'Simpson' AND json_extract(`User`.`data`, '$.employment') != 'None')"
         });
@@ -869,7 +869,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "(CAST((`data`->>'$.price') AS DECIMAL) = 5 AND (`data`->>'$.name') = 'Product')",
+          mysql: "(CAST((`data`->>'$.\"price\"') AS DECIMAL) = 5 AND (`data`->>'$.\"name\"') = 'Product')",
           postgres: "(CAST((\"data\"#>>'{price}') AS DOUBLE PRECISION) = 5 AND (\"data\"#>>'{name}') = 'Product')",
           sqlite: "(CAST(json_extract(`data`, '$.price') AS DOUBLE PRECISION) = 5 AND json_extract(`data`, '$.name') = 'Product')"
         });
@@ -883,7 +883,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             }
           }
         }, {
-          mysql: "(`data`->>'$.nested.attribute') = 'value'",
+          mysql: "(`data`->>'$.\"nested\".\"attribute\"') = 'value'",
           postgres: "(\"data\"#>>'{nested,attribute}') = 'value'",
           sqlite: "json_extract(`data`, '$.nested.attribute') = 'value'"
         });
@@ -897,7 +897,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             }
           }
         }, {
-          mysql: "CAST((`data`->>'$.nested.attribute') AS DECIMAL) = 4",
+          mysql: "CAST((`data`->>'$.\"nested\".\"attribute\"') AS DECIMAL) = 4",
           postgres: "CAST((\"data\"#>>'{nested,attribute}') AS DOUBLE PRECISION) = 4",
           sqlite: "CAST(json_extract(`data`, '$.nested.attribute') AS DOUBLE PRECISION) = 4"
         });
@@ -913,7 +913,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             }
           }
         }, {
-          mysql: "CAST((`data`->>'$.nested.attribute') AS DECIMAL) IN (3, 7)",
+          mysql: "CAST((`data`->>'$.\"nested\".\"attribute\"') AS DECIMAL) IN (3, 7)",
           postgres: "CAST((\"data\"#>>'{nested,attribute}') AS DOUBLE PRECISION) IN (3, 7)",
           sqlite: "CAST(json_extract(`data`, '$.nested.attribute') AS DOUBLE PRECISION) IN (3, 7)"
         });
@@ -929,7 +929,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "CAST((`data`->>'$.nested.attribute') AS DECIMAL) > 2",
+          mysql: "CAST((`data`->>'$.\"nested\".\"attribute\"') AS DECIMAL) > 2",
           postgres: "CAST((\"data\"#>>'{nested,attribute}') AS DOUBLE PRECISION) > 2",
           sqlite: "CAST(json_extract(`data`, '$.nested.attribute') AS DOUBLE PRECISION) > 2"
         });
@@ -945,7 +945,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "CAST((`data`->>'$.nested.attribute') AS DECIMAL) > 2",
+          mysql: "CAST((`data`->>'$.\"nested\".\"attribute\"') AS DECIMAL) > 2",
           postgres: "CAST((\"data\"#>>'{nested,attribute}') AS INTEGER) > 2",
           sqlite: "CAST(json_extract(`data`, '$.nested.attribute') AS INTEGER) > 2"
         });
@@ -962,7 +962,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "CAST((`data`->>'$.nested.attribute') AS DATETIME) > "+sql.escape(dt),
+          mysql: "CAST((`data`->>'$.\"nested\".\"attribute\"') AS DATETIME) > "+sql.escape(dt),
           postgres: "CAST((\"data\"#>>'{nested,attribute}') AS TIMESTAMPTZ) > "+sql.escape(dt),
           sqlite: "json_extract(`data`, '$.nested.attribute') > " + sql.escape(dt.toISOString())
         });
@@ -976,7 +976,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "(`data`->>'$.nested.attribute') = 'true'",
+          mysql: "(`data`->>'$.\"nested\".\"attribute\"') = 'true'",
           postgres: "CAST((\"data\"#>>'{nested,attribute}') AS BOOLEAN) = true",
           sqlite: "CAST(json_extract(`data`, '$.nested.attribute') AS BOOLEAN) = 1"
         });
@@ -992,7 +992,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             }
           }
         }, {
-          mysql: "(`meta_data`->>'$.nested.attribute') = 'value'",
+          mysql: "(`meta_data`->>'$.\"nested\".\"attribute\"') = 'value'",
           postgres: "(\"meta_data\"#>>'{nested,attribute}') = 'value'",
           sqlite: "json_extract(`meta_data`, '$.nested.attribute') = 'value'"
         });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Fixes #8718 , JSON sub path if contain hyphen / dashes it will break find query. We need to quote paths properly to be a valid ECMAScript identifier

https://bugs.mysql.com/bug.php?id=81896