### PR TITLE
feat(addScope): Only warn no override if defaultScope is defined

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1423,7 +1423,7 @@ class Model {
       override: false
     }, options);
 
-    if ((name === 'defaultScope' || name in this.options.scopes) && options.override === false) {
+    if ((name === 'defaultScope' && Object.keys(this.options.defaultScope).length > 0 || name in this.options.scopes) && options.override === false) {
       throw new Error('The scope ' + name + ' already exists. Pass { override: true } as options to silence this error');
     }
 

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -294,6 +294,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       }).to.throw('The scope defaultScope already exists. Pass { override: true } as options to silence this error');
     });
 
+    it('should not warn if default scope is not defined', () => {
+      const Model = current.define('model');
+    
+      expect(() => {
+        Model.addScope('defaultScope', {});
+      }).not.to.throw();
+    });
+
     it('allows me to override a default scope', () => {
       Company.addScope('defaultScope', {
         include: [Project]


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

if default scope has not be defined ie. Object.keys(this.options.defaultScope).length === 0 then addScope('defaultScope', ...) does not throw an error. (Closes #9407 )