### PR TITLE
fix(symbols): symbols not assigned by lodash.defaults

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1356,7 +1356,8 @@ class Model {
     const self = class extends this {};
     let scope;
     let scopeName;
-    Object.defineProperty(self, 'name', {value: this.name});
+
+    Object.defineProperty(self, 'name', { value: this.name });
 
     self._scope = {};
     self._scopeNames = [];
@@ -1367,6 +1368,7 @@ class Model {
     }
 
     const options = _.flatten(arguments);
+
     for (const option of options) {
       scope = null;
       scopeName = null;
@@ -2053,7 +2055,7 @@ class Model {
       if (instance === null) {
         values = _.clone(options.defaults) || {};
         if (_.isPlainObject(options.where)) {
-          values = _.defaults(values, options.where);
+          values = Utils.defaults(values, options.where);
         }
 
         instance = this.build(values);
@@ -2106,7 +2108,7 @@ class Model {
       transaction = t;
       options.transaction = t;
 
-      return this.findOne(_.defaults({transaction}, options));
+      return this.findOne(Utils.defaults({transaction}, options));
     }).then(instance => {
       if (instance !== null) {
         return [instance, false];
@@ -2114,7 +2116,7 @@ class Model {
 
       values = _.clone(options.defaults) || {};
       if (_.isPlainObject(options.where)) {
-        values = _.defaults(values, options.where);
+        values = Utils.defaults(values, options.where);
       }
 
       options.exception = true;
@@ -2148,7 +2150,7 @@ class Model {
         }
 
         // Someone must have created a matching instance inside the same transaction since we last did a find. Let's find it!
-        return this.findOne(_.defaults({
+        return this.findOne(Utils.defaults({
           transaction: internalTransaction ? null : transaction
         }, options)).then(instance => {
           // Sanity check, ideally we caught this at the defaultFeilds/err.fields check
@@ -2184,7 +2186,7 @@ class Model {
 
     let values = _.clone(options.defaults) || {};
     if (_.isPlainObject(options.where)) {
-      values = _.defaults(values, options.where);
+      values = Utils.defaults(values, options.where);
     }
 
 
@@ -2875,8 +2877,8 @@ class Model {
 
     const filteredScope = _.omit(scope, 'include'); // Includes need special treatment
 
-    _.defaults(options, filteredScope);
-    _.defaults(options.where, filteredScope.where);
+    Utils.defaults(options, filteredScope);
+    Utils.defaults(options.where, filteredScope.where);
 
     if (scope.include) {
       options.include = options.include || [];
@@ -2944,7 +2946,7 @@ class Model {
     const updatedAtAttr = this._timestampAttributes.updatedAt;
     const versionAttr = this._versionAttribute;
     const updatedAtAttribute = this.rawAttributes[updatedAtAttr];
-    options = _.defaults({}, options, {
+    options = Utils.defaults({}, options, {
       by: 1,
       attributes: {},
       where: {},
@@ -3737,7 +3739,7 @@ class Model {
   * @return {Promise<this>}
   */
   reload(options) {
-    options = _.defaults({}, options, {
+    options = Utils.defaults({}, options, {
       where: this.where(),
       include: this._options.include || null
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -639,6 +639,45 @@ function camelizeObjectKeys(obj) {
   });
   return newObj;
 }
-
 exports.camelizeObjectKeys = camelizeObjectKeys;
+
+/**
+ * Assigns own and inherited enumerable string and symbol keyed properties of source
+ * objects to the destination object.
+ *
+ * https://lodash.com/docs/4.17.4#defaults
+ *
+ * **Note:** This method mutates `object`.
+ *
+ * @param {Object} object The destination object.
+ * @param {...Object} [sources] The source objects.
+ * @returns {Object} Returns `object`.
+ * @private
+ */
+function defaults(object) {
+  object = Object(object);
+
+  const sources = _.tail(arguments);
+
+  sources.forEach(source => {
+    if (source) {
+      source = Object(source);
+
+      getComplexKeys(source).forEach(key => {
+        const value = object[key];
+        if (
+          value === undefined || (
+            _.eq(value, Object.prototype[key]) &&
+            !Object.prototype.hasOwnProperty.call(object, key)
+          )
+        ) {
+          object[key] = source[key];
+        }
+      });
+    }
+  });
+
+  return object;
+}
+exports.defaults = defaults;
 

--- a/test/integration/model/scope.test.js
+++ b/test/integration/model/scope.test.js
@@ -91,5 +91,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(records[0].get('other_value')).to.equal(10);
         });
     });
+
+    it('should keep symbols after default assignment', function() {
+      return this.ScopeMe.scope('highAccess').findOne()
+        .then(record => {
+          expect(record.username).to.equal('tobi');
+          return this.ScopeMe.scope('lessThanFour').findAll({
+            where: {}
+          });
+        })
+        .then(records => {
+          expect(records).to.have.length(2);
+          expect(records[0].get('access_level')).to.equal(3);
+          expect(records[1].get('access_level')).to.equal(3);
+          return this.ScopeMe.scope('issue8473').findAll();
+        });
+    });
   });
 });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -41,6 +41,34 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
+  suite('defaults', () => {
+    test('defaults normal object', () => {
+      expect(Utils.defaults(
+        { a: 1, c: 3},
+        { b: 2 },
+        { c: 4, d: 4 }
+      )).to.eql({
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4
+      });
+    });
+
+    test('defaults symbol keys', () => {
+      expect(Utils.defaults(
+        { a: 1, [Symbol.for('c')]: 3},
+        { b: 2 },
+        { [Symbol.for('c')]: 4, [Symbol.for('d')]: 4 }
+      )).to.eql({
+        a: 1,
+        b: 2,
+        [Symbol.for('c')]: 3,
+        [Symbol.for('d')]: 4
+      });
+    });
+  });
+
   suite('mapFinderOptions', () => {
     test('virtual attribute dependencies', () => {
       expect(Utils.mapFinderOptions({


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

`lodash.defaults` doesn't pick Symbol properties, this was breaking scopes.
Discussion in https://github.com/sequelize/sequelize/issues/8473#issuecomment-359517259

I have modified `lodash.defaults` as `Utils.defaults` which works for Symbol properties. Replaced in other places where I think was suitable, that should fix multiple potential issues with Symbol operators assignment.