### PR TITLE
fix(model/aggregate): inject scope before conforming options

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1779,8 +1779,8 @@ class Model {
     options = Utils.cloneDeep(options);
     options = _.defaults(options, { attributes: [] });
 
-    this._conformOptions(options, this);
     this._injectScope(options);
+    this._conformOptions(options, this);
 
     if (options.include) {
       this._expandIncludeAll(options);

--- a/test/integration/model/scope/count.test.js
+++ b/test/integration/model/scope/count.test.js
@@ -45,6 +45,26 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   priority: 1
                 }
               }]
+            },
+            withIncludeFunction: () => {
+              return {
+                include: [{
+                  model: this.Child,
+                  where: {
+                    priority: 1
+                  }
+                }]
+              };
+            },
+            withIncludeFunctionAndStringAssociation: () => {
+              return {
+                include: [{
+                  association: 'Children',
+                  where: {
+                    priority: 1
+                  }
+                }]
+              };
             }
           }
         });
@@ -99,6 +119,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('should be able to use where on include', function() {
         return expect(this.ScopeMe.scope('withInclude').count()).to.eventually.equal(1);
+      });
+
+      it('should be able to use include with function scope', function() {
+        return expect(this.ScopeMe.scope('withIncludeFunction').count()).to.eventually.equal(1);
+      });
+
+      it('should be able to use include with function scope and string association', function() {
+        return expect(this.ScopeMe.scope('withIncludeFunctionAndStringAssociation').count()).to.eventually.equal(1);
       });
     });
   });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

It is possible to add a scope as a function and have that function return an `include`, where the association included is specified as a String instead of an object. (Yes, that's an edge case.)
See the added test for an example.

This works well with query methods such as `findAll`, but doesn't work with aggregate methods such as `count`. 
I believe this is due to the aggregate methods going through a different code path where the scopes are injected _after_ conforming the options.

Switching the order of the two lines of code fixes the issue. I don't see any side-effect, but I might be missing something.
