### PR TITLE
fix(tinyint): ignore params for TINYINT on postgres

### DIFF
--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -258,7 +258,7 @@ module.exports = BaseTypes => {
     if (!(this instanceof TINYINT)) return new TINYINT(length);
     BaseTypes.TINYINT.apply(this, arguments);
 
-    // POSTGRES does not support any parameters for bigint
+    // POSTGRES does not support any parameters for tinyint
     if (this._length || this.options.length || this._unsigned || this._zerofill) {
       warn('PostgreSQL does not support TINYINT with options. Plain `TINYINT` will be used instead.');
       this._length = undefined;

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -254,6 +254,27 @@ module.exports = BaseTypes => {
     array_oids: [1185]
   };
 
+  function TINYINT(length) {
+    if (!(this instanceof TINYINT)) return new TINYINT(length);
+    BaseTypes.TINYINT.apply(this, arguments);
+
+    // POSTGRES does not support any parameters for bigint
+    if (this._length || this.options.length || this._unsigned || this._zerofill) {
+      warn('PostgreSQL does not support TINYINT with options. Plain `TINYINT` will be used instead.');
+      this._length = undefined;
+      this.options.length = undefined;
+      this._unsigned = undefined;
+      this._zerofill = undefined;
+    }
+  }
+  inherits(TINYINT, BaseTypes.TINYINT);
+
+  // int2
+  BaseTypes.TINYINT.types.postgres = {
+    oids: [21],
+    array_oids: [1005]
+  };
+
   function SMALLINT(length) {
     if (!(this instanceof SMALLINT)) return new SMALLINT(length);
     BaseTypes.SMALLINT.apply(this, arguments);
@@ -668,6 +689,7 @@ module.exports = BaseTypes => {
     STRING,
     CHAR,
     TEXT,
+    TINYINT,
     SMALLINT,
     INTEGER,
     BIGINT,

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -420,7 +420,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           dataType: DataTypes.TINYINT(2),
           expect: {
             default: 'TINYINT(2)',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -428,7 +429,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           dataType: DataTypes.TINYINT({ length: 2 }),
           expect: {
             default: 'TINYINT(2)',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -436,7 +438,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           dataType: DataTypes.TINYINT.UNSIGNED,
           expect: {
             default: 'TINYINT UNSIGNED',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -445,7 +448,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           expect: {
             default: 'TINYINT(2) UNSIGNED',
             sqlite: 'TINYINT UNSIGNED(2)',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -453,7 +457,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           dataType: DataTypes.TINYINT.UNSIGNED.ZEROFILL,
           expect: {
             default: 'TINYINT UNSIGNED ZEROFILL',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -462,7 +467,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           expect: {
             default: 'TINYINT(2) UNSIGNED ZEROFILL',
             sqlite: 'TINYINT UNSIGNED ZEROFILL(2)',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -470,7 +476,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           dataType: DataTypes.TINYINT.ZEROFILL,
           expect: {
             default: 'TINYINT ZEROFILL',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -479,7 +486,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           expect: {
             default: 'TINYINT(2) ZEROFILL',
             sqlite: 'TINYINT ZEROFILL(2)',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -487,7 +495,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           dataType: DataTypes.TINYINT.ZEROFILL.UNSIGNED,
           expect: {
             default: 'TINYINT UNSIGNED ZEROFILL',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         },
         {
@@ -496,7 +505,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           expect: {
             default: 'TINYINT(2) UNSIGNED ZEROFILL',
             sqlite: 'TINYINT UNSIGNED ZEROFILL(2)',
-            mssql: 'TINYINT'
+            mssql: 'TINYINT',
+            postgres: 'TINYINT'
           }
         }
       ];


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Proposal to fix #9738.
Postgres don't have type TINYINT.
With this PR the mesage error is more clear when use `TINYINT.UNSIGNED`. It's same when use `TINYINT`

From:
`ERROR: syntax error at or near "UNSIGNED"`

To:
`type "tinyint" does not exist`

@sushantdhiman what do you think?


