### PR TITLE
fix(model/init): add schema name to foreign key when generating sql s…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -801,7 +801,7 @@ class Model {
       }
 
       if (_.get(attribute, 'references.model.prototype') instanceof Model) {
-        attribute.references.model = attribute.references.model.tableName;
+        attribute.references.model = attribute.references.model.getTableName();
       }
 
       return attribute;

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -154,8 +154,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     });
 
     it('supports schemas when defining custom foreign key attribute #9029', function() {
-      const self = this,
-        User = this.sequelize.define('UserXYZ', {
+      const User = this.sequelize.define('UserXYZ', {
           uid: {
             type: Sequelize.INTEGER,
             primaryKey: true,
@@ -172,8 +171,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
       Task.belongsTo(User, { foreignKey: 'user_id'});
 
-      return self.sequelize.dropAllSchemas().then(() => {
-        return self.sequelize.createSchema('archive');
+      return this.sequelize.dropAllSchemas().then(() => {
+        return this.sequelize.createSchema('archive');
       }).then(() => {
         return User.sync({force: true });
       }).then(() => {

--- a/test/unit/sql/create-table.test.js
+++ b/test/unit/sql/create-table.test.js
@@ -41,7 +41,6 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       }).schema('bar');
       BarProject.belongsTo(BarUser, { foreignKey: 'user_id' });
       it('references right schema when adding foreign key #9029', () => {
-        console.log(BarProject.rawAttributes);
         expectsql(sql.createTableQuery(BarProject.getTableName(), sql.attributesToSQL(BarProject.rawAttributes), { }), {
           sqlite: 'CREATE TABLE IF NOT EXISTS `bar.projects` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `user_id` INTEGER REFERENCES `bar.users` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE);',
           postgres: 'CREATE TABLE IF NOT EXISTS "bar"."projects" ("id"   SERIAL , "user_id" INTEGER REFERENCES "bar"."users" ("id") ON DELETE NO ACTION ON UPDATE CASCADE, PRIMARY KEY ("id"));',

--- a/test/unit/sql/create-table.test.js
+++ b/test/unit/sql/create-table.test.js
@@ -25,6 +25,31 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
     });
+    describe('with references', () => {
+      const BarUser = current.define('user', {
+        timestamps: false
+      }).schema('bar');
+      const BarProject = current.define('project', {
+        user_id: {
+          type: DataTypes.INTEGER,
+          references: { model: BarUser },
+          onUpdate: 'CASCADE',
+          onDelete: 'NO ACTION'
+        }
+      }, {
+        timestamps: false
+      }).schema('bar');
+      BarProject.belongsTo(BarUser, { foreignKey: 'user_id' });
+      it('references right schema when adding foreign key #9029', () => {
+        console.log(BarProject.rawAttributes);
+        expectsql(sql.createTableQuery(BarProject.getTableName(), sql.attributesToSQL(BarProject.rawAttributes), { }), {
+          sqlite: 'CREATE TABLE IF NOT EXISTS `bar.projects` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `user_id` INTEGER REFERENCES `bar.users` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE);',
+          postgres: 'CREATE TABLE IF NOT EXISTS "bar"."projects" ("id"   SERIAL , "user_id" INTEGER REFERENCES "bar"."users" ("id") ON DELETE NO ACTION ON UPDATE CASCADE, PRIMARY KEY ("id"));',
+          mysql: 'CREATE TABLE IF NOT EXISTS `bar.projects` (`id` INTEGER NOT NULL auto_increment , `user_id` INTEGER, PRIMARY KEY (`id`), FOREIGN KEY (`user_id`) REFERENCES `bar.users` (`id`) ON DELETE NO ACTION ON UPDATE CASCADE) ENGINE=InnoDB;',
+          mssql: 'IF OBJECT_ID(\'[bar].[projects]\', \'U\') IS NULL CREATE TABLE [bar].[projects] ([id] INTEGER NOT NULL IDENTITY(1,1) , [user_id] INTEGER NULL, PRIMARY KEY ([id]), FOREIGN KEY ([user_id]) REFERENCES [bar].[users] ([id]) ON DELETE NO ACTION);'
+        });
+      });
+    });
     if (current.dialect.name === 'postgres') {
       describe('IF NOT EXISTS version check', () => {
         const modifiedSQL = _.clone(sql);


### PR DESCRIPTION
…tatements (#9029) (#2464)

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Fixes #9029 and #2464. Using getTableName() so that schema is added to foreign key reference in generated sql statement.

<!-- Please provide a description of the change here. -->
