### PR TITLE
fix(datatypes): Sequelize.NOW set milliseconds to zero

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -989,7 +989,7 @@ class Model {
       }
 
       if (definition.hasOwnProperty('defaultValue')) {
-        this._defaultValues[name] = _.partial(Utils.toDefaultValue, definition.defaultValue);
+        this._defaultValues[name] = _.partial(Utils.toDefaultValue, definition.defaultValue, this.sequelize.options.dialect);
       }
 
       if (definition.hasOwnProperty('unique') && definition.unique) {
@@ -2838,7 +2838,7 @@ class Model {
 
   static _getDefaultTimestamp(attr) {
     if (!!this.rawAttributes[attr] && !!this.rawAttributes[attr].defaultValue) {
-      return Utils.toDefaultValue(this.rawAttributes[attr].defaultValue);
+      return Utils.toDefaultValue(this.rawAttributes[attr].defaultValue, this.sequelize.options.dialect);
     }
     return undefined;
   }
@@ -3069,24 +3069,24 @@ class Model {
       }
 
       if (this.constructor._timestampAttributes.createdAt && defaults[this.constructor._timestampAttributes.createdAt]) {
-        this.dataValues[this.constructor._timestampAttributes.createdAt] = Utils.toDefaultValue(defaults[this.constructor._timestampAttributes.createdAt]);
+        this.dataValues[this.constructor._timestampAttributes.createdAt] = Utils.toDefaultValue(defaults[this.constructor._timestampAttributes.createdAt], this.sequelize.options.dialect);
         delete defaults[this.constructor._timestampAttributes.createdAt];
       }
 
       if (this.constructor._timestampAttributes.updatedAt && defaults[this.constructor._timestampAttributes.updatedAt]) {
-        this.dataValues[this.constructor._timestampAttributes.updatedAt] = Utils.toDefaultValue(defaults[this.constructor._timestampAttributes.updatedAt]);
+        this.dataValues[this.constructor._timestampAttributes.updatedAt] = Utils.toDefaultValue(defaults[this.constructor._timestampAttributes.updatedAt], this.sequelize.options.dialect);
         delete defaults[this.constructor._timestampAttributes.updatedAt];
       }
 
       if (this.constructor._timestampAttributes.deletedAt && defaults[this.constructor._timestampAttributes.deletedAt]) {
-        this.dataValues[this.constructor._timestampAttributes.deletedAt] = Utils.toDefaultValue(defaults[this.constructor._timestampAttributes.deletedAt]);
+        this.dataValues[this.constructor._timestampAttributes.deletedAt] = Utils.toDefaultValue(defaults[this.constructor._timestampAttributes.deletedAt], this.sequelize.options.dialect);
         delete defaults[this.constructor._timestampAttributes.deletedAt];
       }
 
       if (Object.keys(defaults).length) {
         for (key in defaults) {
           if (values[key] === undefined) {
-            this.set(key, Utils.toDefaultValue(defaults[key]), defaultsOptions);
+            this.set(key, Utils.toDefaultValue(defaults[key], this.sequelize.options.dialect), defaultsOptions);
             delete values[key];
           }
         }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -299,7 +299,7 @@ function removeCommentsFromFunctionString(s) {
 }
 exports.removeCommentsFromFunctionString = removeCommentsFromFunctionString;
 
-function toDefaultValue(value) {
+function toDefaultValue(value, dialect) {
   if (typeof value === 'function') {
     const tmp = value();
     if (tmp instanceof DataTypes.ABSTRACT) {
@@ -312,7 +312,7 @@ function toDefaultValue(value) {
   } else if (value instanceof DataTypes.UUIDV4) {
     return uuid.v4();
   } else if (value instanceof DataTypes.NOW) {
-    return now();
+    return now(dialect);
   } else if (_.isPlainObject(value) || _.isArray(value)) {
     return _.clone(value);
   } else {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -697,6 +697,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(user).to.be.ok;
           expect(user.created_time).to.be.ok;
           expect(user.updated_time).to.be.ok;
+          expect(user.created_time.getMilliseconds()).not.to.equal(0);
+          expect(user.updated_time.getMilliseconds()).not.to.equal(0);
         });
       });
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Fix #8460
Close #8704