### PR TITLE
feat(transactions): Add afterCommit hooks for transactions

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -22,6 +22,7 @@ class Transaction {
   constructor(sequelize, options) {
     this.sequelize = sequelize;
     this.savepoints = [];
+    this._afterCommitHooks = [];
 
     // get dialect specific transaction options
     const transactionOptions = sequelize.dialect.supports.transactionOptions || {};
@@ -71,7 +72,11 @@ class Transaction {
           return this.cleanup();
         }
         return null;
-      });
+      }).tap(
+        () => Utils.Promise.each(
+          this._afterCommitHooks,
+          hook => Utils.Promise.resolve(hook.apply(this, [this])))
+      );
   }
 
   /**
@@ -182,6 +187,19 @@ class Transaction {
         cls.set('transaction', null);
       }
     }
+  }
+
+  /**
+  * A hook that is run after a transaction is committed
+  * @param {Function} fn   A callback function that is called with the committed transaction
+  * @name afterCommit
+  * @memberOf Sequelize.Transaction
+  */
+  afterCommit(fn) {
+    if (!fn || typeof fn !== 'function') {
+      throw new Error('"fn" must be a function');
+    }
+    this._afterCommitHooks.push(fn);
   }
 
   /**

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -5,6 +5,7 @@ const chai = require('chai'),
   Support = require(__dirname + '/support'),
   dialect = Support.getTestDialect(),
   Promise = require(__dirname + '/../../lib/promise'),
+  QueryTypes = require(__dirname + '/../../lib/query-types'),
   Transaction = require(__dirname + '/../../lib/transaction'),
   sinon = require('sinon'),
   current = Support.sequelize;
@@ -76,6 +77,31 @@ if (current.dialect.supports.transactions) {
           return Promise.reject(new Error('Swag'));
         })).to.eventually.be.rejected.then(() => {
           expect(t.finished).to.be.equal('rollback');
+        });
+      });
+
+      it('supports running hooks when a transaction is commited', function() {
+        const hook = sinon.spy();
+        let transaction;
+        return expect(this.sequelize.transaction(t => {
+          transaction = t;
+          transaction.afterCommit(hook);
+          return this.sequelize.query('SELECT 1+1', {transaction, type: QueryTypes.SELECT});
+        }).then(() => {
+          expect(hook).to.have.been.calledOnce;
+          expect(hook).to.have.been.calledWith(transaction);
+        })
+        ).to.eventually.be.fulfilled;
+      });
+
+      it('does not run hooks when a transaction is rolled back', function() {
+        const hook = sinon.spy();
+        return expect(this.sequelize.transaction(transaction => {
+          transaction.afterCommit(hook);
+          return Promise.reject(new Error('Rollback'));
+        })
+        ).to.eventually.be.rejected.then(() => {
+          expect(hook).to.not.have.been.called;
         });
       });
 
@@ -187,6 +213,105 @@ if (current.dialect.supports.transactions) {
           });
         })
       ).to.be.rejectedWith('Transaction cannot be committed because it has been finished with state: commit');
+    });
+
+    it('should run hooks if a non-auto callback transaction is committed', function() {
+      const hook = sinon.spy();
+      let transaction;
+      return expect(
+        this.sequelize.transaction().then(t => {
+          transaction = t;
+          transaction.afterCommit(hook);
+          return t.commit().then(() => {
+            expect(hook).to.have.been.calledOnce;
+            expect(hook).to.have.been.calledWith(t);
+          });
+        }).catch(err => {
+          // Cleanup this transaction so other tests don't
+          // fail due to an open transaction
+          if (!transaction.finished) {
+            return transaction.rollback().then(() => {
+              throw err;
+            });
+          }
+          throw err;
+        })
+      ).to.eventually.be.fulfilled;
+    });
+
+    it('should not run hooks if a non-auto callback transaction is rolled back', function() {
+      const hook = sinon.spy();
+      return expect(
+        this.sequelize.transaction().then(t => {
+          t.afterCommit(hook);
+          return t.rollback().then(() => {
+            expect(hook).to.not.have.been.called;
+          });
+        })
+      ).to.eventually.be.fulfilled;
+    });
+
+    it('should throw an error if null is passed to afterCommit', function() {
+      const hook = null;
+      let transaction;
+      return expect(
+        this.sequelize.transaction().then(t => {
+          transaction = t;
+          transaction.afterCommit(hook);
+          return t.commit();
+        }).catch(err => {
+          // Cleanup this transaction so other tests don't
+          // fail due to an open transaction
+          if (!transaction.finished) {
+            return transaction.rollback().then(() => {
+              throw err;
+            });
+          }
+          throw err;
+        })
+      ).to.eventually.be.rejectedWith('"fn" must be a function');
+    });
+
+    it('should throw an error if undefined is passed to afterCommit', function() {
+      const hook = undefined;
+      let transaction;
+      return expect(
+        this.sequelize.transaction().then(t => {
+          transaction = t;
+          transaction.afterCommit(hook);
+          return t.commit();
+        }).catch(err => {
+          // Cleanup this transaction so other tests don't
+          // fail due to an open transaction
+          if (!transaction.finished) {
+            return transaction.rollback().then(() => {
+              throw err;
+            });
+          }
+          throw err;
+        })
+      ).to.eventually.be.rejectedWith('"fn" must be a function');
+    });
+
+    it('should throw an error if an object is passed to afterCommit', function() {
+      const hook = {};
+      let transaction;
+      return expect(
+        this.sequelize.transaction().then(t => {
+          transaction = t;
+          transaction.afterCommit(hook);
+          return t.commit();
+        }).catch(err => {
+          // Cleanup this transaction so other tests don't
+          // fail due to an open transaction
+          if (!transaction.finished) {
+            return transaction.rollback().then(() => {
+              throw err;
+            });
+          }
+          throw err;
+        })
+      ).to.eventually.be.rejectedWith('"fn" must be a function');
     });
 
     it('does not allow commits after rollback', function() {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Add `afterCommit` hooks for transactions that allows deferring work to
after a transaction has been committed, regardless of if you have
access to the promise chain that created the transaction

Closes: https://github.com/sequelize/sequelize/issues/2805