### PR TITLE
fix(BelongsToMany): catch EmptyResultError in add* and set* accessors

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -8,6 +8,7 @@ const BelongsTo = require('./belongs-to');
 const HasMany = require('./has-many');
 const HasOne = require('./has-one');
 const AssociationError = require('../errors').AssociationError;
+const EmptyResultError = require('../errors').EmptyResultError;
 const Op = require('../operators');
 
 /**
@@ -515,7 +516,7 @@ class BelongsToMany extends Association {
     where[identifier] = sourceInstance.get(sourceKey);
     where = Object.assign(where, association.through.scope);
 
-    return association.through.model.findAll(_.defaults({where, raw: true}, options)).then(currentRows => {
+    const updateAssociations = currentRows => {
       const obsoleteAssociations = [];
       const promises = [];
       let defaultAttributes = options.through || {};
@@ -578,7 +579,14 @@ class BelongsToMany extends Association {
       }
 
       return Utils.Promise.all(promises);
-    });
+    };
+
+    return association.through.model.findAll(_.defaults({where, raw: true}, options))
+      .then(currentRows => updateAssociations(currentRows))
+      .catch(error => {
+        if (error instanceof EmptyResultError) return updateAssociations([]);
+        throw error;
+      });
   }
 
   /**
@@ -611,7 +619,7 @@ class BelongsToMany extends Association {
 
     _.assign(where, association.through.scope);
 
-    return association.through.model.findAll(_.defaults({where, raw: true}, options)).then(currentRows => {
+    const updateAssociations = currentRows => {
       const promises = [];
       const unassociatedObjects = [];
       const changedAssociations = [];
@@ -662,7 +670,14 @@ class BelongsToMany extends Association {
       }
 
       return Utils.Promise.all(promises);
-    });
+    };
+
+    return association.through.model.findAll(_.defaults({where, raw: true}, options))
+      .then(currentRows => updateAssociations(currentRows))
+      .catch(error => {
+        if (error instanceof EmptyResultError) return updateAssociations();
+        throw error;
+      });
   }
 
   /**


### PR DESCRIPTION
When the `rejectOnEmpty` flag is set in a model, an `EmptyResultError` is raised during a `findAll`
promise in add* and set* accessors of the BelongsToMany association. This fix prevents it by
catching only this error and throwing any unexpected others.

fix #9531
