### PR TITLE
[WIP] feat(query-generator): Generate INSERTs using bind parameters

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -81,6 +81,7 @@ const QueryGenerator = {
     const modelAttributeMap = {};
     const fields = [];
     const values = [];
+    const bind = [];
     let query;
     let valueQuery = '<%= tmpTable %>INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>)<%= output %> VALUES (<%= values %>)';
     let emptyQuery = '<%= tmpTable %>INSERT<%= ignoreDuplicates %> INTO <%= table %><%= output %>';
@@ -186,7 +187,12 @@ const QueryGenerator = {
             identityWrapperRequired = true;
           }
 
-          values.push(this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'INSERT' }));
+          if (options.bindParams) {
+            values.push('$' + (bind.length + 1));
+            bind.push(this.format(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'INSERT' }));
+          } else {
+            values.push(this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'INSERT' }));
+          }
         }
       }
     }
@@ -209,7 +215,11 @@ const QueryGenerator = {
       ].join(' ');
     }
 
-    return _.template(query, this._templateSettings)(replacements);
+    query = _.template(query, this._templateSettings)(replacements);
+    if (options.bindParams) {
+      return { query, bind };
+    }
+    return query;
   },
 
   /*
@@ -925,6 +935,38 @@ const QueryGenerator = {
     }
 
     return SqlString.escape(value, this.options.timezone, this.dialect);
+  },
+
+  /*
+    Returns a bind parameter representation of a value (e.g. a string, number or date)
+   @private
+  */
+  format(value, field, options) {
+    options = options || {};
+
+    if (value !== null && value !== undefined) {
+      if (value instanceof Utils.SequelizeMethod) {
+        return this.handleSequelizeMethod(value);
+      } else {
+        if (field && field.type) {
+          if (this.typeValidation && field.type.validate && value) {
+            if (options.isList && Array.isArray(value)) {
+              for (const item of value) {
+                field.type.validate(item, options);
+              }
+            } else {
+              field.type.validate(value, options);
+            }
+          }
+
+          if (field.type.stringify) {
+            value = field.type.stringify(value, { escape: _.identity, field, timezone: this.options.timezone, operation: options.operation });
+          }
+        }
+      }
+    }
+
+    return value;
   },
 
   /*

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1404,6 +1404,33 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
     });
+
+    it('should allow creates using bind parameters', function() {
+      const User = this.sequelize.define('UserUsingBindParams', {
+        'name': {
+          type: DataTypes.STRING
+        },
+        'children': {
+          type: DataTypes.INTEGER
+        },
+        'dob': {
+          type: DataTypes.DATE
+        }
+      }, {
+        bindParams: true
+      });
+
+      const date = new Date();
+      return this.sequelize.sync({force: true}).then(() => {
+        return User.create({ name: 'Test', children: 2, dob: date }, { bindParams: true }).then(user => {
+          return User.findById(user.id).then(user => {
+            expect(user.name).to.equal('Test');
+            expect(user.children).to.equal(2);
+            expect(user.dob).to.be.ok;
+          });
+        });
+      });
+    });
   });
 
   it('should return autoIncrement primary key (create)', function() {

--- a/test/support.js
+++ b/test/support.js
@@ -222,7 +222,7 @@ const Support = {
     if (_.isError(query)) {
       expect(query.message).to.equal(expectation.message);
     } else {
-      expect(query).to.equal(expectation);
+      expect(query.query || query).to.equal(expectation);
     }
   }
 };

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -31,8 +31,29 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           postgres: 'INSERT INTO "users" ("user_name") VALUES (\'triggertest\') RETURNING *;',
           default: "INSERT INTO `users` (`user_name`) VALUES ('triggertest');"
         });
+
     });
 
+    it('with bind parameters', () => {
+      const User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name'
+        }
+      }, {
+        timestamps: false
+      });
+
+      const options = {
+        bindParams: true
+      };
+      expectsql(sql.insertQuery(User.tableName, {user_name: 'bindtest'}, User.rawAttributes, options),
+        {
+          mssql: 'INSERT INTO [users] ([user_name]) VALUES ($1);',
+          postgres: 'INSERT INTO "users" ("user_name") VALUES ($1);',
+          default: 'INSERT INTO `users` (`user_name`) VALUES ($1);',
+        });
+    });
   });
 
   describe('dates', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This provides very basic support for using bind parameters when generating INSERT queries. Known issues:

* Doesn't currently work with SequelizeMethod
* No support for bulk inserts
* Expects MySQL support for bind parameters (pending another PR)

Hopefully I can fix this up soon, but review comments are welcome!