### PR TITLE
Updated the disconnect() method to wait until the connection has been…

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -184,10 +184,7 @@ class ConnectionManager extends AbstractConnectionManager {
   }
 
   disconnect(connection) {
-    return new Promise(resolve => {
-      connection.end()
-      .then(() => resolve());
-    });
+    return Promise.fromCallback(callback => connection.end(callback));
   }
 
   validate(connection) {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -185,8 +185,8 @@ class ConnectionManager extends AbstractConnectionManager {
 
   disconnect(connection) {
     return new Promise(resolve => {
-      connection.end();
-      resolve();
+      connection.end()
+      .then(() => resolve());
     });
   }
 


### PR DESCRIPTION
… ended.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] _Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?_ **No, but the same two tests aren't passing that are on master.**
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

We're using sequelize on AWS lambda with the postgres dialect and the script execution is halted before the connection is closed which causes weird issues with database connections. This change ensures that the connection is properly closed before the execution ends.

Helps with #8468.
