### PR TITLE
feat(connection pool hooks): Add afterPoolAcquire and beforePoolRelease hooks

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -269,10 +269,13 @@ class ConnectionManager {
     } else {
       promise = Promise.resolve();
     }
-
     return promise.then(() => {
       return this.pool.acquire(options.priority, options.type, options.useMaster)
         .then(mayBeConnection => this._determineConnection(mayBeConnection))
+        .then(definitlyConnection => {
+          this.sequelize.runHooks('afterPoolAcquire', definitlyConnection);
+          return definitlyConnection;
+        })
         .tap(() => { debug('connection acquired'); });
     });
   }
@@ -285,6 +288,7 @@ class ConnectionManager {
    * @return {Promise}
    */
   releaseConnection(connection) {
+    this.sequelize.runHooks('beforePoolRelease', connection);
     return this.pool.release(connection)
       .tap(() => { debug('connection released'); })
       .catch(/Resource not currently part of this pool/, () => {});

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -273,11 +273,10 @@ class ConnectionManager {
     return promise.then(() => {
       return this.pool.acquire(options.priority, options.type, options.useMaster)
         .then(mayBeConnection => this._determineConnection(mayBeConnection))
-        .then(definitlyConnection => {
-          this.sequelize.runHooks('afterPoolAcquire', definitlyConnection);
-          return definitlyConnection;
-        })
-        .tap(() => { debug('connection acquired'); });
+        .then(connection => this.sequelize.runHooks('afterPoolAcquire', connection)
+          .return(connection)
+          .tap(() => { debug('connection acquired'); })
+        );
     });
   }
 
@@ -289,10 +288,14 @@ class ConnectionManager {
    * @return {Promise}
    */
   releaseConnection(connection) {
-    this.sequelize.runHooks('beforePoolRelease', connection);
-    return this.pool.release(connection)
-      .tap(() => { debug('connection released'); })
-      .catch(/Resource not currently part of this pool/, () => {});
+    return this.sequelize.runHooks('beforePoolRelease', connection)
+      .then(() => {
+        this.pool.release(connection)
+          .return(connection)
+          .tap(() => { debug('connection released'); })
+          .catch(/Resource not currently part of this pool/, () => {});
+      });
+
   }
 
   /**

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -269,6 +269,7 @@ class ConnectionManager {
     } else {
       promise = Promise.resolve();
     }
+
     return promise.then(() => {
       return this.pool.acquire(options.priority, options.type, options.useMaster)
         .then(mayBeConnection => this._determineConnection(mayBeConnection))

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -43,7 +43,9 @@ const hookTypes = {
   beforeSync: {params: 1},
   afterSync: {params: 1},
   beforeBulkSync: {params: 1},
-  afterBulkSync: {params: 1}
+  afterBulkSync: {params: 1},
+  afterPoolAcquire: {params:1},
+  beforePoolRelease: {params:1},
 };
 exports.hooks = hookTypes;
 
@@ -545,3 +547,19 @@ exports.applyTo = applyTo;
   * @name afterBulkSync
   * @memberOf Sequelize
   */
+
+/**
+ * A hook that is run after a connection is acquired from the connection pool
+ *  @param {String}   name
+ *  @param {Function} fn   A callback function that is called with the connection object.
+ *  @name afterPoolAcquire
+ *  @memberOf Sequelize
+ */
+
+ /**
+ * A hook that is run before a connection is released into the connection pool
+ *  @param {String}   name
+ *  @param {Function} fn   A callback function that is called with the connection object.
+ *  @name beforePoolRelease
+ *  @memberOf Sequelize
+ */

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -44,8 +44,8 @@ const hookTypes = {
   afterSync: {params: 1},
   beforeBulkSync: {params: 1},
   afterBulkSync: {params: 1},
-  afterPoolAcquire: {params:1},
-  beforePoolRelease: {params:1}
+  afterPoolAcquire: {params: 1},
+  beforePoolRelease: {params: 1}
 };
 exports.hooks = hookTypes;
 
@@ -556,7 +556,7 @@ exports.applyTo = applyTo;
  *  @memberOf Sequelize
  */
 
- /**
+/**
  * A hook that is run before a connection is released into the connection pool
  *  @param {String}   name
  *  @param {Function} fn   A callback function that is called with the connection object.

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -45,7 +45,7 @@ const hookTypes = {
   beforeBulkSync: {params: 1},
   afterBulkSync: {params: 1},
   afterPoolAcquire: {params:1},
-  beforePoolRelease: {params:1},
+  beforePoolRelease: {params:1}
 };
 exports.hooks = hookTypes;
 

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -10,7 +10,7 @@ const chai = require('chai'),
   Promise = require('bluebird');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(function () {
+  beforeEach(function() {
     this.User = this.sequelize.define('User', {
       username: {
         type: DataTypes.STRING,
@@ -29,14 +29,14 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         values: ['happy', 'sad', 'neutral']
       }
     }, {
-        paranoid: true
-      });
+      paranoid: true
+    });
 
     return this.sequelize.sync({ force: true });
   });
 
   describe('#define', () => {
-    before(function () {
+    before(function() {
       this.sequelize.addHook('beforeDefine', (attributes, options) => {
         options.modelName = 'bar';
         options.name.plural = 'barrs';
@@ -47,33 +47,33 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         factory.options.name.singular = 'barr';
       });
 
-      this.model = this.sequelize.define('foo', { name: DataTypes.STRING });
+      this.model = this.sequelize.define('foo', {name: DataTypes.STRING});
     });
 
-    it('beforeDefine hook can change model name', function () {
+    it('beforeDefine hook can change model name', function() {
       expect(this.model.name).to.equal('bar');
     });
 
-    it('beforeDefine hook can alter options', function () {
+    it('beforeDefine hook can alter options', function() {
       expect(this.model.options.name.plural).to.equal('barrs');
     });
 
-    it('beforeDefine hook can alter attributes', function () {
+    it('beforeDefine hook can alter attributes', function() {
       expect(this.model.rawAttributes.type).to.be.ok;
     });
 
-    it('afterDefine hook can alter options', function () {
+    it('afterDefine hook can alter options', function() {
       expect(this.model.options.name.singular).to.equal('barr');
     });
 
-    after(function () {
+    after(function() {
       this.sequelize.options.hooks = {};
       this.sequelize.modelManager.removeModel(this.model);
     });
   });
 
   describe('#init', () => {
-    before(function () {
+    before(function() {
       Sequelize.addHook('beforeInit', (config, options) => {
         config.database = 'db2';
         options.host = 'server9';
@@ -86,15 +86,15 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       this.seq = new Sequelize('db', 'user', 'pass', { dialect });
     });
 
-    it('beforeInit hook can alter config', function () {
+    it('beforeInit hook can alter config', function() {
       expect(this.seq.config.database).to.equal('db2');
     });
 
-    it('beforeInit hook can alter options', function () {
+    it('beforeInit hook can alter options', function() {
       expect(this.seq.options.host).to.equal('server9');
     });
 
-    it('afterInit hook can alter options', function () {
+    it('afterInit hook can alter options', function() {
       expect(this.seq.options.protocol).to.equal('udp');
     });
 
@@ -103,81 +103,27 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
   });
 
-  describe('After acquire connection hook', function () {
-    it('should run hooks', function () {
-      const afterPoolAcquireHook = sinon.spy();
-      this.sequelize.addHook('afterPoolAcquire', afterPoolAcquireHook);
-      return this.User.find().then(function () {
-        expect(afterPoolAcquireHook).to.have.been.calledOnce;
-      });
-    });
-
-    it('should pass the connection to the hook', function () {
-      let isConnection = false;
-      this.sequelize.addHook('afterPoolAcquire', function (connection) {
-        expect(connection).to.haveOwnProperty('connection');
-        isConnection = true;
-        return Promise.resolve();
-      });
-      return this.User.find().then(function () {
-        expect(isConnection).to.be.true;
-      });
-    });
-
-    after(function () {
-      this.sequelize.options.hooks = {};
-    });
-
-  });
-
-  describe('Before release connection hook', function () {
-    it('should run hooks', function () {
-      const beforPoolReleaseHook = sinon.spy();
-      this.sequelize.addHook('beforePoolRelease', beforPoolReleaseHook);
-      return this.User.find().then(function () {
-        expect(beforPoolReleaseHook).to.have.been.calledOnce;
-      });
-    });
-
-    it('should pass the connection to the hook', function () {
-      let isConnection = false;
-      this.sequelize.addHook('beforePoolRelease', function (connection) {
-        expect(connection).to.haveOwnProperty('connection');
-        isConnection = true;
-        return Promise.resolve();
-      });
-      return this.User.find().then(function () {
-        expect(isConnection).to.be.true;
-      });
-    });
-
-    after(function () {
-      this.sequelize.options.hooks = {};
-    });
-  });
-
-
   describe('passing DAO instances', () => {
     describe('beforeValidate / afterValidate', () => {
-      it('should pass a DAO instance to the hook', function () {
+      it('should pass a DAO instance to the hook', function() {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-            hooks: {
-              beforeValidate(user) {
-                expect(user).to.be.instanceof(User);
-                beforeHooked = true;
-                return Promise.resolve();
-              },
-              afterValidate(user) {
-                expect(user).to.be.instanceof(User);
-                afterHooked = true;
-                return Promise.resolve();
-              }
+          hooks: {
+            beforeValidate(user) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              return Promise.resolve();
+            },
+            afterValidate(user) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              return Promise.resolve();
             }
-          });
+          }
+        });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(() => {
@@ -188,26 +134,79 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       });
     });
 
+    describe('After acquire connection hook', function() {
+      it('should run hooks', function () {
+        const afterPoolAcquireHook = sinon.spy();
+        this.sequelize.addHook('afterPoolAcquire', afterPoolAcquireHook);
+        return this.User.find().then(function () {
+          expect(afterPoolAcquireHook).to.have.been.calledOnce;
+        });
+      });
+  
+      it('should pass the connection to the hook', function() {
+        let isConnection = false;
+        this.sequelize.addHook('afterPoolAcquire', function(connection) {
+          expect(connection).to.haveOwnProperty('connection');
+          isConnection = true;
+          return Promise.resolve();
+        });
+        return this.User.find().then(function () {
+          expect(isConnection).to.be.true;
+        });
+      });
+  
+      after(function () {
+        this.sequelize.options.hooks = {};
+      });
+  
+    });
+  
+    describe('Before release connection hook', function() {
+      it('should run hooks', function () {
+        const beforPoolReleaseHook = sinon.spy();
+        this.sequelize.addHook('beforePoolRelease', beforPoolReleaseHook);
+        return this.User.find().then(function () {
+          expect(beforPoolReleaseHook).to.have.been.calledOnce;
+        });
+      });
+  
+      it('should pass the connection to the hook', function() {
+        let isConnection = false;
+        this.sequelize.addHook('beforePoolRelease', function (connection) {
+          expect(connection).to.haveOwnProperty('connection');
+          isConnection = true;
+          return Promise.resolve();
+        });
+        return this.User.find().then(function() {
+          expect(isConnection).to.be.true;
+        });
+      });
+  
+      after(function() {
+        this.sequelize.options.hooks = {};
+      });
+    });
+
     describe('beforeCreate / afterCreate', () => {
-      it('should pass a DAO instance to the hook', function () {
+      it('should pass a DAO instance to the hook', function() {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-            hooks: {
-              beforeCreate(user) {
-                expect(user).to.be.instanceof(User);
-                beforeHooked = true;
-                return Promise.resolve();
-              },
-              afterCreate(user) {
-                expect(user).to.be.instanceof(User);
-                afterHooked = true;
-                return Promise.resolve();
-              }
+          hooks: {
+            beforeCreate(user) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              return Promise.resolve();
+            },
+            afterCreate(user) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              return Promise.resolve();
             }
-          });
+          }
+        });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(() => {
@@ -219,25 +218,25 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('beforeDestroy / afterDestroy', () => {
-      it('should pass a DAO instance to the hook', function () {
+      it('should pass a DAO instance to the hook', function() {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-            hooks: {
-              beforeDestroy(user) {
-                expect(user).to.be.instanceof(User);
-                beforeHooked = true;
-                return Promise.resolve();
-              },
-              afterDestroy(user) {
-                expect(user).to.be.instanceof(User);
-                afterHooked = true;
-                return Promise.resolve();
-              }
+          hooks: {
+            beforeDestroy(user) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              return Promise.resolve();
+            },
+            afterDestroy(user) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              return Promise.resolve();
             }
-          });
+          }
+        });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(user => {
@@ -251,25 +250,25 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('beforeDelete / afterDelete', () => {
-      it('should pass a DAO instance to the hook', function () {
+      it('should pass a DAO instance to the hook', function() {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-            hooks: {
-              beforeDelete(user) {
-                expect(user).to.be.instanceof(User);
-                beforeHooked = true;
-                return Promise.resolve();
-              },
-              afterDelete(user) {
-                expect(user).to.be.instanceof(User);
-                afterHooked = true;
-                return Promise.resolve();
-              }
+          hooks: {
+            beforeDelete(user) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              return Promise.resolve();
+            },
+            afterDelete(user) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              return Promise.resolve();
             }
-          });
+          }
+        });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(user => {
@@ -283,25 +282,25 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('beforeUpdate / afterUpdate', () => {
-      it('should pass a DAO instance to the hook', function () {
+      it('should pass a DAO instance to the hook', function() {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-            hooks: {
-              beforeUpdate(user) {
-                expect(user).to.be.instanceof(User);
-                beforeHooked = true;
-                return Promise.resolve();
-              },
-              afterUpdate(user) {
-                expect(user).to.be.instanceof(User);
-                afterHooked = true;
-                return Promise.resolve();
-              }
+          hooks: {
+            beforeUpdate(user) {
+              expect(user).to.be.instanceof(User);
+              beforeHooked = true;
+              return Promise.resolve();
+            },
+            afterUpdate(user) {
+              expect(user).to.be.instanceof(User);
+              afterHooked = true;
+              return Promise.resolve();
             }
-          });
+          }
+        });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(user => {
@@ -318,7 +317,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
   describe('Model#sync', () => {
     describe('on success', () => {
-      it('should run hooks', function () {
+      it('should run hooks', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -331,7 +330,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should not run hooks when "hooks = false" option passed', function () {
+      it('should not run hooks when "hooks = false" option passed', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -347,7 +346,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('on error', () => {
-      it('should return an error from before', function () {
+      it('should return an error from before', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -363,7 +362,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should return an error from after', function () {
+      it('should return an error from after', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -383,7 +382,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
   describe('sequelize#sync', () => {
     describe('on success', () => {
-      it('should run hooks', function () {
+      it('should run hooks', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy(),
           modelBeforeHook = sinon.spy(),
@@ -402,7 +401,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should not run hooks if "hooks = false" option passed', function () {
+      it('should not run hooks if "hooks = false" option passed', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy(),
           modelBeforeHook = sinon.spy(),
@@ -421,14 +420,15 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      afterEach(function () {
+      afterEach(function() {
         this.sequelize.options.hooks = {};
       });
+
     });
 
     describe('on error', () => {
 
-      it('should return an error from before', function () {
+      it('should return an error from before', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
         this.sequelize.beforeBulkSync(() => {
@@ -443,7 +443,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should return an error from after', function () {
+      it('should return an error from after', function() {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -459,7 +459,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      afterEach(function () {
+      afterEach(function() {
         this.sequelize.options.hooks = {};
       });
 
@@ -467,54 +467,54 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
   });
 
   describe('#removal', () => {
-    it('should be able to remove by name', function () {
+    it('should be able to remove by name', function() {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
       this.User.hook('beforeCreate', 'sasuke', sasukeHook);
       this.User.hook('beforeCreate', 'naruto', narutoHook);
 
-      return this.User.create({ username: 'makunouchi' }).then(() => {
+      return this.User.create({ username: 'makunouchi'}).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledOnce;
         this.User.removeHook('beforeCreate', 'sasuke');
-        return this.User.create({ username: 'sendo' });
+        return this.User.create({ username: 'sendo'});
       }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledTwice;
       });
     });
 
-    it('should be able to remove by reference', function () {
+    it('should be able to remove by reference', function() {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
       this.User.hook('beforeCreate', sasukeHook);
       this.User.hook('beforeCreate', narutoHook);
 
-      return this.User.create({ username: 'makunouchi' }).then(() => {
+      return this.User.create({ username: 'makunouchi'}).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledOnce;
         this.User.removeHook('beforeCreate', sasukeHook);
-        return this.User.create({ username: 'sendo' });
+        return this.User.create({ username: 'sendo'});
       }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledTwice;
       });
     });
 
-    it('should be able to remove proxies', function () {
+    it('should be able to remove proxies', function() {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
       this.User.hook('beforeSave', sasukeHook);
       this.User.hook('beforeSave', narutoHook);
 
-      return this.User.create({ username: 'makunouchi' }).then(user => {
+      return this.User.create({ username: 'makunouchi'}).then(user => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledOnce;
         this.User.removeHook('beforeSave', sasukeHook);
-        return user.updateAttributes({ username: 'sendo' });
+        return user.updateAttributes({ username: 'sendo'});
       }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledTwice;

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -10,7 +10,7 @@ const chai = require('chai'),
   Promise = require('bluebird');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(function() {
+  beforeEach(function () {
     this.User = this.sequelize.define('User', {
       username: {
         type: DataTypes.STRING,
@@ -29,14 +29,14 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         values: ['happy', 'sad', 'neutral']
       }
     }, {
-      paranoid: true
-    });
+        paranoid: true
+      });
 
     return this.sequelize.sync({ force: true });
   });
 
   describe('#define', () => {
-    before(function() {
+    before(function () {
       this.sequelize.addHook('beforeDefine', (attributes, options) => {
         options.modelName = 'bar';
         options.name.plural = 'barrs';
@@ -47,33 +47,33 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         factory.options.name.singular = 'barr';
       });
 
-      this.model = this.sequelize.define('foo', {name: DataTypes.STRING});
+      this.model = this.sequelize.define('foo', { name: DataTypes.STRING });
     });
 
-    it('beforeDefine hook can change model name', function() {
+    it('beforeDefine hook can change model name', function () {
       expect(this.model.name).to.equal('bar');
     });
 
-    it('beforeDefine hook can alter options', function() {
+    it('beforeDefine hook can alter options', function () {
       expect(this.model.options.name.plural).to.equal('barrs');
     });
 
-    it('beforeDefine hook can alter attributes', function() {
+    it('beforeDefine hook can alter attributes', function () {
       expect(this.model.rawAttributes.type).to.be.ok;
     });
 
-    it('afterDefine hook can alter options', function() {
+    it('afterDefine hook can alter options', function () {
       expect(this.model.options.name.singular).to.equal('barr');
     });
 
-    after(function() {
+    after(function () {
       this.sequelize.options.hooks = {};
       this.sequelize.modelManager.removeModel(this.model);
     });
   });
 
   describe('#init', () => {
-    before(function() {
+    before(function () {
       Sequelize.addHook('beforeInit', (config, options) => {
         config.database = 'db2';
         options.host = 'server9';
@@ -86,15 +86,15 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       this.seq = new Sequelize('db', 'user', 'pass', { dialect });
     });
 
-    it('beforeInit hook can alter config', function() {
+    it('beforeInit hook can alter config', function () {
       expect(this.seq.config.database).to.equal('db2');
     });
 
-    it('beforeInit hook can alter options', function() {
+    it('beforeInit hook can alter options', function () {
       expect(this.seq.options.host).to.equal('server9');
     });
 
-    it('afterInit hook can alter options', function() {
+    it('afterInit hook can alter options', function () {
       expect(this.seq.options.protocol).to.equal('udp');
     });
 
@@ -103,27 +103,81 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
   });
 
+  describe('After acquire connection hook', function () {
+    it('should run hooks', function () {
+      const afterPoolAcquireHook = sinon.spy();
+      this.sequelize.addHook('afterPoolAcquire', afterPoolAcquireHook);
+      return this.User.find().then(function () {
+        expect(afterPoolAcquireHook).to.have.been.calledOnce;
+      });
+    });
+
+    it('should pass the connection to the hook', function () {
+      let isConnection = false;
+      this.sequelize.addHook('afterPoolAcquire', function (connection) {
+        expect(connection).to.haveOwnProperty('connection');
+        isConnection = true;
+        return Promise.resolve();
+      });
+      return this.User.find().then(function () {
+        expect(isConnection).to.be.true;
+      });
+    });
+
+    after(function () {
+      this.sequelize.options.hooks = {};
+    });
+
+  });
+
+  describe('Before release connection hook', function () {
+    it('should run hooks', function () {
+      const beforPoolReleaseHook = sinon.spy();
+      this.sequelize.addHook('beforePoolRelease', beforPoolReleaseHook);
+      return this.User.find().then(function () {
+        expect(beforPoolReleaseHook).to.have.been.calledOnce;
+      });
+    });
+
+    it('should pass the connection to the hook', function () {
+      let isConnection = false;
+      this.sequelize.addHook('beforePoolRelease', function (connection) {
+        expect(connection).to.haveOwnProperty('connection');
+        isConnection = true;
+        return Promise.resolve();
+      });
+      return this.User.find().then(function () {
+        expect(isConnection).to.be.true;
+      });
+    });
+
+    after(function () {
+      this.sequelize.options.hooks = {};
+    });
+  });
+
+
   describe('passing DAO instances', () => {
     describe('beforeValidate / afterValidate', () => {
-      it('should pass a DAO instance to the hook', function() {
+      it('should pass a DAO instance to the hook', function () {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-          hooks: {
-            beforeValidate(user) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              return Promise.resolve();
-            },
-            afterValidate(user) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              return Promise.resolve();
+            hooks: {
+              beforeValidate(user) {
+                expect(user).to.be.instanceof(User);
+                beforeHooked = true;
+                return Promise.resolve();
+              },
+              afterValidate(user) {
+                expect(user).to.be.instanceof(User);
+                afterHooked = true;
+                return Promise.resolve();
+              }
             }
-          }
-        });
+          });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(() => {
@@ -135,25 +189,25 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('beforeCreate / afterCreate', () => {
-      it('should pass a DAO instance to the hook', function() {
+      it('should pass a DAO instance to the hook', function () {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-          hooks: {
-            beforeCreate(user) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              return Promise.resolve();
-            },
-            afterCreate(user) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              return Promise.resolve();
+            hooks: {
+              beforeCreate(user) {
+                expect(user).to.be.instanceof(User);
+                beforeHooked = true;
+                return Promise.resolve();
+              },
+              afterCreate(user) {
+                expect(user).to.be.instanceof(User);
+                afterHooked = true;
+                return Promise.resolve();
+              }
             }
-          }
-        });
+          });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(() => {
@@ -165,25 +219,25 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('beforeDestroy / afterDestroy', () => {
-      it('should pass a DAO instance to the hook', function() {
+      it('should pass a DAO instance to the hook', function () {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-          hooks: {
-            beforeDestroy(user) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              return Promise.resolve();
-            },
-            afterDestroy(user) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              return Promise.resolve();
+            hooks: {
+              beforeDestroy(user) {
+                expect(user).to.be.instanceof(User);
+                beforeHooked = true;
+                return Promise.resolve();
+              },
+              afterDestroy(user) {
+                expect(user).to.be.instanceof(User);
+                afterHooked = true;
+                return Promise.resolve();
+              }
             }
-          }
-        });
+          });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(user => {
@@ -197,25 +251,25 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('beforeDelete / afterDelete', () => {
-      it('should pass a DAO instance to the hook', function() {
+      it('should pass a DAO instance to the hook', function () {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-          hooks: {
-            beforeDelete(user) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              return Promise.resolve();
-            },
-            afterDelete(user) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              return Promise.resolve();
+            hooks: {
+              beforeDelete(user) {
+                expect(user).to.be.instanceof(User);
+                beforeHooked = true;
+                return Promise.resolve();
+              },
+              afterDelete(user) {
+                expect(user).to.be.instanceof(User);
+                afterHooked = true;
+                return Promise.resolve();
+              }
             }
-          }
-        });
+          });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(user => {
@@ -229,25 +283,25 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('beforeUpdate / afterUpdate', () => {
-      it('should pass a DAO instance to the hook', function() {
+      it('should pass a DAO instance to the hook', function () {
         let beforeHooked = false;
         let afterHooked = false;
         const User = this.sequelize.define('User', {
           username: DataTypes.STRING
         }, {
-          hooks: {
-            beforeUpdate(user) {
-              expect(user).to.be.instanceof(User);
-              beforeHooked = true;
-              return Promise.resolve();
-            },
-            afterUpdate(user) {
-              expect(user).to.be.instanceof(User);
-              afterHooked = true;
-              return Promise.resolve();
+            hooks: {
+              beforeUpdate(user) {
+                expect(user).to.be.instanceof(User);
+                beforeHooked = true;
+                return Promise.resolve();
+              },
+              afterUpdate(user) {
+                expect(user).to.be.instanceof(User);
+                afterHooked = true;
+                return Promise.resolve();
+              }
             }
-          }
-        });
+          });
 
         return User.sync({ force: true }).then(() => {
           return User.create({ username: 'bob' }).then(user => {
@@ -264,7 +318,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
   describe('Model#sync', () => {
     describe('on success', () => {
-      it('should run hooks', function() {
+      it('should run hooks', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -277,7 +331,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should not run hooks when "hooks = false" option passed', function() {
+      it('should not run hooks when "hooks = false" option passed', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -293,7 +347,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     describe('on error', () => {
-      it('should return an error from before', function() {
+      it('should return an error from before', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -309,7 +363,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should return an error from after', function() {
+      it('should return an error from after', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -329,7 +383,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
   describe('sequelize#sync', () => {
     describe('on success', () => {
-      it('should run hooks', function() {
+      it('should run hooks', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy(),
           modelBeforeHook = sinon.spy(),
@@ -348,7 +402,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should not run hooks if "hooks = false" option passed', function() {
+      it('should not run hooks if "hooks = false" option passed', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy(),
           modelBeforeHook = sinon.spy(),
@@ -367,15 +421,14 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      afterEach(function() {
+      afterEach(function () {
         this.sequelize.options.hooks = {};
       });
-
     });
 
     describe('on error', () => {
 
-      it('should return an error from before', function() {
+      it('should return an error from before', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
         this.sequelize.beforeBulkSync(() => {
@@ -390,7 +443,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      it('should return an error from after', function() {
+      it('should return an error from after', function () {
         const beforeHook = sinon.spy(),
           afterHook = sinon.spy();
 
@@ -406,7 +459,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
       });
 
-      afterEach(function() {
+      afterEach(function () {
         this.sequelize.options.hooks = {};
       });
 
@@ -414,54 +467,54 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
   });
 
   describe('#removal', () => {
-    it('should be able to remove by name', function() {
+    it('should be able to remove by name', function () {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
       this.User.hook('beforeCreate', 'sasuke', sasukeHook);
       this.User.hook('beforeCreate', 'naruto', narutoHook);
 
-      return this.User.create({ username: 'makunouchi'}).then(() => {
+      return this.User.create({ username: 'makunouchi' }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledOnce;
         this.User.removeHook('beforeCreate', 'sasuke');
-        return this.User.create({ username: 'sendo'});
+        return this.User.create({ username: 'sendo' });
       }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledTwice;
       });
     });
 
-    it('should be able to remove by reference', function() {
+    it('should be able to remove by reference', function () {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
       this.User.hook('beforeCreate', sasukeHook);
       this.User.hook('beforeCreate', narutoHook);
 
-      return this.User.create({ username: 'makunouchi'}).then(() => {
+      return this.User.create({ username: 'makunouchi' }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledOnce;
         this.User.removeHook('beforeCreate', sasukeHook);
-        return this.User.create({ username: 'sendo'});
+        return this.User.create({ username: 'sendo' });
       }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledTwice;
       });
     });
 
-    it('should be able to remove proxies', function() {
+    it('should be able to remove proxies', function () {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
       this.User.hook('beforeSave', sasukeHook);
       this.User.hook('beforeSave', narutoHook);
 
-      return this.User.create({ username: 'makunouchi'}).then(user => {
+      return this.User.create({ username: 'makunouchi' }).then(user => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledOnce;
         this.User.removeHook('beforeSave', sasukeHook);
-        return user.updateAttributes({ username: 'sendo'});
+        return user.updateAttributes({ username: 'sendo' });
       }).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
         expect(narutoHook).to.have.been.calledTwice;

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -134,34 +134,6 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       });
     });
 
-    describe('After acquire connection hook', () => {
-      it('should run hooks', function() {
-        const afterPoolAcquireHook = sinon.spy();
-        this.sequelize.addHook('afterPoolAcquire', afterPoolAcquireHook);
-        return this.User.find().then(() => {
-          expect(afterPoolAcquireHook).to.have.been.calledOnce;
-        });
-      });
-
-      after(function () {
-        this.sequelize.options.hooks = {};
-      });
-    });
-  
-    describe('Before release connection hook', () => {
-      it('should run hooks', function() {
-        const beforPoolReleaseHook = sinon.spy();
-        this.sequelize.addHook('beforePoolRelease', beforPoolReleaseHook);
-        return this.User.find().then( () => {
-          expect(beforPoolReleaseHook).to.have.been.calledOnce;
-        });
-      });
-
-      after(function() {
-        this.sequelize.options.hooks = {};
-      });
-    });
-
     describe('beforeCreate / afterCreate', () => {
       it('should pass a DAO instance to the hook', function() {
         let beforeHooked = false;

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -138,7 +138,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       it('should run hooks', function() {
         const afterPoolAcquireHook = sinon.spy();
         this.sequelize.addHook('afterPoolAcquire', afterPoolAcquireHook);
-        return this.User.find().then(function () {
+        return this.User.find().then(() => {
           expect(afterPoolAcquireHook).to.have.been.calledOnce;
         });
       });
@@ -146,14 +146,13 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       after(function () {
         this.sequelize.options.hooks = {};
       });
-  
     });
   
     describe('Before release connection hook', () => {
       it('should run hooks', function() {
         const beforPoolReleaseHook = sinon.spy();
         this.sequelize.addHook('beforePoolRelease', beforPoolReleaseHook);
-        return this.User.find().then(function () {
+        return this.User.find().then( () => {
           expect(beforPoolReleaseHook).to.have.been.calledOnce;
         });
       });

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -134,54 +134,30 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       });
     });
 
-    describe('After acquire connection hook', function() {
-      it('should run hooks', function () {
+    describe('After acquire connection hook', () => {
+      it('should run hooks', function() {
         const afterPoolAcquireHook = sinon.spy();
         this.sequelize.addHook('afterPoolAcquire', afterPoolAcquireHook);
         return this.User.find().then(function () {
           expect(afterPoolAcquireHook).to.have.been.calledOnce;
         });
       });
-  
-      it('should pass the connection to the hook', function() {
-        let isConnection = false;
-        this.sequelize.addHook('afterPoolAcquire', function(connection) {
-          expect(connection).to.haveOwnProperty('connection');
-          isConnection = true;
-          return Promise.resolve();
-        });
-        return this.User.find().then(function () {
-          expect(isConnection).to.be.true;
-        });
-      });
-  
+
       after(function () {
         this.sequelize.options.hooks = {};
       });
   
     });
   
-    describe('Before release connection hook', function() {
-      it('should run hooks', function () {
+    describe('Before release connection hook', () => {
+      it('should run hooks', function() {
         const beforPoolReleaseHook = sinon.spy();
         this.sequelize.addHook('beforePoolRelease', beforPoolReleaseHook);
         return this.User.find().then(function () {
           expect(beforPoolReleaseHook).to.have.been.calledOnce;
         });
       });
-  
-      it('should pass the connection to the hook', function() {
-        let isConnection = false;
-        this.sequelize.addHook('beforePoolRelease', function (connection) {
-          expect(connection).to.haveOwnProperty('connection');
-          isConnection = true;
-          return Promise.resolve();
-        });
-        return this.User.find().then(function() {
-          expect(isConnection).to.be.true;
-        });
-      });
-  
+
       after(function() {
         this.sequelize.options.hooks = {};
       });

--- a/test/unit/connection-manager.test.js
+++ b/test/unit/connection-manager.test.js
@@ -81,16 +81,18 @@ describe('connection manager', () => {
 
         const spy = sinon.spy();
 
-        this.sequelize.addHook('afterPoolAcquire', (connection) => {
+        this.sequelize.addHook('afterPoolAcquire', connection => {
           return new Promise(resolve => {
-            setTimeout(() => { spy(connection); resolve(); }, 50);
+            spy(connection); 
+            resolve();
           });
         });
 
         const connectionManager = new ConnectionManager(this.dialect, this.sequelize);
 
-        return connectionManager.getConnection().then((connection) => {
+        return connectionManager.getConnection().then( connection => {
           expect(spy.callCount).to.equal(1);
+          expect(connection).to.equal(this.connection);
           expect(spy.firstCall.args[0]).to.equal(this.connection);
         });
 
@@ -99,21 +101,21 @@ describe('connection manager', () => {
 
     describe('Before release beforePoolRelease hook', () => {
       it('should run beforePoolRelease hook', function() {
-        const beforPoolReleaseHook = sinon.spy();
 
         // bypass retriving database version wich requires an actual connection.
         this.sequelize.options.databaseVersion = -1;
 
         const spy = sinon.spy();
 
-        this.sequelize.addHook('beforePoolRelease', (connection) => {
+        this.sequelize.addHook('beforePoolRelease', connection => {
           return new Promise(resolve => {
-            setTimeout(() => { spy(connection); resolve(); }, 50);
+            spy(connection); 
+            resolve(connection);
           });
         });
 
         const connectionManager = new ConnectionManager(this.dialect, this.sequelize);
-        return connectionManager.releaseConnection(this.connection).then((connection) => {
+        return connectionManager.releaseConnection(this.connection).then(() => {
           expect(spy.callCount).to.equal(1);
           expect(spy.firstCall.args[0]).to.equal(this.connection);
         });


### PR DESCRIPTION
Provide `afterPoolAcquire` and `beforePoolRelease` hooks.
It addresses: #8966 

This is not my use case thought. 
I need to be able to interact with the connection right before and right after it is being used to run a query or open a transaction on the SQL server.

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?


### Description of change

Provide `afterPoolAcquire` and `beforePoolRelease` hooks.
