### PR TITLE
fix: skip validation for undefined values while updating

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2612,6 +2612,15 @@ class Model {
 
         // We want to skip validations for all other fields
         options.skip = Utils._.difference(Object.keys(this.attributes), Object.keys(values));
+
+        // We want to skip validations for undefined values
+        // later they are removed by mapValueFieldNames and not shown in update query
+        Object.keys(values).forEach((key) => {
+          if (values[key] === undefined && options.skip.indexOf(key) < 0) {
+            options.skip.push(key);
+          }
+        });
+
         return build.validate(options).then(attributes => {
           options.skip = undefined;
           if (attributes && attributes.dataValues) {

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -42,6 +42,29 @@ describe(Support.getTestDialectTeaser('Model'), function() {
       });
     });
 
+    it('should not check for notNull Violation for undefined values', function () {
+      var ownerId = 2
+        , accountRowId;
+      return Account.create({
+        ownerId: ownerId,
+        name: Math.random().toString()
+      }).then(function (account) {
+        accountRowId = account.get('id');
+        var accountVal = {
+          name: Math.random().toString(),
+          ownerId: undefined
+        };
+        return Account.update(accountVal, {
+          where: {
+            id: accountRowId
+          }
+        });
+      }).then(function(rows) {
+        return Account.findById(accountRowId);
+      }).then(function(account) {
+        expect(account.ownerId).to.be.equal(ownerId);
+      });
+    });
 
     if (_.get(current.dialect.supports, 'returnValues.returning')) {
       it('should return the updated record', function () {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

### Description of change

Fixes #7056, after #7167 has failed since it affects the `.create` method (and should have not).

As stated in #7056, while assigning `undefined` value into a non-nullable prop and calling `.update` a validation Error is raised, yet while assigning `undefined` to nullable prop is completely ignored and not shown in the update query, due to the `mapValueFieldNames` function which removes `undefined` props as desired.
This also aligning the behavior with #9548 .

BWC checks for non-nullable props : 

- assigning null : no implication
- assigning value : no implicaation
- assigning undefined : no implication in final query yet no exception is raised now.

after this is merged will be happy to help and migrate to v4 / master. (I'm still using v3)
