### PR TITLE
feat(query): add ability to pass arrays as replacements #9050

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -4,6 +4,21 @@ const dataTypes = require('./data-types');
 const util = require('util');
 const _ = require('lodash');
 
+function arrayToList(array, timeZone, dialect, format) {
+  return array.reduce((sql, val, i) => {
+    if (i !== 0) {
+      sql += ', ';
+    }
+    if (Array.isArray(val)) {
+      sql += `(${arrayToList(val, timeZone, dialect, format)})`;
+    } else {
+      sql += escape(val, timeZone, dialect, format);
+    }
+    return sql;
+  }, '');
+}
+exports.arrayToList = arrayToList;
+
 function escape(val, timeZone, dialect, format) {
   let prependN = false;
   if (val === undefined || val === null) {
@@ -44,7 +59,7 @@ function escape(val, timeZone, dialect, format) {
     if (dialect === 'postgres' && !format) {
       return dataTypes.ARRAY.prototype.stringify(val, {escape: partialEscape});
     }
-    return val.map(partialEscape);
+    return arrayToList(val, timeZone, dialect, format);
   }
 
   if (!val.replace) {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -273,6 +273,23 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       return this.sequelize.query(this.insertQuery);
     });
 
+    it('executes a query if a placeholder value is an array', function() {
+      return this.sequelize.query(`INSERT INTO ${qq(this.User.tableName)} (username, email_address, ` +
+        `${qq('createdAt')}, ${qq('updatedAt')}) VALUES ?;`, {
+        replacements: [[
+          ['john', 'john@gmail.com', '2012-01-01 10:10:10', '2012-01-01 10:10:10'],
+          ['michael', 'michael@gmail.com', '2012-01-01 10:10:10', '2012-01-01 10:10:10']
+        ]]
+      })
+        .then(() => this.sequelize.query(`SELECT * FROM ${qq(this.User.tableName)};`, {
+          type: this.sequelize.QueryTypes.SELECT
+        }))
+        .then(rows => {
+          expect(rows).to.be.lengthOf(2);
+          expect(rows[0].username).to.be.equal('john');
+          expect(rows[1].username).to.be.equal('michael');
+        });
+    });
 
     describe('logging', () => {
       it('executes a query with global benchmarking option and default logger', () => {

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -6,6 +6,15 @@ const chai = require('chai'),
   getAbstractQueryGenerator = require(__dirname + '/../../support').getAbstractQueryGenerator;
 
 describe('QueryGenerator', () => {
+  describe('selectQuery', () => {
+    it('should generate correct query using array placeholder', function() {
+      const QG = getAbstractQueryGenerator(this.sequelize);
+
+      QG.selectQuery('foo', {where: {bar: {[Op.like]: {[Op.any]: ['a', 'b']}}}})
+        .should.be.equal('SELECT * FROM foo WHERE foo.bar LIKE ANY (\'a\', \'b\');');
+    });
+  });
+
   describe('whereItemQuery', () => {
     it('should generate correct query for Symbol operators', function() {
       const QG = getAbstractQueryGenerator(this.sequelize);


### PR DESCRIPTION
According to the [feature request](https://github.com/sequelize/sequelize/issues/9050) added ability to pass arrays to `sequelize.query()` as replacements.