### PR TITLE
fix  #8984  duplicate indexes when sync with alter true

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1139,6 +1139,12 @@ class Model {
                   changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), columnName, attributes[columnName]));
                 }
               });
+
+              /**
+               * removing indexes on table to eliminate duplicate index creation
+               */
+              changes.push(() => this.QueryInterface.removeIndexes(this.getTableName(options), options));
+
               _.each(columns, (columnDesc, columnName) => {
                 const currentAttributes = attributes[columnName];
                 if (!currentAttributes) {

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -766,6 +766,25 @@ class QueryInterface {
   }
 
   /**
+   * remove indexes from a table except the primary key 
+   *
+   * @param {String} tableName          Table name to remove index from 
+   * @param {Object} [options]          Query options
+   *
+   * @return {Promise}
+   */
+  removeIndexes(tableName, options) {
+
+    return this.showIndex(tableName, options)
+      .then(indexes => {
+        const indexesToRemove = indexes.map(index => index.primary === false ?
+          this.removeIndex(tableName, index.name) : null);
+
+        return Promise.all(indexesToRemove);
+      });
+  }
+
+  /**
    * Add constraints to table
    *
    * Available constraints:


### PR DESCRIPTION
fix  #8984 

### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
I actually ran the linting and fixed the lint but , I did not ran any other tests cause the change is too small to run a test for it. I think travis will run the tests.

- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?

- [ ] Have you added new tests to prevent regressions?
change was too small to run a test for it.

- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

I added a new function in the query interface to remove all indexes in a table and called it in the
sync function before making any changes in the table to eliminate any duplicates that would happen
while altering

This is my first pull request I hope it helps I also hope that this is the right way to fix this problem
Thanks

