### PR TITLE
feat(addScope): useless scope defaultScope already exists exception #…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1406,7 +1406,7 @@ class Model {
       override: false
     }, options);
 
-    if ((name === 'defaultScope' || name in this.options.scopes) && options.override === false) {
+    if ((name === 'defaultScope' || name in this.options.scopes) && options.override === false && Object.keys(this.options.defaultScope).length > 0) {
       throw new Error('The scope ' + name + ' already exists. Pass { override: true } as options to silence this error');
     }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1406,7 +1406,7 @@ class Model {
       override: false
     }, options);
 
-    if ((name === 'defaultScope' || name in this.options.scopes) && options.override === false && Object.keys(this.options.defaultScope).length > 0) {
+    if ((name === 'defaultScope'  && Object.keys(this.options.defaultScope).length > 0 || name in this.options.scopes) && options.override === false) {
       throw new Error('The scope ' + name + ' already exists. Pass { override: true } as options to silence this error');
     }
 

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -252,6 +252,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       }).not.to.throw();
     });
 
+    it('does not throw if default scope is not defined', () => {
+      const Model = current.define('model');
+
+      expect(() => {
+        Model.addScope('defaultScope', {});
+      }).not.to.throw();
+    });
+
     it('allows me to add a new scope', () => {
       expect(() => {
         Company.scope('newScope');


### PR DESCRIPTION
…9407

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
if default scope has not be defined ie. Object.keys(this.options.defaultScope).length === 0 then addScope('defaultScope', ...) does not throw an error. #9407 

