### PR TITLE
feat(model): Allow many composite unique keys on same field

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -993,14 +993,15 @@ class Model {
       }
 
       if (definition.hasOwnProperty('unique') && definition.unique) {
+        const unique = definition.unique;
         let idxName;
         if (
-          typeof definition.unique === 'object' &&
-          definition.unique.hasOwnProperty('name')
+          typeof unique === 'object' &&
+          unique.hasOwnProperty('name')
         ) {
-          idxName = definition.unique.name;
-        } else if (typeof definition.unique === 'string') {
-          idxName = definition.unique;
+          idxName = unique.name;
+        } else if (typeof unique === 'string') {
+          idxName = unique;
         } else {
           idxName = this.tableName + '_' + name + '_unique';
         }
@@ -1008,10 +1009,10 @@ class Model {
         const idx = this.options.uniqueKeys[idxName] || { fields: [] };
 
         idx.fields.push(definition.field);
-        idx.msg = idx.msg || definition.unique.msg || null;
+        idx.msg = idx.msg || unique.msg || null;
         idx.name = idxName || false;
         idx.column = name;
-        idx.customIndex = definition.unique !== true;
+        idx.customIndex = unique !== true;
 
         this.options.uniqueKeys[idxName] = idx;
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -993,28 +993,30 @@ class Model {
       }
 
       if (definition.hasOwnProperty('unique') && definition.unique) {
-        const unique = definition.unique;
-        let idxName;
-        if (
-          typeof unique === 'object' &&
-          unique.hasOwnProperty('name')
-        ) {
-          idxName = unique.name;
-        } else if (typeof unique === 'string') {
-          idxName = unique;
-        } else {
-          idxName = this.tableName + '_' + name + '_unique';
+        const uniques = [].concat(definition.unique);
+        for (const unique of uniques) {
+          let idxName;
+          if (
+            typeof unique === 'object' &&
+            unique.hasOwnProperty('name')
+          ) {
+            idxName = unique.name;
+          } else if (typeof unique === 'string') {
+            idxName = unique;
+          } else {
+            idxName = this.tableName + '_' + name + '_unique';
+          }
+
+          const idx = this.options.uniqueKeys[idxName] || { fields: [] };
+
+          idx.fields.push(definition.field);
+          idx.msg = idx.msg || unique.msg || null;
+          idx.name = idxName || false;
+          idx.column = name;
+          idx.customIndex = unique !== true;
+
+          this.options.uniqueKeys[idxName] = idx;
         }
-
-        const idx = this.options.uniqueKeys[idxName] || { fields: [] };
-
-        idx.fields.push(definition.field);
-        idx.msg = idx.msg || unique.msg || null;
-        idx.name = idxName || false;
-        idx.column = name;
-        idx.customIndex = unique !== true;
-
-        this.options.uniqueKeys[idxName] = idx;
       }
 
       if (definition.hasOwnProperty('validate')) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -666,7 +666,7 @@ class Model {
    * @param {String|DataTypes}         attributes.column.type A string or a data type
    * @param {Boolean}                 [attributes.column.allowNull=true] If false, the column will have a NOT NULL constraint, and a not null validation will be run before an instance is saved.
    * @param {any}                     [attributes.column.defaultValue=null] A literal default value, a JavaScript function, or an SQL function (see `sequelize.fn`)
-   * @param {String|Boolean}          [attributes.column.unique=false] If true, the column will get a unique constraint. If a string is provided, the column will be part of a composite unique index. If multiple columns have the same string, they will be part of the same unique index
+   * @param {String|Boolean|Array<String|Boolean>}          [attributes.column.unique=false] If true, the column will get a unique constraint. If a string is provided, the column will be part of a composite unique index. If multiple columns have the same string, they will be part of the same unique index. If an array is provided, each entry is processed as described in the previous sentences.
    * @param {Boolean}                 [attributes.column.primaryKey=false]
    * @param {String}                  [attributes.column.field=null] If set, sequelize will map the attribute name to a different name in the database
    * @param {Boolean}                 [attributes.column.autoIncrement=false]


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

This fixes https://github.com/sequelize/sequelize/issues/8148 by allowing the `unique` property value in a model to be an array, where each item is processed as if it were the value instead. See the tests for a usage example.

EDIT: The changes are easier to review when ignoring whitespace: https://github.com/sequelize/sequelize/pull/9150/files?w=1