### PR TITLE
fix: destroy with paranoid ignores operators

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2538,7 +2538,7 @@ class Model {
         where[field] = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
         attrValueHash[field] = Utils.now(this.sequelize.options.dialect);
-        return this.QueryInterface.bulkUpdate(this.getTableName(options), attrValueHash, _.defaults(where, options.where), options, this.rawAttributes);
+        return this.QueryInterface.bulkUpdate(this.getTableName(options), attrValueHash, Object.assign(where, options.where), options, this.rawAttributes);
       } else {
         return this.QueryInterface.bulkDelete(this.getTableName(options), options.where, options, this);
       }

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1649,6 +1649,33 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
     });
+
+    it('should work if model is paranoid and only operator in where clause is a Symbol', function() {
+      const User = this.sequelize.define('User', {
+        username: Sequelize.STRING
+      }, {
+        paranoid: true
+      });
+
+      return User.sync({ force: true})
+        .then(() => User.create({ username: 'foo' }))
+        .then(() => User.create({ username: 'bar' }))
+        .then(() => {
+          return User.destroy({
+            where: {
+              [Sequelize.Op.or]: [
+                { username: 'bar' },
+                { username: 'baz' }
+              ]
+            }
+          });
+        })
+        .then(() => User.findAll())
+        .then(users => {
+          expect(users).to.have.length(1);
+          expect(users[0].get('username')).to.equal('foo');
+        });
+    });
   });
 
   describe('restore', () => {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Fixes #8858