### PR TITLE
feat(paranoid): Revert paranoid to work like in v3

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -69,7 +69,8 @@ class Model {
       }
     }
 
-    if (!model.options.timestamps || !model.options.paranoid || options.paranoid === false) {
+    const paranoid = options.paranoid !== undefined ? options.paranoid : model.options.paranoid;
+    if (!model.options.timestamps || !paranoid) {
       // This model is not paranoid, nothing to do here;
       return options;
     }
@@ -81,12 +82,20 @@ class Model {
 
     let deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
-    deletedAtDefaultValue = deletedAtDefaultValue || {
-      [Op.or]: {
-        [Op.gt]: now,
-        [Op.eq]: null
+    if (!deletedAtDefaultValue) {
+      if (paranoid === 'legacy') {
+        deletedAtDefaultValue = {
+          [Op.or]: {
+            [Op.gt]: now,
+            [Op.eq]: null
+          }
+        };
+      } else {
+        deletedAtDefaultValue = {
+          [Op.eq]: null
+        };
       }
-    };
+    }
 
     deletedAtObject[deletedAtAttribute.field || deletedAtCol] = deletedAtDefaultValue;
 
@@ -686,7 +695,7 @@ class Model {
    * @param {Object}                  [options.scopes] More scopes, defined in the same way as defaultScope above. See `Model.scope` for more information about how scopes are defined, and what you can do with them
    * @param {Boolean}                 [options.omitNull] Don't persist null values. This means that all columns with null values will not be saved
    * @param {Boolean}                 [options.timestamps=true] Adds createdAt and updatedAt timestamps to the model.
-   * @param {Boolean}                 [options.paranoid=false] Calling `destroy` will not delete the model, but instead set a `deletedAt` timestamp if this is true. Needs `timestamps=true` to work
+   * @param {Boolean|String}          [options.paranoid=false] Calling `destroy` will not delete the model, but instead set a `deletedAt` timestamp if this is true. Needs `timestamps=true` to work. If set to `'legacy'`, paranoid queries will use `deletedAt is null or deletedAt > now()` instead of simply `deletedAt is null`. Use `legacy` to retain the logic of `true` from Sequelize v4.
    * @param {Boolean}                 [options.underscored=false] Converts all camelCased columns to underscored if true. Will not affect timestamp fields named explicitly by model options and will not affect fields with explicitly set `field` option
    * @param {Boolean}                 [options.underscoredAll=false] Converts camelCased model names to underscored table names if true. Will not change model name if freezeTableName is set to true
    * @param {Boolean}                 [options.freezeTableName=false] If freezeTableName is true, sequelize will not try to alter the model name to get the table name. Otherwise, the model name will be pluralized

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -992,30 +992,53 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
       });
 
-    });
+      it('should not find records where deletedAt set to future', function() {
+        const User = this.sequelize.define('paranoiduser', {
+          username: Sequelize.STRING
+        }, { paranoid: true });
 
-    it('should find records where deletedAt set to future', function() {
-      const User = this.sequelize.define('paranoiduser', {
-        username: Sequelize.STRING
-      }, { paranoid: true });
-
-      return User.sync({ force: true }).then(() => {
-        return User.bulkCreate([
-          {username: 'Bob'},
-          {username: 'Tobi', deletedAt: moment().add(30, 'minutes').format()},
-          {username: 'Max', deletedAt: moment().add(30, 'days').format()},
-          {username: 'Tony', deletedAt: moment().subtract(30, 'days').format()}
-        ]);
-      }).then(() => {
-        return User.find({ where: {username: 'Tobi'} });
-      }).then(tobi => {
-        expect(tobi).not.to.be.null;
-      }).then(() => {
-        return User.findAll();
-      }).then(users => {
-        expect(users.length).to.be.eql(3);
+        return User.sync({ force: true }).then(() => {
+          return User.bulkCreate([
+            {username: 'Bob'},
+            {username: 'Tobi', deletedAt: moment().add(30, 'minutes').format()},
+            {username: 'Max', deletedAt: moment().add(30, 'days').format()},
+            {username: 'Tony', deletedAt: moment().subtract(30, 'days').format()}
+          ]);
+        }).then(() => {
+          return User.find({ where: {username: 'Tobi'} });
+        }).then(tobi => {
+          expect(tobi).to.be.null;
+        }).then(() => {
+          return User.findAll();
+        }).then(users => {
+          expect(users.length).to.be.eql(1);
+        });
       });
     });
 
+    describe('with legacy paranoid', () => {
+      it('should find records where deletedAt set to future', function() {
+        const User = this.sequelize.define('paranoiduser', {
+          username: Sequelize.STRING
+        }, { paranoid: 'legacy' });
+
+        return User.sync({ force: true }).then(() => {
+          return User.bulkCreate([
+            {username: 'Bob'},
+            {username: 'Tobi', deletedAt: moment().add(30, 'minutes').format()},
+            {username: 'Max', deletedAt: moment().add(30, 'days').format()},
+            {username: 'Tony', deletedAt: moment().subtract(30, 'days').format()}
+          ]);
+        }).then(() => {
+          return User.find({ where: {username: 'Tobi'} });
+        }).then(tobi => {
+          expect(tobi).not.to.be.null;
+        }).then(() => {
+          return User.findAll();
+        }).then(users => {
+          expect(users.length).to.be.eql(3);
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

We are currently upgrading to Sequelize v4. As many others we have run into issue #8496. I do not believe having this functionality is good in any way, and I think it was a mistake for make this the new default in v4. The problems around this is well explained in the linked issue.

This PR tries to move forward by reverting paranoid to work like in v3, with an option to have it work like v4. This will likely be a semver-major change to land in v5.

Closes #8496