### PR TITLE
fix(transaction): fixed unhandled rejection when connection acquiring times out (#9218)

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -152,11 +152,9 @@ class ConnectionManager {
       acquire: (priority, queryType, useMaster) => {
         useMaster = _.isUndefined(useMaster) ? false : useMaster;
         if (queryType === 'SELECT' && !useMaster) {
-          return this.pool.read.acquire(priority)
-            .then(mayBeConnection => this._determineConnection(mayBeConnection));
+          return this.pool.read.acquire(priority);
         } else {
-          return this.pool.write.acquire(priority)
-            .then(mayBeConnection => this._determineConnection(mayBeConnection));
+          return this.pool.write.acquire(priority);
         }
       },
       destroy: mayBeConnection => {
@@ -274,7 +272,7 @@ class ConnectionManager {
     return promise.then(() => {
       return this.pool.acquire(options.priority, options.type, options.useMaster)
         .then(mayBeConnection => this._determineConnection(mayBeConnection))
-        .catch(err => err.name === 'TimeoutError', err => { throw new errors.ConnectionAcquireTimeoutError(err); })
+        .catch({name: 'TimeoutError'}, err => { throw new errors.ConnectionAcquireTimeoutError(err); })
         .tap(() => { debug('connection acquired'); });
     });
   }

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -4,6 +4,7 @@ const Pooling = require('generic-pool');
 const _ = require('lodash');
 const semver = require('semver');
 const Promise = require('../../promise');
+const errors = require('../../errors');
 const logger = require('../../utils/logger');
 const debug = logger.getLogger().debugContext('pool');
 
@@ -273,6 +274,7 @@ class ConnectionManager {
     return promise.then(() => {
       return this.pool.acquire(options.priority, options.type, options.useMaster)
         .then(mayBeConnection => this._determineConnection(mayBeConnection))
+        .catch(/TimeoutError/, err => { throw new errors.ConnectionAcquireTimeoutError(err); })
         .tap(() => { debug('connection acquired'); });
     });
   }

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -274,7 +274,7 @@ class ConnectionManager {
     return promise.then(() => {
       return this.pool.acquire(options.priority, options.type, options.useMaster)
         .then(mayBeConnection => this._determineConnection(mayBeConnection))
-        .catch(/TimeoutError/, err => { throw new errors.ConnectionAcquireTimeoutError(err); })
+        .catch(err => err.name === 'TimeoutError', err => { throw new errors.ConnectionAcquireTimeoutError(err); })
         .tap(() => { debug('connection acquired'); });
     });
   }

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -509,6 +509,20 @@ class ConnectionTimedOutError extends ConnectionError {
 exports.ConnectionTimedOutError = ConnectionTimedOutError;
 
 /**
+ * Thrown when connection is not acquired due to timeout
+ *
+ * @extends ConnectionError
+ */
+class ConnectionAcquireTimeoutError extends ConnectionError {
+  constructor(parent) {
+    super(parent);
+    this.name = 'SequelizeConnectionAcquireTimeoutError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+exports.ConnectionAcquireTimeoutError = ConnectionAcquireTimeoutError;
+
+/**
  * Thrown when a some problem occurred with Instance methods (see message for details)
  *
  * @extends BaseError

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -91,6 +91,10 @@ class Transaction {
       return Promise.reject(new Error('Transaction cannot be rolled back because it has been finished with state: ' + this.finished));
     }
 
+    if (!this.connection) {
+      return Promise.reject(new Error('Transaction cannot be rolled back because it never started'));
+    }
+
     this._clearCls();
 
     return this

--- a/test/integration/pool.test.js
+++ b/test/integration/pool.test.js
@@ -18,7 +18,7 @@ describe(Support.getTestDialectTeaser('Pooling'), function() {
     this.sinon.restore();
   });
 
-  it('should reject when unable to acquire connection in given time', () => {
+  it('should reject with ConnectionAcquireTimeoutError when unable to acquire connection in given time', () => {
     this.testInstance = new Sequelize('localhost', 'ffd', 'dfdf', {
       dialect,
       databaseVersion: '1.2.3',
@@ -31,7 +31,7 @@ describe(Support.getTestDialectTeaser('Pooling'), function() {
       .returns(new Sequelize.Promise(() => {}));
 
     return expect(this.testInstance.authenticate())
-      .to.eventually.be.rejectedWith('ResourceRequest timed out');
+      .to.eventually.be.rejectedWith(Sequelize.ConnectionAcquireTimeoutError);
   });
 
   it('should not result in unhandled promise rejection when unable to acquire connection', () => {
@@ -49,6 +49,6 @@ describe(Support.getTestDialectTeaser('Pooling'), function() {
 
     return expect(this.testInstance.transaction()
       .then(() => this.testInstance.transaction()))
-      .to.eventually.be.rejectedWith('ResourceRequest timed out');
+      .to.eventually.be.rejectedWith(Sequelize.ConnectionAcquireTimeoutError);
   });
 });

--- a/test/integration/pool.test.js
+++ b/test/integration/pool.test.js
@@ -47,8 +47,8 @@ describe(Support.getTestDialectTeaser('Pooling'), function() {
     this.sinon.stub(this.testInstance.connectionManager, '_connect')
       .returns(new Sequelize.Promise(() => {}));
 
-    return expect(this.testInstance.transaction()
-      .then(() => this.testInstance.transaction()))
-      .to.eventually.be.rejectedWith(Sequelize.ConnectionAcquireTimeoutError);
+    return expect(this.testInstance.transaction(() => {
+      return this.testInstance.transaction(() => {});
+    })).to.eventually.be.rejectedWith(Sequelize.ConnectionAcquireTimeoutError);
   });
 });

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -187,6 +187,16 @@ if (current.dialect.supports.transactions) {
       ).to.eventually.be.rejected;
     });
 
+    it('should not rollback if connection was not acquired', function() {
+      this.sinon.stub(this.sequelize.connectionManager, '_connect')
+        .returns(new Support.Sequelize.Promise(() => {}));
+
+      const transaction = new Transaction(this.sequelize);
+
+      return expect(transaction.rollback())
+        .to.eventually.be.rejectedWith('Transaction cannot be rolled back because it never started');
+    });
+
     it('does not allow queries immediatly after rollback call', function() {
       const self = this;
       return expect(


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
<!-- Please provide a description of the change here. -->
Error described in issue #9218 happens when connection acquiring for auto-callback transaction times out: sequelize tries to automatically rollback transaction, but there is no connection to send rollback command.
Added check for inexistent connection, test and special erorr type.
