### PR TITLE
docs(querying): improve random order comment

### DIFF
--- a/docs/querying.md
+++ b/docs/querying.md
@@ -464,7 +464,7 @@ Subtask.findAll({
   // Will order by age ascending assuming ascending is the default order when direction is omitted
   order: sequelize.col('age')
 
-  // Will order by age randomly based on the dialect (instead of fn('RAND') or fn('RANDOM'))
+  // Will order randomly based on the dialect (instead of fn('RAND') or fn('RANDOM'))
   order: sequelize.random()
 })
 ```


### PR DESCRIPTION
The comment line contains some left overs from the copied line above that don't apply to `sequelize.random()`.