### PR TITLE
Fix: Take into account the default attributes values of a foreign key…

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -84,7 +84,7 @@ class BelongsTo extends Association {
     });
 
     if (this.options.constraints !== false) {
-      const source = this.source.rawAttributes[this.foreignKey] || newAttributes[this.foreignKey];
+      const source = { ...newAttributes[this.foreignKey], ...(this.source.rawAttributes[this.foreignKey] || {}) };
       this.options.onDelete = this.options.onDelete || (source.allowNull ? 'SET NULL' : 'NO ACTION');
       this.options.onUpdate = this.options.onUpdate || 'CASCADE';
     }

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -122,7 +122,7 @@ class HasMany extends Association {
     });
 
     if (this.options.constraints !== false) {
-      const target = this.target.rawAttributes[this.foreignKey] || newAttributes[this.foreignKey];
+      const target = { ...newAttributes[this.foreignKey], ...(this.target.rawAttributes[this.foreignKey] || {}) };
       constraintOptions.onDelete = constraintOptions.onDelete || (target.allowNull ? 'SET NULL' : 'CASCADE');
       constraintOptions.onUpdate = constraintOptions.onUpdate || 'CASCADE';
     }

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -84,7 +84,7 @@ class HasOne extends Association {
     this.identifierField = this.target.rawAttributes[this.foreignKey].field || this.foreignKey;
 
     if (this.options.constraints !== false) {
-      const target = this.target.rawAttributes[this.foreignKey] || newAttributes[this.foreignKey];
+      const target = { ...newAttributes[this.foreignKey], ...(this.target.rawAttributes[this.foreignKey] || {}) };
       this.options.onDelete = this.options.onDelete || (target.allowNull ? 'SET NULL' : 'CASCADE');
       this.options.onUpdate = this.options.onUpdate || 'CASCADE';
     }


### PR DESCRIPTION
… if the foreign key is declared both in a relation and in the model.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
No, but they doesn't pass with master neither. The error is: 
```
console.log('#'.repeat(process.env.DIALECT.length + 22) + '\n# Running tests for ' + process.env.DIALECT + ' #\n' + '#'.repeat(process.env.DIALECT.length + 22))

TypeError: Cannot read property 'length' of undefined
```
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
Yes
- [ ] Have you added new tests to prevent regressions?
No
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
No
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?
No

### Description of change

Issue it solves: https://github.com/sequelize/sequelize/issues/8837

While creating the foreign keys, if the foreign key is defined in a model and a relation, it will use the default attributes values if the attributes are not defined. 

It's the first time I see the source code of sequelize so maybe I missed some code to fix too.
