### PR TITLE
Change regex

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -234,7 +234,7 @@ class Query extends AbstractQuery {
       case 1451:
       case 1452: {
         // e.g. CONSTRAINT `example_constraint_name` FOREIGN KEY (`example_id`) REFERENCES `examples` (`id`)
-        const match  = err.message.match(/CONSTRAINT ([`"])(.*)\1 (?:FOREIGN KEY \(\1(.*)\1\) )?(?:REFERENCES \1(.*?)\1)?(?: \(\1(.*)\1\))?/);
+        const match  = err.message.match(/CONSTRAINT ([`"])(.*?)\1 (?:FOREIGN KEY \(\1(.*?)\1\) )?(?:REFERENCES \1(.*?)\1)?(?: \(\1(.*?)\1\))?/);
         const quoteChar = match ? match[1] : '`';
         const fields = match ? match[3].split(new RegExp(`${quoteChar}, *${quoteChar}`)) : undefined;
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -234,7 +234,7 @@ class Query extends AbstractQuery {
       case 1451:
       case 1452: {
         // e.g. CONSTRAINT `example_constraint_name` FOREIGN KEY (`example_id`) REFERENCES `examples` (`id`)
-        const match  = err.message.match(/CONSTRAINT ([`"])(.*)\1 FOREIGN KEY \(\1(.*)\1\) REFERENCES \1(.*)\1 \(\1(.*)\1\)/);
+        const match  = err.message.match(/CONSTRAINT ([`"])(.*)\1 (?:FOREIGN KEY \(\1(.*)\1\) )?(?:REFERENCES \1(.*?)\1)?(?: \(\1(.*)\1\))?/);
         const quoteChar = match ? match[1] : '`';
         const fields = match ? match[3].split(new RegExp(`${quoteChar}, *${quoteChar}`)) : undefined;
 


### PR DESCRIPTION
https://github.com/sequelize/sequelize/issues/9838

### Pull Request check-list
- [x] Change regex


### Description of change

`Dialect: Mysql`

I have changed the regex which was used to match the error message when error string is more than 260 characters.


### Regex match:

Case I:

**Error string**

CONSTRAINT `iamputtingjusttheboringeststuff8lettersandrandomshitt` FOREIGN KEY (`merchant_site_tag_id`) REFERENCES `merchant_site_tags` (`id`)

group 1: `
group 2: iamputtingjusttheboringeststuff8lettersandrandomshitt
group 3: merchant_site_tag_id
group 4: merchant_site_tags
group 5: id

Case II:

**Error string**

CONSTRAINT `iamputtingjusttheboringeststuff8lettersandrandomshitt` FOREIGN KEY (`merchant_site_tag_id`) REFERENCES `merchant_site_tags` (`id

group 1: `
group 2: iamputtingjusttheboringeststuff8lettersandrandomshitt
group 3: merchant_site_tag_id
group 4: merchant_site_tags
group 5: empty

Case II:

**Error string**

Case III:

**Error string**

CONSTRAINT `iamputtingjusttheboringeststuff8lettersandrandomshitt` FOREIGN KEY (`merchant_site_tag_id`) REFERENCES `merchant_site_tags

group 1: `
group 2: iamputtingjusttheboringeststuff8lettersandrandomshitt
group 3: merchant_site_tag_id
group 4: empty
group 5: empty

Case IV:

**Error string**

CONSTRAINT `iamputtingjusttheboringeststuff8lettersandrandomshitt` FOREIGN KEY (`merchant_site_tag_id

group 1: `
group 2: iamputtingjusttheboringeststuff8lettersandrandomshitt
group 3: empty
group 4: empty
group 5: empty