### PR TITLE
V4: fix(model): don't add LIMIT in findOne() queries on unique key

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1745,10 +1745,13 @@ class Model {
     options = Utils.cloneDeep(options);
 
     if (options.limit === undefined) {
-      const pkVal = options.where && options.where[this.primaryKeyAttribute];
+      const uniqueSingleColumns = _.chain(this.uniqueKeys).values().filter(c => c.fields.length === 1).map('column').value();
 
-      // Don't add limit if querying directly on the pk
-      if (!options.where || !(Utils.isPrimitive(pkVal) || Buffer.isBuffer(pkVal))) {
+      // Don't add limit if querying directly on the pk or a unique column
+      if (!options.where || !_.some(options.where, (value, key) =>
+        (key === this.primaryKeyAttribute || _.includes(uniqueSingleColumns, key)) &&
+          (Utils.isPrimitive(value) || Buffer.isBuffer(value))
+      )) {
         options.limit = 1;
       }
     }

--- a/test/unit/model/findone.test.js
+++ b/test/unit/model/findone.test.js
@@ -67,5 +67,49 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    describe('should not add limit when querying on an unique key', () => {
+      it('with custom unique key', function() {
+        const Model = current.define('model', {
+          unique: {
+            type: DataTypes.INTEGER,
+            unique: true
+          }
+        });
+
+        return Model.findOne({ where: { unique: 42 }}).bind(this).then(function() {
+          expect(this.stub.getCall(0).args[0]).to.be.an('object').not.to.have.property('limit');
+        });
+      });
+
+      it('with blob unique key', function() {
+        const Model = current.define('model', {
+          unique: {
+            type: DataTypes.BLOB,
+            unique: true
+          }
+        });
+
+        return Model.findOne({ where: { unique: new Buffer('foo') }}).bind(this).then(function() {
+          expect(this.stub.getCall(0).args[0]).to.be.an('object').not.to.have.property('limit');
+        });
+      });
+    });
+
+    it('should add limit when using multi-column unique key', function() {
+      const Model = current.define('model', {
+        unique1: {
+          type: DataTypes.INTEGER,
+          unique: 'unique'
+        },
+        unique2: {
+          type: DataTypes.INTEGER,
+          unique: 'unique'
+        }
+      });
+
+      return Model.findOne({ where: { unique1: 42}}).bind(this).then(function() {
+        expect(this.stub.getCall(0).args[0]).to.be.an('object').to.have.property('limit');
+      });
+    });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change
Upstream PR: https://github.com/sequelize/sequelize/pull/9248