### PR TITLE
belongsToMany.add returns array of intermediate table instance

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -674,6 +674,7 @@ class BelongsToMany extends Association {
 
     return association.through.model.findAll(_.defaults({where, raw: true}, options))
       .then(currentRows => updateAssociations(currentRows))
+      .spread(associations => associations)
       .catch(error => {
         if (error instanceof EmptyResultError) return updateAssociations();
         throw error;

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -1056,6 +1056,27 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         expect(tasks[0].title).to.equal('get started');
       });
     });
+
+    it('should returns array of intermediate table', function() {
+      const User = this.sequelize.define('User');
+      const Task = this.sequelize.define('Task');
+      const UserTask = this.sequelize.define('UserTask');
+
+      User.belongsToMany(Task, { through: UserTask });
+      Task.belongsToMany(User, { through: UserTask });
+
+      return this.sequelize.sync({ force: true }).then(() => {
+        return Promise.all([
+          User.create(),
+          Task.create()
+        ]).spread((user, task) => {
+          return user.addTask(task);
+        }).then(userTasks => {
+          expect(userTasks).to.be.an('array').that.has.a.lengthOf(1);
+          expect(userTasks[0]).to.be.an.instanceOf(UserTask);
+        });
+      });
+    });
   });
 
   describe('addMultipleAssociations', () => {


### PR DESCRIPTION
…es table

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

belongsToMany.add returns array of intermediate table instance, not nested array of array.

See issue: #8377 


<!-- Please provide a description of the change here. -->

