### PR TITLE
feat: Add query timeout

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -97,6 +97,7 @@ class Sequelize {
    * @param {Integer}  [options.retry.max] How many times a failing query is automatically retried.  Set to 0 to disable retrying on SQL_BUSY error.
    * @param {Boolean}  [options.typeValidation=false] Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like.
    * @param {Object|Boolean} [options.operatorsAliases=true] String based operator alias, default value is true which will enable all operators alias. Pass object to limit set of aliased operators or false to disable completely.
+   * @param {Integer}  [options.queryTimeout] The maximum time, in milliseconds, that query processing before failed
    *
    */
   constructor(database, username, password, options) {
@@ -540,8 +541,19 @@ class Sequelize {
     }).then(connection => {
       const query = new this.dialect.Query(connection, this, options);
       const retryOptions = _.extend(this.options.retry, options.retry || {});
+      const queryPromises = [retry(() => query.run(sql, bindParameters), retryOptions)];
 
-      return retry(() => query.run(sql, bindParameters), retryOptions)
+      if (this.options.queryTimeout) {
+        const timeoutPromise = new Promise((resolve, reject) => setTimeout(
+          () => reject(new Error('Query timed out')),
+          this.options.queryTimeout
+        ));
+
+        queryPromises.push(timeoutPromise);
+      }
+
+      return Promise
+        .race(queryPromises)
         .finally(() => {
           if (!options.transaction) {
             return this.connectionManager.releaseConnection(connection);
@@ -772,7 +784,7 @@ class Sequelize {
   databaseVersion(options) {
     return this.getQueryInterface().databaseVersion(options);
   }
-  
+
   /**
    * Get the fn for random based on the dialect
    *


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test-postgres` pass with this change (including linting)?
- [x] Does the description below contain a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Added timeout for query processing. If query timed out in `options.queryTimeout` ms, then it would be finished with error `Query timed out`.

It allows to solve the issue of losing connections to database. If request was created while connection was lost, then it will never be completed (resolved). Connection is allocating from pool and never released. It leads to state when all connections in pool are in `allocated` status. All new queries are finished with error `ResourceRequest timed out`.