### PR TITLE
fix(model/sync): remove duplicated index after change column

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1182,6 +1182,19 @@ class Model {
         // Assign an auto-generated name to indexes which are not named by the user
         this.options.indexes = this.QueryInterface.nameIndexes(this.options.indexes, this.tableName);
 
+        const existedIndex = {};
+        const duplicatedIndexes = [];
+
+        indexes.forEach(index => {
+          const fieldNameStr = index.fields.map(field => field.attribute).join('_');
+          const key = `${index.type}_${index.primary}_${index.unique}_${fieldNameStr}`;
+          if (existedIndex[key]) {
+            duplicatedIndexes.push(index);
+          } else {
+            existedIndex[key] = true;
+          }
+        });
+
         indexes = _.filter(this.options.indexes, item1 =>
           !_.some(indexes, item2 => item1.name === item2.name)
         ).sort((index1, index2) => {
@@ -1194,15 +1207,23 @@ class Model {
           return 0;
         });
 
-        return Promise.map(indexes, index => this.QueryInterface.addIndex(
-          this.getTableName(options),
-          _.assign({
-            logging: options.logging,
-            benchmark: options.benchmark,
-            transaction: options.transaction
-          }, index),
-          this.tableName
-        ));
+        const tableName = this.getTableName(options);
+        return Promise.all([
+          Promise.map(indexes, index => this.QueryInterface.addIndex(
+            tableName,
+            _.assign({
+              logging: options.logging,
+              benchmark: options.benchmark,
+              transaction: options.transaction
+            }, index),
+            this.tableName
+          )),
+          Promise.map(duplicatedIndexes, index => this.QueryInterface.removeIndex(
+            tableName,
+            index.name,
+            this.options
+          )),
+        ]);
       }).then(() => {
         if (options.hooks) {
           return this.runHooks('afterSync', options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1182,16 +1182,19 @@ class Model {
         // Assign an auto-generated name to indexes which are not named by the user
         this.options.indexes = this.QueryInterface.nameIndexes(this.options.indexes, this.tableName);
 
-        const existedIndex = {};
+        const existedIndexes = {};
         const duplicatedIndexes = [];
 
         indexes.forEach(index => {
           const fieldNameStr = index.fields.map(field => field.attribute).join('_');
           const key = `${index.type}_${index.primary}_${index.unique}_${fieldNameStr}`;
-          if (existedIndex[key]) {
-            duplicatedIndexes.push(index);
+          const existedIndex = existedIndexes[key];
+          if (existedIndex) {
+            if (existedIndex.name !== index.name) {
+              duplicatedIndexes.push(index);
+            }
           } else {
-            existedIndex[key] = true;
+            existedIndexes[key] = index;
           }
         });
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -1026,8 +1026,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         }
       });
 
-      return this.sequelize.sync({ alert: true }).then(() => {
-        return this.sequelize.sync({ alert: true });
+      return this.sequelize.sync({ alter: true }).then(() => {
+        return this.sequelize.sync({ alter: true });
       }).then(() => {
         return this.sequelize.getQueryInterface()
           .showIndex(this.sequelize.models.User.getTableName(), {});


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Remove duplicated indexes after change column in sync.
https://github.com/sequelize/sequelize/issues/7606#issuecomment-364340666

As for alerting a unique column(`alert xxx unique`) will create a unique index, there will be multiple unique indexes for a column after sync with alert multiple times. So it need to find duplicated indexes after change column and remove them.


<!-- Please provide a description of the change here. -->
