### PR TITLE
Bugs/mssql exceed order clause for offset limit queries

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -909,8 +909,11 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     if (options.limit || options.offset) {
       if (!options.order || options.include && !orders.subQueryOrder.length) {
-        fragment += options.order && !isSubQuery ? ', ' : ' ORDER BY ';
-        fragment += this.quoteTable(options.tableAs || model.name) + '.' + this.quoteIdentifier(model.primaryKeyField);
+        const orderFragment = this.quoteTable(options.tableAs || model.name) + '.' + this.quoteIdentifier(model.primaryKeyField);
+        if (!options.order || !orders.mainQueryOrder.some(order => order.startsWith(orderFragment))) {
+          fragment += options.order && !isSubQuery ? ', ' : ' ORDER BY ';
+          fragment += orderFragment;
+        }
       }
 
       if (options.offset || options.limit) {

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -928,7 +928,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
   booleanValue(value) {
     return value ? 1 : 0;
   }
-};
+}
 
 // private methods
 function wrapSingleQuote(identifier) {

--- a/test/unit/sql/offset-limit.test.js
+++ b/test/unit/sql/offset-limit.test.js
@@ -44,6 +44,17 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
 
     testsql({
       limit: 10,
+      model: {primaryKeyField: 'id', name: 'tableRef'},
+      include: [],
+      order: ['id'] // for MSSQL
+    }, {
+      default: ' LIMIT 10',
+      mssql: ' OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY'
+    });
+
+
+    testsql({
+      limit: 10,
       offset: 20,
       order: [
         ['email', 'DESC'] // for MSSQL


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fix https://github.com/sequelize/sequelize/issues/9448

Order clause from main query can already contains PK, so to avoid order term duplication we need to skip adding PK.
