### PR TITLE
fix(escape): Remove null character in postgres

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -55,6 +55,11 @@ function escape(val, timeZone, dialect, format) {
     // http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
     // http://stackoverflow.com/q/603572/130598
     val = val.replace(/'/g, "''");
+
+    if (dialect === 'postgres') {
+      // null character is not allowed in Postgres
+      val = val.replace(/\0/g, '\\0');
+    }
   } else {
     val = val.replace(/[\0\n\r\b\t\\\'\"\x1a]/g, s => {
       switch (s) {

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -68,6 +68,14 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       default: "WHERE [name] = 'a project' AND ([id] IN (1, 2, 3) OR [id] > 10)",
       mssql: "WHERE [name] = N'a project' AND ([id] IN (1, 2, 3) OR [id] > 10)"
     });
+
+    testsql({
+      name: 'here is a null char: \0'
+    }, {
+      default: "WHERE [name] = 'here is a null char: \\0'",
+      mssql: "WHERE [name] = N'here is a null char: \0'",
+      sqlite: "WHERE `name` = 'here is a null char: \0'"
+    });
   });
 
   suite('whereItemQuery', () => {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

This escapes the null character for Postgres, which it does not allow. 

Closes #6311