### PR TITLE
[WIP] feat(query-generator): Generate SELECTs using bind parameters

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1051,6 +1051,14 @@ class QueryGenerator {
     return bindParam(value);
   }
 
+  /**
+   * Dollar escapes a value for use in queries
+   * @param {*} value
+   */
+  bindEscape(value) {
+    return value.replace(/\$/g, '$$$$');
+  }
+
   /*
     Validate a value against a field specification
     @private
@@ -1157,6 +1165,9 @@ class QueryGenerator {
       options,
       subQuery
     };
+    const bind = [];
+    const bindParam = options.bindParam === undefined ? this.bindParam(bind) : options.bindParam;
+
     let mainJoinQueries = [];
     let subJoinQueries = [];
     let query;
@@ -1196,7 +1207,7 @@ class QueryGenerator {
         if (include.separate) {
           continue;
         }
-        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo);
+        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo, bindParam);
 
         subJoinQueries = subJoinQueries.concat(joinQueries.subQuery);
         mainJoinQueries = mainJoinQueries.concat(joinQueries.mainQuery);
@@ -1290,11 +1301,12 @@ class QueryGenerator {
             order: groupedLimitOrder,
             where,
             include,
-            model
+            model,
+            bindParam: false
           },
           model
-        ).replace(/;$/, '') + ')';
-        const placeHolder = this.whereItemQuery(Op.placeholder, true, { model });
+        ).query.replace(/;$/, '') + ')';
+        const placeHolder = this.whereItemQuery(Op.placeholder, true, { model, bindParam: false });
         const splicePos = baseQuery.indexOf(placeHolder);
 
         mainQueryItems.push(this.selectFromTableFragment(options, mainTable.model, attributes.main, '(' +
@@ -1311,7 +1323,7 @@ class QueryGenerator {
               };
             }
 
-            return Utils.spliceStr(baseQuery, splicePos, placeHolder.length, this.getWhereConditions(groupWhere, groupedTableName));
+            return Utils.spliceStr(baseQuery, splicePos, placeHolder.length, this.getWhereConditions(groupWhere, groupedTableName, null, { bindParam }));
           }).join(
             this._dialect.supports['UNION ALL'] ? ' UNION ALL ' : ' UNION '
           )
@@ -1325,7 +1337,8 @@ class QueryGenerator {
 
     // Add WHERE to sub or main query
     if (options.hasOwnProperty('where') && !options.groupedLimit) {
-      options.where = this.getWhereConditions(options.where, mainTable.as || tableName, model, options);
+      const whereOptions = _.defaults({ bindParam }, options);
+      options.where = this.getWhereConditions(options.where, mainTable.as || tableName, model, whereOptions);
       if (options.where) {
         if (subQuery) {
           subQueryItems.push(' WHERE ' + options.where);
@@ -1410,7 +1423,8 @@ class QueryGenerator {
       }
     }
 
-    return `${query};`;
+    query += ';';
+    return { query, bind };
   }
 
   escapeAttributes(attributes, options, mainTableAs) {
@@ -1448,7 +1462,7 @@ class QueryGenerator {
     });
   }
 
-  generateInclude(include, parentTableName, topLevelInfo) {
+  generateInclude(include, parentTableName, topLevelInfo, bindParam) {
     const joinQueries = {
       mainQuery: [],
       subQuery: []
@@ -1522,10 +1536,10 @@ class QueryGenerator {
 
     //through
     if (include.through) {
-      joinQuery = this.generateThroughJoin(include, includeAs, parentTableName.internalAs, topLevelInfo);
+      joinQuery = this.generateThroughJoin(include, includeAs, parentTableName.internalAs, topLevelInfo, bindParam);
     } else {
-      this._generateSubQueryFilter(include, includeAs, topLevelInfo);
-      joinQuery = this.generateJoin(include, topLevelInfo);
+      this._generateSubQueryFilter(include, includeAs, topLevelInfo, bindParam);
+      joinQuery = this.generateJoin(include, topLevelInfo, bindParam);
     }
 
     // handle possible new attributes created in join
@@ -1543,7 +1557,7 @@ class QueryGenerator {
           continue;
         }
 
-        const childJoinQueries = this.generateInclude(childInclude, includeAs, topLevelInfo);
+        const childJoinQueries = this.generateInclude(childInclude, includeAs, topLevelInfo, bindParam);
 
         if (include.required === false && childInclude.required === true) {
           requiredMismatch = true;
@@ -1593,7 +1607,7 @@ class QueryGenerator {
     };
   }
 
-  generateJoin(include, topLevelInfo) {
+  generateJoin(include, topLevelInfo, bindParam) {
     const association = include.association;
     const parent = include.parent;
     const parentIsTop = !!parent && !include.parent.association && include.parent.model.name === topLevelInfo.options.model.name;
@@ -1650,7 +1664,8 @@ class QueryGenerator {
     if (include.where) {
       joinWhere = this.whereItemsQuery(include.where, {
         prefix: this.sequelize.literal(this.quoteIdentifier(asRight)),
-        model: include.model
+        model: include.model,
+        bindParam
       });
       if (joinWhere) {
         if (include.or) {
@@ -1672,7 +1687,7 @@ class QueryGenerator {
     };
   }
 
-  generateThroughJoin(include, includeAs, parentTableName, topLevelInfo) {
+  generateThroughJoin(include, includeAs, parentTableName, topLevelInfo, bindParam) {
     const through = include.through;
     const throughTable = through.model.getTableName();
     const throughAs = `${includeAs.internalAs}->${through.as}`;
@@ -1736,7 +1751,7 @@ class QueryGenerator {
     targetJoinOn += `${this.quoteIdentifier(throughAs)}.${this.quoteIdentifier(identTarget)}`;
 
     if (through.where) {
-      throughWhere = this.getWhereConditions(through.where, this.sequelize.literal(this.quoteIdentifier(throughAs)), through.model);
+      throughWhere = this.getWhereConditions(through.where, this.sequelize.literal(this.quoteIdentifier(throughAs)), through.model, { bindParam });
     }
 
     if (this._dialect.supports.joinTableDependent) {
@@ -1758,14 +1773,15 @@ class QueryGenerator {
 
     if (include.where || include.through.where) {
       if (include.where) {
-        targetWhere = this.getWhereConditions(include.where, this.sequelize.literal(this.quoteIdentifier(includeAs.internalAs)), include.model, topLevelInfo.options);
+        const whereOptions = _.defaults({ bindParam }, topLevelInfo.options);
+        targetWhere = this.getWhereConditions(include.where, this.sequelize.literal(this.quoteIdentifier(includeAs.internalAs)), include.model, whereOptions);
         if (targetWhere) {
           joinCondition += ` AND ${targetWhere}`;
         }
       }
     }
 
-    this._generateSubQueryFilter(include, includeAs, topLevelInfo);
+    this._generateSubQueryFilter(include, includeAs, topLevelInfo, bindParam);
 
     return {
       join: joinType,
@@ -1781,7 +1797,7 @@ class QueryGenerator {
    * table to the include table plus everything that's in required transitive closure of the
    * given include.
    */
