### PR TITLE
docs(query-interface): add inline 'bulkUpdate' docs

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -971,6 +971,25 @@ class QueryInterface {
     return this.sequelize.query(sql, options);
   }
 
+  /**
+   * Update multiple records of a table
+   *
+   * @example
+   * queryInterface.bulkUpdate('roles', {
+   *     label: 'admin',
+   *   }, { 
+   *     userType: 3,
+   *   },
+   * );
+   *
+   * @param {string} tableName     Table name to update
+   * @param {Object} values        Values to be inserted, mapped to field name
+   * @param {Object} identifier    A hash with conditions OR an ID as integer OR a string with conditions
+   * @param {Object} [options]     Various options, please see Model.bulkCreate options
+   * @param {Object} [attributes]  Attributes on return objects if supported by SQL dialect
+   *
+   * @returns {Promise}
+   */
   bulkUpdate(tableName, values, identifier, options, attributes) {
     options = Utils.cloneDeep(options);
     if (typeof identifier === 'object') identifier = Utils.cloneDeep(identifier);


### PR DESCRIPTION
Adds missing documentation on 'bulkUpdate' inline at query-interface.js. Addresses https://github.com/sequelize/sequelize/issues/8820