### PR TITLE
docs: update v5 changelog to indicate minimum required mysql2 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "istanbul": "^0.x",
     "lcov-result-merger": "^3.0.0",
     "mocha": "^5.x",
-    "mysql2": "^1.x",
+    "mysql2": "1.5.1",
     "pg": "^7.x",
     "pg-hstore": "^2.x",
     "pg-native": "^3.0.0",

--- a/test/integration/boolean.test.js
+++ b/test/integration/boolean.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const chai = require('chai'),
+  Sequelize = require('../../index'),
+  expect = chai.expect,
+  Support = require(__dirname + '/support'),
+  DataTypes = require(__dirname + '/../../lib/data-types');
+
+
+describe(Support.getTestDialectTeaser('Boolean'), () => {
+  describe('create', () => {
+    it('should work with booleans" ', async function() {
+      const User = this.sequelize.define('User', {
+        'id': {
+          primaryKey: true,
+          type: DataTypes.UUID,
+          defaultValue: DataTypes.UUIDV4
+        },
+        'someBool': {
+          type: DataTypes.BOOLEAN,
+          defaultValue: true
+        }
+      });
+      await this.sequelize.sync({force: true})
+      let user = await User.create({})
+      user = await user.save()
+      user = await user.reload()
+      expect(user.someBool).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
Took a few days to get to the bottom of this one: below is a test showing how BOOLEAN columns now fail using versions of mysql2 prior to 1.5.2 (see [here](https://github.com/sidorares/node-mysql2/blob/master/Changelog.md) and [here](https://github.com/sidorares/node-mysql2/pull/718/files)).

Would love to see a note included in the v5 changelog to save others the time. Thanks.