### PR TITLE
fix(has-many): Fix if sourcekey different from attribute name it will be set to primary key

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -79,7 +79,7 @@ class HasMany extends Association {
     }
 
     this.sourceKey = this.options.sourceKey || this.source.primaryKeyAttribute;
-    if (this.target.rawAttributes[this.sourceKey]) {
+    if (this.source.rawAttributes[this.sourceKey]) {
       this.sourceKeyField = this.source.rawAttributes[this.sourceKey].field || this.sourceKey;
     } else {
       this.sourceKeyField = this.sourceKey;


### PR DESCRIPTION
fix #7255

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Based on
```
   this.sourceKey = this.options.sourceKey || this.source.primaryKeyAttribute;
    if (this.target.rawAttributes[this.sourceKey]) {
      this.sourceKeyField = this.source.rawAttributes[this.sourceKey].field || this.sourceKey;
    } else {
      this.sourceKeyField = this.sourceKey;
    }
```
I am assuming the if statement is some kinda of typo. 

Correct me if I miss some thing.