### PR TITLE
chore(*): mark aliases as deprecated

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -65,8 +65,8 @@ const User = sequelize.define('user', {
   }
 });
 
-// Method 2 via the .hook() method (or its alias .addHook() method)
-User.hook('beforeValidate', (user, options) => {
+// Method 2 via the .addHook() method
+User.addHook('beforeValidate', (user, options) => {
   user.mood = 'happy';
 });
 

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -217,7 +217,7 @@ sequelize.transaction({
 ## Usage with other sequelize methods
 
 The `transaction` option goes with most other options, which are usually the first argument of a method.
-For methods that take values, like `.create`, `.update()`, `.updateAttributes()` etc. `transaction` should be passed to the option in the second argument.
+For methods that take values, like `.create`, `.update()`, etc. `transaction` should be passed to the option in the second argument.
 If unsure, refer to the API documentation for the method you are using to be sure of the signature.
 
 ## After commit hook

--- a/docs/upgrade-to-v4.md
+++ b/docs/upgrade-to-v4.md
@@ -5,7 +5,7 @@ Sequelize V4 is a major release and it introduces new features and breaking chan
 ### Breaking Changes
 
 - Node version: To use new ES2015 features, we now require at least Node 4. From now on, we will support all current LTS versions of Node.
-- The counter cache plugin, and consequently the counterCache option for associations has been removed. The same behaviour can be achieved using `afterCreate` and `afterDelete` hooks.
+- The counter cache plugin, and consequently the counterCache option for associations has been removed. The same behaviour can be achieved using `afterCreate` and `afterDestroy` hooks.
 - Removed MariaDB dialect. This was just a thin wrapper around MySQL, so using `dialect: 'mysql'` instead should work with no further changes
 - Removed default `REPEATABLE_READ` transaction isolation. The isolation level now defaults to that of the database. Explicitly pass the required isolation level when initiating the transaction.
 - Removed support for `pool: false`. To use a single connection, set `pool.max` to 1.

--- a/lib/associations/base.js
+++ b/lib/associations/base.js
@@ -23,7 +23,7 @@ const AssociationError = require('./../errors').AssociationError;
  * user.getPictures() // gets you all pictures
  * user.getProfilePicture() // gets you only the profile picture
  *
- * User.findAll({
+ * User.findOneAll({
  *   where: ...,
  *   include: [
  *     { model: Picture }, // load all pictures

--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -1,4 +1,5 @@
 'use strict';
+const Utils = require('../utils');
 
 function checkNamingCollision(association) {
   if (association.source.rawAttributes.hasOwnProperty(association.as)) {
@@ -59,6 +60,9 @@ function mixinMethods(association, obj, methods, aliases) {
       const realMethod = aliases[method] || method;
 
       obj[association.accessors[method]] = function() {
+        if (aliases[method]) {
+          Utils.deprecate(`Use ${aliases[method]} instead`);
+        }
         const instance = this;
         const args = [instance].concat(Array.from(arguments));
 

--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -60,9 +60,10 @@ function mixinMethods(association, obj, methods, aliases) {
       const realMethod = aliases[method] || method;
 
       obj[association.accessors[method]] = function() {
-        if (aliases[method]) {
-          Utils.deprecate(`Use ${aliases[method]} instead`);
-        }
+        // REVIEW: Doesn't work right, help pls
+        /* if (aliases[method]) {
+          Utils.deprecate(`Use ${aliases[method]} instead'`);
+        } */
         const instance = this;
         const args = [instance].concat(Array.from(arguments));
 

--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -1,5 +1,4 @@
 'use strict';
-const Utils = require('../utils');
 
 function checkNamingCollision(association) {
   if (association.source.rawAttributes.hasOwnProperty(association.as)) {

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -10,7 +10,7 @@ const BelongsTo = require('./belongs-to');
 function isModel(model, sequelize) {
   return model
     && model.prototype
-    && model.prototype instanceof sequelize.Model;
+    && model.prototype instanceof sequelize.Sequelize.Model;
 }
 
 const Mixin = {

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -10,6 +10,7 @@ const Validator = require('./utils/validator-extras').validator;
 const momentTz = require('moment-timezone');
 const moment = require('moment');
 const Utils = require('./utils');
+const deprecate = require('./utils/deprecate');
 
 function ABSTRACT() {}
 
@@ -911,7 +912,10 @@ const DataTypes = module.exports = {
   NOW,
   BLOB,
   DECIMAL,
-  NUMERIC: DECIMAL,
+  get NUMERIC() {
+    deprecate.deprecate('Use `DECIMAL` instead.');
+    return DECIMAL;
+  },
   UUID,
   UUIDV1,
   UUIDV4,
@@ -920,12 +924,18 @@ const DataTypes = module.exports = {
   JSONB,
   VIRTUAL,
   ARRAY,
-  NONE: VIRTUAL,
+  get NONE() {
+    deprecate.deprecate('Use `VIRTUAL` instead.');
+    return VIRTUAL;
+  },
   ENUM,
   RANGE,
   REAL,
   DOUBLE,
-  'DOUBLE PRECISION': DOUBLE,
+  get 'DOUBLE PRECISION'() {
+    deprecate.deprecate('Use `DOUBLE` instead.');
+    return DOUBLE;
+  },
   GEOMETRY,
   GEOGRAPHY
 };

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1351,6 +1351,7 @@ class QueryGenerator {
         } else if (attr[0].indexOf('(') === -1 && attr[0].indexOf(')') === -1) {
           attr[0] = this.quoteIdentifier(attr[0]);
         } else {
+          console.error(123, attr[0]);
           Utils.deprecate('Use sequelize.fn / sequelize.literal to construct attributes');
         }
         attr = [attr[0], this.quoteIdentifier(attr[1])].join(' AS ');
@@ -1748,7 +1749,7 @@ class QueryGenerator {
         model: topInclude.through.model,
         where: {
           [Op.and]: [
-            this.sequelize.asIs([
+            this.sequelize.literal([
               this.quoteTable(topParent.model.name) + '.' + this.quoteIdentifier(topParent.model.primaryKeyField),
               this.quoteIdentifier(topInclude.through.model.name) + '.' + this.quoteIdentifier(topAssociation.identifierField)
             ].join(' = ')),
@@ -1775,7 +1776,7 @@ class QueryGenerator {
         where: {
           [Op.and]: [
             topInclude.where,
-            { [Op.join]: this.sequelize.asIs(join) }
+            { [Op.join]: this.sequelize.literal(join) }
           ]
         },
         limit: 1,
@@ -1788,7 +1789,7 @@ class QueryGenerator {
       topLevelInfo.options.where[Op.and] = [];
     }
 
-    topLevelInfo.options.where[`__${includeAs.internalAs}`] = this.sequelize.asIs([
+    topLevelInfo.options.where[`__${includeAs.internalAs}`] = this.sequelize.literal([
       '(',
       query.replace(/\;$/, ''),
       ')',

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -49,7 +49,7 @@ MssqlDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype.
     using: false,
     where: true
   },
-  NUMERIC: true,
+  DECIMAL: true,
   tmpTableTrigger: true
 });
 

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -39,7 +39,7 @@ MysqlDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype.
   ignoreDuplicates: ' IGNORE',
   updateOnDuplicate: true,
   indexViaAlter: true,
-  NUMERIC: true,
+  DECIMAL: true,
   GEOMETRY: true,
   JSON: true,
   REGEXP: true

--- a/lib/dialects/mysql/query-interface.js
+++ b/lib/dialects/mysql/query-interface.js
@@ -10,6 +10,7 @@
 
 const _ = require('lodash');
 const UnknownConstraintError = require('../../errors').UnknownConstraintError;
+const Utils = require('../../utils');
 
 /**
   A wrapper that fixes MySQL's inability to cleanly remove columns from existing tables if they have a foreign key constraint.
@@ -38,7 +39,7 @@ function removeColumn(tableName, columnName, options) {
         // No foreign key constraints found, so we can remove the column
         return;
       }
-      return this.sequelize.Promise.map(results, constraint => this.sequelize.query(
+      return Utils.Promise.map(results, constraint => this.sequelize.query(
         this.QueryGenerator.dropForeignKeyQuery(tableName, constraint.constraint_name),
         _.assign({ raw: true }, options)
       ));

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const wkx = require('wkx');
 const inherits = require('../../utils/inherits');
+const deprecate = require('../../utils/deprecate');
 
 module.exports = BaseTypes => {
   const warn = BaseTypes.ABSTRACT.warn.bind(undefined, 'http://www.postgresql.org/docs/9.4/static/datatype.html');
@@ -618,7 +619,10 @@ module.exports = BaseTypes => {
     DATE,
     DATEONLY,
     REAL,
-    'DOUBLE PRECISION': DOUBLE,
+    get 'DOUBLE PRECISION'() {
+      deprecate.deprecate('Use `DOUBLE` instead.');
+      return DOUBLE;
+    },
     FLOAT,
     GEOMETRY,
     GEOGRAPHY,

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -39,7 +39,7 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
     using: 2,
     where: true
   },
-  NUMERIC: true,
+  DECIMAL: true,
   ARRAY: true,
   RANGE: true,
   GEOMETRY: true,

--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const inherits = require('../../utils/inherits');
+const deprecate = require('../../utils/deprecate');
 
 module.exports = BaseTypes => {
   const warn = BaseTypes.ABSTRACT.warn.bind(undefined, 'https://www.sqlite.org/datatype3.html');
@@ -249,7 +250,10 @@ module.exports = BaseTypes => {
     NUMBER,
     FLOAT,
     REAL,
-    'DOUBLE PRECISION': DOUBLE,
+    get 'DOUBLE PRECISION'() {
+      deprecate.deprecate('Use `DOUBLE` instead.');
+      return DOUBLE;
+    },
     TINYINT,
     SMALLINT,
     MEDIUMINT,

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -427,7 +427,7 @@ class Query extends AbstractQuery {
   handleShowIndexesQuery(data) {
 
     // Sqlite returns indexes so the one that was defined last is returned first. Lets reverse that!
-    return this.sequelize.Promise.map(data.reverse(), item => {
+    return Utils.Promise.map(data.reverse(), item => {
       item.fields = [];
       item.primary = false;
       item.unique = !!item.unique;

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -47,6 +47,7 @@ const hookTypes = {
 };
 exports.hooks = hookTypes;
 
+// Deprecated
 const hookAliases = {
   beforeDelete: 'beforeDestroy',
   afterDelete: 'afterDestroy',
@@ -132,6 +133,7 @@ const Hooks = {
   },
 
   hook() {
+    Utils.deprecate('Use addHook instead');
     return Hooks.addHook.apply(this, arguments);
   },
 
@@ -153,6 +155,9 @@ const Hooks = {
 
     debug(`adding hook ${hookType}`);
     hookType = hookAliases[hookType] || hookType;
+    if (hookAliases[hookType]) {
+      Utils.deprecate(`Use ${hookAliases[hookType]} instead.`);
+    }
 
     // check for proxies, add them too
     hookType = getProxiedHooks(hookType);
@@ -176,6 +181,9 @@ const Hooks = {
    */
   removeHook(hookType, name) {
     hookType = hookAliases[hookType] || hookType;
+    if (hookAliases[hookType]) {
+      Utils.deprecate(`Use ${hookAliases[hookType]} instead.`);
+    }
     const isReference = typeof name === 'function' ? true : false;
 
     if (!this.hasHook(hookType)) {
@@ -214,7 +222,6 @@ const Hooks = {
     return this.options.hooks[hookType] && !!this.options.hooks[hookType].length;
   }
 };
-Hooks.hasHooks = Hooks.hasHook;
 
 
 function applyTo(target) {
@@ -308,7 +315,6 @@ exports.applyTo = applyTo;
  * @param {Function} fn   A callback function that is called with instance, options
  *
  * @name beforeDestroy
- * @alias beforeDelete
  * @memberOf Sequelize.Model
  */
 
@@ -318,7 +324,6 @@ exports.applyTo = applyTo;
  * @param {Function} fn   A callback function that is called with instance, options
  *
  * @name afterDestroy
- * @alias afterDelete
  * @memberOf Sequelize.Model
  */
 
@@ -378,7 +383,6 @@ exports.applyTo = applyTo;
  * @param {Function} fn   A callback function that is called with options
  *
  * @name beforeBulkDestroy
- * @alias beforeBulkDelete
  * @memberOf Sequelize.Model
  */
 
@@ -388,7 +392,6 @@ exports.applyTo = applyTo;
  * @param {Function} fn   A callback function that is called with options
  *
  * @name afterBulkDestroy
- * @alias afterBulkDelete
  * @memberOf Sequelize.Model
  */
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -18,6 +18,7 @@ const associationsMixin = require('./associations/mixin');
 const defaultsOptions = { raw: true };
 const assert = require('assert');
 const Op = require('./operators');
+const deprecate = require('./utils/deprecate');
 
 
 /**
@@ -1683,8 +1684,6 @@ class Model {
   /**
    * Search for a single instance by its primary key.
    *
-   * __Alias__: _findByPrimary_
-   *
    * @param  {Number|String|Buffer}      id The value of the desired instance's primary key.
    * @param  {Object}                    [options]
    * @param  {Transaction}               [options.transaction] Transaction to run query under
@@ -1879,16 +1878,14 @@ class Model {
    * ```
    * Because the include for `Profile` has `required` set it will result in an inner join, and only the users who have a profile will be counted. If we remove `required` from the include, both users with and without profiles will be counted
    *
-   * __Alias__: _findAndCountAll_
-   *
    * @param {Object} [findOptions] See findAll
    *
    * @see {@link Model.findAll} for a specification of find and query options
    * @return {Promise<{count: Integer, rows: Model[]}>}
    */
-  static findAndCount(options) {
+  static findAndCountAll(options) {
     if (options !== undefined && !_.isPlainObject(options)) {
-      throw new Error('The argument passed to findAndCount must be an options object, use findById if you wish to pass a single primary key value');
+      throw new Error('The argument passed to findAndCountAll must be an options object, use findById if you wish to pass a single primary key value');
     }
 
     const countOptions = Utils.cloneDeep(options);
@@ -2025,8 +2022,6 @@ class Model {
    * Find a row that matches the query, or build (but don't save) the row if none is found.
    * The successful result of the promise will be (instance, initialized) - Make sure to use .spread()
    *
-   * __Alias__: _findOrInitialize_
-   *
    * @param {Object}   options
    * @param {Object}   options.where A hash of search attributes.
    * @param {Object}   [options.defaults] Default values to use if building a new instance
@@ -2039,14 +2034,14 @@ class Model {
   static findOrBuild(options) {
     if (!options || !options.where || arguments.length > 1) {
       throw new Error(
-        'Missing where attribute in the options parameter passed to findOrInitialize. ' +
+        'Missing where attribute in the options parameter passed to findOrBuild. ' +
         'Please note that the API has changed, and is now options only (an object with where, defaults keys, transaction etc.)'
       );
     }
 
     let values;
 
-    return this.find(options).then(instance => {
+    return this.findOne(options).then(instance => {
       if (instance === null) {
         values = _.clone(options.defaults) || {};
         if (_.isPlainObject(options.where)) {
@@ -2128,11 +2123,11 @@ class Model {
       return this.create(values, options).then(instance => {
         if (instance.get(this.primaryKeyAttribute, { raw: true }) === null) {
           // If the query returned an empty result for the primary key, we know that this was actually a unique constraint violation
-          throw new this.sequelize.UniqueConstraintError();
+          throw new sequelizeErrors.UniqueConstraintError();
         }
 
         return [instance, true];
-      }).catch(this.sequelize.UniqueConstraintError, err => {
+      }).catch(sequelizeErrors.UniqueConstraintError, err => {
         const flattenedWhere = Utils.flattenObjectDeep(options.where);
         const flattenedWhereKeys = _.map(_.keys(flattenedWhere), name => _.last(_.split(name, '.')));
         const whereFields = flattenedWhereKeys.map(name => _.get(this.rawAttributes, `${name}.field`, name));
@@ -2201,7 +2196,7 @@ class Model {
 
       return this.create(values, options)
         .then(result => [result, true])
-        .catch(this.sequelize.UniqueConstraintError, () => this.findOne(options).then(result => [result, false]));
+        .catch(sequelizeErrors.UniqueConstraintError, () => this.findOne(options).then(result => [result, false]));
     });
   }
 
@@ -2215,8 +2210,6 @@ class Model {
    * * SQLite - Implemented as two queries `INSERT; UPDATE`. This means that the update is executed regardless of whether the row already existed or not
    * * MSSQL - Implemented as a single query using `MERGE` and `WHEN (NOT) MATCHED THEN`
    * **Note** that SQLite returns undefined for created, no matter if the row was created or updated. This is because SQLite always runs INSERT OR IGNORE + UPDATE, in a single query, so there is no way to know whether the row was inserted or not.
-   *
-   * __Alias__: _insertOrUpdate_
    *
    * @param  {Object}       values
    * @param  {Object}       [options]
@@ -3289,7 +3282,7 @@ class Model {
    *
    * Set can also be used to build instances for associations, if you have values for those.
    * When using set with associations you need to make sure the property key matches the alias of the association
-   * while also making sure that the proper include options have been set (from .build() or .find())
+   * while also making sure that the proper include options have been set (from .build() or .findOne())
    *
    * If called with a dot.separated key on a JSON/JSONB attribute it will set the value nested and flag the entire object as changed.
    *
@@ -4204,13 +4197,12 @@ class Model {
 }
 
 // Aliases
-Model.prototype.updateAttributes = Model.prototype.update;
-
-Model.findByPrimary = Model.findById;
-Model.find = Model.findOne;
-Model.findAndCountAll = Model.findAndCount;
-Model.findOrInitialize = Model.findOrBuild;
-Model.insertOrUpdate = Model.upsert;
+deprecate.deprecateAlias(Model.prototype, 'update', 'updateAttributes');
+deprecate.deprecateAlias(Model, 'findById', 'findByPrimary');
+deprecate.deprecateAlias(Model, 'findOne', 'find');
+deprecate.deprecateAlias(Model, 'findAndCountAll', 'findAndCount');
+deprecate.deprecateAlias(Model, 'findOrBuild', 'findOrInitialize');
+deprecate.deprecateAlias(Model, 'upsert', 'insertOrUpdate');
 
 _.extend(Model, associationsMixin);
 Hooks.applyTo(Model);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -805,7 +805,7 @@ class Sequelize {
    *
    * Convert a user's username to upper case
    * ```js
-   * instance.updateAttributes({
+   * instance.update({
    *   username: self.sequelize.fn('upper', self.sequelize.col('username'))
    * })
    * ```
@@ -822,7 +822,7 @@ class Sequelize {
    * @memberof Sequelize
    * @return {Sequelize.fn}
    * @example <caption>Convert a user's username to upper case</caption>
-   * instance.updateAttributes({
+   * instance.update({
    *   username: self.sequelize.fn('upper', self.sequelize.col('username'))
    * })
    */
@@ -940,7 +940,7 @@ class Sequelize {
    * ```js
    * sequelize.transaction().then(transaction => {
    *   return User.findOne(..., {transaction})
-   *     .then(user => user.updateAttributes(..., {transaction}))
+   *     .then(user => user.update(..., {transaction}))
    *     .then(() => transaction.commit())
    *     .catch(() => transaction.rollback());
    * })
@@ -951,7 +951,7 @@ class Sequelize {
    * ```js
    * sequelize.transaction(transaction => { // Note that we use a callback rather than a promise.then()
    *   return User.findOne(..., {transaction})
-   *     .then(user => user.updateAttributes(..., {transaction}))
+   *     .then(user => user.update(..., {transaction}))
    * }).then(() => {
    *   // Committed
    * }).catch(err => {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1166,6 +1166,11 @@ Sequelize.options = {hooks: {}};
 Sequelize.prototype.Sequelize = Sequelize;
 
 /**
+ * @private
+ */
+Sequelize.Utils = Utils;
+
+/**
  * A handy reference to the bluebird Promise class
  */
 Sequelize.Promise = Promise;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -20,6 +20,7 @@ const Association = require('./associations/index');
 const Validator = require('./utils/validator-extras').validator;
 const _ = require('lodash');
 const Op = require('./operators');
+const deprecate = require('./utils/deprecate');
 
 /**
  * This is the main class, the entry point to sequelize. To use it, you just need to import sequelize:
@@ -938,7 +939,7 @@ class Sequelize {
    *
    * ```js
    * sequelize.transaction().then(transaction => {
-   *   return User.find(..., {transaction})
+   *   return User.findOne(..., {transaction})
    *     .then(user => user.updateAttributes(..., {transaction}))
    *     .then(() => transaction.commit())
    *     .catch(() => transaction.rollback());
@@ -949,7 +950,7 @@ class Sequelize {
    *
    * ```js
    * sequelize.transaction(transaction => { // Note that we use a callback rather than a promise.then()
-   *   return User.find(..., {transaction})
+   *   return User.findOne(..., {transaction})
    *     .then(user => user.updateAttributes(..., {transaction}))
    * }).then(() => {
    *   // Committed
@@ -1135,16 +1136,21 @@ class Sequelize {
   }
 }
 
+
 // Aliases
+Sequelize.prototype.literal = Sequelize.literal;
+deprecate.deprecateAlias(Sequelize.prototype, 'literal', 'asIs');
+deprecate.deprecateAlias(Sequelize, 'literal', 'asIs');
+Sequelize.prototype.where = Sequelize.where;
+deprecate.deprecateAlias(Sequelize.prototype, 'where', 'condition');
+deprecate.deprecateAlias(Sequelize, 'where', 'condition');
+deprecate.deprecateAlias(Sequelize.prototype, 'authenticate', 'validate');
 Sequelize.prototype.fn = Sequelize.fn;
 Sequelize.prototype.col = Sequelize.col;
 Sequelize.prototype.cast = Sequelize.cast;
-Sequelize.prototype.literal = Sequelize.asIs = Sequelize.prototype.asIs = Sequelize.literal;
 Sequelize.prototype.and = Sequelize.and;
 Sequelize.prototype.or = Sequelize.or;
 Sequelize.prototype.json = Sequelize.json;
-Sequelize.prototype.where = Sequelize.condition = Sequelize.prototype.condition = Sequelize.where;
-Sequelize.prototype.validate = Sequelize.prototype.authenticate;
 
 /**
  * Sequelize version number.
@@ -1160,14 +1166,10 @@ Sequelize.options = {hooks: {}};
 Sequelize.prototype.Sequelize = Sequelize;
 
 /**
- * @private
- */
-Sequelize.prototype.Utils = Sequelize.Utils = Utils;
-
-/**
  * A handy reference to the bluebird Promise class
  */
-Sequelize.prototype.Promise = Sequelize.Promise = Promise;
+Sequelize.Promise = Promise;
+deprecate.deprecateProperty(Sequelize.prototype, 'Promise', Promise, 'Use global `Sequelize.Promise`');
 
 /**
  * Available query types for use with `sequelize.query`
@@ -1179,21 +1181,27 @@ Sequelize.prototype.QueryTypes = Sequelize.QueryTypes = QueryTypes;
  * Available table hints to be used for querying data in mssql for table hints
  * @see {@link TableHints}
  */
-Sequelize.prototype.TableHints = Sequelize.TableHints = TableHints;
+Sequelize.TableHints = TableHints;
+deprecate.deprecateProperty(Sequelize.prototype, 'TableHints', TableHints, 'Use global `Sequelize.TableHints`');
+
 
 /**
  * Operators symbols to be used for querying data
  * @see  {@link Operators}
  */
-Sequelize.prototype.Op = Sequelize.Op = Op;
+Sequelize.Op = Op;
+deprecate.deprecateProperty(Sequelize.prototype, 'Op', Op, 'Use global `Sequelize.Op`');
 
 /**
  * Exposes the validator.js object, so you can extend it with custom validation functions. The validator is exposed both on the instance, and on the constructor.
  * @see https://github.com/chriso/validator.js
  */
-Sequelize.prototype.Validator = Sequelize.Validator = Validator;
+Sequelize.Validator = Validator;
+deprecate.deprecateProperty(Sequelize.prototype, 'Validator', Validator, 'Use global `Sequelize.Validator`');
 
-Sequelize.prototype.Model = Sequelize.Model = Model;
+Sequelize.Model = Model;
+deprecate.deprecateProperty(Sequelize.prototype, 'Model', Model, 'Use global `Sequelize.Model`');
+
 
 Sequelize.DataTypes = DataTypes;
 for (const dataType in DataTypes) {
@@ -1205,20 +1213,24 @@ for (const dataType in DataTypes) {
  * @see {@link Transaction}
  * @see {@link Sequelize.transaction}
  */
-Sequelize.prototype.Transaction = Sequelize.Transaction = Transaction;
+Sequelize.Transaction = Transaction;
+deprecate.deprecateProperty(Sequelize.prototype, 'Transaction', Transaction, 'Use global `Sequelize.Transaction`');
 
 /**
  * A reference to the deferrable collection. Use this to access the different deferrable options.
  * @see {@link Transaction.Deferrable}
  * @see {@link Sequelize#transaction}
  */
-Sequelize.prototype.Deferrable = Sequelize.Deferrable = Deferrable;
+Sequelize.Deferrable = Deferrable;
+deprecate.deprecateProperty(Sequelize.prototype, 'Deferrable', Deferrable, 'Use global `Sequelize.Deferrable`');
 
 /**
  * A reference to the sequelize association class.
  * @see {@link Association}
  */
-Sequelize.prototype.Association = Sequelize.Association = Association;
+Sequelize.Association = Association;
+deprecate.deprecateProperty(Sequelize.prototype, 'Association', Association, 'Use global `Sequelize.Association`');
+
 
 /**
  * Provide alternative version of `inflection` module to be used by `Utils.pluralize` etc.
@@ -1238,12 +1250,16 @@ Hooks.applyTo(Sequelize.prototype);
  */
 for (const error of Object.keys(sequelizeErrors)) {
   if (sequelizeErrors[error] === sequelizeErrors.BaseError) {
-    Sequelize.prototype.Error = Sequelize.Error = sequelizeErrors.BaseError;
+    Sequelize.Error = sequelizeErrors.BaseError;
+    deprecate.deprecateProperty(Sequelize.prototype, 'Error', sequelizeErrors.BaseError, 'Use global `Sequelize.BaseError`');
   } else {
-    Sequelize.prototype[error] = Sequelize[error] = sequelizeErrors[error];
+    Sequelize[error] = sequelizeErrors[error];
+    deprecate.deprecateProperty(Sequelize.prototype, error, sequelizeErrors[error], `Use global \`Sequelize.${error}\``);
   }
 }
 
 module.exports = Sequelize;
 module.exports.Sequelize = Sequelize;
 module.exports.default = Sequelize;
+
+deprecate.enable();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ const SqlString = require('./sql-string');
 const _ = require('lodash');
 const parameterValidator = require('./utils/parameter-validator');
 const Logger = require('./utils/logger');
+const { deprecate } = require('./utils/deprecate');
 const uuid = require('uuid');
 const Promise = require('./promise');
 const operators  = require('./operators');
@@ -12,11 +13,11 @@ const operatorsArray = _.values(operators);
 const primitives = ['string', 'number', 'boolean'];
 
 let inflection = require('inflection');
-const logger = new Logger();
+const logger = Logger.get();
 
 exports.Promise = Promise;
 exports.debug = logger.debug.bind(logger);
-exports.deprecate = logger.deprecate.bind(logger);
+exports.deprecate = deprecate;
 exports.warn = logger.warn.bind(logger);
 exports.getLogger = () =>  logger ;
 

--- a/lib/utils/deprecate.js
+++ b/lib/utils/deprecate.js
@@ -1,0 +1,56 @@
+const Logger = require('./logger');
+
+let enabled = false;
+
+const logger = Logger.get();
+function deprecate(...args) {
+  if (!enabled) {
+    return;
+  }
+  console.log(new Error().stack);
+  logger.deprecate(...args);
+}
+exports.deprecate = deprecate;
+
+/**
+ * Enables deprecation warnings.
+ * Only used to hide deprecation warnings during startup.
+ */
+function enable() {
+  enabled = true;
+}
+exports.enable = enable;
+
+/**
+ * Creates a getter for the specified property that generates a deprecation warning
+ * @param {Object} obj
+ * @param {String} key
+ * @param {*} value
+ * @param {String} message
+ */
+function deprecateProperty(obj, key, value, message) {
+  Object.defineProperty(obj, key, {
+    get() {
+      exports.deprecate(message);
+      return value;
+    },
+  });
+}
+exports.deprecateProperty = deprecateProperty;
+
+/**
+ * Creates a getter for the specified alias on the same object that generates a deprecation warning
+ * @param {Object} obj
+ * @param {String} orig
+ * @param {String} alias
+ */
+function deprecateAlias(obj, orig, alias) {
+  Object.defineProperty(obj, alias, {
+    get() {
+      exports.deprecate(`Use ${orig} instead`);
+      return obj[orig];
+    }
+  });
+}
+
+exports.deprecateAlias = deprecateAlias;

--- a/lib/utils/deprecate.js
+++ b/lib/utils/deprecate.js
@@ -7,7 +7,6 @@ function deprecate(...args) {
   if (!enabled) {
     return;
   }
-  console.log(new Error().stack);
   logger.deprecate(...args);
 }
 exports.deprecate = deprecate;

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -24,8 +24,16 @@ class Logger {
     this.debug = debug(this.config.context);
   }
 
+  static get() {
+    if (!this._logger) {
+      return this._logger = new Logger();
+    }
+    return this._logger;
+  }
+
   deprecate(message) {
     this.depd(message);
+    console.warn(new Error().stack.split('\n').slice(2).join('\n'));
   }
 
   debug(message) {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -39,8 +39,7 @@ class Logger {
     deprecationMessages.add(message);
     this.depd(message);
     const stack = new Error().stack.split('\n').splice(2).join('\n');
-    console.warn(message);
-    console.warn('>>>>', stack);
+    console.warn(stack);
   }
 
   debug(message) {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -11,8 +11,6 @@
 const depd = require('depd');
 const debug = require('debug');
 
-const deprecationMessages = new Set();
-
 class Logger {
   constructor(config) {
 
@@ -33,13 +31,7 @@ class Logger {
   }
 
   deprecate(message) {
-    if (deprecationMessages.has(message)) {
-      return;
-    }
-    deprecationMessages.add(message);
     this.depd(message);
-    const stack = new Error().stack.split('\n').splice(2).join('\n');
-    console.warn(stack);
   }
 
   debug(message) {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -11,9 +11,10 @@
 const depd = require('depd');
 const debug = require('debug');
 
+const deprecationMessages = new Set();
+
 class Logger {
   constructor(config) {
-    this._deprecationMessages = new Set();
 
     this.config = Object.assign({
       context: 'sequelize',
@@ -32,12 +33,14 @@ class Logger {
   }
 
   deprecate(message) {
-    if (this._deprecationMessages.has(message)) {
+    if (deprecationMessages.has(message)) {
       return;
     }
+    deprecationMessages.add(message);
     this.depd(message);
-    const stack = new Error().stack.split('\n').splice(4).join('\n');
-    console.warn(stack);
+    const stack = new Error().stack.split('\n').splice(2).join('\n');
+    console.warn(message);
+    console.warn('>>>>', stack);
   }
 
   debug(message) {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -8,14 +8,14 @@
  * @private
  */
 
-const depd = require('depd'),
-  debug = require('debug'),
-  _ = require('lodash');
+const depd = require('depd');
+const debug = require('debug');
 
 class Logger {
   constructor(config) {
+    this._deprecationMessages = new Set();
 
-    this.config = _.extend({
+    this.config = Object.assign({
       context: 'sequelize',
       debug: true
     }, config || {});
@@ -32,8 +32,12 @@ class Logger {
   }
 
   deprecate(message) {
+    if (this._deprecationMessages.has(message)) {
+      return;
+    }
     this.depd(message);
-    console.warn(new Error().stack.split('\n').slice(2).join('\n'));
+    const stack = new Error().stack.split('\n').splice(4).join('\n');
+    console.warn(stack);
   }
 
   debug(message) {

--- a/test/integration/associations/alias.test.js
+++ b/test/integration/associations/alias.test.js
@@ -24,8 +24,8 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
       expect(task.getOwner).to.be.ok;
 
       return Promise.all([
-        User.find({ where: { id: 1 }, include: [{model: Task, as: 'assignments'}] }),
-        Task.find({ where: { id: 1 }, include: [{model: User, as: 'owner'}] })
+        User.findOne({ where: { id: 1 }, include: [{model: Task, as: 'assignments'}] }),
+        Task.findOne({ where: { id: 1 }, include: [{model: User, as: 'owner'}] })
       ]);
     }).spread((user, task) => {
       expect(user.assignments).to.be.ok;
@@ -50,8 +50,8 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
       expect(task.getOWNER).to.be.ok;
 
       return Promise.all([
-        User.find({ where: { id: 1 }, include: [{model: Task, as: 'ASSIGNMENTS'}] }),
-        Task.find({ where: { id: 1 }, include: [{model: User, as: 'OWNER'}] })
+        User.findOne({ where: { id: 1 }, include: [{model: Task, as: 'ASSIGNMENTS'}] }),
+        Task.findOne({ where: { id: 1 }, include: [{model: User, as: 'OWNER'}] })
       ]);
     }).spread((user, task) => {
       expect(user.ASSIGNMENTS).to.be.ok;
@@ -72,7 +72,7 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
       expect(user.addTask).to.be.ok;
       expect(user.addTaskz).to.be.ok;
     }).then(() => {
-      return User.find({ where: { id: 1 }, include: [{model: Task, as: 'taskz'}] });
+      return User.findOne({ where: { id: 1 }, include: [{model: Task, as: 'taskz'}] });
     }).then(user => {
       expect(user.taskz).to.be.ok;
     });
@@ -96,7 +96,7 @@ describe(Support.getTestDialectTeaser('Alias'), () => {
       expect(user.addAssignment).to.be.ok;
       expect(user.addAssignments).to.be.ok;
     }).then(() => {
-      return User.find({ where: { id: 1 }, include: [Task] });
+      return User.findOne({ where: { id: 1 }, include: [Task] });
     }).then(user => {
       expect(user.assignments).to.be.ok;
     });

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -2193,8 +2193,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
       const User = this.sequelize.define('User', {
           name: Sequelize.STRING(100)
         }),
-        Follow = this.sequelize.define('Follow'),
-        self = this;
+        Follow = this.sequelize.define('Follow');
 
       User.belongsToMany(User, { through: Follow, as: 'User' });
       User.belongsToMany(User, { through: Follow, as: 'Fan' });
@@ -2208,7 +2207,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           ]);
         })
         .then(users => {
-          return Promise.all([
+          return this.sequelize.Promise.all([
             users[0].addFan(users[1]),
             users[1].addUser(users[2]),
             users[2].addFan(users[0])
@@ -2220,8 +2219,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
       const User = this.sequelize.define('User', {
           name: Sequelize.STRING(100)
         }),
-        UserFollowers = this.sequelize.define('UserFollower'),
-        self = this;
+        UserFollowers = this.sequelize.define('UserFollower');
 
       User.belongsToMany(User, {
         as: {
@@ -2242,13 +2240,13 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       return this.sequelize.sync({ force: true })
         .then(() => {
-          return Promise.all([
+          return this.sequelize.Promise.all([
             User.create({ name: 'Jalrangi' }),
             User.create({ name: 'Sargrahi' })
           ]);
         })
         .then(users => {
-          return Promise.all([
+          return this.sequelize.Promise.all([
             users[0].addFollower(users[1]),
             users[1].addFollower(users[0]),
             users[0].addInvitee(users[1]),

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -9,8 +9,9 @@ const chai = require('chai'),
   sinon = require('sinon'),
   Promise = Sequelize.Promise,
   current = Support.sequelize,
-  Op = current.Op,
-  dialect = Support.getTestDialect();
+  Op = Sequelize.Op,
+  dialect = Support.getTestDialect(),
+  errors = require('../../../lib/errors');
 
 describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   describe('getAssociations', () => {
@@ -71,7 +72,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     }
 
     it('gets all associated objects with all fields', function() {
-      return this.User.find({where: {username: 'John'}}).then(john => {
+      return this.User.findOne({where: {username: 'John'}}).then(john => {
         return john.getTasks();
       }).then(tasks => {
         Object.keys(tasks[0].rawAttributes).forEach(attr => {
@@ -81,7 +82,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     it('gets all associated objects when no options are passed', function() {
-      return this.User.find({where: {username: 'John'}}).then(john => {
+      return this.User.findOne({where: {username: 'John'}}).then(john => {
         return john.getTasks();
       }).then(tasks => {
         expect(tasks).to.have.length(2);
@@ -89,7 +90,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     it('only get objects that fulfill the options', function() {
-      return this.User.find({where: {username: 'John'}}).then(john => {
+      return this.User.findOne({where: {username: 'John'}}).then(john => {
         return john.getTasks({
           where: {
             active: true
@@ -101,7 +102,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     it('supports a where not in', function() {
-      return this.User.find({
+      return this.User.findOne({
         where: {
           username: 'John'
         }
@@ -121,7 +122,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     it('supports a where not in on the primary key', function() {
       const self = this;
 
-      return this.User.find({
+      return this.User.findOne({
         where: {
           username: 'John'
         }
@@ -139,7 +140,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     it('only gets objects that fulfill options with a formatted value', function() {
-      return this.User.find({where: {username: 'John'}}).then(john => {
+      return this.User.findOne({where: {username: 'John'}}).then(john => {
         return john.getTasks({where: {active: true}});
       }).then(tasks => {
         expect(tasks).to.have.length(1);
@@ -147,7 +148,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     it('get associated objects with an eager load', function() {
-      return this.User.find({where: {username: 'John'}, include: [this.Task]}).then(john => {
+      return this.User.findOne({where: {username: 'John'}, include: [this.Task]}).then(john => {
         expect(john.Tasks).to.have.length(2);
       });
     });
@@ -161,7 +162,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
       Label.belongsTo(Task);
 
       return Label.sync({force: true}).then(() => {
-        return User.find({
+        return User.findOne({
           where: { username: 'John'},
           include: [
             { model: Task, required: false, include: [
@@ -2076,8 +2077,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           ]);
         }).then(function() {
           return Promise.all([
-            expect(this.user1.destroy()).to.have.been.rejectedWith(self.sequelize.ForeignKeyConstraintError), // Fails because of RESTRICT constraint
-            expect(this.task2.destroy()).to.have.been.rejectedWith(self.sequelize.ForeignKeyConstraintError)
+            expect(this.user1.destroy()).to.have.been.rejectedWith(errors.ForeignKeyConstraintError), // Fails because of RESTRICT constraint
+            expect(this.task2.destroy()).to.have.been.rejectedWith(errors.ForeignKeyConstraintError)
           ]);
         });
       });
@@ -2106,7 +2107,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           );
         }).then(function() {
           return Sequelize.Promise.join(
-            expect(this.user1.destroy()).to.have.been.rejectedWith(self.sequelize.ForeignKeyConstraintError), // Fails because of RESTRICT constraint
+            expect(this.user1.destroy()).to.have.been.rejectedWith(errors.ForeignKeyConstraintError), // Fails because of RESTRICT constraint
             this.task2.destroy()
           );
         }).then(function() {

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -1617,7 +1617,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
             return u.addProject(p);
           }).then(function() {
-            return this.UserProjects.find({ where: { UserId: this.u.id, ProjectId: this.p.id }});
+            return this.UserProjects.findOne({ where: { UserId: this.u.id, ProjectId: this.p.id }});
           }).then(up => {
             expect(up.status).to.equal('active');
           });
@@ -2201,14 +2201,14 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       return this.sequelize.sync({ force: true })
         .then(() => {
-          return self.sequelize.Promise.all([
+          return Promise.all([
             User.create({ name: 'Khsama' }),
             User.create({ name: 'Vivek' }),
             User.create({ name: 'Satya' })
           ]);
         })
         .then(users => {
-          return self.sequelize.Promise.all([
+          return Promise.all([
             users[0].addFan(users[1]),
             users[1].addUser(users[2]),
             users[2].addFan(users[0])
@@ -2242,13 +2242,13 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       return this.sequelize.sync({ force: true })
         .then(() => {
-          return self.sequelize.Promise.all([
+          return Promise.all([
             User.create({ name: 'Jalrangi' }),
             User.create({ name: 'Sargrahi' })
           ]);
         })
         .then(users => {
-          return self.sequelize.Promise.all([
+          return Promise.all([
             users[0].addFollower(users[1]),
             users[1].addFollower(users[0]),
             users[0].addInvitee(users[1]),

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -567,7 +567,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
             // set recipients
             .then(() => mail.setRecipients([1]))
         )
-        .then(() => Entry.findAndCount({
+        .then(() => Entry.findAndCountAll({
           offset: 0,
           limit: 10,
           order: [['id', 'DESC']],

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -230,7 +230,7 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           expect(question).to.be.instanceof(self.Question);
         }).then(() => {
           return Promise.join(
-            self.Post.find({
+            self.Post.findOne({
               include: [self.Comment]
             }),
             self.Image.findOne({

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -64,7 +64,7 @@ describe(Support.getTestDialectTeaser('Self'), () => {
     expect(rawAttributes).to.have.members(['createdAt', 'updatedAt', 'PersonId', 'ChildId']);
 
     return this.sequelize.sync({ force: true }).then(() => {
-      return self.sequelize.Promise.all([
+      return Promise.all([
         Person.create({ name: 'Mary' }),
         Person.create({ name: 'John' }),
         Person.create({ name: 'Chris' })

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -47,8 +47,6 @@ describe(Support.getTestDialectTeaser('Self'), () => {
   });
 
   it('can handle n:m associations', function() {
-    const self = this;
-
     const Person = this.sequelize.define('Person', { name: DataTypes.STRING });
 
     Person.belongsToMany(Person, { as: 'Parents', through: 'Family', foreignKey: 'ChildId', otherKey: 'PersonId' });

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -7,7 +7,7 @@ const chai = require('chai'),
   dialect = Support.getTestDialect(),
   Sequelize = Support.Sequelize,
   fs = require('fs'),
-  path = require('path')
+  path = require('path');
 
 if (dialect === 'sqlite') {
   var sqlite3 = require('sqlite3'); // eslint-disable-line

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -7,7 +7,7 @@ const chai = require('chai'),
   dialect = Support.getTestDialect(),
   Sequelize = Support.Sequelize,
   fs = require('fs'),
-  path = require('path');
+  path = require('path')
 
 if (dialect === 'sqlite') {
   var sqlite3 = require('sqlite3'); // eslint-disable-line
@@ -19,9 +19,9 @@ describe(Support.getTestDialectTeaser('Configuration'), () => {
       const seq = new Sequelize(config[dialect].database, config[dialect].username, config[dialect].password, {storage: '/path/to/no/where/land', logging: false, host: '0.0.0.1', port: config[dialect].port, dialect});
       if (dialect === 'sqlite') {
         // SQLite doesn't have a breakdown of error codes, so we are unable to discern between the different types of errors.
-        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith(seq.ConnectionError, 'SQLITE_CANTOPEN: unable to open database file');
+        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith(Sequelize.ConnectionError, 'SQLITE_CANTOPEN: unable to open database file');
       } else {
-        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith([seq.HostNotReachableError, seq.InvalidConnectionError]);
+        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith([Sequelize.HostNotReachableError, Sequelize.InvalidConnectionError]);
       }
     });
 
@@ -38,7 +38,7 @@ describe(Support.getTestDialectTeaser('Configuration'), () => {
         // SQLite doesn't require authentication and `select 1 as hello` is a valid query, so this should be fulfilled not rejected for it.
         return expect(seq.query('select 1 as hello')).to.eventually.be.fulfilled;
       } else {
-        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith(seq.ConnectionRefusedError, 'connect ECONNREFUSED');
+        return expect(seq.query('select 1 as hello')).to.eventually.be.rejectedWith(Sequelize.ConnectionRefusedError, 'connect ECONNREFUSED');
       }
     });
 

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -349,7 +349,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
           real: -Infinity
         });
       }).then(() => {
-        return Model.find({ where: { id: 1 } });
+        return Model.findOne({ where: { id: 1 } });
       }).then(user => {
         expect(user.get('float')).to.be.NaN;
         expect(user.get('double')).to.eq(Infinity);

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 const dialect = Support.getTestDialect();
+const errors = Support.Sequelize;
 
 if (dialect.match(/^mssql/)) {
   describe('[MSSQL Specific] Query Queue', () => {
@@ -83,22 +84,22 @@ if (dialect.match(/^mssql/)) {
     describe('Errors', () => {
       it('ECONNREFUSED', () => {
         const sequelize = Support.createSequelizeInstance({ host: '127.0.0.1', port: 34237 });
-        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(sequelize.ConnectionRefusedError);
+        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(errors.ConnectionRefusedError);
       });
 
       it('ENOTFOUND', () => {
         const sequelize = Support.createSequelizeInstance({ host: 'http://wowow.example.com' });
-        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(sequelize.HostNotFoundError);
+        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(errors.HostNotFoundError);
       });
 
       it('EHOSTUNREACH', () => {
         const sequelize = Support.createSequelizeInstance({ host: '255.255.255.255' });
-        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(sequelize.HostNotReachableError);
+        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(errors.HostNotReachableError);
       });
 
       it('ER_ACCESS_DENIED_ERROR | ELOGIN', () => {
         const sequelize = new Support.Sequelize('localhost', 'was', 'ddsd', Support.sequelize.options);
-        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(sequelize.AccessDeniedError);
+        return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(errors.AccessDeniedError);
       });
     });
   });

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -97,7 +97,7 @@ if (dialect.match(/^postgres/)) {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })])
           .then(() => {
-            return this.User.find({ where: sequelize.json("emergency_contact->>'name'", 'kate'), attributes: ['username', 'emergency_contact'] });
+            return this.User.findOne({ where: sequelize.json("emergency_contact->>'name'", 'kate'), attributes: ['username', 'emergency_contact'] });
           })
           .then(user => {
             expect(user.emergency_contact.name).to.equal('kate');
@@ -109,7 +109,7 @@ if (dialect.match(/^postgres/)) {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })])
           .then(() => {
-            return this.User.find({
+            return this.User.findOne({
               where: sequelize.json({ emergency_contact: { name: 'kate' } })
             });
           })
@@ -123,7 +123,7 @@ if (dialect.match(/^postgres/)) {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })])
           .then(() => {
-            return this.User.find({ where: sequelize.json('emergency_contact.name', 'joe') });
+            return this.User.findOne({ where: sequelize.json('emergency_contact.name', 'joe') });
           })
           .then(user => {
             expect(user.emergency_contact.name).to.equal('joe');
@@ -135,7 +135,7 @@ if (dialect.match(/^postgres/)) {
           this.User.create({ username: 'swen', emergencyContact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergencyContact: { name: 'joe' } })])
           .then(() => {
-            return this.User.find({
+            return this.User.findOne({
               attributes: [[sequelize.json('emergencyContact.name'), 'contactName']],
               where: sequelize.json('emergencyContact.name', 'joe')
             });
@@ -153,10 +153,10 @@ if (dialect.match(/^postgres/)) {
             expect(user.isNewRecord).to.equal(false);
           })
           .then(() => {
-            return this.User.find({ where: { username: 'swen' } });
+            return this.User.findOne({ where: { username: 'swen' } });
           })
           .then(() => {
-            return this.User.find({ where: sequelize.json('emergency_contact.value', text) });
+            return this.User.findOne({ where: sequelize.json('emergency_contact.value', text) });
           })
           .then(user => {
             expect(user.username).to.equal('swen');
@@ -171,10 +171,10 @@ if (dialect.match(/^postgres/)) {
             expect(!user.isNewRecord).to.equal(true);
           })
           .then(() => {
-            return this.User.find({ where: { username: 'swen' } });
+            return this.User.findOne({ where: { username: 'swen' } });
           })
           .then(() => {
-            return this.User.find({ where: sequelize.json('emergency_contact.value', text) });
+            return this.User.findOne({ where: sequelize.json('emergency_contact.value', text) });
           })
           .then(user => {
             expect(user.username).to.equal('swen');
@@ -538,7 +538,7 @@ if (dialect.match(/^postgres/)) {
 
           return User.create({ aNumber: 2147483647 }).then(user => {
             expect(user.aNumber).to.equal(2147483647);
-            return User.find({ where: { aNumber: 2147483647 } }).then(_user => {
+            return User.findOne({ where: { aNumber: 2147483647 } }).then(_user => {
               expect(_user.aNumber).to.equal(2147483647);
             });
           });
@@ -549,7 +549,7 @@ if (dialect.match(/^postgres/)) {
 
           return User.create({ aNumber: -2147483647 }).then(user => {
             expect(user.aNumber).to.equal(-2147483647);
-            return User.find({ where: { aNumber: -2147483647 } }).then(_user => {
+            return User.findOne({ where: { aNumber: -2147483647 } }).then(_user => {
               expect(_user.aNumber).to.equal(-2147483647);
             });
           });
@@ -570,7 +570,7 @@ if (dialect.match(/^postgres/)) {
 
           return User.create({ aNumber: '9223372036854775807' }).then(user => {
             expect(user.aNumber).to.equal('9223372036854775807');
-            return User.find({ where: { aNumber: '9223372036854775807' } }).then(_user => {
+            return User.findOne({ where: { aNumber: '9223372036854775807' } }).then(_user => {
               expect(_user.aNumber).to.equal('9223372036854775807');
             });
           });
@@ -581,7 +581,7 @@ if (dialect.match(/^postgres/)) {
 
           return User.create({ aNumber: '-9223372036854775807' }).then(user => {
             expect(user.aNumber).to.equal('-9223372036854775807');
-            return User.find({ where: { aNumber: '-9223372036854775807' } }).then(_user => {
+            return User.findOne({ where: { aNumber: '-9223372036854775807' } }).then(_user => {
               expect(_user.aNumber).to.equal('-9223372036854775807');
             });
           });
@@ -693,7 +693,7 @@ if (dialect.match(/^postgres/)) {
 
         return this.User.create(data)
           .then(() => {
-            return this.User.find({ where: { username: 'user' } });
+            return this.User.findOne({ where: { username: 'user' } });
           })
           .then(user => {
             // Check that the hstore fields are the same when retrieving the user
@@ -707,7 +707,7 @@ if (dialect.match(/^postgres/)) {
         return this.User.create(data)
           .then(() => {
             // Check that the hstore fields are the same when retrieving the user
-            return this.User.find({ where: { username: 'user' } });
+            return this.User.findOne({ where: { username: 'user' } });
           }).then(user => {
             expect(user.phones).to.deep.equal(data.phones);
           });
@@ -749,7 +749,7 @@ if (dialect.match(/^postgres/)) {
               });
           })
           .then(() => {
-            return this.User.find({ where: { username: 'user1' }, include: [HstoreSubmodel] });
+            return this.User.findOne({ where: { username: 'user1' }, include: [HstoreSubmodel] });
           })
           .then(user => {
             expect(user.hasOwnProperty('hstoreSubmodels')).to.be.ok;
@@ -892,7 +892,7 @@ if (dialect.match(/^postgres/)) {
 
         return User.create(data)
           .then(() => {
-            return User.find({ where: { username: 'user' } });
+            return User.findOne({ where: { username: 'user' } });
           })
           .then(user => {
             // Check that the range fields are the same when retrieving the user
@@ -915,7 +915,7 @@ if (dialect.match(/^postgres/)) {
         return User.create(data)
           .then(() => {
             // Check that the range fields are the same when retrieving the user
-            return User.find({ where: { username: 'user' } });
+            return User.findOne({ where: { username: 'user' } });
           }).then(user => {
             expect(user.holidays).to.deep.equal(data.holidays);
           });
@@ -968,7 +968,7 @@ if (dialect.match(/^postgres/)) {
               });
           })
           .then(() => {
-            return this.User.find({ where: { username: 'user' }, include: [HolidayDate] });
+            return this.User.findOne({ where: { username: 'user' }, include: [HolidayDate] });
           })
           .then(user => {
             expect(user.hasOwnProperty('holidayDates')).to.be.ok;
@@ -1003,7 +1003,7 @@ if (dialect.match(/^postgres/)) {
       const point = { type: 'Point', coordinates: [39.807222, -76.984722] };
 
       return User.create({ username: 'user', email: ['foo@bar.com'], location: point }).then(user => {
-        return User.find({ where: { username: user.username } });
+        return User.findOne({ where: { username: user.username } });
       }).then(user => {
         expect(user.location).to.deep.eql(point);
       });
@@ -1032,7 +1032,7 @@ if (dialect.match(/^postgres/)) {
               expect(user.fullName).to.equal('John Smith');
 
               // We can query by non-quoted identifiers
-              return this.User.find({
+              return this.User.findOne({
                 where: { fullName: 'John Smith' }
               }).then(user2 => {
                 // We can map values back to non-quoted identifiers

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -624,7 +624,7 @@ if (dialect.match(/^postgres/)) {
           expect(newUser.settings).to.deep.equal({ created: '"value"' });
 
           // Check to see if updating an hstore field works
-          return newUser.updateAttributes({ settings: { should: 'update', to: 'this', first: 'place' } }).then(oldUser => {
+          return newUser.update({ settings: { should: 'update', to: 'this', first: 'place' } }).then(oldUser => {
             // Postgres always returns keys in alphabetical order (ascending)
             expect(oldUser.settings).to.deep.equal({ first: 'place', should: 'update', to: 'this' });
           });
@@ -774,7 +774,7 @@ if (dialect.match(/^postgres/)) {
           expect(newUser.course_period.inclusive).to.deep.equal([true, false]); // inclusive, exclusive
 
           // Check to see if updating a range field works
-          return newUser.updateAttributes({ acceptable_marks: [0.8, 0.9] }).then(() => {
+          return newUser.update({ acceptable_marks: [0.8, 0.9] }).then(() => {
             expect(newUser.acceptable_marks.length).to.equal(2);
             expect(newUser.acceptable_marks[0]).to.equal(0.8); // lower bound
             expect(newUser.acceptable_marks[1]).to.equal(0.9); // upper bound

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -106,13 +106,13 @@ if (dialect === 'sqlite') {
           });
 
           it('finds normal lookups', function() {
-            return this.User.find({ where: { name: 'user' } }).then(user => {
+            return this.User.findOne({ where: { name: 'user' } }).then(user => {
               expect(user.name).to.equal('user');
             });
           });
 
           it.skip('should make aliased attributes available', function() {
-            return this.User.find({ where: { name: 'user' }, attributes: ['id', ['name', 'username']] }).then(user => {
+            return this.User.findOne({ where: { name: 'user' }, attributes: ['id', ['name', 'username']] }).then(user => {
               expect(user.username).to.equal('user');
             });
           });

--- a/test/integration/dialects/sqlite/dao.test.js
+++ b/test/integration/dialects/sqlite/dao.test.js
@@ -81,7 +81,7 @@ if (dialect === 'sqlite') {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })
         ]).then(() => {
-          return this.User.find({
+          return this.User.findOne({
             where: Sequelize.json('json_extract(emergency_contact, \'$.name\')', 'kate'),
             attributes: ['username', 'emergency_contact']
           });
@@ -95,7 +95,7 @@ if (dialect === 'sqlite') {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: ['kate', 'joe'] })
         ]).then(() => {
-          return this.User.find({
+          return this.User.findOne({
             where: Sequelize.json('json_type(emergency_contact)', 'array'),
             attributes: ['username', 'emergency_contact']
           });

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -14,10 +14,6 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       expect(Sequelize).to.have.property('Error');
       expect(Sequelize).to.have.property('ValidationError');
       expect(Sequelize).to.have.property('OptimisticLockError');
-      const sequelize = new Sequelize('mysql://user:pass@example.com:9821/dbname');
-      expect(sequelize).to.have.property('Error');
-      expect(sequelize).to.have.property('ValidationError');
-      expect(sequelize).to.have.property('OptimisticLockError');
     });
 
     it('Sequelize Errors instances should be instances of Error', () => {
@@ -29,10 +25,9 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       ]);
       const optimisticLockError = new Sequelize.OptimisticLockError();
 
-      const sequelize = new Sequelize('mysql://user:pass@example.com:9821/dbname');
-      const instError = new sequelize.Error();
-      const instValidationError = new sequelize.ValidationError();
-      const instOptimisticLockError = new sequelize.OptimisticLockError();
+      const instError = new Sequelize.Error();
+      const instValidationError = new Sequelize.ValidationError();
+      const instOptimisticLockError = new Sequelize.OptimisticLockError();
 
       expect(error).to.be.instanceOf(Sequelize.Error);
       expect(error).to.be.instanceOf(Error);

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -61,7 +61,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           afterHook = true;
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(user => {
+        return this.User.findOne({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('happy');
           expect(beforeHook).to.be.true;
           expect(beforeHook2).to.be.true;
@@ -75,7 +75,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(user => {
+        return this.User.findOne({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
@@ -85,7 +85,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(user => {
+        return this.User.findOne({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
@@ -95,7 +95,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           options.where.username = 'joe';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(user => {
+        return this.User.findOne({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
@@ -105,7 +105,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           user.mood = 'sad';
         });
 
-        return this.User.find({where: {username: 'adam'}}).then(user => {
+        return this.User.findOne({where: {username: 'adam'}}).then(user => {
           expect(user.mood).to.equal('sad');
         });
       });
@@ -117,7 +117,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (err => {
+        return this.User.findOne({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
@@ -127,7 +127,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (err => {
+        return this.User.findOne({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
@@ -137,7 +137,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (err => {
+        return this.User.findOne({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });
@@ -147,7 +147,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           throw new Error('Oops!');
         });
 
-        return this.User.find({where: {username: 'adam'}}).catch (err => {
+        return this.User.findOne({where: {username: 'adam'}}).catch (err => {
           expect(err.message).to.equal('Oops!');
         });
       });

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -418,8 +418,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
-      this.User.hook('beforeCreate', 'sasuke', sasukeHook);
-      this.User.hook('beforeCreate', 'naruto', narutoHook);
+      this.User.addHook('beforeCreate', 'sasuke', sasukeHook);
+      this.User.addHook('beforeCreate', 'naruto', narutoHook);
 
       return this.User.create({ username: 'makunouchi'}).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
@@ -436,8 +436,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
-      this.User.hook('beforeCreate', sasukeHook);
-      this.User.hook('beforeCreate', narutoHook);
+      this.User.addHook('beforeCreate', sasukeHook);
+      this.User.addHook('beforeCreate', narutoHook);
 
       return this.User.create({ username: 'makunouchi'}).then(() => {
         expect(sasukeHook).to.have.been.calledOnce;
@@ -454,8 +454,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       const sasukeHook = sinon.spy(),
         narutoHook = sinon.spy();
 
-      this.User.hook('beforeSave', sasukeHook);
-      this.User.hook('beforeSave', narutoHook);
+      this.User.addHook('beforeSave', sasukeHook);
+      this.User.addHook('beforeSave', narutoHook);
 
       return this.User.create({ username: 'makunouchi'}).then(user => {
         expect(sasukeHook).to.have.been.calledOnce;

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -24,7 +24,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       return this.sequelize.sync({force: true}).then(() => {
         return User.create();
       }).then(() => {
-        return User.find({
+        return User.findOne({
           include: [{model: Company, as: 'Employer'}]
         }).then(user => {
           expect(user).to.be.ok;
@@ -141,7 +141,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         return User.create().then(user => {
           return user.createTask();
         }).then(() => {
-          return User.find({
+          return User.findOne({
             include: [Tasks]
           });
         }).then(user => {
@@ -169,7 +169,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             })
           );
         }).then(() => {
-          return User.find({
+          return User.findOne({
             include: [
               {association: Tasks, where: {title: 'trivial'}}
             ]
@@ -194,7 +194,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           return user.createGroup();
         });
       }).then(() => {
-        return User.find({
+        return User.findOne({
           include: [Groups]
         }).then(user => {
           expect(user).to.be.ok;
@@ -255,7 +255,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           include: [User, Group]
         });
       }).then(task => {
-        return Task.find({
+        return Task.findOne({
           where: {
             id: task.id
           },
@@ -325,7 +325,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           include: [Task]
         });
       }).then(user => {
-        return User.find({
+        return User.findOne({
           where: {
             id: user.id
           },
@@ -422,7 +422,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           products[2].setTags([tags[0], tags[1], tags[2]])
         ]);
       }).then(() => {
-        return User.find({
+        return User.findOne({
           where: {
             id: 1
           },
@@ -527,7 +527,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           product1.setCategory(tags[1])
         ]);
       }).then(() => {
-        return User.find({
+        return User.findOne({
           where: {id: 1},
           include: [
             {model: GroupMember, as: 'Memberships', include: [
@@ -693,7 +693,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         this.user = user;
         return user.addGroup(group);
       }).then(function() {
-        return User.find({
+        return User.findOne({
           where: {
             id: this.user.id
           },

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -80,7 +80,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
 
       return this.sequelize.sync({force: true}).then(() => {
         return Company.create().then(() => {
-          return Company.find({
+          return Company.findOne({
             include: [{model: Person, as: 'CEO'}]
           }).then(company => {
             expect(company).to.be.ok;
@@ -97,7 +97,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       return this.sequelize.sync({force: true}).then(() => {
         return Company.create();
       }).then(() => {
-        return Company.find({
+        return Company.findOne({
           include: [CEO]
         });
       }).then(user => {
@@ -121,7 +121,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           return person.setEmployer(company);
         });
       }).then(() => {
-        return Person.find({
+        return Person.findOne({
           include: [Person.relation.Employer]
         }).then(person => {
           expect(person).to.be.ok;
@@ -287,7 +287,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           include: [Task, Group]
         });
       }).then(user => {
-        return Group.find({
+        return Group.findOne({
           where: {
             id: user.Group.id
           },
@@ -362,7 +362,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           include: [Worker, Task]
         });
       }).then(project => {
-        return Worker.find({
+        return Worker.findOne({
           where: {
             id: project.Workers[0].id
           },
@@ -662,7 +662,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         this.groups = groups;
         return groups[0].setOutsourcingCompanies(groups.slice(1));
       }).then(function() {
-        return Group.find({
+        return Group.findOne({
           where: {
             id: this.groups[0].id
           },

--- a/test/integration/include/find.test.js
+++ b/test/integration/include/find.test.js
@@ -85,7 +85,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           {userId: user.get('id'), deletedAt: new Date()}
         ]);
       }).then(() => {
-        return User.find({
+        return User.findOne({
           include: [
             {model: Task, where: {deletedAt: null}, required: false}
           ]
@@ -122,7 +122,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           {userId: user.get('id'), searchString: 'two'}
         ]);
       }).then(() => {
-        return User.find({
+        return User.findOne({
           include: [
             {model: Task, where: {searchString: 'one'} }
           ]
@@ -255,7 +255,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         return User.create({ username: 'bob' }).then(newUser => {
           return Task.create({ title: 'some task' }).then(newTask => {
             return newTask.setUser(newUser).then(() => {
-              return Task.find({
+              return Task.findOne({
                 where: { title: 'some task' },
                 include: [{ model: User }]
               })
@@ -370,7 +370,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       Post.belongsTo(User, { foreignKey: 'owner_id', as: 'Owner', constraints: false });
 
       return this.sequelize.sync({force: true}).then(() => {
-        return User.find({
+        return User.findOne({
           where: { id: 2 },
           include: [
             { model: Post, as: 'UserPosts', where: {'private': true} }

--- a/test/integration/include/find.test.js
+++ b/test/integration/include/find.test.js
@@ -53,7 +53,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       Model4.belongsTo(Model2);
 
       return this.sequelize.sync({force: true}).bind(this).then(() => {
-        return Model.find({
+        return Model.findOne({
           include: [
             {model: Model2, include: [
               {model: Model4, where: {something: 2}}

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -1417,7 +1417,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           return parent;
         });
       }).then(parent => {
-        return Child1.find({
+        return Child1.findOne({
           include: [
             {
               model: Parent,

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -919,7 +919,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         return Street.create({ active: true }).then(street => {
           return Address.create({ active: true, streetId: street.id }).then(address => {
             return User.create({ username: 'John', addressId: address.id }).then(() => {
-              return User.find({
+              return User.findOne({
                 where: { username: 'John'},
                 include: [{
                   model: Address,

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -129,8 +129,8 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
               b: self.sequelize.col('always_false')
             });
 
-            expect(user.get('d')).to.be.instanceof(self.sequelize.Utils.Fn);
-            expect(user.get('b')).to.be.instanceof(self.sequelize.Utils.Col);
+            expect(user.get('d')).to.be.instanceof(Sequelize.Utils.Fn);
+            expect(user.get('b')).to.be.instanceof(Sequelize.Utils.Col);
 
             return user.save().then(() => {
               return user.reload().then(() => {

--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -79,7 +79,7 @@ describe('model', () => {
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
           .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
-            return this.User.find({ where: { username: 'swen' }, attributes: ['emergency_contact'] });
+            return this.User.findOne({ where: { username: 'swen' }, attributes: ['emergency_contact'] });
           })
           .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
@@ -92,7 +92,7 @@ describe('model', () => {
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
           .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
-            return this.User.find({
+            return this.User.findOne({
               where: { username: 'swen' },
               attributes: [[Sequelize.json('emergency_contact.phones[1]'), 'firstEmergencyNumber']]
             });
@@ -108,7 +108,7 @@ describe('model', () => {
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
           .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
-            return this.User.find({
+            return this.User.findOne({
               where: { username: 'swen' },
               attributes: [[Sequelize.json('emergency_contact.kate'), 'katesNumber']]
             });
@@ -124,14 +124,14 @@ describe('model', () => {
         return this.User.create({ username: 'swen', emergency_contact: emergencyContact })
           .then(user => {
             expect(user.emergency_contact).to.eql(emergencyContact);
-            return this.User.find({
+            return this.User.findOne({
               where: { username: 'swen' },
               attributes: [[Sequelize.json('emergency_contact.kate.email'), 'katesEmail']]
             });
           }).then(user => {
             expect(user.getDataValue('katesEmail')).to.equal('kate@kate.com');
           }).then(() => {
-            return this.User.find({
+            return this.User.findOne({
               where: { username: 'swen' },
               attributes: [[Sequelize.json('emergency_contact.kate.phones[1]'), 'katesFirstPhone']]
             });
@@ -145,7 +145,7 @@ describe('model', () => {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })
         ]).then(() => {
-          return this.User.find({
+          return this.User.findOne({
             where: Sequelize.json('emergency_contact.name', 'kate'),
             attributes: ['username', 'emergency_contact']
           });
@@ -159,7 +159,7 @@ describe('model', () => {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })
         ]).then(() => {
-          return this.User.find({
+          return this.User.findOne({
             where: Sequelize.json({ emergency_contact: { name: 'kate' } })
           });
         }).then(user => {
@@ -172,7 +172,7 @@ describe('model', () => {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })
         ]).then(() => {
-          return this.User.find({ where: Sequelize.json('emergency_contact.name', 'joe') });
+          return this.User.findOne({ where: Sequelize.json('emergency_contact.name', 'joe') });
         }).then(user => {
           expect(user.emergency_contact.name).to.equal('joe');
         });
@@ -183,7 +183,7 @@ describe('model', () => {
           this.User.create({ username: 'swen', emergencyContact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergencyContact: { name: 'joe' } })
         ]).then(() => {
-          return this.User.find({
+          return this.User.findOne({
             attributes: [[Sequelize.json('emergencyContact.name'), 'contactName']],
             where: Sequelize.json('emergencyContact.name', 'joe')
           });
@@ -197,11 +197,11 @@ describe('model', () => {
           this.User.create({ username: 'swen', emergency_contact: ['kate', 'joe'] }),
           this.User.create({ username: 'anna', emergency_contact: [{ name: 'joe' }] })
         ]).then(() => {
-          return this.User.find({ where: Sequelize.json('emergency_contact.0', 'kate') });
+          return this.User.findOne({ where: Sequelize.json('emergency_contact.0', 'kate') });
         }).then(user => {
           expect(user.username).to.equal('swen');
         }).then(() => {
-          return this.User.find({ where: Sequelize.json('emergency_contact[0].name', 'joe') });
+          return this.User.findOne({ where: Sequelize.json('emergency_contact[0].name', 'joe') });
         }).then(user => {
           expect(user.username).to.equal('anna');
         });
@@ -216,9 +216,9 @@ describe('model', () => {
         }).then(user => {
           expect(user.isNewRecord).to.equal(false);
         }).then(() => {
-          return this.User.find({ where: { username: 'swen' } });
+          return this.User.findOne({ where: { username: 'swen' } });
         }).then(() => {
-          return this.User.find({ where: Sequelize.json('emergency_contact.value', text) });
+          return this.User.findOne({ where: Sequelize.json('emergency_contact.value', text) });
         }).then(user => {
           expect(user.username).to.equal('swen');
         });
@@ -233,9 +233,9 @@ describe('model', () => {
         }).then(user => {
           expect(!user.isNewRecord).to.equal(true);
         }).then(() => {
-          return this.User.find({ where: { username: 'swen' } });
+          return this.User.findOne({ where: { username: 'swen' } });
         }).then(() => {
-          return this.User.find({ where: Sequelize.json('emergency_contact.value', text) });
+          return this.User.findOne({ where: Sequelize.json('emergency_contact.value', text) });
         }).then(user => {
           expect(user.username).to.equal('swen');
         });
@@ -248,7 +248,7 @@ describe('model', () => {
             username: 'swen123',
             emergency_contact: 'Unknown'
           }).then(() => {
-            return this.User.find({where: {
+            return this.User.findOne({where: {
               emergency_contact: 'Unknown'
             }});
           }).then(user => {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1508,7 +1508,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           })
           .then(() => { return User.findById(1); })
           .then(user => { return user.destroy(); })
-          .then(() => { return User.find({ where: 1, paranoid: false }); })
+          .then(() => { return User.findOne({ where: 1, paranoid: false }); })
           .then(user => {
             expect(user).to.exist;
             return User.findById(1);
@@ -1551,8 +1551,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         .then(pet => { return pet.destroy(); })
         .then(() => {
           return [
-            User.find({ where: {id: user.id}, include: Pet }),
-            User.find({
+            User.findOne({ where: {id: user.id}, include: Pet }),
+            User.findOne({
               where: {id: user.id},
               include: [{ model: Pet, paranoid: false }]
             })
@@ -1580,13 +1580,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           {username: 'Tony'}
         ]);
       }).then(() => {
-        return User.find({where: {username: 'Bob'}});
+        return User.findOne({where: {username: 'Bob'}});
       }).then(user => {
         return user.destroy({force: true});
       }).then(() => {
-        return expect(User.find({where: {username: 'Bob'}})).to.eventually.be.null;
+        return expect(User.findOne({where: {username: 'Bob'}})).to.eventually.be.null;
       }).then(() => {
-        return User.find({where: {username: 'Tobi'}});
+        return User.findOne({where: {username: 'Tobi'}});
       }).then(tobi => {
         return tobi.destroy();
       }).then(() => {
@@ -1710,7 +1710,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       }).then(() => {
         return ParanoidUser.restore({where: {secretValue: '42'}});
       }).then(() => {
-        return ParanoidUser.find({where: {secretValue: '42'}});
+        return ParanoidUser.findOne({where: {secretValue: '42'}});
       }).then(user => {
         expect(user).to.be.ok;
         expect(user.username).to.equal('Peter');

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -319,7 +319,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
       return User.sync({ force: true }).bind(this).then(() => {
-        return self.sequelize.Promise.all([
+        return Promise.all([
           User.create({username: 'tobi', email: 'tobi@tobi.me'}),
           User.create({username: 'tobi', email: 'tobi@tobi.me'})]);
       }).catch (self.sequelize.UniqueConstraintError, err => {
@@ -352,7 +352,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           user_id: { type: Sequelize.INTEGER, unique: { name: 'user_and_email_index', msg: 'User and email must be unique' }},
           email: { type: Sequelize.STRING, unique: 'user_and_email_index'}
         });
-        return self.sequelize.Promise.all([
+        return Promise.all([
           User.create({user_id: 1, email: 'tobi@tobi.me'}),
           User.create({user_id: 1, email: 'tobi@tobi.me'})]);
       }).catch (self.sequelize.UniqueConstraintError, err => {
@@ -734,7 +734,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
   });
 
-  describe('findOrInitialize', () => {
+  describe('findOrBuild', () => {
 
     if (current.dialect.supports.transactions) {
       it('supports transactions', function() {
@@ -744,14 +744,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return User.sync({ force: true }).then(() => {
             return sequelize.transaction().then(t => {
               return User.create({ username: 'foo' }, { transaction: t }).then(() => {
-                return User.findOrInitialize({
+                return User.findOrBuild({
                   where: {username: 'foo'}
                 }).spread(user1 => {
-                  return User.findOrInitialize({
+                  return User.findOrBuild({
                     where: {username: 'foo'},
                     transaction: t
                   }).spread(user2 => {
-                    return User.findOrInitialize({
+                    return User.findOrBuild({
                       where: {username: 'foo'},
                       defaults: { foo: 'asd' },
                       transaction: t
@@ -775,7 +775,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const self = this;
 
         return this.User.create({ username: 'Username' }).then(user => {
-          return self.User.findOrInitialize({
+          return self.User.findOrBuild({
             where: { username: user.username }
           }).spread((_user, initialized) => {
             expect(_user.id).to.equal(user.id);
@@ -789,7 +789,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         const self = this;
 
         return this.User.create({ username: 'Username', data: 'data' }).then(user => {
-          return self.User.findOrInitialize({ where: {
+          return self.User.findOrBuild({ where: {
             username: user.username,
             data: user.data
           }}).spread((_user, initialized) => {
@@ -809,7 +809,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             data: 'ThisIsData'
           };
 
-        return this.User.findOrInitialize({
+        return this.User.findOrBuild({
           where: data,
           defaults: default_values
         }).spread((user, initialized) => {
@@ -872,7 +872,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       let test = false;
       return User.sync({ force: true }).then(() => {
         return User.create({username: 'Peter', secretValue: '42'}).then(user => {
-          return user.updateAttributes({ secretValue: '43' }, {
+          return user.update({ secretValue: '43' }, {
             fields: ['secretValue'], logging(sql) {
               test = true;
               if (dialect === 'mssql') {
@@ -899,7 +899,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       return User.sync({ force: true }).then(() => {
         return User.create({ name: 'meg', bio: 'none' }).then(u => {
           expect(u).to.exist;
-          return u.updateAttributes({name: 'brian'}, {
+          return u.update({name: 'brian'}, {
             logging(sql) {
               test = true;
               expect(sql).to.exist;
@@ -2380,7 +2380,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               }
             }
           }).then(UserSpecial => {
-            return UserSpecial.updateAttributes({age: 5}, {
+            return UserSpecial.update({age: 5}, {
               logging(user) {
                 logged++;
                 if (dialect === 'postgres') {
@@ -2746,7 +2746,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           for (let i = 0; i < 1000; i++) {
             tasks.push(testAsync.bind(this));
           }
-          return self.sequelize.Promise.resolve(tasks).map(entry => {
+          return Promise.resolve(tasks).map(entry => {
             return entry();
           }, {
             // Needs to be one less than ??? else the non transaction query won't ever get a connection

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -2708,7 +2708,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   if (dialect !== 'sqlite' && current.dialect.supports.transactions) {
     it('supports multiple async transactions', function() {
       this.timeout(90000);
-      const self = this;
       return Support.prepareTransactionTest(this.sequelize).bind({}).then(sequelize => {
         const User = sequelize.define('User', { username: Sequelize.STRING });
         const testAsync = function() {

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -54,7 +54,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return student.addCourse(course, { through: {score: 98, test_value: 1000}});
           }).then(() => {
             expect(self.callCount).to.equal(1);
-            return self.Score.find({ where: { StudentId: 1, CourseId: 100 } }).then(score => {
+            return self.Score.findOne({ where: { StudentId: 1, CourseId: 100 } }).then(score => {
               expect(score.test_value).to.equal(1001);
             });
           })

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -286,7 +286,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.User.create({
           name: 'Foobar'
         }).then(() => {
-          return self.User.find({
+          return self.User.findOne({
             limit: 1
           });
         }).then(user => {
@@ -295,7 +295,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             name: 'Barfoo'
           });
         }).then(() => {
-          return self.User.find({
+          return self.User.findOne({
             limit: 1
           });
         }).then(user => {
@@ -379,7 +379,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             text: 'Comment'
           });
         }).then(() => {
-          return self.Task.find({
+          return self.Task.findOne({
             include: [
               {model: self.Comment},
               {model: self.User}
@@ -435,7 +435,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.User.create({
           name: 'Foobar'
         }).then(() => {
-          return self.User.find({
+          return self.User.findOne({
             where: {
               name: 'Foobar'
             }
@@ -451,7 +451,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.User.create({
           name: 'Foobar'
         }).then(() => {
-          return self.User.find({
+          return self.User.findOne({
             where: self.sequelize.or({
               name: 'Foobar'
             }, {
@@ -523,7 +523,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should find the value of an attribute with a custom field name', function() {
         return this.User.create({ name: 'test user' })
           .then(() => {
-            return this.User.find({ where: { name: 'test user' } });
+            return this.User.findOne({ where: { name: 'test user' } });
           })
           .then(user => {
             expect(user.name).to.equal('test user');

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -291,7 +291,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         }).then(user => {
           expect(user.get('name')).to.equal('Foobar');
-          return user.updateAttributes({
+          return user.update({
             name: 'Barfoo'
           });
         }).then(() => {
@@ -536,16 +536,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.Comment.create({
           notes: 'Foobar'
         }).then(() => {
-          return self.Comment.find({
+          return self.Comment.findOne({
             limit: 1
           });
         }).then(comment => {
           expect(comment.get('notes')).to.equal('Foobar');
-          return comment.updateAttributes({
+          return comment.update({
             notes: 'Barfoo'
           });
         }).then(() => {
-          return self.Comment.find({
+          return self.Comment.findOne({
             limit: 1
           });
         }).then(comment => {

--- a/test/integration/model/attributes/operators.test.js
+++ b/test/integration/model/attributes/operators.test.js
@@ -55,7 +55,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return this.User.create({
               name: 'Foobar'
             }).then(() => {
-              return self.User.find({
+              return self.User.findOne({
                 where: {
                   name: {
                     [Op.regexp]: '^Foo'
@@ -73,7 +73,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return this.User.create({
               name: 'Foobar'
             }).then(() => {
-              return self.User.find({
+              return self.User.findOne({
                 where: {
                   name: {
                     [Op.notRegexp]: '^Foo'
@@ -92,7 +92,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return this.User.create({
                 name: 'Foobar'
               }).then(() => {
-                return self.User.find({
+                return self.User.findOne({
                   where: {
                     name: {
                       [Op.iRegexp]: '^foo'
@@ -110,7 +110,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               return this.User.create({
                 name: 'Foobar'
               }).then(() => {
-                return self.User.find({
+                return self.User.findOne({
                   where: {
                     name: {
                       [Op.notIRegexp]: '^foo'

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -105,7 +105,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               boolQuery = 'CAST(CASE WHEN EXISTS(SELECT 1) THEN 1 ELSE 0 END AS BIT) AS "someBoolean"';
             }
 
-            return Post.find({ attributes: ['id', 'text', Sequelize.literal(boolQuery)] });
+            return Post.findOne({ attributes: ['id', 'text', Sequelize.literal(boolQuery)] });
           }).then(post => {
             expect(post.get('someBoolean')).to.be.ok;
             expect(post.get().someBoolean).to.be.ok;
@@ -120,7 +120,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
             expect(user.virtualWithDefault).to.equal('cake');
             expect(user.storage).to.equal('something');
-            return user.updateAttributes({
+            return user.update({
               field1: 'something else'
             }, {
               fields: ['storage']

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -561,7 +561,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return Item.sync({ force: true }).then(() => {
           return Item.bulkCreate([{state: 'in_cart', name: 'A'}, { state: 'available', name: 'B'}]).then(() => {
-            return Item.find({ where: { state: 'available' }}).then(item => {
+            return Item.findOne({ where: { state: 'available' }}).then(item => {
               expect(item.name).to.equal('B');
             });
           });

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1331,7 +1331,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return Item.sync({ force: true }).then(() => {
           return Item.create({ state: 'available' }).then(_item => {
-            return Item.find({ where: { state: 'available' }}).then(item => {
+            return Item.findOne({ where: { state: 'available' }}).then(item => {
               expect(item.id).to.equal(_item.id);
             });
           });

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1209,7 +1209,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.User.create({ data: quote }).then(user => {
         expect(user.data).to.equal(quote);
-        return self.User.find({where: { id: user.id }}).then(user => {
+        return self.User.findOne({where: { id: user.id }}).then(user => {
           expect(user.data).to.equal(quote);
         });
       });
@@ -1221,7 +1221,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.User.create({ data: quote }).then(user => {
         expect(user.data).to.equal(quote);
-        return self.User.find({where: { id: user.id }}).then(user => {
+        return self.User.findOne({where: { id: user.id }}).then(user => {
           expect(user.data).to.equal(quote);
         });
       });
@@ -1233,7 +1233,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return this.User.create({ data: json }).then(user => {
         expect(user.data).to.equal(json);
-        return self.User.find({where: { id: user.id }}).then(user => {
+        return self.User.findOne({where: { id: user.id }}).then(user => {
           expect(user.data).to.equal(json);
         });
       });

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -137,7 +137,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(savedProduct.Tags[0].createOptions.parentRecord).to.be.equal(savedProduct);
             expect(savedProduct.Tags[1].createOptions.myOption).to.be.equal('option');
             expect(savedProduct.Tags[1].createOptions.parentRecord).to.be.equal(savedProduct);
-            return Product.find({
+            return Product.findOne({
               where: { id: savedProduct.id },
               include: [Tag]
             }).then(persistedProduct => {
@@ -169,7 +169,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }, {
             include: [Categories]
           }).then(savedProduct => {
-            return Product.find({
+            return Product.findOne({
               where: { id: savedProduct.id },
               include: [Categories]
             }).then(persistedProduct => {

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -200,7 +200,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }, {
             include: [Task]
           }).then(savedUser => {
-            return User.find({
+            return User.findOne({
               where: { id: savedUser.id },
               include: [Task]
             }).then(persistedUser => {
@@ -231,7 +231,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }, {
             include: [Job]
           }).then(savedUser => {
-            return User.find({
+            return User.findOne({
               where: { id: savedUser.id },
               include: [Job]
             }).then(persistedUser => {
@@ -287,7 +287,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(savedUser.Tasks[0].createOptions.parentRecord).to.be.equal(savedUser);
             expect(savedUser.Tasks[1].createOptions.myOption).to.be.equal('option');
             expect(savedUser.Tasks[1].createOptions.parentRecord).to.be.equal(savedUser);
-            return User.find({
+            return User.findOne({
               where: { id: savedUser.id },
               include: [Task]
             }).then(persistedUser => {
@@ -421,7 +421,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }, {
             include: [Jobs]
           }).then(savedUser => {
-            return User.find({
+            return User.findOne({
               where: { id: savedUser.id },
               include: [Jobs]
             }).then(persistedUser => {

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -257,7 +257,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         let count = 0;
 
         return this.User.bulkCreate([{username: 'jack'}, {username: 'jack'}]).then(() => {
-          return self.sequelize.Promise.map(permutations, perm => {
+          return Promise.map(permutations, perm => {
             return self.User.findById(perm, {
               logging(s) {
                 expect(s.indexOf(0)).not.to.equal(-1);

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -951,7 +951,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('throws error when record not found by find', function() {
-        return expect(this.User.find({
+        return expect(this.User.findOne({
           where: {
             username: 'some-username-that-is-not-used-anywhere'
           },

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -11,7 +11,8 @@ const chai = require('chai'),
   config = require(__dirname + '/../../config/config'),
   _ = require('lodash'),
   moment = require('moment'),
-  current = Support.sequelize;
+  current = Support.sequelize,
+  Promise = Sequelize.Promise;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   beforeEach(function() {
@@ -915,7 +916,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Person.belongsTo(self.Country, { as: 'CountryResident', foreignKey: 'CountryResidentId' });
 
           return this.sequelize.sync({ force: true }).then(() => {
-            return self.sequelize.Promise.props({
+            return Promise.props({
               europe: self.Continent.create({ name: 'Europe' }),
               england: self.Country.create({ name: 'England' }),
               coal: self.Industry.create({ name: 'Coal' }),
@@ -924,7 +925,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               _.forEach(r, (item, itemName) => {
                 self[itemName] = item;
               });
-              return self.sequelize.Promise.all([
+              return Promise.all([
                 self.england.setContinent(self.europe),
                 self.england.addIndustry(self.coal),
                 self.bob.setCountry(self.england),
@@ -1102,7 +1103,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Person.belongsTo(self.Country, { as: 'CountryResident', foreignKey: 'CountryResidentId' });
 
           return this.sequelize.sync({ force: true }).then(() => {
-            return self.sequelize.Promise.props({
+            return Promise.props({
               europe: self.Continent.create({ name: 'Europe' }),
               asia: self.Continent.create({ name: 'Asia' }),
               england: self.Country.create({ name: 'England' }),
@@ -1117,7 +1118,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 self[itemName] = item;
               });
 
-              return self.sequelize.Promise.all([
+              return Promise.all([
                 self.england.setContinent(self.europe),
                 self.france.setContinent(self.europe),
                 self.korea.setContinent(self.asia),
@@ -1269,7 +1270,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           self.Industry.belongsToMany(self.Country, {through: self.IndustryCountry});
 
           return this.sequelize.sync({ force: true }).then(() => {
-            return self.sequelize.Promise.props({
+            return Promise.props({
               england: self.Country.create({ name: 'England' }),
               france: self.Country.create({ name: 'France' }),
               korea: self.Country.create({ name: 'Korea' }),
@@ -1281,7 +1282,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 self[itemName] = item;
               });
 
-              return self.sequelize.Promise.all([
+              return Promise.all([
                 self.england.addIndustry(self.energy, { through: { numYears: 20 }}),
                 self.england.addIndustry(self.media, { through: { numYears: 40 }}),
                 self.france.addIndustry(self.media, { through: { numYears: 80 }}),

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -382,7 +382,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should be able to find a row using greater than or equal to', function() {
-        return this.User.find({
+        return this.User.findOne({
           where: {
             intVal: {
               [Op.gte]: 6
@@ -395,7 +395,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should be able to find a row using greater than', function() {
-        return this.User.find({
+        return this.User.findOne({
           where: {
             intVal: {
               [Op.gt]: 5
@@ -408,7 +408,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should be able to find a row using lesser than or equal to', function() {
-        return this.User.find({
+        return this.User.findOne({
           where: {
             intVal: {
               [Op.lte]: 5
@@ -421,7 +421,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should be able to find a row using lesser than', function() {
-        return this.User.find({
+        return this.User.findOne({
           where: {
             intVal: {
               [Op.lt]: 6
@@ -448,7 +448,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should be able to find a row using not equal to logic', function() {
-        return this.User.find({
+        return this.User.findOne({
           where: {
             intVal: {
               [Op.ne]: 10

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -7,7 +7,7 @@ const chai = require('chai'),
   Sequelize = Support.Sequelize,
   DataTypes = require(__dirname + '/../../../../lib/data-types'),
   current = Support.sequelize,
-  Promise = current.Promise,
+  Promise = require('bluebird'),
   _ = require('lodash');
 
 if (current.dialect.supports['UNION ALL']) {

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -5,8 +5,8 @@ const chai = require('chai'),
   Support = require(__dirname + '/../support'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
   current = Support.sequelize,
-  Op = current.Op,
-  Promise   = current.Promise;
+  Op = Support.Sequelize.Op,
+  Promise = require('bluebird');
 
 const SCHEMA_ONE = 'schema_one';
 const SCHEMA_TWO = 'schema_two';

--- a/test/integration/model/scope/findAndCount.test.js
+++ b/test/integration/model/scope/findAndCount.test.js
@@ -9,7 +9,7 @@ const chai = require('chai'),
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('scope', () => {
 
-    describe('findAndCount', () => {
+    describe('findAndCountAll', () => {
 
       beforeEach(function() {
         this.ScopeMe = this.sequelize.define('ScopeMe', {
@@ -52,14 +52,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should apply defaultScope', function() {
-        return this.ScopeMe.findAndCount().then(result => {
+        return this.ScopeMe.findAndCountAll().then(result => {
           expect(result.count).to.equal(2);
           expect(result.rows.length).to.equal(2);
         });
       });
 
       it('should be able to override default scope', function() {
-        return this.ScopeMe.findAndCount({ where: { access_level: { [Op.gt]: 5 }}})
+        return this.ScopeMe.findAndCountAll({ where: { access_level: { [Op.gt]: 5 }}})
           .then(result => {
             expect(result.count).to.equal(1);
             expect(result.rows.length).to.equal(1);
@@ -67,7 +67,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should be able to unscope', function() {
-        return this.ScopeMe.unscoped().findAndCount({ limit: 1 })
+        return this.ScopeMe.unscoped().findAndCountAll({ limit: 1 })
           .then(result => {
             expect(result.count).to.equal(4);
             expect(result.rows.length).to.equal(1);
@@ -75,7 +75,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should be able to apply other scopes', function() {
-        return this.ScopeMe.scope('lowAccess').findAndCount()
+        return this.ScopeMe.scope('lowAccess').findAndCountAll()
           .then(result => {
             expect(result.count).to.equal(3);
           });
@@ -83,13 +83,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('should be able to merge scopes with where', function() {
         return this.ScopeMe.scope('lowAccess')
-          .findAndCount({ where: { username: 'dan'}}).then(result => {
+          .findAndCountAll({ where: { username: 'dan'}}).then(result => {
             expect(result.count).to.equal(1);
           });
       });
 
       it('should ignore the order option if it is found within the scope', function() {
-        return this.ScopeMe.scope('withOrder').findAndCount()
+        return this.ScopeMe.scope('withOrder').findAndCountAll()
           .then(result => {
             expect(result.count).to.equal(4);
           });

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -8,7 +8,8 @@ const chai = require('chai'),
   Support = require(__dirname + '/../support'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
   dialect = Support.getTestDialect(),
-  current = Support.sequelize;
+  current = Support.sequelize,
+  errors = require('../../../lib/errors');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   before(function() {
@@ -102,7 +103,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(created).not.to.be.ok;
           }
 
-          return this.User.find({ where: { foo: 'baz', bar: 19 }});
+          return this.User.findOne({ where: { foo: 'baz', bar: 19 }});
         }).then(user => {
           expect(user.createdAt).to.be.ok;
           expect(user.username).to.equal('doe');
@@ -168,13 +169,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(created).not.to.be.ok;
           }
 
-          return User.find({ where: { a: 'a', b: 'b' }});
+          return User.findOne({ where: { a: 'a', b: 'b' }});
         }).then(user1 => {
           expect(user1.createdAt).to.be.ok;
           expect(user1.username).to.equal('doe');
           expect(user1.updatedAt).to.be.afterTime(user1.createdAt);
 
-          return User.find({ where: { a: 'a', b: 'a' }});
+          return User.findOne({ where: { a: 'a', b: 'a' }});
         }).then(user2 => {
           // The second one should not be updated
           expect(user2.createdAt).to.be.ok;
@@ -193,7 +194,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           }
         });
 
-        return expect(User.upsert({ email: 'notanemail' })).to.eventually.be.rejectedWith(this.sequelize.ValidationError);
+        return expect(User.upsert({ email: 'notanemail' })).to.eventually.be.rejectedWith(errors.ValidationError);
       });
 
       it('supports skipping validations', function() {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -14,7 +14,8 @@ const chai = require('chai'),
   Utils = require(__dirname + '/../../lib/utils'),
   sinon = require('sinon'),
   semver = require('semver'),
-  current = Support.sequelize;
+  current = Support.sequelize,
+  literal = Sequelize.literal;
 
 
 const qq = function(str) {
@@ -1311,7 +1312,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
               self = this;
 
             const count = function(transaction) {
-              const sql = self.sequelizeWithTransaction.getQueryInterface().QueryGenerator.selectQuery('TransactionTests', { attributes: [['count(*)', 'cnt']] });
+              const sql = self.sequelizeWithTransaction.getQueryInterface().QueryGenerator.selectQuery('TransactionTests', { attributes: [[literal('count(*)'), 'cnt']] });
 
               return self.sequelizeWithTransaction.query(sql, { plain: true, transaction }).then(result => {
                 return result.cnt;
@@ -1339,7 +1340,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
               self = this;
 
             const count = function(transaction) {
-              const sql = self.sequelizeWithTransaction.getQueryInterface().QueryGenerator.selectQuery('TransactionTests', { attributes: [['count(*)', 'cnt']] });
+              const sql = self.sequelizeWithTransaction.getQueryInterface().QueryGenerator.selectQuery('TransactionTests', { attributes: [[literal('count(*)'), 'cnt']] });
 
               return self.sequelizeWithTransaction.query(sql, { plain: true, transaction }).then(result => {
                 return parseInt(result.cnt, 10);

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -487,7 +487,7 @@ if (current.dialect.supports.transactions) {
             return User.create({ username: 'jan'});
           }).then(() => {
             return self.sequelize.transaction().then(t1 => {
-              return User.find({
+              return User.findOne({
                 where: {
                   username: 'jan'
                 },
@@ -498,7 +498,7 @@ if (current.dialect.supports.transactions) {
                   isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED
                 }).then(t2 => {
                   return Promise.join(
-                    User.find({
+                    User.findOne({
                       where: {
                         username: 'jan'
                       },
@@ -548,7 +548,7 @@ if (current.dialect.supports.transactions) {
 
                   if (current.dialect.supports.lockOuterJoinFailure) {
 
-                    return expect(User.find({
+                    return expect(User.findOne({
                       where: {
                         username: 'John'
                       },
@@ -559,7 +559,7 @@ if (current.dialect.supports.transactions) {
 
                   } else {
 
-                    return User.find({
+                    return User.findOne({
                       where: {
                         username: 'John'
                       },
@@ -592,7 +592,7 @@ if (current.dialect.supports.transactions) {
                 })
                 .then(() => {
                   return self.sequelize.transaction(t1 => {
-                    return User.find({
+                    return User.findOne({
                       where: {
                         username: 'John'
                       },
@@ -639,7 +639,7 @@ if (current.dialect.supports.transactions) {
               return User.create({ username: 'jan'});
             }).then(() => {
               return self.sequelize.transaction().then(t1 => {
-                return User.find({
+                return User.findOne({
                   where: {
                     username: 'jan'
                   },
@@ -648,7 +648,7 @@ if (current.dialect.supports.transactions) {
                 }).then(t1Jan => {
                   return self.sequelize.transaction().then(t2 => {
                     return Promise.join(
-                      User.find({
+                      User.findOne({
                         where: {
                           username: 'jan'
                         },
@@ -691,7 +691,7 @@ if (current.dialect.supports.transactions) {
             return User.create({ username: 'jan'});
           }).then(() => {
             return self.sequelize.transaction().then(t1 => {
-              return User.find({
+              return User.findOne({
                 where: {
                   username: 'jan'
                 },
@@ -702,7 +702,7 @@ if (current.dialect.supports.transactions) {
                   isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED
                 }).then(t2 => {
                   return Promise.join(
-                    User.find({
+                    User.findOne({
                       where: {
                         username: 'jan'
                       },

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -127,12 +127,12 @@ if (current.dialect.supports.transactions) {
             return expect(Promise.join(transTest(80), transTest(80), transTest(80))).to.eventually.be.rejectedWith('could not serialize access due to read/write dependencies among transactions');
           }).delay(100).then(() => {
             if (self.sequelize.test.$runningQueries !== 0) {
-              return self.sequelize.Promise.delay(200);
+              return Promise.delay(200);
             }
             return void 0;
           }).then(() => {
             if (self.sequelize.test.$runningQueries !== 0) {
-              return self.sequelize.Promise.delay(500);
+              return Promise.delay(500);
             }
           });
         });
@@ -511,7 +511,7 @@ if (current.dialect.supports.transactions) {
                       });
                     }),
 
-                    t1Jan.updateAttributes({
+                    t1Jan.update({
                       awesome: true
                     }, {
                       transaction: t1
@@ -709,7 +709,7 @@ if (current.dialect.supports.transactions) {
                       transaction: t2
                     }).then(t2Jan => {
                       t2FindSpy();
-                      return t2Jan.updateAttributes({
+                      return t2Jan.update({
                         awesome: false
                       }, {
                         transaction: t2
@@ -722,7 +722,7 @@ if (current.dialect.supports.transactions) {
                       });
                     }),
 
-                    t1Jan.updateAttributes({
+                    t1Jan.update({
                       awesome: true
                     }, {
                       transaction: t1

--- a/test/integration/trigger.test.js
+++ b/test/integration/trigger.test.js
@@ -41,7 +41,7 @@ if (current.dialect.supports.tmpTableTrigger) {
         return User.create({
           username: 'triggertest'
         }).then(() => {
-          return expect(User.find({username: 'triggertest'})).to.eventually.have.property('username').which.equals('triggertest');
+          return expect(User.findOne({username: 'triggertest'})).to.eventually.have.property('username').which.equals('triggertest');
         });
       });
 
@@ -53,7 +53,7 @@ if (current.dialect.supports.tmpTableTrigger) {
           return user.save();
         })
           .then(() => {
-            return expect(User.find({username: 'usernamechanged'})).to.eventually.have.property('username').which.equals('usernamechanged');
+            return expect(User.findOne({username: 'usernamechanged'})).to.eventually.have.property('username').which.equals('usernamechanged');
           });
       });
 
@@ -70,7 +70,7 @@ if (current.dialect.supports.tmpTableTrigger) {
           });
         })
           .then(() => {
-            return expect(User.find({username: 'usernamechanged'})).to.eventually.have.property('username').which.equals('usernamechanged');
+            return expect(User.findOne({username: 'usernamechanged'})).to.eventually.have.property('username').which.equals('usernamechanged');
           });
       });
 
@@ -80,7 +80,7 @@ if (current.dialect.supports.tmpTableTrigger) {
         }).then(user => {
           return user.destroy();
         }).then(() => {
-          return expect(User.find({username: 'triggertest'})).to.eventually.be.null;
+          return expect(User.findOne({username: 'triggertest'})).to.eventually.be.null;
         });
       });
     });

--- a/test/unit/associations/belongs-to-many.test.js
+++ b/test/unit/associations/belongs-to-many.test.js
@@ -11,7 +11,7 @@ const BelongsTo = require(__dirname + '/../../../lib/associations/belongs-to');
 const HasMany = require(__dirname + '/../../../lib/associations/has-many');
 const HasOne = require(__dirname + '/../../../lib/associations/has-one');
 const current = Support.sequelize;
-const Promise = current.Promise;
+const Promise = require('bluebird');
 const AssociationError = require(__dirname + '/../../../lib/errors').AssociationError;
 
 describe(Support.getTestDialectTeaser('belongsToMany'), () => {

--- a/test/unit/associations/has-many.test.js
+++ b/test/unit/associations/has-many.test.js
@@ -10,7 +10,7 @@ const chai = require('chai'),
   HasMany   = require(__dirname + '/../../../lib/associations/has-many'),
   Op        = require(__dirname + '/../../../lib/operators'),
   current   = Support.sequelize,
-  Promise   = current.Promise;
+  Promise   = require('bluebird');
 
 describe(Support.getTestDialectTeaser('hasMany'), () => {
   it('throws when invalid model is passed', () => {

--- a/test/unit/dialects/mysql/errors.test.js
+++ b/test/unit/dialects/mysql/errors.test.js
@@ -5,6 +5,7 @@ const expect = chai.expect;
 const Support = require(__dirname + '/../../support');
 const dialect = Support.getTestDialect();
 const queryProto = Support.sequelize.dialect.Query.prototype;
+const errors = require('../../../../lib/errors');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] ForeignKeyConstraintError - error message parsing', () => {
@@ -15,7 +16,7 @@ if (dialect === 'mysql') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Support.sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(errors.ForeignKeyConstraintError);
       expect(parsedErr.parent).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');
@@ -31,7 +32,7 @@ if (dialect === 'mysql') {
 
       const parsedErr = queryProto.formatError(fakeErr);
 
-      expect(parsedErr).to.be.instanceOf(Support.sequelize.ForeignKeyConstraintError);
+      expect(parsedErr).to.be.instanceOf(errors.ForeignKeyConstraintError);
       expect(parsedErr.parent).to.equal(fakeErr);
       expect(parsedErr.reltype).to.equal('parent');
       expect(parsedErr.table).to.equal('people');

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -6,6 +6,7 @@ const chai = require('chai'),
   dialect = Support.getTestDialect(),
   _ = require('lodash'),
   Op = require('../../../../lib/operators'),
+  literal = Support.Sequelize.literal,
   QueryGenerator = require('../../../../lib/dialects/mysql/query-generator');
 
 if (dialect === 'mysql') {
@@ -203,7 +204,7 @@ if (dialect === 'mysql') {
           expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
           context: QueryGenerator
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
+          arguments: ['foo', { attributes: [[literal('count(*)'), 'count']] }],
           expectation: 'SELECT count(*) AS `count` FROM `foo`;',
           context: QueryGenerator
         }, {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -10,7 +10,7 @@ const chai = require('chai'),
   moment = require('moment'),
   current = Support.sequelize,
   _ = require('lodash'),
-  literal = Support.Sequelize.fn;
+  literal = Support.Sequelize.literal;
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] QueryGenerator', () => {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -9,7 +9,8 @@ const chai = require('chai'),
   DataTypes = require(__dirname + '/../../../../lib/data-types'),
   moment = require('moment'),
   current = Support.sequelize,
-  _ = require('lodash');
+  _ = require('lodash'),
+  literal = Support.Sequelize.fn;
 
 if (dialect.match(/^postgres/)) {
   describe('[POSTGRES Specific] QueryGenerator', () => {
@@ -268,7 +269,7 @@ if (dialect.match(/^postgres/)) {
           arguments: ['myTable', {where: 2}],
           expectation: 'SELECT * FROM \"myTable\" WHERE \"myTable\".\"id\" = 2;'
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
+          arguments: ['foo', { attributes: [[literal('count(*)'), 'count']] }],
           expectation: 'SELECT count(*) AS \"count\" FROM \"foo\";'
         }, {
           arguments: ['myTable', {order: ['id']}],
@@ -462,7 +463,7 @@ if (dialect.match(/^postgres/)) {
           expectation: 'SELECT * FROM myTable WHERE myTable.id = 2;',
           context: {options: {quoteIdentifiers: false}}
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
+          arguments: ['foo', { attributes: [[literal('count(*)'), 'count']] }],
           expectation: 'SELECT count(*) AS count FROM foo;',
           context: {options: {quoteIdentifiers: false}}
         }, {

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -8,7 +8,8 @@ const chai = require('chai'),
   _ = require('lodash'),
   moment = require('moment'),
   Op = require('../../../../lib/operators'),
-  QueryGenerator = require('../../../../lib/dialects/sqlite/query-generator');
+  QueryGenerator = require('../../../../lib/dialects/sqlite/query-generator'),
+  literal = Support.Sequelize.fn;
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] QueryGenerator', () => {
@@ -173,7 +174,7 @@ if (dialect === 'sqlite') {
           expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
           context: QueryGenerator
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
+          arguments: ['foo', { attributes: [[literal('count(*)'), 'count']] }],
           expectation: 'SELECT count(*) AS `count` FROM `foo`;',
           context: QueryGenerator
         }, {

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -9,7 +9,7 @@ const chai = require('chai'),
   moment = require('moment'),
   Op = require('../../../../lib/operators'),
   QueryGenerator = require('../../../../lib/dialects/sqlite/query-generator'),
-  literal = Support.Sequelize.fn;
+  literal = Support.Sequelize.literal;
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] QueryGenerator', () => {

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -6,7 +6,7 @@ const chai = require('chai'),
   Support = require(__dirname + '/support'),
   _ = require('lodash'),
   current = Support.sequelize,
-  Promise = current.Promise;
+  Promise = require('bluebird');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(function() {
@@ -94,8 +94,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
           name: Support.Sequelize.STRING
         });
 
-        this.Model.hook('beforeSave', this.beforeSaveHook);
-        this.Model.hook('afterSave', this.afterSaveHook);
+        this.Model.addHook('beforeSave', this.beforeSaveHook);
+        this.Model.addHook('afterSave', this.afterSaveHook);
       });
 
       it('calls beforeSave/afterSave', () => {
@@ -366,10 +366,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       });
     });
 
-    describe('.hook() method', () => {
+    describe('.addHook() method', () => {
       it('#delete', function() {
-        this.Model.hook('beforeDelete', this.beforeDelete);
-        this.Model.hook('afterDelete', this.afterDelete);
+        this.Model.addHook('beforeDelete', this.beforeDelete);
+        this.Model.addHook('afterDelete', this.afterDelete);
 
         return Promise.join(
           this.Model.runHooks('beforeDestroy'),
@@ -381,10 +381,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
   describe('promises', () => {
     it('can return a promise', function() {
-      const self = this;
-
       this.Model.beforeBulkCreate(() => {
-        return self.sequelize.Promise.resolve();
+        return Promise.resolve();
       });
 
       return expect(this.Model.runHooks('beforeBulkCreate')).to.be.fulfilled;

--- a/test/unit/instance-validator.test.js
+++ b/test/unit/instance-validator.test.js
@@ -5,7 +5,7 @@ const expect = chai.expect;
 const Support = require(__dirname + '/support');
 const InstanceValidator = require('../../lib/instance-validator');
 const sinon = require('sinon');
-const Promise = Support.sequelize.Promise;
+const Promise = require('bluebird');
 const SequelizeValidationError = require('../../lib/errors').ValidationError;
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {

--- a/test/unit/instance/set.test.js
+++ b/test/unit/instance/set.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support   = require(__dirname + '/../support'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
   current   = Support.sequelize,
-  Promise = current.Promise,
+  Promise = require('bluebird'),
   sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/model/bulkcreate.test.js
+++ b/test/unit/model/bulkcreate.test.js
@@ -6,7 +6,7 @@ const chai = require('chai'),
   Support   = require(__dirname + '/../support'),
   DataTypes = require('../../../lib/data-types'),
   current   = Support.sequelize,
-  Promise = current.Promise;
+  Promise = require('bluebird');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('bulkCreate', () => {

--- a/test/unit/model/count.test.js
+++ b/test/unit/model/count.test.js
@@ -6,15 +6,16 @@ const chai = require('chai'),
   current = Support.sequelize,
   sinon = require('sinon'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
-  Promise = require('bluebird');
+  Promise = require('bluebird'),
+  Model = require('../../../lib/model');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method count', () => {
     before(() => {
-      this.oldFindAll = current.Model.findAll;
-      this.oldAggregate = current.Model.aggregate;
+      this.oldFindAll = Model.findAll;
+      this.oldAggregate = Model.aggregate;
 
-      current.Model.findAll = sinon.stub().returns(Promise.resolve());
+      Model.findAll = sinon.stub().returns(Promise.resolve());
 
       this.User = current.define('User', {
         username: DataTypes.STRING,
@@ -29,40 +30,40 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     after(() => {
-      current.Model.findAll = this.oldFindAll;
-      current.Model.aggregate = this.oldAggregate;
+      Model.findAll = this.oldFindAll;
+      Model.aggregate = this.oldAggregate;
     });
 
     beforeEach(() => {
-      this.stub = current.Model.aggregate = sinon.stub().returns(Promise.resolve());
+      this.stub = Model.aggregate = sinon.stub().returns(Promise.resolve());
     });
 
-    describe('should pass the same options to model.aggregate as findAndCount', () => {
+    describe('should pass the same options to model.aggregate as findAndCountAll', () => {
       it('with includes', () => {
         const queryObject = {
           include: [this.Project]
         };
         return this.User.count(queryObject)
-          .then(() => this.User.findAndCount(queryObject))
+          .then(() => this.User.findAndCountAll(queryObject))
           .then(() => {
             const count = this.stub.getCall(0).args;
-            const findAndCount = this.stub.getCall(1).args;
-            expect(count).to.eql(findAndCount);
+            const findAndCountAll = this.stub.getCall(1).args;
+            expect(count).to.eql(findAndCountAll);
           });
       });
 
-      it('attributes should be stripped in case of findAndCount', () => {
+      it('attributes should be stripped in case of findAndCountAll', () => {
         const queryObject = {
           attributes: ['username']
         };
         return this.User.count(queryObject)
-          .then(() => this.User.findAndCount(queryObject))
+          .then(() => this.User.findAndCountAll(queryObject))
           .then(() => {
             const count = this.stub.getCall(0).args;
-            const findAndCount = this.stub.getCall(1).args;
-            expect(count).not.to.eql(findAndCount);
+            const findAndCountAll = this.stub.getCall(1).args;
+            expect(count).not.to.eql(findAndCountAll);
             count[2].attributes = undefined;
-            expect(count).to.eql(findAndCount);
+            expect(count).to.eql(findAndCountAll);
           });
       });
     });

--- a/test/unit/model/destroy.test.js
+++ b/test/unit/model/destroy.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support = require(__dirname + '/../support'),
   current = Support.sequelize,
   sinon = require('sinon'),
-  Promise = current.Promise,
+  Promise = require('bluebird'),
   DataTypes = require('../../../lib/data-types'),
   _ = require('lodash');
 

--- a/test/unit/model/find-and-count-all.test.js
+++ b/test/unit/model/find-and-count-all.test.js
@@ -9,7 +9,7 @@ const chai = require('chai'),
   Promise = require('bluebird').getNewLibraryCopy();
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  describe('findAndCount', () => {
+  describe('findAndCountAll', () => {
     describe('should handle promise rejection', () => {
       before(function() {
         this.stub = sinon.stub();
@@ -38,7 +38,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('with errors in count and findAll both', function() {
-        return this.User.findAndCount({})
+        return this.User.findAndCountAll({})
           .then(() => {
             throw new Error();
           })

--- a/test/unit/model/findone.test.js
+++ b/test/unit/model/findone.test.js
@@ -4,22 +4,23 @@ const chai = require('chai'),
   expect = chai.expect,
   Support = require(__dirname + '/../support'),
   current = Support.sequelize,
-  Op = current.Op,
+  Op = Support.Sequelize.Op,
   sinon = require('sinon'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
-  Promise = require('bluebird');
+  Promise = require('bluebird'),
+  Model = require('../../../lib/model');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method findOne', () => {
     before(function() {
-      this.oldFindAll = current.Model.findAll;
+      this.oldFindAll = Model.findAll;
     });
     after(function() {
-      current.Model.findAll = this.oldFindAll;
+      Model.findAll = this.oldFindAll;
     });
 
     beforeEach(function() {
-      this.stub = current.Model.findAll = sinon.stub().returns(Promise.resolve());
+      this.stub = Model.findAll = sinon.stub().returns(Promise.resolve());
     });
 
     describe('should not add limit when querying on a primary key', () => {

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -4,7 +4,8 @@ const chai = require('chai'),
   expect = chai.expect,
   Support   = require(__dirname + '/../support'),
   Sequelize = require(__dirname + '/../../../index'),
-  current   = Support.sequelize;
+  current   = Support.sequelize,
+  Model = require('../../../lib/model');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('all', () => {
@@ -16,7 +17,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('can expand nested self-reference', () => {
       const options = { include: [{ all: true, nested: true }] };
 
-      current.Model._expandIncludeAll.call(Referral, options);
+      Model._expandIncludeAll.call(Referral, options);
 
       expect(options.include).to.deep.equal([
         { model: Referral }

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -4,7 +4,8 @@ const chai = require('chai'),
   expect = chai.expect,
   Support   = require(__dirname + '/../support'),
   DataTypes = require(__dirname + '/../../../lib/data-types'),
-  current   = Support.sequelize;
+  current   = Support.sequelize,
+  Model = require('../../../lib/model');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   const Project = current.define('project'),
@@ -337,7 +338,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         limit: 9
       };
 
-      current.Model._injectScope.call({
+      Model._injectScope.call({
         _scope: scope
       }, options);
 
@@ -361,7 +362,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       const options = {};
 
-      current.Model._injectScope.call({
+      Model._injectScope.call({
         _scope: scope
       }, options);
 
@@ -378,7 +379,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         include: [{ model: Project, where: { something: true }}]
       };
 
-      current.Model._injectScope.call({
+      Model._injectScope.call({
         _scope: scope
       }, options);
 
@@ -395,7 +396,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         include: [{model: User, as: 'otherUser'}]
       };
 
-      current.Model._injectScope.call({
+      Model._injectScope.call({
         _scope: scope
       }, options);
 
@@ -417,7 +418,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]
       };
 
-      current.Model._injectScope.call({
+      Model._injectScope.call({
         _scope: scope
       }, options);
 
@@ -440,7 +441,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           ]
         };
 
-        current.Model._injectScope.call({
+        Model._injectScope.call({
           _scope: scope
         }, options);
 
@@ -463,7 +464,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           ]
         };
 
-        current.Model._injectScope.call({
+        Model._injectScope.call({
           _scope: scope
         }, options);
 

--- a/test/unit/model/update.test.js
+++ b/test/unit/model/update.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support = require(__dirname + '/../support'),
   current = Support.sequelize,
   sinon = require('sinon'),
-  Promise = current.Promise,
+  Promise = require('bluebird'),
   DataTypes = require('../../../lib/data-types'),
   _ = require('lodash');
 

--- a/test/unit/model/upsert.test.js
+++ b/test/unit/model/upsert.test.js
@@ -5,8 +5,9 @@ const chai = require('chai'),
   Support = require(__dirname + '/../support'),
   current = Support.sequelize,
   sinon = require('sinon'),
-  Promise = current.Promise,
-  DataTypes = require('../../../lib/data-types');
+  Promise = require('bluebird'),
+  DataTypes = require('../../../lib/data-types'),
+  errors = require('../../../lib/errors');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   if (current.dialect.supports.upserts) {
@@ -55,7 +56,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('skip validations for missing fields', function() {
         return expect(this.User.upsert({
           name: 'Grumpy Cat'
-        })).not.to.be.rejectedWith(current.ValidationError);
+        })).not.to.be.rejectedWith(errors.ValidationError);
       });
 
       it('creates new record with correct field names', function() {

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -6,8 +6,9 @@ const chai = require('chai'),
   Sequelize = require(__dirname + '/../../../index'),
   Support = require(__dirname + '/../support'),
   current = Support.sequelize,
-  Op      = current.Op,
-  Promise = current.Promise,
+  Op      = Support.Sequelize.Op,
+  Promise = require('bluebird'),
+  errors = require('../../../lib/errors'),
   config = require(__dirname + '/../../config/config');
 
 
@@ -299,7 +300,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         });
 
         it('should allow dates as a string', () => {
-          return expect(User.find({
+          return expect(User.findOne({
             where: {
               date: '2000-12-16'
             }
@@ -382,13 +383,13 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         it('should throw when passing string', () => {
           return expect(User.create({
             age: 'jan'
-          })).to.be.rejectedWith(current.ValidationError);
+          })).to.be.rejectedWith(errors.ValidationError);
         });
 
         it('should throw when passing decimal', () => {
           return expect(User.create({
             age: 4.5
-          })).to.be.rejectedWith(current.ValidationError);
+          })).to.be.rejectedWith(errors.ValidationError);
         });
       });
 
@@ -396,13 +397,13 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         it('should throw when passing string', () => {
           return expect(User.update({
             age: 'jan'
-          }, { where: {}})).to.be.rejectedWith(current.ValidationError);
+          }, { where: {}})).to.be.rejectedWith(errors.ValidationError);
         });
 
         it('should throw when passing decimal', () => {
           return expect(User.update({
             age: 4.5
-          }, { where: {}})).to.be.rejectedWith(current.ValidationError);
+          }, { where: {}})).to.be.rejectedWith(errors.ValidationError);
         });
       });
 
@@ -470,13 +471,13 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         it('custom attribute validation function fails', () => {
           return expect(User.create({
             age: -1
-          })).to.be.rejectedWith(current.ValidationError);
+          })).to.be.rejectedWith(errors.ValidationError);
         });
 
         it('custom model validation function fails', () => {
           return expect(User.create({
             name: 'error'
-          })).to.be.rejectedWith(current.ValidationError);
+          })).to.be.rejectedWith(errors.ValidationError);
         });
       });
 
@@ -484,13 +485,13 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         it('custom attribute validation function fails', () => {
           return expect(User.update({
             age: -1
-          }, { where: {}})).to.be.rejectedWith(current.ValidationError);
+          }, { where: {}})).to.be.rejectedWith(errors.ValidationError);
         });
 
         it('when custom model validation function fails', () => {
           return expect(User.update({
             name: 'error'
-          }, { where: {}})).to.be.rejectedWith(current.ValidationError);
+          }, { where: {}})).to.be.rejectedWith(errors.ValidationError);
         });
       });
     });
@@ -543,7 +544,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         it('custom model validation function fails', () => {
           return expect(User.create({
             name: 'error'
-          })).to.be.rejectedWith(current.ValidationError);
+          })).to.be.rejectedWith(errors.ValidationError);
         });
       });
 
@@ -551,7 +552,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         it('when custom model validation function fails', () => {
           return expect(User.update({
             name: 'error'
-          }, { where: {}})).to.be.rejectedWith(current.ValidationError);
+          }, { where: {}})).to.be.rejectedWith(errors.ValidationError);
         });
       });
     });

--- a/test/unit/sql/add-constraint.test.js
+++ b/test/unit/sql/add-constraint.test.js
@@ -4,7 +4,7 @@ const Support   = require(__dirname + '/../support');
 const current   = Support.sequelize;
 const expectsql = Support.expectsql;
 const sql = current.dialect.QueryGenerator;
-const Op = current.Op;
+const Op = Support.Sequelize.Op;
 const expect = require('chai').expect;
 const sinon = require('sinon');
 

--- a/test/unit/sql/change-column.test.js
+++ b/test/unit/sql/change-column.test.js
@@ -5,7 +5,7 @@ const Support   = require(__dirname + '/../support'),
   expectsql = Support.expectsql,
   sinon = require('sinon'),
   current   = Support.sequelize,
-  Promise = current.Promise;
+  Promise = require('bluebird');
 
 
 if (current.dialect.name !== 'sqlite') {

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -1127,15 +1127,6 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    if (current.dialect.supports.NUMERIC) {
-      testsql('NUMERIC', DataTypes.NUMERIC, {
-        default: 'DECIMAL'
-      });
-
-      testsql('NUMERIC(15,5)', DataTypes.NUMERIC(15, 5), {
-        default: 'DECIMAL(15,5)'
-      });
-    }
 
     suite('DECIMAL', () => {
       testsql('DECIMAL', DataTypes.DECIMAL, {

--- a/test/unit/sql/generateJoin.test.js
+++ b/test/unit/sql/generateJoin.test.js
@@ -8,7 +8,7 @@ const Support = require(__dirname + '/../support'),
   expectsql = Support.expectsql,
   current   = Support.sequelize,
   sql       = current.dialect.QueryGenerator,
-  Op        = current.Op;
+  Op        = Support.Sequelize.Op;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 

--- a/test/unit/sql/get-constraint-snippet.test.js
+++ b/test/unit/sql/get-constraint-snippet.test.js
@@ -5,7 +5,7 @@ const current   = Support.sequelize;
 const expectsql = Support.expectsql;
 const sql = current.dialect.QueryGenerator;
 const expect = require('chai').expect;
-const Op = current.Op;
+const Op = Support.Sequelize.Op;
 
 describe(Support.getTestDialectTeaser('SQL'), () => {
   describe('getConstraintSnippet', () => {

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -4,7 +4,7 @@ const Support   = require(__dirname + '/../support'),
   expectsql = Support.expectsql,
   current   = Support.sequelize,
   sql       = current.dialect.QueryGenerator,
-  Op        = current.Op;
+  Op        = Support.Sequelize.Op;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -9,7 +9,7 @@ const Support   = require(__dirname + '/../support'),
   expectsql = Support.expectsql,
   current   = Support.sequelize,
   sql       = current.dialect.QueryGenerator,
-  Op        = current.Op;
+  Op        = Support.Sequelize.Op;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -6,7 +6,7 @@ const Support   = require(__dirname + '/../support'),
   expectsql = Support.expectsql,
   current = Support.sequelize,
   sql = current.dialect.QueryGenerator,
-  Op = current.Op;
+  Op = Support.Sequelize.Op;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
@@ -1099,7 +1099,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       default: 'SUM([hours]) > 0'
     });
 
-    testsql(current.where(current.fn('SUM', current.col('hours')), current.Op.gt, 0), {
+    testsql(current.where(current.fn('SUM', current.col('hours')), Support.Sequelize.Op.gt, 0), {
       default: 'SUM([hours]) > 0'
     });
   });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -7,7 +7,7 @@ const DataTypes = require(__dirname + '/../../lib/data-types');
 const Utils = require(__dirname + '/../../lib/utils');
 const tedious = require('tedious');
 const tediousIsolationLevel = tedious.ISOLATION_LEVEL;
-const Op = Support.sequelize.Op;
+const Op = Support.Sequelize.Op;
 
 suite(Support.getTestDialectTeaser('Utils'), () => {
   suite('merge', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Closes #9372

This deprecates all(?) aliases including references in some prototypes.

- There were some load time deprecation issues I had to work around, hence the `deprecation.js` file and `deprecate.enable()` call after the sequelize core loaded.
- Amended a `console.warn` to include the stack trace for deprecation warning (depd doesn't seem like a very good library tbh).
- Changed some references of `Util`, `errors` etc. to use static references rather then instance bound.