### PR TITLE
Proposed formatting for code examples in Docs

### DIFF
--- a/docs/raw-queries.md
+++ b/docs/raw-queries.md
@@ -5,18 +5,28 @@ As there are often use cases in which it is just easier to execute raw / already
 By default the function will return two arguments - a results array, and an object containing metadata (affected rows etc.). Note that since this is a raw query, the metadata (property names etc.) is dialect specific. Some dialects return the metadata "within" the results object (as properties on an array). However, two arguments will always be returned, but for MSSQL and MySQL it will be two references to the same object.
 
 ```js
-sequelize.query("UPDATE users SET y = 42 WHERE x = 12").spread((results, metadata) => {
-  // Results will be an empty array and metadata will contain the number of affected rows.
-})
+sequelize.query(
+  "UPDATE users SET y = 42 WHERE x = 12"
+).spread(
+  (results, metadata) => {
+    // Results will be an empty array and metadata will contain the number of affected rows.
+  }
+)
 ```
 
 In cases where you don't need to access the metadata you can pass in a query type to tell sequelize how to format the results. For example, for a simple select query you could do:
 
 ```js
-sequelize.query("SELECT * FROM `users`", { type: sequelize.QueryTypes.SELECT})
-  .then(users => {
-    // We don't need spread here, since only the results will be returned for select queries
-  })
+sequelize.query(
+  "SELECT * FROM `users`",
+  {
+    type: sequelize.QueryTypes.SELECT
+  }
+).then( // We don't need spread here, since only the results will be returned for select queries
+  users => {
+    // Results will be an array of records from users.
+  }
+)
 ```
 
 Several other query types are available. [Peek into the source for details](https://github.com/sequelize/sequelize/blob/master/lib/query-types.js)
@@ -25,14 +35,17 @@ A second option is the model. If you pass a model the returned data will be inst
 
 ```js
 // Callee is the model definition. This allows you to easily map a query to a predefined model
-sequelize
-  .query('SELECT * FROM projects', {
+sequelize.query(
+  'SELECT * FROM projects',
+  {
     model: Projects,
     mapToModel: true // pass true here if you have any mapped fields
-  })
-  .then(projects => {
+  }
+).then(
+  projects => {
     // Each record will now be an instance of Project
-  })
+  }
+)
 ```
 
 ## Replacements
@@ -42,37 +55,68 @@ Replacements in a query can be done in two different ways, either using named pa
 * If an object is passed, `:key` will be replaced with the keys from that object. If the object contains keys not found in the query or vice versa, an exception will be thrown.
 
 ```js
-sequelize.query('SELECT * FROM projects WHERE status = ?',
-  { replacements: ['active'], type: sequelize.QueryTypes.SELECT }
-).then(projects => {
-  console.log(projects)
-})
+sequelize.query(
+  'SELECT * FROM projects WHERE status = ?',
+  {
+    replacements: ['active'],
+    type: sequelize.QueryTypes.SELECT
+  }
+).then(
+  projects => {
+    console.log(projects)
+  }
+)
 
-sequelize.query('SELECT * FROM projects WHERE status = :status ',
-  { replacements: { status: 'active' }, type: sequelize.QueryTypes.SELECT }
-).then(projects => {
-  console.log(projects)
-})
+sequelize.query(
+  'SELECT * FROM projects WHERE status = :status ',
+  {
+    replacements: {status: 'active'},
+    type: sequelize.QueryTypes.SELECT
+  }
+).then(
+  projects => {
+    console.log(projects)
+  }
+)
 ```
 
 Array replacements will automatically be handled, the following query searches for projects where the status matches an array of values.
 
 ```js
-sequelize.query('SELECT * FROM projects WHERE status IN(:status) ',
-  { replacements: { status: ['active', 'inactive'] }, type: sequelize.QueryTypes.SELECT }
-).then(projects => {
-  console.log(projects)
-})
+sequelize.query(
+  'SELECT * FROM projects WHERE status IN(:status) ',
+  {
+    replacements: {
+      status: [
+        'active',
+        'inactive'
+      ]
+    },
+    type: sequelize.QueryTypes.SELECT
+  }
+).then(
+  projects => {
+    console.log(projects)
+  }
+)
 ```
 
 To use the wildcard operator %, append it to your replacement. The following query matches users with names that start with 'ben'.
 
 ```js
-sequelize.query('SELECT * FROM users WHERE name LIKE :search_name ',
-  { replacements: { search_name: 'ben%'  }, type: sequelize.QueryTypes.SELECT }
-).then(projects => {
-  console.log(projects)
-})
+sequelize.query(
+  'SELECT * FROM users WHERE name LIKE :search_name ',
+  {
+    replacements: {
+      search_name: 'ben%'
+    },
+    type: sequelize.QueryTypes.SELECT
+  }
+).then(
+  projects => {
+    console.log(projects)
+  }
+)
 ```
 
 ## Bind Parameter
@@ -87,16 +131,32 @@ The array or object must contain all bound values or Sequelize will throw an exc
 The database may add further restrictions to this. Bind parameters cannot be SQL keywords, nor table or column names. They are also ignored in quoted text or data. In PostgreSQL it may also be needed to typecast them, if the type cannot be inferred from the context `$1::varchar`.
 
 ```js
-sequelize.query('SELECT *, "text with literal $$1 and literal $$status" as t FROM projects WHERE status = $1',
-  { bind: ['active'], type: sequelize.QueryTypes.SELECT }
-).then(projects => {
-  console.log(projects)
-})
+sequelize.query(
+  'SELECT *, "text with literal $$1 and literal $$status" as t FROM projects WHERE status = $1',
+  {
+    bind: [
+      'active'
+    ],
+    type: sequelize.QueryTypes.SELECT
+  }
+).then(
+  projects => {
+    console.log(projects)
+  }
+)
 
-sequelize.query('SELECT *, "text with literal $$1 and literal $$status" as t FROM projects WHERE status = $status',
-  { bind: { status: 'active' }, type: sequelize.QueryTypes.SELECT }
-).then(projects => {
-  console.log(projects)
-})
+sequelize.query(
+  'SELECT *, "text with literal $$1 and literal $$status" as t FROM projects WHERE status = $status',
+  {
+    bind: {
+      status: 'active'
+    },
+    type: sequelize.QueryTypes.SELECT
+  }
+).then(
+  projects => {
+    console.log(projects)
+  }
+)
 ```
 


### PR DESCRIPTION
This PR isn't intended to be merged, but rather to start a conversation about the code formatting in the documentation. This is just one doc, as an example.

I understand there's a good chance this code style isn't everyone's favorite (is any code style?), but documentation code examples shouldn't be going into anyone's source code, as-is, anyway; right?

As we aren't saving any trees, by being terse, I feel it's helpful to developers see code with liberal use of whitespace, so argument/object structure is clear and obvious. Compact code examples make it more difficult to see the nuances of the API.

I welcome a discussion.