### PR TITLE
fix(postgres): base type wont work after model with ENUM is synced

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -255,10 +255,7 @@ class QueryInterface {
           .tap(() => {
             // If ENUM processed, then refresh OIDs
             if (promises.length) {
-              return this.sequelize.dialect.connectionManager._refreshDynamicOIDs()
-                .then(() => {
-                  return this.sequelize.refreshTypes(DataTypes.postgres);
-                });
+              return this.sequelize.dialect.connectionManager._refreshDynamicOIDs();
             }
           })
           .then(() => {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -87,8 +87,6 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
       return Sequelize.ABSTRACT.prototype.stringify.apply(this, arguments);
     });
 
-    current.refreshTypes();
-
     const User = current.define('user', {
       field: Type
     }, {
@@ -96,6 +94,9 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     });
 
     return current.sync({ force: true }).then(() => {
+
+      current.refreshTypes();
+
       return User.create({
         field: value
       });

--- a/test/integration/dialects/postgres/regressions.test.js
+++ b/test/integration/dialects/postgres/regressions.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support = require(__dirname + '/../../support'),
+  Sequelize = Support.Sequelize,
+  dialect = Support.getTestDialect();
+
+if (dialect.match(/^postgres/)) {
+  describe('[POSTGRES Specific] Regressions', () => {
+    it('properly fetch OIDs after sync, #8749', function() {
+      const User = this.sequelize.define('User', {
+        active: Sequelize.BOOLEAN
+      });
+
+      /**
+       * This Model is important, sync will try to fetch OIDs after each ENUM model sync
+       * Having ENUM in this model will force OIDs re-fetch
+       * We are testing that OID refresh keep base type intact
+       */
+      const Media = this.sequelize.define('Media', {
+        type: Sequelize.ENUM([
+          'image', 'video', 'audio'
+        ])
+      });
+
+      User.hasMany(Media);
+      Media.belongsTo(User);
+
+      return this.sequelize
+        .sync({ force: true })
+        .then(() => User.create({ active: true }))
+        .then(user => {
+          expect(user.active).to.be.true;
+          expect(user.get('active')).to.be.true;
+
+          return User.findOne();
+        })
+        .then(user => {
+          expect(user.active).to.be.true;
+          expect(user.get('active')).to.be.true;
+
+          return User.findOne({ raw: true });
+        })
+        .then(user => {
+          expect(user.active).to.be.true;
+        });
+    });
+  });
+}


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Fixes https://github.com/sequelize/sequelize/issues/8749

This issue was caused due to improper datatypes refresh after new OIDs are obtained