### PR TITLE
Adds support for querying sqlite_master table

### DIFF
--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -153,7 +153,7 @@ function addConstraint(tableName, options) {
   const describeCreateTableSql = this.QueryGenerator.describeCreateTableQuery(tableName);
   let createTableSql;
 
-  return this.sequelize.query(describeCreateTableSql, { ...options, type: QueryTypes.SELECT, raw: true })
+  return this.sequelize.query(describeCreateTableSql, _.assign({}, options, { type: QueryTypes.SELECT, raw: true }))
     .then(constraints => {
       const sql = constraints[0].sql;
       const index = sql.length - 1;

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const Promise = require('../../promise');
 const sequelizeErrors = require('../../errors');
+const QueryTypes = require('../../query-types');
 
 /**
  Returns an object that treats SQLite's inabilities to do certain queries.
@@ -152,7 +153,7 @@ function addConstraint(tableName, options) {
   const describeCreateTableSql = this.QueryGenerator.describeCreateTableQuery(tableName);
   let createTableSql;
 
-  return this.sequelize.query(describeCreateTableSql, options)
+  return this.sequelize.query(describeCreateTableSql, { type: QueryTypes.SELECT, raw: true })
     .then(constraints => {
       const sql = constraints[0].sql;
       const index = sql.length - 1;

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -153,7 +153,7 @@ function addConstraint(tableName, options) {
   const describeCreateTableSql = this.QueryGenerator.describeCreateTableQuery(tableName);
   let createTableSql;
 
-  return this.sequelize.query(describeCreateTableSql, { type: QueryTypes.SELECT, raw: true })
+  return this.sequelize.query(describeCreateTableSql, { ...options, type: QueryTypes.SELECT, raw: true })
     .then(constraints => {
       const sql = constraints[0].sql;
       const index = sql.length - 1;

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -144,14 +144,12 @@ class Query extends AbstractQuery {
                     }
                   }
 
-                  if (query.sql.indexOf('sqlite_master') !== -1) {
-                    if (query.sql.indexOf('SELECT sql FROM sqlite_master WHERE tbl_name') !== -1) {
-                      result = results;
-                      if (result && result[0] && result[0].sql.indexOf('CONSTRAINT') !== -1) {
-                        result = query.parseConstraintsFromSql(results[0].sql);
-                      }
-                    } else {
-                      result = results.map(resultSet => resultSet.name);
+                  if (query.isShowTablesQuery()) {
+	                  result = results.map(row => row.name);
+                  } else if (query.isShowConstraintsQuery()) {
+                    result = results;
+                    if (results && results[0] && results[0].sql) {
+                      result = query.parseConstraintsFromSql(results[0].sql);
                     }
                   } else if (query.isSelectQuery()) {
                     if (!query.options.raw) {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -639,7 +639,10 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
         return record.reload();
       }).then(record => {
         expect(typeof record.stamp).to.be.eql('string');
-        expect(new Date(record.stamp)).to.equalDate(newDate);
+        const recordDate = new Date(record.stamp);
+        expect(recordDate.getUTCFullYear()).to.equal(newDate.getUTCFullYear());
+        expect(recordDate.getUTCDate()).to.equal(newDate.getUTCDate());
+        expect(recordDate.getUTCMonth()).to.equal(newDate.getUTCMonth());
       });
   });
 

--- a/test/integration/dialects/sqlite/sqlite-master.test.js
+++ b/test/integration/dialects/sqlite/sqlite-master.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support = require(__dirname + '/../../support'),
+  dialect = Support.getTestDialect(),
+  DataTypes = require(__dirname + '/../../../../lib/data-types');
+
+if (dialect === 'sqlite') {
+  describe('[SQLITE Specific] sqlite_master raw queries', () => {
+    beforeEach(function() {
+      this.sequelize.define('SomeTable', {
+        someColumn: DataTypes.INTEGER
+      }, {
+        freezeTableName: true,
+        timestamps: false
+      });
+
+      return this.sequelize.sync({ force: true });
+    });
+
+    it('should be able to select with tbl_name filter', function() {
+      return this.sequelize.query('SELECT * FROM sqlite_master WHERE tbl_name=\'SomeTable\'')
+        .then(result => {
+          const rows = result[0];
+          expect(rows).to.have.length(1);
+          const row = rows[0];
+          expect(row).to.have.property('type', 'table');
+          expect(row).to.have.property('name', 'SomeTable');
+          expect(row).to.have.property('tbl_name', 'SomeTable');
+          expect(row).to.have.property('sql');
+        });
+    });
+
+    it('should be able to select *', function() {
+      return this.sequelize.query('SELECT * FROM sqlite_master')
+        .then(result => {
+          const rows = result[0];
+          expect(rows).to.have.length(2);
+          rows.forEach(row => {
+            expect(row).to.have.property('type');
+            expect(row).to.have.property('name');
+            expect(row).to.have.property('tbl_name');
+            expect(row).to.have.property('rootpage');
+            expect(row).to.have.property('sql');
+          });
+        });
+    });
+
+    it('should be able to select just "sql" column and get rows back', function() {
+      return this.sequelize.query('SELECT sql FROM sqlite_master WHERE tbl_name=\'SomeTable\'')
+        .then(result => {
+          const rows = result[0];
+          expect(rows).to.have.length(1);
+          const row = rows[0];
+          expect(row).to.have.property('sql',
+            'CREATE TABLE `SomeTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `someColumn` INTEGER)');
+        });
+    });
+  });
+}


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Raw queries to the `sqlite_master` table were being special-cased and as such would return inconsistent values. For example, `SELECT * FROM sqlite_master` would simply return an array populated with just the value in the `name` column. This change allows you to query the `sqlite_master` just like any other table, and removes hardcoded SQL string checks in favor of using the `QueryTypes` enum.

This is related to #1612 and #8769. Previous workarounds were to shove the `sqlite_master` table into a view so that its table name wouldn't be caught by the `indexOf` check and query the view instead.

This changeset also fixes a DataTypes test that was failing due to timezone issues.