### PR TITLE
Fix pg7 - Cannot read property '0' 

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -96,7 +96,7 @@ class Query extends AbstractQuery {
       })
       .then(queryResult => {
         const rows = Array.isArray(queryResult) ? queryResult.reduce((rows, r) => rows.concat(r.rows), []) : queryResult.rows;
-        const rowCount = Array.isArray(queryResult) ? queryResult[0].rowCount : queryResult.rowCount;
+        const rowCount = Array.isArray(queryResult) ? queryResult.reduce((rowCount, r) => rowCount + r.rowCount, 0) : queryResult.rowCount;
         const isTableNameQuery = sql.indexOf('SELECT table_name FROM information_schema.tables') === 0;
         const isRelNameQuery = sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0;
 

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -95,8 +95,8 @@ class Query extends AbstractQuery {
         return queryResult;
       })
       .then(queryResult => {
-        const rows = queryResult.rows;
-        const rowCount = queryResult.rowCount;
+        const rows = Array.isArray(queryResult) ? queryResult.reduce((rows, r) => rows.concat(r.rows), []) : queryResult.rows;
+        const rowCount = Array.isArray(queryResult) ? queryResult[0].rowCount : queryResult.rowCount;
         const isTableNameQuery = sql.indexOf('SELECT table_name FROM information_schema.tables') === 0;
         const isRelNameQuery = sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0;
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Handle pg7 multi-queries format. See #8043.
The idea is to check for an array and re-concatenate the rows as it was in pg 6.
See the following:

There is a problem as soon as their is more than one query executed at a time.
Given the following code:

```
const { Client } = require('pg')
const query = "SELECT 'hello'; SELECT 'world';";
const client = new Client()

const f = async () => {
	await client.connect()
	const res = await client.query(query);
	console.log(res);
	await client.end()
};

f();
```

It outputs with pg 6:

```
➜  /tmp node pg6/index.js
Result {
  command: 'SELECT',
  rowCount: 1,
  oid: NaN,
  rows:
   [ anonymous { '?column?': 'hello' },
     anonymous { '?column?': 'world' } ],
  fields:
   [ Field {
       name: '?column?',
       tableID: 0,
       columnID: 0,
       dataTypeID: 705,
       dataTypeSize: -2,
       dataTypeModifier: -1,
       format: 'text' } ],
  _parsers: [ [Function: noParse] ],
  RowCtor: [Function: anonymous],
  rowAsArray: false,
  _getTypeParser: [Function: bound ] }
```

And it outputs with pg 7 :

```
➜  /tmp node pg7/index.js
[ Result {
    command: 'SELECT',
    rowCount: 1,
    oid: null,
    rows: [ [anonymous] ],
    fields: [ [Field] ],
    _parsers: [ [Function: noParse] ],
    RowCtor: [Function: anonymous],
    rowAsArray: false,
    _getTypeParser: [Function: bound ] },
  Result {
    command: 'SELECT',
    rowCount: 1,
    oid: null,
    rows: [ [anonymous] ],
    fields: [ [Field] ],
    _parsers: [ [Function: noParse] ],
    RowCtor: [Function: anonymous],
    rowAsArray: false } ]
➜  /tmp
```

This PR, check for an array as query result and turn it back into a single result (by concatenating rows). The queryResult can be use as metadata for raw queries but the rowCount was always 1 for multi-queries anyway so it doesn't really matter. 