### PR TITLE
fix(postgres/conectionmanager): Don't leak OIDs between instances

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -29,6 +29,9 @@ ConnectionManager = function(dialect, sequelize) {
     throw err;
   }
 
+  this.oidMap = {};
+  this.arrayOidMap = {};
+
   this._oidsFetched = false;
   this.refreshTypeParser(dataTypes.postgres);
 };
@@ -41,21 +44,31 @@ ConnectionManager.prototype.$refreshTypeParser = function (dataType) {
 
   if (dataType.types.postgres.oids) {
     dataType.types.postgres.oids.forEach(function (oid) {
-      self.lib.types.setTypeParser(oid, function (value) {
+      self.oidMap[oid] = function (value) {
         return dataType.parse(value, oid, self.lib.types.getTypeParser);
-      });
+      };
     });
   }
 
   if (dataType.types.postgres.array_oids) {
     dataType.types.postgres.array_oids.forEach(function (oid) {
-      self.lib.types.setTypeParser(oid, function (value) {
+      self.arrayOidMap[oid] = function (value) {
         return self.lib.types.arrayParser.create(value, function (value) {
           return dataType.parse(value, oid, self.lib.types.getTypeParser);
         }).parse();
-      });
+      };
     });
   }
+};
+
+ConnectionManager.prototype.getTypeParser = function (oid, format) {
+  if (this.oidMap[oid]) {
+    return this.oidMap[oid];
+  } else if (this.arrayOidMap[oid]) {
+    return this.arrayOidMap[oid];
+  }
+
+  return this.lib.types.getTypeParser.apply(undefined, arguments);
 };
 
 ConnectionManager.prototype.connect = function(config) {
@@ -66,6 +79,10 @@ ConnectionManager.prototype.connect = function(config) {
   connectionConfig = Utils._.pick(config, [
     'user', 'password', 'host', 'database', 'port'
   ]);
+
+  connectionConfig.types = {
+    getTypeParser: ConnectionManager.prototype.getTypeParser.bind(this)
+  };
 
   if (config.dialectOptions) {
     Utils._.merge(connectionConfig,


### PR DESCRIPTION
This problem happens under the following circumstances:

* Several sequelize instances, connecting to different databases.
* Each database contains some custom enum types, with overlapping OIDs (so databaseB has typeA with oid X, while databaseB has typeB, also with oid X)

Since the two sequelize instances share the same copy of the pg lib, they will overwrite each others' type parsers. This is especially appearent when the datatype in one db is an array, and the other is not - So suddenly what you expect to be a string is now an array.

I've fixed this by keeping a local copy of the oids on the connection manager and setting the type parser on the pg client instance, instead of mutating the pg-types object.

Tested on snaplytics, where it fixed the bug that suddenly an enum type became an array.