### PR TITLE
feat(associations): Added createMultiple for hasMany associations #3277

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -101,6 +101,7 @@ class HasMany extends Association {
       addMultiple: 'add' + plural,
       add: 'add' + singular,
       create: 'create' + singular,
+      createMultiple: 'create' + plural,
       remove: 'remove' + singular,
       removeMultiple: 'remove' + plural,
       hasSingle: 'has' + singular,
@@ -143,7 +144,7 @@ class HasMany extends Association {
   }
 
   mixin(obj) {
-    const methods = ['get', 'count', 'hasSingle', 'hasAll', 'set', 'add', 'addMultiple', 'remove', 'removeMultiple', 'create'];
+    const methods = ['get', 'count', 'hasSingle', 'hasAll', 'set', 'add', 'addMultiple', 'remove', 'removeMultiple', 'create', 'createMultiple'];
     const aliases = {
       hasSingle: 'has',
       hasAll: 'has',
@@ -433,6 +434,42 @@ class HasMany extends Association {
     return this.target.unscoped().update(update, _.defaults({where}, options)).return(this);
   }
 
+  _create(sourceInstance, values) {
+    if (values === undefined) {
+      values = {};
+    }
+
+    if (this.scope) {
+      for (const attribute of Object.keys(this.scope)) {
+        values[attribute] = this.scope[attribute];
+      }
+    }
+
+    values[this.foreignKey] = sourceInstance.get(this.sourceKey);
+
+    return values;
+  }
+
+  _createOptions(options = {}) {
+    const association = this;
+
+    if (Array.isArray(options)) {
+      options = {
+        fields: options
+      };
+    }
+
+    if (this.scope) {
+      for (const attribute of Object.keys(this.scope)) {
+        if (options.fields) options.fields.push(attribute);
+      }
+    }
+
+    if (options.fields) options.fields.push(this.foreignKey);
+
+    return options;
+  }
+
   /**
    * Create a new instance of the associated model and associate it with this.
    *
@@ -442,27 +479,31 @@ class HasMany extends Association {
    *
    * @returns {Promise}
    */
-  create(sourceInstance, values, options = {}) {
-    if (Array.isArray(options)) {
-      options = {
-        fields: options
-      };
-    }
+  create(sourceInstance, values, options) {
+    const association = this;
 
-    if (values === undefined) {
-      values = {};
-    }
+    options = this._createOptions(options);
+    values = this._create(sourceInstance, values);
 
-    if (this.scope) {
-      for (const attribute of Object.keys(this.scope)) {
-        values[attribute] = this.scope[attribute];
-        if (options.fields) options.fields.push(attribute);
-      }
-    }
+    return association.target.create(values, options);
+  }
 
-    values[this.foreignKey] = sourceInstance.get(this.sourceKey);
-    if (options.fields) options.fields.push(this.foreignKey);
-    return this.target.create(values, options);
+  /**
+   * Create new instances of the associated model and associate them with this.
+   *
+   * @param {<Model>} sourceInstance source instance
+   * @param {Object[]} [values] values for target model instances
+   * @param {Object} [options] Options passed to `target.create`
+   *
+   * @returns {Promise}
+   */
+  createMultiple(sourceInstance, values, options) {
+    const association = this;
+
+    options = this._createOptions(options);
+    values = values.map(v => this._create(sourceInstance, v));
+
+    return association.target.bulkCreate(values, options);
   }
 }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This change adds a createMultiple method for hasMany associations, as requested by #3277 (I believe that bulk creating associations only applies to hasMany, hence not implementing it elsewhere), along with the create[Association]s helper method. I refactored the create method so that I could reuse code between create and createMultiple. I have checked that the hooks execute as expected - currently I'm a bit confused because the issue has been open for over 3 years, but the functionality was very simple to implement...have I missed something?

Side note: I get two test failures when doing `npm run test-integration-postgres test/integration/associations/has-many.test.js` even before making my changes:

```
 9) [POSTGRES] Model
      findAll
        group
          should correctly group with attributes, #3009:

     AssertionError: expected 2 to equal 3
     + expected - actual

     -2
     +3

     at Proxy.assertEqual (node_modules/chai/lib/chai/core/assertions.js:1022:12)
     at Proxy.methodWrapper (node_modules/chai/lib/chai/utils/addMethod.js:57:25)
     at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:289:22)
     at Proxy.<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:20)
     at Proxy.overwritingMethodWrapper (node_modules/chai/lib/chai/utils/overwriteMethod.js:78:33)
     at current.sync.then.then.then.then.posts (test/integration/model/findAll/group.test.js:50:65)
     at /www/sb23/sequelize/node_modules/continuation-local-storage/context.js:84:17
 From previous event:
     at Promise.then (node_modules/cls-bluebird/lib/shimMethod.js:38:20)
     at Context.it (test/integration/model/findAll/group.test.js:49:12)

 10) [POSTGRES] Model
      findAll
        group
          should not add primary key when grouping using a belongsTo association:

     AssertionError: expected 2 to equal 3
     + expected - actual

     -2
     +3

     at Proxy.assertEqual (node_modules/chai/lib/chai/core/assertions.js:1022:12)
     at Proxy.methodWrapper (node_modules/chai/lib/chai/utils/addMethod.js:57:25)
     at doAsserterAsyncAndAddThen (node_modules/chai-as-promised/lib/chai-as-promised.js:289:22)
     at Proxy.<anonymous> (node_modules/chai-as-promised/lib/chai-as-promised.js:255:20)
     at Proxy.overwritingMethodWrapper (node_modules/chai/lib/chai/utils/overwriteMethod.js:78:33)
     at current.sync.then.then.then.then.posts (test/integration/model/findAll/group.test.js:93:65)
     at /www/sb23/sequelize/node_modules/continuation-local-storage/context.js:84:17
 From previous event:
     at Promise.then (node_modules/cls-bluebird/lib/shimMethod.js:38:20)
     at Context.it (test/integration/model/findAll/group.test.js:90:12)
```