### PR TITLE
fix(query-interface): using normalizeAttribute instead of normalizeDataype

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -516,7 +516,7 @@ class QueryInterface {
       attributes[attributeName] = dataTypeOrOptions;
     }
 
-    attributes[attributeName].type = this.sequelize.normalizeDataType(attributes[attributeName].type);
+    attributes[attributeName] = this.sequelize.normalizeAttribute(attributes[attributeName]);
 
     if (this.sequelize.options.dialect === 'sqlite') {
       // sqlite needs some special treatment as it cannot change a column


### PR DESCRIPTION
fix #9874

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

using `normalizeAttribute` instead of `normalizeDataype`.

`normalizeAttribute` updates `attribute.values` in case of ENUM. Otherwise, `attribute.values` remain undefined and is not updated.
`normalizeAttribute` also performs `normalizeDataype`.

