### PR TITLE
Bypass possibly overloaded static methods in Model

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1387,10 +1387,6 @@ class Model {
     return self;
   }
 
-  static all(options) {
-    return this.findAll(options);
-  }
-
   /**
    * Search for multiple instances.
    *
@@ -1684,7 +1680,7 @@ class Model {
     }
 
     // Bypass a possible overloaded findOne
-    return this.findOne(options);
+    return Model.findOne.call(this, options);
   }
 
   /**
@@ -1715,7 +1711,7 @@ class Model {
     }
 
     // Bypass a possible overloaded findAll.
-    return this.findAll(_.defaults(options, {
+    return Model.findAll.call(this, _.defaults(options, {
       plain: true,
       rejectOnEmpty: false
     }));
@@ -1818,7 +1814,7 @@ class Model {
       options.offset = null;
       options.order = null;
 
-      return this.aggregate(col, 'count', options);
+      return Model.aggregate.call(this, col, 'count', options);
     });
   }
 
@@ -1866,8 +1862,8 @@ class Model {
       countOptions.attributes = undefined;
     }
 
-    const countQuery = this.count(countOptions);
-    const findQuery = this.findAll(options);
+    const countQuery = Model.count.call(this, countOptions);
+    const findQuery = Model.findAll.call(this, options);
 
     return countQuery.then(count => {
       if (count === 0) {
@@ -1893,7 +1889,7 @@ class Model {
    * @return {Promise<Any>}
    */
   static max(field, options) {
-    return this.aggregate(field, 'max', options);
+    return Model.aggregate.call(this, field, 'max', options);
   }
 
   /**
@@ -1906,7 +1902,7 @@ class Model {
    * @return {Promise<Any>}
    */
   static min(field, options) {
-    return this.aggregate(field, 'min', options);
+    return Model.aggregate.call(this, field, 'min', options);
   }
 
   /**
@@ -1919,7 +1915,7 @@ class Model {
    * @return {Promise<Number>}
    */
   static sum(field, options) {
-    return this.aggregate(field, 'sum', options);
+    return Model.aggregate.call(this, field, 'sum', options);
   }
 
   /**
@@ -2023,7 +2019,7 @@ class Model {
 
     let values;
 
-    return this.find(options).then(instance => {
+    return Model.find.call(this, options).then(instance => {
       if (instance === null) {
         values = _.clone(options.defaults) || {};
         if (_.isPlainObject(options.where)) {
@@ -2080,7 +2076,7 @@ class Model {
       transaction = t;
       options.transaction = t;
 
-      return this.findOne(_.defaults({transaction}, options));
+      return Model.findOne.call(this, _.defaults({transaction}, options));
     }).then(instance => {
       if (instance !== null) {
         return [instance, false];
@@ -2122,7 +2118,7 @@ class Model {
         }
 
         // Someone must have created a matching instance inside the same transaction since we last did a find. Let's find it!
-        return this.findOne(_.defaults({
+        return Model.findOne.call(this, _.defaults({
           transaction: internalTransaction ? null : transaction
         }, options)).then(instance => {
           // Sanity check, ideally we caught this at the defaultFeilds/err.fields check
@@ -2162,12 +2158,12 @@ class Model {
     }
 
 
-    return this.findOne(options).then(result => {
+    return Model.findOne.call(this, options).then(result => {
       if (result) return [result, false];
 
       return this.create(values, options)
         .then(result => [result, true])
-        .catch(this.sequelize.UniqueConstraintError, () => this.findOne(options).then(result => [result, false]));
+        .catch(this.sequelize.UniqueConstraintError, () => Model.findOne.call(this, options).then(result => [result, false]));
     });
   }
 
@@ -2487,7 +2483,7 @@ class Model {
     }).then(() => {
       // Get daos and run beforeDestroy hook on each record individually
       if (options.individualHooks) {
-        return this.findAll({where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark})
+        return Model.findAll.call(this, {where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark})
           .map(instance => this.runHooks('beforeDestroy', instance, options).then(() => instance))
           .then(_instances => {
             instances = _instances;
@@ -2561,7 +2557,7 @@ class Model {
     }).then(() => {
       // Get daos and run beforeRestore hook on each record individually
       if (options.individualHooks) {
-        return this.findAll({where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark, paranoid: false})
+        return Model.findAll.call(this, {where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark, paranoid: false})
           .map(instance => this.runHooks('beforeRestore', instance, options).then(() => instance))
           .then(_instances => {
             instances = _instances;
@@ -2692,7 +2688,7 @@ class Model {
 
       // Get instances and run beforeUpdate hook on each record individually
       if (options.individualHooks) {
-        return this.findAll({where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark}).then(_instances => {
+        return Model.findAll.call(this, {where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark}).then(_instances => {
           instances = _instances;
           if (!instances.length) {
             return [];
@@ -4122,6 +4118,7 @@ Model.find = Model.findOne;
 Model.findAndCountAll = Model.findAndCount;
 Model.findOrInitialize = Model.findOrBuild;
 Model.insertOrUpdate = Model.upsert;
+Model.all = Model.findAll;
 
 _.extend(Model, associationsMixin);
 Hooks.applyTo(Model);


### PR DESCRIPTION
### Pull Request check-list

- [y] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [y] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [n] Have you added new tests to prevent regressions?
- [n] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [n] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

At my company we ran into an issue where we want to overload the `findOne` function, but many other sequelize functions break as a result.

In the sequelize source code, comments exist such as:
> Bypass a possible overloaded findOne (lib/model.js:1686)

However, the code doesn't do what it says it's trying to do. With this PR, static Model methods actually do bypass methods overloaded by the user.
  