### PR TITLE
refactor(Model): Unify the QueryInterface accessors (Fix issue #9118)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2995,9 +2995,9 @@ class Model {
 
     let promise;
     if (!options.increment) {
-      promise = this.sequelize.getQueryInterface().decrement(this, this.getTableName(options), values, where, options);
+      promise = this.QueryInterface.decrement(this, this.getTableName(options), values, where, options);
     } else {
-      promise = this.sequelize.getQueryInterface().increment(this, this.getTableName(options), values, where, options);
+      promise = this.QueryInterface.increment(this, this.getTableName(options), values, where, options);
     }
 
     return promise.then(affectedRows => {
@@ -3649,7 +3649,7 @@ class Model {
         args = [this, this.constructor.getTableName(options), values, where, options];
       }
 
-      return this.sequelize.getQueryInterface()[query].apply(this.sequelize.getQueryInterface(), args)
+      return this.constructor.QueryInterface[query].apply(this.constructor.QueryInterface, args)
         .then(results => {
           const result = _.head(results);
           const rowsUpdated = results[1];
@@ -3860,7 +3860,7 @@ class Model {
 
         this.setDataValue(field, values[field]);
 
-        return this.sequelize.getQueryInterface().update(
+        return this.constructor.QueryInterface.update(
           this, this.constructor.getTableName(options), values, where, _.defaults({ hooks: false, model: this.constructor }, options)
         ).then(results => {
           const rowsUpdated = results[1];
@@ -3874,7 +3874,7 @@ class Model {
           return _.head(results);
         });
       } else {
-        return this.sequelize.getQueryInterface().delete(this, this.constructor.getTableName(options), where, _.assign({ type: QueryTypes.DELETE, limit: null }, options));
+        return this.constructor.QueryInterface.delete(this, this.constructor.getTableName(options), where, _.assign({ type: QueryTypes.DELETE, limit: null }, options));
       }
     }).tap(() => {
       // Run after hook


### PR DESCRIPTION
Finish missed code refactoring.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Closes #9118, replaced the this.sequlize.getQueryInterface() calls with the models own accessor.
<!-- Please provide a description of the change here. -->
