### PR TITLE
fix(constructor): set the username, the password and the database via constructor options

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -195,14 +195,10 @@ class Sequelize {
 
     this._setupHooks(options.hooks);
 
-    if (['', null, false].indexOf(config.password) > -1 || typeof config.password === 'undefined') {
-      config.password = null;
-    }
-
     this.config = {
-      database: config.database,
-      username: config.username,
-      password: config.password,
+      database: config.database || this.options.database,
+      username: config.username || this.options.username,
+      password: config.password || this.options.password || null,
       host: config.host || this.options.host,
       port: config.port || this.options.port,
       pool: this.options.pool,

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -121,6 +121,20 @@ describe('Sequelize', () => {
       expect(config.password).to.be.null;
     });
 
+    it('should correctly set the username, the password and the database through options', () => {
+      const options = {
+        username: 'root',
+        password: 'pass',
+        database: 'dbname'
+      };
+      const sequelize = new Sequelize('mysql://example.com:9821', options);
+      const config = sequelize.config;
+
+      expect(config.username).to.equal(options.username);
+      expect(config.password).to.equal(options.password);
+      expect(config.database).to.equal(options.database);
+    });
+
     it('should use the default port when no other is specified', () => {
       const sequelize = new Sequelize('dbname', 'root', 'pass', {
           dialect


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

The [document](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor) says that the username, the password and the database can be passed as options with URL. (e.g. `new Sequelize('mysql://localhost:3306', { database, username, password })`)  
But the current behavior does not honour these fields in options. This PR allows to pass these fields as options.
