### PR TITLE
fea(sync): add missing columns in database by default (#9731)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1250,24 +1250,24 @@ class Model {
     })
       .then(() => this.QueryInterface.createTable(this.getTableName(options), attributes, options, this))
       .then(() => {
-        if (options.alter) {
-          return Promise.all([
-            this.QueryInterface.describeTable(this.getTableName(options)),
-            this.QueryInterface.getForeignKeyReferencesForTable(this.getTableName(options))
-          ])
-            .then(tableInfos => {
-              const columns = tableInfos[0];
-              // Use for alter foreign keys
-              const foreignKeyReferences = tableInfos[1];
+        return Promise.all([
+          this.QueryInterface.describeTable(this.getTableName(options)),
+          this.QueryInterface.getForeignKeyReferencesForTable(this.getTableName(options))
+        ])
+          .then(tableInfos => {
+            const columns = tableInfos[0];
+            // Use for alter foreign keys
+            const foreignKeyReferences = tableInfos[1];
 
-              const changes = []; // array of promises to run
-              const removedConstraints = {};
+            const changes = []; // array of promises to run
+            const removedConstraints = {};
 
-              _.each(attributes, (columnDesc, columnName) => {
-                if (!columns[columnName]) {
-                  changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), attributes[columnName].field || columnName, attributes[columnName]));
-                }
-              });
+            _.each(attributes, (columnDesc, columnName) => {
+              if (!columns[columnName]) {
+                changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), attributes[columnName].field || columnName, attributes[columnName]));
+              }
+            });
+            if (options.alter) {
               _.each(columns, (columnDesc, columnName) => {
                 const currentAttribute = rawAttributes[columnName];
                 if (!currentAttribute) {
@@ -1297,9 +1297,9 @@ class Model {
                   changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnName, currentAttribute));
                 }
               });
-              return changes.reduce((p, fn) => p.then(fn), Promise.resolve());
-            });
-        }
+            }
+            return changes.reduce((p, fn) => p.then(fn), Promise.resolve());
+          });
       })
       .then(() => this.QueryInterface.showIndex(this.getTableName(options), options))
       .then(indexes => {

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -66,7 +66,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           age: Sequelize.INTEGER,
           height: { type: Sequelize.INTEGER, field: 'height_cm' }
         }))
-        .then(() => this.sequelize.sync({alter: true}))
+        .then(() => this.sequelize.sync())
         .then(() => testSync.describe())
         .then(data => {
           expect(data).to.have.ownProperty('age');

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -56,6 +56,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
     });
 
+    it('should default to add a column if it does not exist in the database (#9731)', function() {
+      const testSync = this.sequelize.define('testSync', {
+        name: Sequelize.STRING
+      });
+      return this.sequelize.sync()
+        .then(() => this.sequelize.define('testSync', {
+          name: Sequelize.STRING,
+          age: Sequelize.INTEGER,
+          height: { type: Sequelize.INTEGER, field: 'height_cm' }
+        }))
+        .then(() => this.sequelize.sync({alter: true}))
+        .then(() => testSync.describe())
+        .then(data => {
+          expect(data).to.have.ownProperty('age');
+          expect(data).to.have.ownProperty('height_cm');
+          expect(data).not.to.have.ownProperty('height');
+        });
+    });
+
     it('should alter a column using the correct column name (#9515)', function() {
       const testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
With this PR `seqzelize.sync()` adds columns that exists in the model, but does not exists on the database without using the risky `seqzelize.sync({alter: true})` variant.

A new testcase is added to proof this behaviour. The test that are failing on master are the same as without this PR.

The documentation is not explicit about the current behaviour of sequelize.sync() in this case now, so I dont know if it need to change.

Closes #9731.
