### PR TITLE
fix(scope): do not assign scope on eagerly loaded associations

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3503,11 +3503,9 @@ class Model {
           value = value[0];
         }
         isEmpty = value && value[primaryKeyAttribute] === null || value === null;
-        value = !isEmpty && _.assign(value, association.scope);
         this[accessor] = this.dataValues[accessor] = isEmpty ? null : include.model.build(value, childOptions);
       } else {
         isEmpty = value[0] && value[0][primaryKeyAttribute] === null;
-        value = !isEmpty && value.map(v => _.assign(v, association.scope));
         this[accessor] = this.dataValues[accessor] = isEmpty ? [] : include.model.bulkBuild(value, childOptions);
       }
     }
@@ -3759,6 +3757,7 @@ class Model {
                 });
               } else {
                 instance.set(include.association.foreignKey, this.get(include.association.sourceKey || this.constructor.primaryKeyAttribute, {raw: true}));
+                _.assign(instance, include.association.scope);
                 return instance.save(includeOptions);
               }
             });

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -5,7 +5,8 @@ const chai = require('chai'),
   Support = require(__dirname + '/../support'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
   Sequelize = require('../../../index'),
-  Promise = Sequelize.Promise;
+  Promise = Sequelize.Promise,
+  Op = Sequelize.Op;
 
 describe(Support.getTestDialectTeaser('associations'), () => {
   describe('scope', () => {
@@ -15,6 +16,7 @@ describe(Support.getTestDialectTeaser('associations'), () => {
       this.Question = this.sequelize.define('question', {});
       this.Comment = this.sequelize.define('comment', {
         title: Sequelize.STRING,
+        type: Sequelize.STRING,
         commentable: Sequelize.STRING,
         commentable_id: Sequelize.INTEGER,
         isMain: {
@@ -40,6 +42,15 @@ describe(Support.getTestDialectTeaser('associations'), () => {
         foreignKey: 'commentable_id',
         scope: {
           commentable: 'post'
+        },
+        constraints: false
+      });
+      this.Post.hasMany(this.Comment, {
+        foreignKey: 'commentable_id',
+        as: 'coloredComments',
+        scope: {
+          commentable: 'post',
+          type: { [Op.in]: ['blue', 'green'] }
         },
         constraints: false
       });
@@ -285,6 +296,40 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           return post.getComments();
         }).each(comment => {
           expect(comment.get('commentable')).to.equal('post');
+        });
+      });
+      it('should include associations with operator scope values', function() {
+        return this.sequelize.sync({force: true}).then(() => {
+          return Promise.join(
+            this.Post.create(),
+            this.Comment.create({
+              title: 'I am a blue comment',
+              type: 'blue'
+            }),
+            this.Comment.create({
+              title: 'I am a red comment',
+              type: 'red'
+            }),
+            this.Comment.create({
+              title: 'I am a green comment',
+              type: 'green'
+            })
+          );
+        }).spread((post, commentA, commentB, commentC) => {
+          this.post = post;
+          return post.addComments([commentA, commentB, commentC]);
+        }).then(() => {
+          return this.Post.findById(this.post.id, {
+            include: [{
+              model: this.Comment,
+              as: 'coloredComments'
+            }]
+          });
+        }).then(post => {
+          expect(post.coloredComments.length).to.equal(2);
+          for (const comment of post.coloredComments) {
+            expect(comment.type).to.match(/blue|green/);
+          }
         });
       });
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Fix an issue introduced by #9127 when eager loading association with complex scope, such as:
```js
Post.hasMany(this.Comment, {
    foreignKey: 'commentable_id',
    as: 'coloredComments',
    scope: {
        commentable: 'post',
        type: { [Op.in]: ['blue', 'green'] }
    },
    constraints: false
});
```

When assigning the scope to the instance in `_setInclude`, the instance's property `type` became `comment.type === { [Op.in]: ['blue', 'green'] }`.

This fix move the assignation of the association scope only on creation.


