### PR TITLE
fix(connection-manager): handle null connections in PG

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -296,13 +296,15 @@ class ConnectionManager {
    *
    * @param {Object|Error} mayBeConnection Object which can be either connection or error
    *
-   * @retun {Promise<Connection>}
+   * @return {Promise<Connection>}
    */
   _determineConnection(mayBeConnection) {
     if (mayBeConnection instanceof Error) {
       return Promise.resolve(this.pool.destroy(mayBeConnection))
         .catch(/Resource not currently part of this pool/, () => {})
         .then(() => { throw mayBeConnection; });
+    } else if (!mayBeConnection) {
+      return Promise.reject(new Error('Did not acquire connection'));
     }
 
     return Promise.resolve(mayBeConnection);


### PR DESCRIPTION
Starting discussion about ways to fix #8087.

### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?


### Description of change

I think the cause of #8087 is that`getConnection` returns `undefined` sometimes. By throwing an error when this happens, I think we'll retry the query. Let me know if that's way off track, it's hard to test without a reliable way to reproduce the error.

I can add tests that stub out `getConnection` if you're OK with this approach.