### PR TITLE
fix(hasMany): don't propagate group to separated queries

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1828,7 +1828,7 @@ class Model {
 
       return include.association.get(results, _.assign(
         {},
-        _.omit(options, ['include', 'attributes', 'originalAttributes', 'order', 'where', 'limit', 'offset', 'plain']),
+        _.omit(options, ['include', 'attributes', 'originalAttributes', 'order', 'where', 'limit', 'offset', 'plain', 'group']),
         _.omit(include, ['parent', 'association', 'as', 'originalAttributes'])
       )).then(map => {
         for (const result of results) {

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -1464,11 +1464,6 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
           expect(rows[0].tasks[0].title).to.equal('Task #1');
           expect(rows[0].tasks[0].jobs.length).to.equal(2);
           expect(rows[0].tasks[0].jobs[0].title).to.equal('Job #1');
-        })
-        // if we get here, this will fail (as it should)
-        .catch(ex => {
-          console.log(ex);
-          expect(ex).to.be.undefined;
         });
     });
   });

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -1452,6 +1452,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         })
         .then(() => {
           return User.findAndCountAll({
+            attributes: ['userId'],
             include: [
               { model: Task, separate: true, include: [{ model: Job, separate: true }]}
             ],
@@ -1460,7 +1461,6 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         })
         .then(({ count, rows }) => {
           expect(count.length).to.equal(1);
-          expect(rows[0].username).to.equal('John Doe');
           expect(rows[0].tasks[0].title).to.equal('Task #1');
           expect(rows[0].tasks[0].jobs.length).to.equal(2);
           expect(rows[0].tasks[0].jobs[0].title).to.equal('Job #1');

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -1461,9 +1461,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         })
         .then(({ count, rows }) => {
           expect(count.length).to.equal(1);
-          expect(rows[0].tasks[0].title).to.equal('Task #1');
           expect(rows[0].tasks[0].jobs.length).to.equal(2);
-          expect(rows[0].tasks[0].jobs[0].title).to.equal('Job #1');
         });
     });
   });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes issue #9748 