### PR TITLE
docs(Getting Started): Add `operatorsAliases: Op`

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,7 @@ const Sequelize = require('sequelize');
 const sequelize = new Sequelize('database', 'username', 'password', {
   host: 'localhost',
   dialect: 'mysql'|'sqlite'|'postgres'|'mssql',
-  operatorsAliases: Sequelize.Op,
+  operatorsAliases: false,
 
   pool: {
     max: 5,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,6 +33,7 @@ const Sequelize = require('sequelize');
 const sequelize = new Sequelize('database', 'username', 'password', {
   host: 'localhost',
   dialect: 'mysql'|'sqlite'|'postgres'|'mssql',
+  operatorsAliases: Sequelize.Op,
 
   pool: {
     max: 5,


### PR DESCRIPTION
### Description of change

<!-- Please provide a description of the change here. -->

Running the code provided on Getting Started cause a deprecation warning. This PR adds `operatorsAliases: Op` to the code on Getting Started, which is already recommended in other documents, like [Querying](http://docs.sequelizejs.com/manual/tutorial/querying.html#operators-aliases):

> For better security it is highly advised to use Sequelize.Op and not depend on any string alias at all.

This change was suggested in https://github.com/sequelize/sequelize/issues/8417#issuecomment-337884136 a few months ago and received positive response.