### PR TITLE
feat(model): Enable bulk-create by already built instances

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2411,7 +2411,7 @@ class Model {
    *
    * If validation fails, the promise is rejected with an array-like [AggregateError](http://bluebirdjs.com/docs/api/aggregateerror.html)
    *
-   * @param  {Array}        records                          List of objects (key/value pairs) to create instances from
+   * @param  {Array}        records                          List of objects (key/value pairs) to create instances from, or a list of already built instances (in which case they have to be new records).
    * @param  {Object}       [options]
    * @param  {Array}        [options.fields]                 Fields to insert (defaults to all fields)
    * @param  {Boolean}      [options.validate=false]         Should each row be subject to validation before it is inserted. The whole insert will fail if one row fails validation
@@ -2461,13 +2461,23 @@ class Model {
       }
     }
 
+    const recordsAlreadyBuilt = records[0] instanceof this;
+
+    if (recordsAlreadyBuilt) {
+      const nonNewRecord = _.find(records, {isNewRecord: false});
+
+      if (nonNewRecord) {
+        return Promise.reject(new Error('records must not contain items already persisted to the DB (!isNewRecord).'));
+      }
+    }
+
     options.model = this;
 
     const createdAtAttr = this._timestampAttributes.createdAt;
     const updatedAtAttr = this._timestampAttributes.updatedAt;
     const now = Utils.now(this.sequelize.options.dialect);
 
-    let instances = records.map(values => this.build(values, {isNewRecord: true}));
+    let instances = recordsAlreadyBuilt ? records : records.map(values => this.build(values, {isNewRecord: true}));
 
     return Promise.try(() => {
       // Run before hook

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -152,6 +152,31 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    it('properly handles already built records', function() {
+      const self = this,
+        data = [this.User.build({username: 'Mary', uniqueName: '11' }),
+          this.User.build({username: 'Linda', uniqueName: '12'}),
+          this.User.build({username: 'Susan', uniqueName: '13'})];
+
+      return this.User.bulkCreate(data).then(() => {
+        return self.User.findAll({where: {username: 'Mary'}}).then(users => {
+          expect(users.length).to.equal(1);
+          expect(users[0].username).to.equal('Mary');
+          expect(users[0].uniqueName).to.equal('11');
+        });
+      });
+    });
+
+    it('emits an error when a non-new record is included', function() {
+      const data = [this.User.build({username: 'Margaret', uniqueName: '14' }),
+        this.User.build({username: 'Lisa', uniqueName: '15'}, {isNewRecord: false}),
+        this.User.build({username: 'Sandra', uniqueName: '16'})];
+
+      return expect(
+        this.User.bulkCreate(data)
+      ).to.be.rejectedWith('records must not contain items already persisted to the DB (!isNewRecord).');
+    });
+
     it('inserts multiple values respecting the white list', function() {
       const self = this,
         data = [{ username: 'Peter', secretValue: '42', uniqueName: '1' },


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
  - Ran all dialect tests except MSSQL, couldn't get the server to work.
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

`bulkCreate` can now be passed an array of already built model instances as `records` parameter. In case an instance is not a new record, an error is returned.
