### PR TITLE
Update raw query docs on model mapping

### DIFF
--- a/docs/raw-queries.md
+++ b/docs/raw-queries.md
@@ -25,9 +25,14 @@ A second option is the model. If you pass a model the returned data will be inst
 
 ```js
 // Callee is the model definition. This allows you to easily map a query to a predefined model
-sequelize.query('SELECT * FROM projects', { model: Projects }).then(projects => {
-  // Each record will now be a instance of Project
-})
+sequelize
+  .query('SELECT * FROM projects', {
+    model: Projects,
+    mapToModel: true // pass true here if you have any mapped fields
+  })
+  .then(projects => {
+    // Each record will now be an instance of Project
+  })
 ```
 
 ## Replacements


### PR DESCRIPTION
I've been using sequelize for a while already. Thanks for a good work!

I've stumbled upon a confusion when using `sequelize.query()` with `model` option. Not sure what was the maintainers' decision when disabling fields mapping by default, but it is quite confusing to not have mapping when model is passed. Changing default behavior may break, that's why I've updated the docs to clearly indicate the library users that the `mapToModel` property controls whether table fields will be mapped to the model or not.

closes https://github.com/sequelize/sequelize/issues/9687