### PR TITLE
Update data-types.js

### DIFF
--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -49,6 +49,9 @@ module.exports = BaseTypes => {
   inherits(DATE, BaseTypes.DATE);
 
   DATE.parse = function parse(date, options) {
+    if (typeof date === 'number') {
+      return new Date(date);
+    }
     if (date.indexOf('+') === -1) {
       // For backwards compat. Dates inserted by sequelize < 2.0dev12 will not have a timestamp set
       return new Date(date + options.timezone);


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
This pull request fixes the problem **date.indexOf is not a function** error when using SQLite with createdAt/updatedAt DATE fields. Problem occurs since DATE fields are saved as timestamps so that the function at _/dialects/sqlite/data-types.js_ throws date.indexOf is not a function because of the fact that `date` parameter here is a number and not a string. This pull request just adds required type-checking.
<!-- Please provide a description of the change here. -->
