### PR TITLE
fix(query-generator): add spaces around comparator

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1918,7 +1918,7 @@ class QueryGenerator {
       if (value && value instanceof Utils.SequelizeMethod) {
         value = this.getWhereConditions(value, tableName, factory, options, prepend);
 
-        result = value === 'NULL' ? key + ' IS NULL' : [key, value].join(smth.comparator);
+        result = value === 'NULL' ? key + ' IS NULL' : [key, value].join(' ' + smth.comparator + ' ');
       } else if (_.isPlainObject(value)) {
         result = this.whereItemQuery(smth.attribute, value, {
           model: factory

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -86,6 +86,12 @@ describe('QueryGenerator', () => {
       expect(() => QG.whereItemQuery('test', {$in: [4]}))
         .to.throw('Invalid value { \'$in\': [ 4 ] }');
     });
+
+    it('should correctly parse sequelize.where with .fn as logic', function() {
+      const QG = getAbstractQueryGenerator(this.sequelize);
+      QG.handleSequelizeMethod(this.sequelize.where(this.sequelize.col('foo'), 'LIKE', this.sequelize.col('bar')))
+        .should.be.equal('foo LIKE bar');
+    });
   });
 });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

When passing a `sequelize.where` created object with another sequelize object in the `logic` property, we enter a case where the comparator is added without padded spaces, causing an error in the generated SQL. This PR adds the missing spaces.