### PR TITLE
fix(query-generator): generate subQueryFilter even for nested joins

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1249,7 +1249,7 @@ const QueryGenerator = {
           ? this.quoteIdentifiers(attr)
           : this.escape(attr);
       }
-      if (options.include && attr.indexOf('.') === -1 && addTable) {
+      if (!_.isEmpty(options.include) && attr.indexOf('.') === -1 && addTable) {
         attr = mainTableAs + '.' + attr;
       }
 
@@ -1258,7 +1258,6 @@ const QueryGenerator = {
   },
 
   generateInclude(include, parentTableName, topLevelInfo) {
-    const association = include.association;
     const joinQueries = {
       mainQuery: [],
       subQuery: []
@@ -1334,43 +1333,7 @@ const QueryGenerator = {
     if (include.through) {
       joinQuery = this.generateThroughJoin(include, includeAs, parentTableName.internalAs, topLevelInfo);
     } else {
-      if (topLevelInfo.subQuery && include.subQueryFilter) {
-        const associationWhere = {};
-
-        associationWhere[association.identifierField] = {
-          [Op.eq]: this.sequelize.literal(`${this.quoteTable(parentTableName.internalAs)}.${this.quoteIdentifier(association.sourceKeyField || association.source.primaryKeyField)}`)
-        };
-
-        if (!topLevelInfo.options.where) {
-          topLevelInfo.options.where = {};
-        }
-
-        // Creating the as-is where for the subQuery, checks that the required association exists
-        const $query = this.selectQuery(include.model.getTableName(), {
-          attributes: [association.identifierField],
-          where: {
-            [Op.and]: [
-              associationWhere,
-              include.where || {}
-            ]
-          },
-          limit: 1,
-          tableAs: include.as
-        }, include.model);
-
-        const subQueryWhere = this.sequelize.asIs([
-          '(',
-          $query.replace(/\;$/, ''),
-          ')',
-          'IS NOT NULL'
-        ].join(' '));
-
-        if (_.isPlainObject(topLevelInfo.options.where)) {
-          topLevelInfo.options.where['__' + includeAs.internalAs] = subQueryWhere;
-        } else {
-          topLevelInfo.options.where = { [Op.and]: [topLevelInfo.options.where, subQueryWhere] };
-        }
-      }
+      this._generateSubQueryFilter(include, includeAs, topLevelInfo);
       joinQuery = this.generateJoin(include, topLevelInfo);
     }
 
@@ -1609,70 +1572,9 @@ const QueryGenerator = {
           joinCondition += ` AND ${targetWhere}`;
         }
       }
-      if (topLevelInfo.subQuery && include.required) {
-        if (!topLevelInfo.options.where) {
-          topLevelInfo.options.where = {};
-        }
-        let parent = include;
-        let child = include;
-        let nestedIncludes = [];
-        let query;
-
-        while ((parent = parent.parent)) { // eslint-disable-line
-          nestedIncludes = [_.extend({}, child, { include: nestedIncludes })];
-          child = parent;
-        }
-
-        const topInclude = nestedIncludes[0];
-        const topParent = topInclude.parent;
-
-        if (topInclude.through && Object(topInclude.through.model) === topInclude.through.model) {
-          query = this.selectQuery(topInclude.through.model.getTableName(), {
-            attributes: [topInclude.through.model.primaryKeyField],
-            include: Model._validateIncludedElements({
-              model: topInclude.through.model,
-              include: [{
-                association: topInclude.association.toTarget,
-                required: true
-              }]
-            }).include,
-            model: topInclude.through.model,
-            where: {
-              [Op.and]: [
-                this.sequelize.asIs([
-                  this.quoteTable(topParent.model.name) + '.' + this.quoteIdentifier(topParent.model.primaryKeyField),
-                  this.quoteIdentifier(topInclude.through.model.name) + '.' + this.quoteIdentifier(topInclude.association.identifierField)
-                ].join(' = ')),
-                topInclude.through.where
-              ]
-            },
-            limit: 1,
-            includeIgnoreAttributes: false
-          }, topInclude.through.model);
-        } else {
-          const isBelongsTo = topInclude.association.associationType === 'BelongsTo';
-          const join = [
-            this.quoteTable(topParent.model.name) + '.' + this.quoteIdentifier(isBelongsTo ? topInclude.association.identifierField : topParent.model.primaryKeyAttributes[0]),
-            this.quoteIdentifier(topInclude.model.name) + '.' + this.quoteIdentifier(isBelongsTo ? topInclude.model.primaryKeyAttributes[0] : topInclude.association.identifierField)
-          ].join(' = ');
-          query = this.selectQuery(topInclude.model.tableName, {
-            attributes: [topInclude.model.primaryKeyAttributes[0]],
-            include: topInclude.include,
-            where: {
-              [Op.join]: this.sequelize.asIs(join)
-            },
-            limit: 1,
-            includeIgnoreAttributes: false
-          }, topInclude.model);
-        }
-        topLevelInfo.options.where['__' + throughAs] = this.sequelize.asIs([
-          '(',
-          query.replace(/\;$/, ''),
-          ')',
-          'IS NOT NULL'
-        ].join(' '));
-      }
     }
+
+    this._generateSubQueryFilter(include, includeAs, topLevelInfo);
 
     return {
       join: joinType,
@@ -1680,6 +1582,123 @@ const QueryGenerator = {
       condition: joinCondition,
       attributes
     };
+  },
+
+  /*
+   * Generates subQueryFilter - a select nested in the where clause of the subQuery.
+   * For a given include a query is generated that contains all the way from the subQuery
+   * table to the include table plus everything that's in required transitive closure of the
+   * given include.
+   */
+  _generateSubQueryFilter(include, includeAs, topLevelInfo) {
+    if (!topLevelInfo.subQuery || !include.subQueryFilter) {
+      return;
+    }
+
+    if (!topLevelInfo.options.where) {
+      topLevelInfo.options.where = {};
+    }
+    let parent = include;
+    let child = include;
+    let nestedIncludes = this._getRequiredClosure(include).include;
+    let query;
+
+    while ((parent = parent.parent)) { // eslint-disable-line
+      if (parent.parent && !parent.required) {
+        return; // only generate subQueryFilter if all the parents of this include are required
+      }
+
+      if (parent.subQueryFilter) {
+        // the include is already handled as this parent has the include on its required closure
+        // skip to prevent duplicate subQueryFilter
+        return;
+      }
+
+      nestedIncludes = [_.extend({}, child, { include: nestedIncludes, attributes: [] })];
+      child = parent;
+    }
+
+    const topInclude = nestedIncludes[0];
+    const topParent = topInclude.parent;
+    const topAssociation = topInclude.association;
+    topInclude.association = undefined;
+
+    if (topInclude.through && Object(topInclude.through.model) === topInclude.through.model) {
+      query = this.selectQuery(topInclude.through.model.getTableName(), {
+        attributes: [topInclude.through.model.primaryKeyField],
+        include: Model._validateIncludedElements({
+          model: topInclude.through.model,
+          include: [{
+            association: topAssociation.toTarget,
+            required: true,
+            where: topInclude.where,
+            include: topInclude.include
+          }]
+        }).include,
+        model: topInclude.through.model,
+        where: {
+          [Op.and]: [
+            this.sequelize.asIs([
+              this.quoteTable(topParent.model.name) + '.' + this.quoteIdentifier(topParent.model.primaryKeyField),
+              this.quoteIdentifier(topInclude.through.model.name) + '.' + this.quoteIdentifier(topAssociation.identifierField)
+            ].join(' = ')),
+            topInclude.through.where
+          ]
+        },
+        limit: 1,
+        includeIgnoreAttributes: false
+      }, topInclude.through.model);
+    } else {
+      const isBelongsTo = topAssociation.associationType === 'BelongsTo';
+      const sourceField = isBelongsTo ? topAssociation.identifierField : (topAssociation.sourceKeyField || topParent.model.primaryKeyField);
+      const targetField = isBelongsTo ? (topAssociation.sourceKeyField || topInclude.model.primaryKeyField) : topAssociation.identifierField;
+
+      const join = [
+        this.quoteIdentifier(topInclude.as) + '.' + this.quoteIdentifier(targetField),
+        this.quoteTable(topParent.as || topParent.model.name) + '.' + this.quoteIdentifier(sourceField)
+      ].join(' = ');
+
+      query = this.selectQuery(topInclude.model.getTableName(), {
+        attributes: [targetField],
+        include: Model._validateIncludedElements(topInclude).include,
+        model: topInclude.model,
+        where: {
+          [Op.and]: [{
+            [Op.join]: this.sequelize.asIs(join)
+          }]
+        },
+        limit: 1,
+        tableAs: topInclude.as,
+        includeIgnoreAttributes: false
+      }, topInclude.model);
+    }
+
+    if (!topLevelInfo.options.where[Op.and]) {
+      topLevelInfo.options.where[Op.and] = [];
+    }
+
+    topLevelInfo.options.where[`__${includeAs.internalAs}`] = this.sequelize.asIs([
+      '(',
+      query.replace(/\;$/, ''),
+      ')',
+      'IS NOT NULL'
+    ].join(' '));
+  },
+
+  /*
+   * For a given include hierarchy creates a copy of it where only the required includes
+   * are preserved.
+   */
+  _getRequiredClosure(include) {
+    const copy = _.extend({}, include, {attributes: [], include: []});
+
+    if (Array.isArray(include.include)) {
+      copy.include = include.include
+        .filter(i => i.required)
+        .map(inc => this._getRequiredClosure(inc));
+    }
+
+    return copy;
   },
 
   getQueryOrders(options, model, subQuery) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -390,6 +390,7 @@ class Model {
     options.include = options.include.map(include => {
       include = this._conformInclude(include);
       include.parent = options;
+      include.topLimit = options.topLimit;
 
       this._validateIncludedElement.call(options.model, include, tableNames, options);
 

--- a/test/integration/include/limit.test.js
+++ b/test/integration/include/limit.test.js
@@ -1,0 +1,695 @@
+'use strict';
+
+const chai = require('chai'),
+  Sequelize = require('../../../index'),
+  expect = chai.expect,
+  Support = require(__dirname + '/../support'),
+  DataTypes = require(__dirname + '/../../../lib/data-types'),
+  Promise = Sequelize.Promise,
+  Op = Sequelize.Op;
+
+describe(Support.getTestDialectTeaser('Include'), () => {
+
+  describe('LIMIT', () => {
+    /*
+     * shortcut for building simple {name: 'foo'} seed data
+     */
+    function build() {
+      return Array.prototype.slice.call(arguments).map(arg => ({name: arg}));
+    }
+
+    /*
+     * association overview
+     * [Task]N---N[Project]N---N[User]N---N[Hobby]
+     *                            1
+     *                            |
+     *                            |
+     *                            |
+     *                            N
+     *            [Comment]N---1[Post]N---N[Tag]N---1[Color]
+     *                            1
+     *                            |
+     *                            |
+     *                            |
+     *                        [Footnote]
+     */
+    beforeEach(function () {
+      this.Project = this.sequelize.define('Project', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.User = this.sequelize.define('User', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.Task = this.sequelize.define('Task', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.Hobby = this.sequelize.define('Hobby', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.User.belongsToMany(this.Project, {through: 'user_project'});
+      this.Project.belongsToMany(this.User, {through: 'user_project'});
+
+      this.Project.belongsToMany(this.Task, {through: 'task_project'});
+      this.Task.belongsToMany(this.Project, {through: 'task_project'});
+
+      this.User.belongsToMany(this.Hobby, {through: 'user_hobby'});
+      this.Hobby.belongsToMany(this.User, {through: 'user_hobby'});
+
+      this.Post = this.sequelize.define('Post', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.Comment = this.sequelize.define('Comment', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.Tag = this.sequelize.define('Tag', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.Color = this.sequelize.define('Color', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.Footnote = this.sequelize.define('Footnote', {
+        name: {
+          type: DataTypes.STRING,
+          primaryKey: true
+        }
+      }, {timestamps: false});
+
+      this.Post.hasMany(this.Comment);
+      this.Comment.belongsTo(this.Post);
+
+      this.Post.belongsToMany(this.Tag, {through: 'post_tag'});
+      this.Tag.belongsToMany(this.Post, {through: 'post_tag'});
+
+      this.Post.hasMany(this.Footnote);
+      this.Footnote.belongsTo(this.Post);
+
+      this.User.hasMany(this.Post);
+      this.Post.belongsTo(this.User);
+
+      this.Tag.belongsTo(this.Color);
+      this.Color.hasMany(this.Tag);
+    });
+
+    /*
+     * many-to-many
+     */
+    it('supports many-to-many association with where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.User.bulkCreate(build('Alice', 'Bob'))
+        ))
+        .spread((projects, users) => Promise.join(
+          projects[0].addUser(users[0]),
+          projects[1].addUser(users[1]),
+          projects[2].addUser(users[0])
+        ))
+        .then(() => this.Project.findAll({
+          include: [{
+            model: this.User,
+            where: {
+              name: 'Alice'
+            }
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports 2 levels of required many-to-many associations', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.User.bulkCreate(build('Alice', 'Bob')),
+          this.Hobby.bulkCreate(build('archery', 'badminton'))
+        ))
+        .spread((projects, users, hobbies) => Promise.join(
+          projects[0].addUser(users[0]),
+          projects[1].addUser(users[1]),
+          projects[2].addUser(users[0]),
+          users[0].addHobby(hobbies[0])
+        ))
+        .then(() => this.Project.findAll({
+          include: [{
+            model: this.User,
+            required: true,
+            include: [{
+              model: this.Hobby,
+              required: true
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports 2 levels of required many-to-many associations with where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.User.bulkCreate(build('Alice', 'Bob')),
+          this.Hobby.bulkCreate(build('archery', 'badminton'))
+        ))
+        .spread((projects, users, hobbies) => Promise.join(
+          projects[0].addUser(users[0]),
+          projects[1].addUser(users[1]),
+          projects[2].addUser(users[0]),
+          users[0].addHobby(hobbies[0]),
+          users[1].addHobby(hobbies[1])
+        ))
+        .then(() => this.Project.findAll({
+          include: [{
+            model: this.User,
+            required: true,
+            include: [{
+              model: this.Hobby,
+              where: {
+                name: 'archery'
+              }
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports 2 levels of required many-to-many associations with through.where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.User.bulkCreate(build('Alice', 'Bob')),
+          this.Hobby.bulkCreate(build('archery', 'badminton'))
+        ))
+        .spread((projects, users, hobbies) => Promise.join(
+          projects[0].addUser(users[0]),
+          projects[1].addUser(users[1]),
+          projects[2].addUser(users[0]),
+          users[0].addHobby(hobbies[0]),
+          users[1].addHobby(hobbies[1])
+        ))
+        .then(() => this.Project.findAll({
+          include: [{
+            model: this.User,
+            required: true,
+            include: [{
+              model: this.Hobby,
+              required: true,
+              through: {
+                where: {
+                  HobbyName: 'archery'
+                }
+              }
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports 3 levels of required many-to-many associations with where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Task.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.User.bulkCreate(build('Alice', 'Bob', 'Charlotte')),
+          this.Hobby.bulkCreate(build('archery', 'badminton'))
+        ))
+        .spread((tasks, projects, users, hobbies) => Promise.join(
+          tasks[0].addProject(projects[0]),
+          tasks[1].addProject(projects[1]),
+          tasks[2].addProject(projects[2]),
+          projects[0].addUser(users[0]),
+          projects[1].addUser(users[1]),
+          projects[2].addUser(users[0]),
+          users[0].addHobby(hobbies[0]),
+          users[1].addHobby(hobbies[1])
+        ))
+        .then(() => this.Task.findAll({
+          include: [{
+            model: this.Project,
+            required: true,
+            include: [{
+              model: this.User,
+              required: true,
+              include: [{
+                model: this.Hobby,
+                where: {
+                  name: 'archery'
+                }
+              }]
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports required many-to-many association', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.User.bulkCreate(build('Alice', 'Bob'))
+        ))
+        .spread((projects, users) => Promise.join(
+          projects[0].addUser(users[0]), // alpha
+          projects[2].addUser(users[0]) // charlie
+        ))
+        .then(() => this.Project.findAll({
+          include: [{
+            model: this.User,
+            required: true
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports 2 required many-to-many association', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie', 'delta')),
+          this.User.bulkCreate(build('Alice', 'Bob', 'David')),
+          this.Task.bulkCreate(build('a', 'c', 'd'))
+        ))
+        .spread((projects, users, tasks) => Promise.join(
+          projects[0].addUser(users[0]),
+          projects[0].addTask(tasks[0]),
+          projects[1].addUser(users[1]),
+          projects[2].addTask(tasks[1]),
+          projects[3].addUser(users[2]),
+          projects[3].addTask(tasks[2])
+        ))
+        .then(() => this.Project.findAll({
+          include: [{
+            model: this.User,
+            required: true
+          }, {
+            model: this.Task,
+            required: true
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('delta');
+        });
+    });
+
+    /*
+     * one-to-one
+     */
+    it('supports required one-to-many association', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Post.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.Comment.bulkCreate(build('comment0', 'comment1'))
+        ))
+        .spread((posts, comments) => Promise.join(
+          posts[0].addComment(comments[0]),
+          posts[2].addComment(comments[1])
+        ))
+        .then(() => this.Post.findAll({
+          include: [{
+            model: this.Comment,
+            required: true
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports required one-to-many association with where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Post.bulkCreate(build('alpha', 'bravo', 'charlie')),
+          this.Comment.bulkCreate(build('comment0', 'comment1'))
+        ))
+        .spread((posts, comments) => Promise.join(
+          posts[0].addComment(comments[0]),
+          posts[2].addComment(comments[1])
+        ))
+        .then(() => this.Post.findAll({
+          include: [{
+            model: this.Comment,
+            required: true,
+            where: {
+              name: {
+                [this.sequelize.Op.like]: 'comment%'
+              }
+            }
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('charlie');
+        });
+    });
+
+    it('supports 2 levels of required one-to-many associations', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.User.bulkCreate(build('Alice', 'Bob', 'Charlotte', 'David')),
+          this.Post.bulkCreate(build('post0', 'post1', 'post2')),
+          this.Comment.bulkCreate(build('comment0', 'comment1', 'comment2'))
+        ))
+        .spread((users, posts, comments) => Promise.join(
+          users[0].addPost(posts[0]),
+          users[1].addPost(posts[1]),
+          users[3].addPost(posts[2]),
+          posts[0].addComment(comments[0]),
+          posts[2].addComment(comments[2])
+        ))
+        .then(() => this.User.findAll({
+          include: [{
+            model: this.Post,
+            required: true,
+            include: [{
+              model: this.Comment,
+              required: true
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('David');
+        });
+    });
+
+    /*
+     * mixed many-to-many, one-to-many and many-to-one
+     */
+    it('supports required one-to-many association with nested required many-to-many association', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.User.bulkCreate(build('Alice', 'Bob', 'Charlotte', 'David')),
+          this.Post.bulkCreate(build('alpha', 'charlie', 'delta')),
+          this.Tag.bulkCreate(build('atag', 'btag', 'dtag'))
+        ))
+        .spread((users, posts, tags) => Promise.join(
+          users[0].addPost(posts[0]),
+          users[2].addPost(posts[1]),
+          users[3].addPost(posts[2]),
+
+          posts[0].addTag([tags[0]]),
+          posts[2].addTag([tags[2]])
+        ))
+        .then(() => this.User.findAll({
+          include: [{
+            model: this.Post,
+            required: true,
+            include: [{
+              model: this.Tag,
+              required: true
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('David');
+        });
+    });
+
+    it('supports required many-to-many association with nested required one-to-many association', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+          this.Project.bulkCreate(build('alpha', 'bravo', 'charlie', 'delta')),
+          this.User.bulkCreate(build('Alice', 'Bob', 'David')),
+          this.Post.bulkCreate(build('post0', 'post1', 'post2'))
+        ))
+        .spread((projects, users, posts) => Promise.join(
+          projects[0].addUser(users[0]),
+          projects[1].addUser(users[1]),
+          projects[3].addUser(users[2]),
+
+          users[0].addPost([posts[0]]),
+          users[2].addPost([posts[2]])
+        ))
+        .then(() => this.Project.findAll({
+          include: [{
+            model: this.User,
+            required: true,
+            include: [{
+              model: this.Post,
+              required: true,
+              duplicating: true
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('delta');
+        });
+    });
+
+    it('supports required many-to-one association with nested many-to-many association with where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+
+          this.Post.bulkCreate(build('post0', 'post1', 'post2', 'post3')),
+          this.User.bulkCreate(build('Alice', 'Bob', 'Charlotte', 'David')),
+          this.Hobby.bulkCreate(build('archery', 'badminton'))
+        ))
+        .spread((posts, users, hobbies) => Promise.join(
+          posts[0].setUser(users[0]),
+          posts[1].setUser(users[1]),
+          posts[3].setUser(users[3]),
+          users[0].addHobby(hobbies[0]),
+          users[1].addHobby(hobbies[1]),
+          users[3].addHobby(hobbies[0])
+        ))
+        .then(() => this.Post.findAll({
+          include: [{
+            model: this.User,
+            required: true,
+            include: [{
+              model: this.Hobby,
+              where: {
+                name: 'archery'
+              }
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('post3');
+        });
+    });
+
+    it('supports required many-to-one association with nested many-to-many association with through.where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+
+          this.Post.bulkCreate(build('post0', 'post1', 'post2', 'post3')),
+          this.User.bulkCreate(build('Alice', 'Bob', 'Charlotte', 'David')),
+          this.Hobby.bulkCreate(build('archery', 'badminton'))
+        ))
+        .spread((posts, users, hobbies) => Promise.join(
+          posts[0].setUser(users[0]),
+          posts[1].setUser(users[1]),
+          posts[3].setUser(users[3]),
+          users[0].addHobby(hobbies[0]),
+          users[1].addHobby(hobbies[1]),
+          users[3].addHobby(hobbies[0])
+        ))
+        .then(() => this.Post.findAll({
+          include: [{
+            model: this.User,
+            required: true,
+            include: [{
+              model: this.Hobby,
+              required: true,
+              through: {
+                where: {
+                  HobbyName: 'archery'
+                }
+              }
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('post3');
+        });
+    });
+
+    it('supports required many-to-one association with multiple nested associations with where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+
+          this.Comment.bulkCreate(build('comment0', 'comment1', 'comment2', 'comment3', 'comment4', 'comment5')),
+          this.Post.bulkCreate(build('post0', 'post1', 'post2', 'post3', 'post4')),
+          this.User.bulkCreate(build('Alice', 'Bob')),
+          this.Tag.bulkCreate(build('tag0', 'tag1'))
+        ))
+        .spread((comments, posts, users, tags) => Promise.join(
+          comments[0].setPost(posts[0]),
+          comments[1].setPost(posts[1]),
+          comments[3].setPost(posts[2]),
+          comments[4].setPost(posts[3]),
+          comments[5].setPost(posts[4]),
+
+          posts[0].addTag(tags[0]),
+          posts[3].addTag(tags[0]),
+          posts[4].addTag(tags[0]),
+          posts[1].addTag(tags[1]),
+
+          posts[0].setUser(users[0]),
+          posts[2].setUser(users[0]),
+          posts[4].setUser(users[0]),
+          posts[1].setUser(users[1])
+        ))
+        .then(() => this.Comment.findAll({
+          include: [{
+            model: this.Post,
+            required: true,
+            include: [{
+              model: this.User,
+              where: {
+                name: 'Alice'
+              }
+            }, {
+              model: this.Tag,
+              where: {
+                name: 'tag0'
+              }
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('comment5');
+        });
+    });
+
+    it('supports required many-to-one association with nested one-to-many association with where clause', function () {
+      return this.sequelize.sync({ force: true })
+        .then(() => Promise.join(
+
+          this.Comment.bulkCreate(build('comment0', 'comment1', 'comment2')),
+          this.Post.bulkCreate(build('post0', 'post1', 'post2')),
+          this.Footnote.bulkCreate(build('footnote0', 'footnote1', 'footnote2'))
+        ))
+        .spread((comments, posts, footnotes) => Promise.join(
+          comments[0].setPost(posts[0]),
+          comments[1].setPost(posts[1]),
+          comments[2].setPost(posts[2]),
+          posts[0].addFootnote(footnotes[0]),
+          posts[1].addFootnote(footnotes[1]),
+          posts[2].addFootnote(footnotes[2])
+        ))
+        .then(() => this.Comment.findAll({
+          include: [{
+            model: this.Post,
+            required: true,
+            include: [{
+              model: this.Footnote,
+              where: {
+                [Op.or]: [{
+                  name: 'footnote0'
+                }, {
+                  name: 'footnote2'
+                }]
+              }
+            }]
+          }],
+          order: ['name'],
+          limit: 1,
+          offset: 1
+        }))
+        .then(result => {
+          expect(result.length).to.equal(1);
+          expect(result[0].name).to.equal('comment2');
+        });
+    });
+  });
+});


### PR DESCRIPTION
Closes https://github.com/sequelize/sequelize/issues/9157

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

This code introduces `generateSubQueryFilter()` which builds upon code previously developed in `generateThroughJoin()` and `generateInclude()` to guarantee that proper subQueryFilter even in scenarios where multiple levels of duplicating joins are nested in a query that uses LIMIT / OFFSET.

Here's an example:

Consider the following query:

```js
Project.findAll({
  include: [{
    model: this.User,
    required: true,
    include: [{
      model: this.Hobby,
      where: {
        name: 'archery'
      }
    }]
  }],
  order: ['name'],
  limit: 1,
  offset: 1
})
```

Project --> User and User --> Hobby are many-to-many queries.

For limit and offset to work properly with duplicating joins it is necessary to push the required joins and where clauses down to subQueryFilter. Currently, sequelize produces the following output:

```sql
SELECT `Project`.*, `Users`.`name` AS `Users.name`, `Users->user_project`.`createdAt` AS `Users.user_project.createdAt`, `Users->user_project`.`updatedAt` AS `Users.user_project.updatedAt`, `Users->user_project`.`UserName` AS `Users.user_project.UserName`, `Users->user_project`.`ProjectName` AS `Users.user_project.ProjectName`, `Users->Hobbies`.`name` AS `Users.Hobbies.name`, `Users->Hobbies->user_hobby`.`createdAt` AS `Users.Hobbies.user_hobby.createdAt`, `Users->Hobbies->user_hobby`.`updatedAt` AS `Users.Hobbies.user_hobby.updatedAt`, `Users->Hobbies->user_hobby`.`UserName` AS `Users.Hobbies.user_hobby.UserName`, `Users->Hobbies->user_hobby`.`HobbyName` AS `Users.Hobbies.user_hobby.HobbyName` FROM 
(
    SELECT `Project`.`name` FROM `Projects` AS `Project` WHERE (
        SELECT `user_project`.`UserName` FROM `user_project` AS `user_project` INNER JOIN `Users` AS `User` ON `user_project`.`UserName` = `User`.`name` WHERE (`Project`.`name` = `user_project`.`ProjectName`) LIMIT 1 
    ) IS NOT NULL ORDER BY `Project`.`name` LIMIT 1, 1
) AS `Project` INNER JOIN ( `user_project` AS `Users->user_project` INNER JOIN `Users` AS `Users` ON `Users`.`name` = `Users->user_project`.`UserName`) ON `Project`.`name` = `Users->user_project`.`ProjectName` INNER JOIN ( `user_hobby` AS `Users->Hobbies->user_hobby` INNER JOIN `Hobbies` AS `Users->Hobbies` ON `Users->Hobbies`.`name` = `Users->Hobbies->user_hobby`.`HobbyName`) ON `Users`.`name` = `Users->Hobbies->user_hobby`.`UserName` AND `Users->Hobbies`.`name` = 'archery' ORDER BY `Project`.`name`;

```

Upon closer inspection this is wrong as the subQueryFilter (most nested query) does not join into the required Hobbies table nor does it check for `name: 'archery'`. As a result a User that is associated with the Project but does not have association with `archery` Hobby entity may come out of the subQuery. Such user would then be filtered out in the top-most query, resulting in an empty result set.

SQL generated after this patch:

```sql
SELECT `Project`.*, `Users`.`name` AS `Users.name`, `Users->user_project`.`createdAt` AS `Users.user_project.createdAt`, `Users->user_project`.`updatedAt` AS `Users.user_project.updatedAt`, `Users->user_project`.`UserName` AS `Users.user_project.UserName`, `Users->user_project`.`ProjectName` AS `Users.user_project.ProjectName`, `Users->Hobbies`.`name` AS `Users.Hobbies.name`, `Users->Hobbies->user_hobby`.`createdAt` AS `Users.Hobbies.user_hobby.createdAt`, `Users->Hobbies->user_hobby`.`updatedAt` AS `Users.Hobbies.user_hobby.updatedAt`, `Users->Hobbies->user_hobby`.`UserName` AS `Users.Hobbies.user_hobby.UserName`, `Users->Hobbies->user_hobby`.`HobbyName` AS `Users.Hobbies.user_hobby.HobbyName` FROM 
(
    SELECT `Project`.`name` FROM `Projects` AS `Project` WHERE ((
        SELECT `user_project`.`UserName` FROM `user_project` AS `user_project` INNER JOIN `Users` AS `User` ON `user_project`.`UserName` = `User`.`name` INNER JOIN ( `user_hobby` AS `User->Hobbies->user_hobby` INNER JOIN `Hobbies` AS `User->Hobbies` ON `User->Hobbies`.`name` = `User->Hobbies->user_hobby`.`HobbyName`) ON `User`.`name` = `User->Hobbies->user_hobby`.`UserName` AND `User->Hobbies`.`name` = 'archery' WHERE (`Project`.`name` = `user_project`.`ProjectName`) LIMIT 1
    ) IS NOT NULL) ORDER BY `Project`.`name` LIMIT 1, 1
) AS `Project` INNER JOIN ( `user_project` AS `Users->user_project` INNER JOIN `Users` AS `Users` ON `Users`.`name` = `Users->user_project`.`UserName`) ON `Project`.`name` = `Users->user_project`.`ProjectName` INNER JOIN ( `user_hobby` AS `Users->Hobbies->user_hobby` INNER JOIN `Hobbies` AS `Users->Hobbies` ON `Users->Hobbies`.`name` = `Users->Hobbies->user_hobby`.`HobbyName`) ON `Users`.`name` = `Users->Hobbies->user_hobby`.`UserName` AND `Users->Hobbies`.`name` = 'archery' ORDER BY `Project`.`name`;
```

Notice how here the subQueryFilter joins into Hobies table and checks for `name=archery`.

I tested this patch extensively both in our project and with Sequelize testsuite. However, please review `generateSubQueryFilter` carefully as may have missed some special cases.