### PR TITLE
Issue 8816 found bug with Op.is. When it has a null value it checks for IS NOT. This fixes

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2389,7 +2389,7 @@ const QueryGenerator = {
 
     if (value === null && comparator === this.OperatorMap[Op.eq]) {
       return this._joinKeyValue(key, this.escape(value, field, escapeOptions), this.OperatorMap[Op.is], options.prefix);
-    } else if (value === null && this.OperatorMap[Op.ne]) {
+    } else if (value === null && comparator === this.OperatorMap[Op.ne]) {
       return this._joinKeyValue(key, this.escape(value, field, escapeOptions), this.OperatorMap[Op.not], options.prefix);
     }
 

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -14,6 +14,9 @@ describe('QueryGenerator', () => {
 
       QG.whereItemQuery(Op.and, [{test: {[Op.between]: [2, 5]}}, {test: {[Op.ne]: 3}}, {test: {[Op.not]: 4}}])
         .should.be.equal('(test BETWEEN 2 AND 5 AND test != 3 AND test != 4)');
+
+      QG.whereItemQuery(Op.or, [{test: {[Op.is]: null}}, {testSame: {[Op.eq]: null}}])
+        .should.be.equal('(test IS NULL OR testSame IS NULL)');
     });
 
     it('should not parse any strings as aliases  operators', function() {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Issue #8816 found bug with `Op.is`. When it has a null value it checks for `IS NOT`. This happens because the `Op.ne` check with null value is not comparing with the passed comparator. Adding in that comparison stops `Op.ne` catching other operators (such as `Op.is`)

Added a test which fails before and passes after for `Op.is`, alongside `Op.eq` to check they have the same output. There is no existing `Op.eq` test either, which catches its change to `Op.is` so this also adds that