### PR TITLE
doc(options): add missing schema option

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -65,6 +65,7 @@ class Sequelize {
    * @param {string}   [options.protocol='tcp'] The protocol of the relational database.
    * @param {Object}   [options.define={}] Default options for model definitions. See sequelize.define for options
    * @param {Object}   [options.query={}] Default options for sequelize.query
+   * @param {string}   [options.schema=null] A schema to use
    * @param {Object}   [options.set={}] Default options for sequelize.set
    * @param {Object}   [options.sync={}] Default options for sequelize.sync
    * @param {string}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.


### PR DESCRIPTION
### Description of change
The doc seems to be missing the schema option, which I verified works for PostgreSQL