### PR TITLE
docs(connection-manager): fix typo

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -296,7 +296,7 @@ class ConnectionManager {
    *
    * @param {Object|Error} mayBeConnection Object which can be either connection or error
    *
-   * @retun {Promise<Connection>}
+   * @return {Promise<Connection>}
    */
   _determineConnection(mayBeConnection) {
     if (mayBeConnection instanceof Error) {


### PR DESCRIPTION
Fix a small JSDoc typo.
