### PR TITLE
detects autoIncrement flag from MySQL

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -144,7 +144,8 @@ class Query extends AbstractQuery {
           type: enumRegex.test(_result.Type) ? _result.Type.replace(enumRegex, 'ENUM') : _result.Type.toUpperCase(),
           allowNull: _result.Null === 'YES',
           defaultValue: _result.Default,
-          primaryKey: _result.Key === 'PRI'
+          primaryKey: _result.Key === 'PRI',
+          autoIncrement: _result.hasOwnProperty('Extra') && _result.Extra.toLowerCase() === 'auto_increment'
         };
       }
     } else if (this.isShowIndexesQuery()) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Includes the autoIncrement flag on thee mysql dialect, just like the mssql dialect behaves. Closes #9826