### PR TITLE
fix(sequelize/query): use hasOwnProperty for keys in query (#9100)

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -419,7 +419,7 @@ class AbstractQuery {
     // Map each key to an include option
     let previousPiece;
     const buildIncludeMap = piece => {
-      if ($current.includeMap[piece]) {
+      if ($current.includeMap.hasOwnProperty(piece)) {
         includeMap[key] = $current = $current.includeMap[piece];
         if (previousPiece) {
           previousPiece = previousPiece+'.'+piece;
@@ -432,7 +432,7 @@ class AbstractQuery {
     // Calculate the string prefix of a key ('User.Results' for 'User.Results.id')
     const keyPrefixStringMemo = {};
     const keyPrefixString = (key, memo) => {
-      if (!memo[key]) {
+      if (!memo.hasOwnProperty(key)) {
         memo[key] = key.substr(0, key.lastIndexOf('.'));
       }
       return memo[key];
@@ -440,7 +440,7 @@ class AbstractQuery {
     // Removes the prefix from a key ('id' for 'User.Results.id')
     const removeKeyPrefixMemo = {};
     const removeKeyPrefix = key => {
-      if (!removeKeyPrefixMemo[key]) {
+      if (!removeKeyPrefixMemo.hasOwnProperty(key)) {
         const index = key.lastIndexOf('.');
         removeKeyPrefixMemo[key] = key.substr(index === -1 ? 0 : index + 1);
       }
@@ -450,9 +450,9 @@ class AbstractQuery {
     const keyPrefixMemo = {};
     const keyPrefix = key => {
       // We use a double memo and keyPrefixString so that different keys with the same prefix will receive the same array instead of differnet arrays with equal values
-      if (!keyPrefixMemo[key]) {
+      if (!keyPrefixMemo.hasOwnProperty(key)) {
         const prefixString = keyPrefixString(key, keyPrefixStringMemo);
-        if (!keyPrefixMemo[prefixString]) {
+        if (!keyPrefixMemo.hasOwnProperty(prefixString)) {
           keyPrefixMemo[prefixString] = prefixString ? prefixString.split('.') : [];
         }
         keyPrefixMemo[key] = keyPrefixMemo[prefixString];
@@ -462,7 +462,7 @@ class AbstractQuery {
     // Calcuate the last item in the array prefix ('Results' for 'User.Results.id')
     const lastKeyPrefixMemo = {};
     const lastKeyPrefix = key => {
-      if (!lastKeyPrefixMemo[key]) {
+      if (!lastKeyPrefixMemo.hasOwnProperty(key)) {
         const prefix = keyPrefix(key);
         const length = prefix.length;
 
@@ -527,7 +527,7 @@ class AbstractQuery {
         $keyPrefix = keyPrefix(key);
 
         // On the first row we compute the includeMap
-        if (rowsI === 0 && includeMap[key] === undefined) {
+        if (rowsI === 0 && !includeMap.hasOwnProperty(key)) {
           if (!$keyPrefix.length) {
             includeMap[key] = includeMap[''] = includeOptions;
           } else {

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -96,6 +96,41 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(person.get('toString')).to.equal('Jozef');
           });
       });
+
+      it('allows for an attribute to be called "toString" with associations', function () {
+        const Person = this.sequelize.define('person', {
+          name: Sequelize.STRING,
+          nick: Sequelize.STRING
+        });
+
+        const Computer = this.sequelize.define('computer', {
+          hostname: Sequelize.STRING,
+        });
+
+        Person.hasMany(Computer);
+
+        return this.sequelize.sync({force: true})
+          .then(() => Person.create({name: 'Jozef', nick: 'Joe'}))
+          .then(person => person.createComputer({hostname: 'laptop'}))
+          .then(() => Person.findAll({
+            attributes: [
+              'nick',
+              ['name', 'toString']
+            ],
+            include: {
+              model: Computer
+            },
+            where: {
+              name: 'Jozef'
+            }
+          }))
+          .then(result => {
+            expect(result.length).to.equal(1);
+            expect(result[0].dataValues['toString']).to.equal('Jozef');
+            expect(result[0].get('toString')).to.equal('Jozef');
+            expect(result[0].get('computers')[0].hostname).to.equal('laptop');
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
Closes https://github.com/sequelize/sequelize/issues/9100

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?
