### PR TITLE
feat(mysql/connection-manager): do not execute SET time_zone query if…

### DIFF
--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -124,13 +124,17 @@ class ConnectionManager extends AbstractConnectionManager {
       .tap (() => { debug('connection acquired'); })
       .then(connection => {
         return new Utils.Promise((resolve, reject) => {
-        // set timezone for this connection
-        // but named timezone are not directly supported in mysql, so get its offset first
-          let tzOffset = this.sequelize.options.timezone;
-          tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
-          connection.query(`SET time_zone = '${tzOffset}'`, err => {
-            if (err) { reject(err); } else { resolve(connection); }
-          });
+          if (!this.sequelize.config.keepDefaultTimezone) {
+            // set timezone for this connection
+            // but named timezone are not directly supported in mysql, so get its offset first
+            let tzOffset = this.sequelize.options.timezone;
+            tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z') : tzOffset;
+            return connection.query(`SET time_zone = '${tzOffset}'`, err => {
+              if (err) { reject(err); } else { resolve(connection); }
+            });
+          }
+          // return connection without executing SET time_zone query
+          resolve(connection);
         });
       })
       .catch(err => {

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -150,5 +150,17 @@ if (dialect === 'mysql') {
           return cm.releaseConnection(connection);
         });
     });
+
+    it('should acquire a valid connection when keepDefaultTimezone is true', () => {
+      const sequelize = Support.createSequelizeInstance({keepDefaultTimezone: true, pool: {min: 1, max: 1, handleDisconnects: true, idle: 5000}});
+      const cm = sequelize.connectionManager;
+      return sequelize
+        .sync()
+        .then(() => cm.getConnection())
+        .then(connection => {
+          expect(cm.validate(connection)).to.be.ok;
+          return cm.releaseConnection(connection);
+        });
+    });
   });
 }


### PR DESCRIPTION
… keepDefaultTimezone config is true

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Do not execute "SET time_zone=..." if keepDefaultTimezone option is set to true
