### PR TITLE
docs(migrations): fix config.json example

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -32,26 +32,26 @@ Before continuing further we will need to tell CLI how to connect to database. T
 
 ```json
 {
-  development: {
-    username: 'root',
-    password: null,
-    database: 'database_development',
-    host: '127.0.0.1',
-    dialect: 'mysql'
+  "development": {
+    "username": "root",
+    "password": null,
+    "database": "database_development",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
   },
-  test: {
-    username: 'root',
-    password: null,
-    database: 'database_test',
-    host: '127.0.0.1',
-    dialect: 'mysql'
+  "test": {
+    "username": "root",
+    "password": null,
+    "database": "database_test",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
   },
-  production: {
-    username: process.env.PROD_DB_USERNAME,
-    password: process.env.PROD_DB_PASSWORD,
-    database: process.env.PROD_DB_NAME,
-    host: process.env.PROD_DB_HOSTNAME,
-    dialect: 'mysql'
+  "production": {
+    "username": "root",
+    "password": null,
+    "database": "database_test",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
   }
 }
 ```


### PR DESCRIPTION
### Description of change

The config.json example in the migration tutorial is not valid JSON. Added double quotes and removed dynamic attributes from the example to make it valid.