### PR TITLE
Add option to `sync` similar to `alter` but without `removeColumn`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1121,7 +1121,7 @@ class Model {
     })
       .then(() => this.QueryInterface.createTable(this.getTableName(options), attributes, options, this))
       .then(() => {
-        if (options.alter) {
+        if (options.alter || options.alterKeepColumns) {
           return Promise.all([
             this.QueryInterface.describeTable(this.getTableName(options)),
             this.QueryInterface.getForeignKeyReferencesForTable(this.getTableName(options))
@@ -1142,7 +1142,9 @@ class Model {
               _.each(columns, (columnDesc, columnName) => {
                 const currentAttributes = attributes[columnName];
                 if (!currentAttributes) {
-                  changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
+                  if (!options.alterKeepColumns) {
+                    changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
+                  }
                 } else if (!currentAttributes.primaryKey) {
                   // Check foreign keys. If it's a foreign key, it should remove constraint first.
                   const references = currentAttributes.references;


### PR DESCRIPTION
This is a 2-line change that I thought would be useful. The idea is that it would allow the dev to write something like `User.sync({alterKeepColumns: true})` which does the same thing as `{alter: true}` only it doesn't remove old columns. This way you don't have to risk data deletion if you were to typo or something. I'm a bit crunched for time at the moment so I didn't test this or anything - I wouldn't say it's ready to be merged but was hoping to get a conversation going on the possibility of adding this to the API.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
