### PR TITLE
fix(model): Made sure errors with messages are passed to AggregateError for bulk creates.

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -167,7 +167,7 @@ Task.bulkCreate([
 }).spread((affectedCount, affectedRows) => {
   // .update returns two values in an array, therefore we use .spread
   // Notice that affectedRows will only be defined in dialects which support returning: true
-  
+
   // affectedCount will be 2
   return Task.findAll();
 }).then(tasks => {
@@ -235,7 +235,7 @@ Tasks.bulkCreate([
   [
     { record:
     ...
-    name: 'SequelizeRecordLinkedError',
+    name: 'SequelizeBulkRecordError',
     message: 'Validation error',
     errors:
       { name: 'SequelizeValidationError',
@@ -243,7 +243,7 @@ Tasks.bulkCreate([
         errors: [Object] } },
     { record:
       ...
-      name: 'SequelizeRecordLinkedError',
+      name: 'SequelizeBulkRecordError',
       message: 'Validation error',
       errors:
         { name: 'SequelizeValidationError',

--- a/docs/instances.md
+++ b/docs/instances.md
@@ -235,12 +235,16 @@ Tasks.bulkCreate([
   [
     { record:
     ...
+    name: 'SequelizeRecordLinkedError',
+    message: 'Validation error',
     errors:
       { name: 'SequelizeValidationError',
         message: 'Validation error',
         errors: [Object] } },
     { record:
       ...
+      name: 'SequelizeRecordLinkedError',
+      message: 'Validation error',
       errors:
         { name: 'SequelizeValidationError',
         message: 'Validation error',

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -537,10 +537,8 @@ exports.QueryError = QueryError;
 class RecordLinkedError extends BaseError {
   constructor(err, record) {
     super(err.message);
+    this.name = 'SequelizeRecordLinkedError';
     this.errors = err;
-    this.message = err.message;
-    delete this.name;
-    // this.name = 'SequelizeRecordLinkedError';
     this.record = record;
     Error.captureStackTrace(this, this.constructor);
   }

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -527,7 +527,7 @@ exports.QueryError = QueryError;
 
 
 /**
- * Thrown when errors need to be linked back to a given record/instance. For example items within a BulkCreate AggregationError
+ * Thrown when errors need to be linked back to a given record/instance, for example items within a BulkCreate AggregationError
  * @param {Error} err
  * Any error that needs to be linked back to a given record/instance.
  *

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -525,23 +525,20 @@ class QueryError extends BaseError {
 }
 exports.QueryError = QueryError;
 
-
 /**
- * Thrown when errors need to be linked back to a given record/instance, for example items within a BulkCreate AggregationError
- * @param {Error} err
- * Any error that needs to be linked back to a given record/instance.
+ * Thrown when bulk operation fails, it represent per record level error.
+ * Used with Promise.AggregateError
  *
- * @param {Model} record
- * The model instance the error should be linked to.
-*/
-class RecordLinkedError extends BaseError {
-  constructor(err, record) {
-    super(err.message);
-    this.name = 'SequelizeRecordLinkedError';
-    this.errors = err;
+ * @param {Error}  error   Error for a given record/instance
+ * @param {Object} record  DAO instance that error belongs to
+ */
+class BulkRecordError extends BaseError {
+  constructor(error, record) {
+    super(error.message);
+    this.name = 'SequelizeBulkRecordError';
+    this.errors = error;
     this.record = record;
     Error.captureStackTrace(this, this.constructor);
   }
 }
-
-exports.RecordLinkedError = RecordLinkedError;
+exports.BulkRecordError = BulkRecordError;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -524,3 +524,26 @@ class QueryError extends BaseError {
   }
 }
 exports.QueryError = QueryError;
+
+
+/**
+ * Thrown when errors need to be linked back to a given record/instance. For example items within a BulkCreate AggregationError
+ * @param {Error} err
+ * Any error that needs to be linked back to a given record/instance.
+ *
+ * @param {Model} record
+ * The model instance the error should be linked to.
+*/
+class RecordLinkedError extends BaseError {
+  constructor(err, record) {
+    super(err.message);
+    this.errors = err;
+    this.message = err.message;
+    delete this.name;
+    // this.name = 'SequelizeRecordLinkedError';
+    this.record = record;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+exports.RecordLinkedError = RecordLinkedError;

--- a/lib/model.js
+++ b/lib/model.js
@@ -2374,11 +2374,7 @@ class Model {
 
         return Promise.map(instances, instance =>
           instance.validate(validateOptions).catch(err => {
-            /**
-             * Simply extending the value of `err` would cause a breaking change as the `errors`
-             * property is expected on each item in the array of errors.
-             */
-            errors.push(new sequelizeErrors.RecordLinkedError(err, instance));
+            errors.push(new sequelizeErrors.BulkRecordError(err, instance));
           })
         ).then(() => {
           delete options.skip;

--- a/lib/model.js
+++ b/lib/model.js
@@ -2374,7 +2374,11 @@ class Model {
 
         return Promise.map(instances, instance =>
           instance.validate(validateOptions).catch(err => {
-            errors.push({record: instance, errors: err});
+            /**
+             * Simply extending the value of `err` would cause a breaking change as the `errors`
+             * property is expected on each item in the array of errors.
+             */
+            errors.push(new sequelizeErrors.RecordLinkedError(err, instance));
           })
         ).then(() => {
           delete options.skip;

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -292,6 +292,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           {code: '1234'},
           {name: 'bar', code: '1'}
         ], { validate: true }).catch(errors => {
+          const expectedValidationError = 'Validation len on code failed';
+          const expectedNotNullError = 'notNull Violation: Task.name cannot be null';
+
+          expect(errors.toString()).to.include(expectedValidationError).and.to.include(expectedNotNullError);
           expect(errors).to.be.instanceof(Promise.AggregateError);
           expect(errors).to.have.length(2);
 
@@ -302,7 +306,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           expect(errors[1].record.name).to.equal('bar');
           expect(errors[1].record.code).to.equal('1');
-          expect(errors[1].errors.get('code')[0].message).to.equal('Validation len on code failed');
+          expect(errors[1].errors.get('code')[0].message).to.equal(expectedValidationError);
         });
       });
     });

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -295,8 +295,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expectedValidationError = 'Validation len on code failed';
           const expectedNotNullError = 'notNull Violation: Task.name cannot be null';
 
-          expect(errors.toString()).to.include(expectedValidationError).and.to.include(expectedNotNullError);
           expect(errors).to.be.instanceof(Promise.AggregateError);
+          expect(errors.toString()).to.include(expectedValidationError)
+            .and.to.include(expectedNotNullError);
           expect(errors).to.have.length(2);
 
           const e0name0 = errors[0].errors.get('name')[0];


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Previously objects passed to the AggregateError did not have a message property, causing them to be
rendered as [object Object] in the console log. This change fixes the issue of a missing message
property.

fixes #8989
