### PR TITLE
feat(query-generator): Generate INSERTs using bind parameters

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -118,7 +118,12 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 
   // isolation level of each transaction
   // defaults to dialect default
-  isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ
+  isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ,
+
+  // Generate queries with bind parameters
+  // Currently only has an effect for non-bulk INSERTs
+  // - default: false
+  bindParams: true
 })
 ```
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -106,6 +106,7 @@ class QueryGenerator {
     const modelAttributeMap = {};
     const fields = [];
     const values = [];
+    const bind = [];
     let query;
     let valueQuery = '<%= tmpTable %>INSERT<%= ignoreDuplicates %> INTO <%= table %> (<%= attributes %>)<%= output %> VALUES (<%= values %>)';
     let emptyQuery = '<%= tmpTable %>INSERT<%= ignoreDuplicates %> INTO <%= table %><%= output %>';
@@ -211,7 +212,12 @@ class QueryGenerator {
             identityWrapperRequired = true;
           }
 
-          values.push(this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'INSERT' }));
+          if (!options.bindParams || value instanceof Utils.SequelizeMethod) {
+            values.push(this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'INSERT' }));
+          } else {
+            bind.push(this.format(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'INSERT' }));
+            values.push('$' + bind.length);
+          }
         }
       }
     }
@@ -234,7 +240,11 @@ class QueryGenerator {
       ].join(' ');
     }
 
-    return _.template(query, this._templateSettings)(replacements);
+    query = _.template(query, this._templateSettings)(replacements);
+    if (options.bindParams) {
+      return { query, bind };
+    }
+    return query;
   }
 
   /**
@@ -961,15 +971,7 @@ class QueryGenerator {
         return this.handleSequelizeMethod(value);
       } else {
         if (field && field.type) {
-          if (this.typeValidation && field.type.validate && value) {
-            if (options.isList && Array.isArray(value)) {
-              for (const item of value) {
-                field.type.validate(item, options);
-              }
-            } else {
-              field.type.validate(value, options);
-            }
-          }
+          this.validate(value, field, options);
 
           if (field.type.stringify) {
             // Users shouldn't have to worry about these args - just give them a function that takes a single arg
@@ -987,6 +989,46 @@ class QueryGenerator {
     }
 
     return SqlString.escape(value, this.options.timezone, this.dialect);
+  }
+
+  /*
+    Returns a bind parameter representation of a value (e.g. a string, number or date)
+    @private
+  */
+  format(value, field, options) {
+    options = options || {};
+
+    if (value !== null && value !== undefined) {
+      if (value instanceof Utils.SequelizeMethod) {
+        throw new Error('Cannot pass SequelizeMethod as a bind parameter - use escape instead');
+      } else {
+        if (field && field.type) {
+          this.validate(value, field, options);
+
+          if (field.type.stringify) {
+            value = field.type.stringify(value, { escape: _.identity, field, timezone: this.options.timezone, operation: options.operation });
+          }
+        }
+      }
+    }
+
+    return value;
+  }
+
+  /*
+    Validate a value against a field specification
+    @private
+  */
+  validate(value, field, options) {
+    if (this.typeValidation && field.type.validate && value) {
+      if (options.isList && Array.isArray(value)) {
+        for (const item of value) {
+          field.type.validate(item, options);
+        }
+      } else {
+        field.type.validate(value, options);
+      }
+    }
   }
 
   isIdentifierQuoted(identifier) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -706,6 +706,7 @@ class Model {
    * @param {String}                  [options.initialAutoIncrement] Set the initial AUTO_INCREMENT value for the table in MySQL.
    * @param {Object}                  [options.hooks] An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, validationFailed, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, afterDestroy, afterUpdate, afterBulkCreate, afterBulkDestory and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions.
    * @param {Object}                  [options.validate] An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error.
+   * @param {Boolean}                 [options.bindParams] Generate queries with bind parameters. Currently only has an effect for non-bulk INSERTs.
 
    * @return {Model}
    */

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -97,6 +97,7 @@ class Sequelize {
    * @param {Integer}  [options.retry.max] How many times a failing query is automatically retried.  Set to 0 to disable retrying on SQL_BUSY error.
    * @param {Boolean}  [options.typeValidation=false] Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like.
    * @param {Object}   [options.operatorsAliases] String based operator alias. Pass object to limit set of aliased operators.
+   * @param {Boolean}  [options.bindParams] Generate queries with bind parameters. Currently only has an effect for non-bulk INSERTs.
    *
    */
   constructor(database, username, password, options) {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1437,6 +1437,33 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
     });
+
+    it('should allow creates using bind parameters', function() {
+      const User = this.sequelize.define('UserUsingBindParams', {
+        'name': {
+          type: DataTypes.STRING
+        },
+        'children': {
+          type: DataTypes.INTEGER
+        },
+        'dob': {
+          type: DataTypes.DATE
+        }
+      }, {
+        bindParams: true
+      });
+
+      const date = new Date();
+      return this.sequelize.sync({force: true}).then(() => {
+        return User.create({ name: 'Test', children: 2, dob: date }, { bindParams: true }).then(user => {
+          return User.findById(user.id).then(user => {
+            expect(user.name).to.equal('Test');
+            expect(user.children).to.equal(2);
+            expect(user.dob).to.be.ok;
+          });
+        });
+      });
+    });
   });
 
   it('should return autoIncrement primary key (create)', function() {

--- a/test/support.js
+++ b/test/support.js
@@ -213,7 +213,8 @@ const Support = {
     return url;
   },
 
-  expectsql(query, expectations) {
+  expectsql(query, assertions) {
+    const expectations = assertions.query || assertions;
     let expectation = expectations[Support.sequelize.dialect.name];
 
     if (!expectation) {
@@ -229,7 +230,11 @@ const Support = {
     if (_.isError(query)) {
       expect(query.message).to.equal(expectation.message);
     } else {
-      expect(query).to.equal(expectation);
+      expect(query.query || query).to.equal(expectation);
+    }
+
+    if (assertions.bind) {
+      expect(query.bind).to.deep.equal(assertions.bind);
     }
   }
 };

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -87,5 +87,13 @@ describe('QueryGenerator', () => {
         .to.throw('Invalid value { \'$in\': [ 4 ] }');
     });
   });
+
+  describe('format', () => {
+    it('should throw an error if passed SequelizeMethod', function() {
+      const QG = getAbstractQueryGenerator(this.sequelize);
+      const value = this.sequelize.fn('UPPER', 'test');
+      expect(() => QG.format(value)).to.throw(Error);
+    });
+  });
 });
 

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -31,8 +31,40 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           postgres: 'INSERT INTO "users" ("user_name") VALUES (\'triggertest\') RETURNING *;',
           default: "INSERT INTO `users` (`user_name`) VALUES ('triggertest');"
         });
+
     });
 
+    it('with bind parameters', () => {
+      const User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user'
+        },
+        name: {
+          type: DataTypes.STRING,
+          field: 'name'
+        }
+      }, {
+        timestamps: false
+      });
+
+      const values = {
+        user: 'bindtest',
+        name: Support.sequelize.fn('UPPER', 'bindtest')
+      };
+      const options = {
+        bindParams: true
+      };
+      expectsql(sql.insertQuery(User.tableName, values, User.rawAttributes, options),
+        {
+          query: {
+            mssql: 'INSERT INTO [users] ([user],[name]) VALUES ($1,UPPER(N\'bindtest\'));',
+            postgres: 'INSERT INTO "users" ("user","name") VALUES ($1,UPPER(\'bindtest\'));',
+            default: 'INSERT INTO `users` (`user`,`name`) VALUES ($1,UPPER(\'bindtest\'));',
+          },
+          bind: ['bindtest']
+        });
+    });
   });
 
   describe('dates', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
This provides very basic support for using bind parameters when generating INSERT queries and partly addresses #1608. Re-do of #8923 