### PR TITLE
handle postgres schema in getForeignKeyReferencesForTable

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -724,6 +724,11 @@ class QueryInterface {
    * @returns {Promise}
    */
   getForeignKeyReferencesForTable(tableName, options) {
+    let schema = null;
+    if (typeof tableName === 'object' && tableName !== null) {
+      schema = tableName.schema;
+      tableName = tableName.tableName;
+    }
     const queryOptions = Object.assign({}, options, {
       type: QueryTypes.FOREIGNKEYS
     });
@@ -736,7 +741,7 @@ class QueryInterface {
       {
         // postgres needs some special treatment as those field names returned are all lowercase
         // in order to keep same result with other dialects.
-        const query = this.QueryGenerator.getForeignKeyReferencesQuery(tableName, catalogName);
+        const query = this.QueryGenerator.getForeignKeyReferencesQuery(tableName, catalogName, schema);
         return this.sequelize.query(query, queryOptions)
           .then(result => result.map(Utils.camelizeObjectKeys));
       }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
handle postgres schema in getForeignKeyReferencesForTable similar to describeTable

schema was not getting passed to getForeignKeyReferencesQuery where needed, so no references were found.