### PR TITLE
Enable RIGHT OUTER JOINs

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1471,7 +1471,8 @@ const QueryGenerator = {
     }
 
     return {
-      join: include.required ? 'INNER JOIN' : 'LEFT OUTER JOIN',
+      join: include.required ? 'INNER JOIN'
+        : (include.right ? 'RIGHT' : 'LEFT') + ' OUTER JOIN',
       body: this.quoteTable(tableRight, asRight),
       condition: joinOn,
       attributes: {
@@ -1501,7 +1502,8 @@ const QueryGenerator = {
     const identTarget = association.foreignIdentifierField;
     const attrTarget = association.target.rawAttributes[primaryKeysTarget[0]].field || primaryKeysTarget[0];
 
-    const joinType = include.required ? 'INNER JOIN' : 'LEFT OUTER JOIN';
+    const joinType = include.required ? 'INNER JOIN'
+      : (include.right ? 'RIGHT' : 'LEFT') + ' OUTER JOIN';
     let joinBody;
     let joinCondition;
     const attributes = {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

For included (eager-loaded) models, allow `RIGHT OUTER JOIN`s.

This functionality can easily be used by adding the `right: true` property to any include object.

Example usage:
```node
User.findAll({
    where: {
        '$Instruments.name$': { [Op.iLike]: '%ooth%' }
    },
    include: [{
        model: Tool,
        as: 'Instruments',
        right: true
    }]
})
```