### PR TITLE
refactor(Model): remove .all() alias of .findAll()

### DIFF
--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -150,11 +150,6 @@ Project.findAll().then(projects => {
   // projects will be an array of all Project instances
 })
 
-// also possible:
-Project.all().then(projects => {
-  // projects will be an array of all Project instances
-})
-
 // search for specific attributes - hash usage
 Project.findAll({ where: { name: 'A Project' } }).then(projects => {
   // projects will be an array of Project instances with the specified name

--- a/lib/model.js
+++ b/lib/model.js
@@ -1556,10 +1556,6 @@ class Model {
     return self;
   }
 
-  static all(options) {
-    return this.findAll(options);
-  }
-
   /**
    * Search for multiple instances.
    *

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -55,12 +55,12 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           this.t = t;
           return article.setLabels([label], { transaction: t });
         }).then(function() {
-          return this.Article.all({ transaction: this.t });
+          return this.Article.findAll({ transaction: this.t });
         }).then(articles => {
           return articles[0].getLabels();
         }).then(function(labels) {
           expect(labels).to.have.length(0);
-          return this.Article.all({ transaction: this.t });
+          return this.Article.findAll({ transaction: this.t });
         }).then(function(articles) {
           return articles[0].getLabels({ transaction: this.t });
         }).then(function(labels) {

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -77,10 +77,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
               return Group.create({ name: 'bar' }).then(group => {
                 return sequelize.transaction().then(t => {
                   return group.setUser(user, { transaction: t }).then(() => {
-                    return Group.all().then(groups => {
+                    return Group.findAll().then(groups => {
                       return groups[0].getUser().then(associatedUser => {
                         expect(associatedUser).to.be.null;
-                        return Group.all({ transaction: t }).then(groups => {
+                        return Group.findAll({ transaction: t }).then(groups => {
                           return groups[0].getUser({ transaction: t }).then(associatedUser => {
                             expect(associatedUser).to.be.not.null;
                             return t.rollback();
@@ -207,7 +207,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
               return Group.create({ name: 'bar' }).then(group => {
                 return sequelize.transaction().then(t => {
                   return group.setUser(user, { transaction: t }).then(() => {
-                    return Group.all().then(groups => {
+                    return Group.findAll().then(groups => {
                       return groups[0].getUser().then(associatedUser => {
                         expect(associatedUser).to.be.null;
                         return t.rollback();

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -488,13 +488,13 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
             t = _t;
             return article.setLabels([label], { transaction: t });
           }).then(() => {
-            return Article.all({ transaction: t });
+            return Article.findAll({ transaction: t });
           }).then(articles => {
             return articles[0].hasLabel(label).then(hasLabel => {
               expect(hasLabel).to.be.false;
             });
           }).then(() => {
-            return Article.all({ transaction: t });
+            return Article.findAll({ transaction: t });
           }).then(articles => {
             return articles[0].hasLabel(label, { transaction: t }).then(hasLabel => {
               expect(hasLabel).to.be.true;
@@ -594,7 +594,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
             this.t = t;
             return this.article.setLabels([this.label], { transaction: t });
           }).then(function() {
-            return this.Article.all({ transaction: this.t });
+            return this.Article.findAll({ transaction: this.t });
           }).then(function(articles) {
             return Promise.all([
               articles[0].hasLabels([this.label]),

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -76,10 +76,10 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
                 return Group.create({ name: 'bar' }).then(group => {
                   return sequelize.transaction().then(t => {
                     return group.setUser(user, { transaction: t }).then(() => {
-                      return Group.all().then(groups => {
+                      return Group.findAll().then(groups => {
                         return groups[0].getUser().then(associatedUser => {
                           expect(associatedUser).to.be.null;
-                          return Group.all({ transaction: t }).then(groups => {
+                          return Group.findAll({ transaction: t }).then(groups => {
                             return groups[0].getUser({ transaction: t }).then(associatedUser => {
                               expect(associatedUser).not.to.be.null;
                               expect(associatedUser.id).to.equal(user.id);
@@ -140,7 +140,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
         ]);
       }).spread((fakeUser, user, group) => {
         return group.setUser(user).then(() => {
-          return Group.all().then(groups => {
+          return Group.findAll().then(groups => {
             return groups[0].getUser().then(associatedUser => {
               expect(associatedUser).not.to.be.null;
               expect(associatedUser.id).to.equal(user.id);
@@ -174,7 +174,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
               return Group.create({ name: 'bar' }).then(group => {
                 return sequelize.transaction().then(t => {
                   return group.setUser(user, { transaction: t }).then(() => {
-                    return Group.all().then(groups => {
+                    return Group.findAll().then(groups => {
                       return groups[0].getUser().then(associatedUser => {
                         expect(associatedUser).to.be.null;
                         return t.rollback();
@@ -365,10 +365,10 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
             return User.create({ username: 'bob' }).then(user => {
               return sequelize.transaction().then(t => {
                 return user.createGroup({ name: 'testgroup' }, { transaction: t }).then(() => {
-                  return User.all().then(users => {
+                  return User.findAll().then(users => {
                     return users[0].getGroup().then(group => {
                       expect(group).to.be.null;
-                      return User.all({ transaction: t }).then(users => {
+                      return User.findAll({ transaction: t }).then(users => {
                         return users[0].getGroup({ transaction: t }).then(group => {
                           expect(group).to.be.not.null;
                           return t.rollback();

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -73,7 +73,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('should be able to use a defaultScope if declared', function() {
-      return this.ScopeMe.all().then(users => {
+      return this.ScopeMe.findAll().then(users => {
         expect(users).to.have.length(2);
         expect([10, 5].indexOf(users[0].access_level) !== -1).to.be.true;
         expect([10, 5].indexOf(users[1].access_level) !== -1).to.be.true;

--- a/test/integration/sequelize.transaction.test.js
+++ b/test/integration/sequelize.transaction.test.js
@@ -85,7 +85,7 @@ if (current.dialect.supports.transactions) {
               return t.commit();
             });
           }).then(function() {
-            return this.User.all();
+            return this.User.findAll();
           }).then(users => {
             expect(users.length).to.equal(1);
             expect(users[0].name).to.equal('foo');

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -353,7 +353,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
       describe('findAll', () => {
         it('should allow $in', () => {
-          return expect(User.all({
+          return expect(User.findAll({
             where: {
               name: {
                 [Op.like]: {
@@ -365,7 +365,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
         });
 
         it('should allow $like for uuid', () => {
-          return expect(User.all({
+          return expect(User.findAll({
             where: {
               uid: {
                 [Op.like]: '12345678%'


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Little addition to the previous PR https://github.com/sequelize/sequelize/pull/9933
Remove the .all() alias of .findAll()
