### PR TITLE
Fix JSDoc for "createTable"

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -148,7 +148,7 @@ class QueryInterface {
    * ```
    *
    * @param {String} tableName  Name of table to create
-   * @param {Array}  attributes List of table attributes to create
+   * @param {Object} attributes Object representing a list of table attributes to create
    * @param {Object} [options]
    * @param {Model}  [model]
    *


### PR DESCRIPTION
My PR only contains changes to documentation. In the "createTable" queryInterface method, the parameter "attributes" was set as an Array when it should be an Object.