### PR TITLE
feat: add indexHint

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1756,6 +1756,35 @@ const QueryGenerator = {
       fragment += ' AS ' + mainTableAs;
     }
 
+    // Add IndexHint to sub or main query
+    if (options.hasOwnProperty('indexHint')) {
+      // 'my_index'
+      // or
+      // [{value: ' USE INDEX(`my_index`)'}]
+      // or
+      // [['USE', 'my_index']]
+      // or
+      // ['my_index']
+      if (Array.isArray(options.indexHint)) {
+        _.each(options.indexHint, hint => {
+          let line = ' ';
+          if (hint.hasOwnProperty('value')) {
+            line += hint.value;
+          } else if (Array.isArray(hint)) {
+            line += String(hint[0]).toUpperCase();
+            line += ' INDEX(`' + String(hint[1]) + '`)';
+            if (hint[2]) line += ' ' + String(hint[2]);
+          } else {
+            line += ` USE INDEX(\`${options.indexHint}\`)`;
+          }
+          fragment += line;
+        });
+      } else {
+        fragment += ` USE INDEX(\`${options.indexHint}\`)`;
+
+      }
+    }
+
     return fragment;
   },
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -47,6 +47,53 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       mssql: "SELECT [email], [first_name] AS [firstName] FROM [User] WHERE [User].[email] = N'jon.snow@gmail.com' ORDER BY [email] DESC OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;"
     });
 
+    const indexName = 'my_index';
+    const indexHintsUseExamples = [
+      'my_index',
+      [['use', indexName]],
+      [{ value: `USE INDEX(\`${indexName}\`)` }],
+    ];
+
+    indexHintsUseExamples.forEach(hint => {
+      testsql(
+        {
+          table: 'User',
+          attributes: ['email', ['first_name', 'firstName']],
+          where: {
+            email: 'jon.snow@gmail.com',
+          },
+          indexHint: hint,
+          order: [['email', 'DESC']],
+          limit: 10,
+        },
+        {
+          default:
+            "SELECT [email], [first_name] AS [firstName] FROM [User] USE INDEX(`my_index`) WHERE [User].[email] = 'jon.snow@gmail.com' ORDER BY [email] DESC LIMIT 10;",
+          mssql:
+            "SELECT [email], [first_name] AS [firstName] FROM [User] USE INDEX (my_index) WHERE [User].[email] = N'jon.snow@gmail.com' ORDER BY [email] DESC OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;",
+        }
+      );
+    });
+
+    testsql(
+      {
+        table: 'User',
+        attributes: ['email', ['first_name', 'firstName']],
+        where: {
+          email: 'jon.snow@gmail.com',
+        },
+        indexHint: [['force', 'my_index']],
+        order: [['email', 'DESC']],
+        limit: 10,
+      },
+      {
+        default:
+          "SELECT [email], [first_name] AS [firstName] FROM [User] FORCE INDEX(`my_index`) WHERE [User].[email] = 'jon.snow@gmail.com' ORDER BY [email] DESC LIMIT 10;",
+        mssql:
+          "SELECT [email], [first_name] AS [firstName] FROM [User] FORCE INDEX (my_index) WHERE [User].[email] = N'jon.snow@gmail.com' ORDER BY [email] DESC OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY;",
+      }
+    );
+
     testsql({
       table: 'User',
       attributes: [


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->



Hi, this PR is for adding a way to add index hints to a select query by using `USE` or `FORCE`.

How to use it:
```sql
sequelize.Order.findAll({
  where: {
    statusId: 1,
  },
  indexHint: 'idx_status_id',
});
```

This will allow the end user to pass the indexHint different ways.

Examples: 

	indexHint: 'idx_status_id'
	
	indexHint: [{value: ' USE INDEX(`idx_status_id `)'}]
	
	indexHint: [['USE', 'idx_status_id']]
	
	indexHint: ['idx_status_id']

##### This will generates
`SELECT * FROM `Order` USE INDEX(idx_status_id) WHERE status_id = 1`

I have done testing under `test/unit/sql/select.test.js`


