### PR TITLE
feat(model): allow serializing model instances into mongodb

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4020,6 +4020,16 @@ class Model {
       })
     );
   }
+  
+  /**
+   * For serializing this object into MongoDB
+   *
+   * @see {@link Model#get}
+   * @return {object}
+   */
+  toBSON() {
+    return this.toJSON();
+  }
 
   /**
    * Creates a 1:m association between this (the source) and the provided target. The foreign key is added on the target.


### PR DESCRIPTION
Hi,

Admittedly this is a strange PR, but we've seen instances of people trying to store sequelize objects in MongoDB (like https://github.com/agenda/agenda/issues/562#issuecomment-353486543). It would be handy if sequelize could implement a `toBSON()` function so the [mongodb driver could automatically serialize it correctly](https://github.com/mongodb/js-bson/pull/231).

Thanks and happy holidays!

Valeri