### PR TITLE
docs: fixed small mistake

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -23,7 +23,7 @@ Built instances will automatically get default values when they were defined&col
 // first define the model
 const Task = sequelize.define('task', {
   title: Sequelize.STRING,
-  rating: { type: Sequelize.STRING, defaultValue: 3 }
+  rating: { type: Sequelize.TINYINT, defaultValue: 3 }
 })
  
 // now instantiate an object


### PR DESCRIPTION
Rating is tinyint, not string. I think, someone might get confused because of this.
Proof at L33: `==> 3`, not `==> '3'`