-  _generateSubQueryFilter(include, includeAs, topLevelInfo) {
+  _generateSubQueryFilter(include, includeAs, topLevelInfo, bindParam) {
     if (!topLevelInfo.subQuery || !include.subQueryFilter) {
       return;
     }
@@ -1792,7 +1808,7 @@ class QueryGenerator {
     let parent = include;
     let child = include;
     let nestedIncludes = this._getRequiredClosure(include).include;
-    let query;
+    let select;
 
     while ((parent = parent.parent)) { // eslint-disable-line
       if (parent.parent && !parent.required) {
@@ -1815,7 +1831,7 @@ class QueryGenerator {
     topInclude.association = undefined;
 
     if (topInclude.through && Object(topInclude.through.model) === topInclude.through.model) {
-      query = this.selectQuery(topInclude.through.model.getTableName(), {
+      select = this.selectQuery(topInclude.through.model.getTableName(), {
         attributes: [topInclude.through.model.primaryKeyField],
         include: Model._validateIncludedElements({
           model: topInclude.through.model,
@@ -1837,7 +1853,8 @@ class QueryGenerator {
           ]
         },
         limit: 1,
-        includeIgnoreAttributes: false
+        includeIgnoreAttributes: false,
+        bindParam
       }, topInclude.through.model);
     } else {
       const isBelongsTo = topAssociation.associationType === 'BelongsTo';
@@ -1849,7 +1866,7 @@ class QueryGenerator {
         this.quoteTable(topParent.as || topParent.model.name) + '.' + this.quoteIdentifier(sourceField)
       ].join(' = ');
 
-      query = this.selectQuery(topInclude.model.getTableName(), {
+      select = this.selectQuery(topInclude.model.getTableName(), {
         attributes: [targetField],
         include: Model._validateIncludedElements(topInclude).include,
         model: topInclude.model,
@@ -1861,7 +1878,8 @@ class QueryGenerator {
         },
         limit: 1,
         tableAs: topInclude.as,
-        includeIgnoreAttributes: false
+        includeIgnoreAttributes: false,
+        bindParam
       }, topInclude.model);
     }
 
@@ -1871,7 +1889,7 @@ class QueryGenerator {
 
     topLevelInfo.options.where[`__${includeAs.internalAs}`] = this.sequelize.asIs([
       '(',
-      query.replace(/\;$/, ''),
+      select.query.replace(/\;$/, ''),
       ')',
       'IS NOT NULL'
     ].join(' '));
@@ -2126,6 +2144,7 @@ class QueryGenerator {
     }
 
     if (!value) {
+      value = value === undefined ? null : value;
       const opValue = options.bindParam ? this.format(value, field, options, options.bindParam) : this.escape(value, field);
       return this._joinKeyValue(key, opValue, this.OperatorMap[Op.eq], options.prefix);
     }
@@ -2263,14 +2282,14 @@ class QueryGenerator {
     });
 
     _.forOwn(value, (item, prop) => {
-      this._traverseJSON(items, baseKey, prop, item, [prop]);
+      this._traverseJSON(items, baseKey, prop, item, [prop], options);
     });
 
     const result = items.join(this.OperatorMap[Op.and]);
     return items.length > 1 ? '('+result+')' : result;
   }
 
-  _traverseJSON(items, baseKey, prop, item, path) {
+  _traverseJSON(items, baseKey, prop, item, path, options) {
     let cast;
 
     if (path[path.length - 1].indexOf('::') > -1) {
@@ -2279,22 +2298,26 @@ class QueryGenerator {
       path[path.length - 1] = tmp[0];
     }
 
-    const pathKey = this.jsonPathExtractionQuery(baseKey, path);
+    let pathKey = this.jsonPathExtractionQuery(baseKey, path);
+    // Paths can contain $ symbols, if bindParams are used need to escape
+    if (options.bindParam) {
+      pathKey = this.bindEscape(pathKey);
+    }
 
     if (_.isPlainObject(item)) {
       Utils.getOperators(item).forEach(op => {
         const value = this._toJSONValue(item[op]);
-        items.push(this.whereItemQuery(this._castKey(pathKey, value, cast), {[op]: value}));
+        items.push(this.whereItemQuery(this._castKey(pathKey, value, cast), {[op]: value}, { bindParam: options.bindParam }));
       });
       _.forOwn(item, (value, itemProp) => {
-        this._traverseJSON(items, baseKey, itemProp, value, path.concat([itemProp]));
+        this._traverseJSON(items, baseKey, itemProp, value, path.concat([itemProp]), options);
       });
 
       return;
     }
 
     item = this._toJSONValue(item);
-    items.push(this.whereItemQuery(this._castKey(pathKey, item, cast), {[Op.eq]: item}));
+    items.push(this.whereItemQuery(this._castKey(pathKey, item, cast), {[Op.eq]: item}, { bindParam: options.bindParam }));
   }
 
   _toJSONValue(value) {
@@ -2477,7 +2500,8 @@ class QueryGenerator {
     } else if (_.isPlainObject(smth)) {
       return this.whereItemsQuery(smth, {
         model: factory,
-        prefix: prepend && tableName
+        prefix: prepend && tableName,
+        bindParam: options.bindParam
       });
     } else if (typeof smth === 'number') {
       let primaryKeys = factory ? Object.keys(factory.primaryKeys) : [];
@@ -2493,12 +2517,14 @@ class QueryGenerator {
 
       return this.whereItemsQuery(where, {
         model: factory,
-        prefix: prepend && tableName
+        prefix: prepend && tableName,
+        bindParam: options.bindParam
       });
     } else if (typeof smth === 'string') {
       return this.whereItemsQuery(smth, {
         model: factory,
-        prefix: prepend && tableName
+        prefix: prepend && tableName,
+        bindParam: options.bindParam
       });
     } else if (Buffer.isBuffer(smth)) {
       result = this.escape(smth);
@@ -2513,7 +2539,8 @@ class QueryGenerator {
     } else if (smth === null) {
       return this.whereItemsQuery(smth, {
         model: factory,
-        prefix: prepend && tableName
+        prefix: prepend && tableName,
+        bindParam: options.bindParam
       });
     }
 

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -161,12 +161,19 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
   }
 
   handleSequelizeMethod(smth, tableName, factory, options, prepend) {
+    options = options || {};
+
     if (smth instanceof Utils.Json) {
       // Parse nested object
       if (smth.conditions) {
-        const conditions = _.map(this.parseConditionObject(smth.conditions), condition =>
-          `${this.quoteIdentifier(_.first(condition.path))}->>'\$.${_.tail(condition.path).join('.')}' = '${condition.value}'`
-        );
+        const conditions = _.map(this.parseConditionObject(smth.conditions), condition => {
+          const value = options.bindParam ? options.bindParam(condition.value) : `'${condition.value}'`;
+          let pathKey = `\$.${_.tail(condition.path).join('.')}`;
+          if (options.bindParam) {
+            pathKey = this.bindEscape(pathKey);
+          }
+          return `${this.quoteIdentifier(_.first(condition.path))}->>'${pathKey}' = ${value}`;
+        });
 
         return conditions.join(' and ');
       } else if (smth.path) {
@@ -196,11 +203,16 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
             startWithDot = false;
           }
 
-          str = `${this.quoteIdentifier(columnName)}->>'\$${startWithDot ? '.' : ''}${path.join('.')}'`;
+          let pathKey = `\$${startWithDot ? '.' : ''}${path.join('.')}`;
+          if (options.bindParam) {
+            pathKey = this.bindEscape(pathKey);
+          }
+
+          str = `${this.quoteIdentifier(columnName)}->>'${pathKey}'`;
         }
 
         if (smth.value) {
-          str += util.format(' = %s', this.escape(smth.value));
+          str += util.format(' = %s', options.bindParam ? options.bindParam(smth.value) : this.escape(smth.value));
         }
 
         return str;

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -146,6 +146,8 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
 
 
   handleSequelizeMethod(smth, tableName, factory, options, prepend) {
+    options = options || {};
+
     if (smth instanceof Utils.Json) {
       // Parse nested object
       if (smth.conditions) {
@@ -168,7 +170,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
         }
 
         if (smth.value) {
-          str += util.format(' = %s', this.escape(smth.value));
+          str += util.format(' = %s', options.bindParam ? options.bindParam(smth.value) : this.escape(smth.value));
         }
 
         return str;

--- a/test/integration/model/find.test.js
+++ b/test/integration/model/find.test.js
@@ -112,7 +112,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           where: {'specialkey': 'awesome'},
           logging(sql) {
             test = true;
-            expect(sql).to.match(/WHERE ["|`|\[]UserPrimary["|`|\]]\.["|`|\[]specialkey["|`|\]] = N?'awesome'/);
+            expect(sql).to.match(/WHERE ["|`|\[]UserPrimary["|`|\]]\.["|`|\[]specialkey["|`|\]] = (\$1|\?)/);
           }
         }).then(() => {
           expect(test).to.be.true;
@@ -259,8 +259,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return this.User.bulkCreate([{username: 'jack'}, {username: 'jack'}]).then(() => {
           return self.sequelize.Promise.map(permutations, perm => {
             return self.User.findById(perm, {
-              logging(s) {
-                expect(s.indexOf(0)).not.to.equal(-1);
+              logging(sql) {
+                expect(sql).to.match(/(\$1|\?)/);
                 count++;
               }
             }).then(user => {

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -180,56 +180,95 @@ if (dialect === 'mysql') {
       selectQuery: [
         {
           arguments: ['myTable'],
-          expectation: 'SELECT * FROM `myTable`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {attributes: ['id', 'name']}],
-          expectation: 'SELECT `id`, `name` FROM `myTable`;',
+          expectation: {
+            query: 'SELECT `id`, `name` FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: {id: 2}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = $1;',
+            bind: [2]
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: {name: 'foo'}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`name` = 'foo';",
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`name` = $1;',
+            bind: ['foo']
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: {name: "foo';DROP TABLE myTable;"}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`name` = 'foo\\';DROP TABLE myTable;';",
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`name` = $1;',
+            bind: ["foo';DROP TABLE myTable;"]
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: 2}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = $1;',
+            bind: [2]
+          },
           context: QueryGenerator
         }, {
           arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS `count` FROM `foo`;',
+          expectation: {
+            query: 'SELECT count(*) AS `count` FROM `foo`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['id']}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `id`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `id`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['id', 'DESC']}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `id`, `DESC`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `id`, `DESC`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['myTable.id']}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['myTable.id', 'DESC']]}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id` DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id` DESC;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['id', 'DESC']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {order: [['id', 'DESC'], ['name']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC, `myTable`.`name`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC, `myTable`.`name`;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -239,7 +278,10 @@ if (dialect === 'mysql') {
               order: [[sequelize.fn('f1', sequelize.fn('f2', sequelize.col('id'))), 'DESC']]
             };
           }],
-          expectation: 'SELECT * FROM `myTable` ORDER BY f1(f2(`id`)) DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY f1(f2(`id`)) DESC;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -252,7 +294,10 @@ if (dialect === 'mysql') {
               ]
             };
           }],
-          expectation: "SELECT * FROM `myTable` ORDER BY f1(`myTable`.`id`) DESC, f2(12, 'lalala', '2011-03-27 10:01:55') ASC;",
+          expectation: {
+            query: "SELECT * FROM `myTable` ORDER BY f1(`myTable`.`id`) DESC, f2(12, 'lalala', '2011-03-27 10:01:55') ASC;",
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -265,7 +310,10 @@ if (dialect === 'mysql') {
               )
             };
           }],
-          expectation: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) = 'jan' AND `myTable`.`type` = 1);",
+          expectation: {
+            query: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) = 'jan' AND `myTable`.`type` = $1);",
+            bind: [1]
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -278,17 +326,26 @@ if (dialect === 'mysql') {
               )
             };
           }],
-          expectation: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) LIKE '%t%' AND `myTable`.`type` = 1);",
+          expectation: {
+            query: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) LIKE '%t%' AND `myTable`.`type` = $1);",
+            bind: [1]
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           title: 'single string argument should be quoted',
           arguments: ['myTable', {group: 'name'}],
-          expectation: 'SELECT * FROM `myTable` GROUP BY `name`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY `name`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', { group: ['name'] }],
-          expectation: 'SELECT * FROM `myTable` GROUP BY `name`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY `name`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'functions work for group by',
@@ -297,7 +354,10 @@ if (dialect === 'mysql') {
               group: [sequelize.fn('YEAR', sequelize.col('createdAt'))]
             };
           }],
-          expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -307,12 +367,18 @@ if (dialect === 'mysql') {
               group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title']
             };
           }],
-          expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {group: 'name', order: [['id', 'DESC']]}],
-          expectation: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'HAVING clause works with where-like hash',
@@ -323,7 +389,10 @@ if (dialect === 'mysql') {
               having: { creationYear: { [Op.gt]: 2002 } }
             };
           }],
-          expectation: 'SELECT *, YEAR(`createdAt`) AS `creationYear` FROM `myTable` GROUP BY `creationYear`, `title` HAVING `creationYear` > 2002;',
+          expectation: {
+            query: 'SELECT *, YEAR(`createdAt`) AS `creationYear` FROM `myTable` GROUP BY `creationYear`, `title` HAVING `creationYear` > 2002;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -336,86 +405,137 @@ if (dialect === 'mysql') {
               )
             };
           }],
-          expectation: "SELECT * FROM `myTable` WHERE (`myTable`.`archived` IS NULL AND COALESCE(`place_type_codename`, `announcement_type_codename`) IN ('Lost', 'Found'));",
+          expectation: {
+            query: "SELECT * FROM `myTable` WHERE (`myTable`.`archived` IS NULL AND COALESCE(`place_type_codename`, `announcement_type_codename`) IN ('Lost', 'Found'));",
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {limit: 10}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 10;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 10;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {limit: 10, offset: 2}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 2, 10;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 2, 10;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'uses default limit if only offset is specified',
           arguments: ['myTable', {offset: 2}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 2, 10000000000000;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 2, 10000000000000;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'uses limit 0',
           arguments: ['myTable', {limit: 0}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 0;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 0;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'uses offset 0',
           arguments: ['myTable', {offset: 0}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 0, 10000000000000;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 0, 10000000000000;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'multiple where arguments',
           arguments: ['myTable', {where: {boat: 'canoe', weather: 'cold'}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`boat` = 'canoe' AND `myTable`.`weather` = 'cold';",
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`boat` = $1 AND `myTable`.`weather` = $2;',
+            bind: ['canoe', 'cold']
+          },
           context: QueryGenerator
         }, {
           title: 'no where arguments (object)',
           arguments: ['myTable', {where: {}}],
-          expectation: 'SELECT * FROM `myTable`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'no where arguments (string)',
           arguments: ['myTable', {where: ['']}],
-          expectation: 'SELECT * FROM `myTable` WHERE 1=1;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE 1=1;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'no where arguments (null)',
           arguments: ['myTable', {where: null}],
-          expectation: 'SELECT * FROM `myTable`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'buffer as where argument',
-          arguments: ['myTable', {where: { field: new Buffer('Sequelize')}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`field` = X'53657175656c697a65';",
+          arguments: ['myTable', {where: { field: Buffer.from('Sequelize')}}],
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` = $1;',
+            bind: [Buffer.from('Sequelize')]
+          },
           context: QueryGenerator
         }, {
           title: 'use != if ne !== null',
           arguments: ['myTable', {where: {field: {[Op.ne]: 0}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 0;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 0;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'use IS NOT if ne === null',
           arguments: ['myTable', {where: {field: {[Op.ne]: null}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT NULL;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT NULL;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'use IS NOT if not === BOOLEAN',
           arguments: ['myTable', {where: {field: {[Op.not]: true}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT true;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT true;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'use != if not !== BOOLEAN',
           arguments: ['myTable', {where: {field: {[Op.not]: 3}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 3;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 3;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'Regular Expression in where clause',
           arguments: ['myTable', {where: {field: {[Op.regexp]: '^[h|a|t]'}}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`field` REGEXP '^[h|a|t]';",
+          expectation: {
+            query: "SELECT * FROM `myTable` WHERE `myTable`.`field` REGEXP '^[h|a|t]';",
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'Regular Expression negation in where clause',
           arguments: ['myTable', {where: {field: {[Op.notRegexp]: '^[h|a|t]'}}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`field` NOT REGEXP '^[h|a|t]';",
+          expectation: {
+            query: "SELECT * FROM `myTable` WHERE `myTable`.`field` NOT REGEXP '^[h|a|t]';",
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'Empty having',
@@ -424,7 +544,10 @@ if (dialect === 'mysql') {
               having: {}
             };
           }],
-          expectation: 'SELECT * FROM `myTable`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -436,7 +559,10 @@ if (dialect === 'mysql') {
               having: { creationYear: { [Op.gt]: 2002 } }
             };
           }],
-          expectation: 'SELECT `test`.* FROM (SELECT * FROM `myTable` AS `test` HAVING `creationYear` > 2002) AS `test`;',
+          expectation: {
+            query: 'SELECT `test`.* FROM (SELECT * FROM `myTable` AS `test` HAVING `creationYear` > 2002) AS `test`;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -255,60 +255,105 @@ if (dialect.match(/^postgres/)) {
       selectQuery: [
         {
           arguments: ['myTable'],
-          expectation: 'SELECT * FROM \"myTable\";'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\";',
+            bind: []
+          }
         }, {
           arguments: ['myTable', {attributes: ['id', 'name']}],
-          expectation: 'SELECT \"id\", \"name\" FROM \"myTable\";'
+          expectation: {
+            query: 'SELECT \"id\", \"name\" FROM \"myTable\";',
+            bind: []
+          }
         }, {
           arguments: ['myTable', {where: {id: 2}}],
-          expectation: 'SELECT * FROM \"myTable\" WHERE \"myTable\".\"id\" = 2;'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" WHERE \"myTable\".\"id\" = $1;',
+            bind: [2]
+          }
         }, {
           arguments: ['myTable', {where: {name: 'foo'}}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"name\" = 'foo';"
+          expectation: {
+            query: 'SELECT * FROM "myTable" WHERE "myTable"."name" = $1;',
+            bind: ['foo']
+          }
         }, {
           arguments: ['myTable', {where: {name: "foo';DROP TABLE myTable;"}}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"name\" = 'foo'';DROP TABLE myTable;';"
+          expectation: {
+            query: 'SELECT * FROM "myTable" WHERE "myTable"."name" = $1;',
+            bind: ["foo';DROP TABLE myTable;"]
+          }
         }, {
           arguments: ['myTable', {where: 2}],
-          expectation: 'SELECT * FROM \"myTable\" WHERE \"myTable\".\"id\" = 2;'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" WHERE \"myTable\".\"id\" = $1;',
+            bind: [2]
+          }
         }, {
           arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS \"count\" FROM \"foo\";'
+          expectation: {
+            query: 'SELECT count(*) AS \"count\" FROM \"foo\";',
+            bind: []
+          }
         }, {
           arguments: ['myTable', {order: ['id']}],
-          expectation: 'SELECT * FROM "myTable" ORDER BY "id";',
+          expectation: {
+            query: 'SELECT * FROM "myTable" ORDER BY "id";',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['id', 'DESC']}],
-          expectation: 'SELECT * FROM "myTable" ORDER BY "id", "DESC";',
+          expectation: {
+            query: 'SELECT * FROM "myTable" ORDER BY "id", "DESC";',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['myTable.id']}],
-          expectation: 'SELECT * FROM "myTable" ORDER BY "myTable"."id";',
+          expectation: {
+            query: 'SELECT * FROM "myTable" ORDER BY "myTable"."id";',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['myTable.id', 'DESC']]}],
-          expectation: 'SELECT * FROM "myTable" ORDER BY "myTable"."id" DESC;',
+          expectation: {
+            query: 'SELECT * FROM "myTable" ORDER BY "myTable"."id" DESC;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['id', 'DESC']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM "myTable" AS "myTable" ORDER BY "myTable"."id" DESC;',
+          expectation: {
+            query: 'SELECT * FROM "myTable" AS "myTable" ORDER BY "myTable"."id" DESC;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {order: [['id', 'DESC'], ['name']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM "myTable" AS "myTable" ORDER BY "myTable"."id" DESC, "myTable"."name";',
+          expectation: {
+            query: 'SELECT * FROM "myTable" AS "myTable" ORDER BY "myTable"."id" DESC, "myTable"."name";',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           title: 'uses limit 0',
           arguments: ['myTable', {limit: 0}],
-          expectation: 'SELECT * FROM "myTable" LIMIT 0;',
+          expectation: {
+            query: 'SELECT * FROM "myTable" LIMIT 0;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'uses offset 0',
           arguments: ['myTable', {offset: 0}],
-          expectation: 'SELECT * FROM "myTable" OFFSET 0;',
+          expectation: {
+            query: 'SELECT * FROM "myTable" OFFSET 0;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'sequelize.where with .fn as attribute and default comparator',
@@ -320,7 +365,10 @@ if (dialect.match(/^postgres/)) {
               )
             };
           }],
-          expectation: 'SELECT * FROM "myTable" WHERE (LOWER("user"."name") = \'jan\' AND "myTable"."type" = 1);',
+          expectation: {
+            query: 'SELECT * FROM "myTable" WHERE (LOWER("user"."name") = \'jan\' AND "myTable"."type" = $1);',
+            bind: [1]
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -333,7 +381,10 @@ if (dialect.match(/^postgres/)) {
               )
             };
           }],
-          expectation: 'SELECT * FROM "myTable" WHERE (LOWER("user"."name") LIKE \'%t%\' AND "myTable"."type" = 1);',
+          expectation: {
+            query: 'SELECT * FROM "myTable" WHERE (LOWER("user"."name") LIKE \'%t%\' AND "myTable"."type" = $1);',
+            bind: [1]
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -343,7 +394,10 @@ if (dialect.match(/^postgres/)) {
               order: [[sequelize.fn('f1', sequelize.fn('f2', sequelize.col('id'))), 'DESC']]
             };
           }],
-          expectation: 'SELECT * FROM "myTable" ORDER BY f1(f2("id")) DESC;',
+          expectation: {
+            query: 'SELECT * FROM "myTable" ORDER BY f1(f2("id")) DESC;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -356,7 +410,10 @@ if (dialect.match(/^postgres/)) {
               ]
             };
           }],
-          expectation: 'SELECT * FROM "myTable" ORDER BY f1("myTable"."id") DESC, f2(12, \'lalala\', \'2011-03-27 10:01:55.000 +00:00\') ASC;',
+          expectation: {
+            query: 'SELECT * FROM "myTable" ORDER BY f1("myTable"."id") DESC, f2(12, \'lalala\', \'2011-03-27 10:01:55.000 +00:00\') ASC;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -369,16 +426,25 @@ if (dialect.match(/^postgres/)) {
               )
             };
           }],
-          expectation: 'SELECT * FROM "myTable" WHERE ("myTable"."archived" IS NULL AND COALESCE("place_type_codename", "announcement_type_codename") IN (\'Lost\', \'Found\'));',
+          expectation: {
+            query: 'SELECT * FROM "myTable" WHERE ("myTable"."archived" IS NULL AND COALESCE("place_type_codename", "announcement_type_codename") IN (\'Lost\', \'Found\'));',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           title: 'single string argument should be quoted',
           arguments: ['myTable', {group: 'name'}],
-          expectation: 'SELECT * FROM \"myTable\" GROUP BY \"name\";'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" GROUP BY \"name\";',
+            bind: []
+          }
         }, {
           arguments: ['myTable', {group: ['name']}],
-          expectation: 'SELECT * FROM \"myTable\" GROUP BY \"name\";'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" GROUP BY \"name\";',
+            bind: []
+          }
         }, {
           title: 'functions work for group by',
           arguments: ['myTable', function(sequelize) {
@@ -386,7 +452,10 @@ if (dialect.match(/^postgres/)) {
               group: [sequelize.fn('YEAR', sequelize.col('createdAt'))]
             };
           }],
-          expectation: 'SELECT * FROM \"myTable\" GROUP BY YEAR(\"createdAt\");',
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" GROUP BY YEAR(\"createdAt\");',
+            bind: []
+          },
           needsSequelize: true
         }, {
           title: 'It is possible to mix sequelize.fn and string arguments to group by',
@@ -395,12 +464,18 @@ if (dialect.match(/^postgres/)) {
               group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title']
             };
           }],
-          expectation: 'SELECT * FROM \"myTable\" GROUP BY YEAR(\"createdAt\"), \"title\";',
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" GROUP BY YEAR(\"createdAt\"), \"title\";',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {group: ['name', 'title']}],
-          expectation: 'SELECT * FROM \"myTable\" GROUP BY \"name\", \"title\";'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" GROUP BY \"name\", \"title\";',
+            bind: []
+          }
         }, {
           title: 'HAVING clause works with where-like hash',
           arguments: ['myTable', function(sequelize) {
@@ -410,141 +485,237 @@ if (dialect.match(/^postgres/)) {
               having: { creationYear: { [Op.gt]: 2002 } }
             };
           }],
-          expectation: 'SELECT *, YEAR(\"createdAt\") AS \"creationYear\" FROM \"myTable\" GROUP BY \"creationYear\", \"title\" HAVING \"creationYear\" > 2002;',
+          expectation: {
+            query: 'SELECT *, YEAR(\"createdAt\") AS \"creationYear\" FROM \"myTable\" GROUP BY \"creationYear\", \"title\" HAVING \"creationYear\" > 2002;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {limit: 10}],
-          expectation: 'SELECT * FROM \"myTable\" LIMIT 10;'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" LIMIT 10;',
+            bind: []
+          }
         }, {
           arguments: ['myTable', {limit: 10, offset: 2}],
-          expectation: 'SELECT * FROM \"myTable\" LIMIT 10 OFFSET 2;'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" LIMIT 10 OFFSET 2;',
+            bind: []
+          }
         }, {
           title: 'uses offset even if no limit was passed',
           arguments: ['myTable', {offset: 2}],
-          expectation: 'SELECT * FROM \"myTable\" OFFSET 2;'
+          expectation: {
+            query: 'SELECT * FROM \"myTable\" OFFSET 2;',
+            bind: []
+          }
         }, {
           arguments: [{tableName: 'myTable', schema: 'mySchema'}],
-          expectation: 'SELECT * FROM \"mySchema\".\"myTable\";'
+          expectation: {
+            query: 'SELECT * FROM \"mySchema\".\"myTable\";',
+            bind: []
+          }
         }, {
           arguments: [{tableName: 'myTable', schema: 'mySchema'}, {where: {name: "foo';DROP TABLE mySchema.myTable;"}}],
-          expectation: "SELECT * FROM \"mySchema\".\"myTable\" WHERE \"mySchema\".\"myTable\".\"name\" = 'foo'';DROP TABLE mySchema.myTable;';"
+          expectation: {
+            query: 'SELECT * FROM "mySchema"."myTable" WHERE "mySchema"."myTable"."name" = $1;',
+            bind: ["foo';DROP TABLE mySchema.myTable;"]
+          }
         }, {
           title: 'buffer as where argument',
-          arguments: ['myTable', {where: { field: new Buffer('Sequelize')}}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" = E'\\\\x53657175656c697a65';",
+          arguments: ['myTable', {where: { field: Buffer.from('Sequelize')}}],
+          expectation: {
+            query: 'SELECT * FROM "myTable" WHERE "myTable"."field" = $1;',
+            bind: [Buffer.from('Sequelize')]
+          },
           context: QueryGenerator
         }, {
           title: 'string in array should escape \' as \'\'',
           arguments: ['myTable', {where: { aliases: {[Op.contains]: ['Queen\'s']} }}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"aliases\" @> ARRAY['Queen''s'];"
+          expectation: {
+            query: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"aliases\" @> ARRAY['Queen''s'];",
+            bind: []
+          }
         },
 
         // Variants when quoteIdentifiers is false
         {
           arguments: ['myTable'],
-          expectation: 'SELECT * FROM myTable;',
+          expectation: {
+            query: 'SELECT * FROM myTable;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {attributes: ['id', 'name']}],
-          expectation: 'SELECT id, name FROM myTable;',
+          expectation: {
+            query: 'SELECT id, name FROM myTable;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {where: {id: 2}}],
-          expectation: 'SELECT * FROM myTable WHERE myTable.id = 2;',
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.id = $1;',
+            bind: [2]
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {where: {name: 'foo'}}],
-          expectation: "SELECT * FROM myTable WHERE myTable.name = 'foo';",
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.name = $1;',
+            bind: ['foo']
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {where: {name: "foo';DROP TABLE myTable;"}}],
-          expectation: "SELECT * FROM myTable WHERE myTable.name = 'foo'';DROP TABLE myTable;';",
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.name = $1;',
+            bind: ["foo';DROP TABLE myTable;"]
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {where: 2}],
-          expectation: 'SELECT * FROM myTable WHERE myTable.id = 2;',
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.id = $1;',
+            bind: [2]
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS count FROM foo;',
+          expectation: {
+            query: 'SELECT count(*) AS count FROM foo;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {order: ['id DESC']}],
-          expectation: 'SELECT * FROM myTable ORDER BY id DESC;',
+          expectation: {
+            query: 'SELECT * FROM myTable ORDER BY id DESC;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {group: 'name'}],
-          expectation: 'SELECT * FROM myTable GROUP BY name;',
+          expectation: {
+            query: 'SELECT * FROM myTable GROUP BY name;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {group: ['name']}],
-          expectation: 'SELECT * FROM myTable GROUP BY name;',
+          expectation: {
+            query: 'SELECT * FROM myTable GROUP BY name;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {group: ['name', 'title']}],
-          expectation: 'SELECT * FROM myTable GROUP BY name, title;',
+          expectation: {
+            query: 'SELECT * FROM myTable GROUP BY name, title;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {limit: 10}],
-          expectation: 'SELECT * FROM myTable LIMIT 10;',
+          expectation: {
+            query: 'SELECT * FROM myTable LIMIT 10;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: ['myTable', {limit: 10, offset: 2}],
-          expectation: 'SELECT * FROM myTable LIMIT 10 OFFSET 2;',
+          expectation: {
+            query: 'SELECT * FROM myTable LIMIT 10 OFFSET 2;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           title: 'uses offset even if no limit was passed',
           arguments: ['myTable', {offset: 2}],
-          expectation: 'SELECT * FROM myTable OFFSET 2;',
+          expectation: {
+            query: 'SELECT * FROM myTable OFFSET 2;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: [{tableName: 'myTable', schema: 'mySchema'}],
-          expectation: 'SELECT * FROM mySchema.myTable;',
+          expectation: {
+            query: 'SELECT * FROM mySchema.myTable;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           arguments: [{tableName: 'myTable', schema: 'mySchema'}, {where: {name: "foo';DROP TABLE mySchema.myTable;"}}],
-          expectation: "SELECT * FROM mySchema.myTable WHERE mySchema.myTable.name = 'foo'';DROP TABLE mySchema.myTable;';",
+          expectation: {
+            query: 'SELECT * FROM mySchema.myTable WHERE mySchema.myTable.name = $1;',
+            bind: ["foo';DROP TABLE mySchema.myTable;"]
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           title: 'use != if Op.ne !== null',
           arguments: ['myTable', {where: {field: {[Op.ne]: 0}}}],
-          expectation: 'SELECT * FROM myTable WHERE myTable.field != 0;',
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.field != 0;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           title: 'use IS NOT if Op.ne === null',
           arguments: ['myTable', {where: {field: {[Op.ne]: null}}}],
-          expectation: 'SELECT * FROM myTable WHERE myTable.field IS NOT NULL;',
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.field IS NOT NULL;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           title: 'use IS NOT if Op.not === BOOLEAN',
           arguments: ['myTable', {where: {field: {[Op.not]: true}}}],
-          expectation: 'SELECT * FROM myTable WHERE myTable.field IS NOT true;',
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.field IS NOT true;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           title: 'use != if Op.not !== BOOLEAN',
           arguments: ['myTable', {where: {field: {[Op.not]: 3}}}],
-          expectation: 'SELECT * FROM myTable WHERE myTable.field != 3;',
+          expectation: {
+            query: 'SELECT * FROM myTable WHERE myTable.field != 3;',
+            bind: []
+          },
           context: {options: {quoteIdentifiers: false}}
         }, {
           title: 'Regular Expression in where clause',
           arguments: ['myTable', {where: {field: {[Op.regexp]: '^[h|a|t]'}}}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" ~ '^[h|a|t]';",
+          expectation: {
+            query: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" ~ '^[h|a|t]';",
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'Regular Expression negation in where clause',
           arguments: ['myTable', {where: {field: {[Op.notRegexp]: '^[h|a|t]'}}}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" !~ '^[h|a|t]';",
+          expectation: {
+            query: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" !~ '^[h|a|t]';",
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'Case-insensitive Regular Expression in where clause',
           arguments: ['myTable', {where: {field: {[Op.iRegexp]: '^[h|a|t]'}}}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" ~* '^[h|a|t]';",
+          expectation: {
+            query: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" ~* '^[h|a|t]';",
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'Case-insensitive Regular Expression negation in where clause',
           arguments: ['myTable', {where: {field: {[Op.notIRegexp]: '^[h|a|t]'}}}],
-          expectation: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" !~* '^[h|a|t]';",
+          expectation: {
+            query: "SELECT * FROM \"myTable\" WHERE \"myTable\".\"field\" !~* '^[h|a|t]';",
+            bind: []
+          },
           context: QueryGenerator
         }
       ],

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -150,56 +150,95 @@ if (dialect === 'sqlite') {
       selectQuery: [
         {
           arguments: ['myTable'],
-          expectation: 'SELECT * FROM `myTable`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {attributes: ['id', 'name']}],
-          expectation: 'SELECT `id`, `name` FROM `myTable`;',
+          expectation: {
+            query: 'SELECT `id`, `name` FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: {id: 2}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = $1;',
+            bind: [2]
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: {name: 'foo'}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`name` = 'foo';",
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`name` = $1;',
+            bind: ['foo']
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: {name: "foo';DROP TABLE myTable;"}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`name` = 'foo\'\';DROP TABLE myTable;';",
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`name` = $1;',
+            bind: ["foo';DROP TABLE myTable;"]
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {where: 2}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = $1;',
+            bind: [2]
+          },
           context: QueryGenerator
         }, {
           arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS `count` FROM `foo`;',
+          expectation: {
+            query: 'SELECT count(*) AS `count` FROM `foo`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['id']}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `id`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `id`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['id', 'DESC']}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `id`, `DESC`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `id`, `DESC`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: ['myTable.id']}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['myTable.id', 'DESC']]}],
-          expectation: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id` DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY `myTable`.`id` DESC;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {order: [['id', 'DESC']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {order: [['id', 'DESC'], ['name']]}, function(sequelize) {return sequelize.define('myTable', {});}],
-          expectation: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC, `myTable`.`name`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` AS `myTable` ORDER BY `myTable`.`id` DESC, `myTable`.`name`;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -212,7 +251,11 @@ if (dialect === 'sqlite') {
               )
             };
           }],
-          expectation: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) = 'jan' AND `myTable`.`type` = 1);",
+          // TODO: Enhance WHERE bind params
+          expectation: {
+            query: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) = 'jan' AND `myTable`.`type` = $1);",
+            bind: [1]
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -225,7 +268,11 @@ if (dialect === 'sqlite') {
               )
             };
           }],
-          expectation: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) LIKE '%t%' AND `myTable`.`type` = 1);",
+          // TODO: Enhance WHERE bind params
+          expectation: {
+            query: "SELECT * FROM `myTable` WHERE (LOWER(`user`.`name`) LIKE '%t%' AND `myTable`.`type` = $1);",
+            bind: [1]
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -235,7 +282,10 @@ if (dialect === 'sqlite') {
               order: [[sequelize.fn('f1', sequelize.fn('f2', sequelize.col('id'))), 'DESC']]
             };
           }],
-          expectation: 'SELECT * FROM `myTable` ORDER BY f1(f2(`id`)) DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` ORDER BY f1(f2(`id`)) DESC;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -248,17 +298,26 @@ if (dialect === 'sqlite') {
               ]
             };
           }],
-          expectation: "SELECT * FROM `myTable` ORDER BY f1(`myTable`.`id`) DESC, f2(12, 'lalala', '2011-03-27 10:01:55.000 +00:00') ASC;",
+          expectation: {
+            query: "SELECT * FROM `myTable` ORDER BY f1(`myTable`.`id`) DESC, f2(12, 'lalala', '2011-03-27 10:01:55.000 +00:00') ASC;",
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           title: 'single string argument should be quoted',
           arguments: ['myTable', {group: 'name'}],
-          expectation: 'SELECT * FROM `myTable` GROUP BY `name`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY `name`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {group: ['name']}],
-          expectation: 'SELECT * FROM `myTable` GROUP BY `name`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY `name`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'functions work for group by',
@@ -267,7 +326,10 @@ if (dialect === 'sqlite') {
               group: [sequelize.fn('YEAR', sequelize.col('createdAt'))]
             };
           }],
-          expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`);',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
@@ -277,16 +339,25 @@ if (dialect === 'sqlite') {
               group: [sequelize.fn('YEAR', sequelize.col('createdAt')), 'title']
             };
           }],
-          expectation: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY YEAR(`createdAt`), `title`;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {group: ['name', 'title']}],
-          expectation: 'SELECT * FROM `myTable` GROUP BY `name`, `title`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY `name`, `title`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {group: 'name', order: [['id', 'DESC']]}],
-          expectation: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'HAVING clause works with where-like hash',
@@ -297,66 +368,106 @@ if (dialect === 'sqlite') {
               having: { creationYear: { [Op.gt]: 2002 } }
             };
           }],
-          expectation: 'SELECT *, YEAR(`createdAt`) AS `creationYear` FROM `myTable` GROUP BY `creationYear`, `title` HAVING `creationYear` > 2002;',
+          expectation: {
+            query: 'SELECT *, YEAR(`createdAt`) AS `creationYear` FROM `myTable` GROUP BY `creationYear`, `title` HAVING `creationYear` > 2002;',
+            bind: []
+          },
           context: QueryGenerator,
           needsSequelize: true
         }, {
           arguments: ['myTable', {limit: 10}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 10;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 10;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           arguments: ['myTable', {limit: 10, offset: 2}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 2, 10;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 2, 10;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'uses default limit if only offset is specified',
           arguments: ['myTable', {offset: 2}],
-          expectation: 'SELECT * FROM `myTable` LIMIT 2, 10000000000000;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` LIMIT 2, 10000000000000;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'multiple where arguments',
           arguments: ['myTable', {where: {boat: 'canoe', weather: 'cold'}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`boat` = 'canoe' AND `myTable`.`weather` = 'cold';",
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`boat` = $1 AND `myTable`.`weather` = $2;',
+            bind: ['canoe', 'cold']
+          },
           context: QueryGenerator
         }, {
           title: 'no where arguments (object)',
           arguments: ['myTable', {where: {}}],
-          expectation: 'SELECT * FROM `myTable`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'no where arguments (string)',
           arguments: ['myTable', {where: ['']}],
-          expectation: 'SELECT * FROM `myTable` WHERE 1=1;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE 1=1;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'no where arguments (null)',
           arguments: ['myTable', {where: null}],
-          expectation: 'SELECT * FROM `myTable`;',
+          expectation: {
+            query: 'SELECT * FROM `myTable`;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'buffer as where argument',
-          arguments: ['myTable', {where: { field: new Buffer('Sequelize')}}],
-          expectation: "SELECT * FROM `myTable` WHERE `myTable`.`field` = X'53657175656c697a65';",
+          arguments: ['myTable', {where: { field: Buffer.from('Sequelize')}}],
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` = $1;',
+            bind: [Buffer.from('Sequelize')]
+          },
           context: QueryGenerator
         }, {
+          // TODO: Enhance WHERE bind params
           title: 'use != if ne !== null',
           arguments: ['myTable', {where: {field: {[Op.ne]: 0}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 0;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 0;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'use IS NOT if ne === null',
           arguments: ['myTable', {where: {field: {[Op.ne]: null}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT NULL;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT NULL;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'use IS NOT if not === BOOLEAN',
           arguments: ['myTable', {where: {field: {[Op.not]: true}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT 1;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` IS NOT 1;',
+            bind: []
+          },
           context: QueryGenerator
         }, {
           title: 'use != if not !== BOOLEAN',
           arguments: ['myTable', {where: {field: {[Op.not]: 3}}}],
-          expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 3;',
+          expectation: {
+            query: 'SELECT * FROM `myTable` WHERE `myTable`.`field` != 3;',
+            bind: []
+          },
           context: QueryGenerator
         }
       ],


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

WIP changes to allow SELECTs to use bind parameters instead of directly included values. For example, instead of:

```sql
SELECT `email`, `first_name` AS `firstName` FROM `User` WHERE `User`.`email` = 'jon.snow@gmail.com' ORDER BY `email` DESC LIMIT 10;
```

Generate:

```sql
SELECT `email`, `first_name` AS `firstName` FROM `User` WHERE `User`.`email` = $1 ORDER BY `email` DESC LIMIT 10;
```

(with parameter 'jon.snow@gmail.com')
