### PR TITLE
fix(hook): maintain CLS context in `after` hooks

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -448,7 +448,7 @@ class Sequelize {
 
     let bindParameters;
 
-    return retry(retryParameters => Promise.try(() => {
+    return Promise.resolve(retry(retryParameters => Promise.try(() => {
       const isFirstTry = retryParameters.current === 1;
 
       if (options.instance && !options.model) {
@@ -562,7 +562,7 @@ class Sequelize {
             return this.connectionManager.releaseConnection(connection);
           }
         });
-    }), retryOptions);
+    }), retryOptions));
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "rimraf": "^2.x",
     "semantic-release": "^15.x",
     "sinon": "^4.x",
-    "sinon-chai": "^2.x",
+    "sinon-chai": "^3.1.0",
     "sqlite3": "^4.x",
     "tedious": "^2.x",
     "uuid-validate": "^0.0.2",

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -79,7 +79,7 @@ if (current.dialect.supports.transactions) {
           });
         });
       });
-      
+
       it('does not leak variables to the outer scope', function() {
         // This is a little tricky. We want to check the values in the outer scope, when the transaction has been successfully set up, but before it has been comitted.
         // We can't just call another function from inside that transaction, since that would transfer the context to that function - exactly what we are trying to prevent;

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -164,17 +164,17 @@ if (current.dialect.supports.transactions) {
     it('CLS namespace is stored in Sequelize._cls', function() {
       expect(Sequelize._cls).to.equal(this.ns);
     });
-    
-    it('promises returned by sequelize.query are correctly patched', function(){
-        const self = this;
-        expect(self.ns.get('transaction')).to.be.undefined;
-        self.sequelize.transaction(t1 =>
-            self.sequelize.query("select 1", {type: Sequelize.QueryTypes.SELECT})
-            .then(() => {
-              expect(self.ns.get('transaction')).to.exist;
-              expect(self.ns.get('transaction')).to.equal(t1);
-            })
-        )
+
+    it('promises returned by sequelize.query are correctly patched', function() {
+      const self = this;
+      expect(self.ns.get('transaction')).to.be.undefined;
+      return self.sequelize.transaction(t =>
+        self.sequelize.query('select 1', {type: Sequelize.QueryTypes.SELECT})
+          .then(() => {
+            expect(self.ns.get('transaction')).to.exist;
+            expect(self.ns.get('transaction')).to.equal(t);
+          })
+      );
     });
   });
 }

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -166,14 +166,9 @@ if (current.dialect.supports.transactions) {
     });
 
     it('promises returned by sequelize.query are correctly patched', function() {
-      const self = this;
-      expect(self.ns.get('transaction')).to.be.undefined;
-      return self.sequelize.transaction(t =>
-        self.sequelize.query('select 1', {type: Sequelize.QueryTypes.SELECT})
-          .then(() => {
-            expect(self.ns.get('transaction')).to.exist;
-            expect(self.ns.get('transaction')).to.equal(t);
-          })
+      return this.sequelize.transaction(t =>
+        this.sequelize.query('select 1', {type: Sequelize.QueryTypes.SELECT})
+          .then(() => expect(this.ns.get('transaction')).to.equal(t))
       );
     });
   });

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -79,7 +79,7 @@ if (current.dialect.supports.transactions) {
           });
         });
       });
-
+      
       it('does not leak variables to the outer scope', function() {
         // This is a little tricky. We want to check the values in the outer scope, when the transaction has been successfully set up, but before it has been comitted.
         // We can't just call another function from inside that transaction, since that would transfer the context to that function - exactly what we are trying to prevent;
@@ -163,6 +163,18 @@ if (current.dialect.supports.transactions) {
 
     it('CLS namespace is stored in Sequelize._cls', function() {
       expect(Sequelize._cls).to.equal(this.ns);
+    });
+    
+    it('promises returned by sequelize.query are correctly patched', function(){
+        const self = this;
+        expect(self.ns.get('transaction')).to.be.undefined;
+        self.sequelize.transaction(t1 =>
+            self.sequelize.query("select 1", {type: Sequelize.QueryTypes.SELECT})
+            .then(() => {
+              expect(self.ns.get('transaction')).to.exist;
+              expect(self.ns.get('transaction')).to.equal(t1);
+            })
+        )
     });
   });
 }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Encapsulate promises returned by `retry-as-promised` with `Promise.resolve` to maintain CLS context in `afterXXX` hooks.

fix #9472
fix #9071
