### PR TITLE
fix(postgresql): search path with type query

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -210,7 +210,7 @@ class ConnectionManager extends AbstractConnectionManager {
     ).then(results => {
       let result = Array.isArray(results) ? results.pop() : results;
 
-      // When the searchPath is prepended then two statement is executed and the result is
+      // When searchPath is prepended then two statement are executed and the result is
       // an array of those two statements, the first one is the SET search_path and we need the
       // second result which contains the actual SELECT query result.
       if (Array.isArray(result)) {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -208,7 +208,16 @@ class ConnectionManager extends AbstractConnectionManager {
     return (connection || this.sequelize).query(
       "SELECT typname, typtype, oid, typarray FROM pg_type WHERE (typtype = 'b' AND typname IN ('hstore', 'geometry', 'geography')) OR (typtype = 'e')"
     ).then(results => {
-      const result = Array.isArray(results) ? results.pop() : results;
+      let result = Array.isArray(results) ? results.pop() : results;
+
+      // When the searchPath is prepended then two statement is executed and the result is
+      // an array of those two statements, the first one is the SET search_path and we need the
+      // second result which contains the actual SELECT query result.
+      if (Array.isArray(result)) {
+        if (result[0].command === 'SET') {
+          result = result.pop();
+        }
+      }
 
       // Reset OID mapping for dynamic type
       [

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -210,9 +210,9 @@ class ConnectionManager extends AbstractConnectionManager {
     ).then(results => {
       let result = Array.isArray(results) ? results.pop() : results;
 
-      // When searchPath is prepended then two statement are executed and the result is
-      // an array of those two statements, the first one is the SET search_path and we need the
-      // second result which contains the actual SELECT query result.
+      // When searchPath is prepended then two statements are executed and the result is
+      // an array of those two statements. First one is the SET search_path and second is
+      // the SELECT query result.
       if (Array.isArray(result)) {
         if (result[0].command === 'SET') {
           result = result.pop();

--- a/test/integration/model/searchPath.test.js
+++ b/test/integration/model/searchPath.test.js
@@ -18,7 +18,6 @@ let locationId;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   if (current.dialect.supports.searchPath) {
-
     describe('SEARCH PATH', () => {
       before(function() {
         this.Restaurant = current.define('restaurant', {
@@ -27,7 +26,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         },
         {tableName: 'restaurants'});
         this.Location = current.define('location', {
-          name: DataTypes.STRING
+          name: DataTypes.STRING,
+          type: DataTypes.ENUM('a', 'b')
         },
         {tableName: 'locations'});
         this.Employee = current.define('employee', {
@@ -51,7 +51,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
 
-
       beforeEach('build restaurant tables', function() {
         const Restaurant = this.Restaurant;
         return current.createSchema('schema_one').then(() => {
@@ -68,6 +67,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       afterEach('drop schemas', () => {
         return current.dropSchema('schema_one').then(() => {
           return current.dropSchema('schema_two');
+        });
+      });
+
+      describe('enum case', () => {
+        it('able to refresh enum when searchPath is used', function () {
+          return this.Location.sync({ force: true });
         });
       });
 
@@ -292,7 +297,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         });
 
-
         it('should be able to insert and retrieve associated data into the table in schema_two', function() {
           const Restaurant = this.Restaurant;
           const Location = this.Location;
@@ -378,7 +382,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(restaurant.foo).to.equal('one');
           });
         });
-
 
         it('should be able to insert and retrieve associated data into the table in schema_two', function() {
           const Restaurant = this.Restaurant;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?
### Description of change

So here we go with the explanation :)

Problem comes from [here](https://github.com/sequelize/sequelize/blob/master/lib/dialects/postgres/connection-manager.js#L209), the script runs a simple __select__ query, or it belives it does! :D Because if the connection has a searchPath and a prependSearchPath option then actualy 2 statement is executed like: 

```sql
SET search_path to schema1, schema2; SELECT typname, typtype, oid, typarray FROM pg_type WHERE (typtype = 'b' AND typname IN ('hstore', 'geometry', 'geography')) OR (typtype = 'e')
```
But the result handler expects a single result and trying to access the __result.rows__ key which does not exists, this little fix only assures to avoid this edge case.

Wanted to write a test to ensure this does not happen in the future, but I did not found anything alike to this case, but would still gladly create the test just please point me to a sample how this is done in this environment ^.^