### PR TITLE
fix(scope): include scope on eagerly created associations

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3459,11 +3459,12 @@ class Model {
         if (Array.isArray(value)) {
           value = value[0];
         }
-
         isEmpty = value && value[primaryKeyAttribute] === null || value === null;
+        value = !isEmpty && _.assign(value, association.scope);
         this[accessor] = this.dataValues[accessor] = isEmpty ? null : include.model.build(value, childOptions);
       } else {
         isEmpty = value[0] && value[0][primaryKeyAttribute] === null;
+        value = !isEmpty && value.map(v => _.assign(v, association.scope));
         this[accessor] = this.dataValues[accessor] = isEmpty ? [] : include.model.bulkBuild(value, childOptions);
       }
     }

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -137,6 +137,24 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           expect(mainComment.get('title')).to.equal('I am a future main comment');
         });
       });
+      it('should create included association with scope values', function() {
+        return this.sequelize.sync({force: true}).then(() => {
+          return this.Post.create({
+            mainComment: {
+              title: 'I am a main comment created with a post'
+            }
+          }, {
+            include: [{model: this.Comment, as: 'mainComment'}]
+          });
+        }).then(post => {
+          expect(post.mainComment.get('commentable')).to.equal('post');
+          expect(post.mainComment.get('isMain')).to.be.true;
+          return this.Post.scope('withMainComment').findById(post.id);
+        }).then(post => {
+          expect(post.mainComment.get('commentable')).to.equal('post');
+          expect(post.mainComment.get('isMain')).to.be.true;
+        });
+      });
     });
 
     describe('1:M', () => {
@@ -243,6 +261,30 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           });
         }).then(() => {
           expect(logs[0]).to.equal(logs[1]);
+        });
+      });
+      it('should created included association with scope values', function() {
+        return this.sequelize.sync({force: true}).then(() => {
+          return this.Post.create({
+            comments: [{
+              title: 'I am a comment created with a post'
+            }, {
+              title: 'I am a second comment created with a post'
+            }]
+          }, {
+            include: [{model: this.Comment, as: 'comments'}]
+          });
+        }).then(post => {
+          this.post = post;
+          return post.comments;
+        }).each(comment => {
+          expect(comment.get('commentable')).to.equal('post');
+        }).then(() => {
+          return this.Post.scope('withComments').findById(this.post.id);
+        }).then(post => {
+          return post.getComments();
+        }).each(comment => {
+          expect(comment.get('commentable')).to.equal('post');
         });
       });
     });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Models being created with included associations do not include the association scope on the created models. Example:

```js
const Post = sequelize.define('post', {});
const Comment = sequelize.define('comment', {
  title: Sequelize.STRING,
  commentable: Sequelize.STRING,
  commentable_id: Sequelize.INTEGER
});
Post.Comments = Post.hasMany(Comment, {
  foreignKey: 'commentable_id',
  scope: {
    commentable: 'post'
  },
  constraints: false
});

const post = Post.create({
  comments:[{
    title: 'This is a comment'
  }]
}, {
  include: [Post.Comments]
});

// post.comments[0].commentable == null
```
i.e. association scope is only injected when creating via `Post.Comments.create` (and methods that call it), and not with `Post.create({comments: [...], include:[Post.Comments]})`

This PR causes scope to be injected on included associations at parent model build time, such that 
in the previous example, `post.comments[0].commentable` would be set to `'post'`