### PR TITLE
fix(query): uuid require statements fixed

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -3,7 +3,7 @@
 const util = require('util');
 const _ = require('lodash');
 const Dottie = require('dottie');
-const uuid = require('uuid');
+const uuidv4 = require('uuid/v4');
 const semver = require('semver');
 
 const Utils = require('../../utils');
@@ -183,7 +183,7 @@ class QueryGenerator {
       // pg_temp functions are private per connection, so we never risk this function interfering with another one.
       if (semver.gte(this.sequelize.options.databaseVersion, '9.2.0')) {
         // >= 9.2 - Use a UUID but prefix with 'func_' (numbers first not allowed)
-        const delimiter = '$func_' + uuid.v4().replace(/-/g, '') + '$';
+        const delimiter = '$func_' + uuidv4().replace(/-/g, '') + '$';
 
         options.exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
         valueQuery = 'CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response <%= table %>, OUT sequelize_caught_exception text) RETURNS RECORD AS ' + delimiter +

--- a/lib/dialects/abstract/query-generator/transaction.js
+++ b/lib/dialects/abstract/query-generator/transaction.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const uuid = require('uuid');
+const uuidv4 = require('uuid/v4');
 
 const TransactionQueries = {
   /**
@@ -41,7 +41,7 @@ const TransactionQueries = {
   },
 
   generateTransactionId() {
-    return uuid.v4();
+    return uuidv4();
   },
 
   /**

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -3,7 +3,7 @@
 const Utils = require('../../utils');
 const debug = Utils.getLogger().debugContext('sql:mysql');
 const AbstractQuery = require('../abstract/query');
-const uuid = require('uuid');
+const uuidv4 = require('uuid/v4');
 const sequelizeErrors = require('../../errors');
 const _ = require('lodash');
 
@@ -14,7 +14,7 @@ class Query extends AbstractQuery {
     this.instance = options.instance;
     this.model = options.model;
     this.sequelize = sequelize;
-    this.uuid = uuid.v4();
+    this.uuid = uuidv4();
     this.options = _.extend({
       logging: console.log,
       plain: false,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,8 @@ const SqlString = require('./sql-string');
 const _ = require('lodash');
 const parameterValidator = require('./utils/parameter-validator');
 const Logger = require('./utils/logger');
-const uuid = require('uuid');
+const uuidv1 = require('uuid/v1');
+const uuidv4 = require('uuid/v4');
 const Promise = require('./promise');
 const operators  = require('./operators');
 const operatorsArray = _.values(operators);
@@ -266,9 +267,9 @@ function toDefaultValue(value, dialect) {
       return tmp;
     }
   } else if (value instanceof DataTypes.UUIDV1) {
-    return uuid.v1();
+    return uuidv1();
   } else if (value instanceof DataTypes.UUIDV4) {
-    return uuid.v4();
+    return uuidv4();
   } else if (value instanceof DataTypes.NOW) {
     return now(dialect);
   } else if (_.isPlainObject(value) || _.isArray(value)) {


### PR DESCRIPTION
As of version 3.x of uuid library `require('uuid')` statement is deprecated and should be changed to
`require('uuid/[v1|v3|v4|v5]')` respectively. This PR changes those statements with the new ones.

fix #9591

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](../CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

- Changed `require('uuid')` statements to `require('uuid/v4')` where version 4 used and added an extra require in `utils.js` file to allow also use version 1
- Changed constants' names to `uuidv4` and `uuidv1` to have distinction between them