### PR TITLE
Add UniqueIdentifier type support for MSSQL

### DIFF
--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -28,7 +28,7 @@ module.exports = BaseTypes => {
   BaseTypes.BOOLEAN.types.mssql = [104];
   BaseTypes.BLOB.types.mssql = [165];
   BaseTypes.DECIMAL.types.mssql = [106];
-  BaseTypes.UUID.types.mssql = false;
+  BaseTypes.UUID.types.mssql = [36];
   BaseTypes.ENUM.types.mssql = false;
   BaseTypes.REAL.types.mssql = [109];
   BaseTypes.DOUBLE.types.mssql = [109];
@@ -115,7 +115,7 @@ module.exports = BaseTypes => {
   inherits(UUID, BaseTypes.UUID);
 
   UUID.prototype.toSql = function toSql() {
-    return 'CHAR(36)';
+    return 'UniqueIdentifier';
   };
 
   function NOW() {


### PR DESCRIPTION
Hi,

With my team which use Sequelize we're trying to improve database performance.
Microsoft database does have it own type for UUIDs - UniqueIdentifier.

SQL Server does have special alghoritms for indexing UUIDs and it store UUIDs using less bytes.
It has an impact into time of SELECT operations.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
