### PR TITLE
feat(select): add 'indexHint' option

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1866,6 +1866,10 @@ class QueryGenerator {
       fragment += ' AS ' + mainTableAs;
     }
 
+    if (options.indexHint) {
+      fragment += ` USE INDEX (${options.indexHint})`;
+    }
+
     return fragment;
   }
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -52,6 +52,25 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       table: 'User',
       attributes: [
         'email',
+        ['first_name', 'firstName']
+      ],
+      where: {
+        email: 'jon.snow@gmail.com'
+      },
+      indexHint: 'my_index',
+      order: [
+        ['email', 'DESC']
+      ],
+      limit: 10
+    }, {
+      default: "SELECT [email], [first_name] AS [firstName] FROM [User] USE INDEX (my_index) WHERE [User].[email] = 'jon.snow@gmail.com' ORDER BY [email] DESC LIMIT 10;",
+      mssql: "SELECT [email], [first_name] AS [firstName] FROM [User] USE INDEX (my_index) WHERE [User].[email] = N'jon.snow@gmail.com' ORDER BY [email] DESC OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;"
+    });
+
+    testsql({
+      table: 'User',
+      attributes: [
+        'email',
         ['first_name', 'firstName'],
         ['last_name', 'lastName']
       ],


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

I'm adding way to add index hints to a select query.

Example usage:
```
db.User.findOne({
    where: {
        email: 'joe@example.com',
    },
    indexHint: 'idx_name',
});

// This generates SELECT * FROM `User` USE INDEX (idx_name) WHERE ...
```
Here's an issue from a while ago requesting this feature. https://github.com/sequelize/sequelize/issues/6370
It went stale and was closed though.


(This is my first PR to open source/on github. I couldn't figure out how to get permissions to make a feature branch so I created a fork instead. If this is not desired I can change it.)