### PR TITLE
fix(model): check attribute overrides when defining assoc mixins (#9952)

### DIFF
--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -57,7 +57,7 @@ function mixinMethods(association, obj, methods, aliases) {
 
   for (const method of methods) {
     // don't override custom methods
-    if (!obj[association.accessors[method]]) {
+    if (!obj.hasOwnProperty(association.accessors[method])) {
       const realMethod = aliases[method] || method;
 
       obj[association.accessors[method]] = function() {

--- a/test/unit/associations/has-many.test.js
+++ b/test/unit/associations/has-many.test.js
@@ -124,6 +124,16 @@ describe(Support.getTestDialectTeaser('hasMany'), () => {
         expect(user[method]()).to.be.a('function');
       });
     });
+
+    it('should not override attributes', () => {
+      const Project = current.define('Project', {hasTasks: DataTypes.BOOLEAN});
+
+      Project.hasMany(Task);
+
+      const company = Project.build();
+
+      expect(company.hasTasks).not.to.be.a('function');
+    });
   });
 
   describe('get', () => {


### PR DESCRIPTION
### Description of change

Closes #9952 
