### PR TITLE
fix(query-generator): make it possible to use Op as comparator in Seq…

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1861,6 +1861,10 @@ const QueryGenerator = {
   handleSequelizeMethod(smth, tableName, factory, options, prepend) {
     let result;
 
+    if (this.OperatorMap.hasOwnProperty(smth.comparator)) {
+      smth.comparator = this.OperatorMap[smth.comparator];
+    }
+
     if (smth instanceof Utils.Where) {
       let value = smth.logic;
       let key;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -927,7 +927,7 @@ class Sequelize {
    * @see {@link Model.findAll}
    *
    * @param {Object} attr The attribute, which can be either an attribute object from `Model.rawAttributes` or a sequelize object, for example an instance of `sequelize.fn`. For simple string attributes, use the POJO syntax
-   * @param {string} [comparator='=']
+   * @param {String|Op} [comparator='&#61;']
    * @param {String|Object} logic The condition. Can be both a simply type, or a further condition (`or`, `and`, `.literal` etc.)
    * @alias condition
    * @since v2.0.0-dev3

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -1117,5 +1117,13 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     testsql(current.where(current.fn('lower', current.col('name')), null), {
       default: 'lower([name]) IS NULL'
     });
+
+    testsql(current.where(current.fn('SUM', current.col('hours')), '>', 0), {
+      default: 'SUM([hours]) > 0'
+    });
+
+    testsql(current.where(current.fn('SUM', current.col('hours')), current.Op.gt, 0), {
+      default: 'SUM([hours]) > 0'
+    });
   });
 });


### PR DESCRIPTION
…uelize.where (#9123)

Closes https://github.com/sequelize/sequelize/issues/9123

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

make it possible to use Op operators in Sequelize.where, e.g.:
```js
sequelize.where(sequelize.fn('SUM', sequelize.col('price')), Op.gt, 0);
```
