### PR TITLE
fix(postgres): enum with string COMMENT breaks query

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -99,7 +99,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
         let dataType = attributes[attr];
         let match;
 
-        if (_.includes(dataType, 'COMMENT')) {
+        if (_.includes(dataType, 'COMMENT ')) {
           const commentMatch = dataType.match(/^(.+) (COMMENT.*)$/);
           const commentText = commentMatch[2].replace(/COMMENT/, '').trim();
           commentStr += _.template(commentTemplate, this._templateSettings)({

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -49,7 +49,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
     for (const attr in attributes) {
       const quotedAttr = this.quoteIdentifier(attr);
-      const i = attributes[attr].indexOf('COMMENT');
+      const i = attributes[attr].indexOf('COMMENT ');
       if (i !== -1) {
         // Move comment to a separate query
         const escapedCommentText = this.escape(attributes[attr].substring(i + 8));

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -71,6 +71,15 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       });
     });
 
+    it('should work with enums (5)', function () {
+      return this.queryInterface.createTable('SomeTable', {
+        someEnum: {
+          type: DataTypes.ENUM(['COMMENT']),
+          comment: 'special enum col'
+        }
+      });
+    });
+
     it('should work with schemas', function () {
       const self = this;
       return self.sequelize.createSchema('hero').then(() => {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes #9149 

Added a space in `indexOf` check, enum with `COMMENT` is common but `COMMENT<space>` should be rare or invalid for most use cases, just enough to fix this bug