### PR TITLE
docs(hooks.md, model.js): add warnings about memory limitations of individualHooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -212,6 +212,8 @@ afterBulkDestroy(options)
 
 If you want to emit hooks for each individual record, along with the bulk hooks you can pass `individualHooks: true` to the call.
 
+**WARNING**: if you use individual hooks, *all instances that are updated or destroyed will get loaded into memory* before your hooks are called.  The number of instances Sequelize can handle with individual hooks is limited by available memory.
+
 ```js
 Model.destroy({ where: {accessLevel: 0}, individualHooks: true});
 // Will select all records that are about to be deleted and emit before- + after- Destroy on each instance


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

**Not applicable, this is a document only change**
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
I was very disappointed to realize today that if were to update or destroy a billion instances with individual hooks, Sequelize would try to fetch all billion of them into memory before running the individual hooks.  I had mistakenly assumed it would iterate through them in batches or using cursors of some kind...

I wish I had been warned about this before I decided to start using hooks, so I'm adding this warning to the docs.