### PR TITLE
fix(query): check valid warn message (#9919)

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -178,6 +178,7 @@ class Query extends AbstractQuery {
       const warningMessage = 'MySQL Warnings (' + (this.connection.uuid||'default') + '): ';
       const messages = [];
       for (const _warningRow of warningResults) {
+        if (typeof _warningRow ==='undefined' || typeof _warningRow[Symbol.iterator] !== 'function') continue;
         for (const _warningResult of _warningRow) {
           if (_warningResult.hasOwnProperty('Message')) {
             messages.push(_warningResult.Message);

--- a/test/integration/dialects/mysql/warning.test.js
+++ b/test/integration/dialects/mysql/warning.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('../../../support');
+const Sequelize = Support.Sequelize;
+const dialect = Support.getTestDialect();
+const sinon = require('sinon');
+
+describe(Support.getTestDialectTeaser('Warning'), () => {
+  // We can only test MySQL warnings when using MySQL.
+  if (dialect === 'mysql') {
+    describe('logging', () => {
+      it('logs warnings when there are warnings', () => {
+        const logger = sinon.spy(console, 'log');
+        const sequelize = Support.createSequelizeInstance({
+          logging: logger,
+          benchmark: false,
+          showWarnings: true
+        });
+
+        const Model = sequelize.define('model', {
+          name: Sequelize.DataTypes.STRING(1, true)
+        });
+          
+        return sequelize.sync({ force: true }).then(() => {
+          return sequelize.authenticate();
+        }).then(() => {
+          return sequelize.query("SET SESSION sql_mode='';");
+        }).then(() => {
+          return Model.create({
+            name: 'very-long-long-name'
+          });
+        }).then(() => {
+          // last log is warning message
+          expect(logger.args[logger.args.length - 1][0]).to.be.match(/^MySQL Warnings \(default\):.*/m);
+        }, () => {
+          expect.fail();
+        });
+      });
+    });
+  }
+}); 

--- a/test/unit/dialects/mysql/query.test.js
+++ b/test/unit/dialects/mysql/query.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const path = require('path');
+const Query = require(path.resolve('./lib/dialects/mysql/query.js'));
+const Support = require(path.join(__dirname, './../../support'));
+const chai = require('chai');
+const sinon = require('sinon');
+
+const current = Support.sequelize;
+const expect = chai.expect;
+
+describe('[MYSQL Specific] Query', () => {
+  describe('logWarnings', () => {
+    beforeEach(() => {
+      sinon.spy(console, 'log');
+    });
+
+    afterEach(() => {
+      console.log.restore();
+    });
+
+    it('check iterable', () => {
+      const validWarning = [];
+      const invalidWarning = {};
+      const warnings = [validWarning, undefined, invalidWarning];      
+      
+      const query = new Query({}, current, {});
+      const stub = sinon.stub(query, 'run');
+      stub.onFirstCall().resolves(warnings);
+
+      return query.logWarnings('dummy-results').then(results => {
+        expect('dummy-results').to.equal(results);
+        expect(true).to.equal(console.log.calledOnce);
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
fix #9919 
validate that warning row is iterable
