### PR TITLE
Fix bulkCreate with updateOnDuplicate option, Now it properly maps fields to attributes from camelCase to snake_case

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -249,11 +249,12 @@ const QueryGenerator = {
     }
 
     if (this._dialect.supports.updateOnDuplicate && options.updateOnDuplicate) {
-      onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + options.updateOnDuplicate.map(attr => {
-        const field = rawAttributes && rawAttributes[attr] && rawAttributes[attr].field || attr;
-        const key = this.quoteIdentifier(field);
-        return key + '=VALUES(' + key + ')';
-      }).join(',');
+      onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + Object.keys(rawAttributes)
+        .filter(attr => (options.updateOnDuplicate.includes(rawAttributes[attr].fieldName)))
+        .map(attr => {
+          const key = this.quoteIdentifier(rawAttributes[attr].field);
+          return key + '=VALUES(' + key + ')';
+        }).join(',');
     }
 
     const replacements = {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -249,8 +249,7 @@ const QueryGenerator = {
     }
 
     if (this._dialect.supports.updateOnDuplicate && options.updateOnDuplicate) {
-      const fields = _.isEmpty(rawAttributes) ? options.updateOnDuplicate : Object.keys(rawAttributes)
-        .filter(attr => (options.updateOnDuplicate.includes(rawAttributes[attr].fieldName)));
+      const fields = _.isEmpty(rawAttributes) ? options.updateOnDuplicate : _.intersection(Object.keys(rawAttributes), options.updateOnDuplicate);
       onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + fields.map(attr => {
         const field = (rawAttributes && rawAttributes[attr]) ? rawAttributes[attr].field : attr;
         const key = this.quoteIdentifier(field);

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -252,10 +252,10 @@ const QueryGenerator = {
       const fields = _.isEmpty(rawAttributes) ? options.updateOnDuplicate : Object.keys(rawAttributes)
         .filter(attr => (options.updateOnDuplicate.includes(rawAttributes[attr].fieldName)));
       onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + fields.map(attr => {
-          const field = (rawAttributes && rawAttributes[attr]) ? rawAttributes[attr].field : attr;
-          const key = this.quoteIdentifier(field);
-          return key + '=VALUES(' + key + ')';
-        }).join(',');
+        const field = (rawAttributes && rawAttributes[attr]) ? rawAttributes[attr].field : attr;
+        const key = this.quoteIdentifier(field);
+        return key + '=VALUES(' + key + ')';
+      }).join(',');
     }
 
     const replacements = {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -249,10 +249,11 @@ const QueryGenerator = {
     }
 
     if (this._dialect.supports.updateOnDuplicate && options.updateOnDuplicate) {
-      onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + Object.keys(rawAttributes)
-        .filter(attr => (options.updateOnDuplicate.includes(rawAttributes[attr].fieldName)))
-        .map(attr => {
-          const key = this.quoteIdentifier(rawAttributes[attr].field);
+      const fields = _.isEmpty(rawAttributes) ? options.updateOnDuplicate : Object.keys(rawAttributes)
+        .filter(attr => (options.updateOnDuplicate.includes(rawAttributes[attr].fieldName)));
+      onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + fields.map(attr => {
+          const field = (rawAttributes && rawAttributes[attr]) ? rawAttributes[attr].field : attr;
+          const key = this.quoteIdentifier(field);
           return key + '=VALUES(' + key + ')';
         }).join(',');
     }

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -249,7 +249,8 @@ const QueryGenerator = {
     }
 
     if (this._dialect.supports.updateOnDuplicate && options.updateOnDuplicate) {
-      const fields = _.isEmpty(rawAttributes) ? options.updateOnDuplicate : _.intersection(Object.keys(rawAttributes), options.updateOnDuplicate);
+      const fields = _.isEmpty(rawAttributes) ? options.updateOnDuplicate : Object.keys(rawAttributes)
+        .filter(attr => (_.includes(options.updateOnDuplicate, rawAttributes[attr].fieldName)));
       onDuplicateKeyUpdate += ' ON DUPLICATE KEY UPDATE ' + fields.map(attr => {
         const field = (rawAttributes && rawAttributes[attr]) ? rawAttributes[attr].field : attr;
         const key = this.quoteIdentifier(field);


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Closes #9016 
<!-- Please provide a description of the change here. -->
Now fields with camelCase on updateOnDuplicate array will be properly maps to attributes with snake_case.
