### PR TITLE
Fix documentation error

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -811,7 +811,7 @@ class QueryInterface {
    * Foreign Key
    * ```js
    * queryInterface.addConstraint('Posts', ['username'], {
-   *   type: 'FOREIGN KEY',
+   *   type: 'foreign key',
    *   name: 'custom_fkey_constraint_name',
    *   references: { //Required field
    *     table: 'target_table_name',


### PR DESCRIPTION
Hello,

I just change the case for "options.type" in documentation for "queryInterface.addConstraint".

It seems that the type option must be in lower case.
