### PR TITLE
Add keyword MariaDB to package.json, why not?

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "keywords": [
     "mysql",
+    "mariadb",
     "sqlite",
     "postgresql",
     "postgres",


### PR DESCRIPTION
a ton of people are searching for MariaDB and sequelize does not have this keyword?

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
