### PR TITLE
fix: Use node 8 on docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:6
+FROM node:8
 
 RUN apt-get install libpq-dev
 


### PR DESCRIPTION
The package @semantic-release/github, that is a direct dependency for the project requires node >=8.3.
