### PR TITLE
fix(model): potential fix for #6423

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -530,8 +530,8 @@ const Bar = sequelize.define('bar', { /* bla */ }, {
   // timestamps are enabled
   paranoid: true,
 
-  // don't use camelcase for automatically added attributes but underscore style
-  // so updatedAt will be updated_at
+  // don't use camelcase for attributes including system added but underscore style
+  // so updatedAt will be updated_at, userId would be user_id
   underscored: true,
 
   // disable the modification of table names; By default, sequelize will automatically

--- a/lib/model.js
+++ b/lib/model.js
@@ -804,6 +804,10 @@ class Model {
         attribute.references.model = attribute.references.model.tableName;
       }
 
+      const _underscored = attribute.underscored === undefined ? this.options.underscored : attribute.underscored;
+      if (attribute.field === undefined && _underscored !== undefined) {
+        attribute.field = Utils.underscoredIf(name, _underscored);
+      }
       return attribute;
     });
 
@@ -950,8 +954,9 @@ class Model {
       definition.fieldName = name;
       definition._modelAttribute = true;
 
-      if (definition.field === undefined) {
-        definition.field = name;
+      const _underscored = definition.underscored === undefined ? this.options.underscored : definition.underscored;
+      if (definition.field === undefined && _underscored !== undefined) {
+        definition.field = Utils.underscoredIf(name, _underscored);
       }
 
       if (definition.primaryKey === true) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -804,10 +804,6 @@ class Model {
         attribute.references.model = attribute.references.model.tableName;
       }
 
-      const _underscored = attribute.underscored === undefined ? this.options.underscored : attribute.underscored;
-      if (attribute.field === undefined && _underscored !== undefined) {
-        attribute.field = Utils.underscoredIf(name, _underscored);
-      }
       return attribute;
     });
 
@@ -817,13 +813,13 @@ class Model {
     this._timestampAttributes = {};
     if (this.options.timestamps) {
       if (this.options.createdAt !== false) {
-        this._timestampAttributes.createdAt = this.options.createdAt || Utils.underscoredIf('createdAt', this.options.underscored);
+        this._timestampAttributes.createdAt = this.options.createdAt || 'createdAt';
       }
       if (this.options.updatedAt !== false) {
-        this._timestampAttributes.updatedAt = this.options.updatedAt || Utils.underscoredIf('updatedAt', this.options.underscored);
+        this._timestampAttributes.updatedAt = this.options.updatedAt || 'updatedAt';
       }
       if (this.options.paranoid && this.options.deletedAt !== false) {
-        this._timestampAttributes.deletedAt = this.options.deletedAt || Utils.underscoredIf('deletedAt', this.options.underscored);
+        this._timestampAttributes.deletedAt = this.options.deletedAt || 'deletedAt';
       }
     }
     if (this.options.version) {

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -26,6 +26,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(Model.rawAttributes).not.to.have.property('updated_at');
     });
 
+    it('should convert all properties to snake_case when using underscored: true', () => {
+      const Model = current.define('User', {
+        adminUser: DataTypes.STRING,
+        notSnakeCase: {type: DataTypes.STRING, underscored: false}
+      }, { underscored: true});
+
+      expect(Model.rawAttributes).to.have.property('adminUser').that.has.property('field').that.is.equal('admin_user');
+      expect(Model.rawAttributes).to.have.property('notSnakeCase').that.has.property('field').that.is.equal('notSnakeCase');
+    });
+
     it('should throw when id is added but not marked as PK', () => {
       expect(() => {
         current.define('foo', {

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -34,6 +34,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       expect(Model.rawAttributes).to.have.property('adminUser').that.has.property('field').that.is.equal('admin_user');
       expect(Model.rawAttributes).to.have.property('notSnakeCase').that.has.property('field').that.is.equal('notSnakeCase');
+      expect(Model.rawAttributes).to.have.property('createdAt').that.has.property('field').that.is.equal('created_at');
     });
 
     it('should throw when id is added but not marked as PK', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Can provide a fix for #6423 to match what most users expect when defining **_underscored_** in the options.

Provides snake_case for all property names by setting field to snake_case
but keeping the name as camelCase.

The alternative is to manually define a hook which most users won't.

```javascript
sequelize.addHook('beforeDefine', (attributes) => {
    Object.keys(attributes).forEach((name) => {
        if (typeof attributes[name] !== 'function') {
            attribute = attributes[name];
            const _underscored = attribute.underscored === undefined ? sequelize.options.define.underscored : attribute.underscored;
            if (attribute.field === undefined && _underscored !== undefined) {
                attribute.field = sequelize.Utils.underscoredIf(name, _underscored);
            }
        }
    });
});
```
*NOTE: I run ``npm run test-docker-unit`` successfully.*