### PR TITLE
fix(postgres): native getter is triggered on cloning sequelize

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -18,12 +18,22 @@ class ConnectionManager extends AbstractConnectionManager {
 
     try {
       let pgLib;
+      
       if (sequelize.config.dialectModulePath) {
         pgLib = require(sequelize.config.dialectModulePath);
       } else {
         pgLib = require('pg');
       }
-      this.lib = sequelize.config.native ? pgLib.native : pgLib;
+
+      if (sequelize.config.native) {
+        this.lib = pgLib.native;
+      } else {
+        // Fix an issue where cloning sequelize triggers this native getter
+        // Which fails for non native cases due to missing "pg-native" dependency
+        // https://github.com/sequelize/sequelize/issues/3781#issuecomment-104278869
+        delete pgLib.native;
+        this.lib = pgLib;
+      }
     } catch (err) {
       if (err.code === 'MODULE_NOT_FOUND') {
         throw new Error('Please install \'' + (sequelize.config.dialectModulePath || 'pg') + '\' module manually');


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Closes #3781

https://github.com/sequelize/sequelize/issues/3781#issuecomment-104278869

I have verified its working with following code, this can't be tested in CI as we always have `pg-native` dependency installed

```js
const Sequelize = require('sequelize');
const { cloneDeep } = require('lodash');

const sequelize = new Sequelize({
  dialect: 'postgres'
});

cloneDeep(sequelize);
```