### PR TITLE
Prevented Unhandled Rejection in Postgres Upsert (`pg` version >= 7.0)

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -96,6 +96,9 @@ class Query extends AbstractQuery {
       })
       .then(queryResult => {
         const rows = queryResult.rows;
+        if (typeof rows !== 'object') {
+          return null
+        }
         const rowCount = queryResult.rowCount;
         const isTableNameQuery = sql.indexOf('SELECT table_name FROM information_schema.tables') === 0;
         const isRelNameQuery = sql.indexOf('SELECT relname FROM pg_class WHERE oid IN') === 0;

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -965,7 +965,7 @@ class QueryInterface {
     return this.sequelize.query(sql, options).then(result => {
       switch (this.sequelize.options.dialect) {
         case 'postgres':
-          return [result.created, result.primary_key];
+          return [result ? result.created : { message: 'Warning: result is empty! (may be expected...)', success: true }, result ? result.primary_key : model.primaryKeyField];
 
         case 'mssql':
           return [


### PR DESCRIPTION
When attempting to use `Model::upsert()` using Postgres (`pg` module version `7.4.1`), an unhandled rejection would be thrown consistently when `queryResult` is `undefined`.

This closed issue was my starting point: https://github.com/sequelize/sequelize/issues/7999

QueryInterface::upsert() will now resolve a warning object if result is empty, to prevent accessing properties of a non-object, throwing an exception.