### PR TITLE
Add ssl option to uri for postgres

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -105,7 +105,7 @@ class Sequelize {
       config = {};
       options = username || {};
 
-      const urlParts = url.parse(arguments[0]);
+      const urlParts = url.parse(arguments[0], true);
 
       options.dialect = urlParts.protocol.replace(/:$/, '');
       options.host = urlParts.hostname;
@@ -130,6 +130,13 @@ class Sequelize {
 
         if (authParts.length > 1)
           config.password = authParts.slice(1).join(':');
+      }
+
+      if (urlParts.query) {
+        if (options.dialectOptions)
+          _.assign(options.dialectOptions, urlParts.query);
+        else
+          options.dialectOptions = urlParts.query;
       }
     } else {
       // new Sequelize(database, username, password, { ... options })

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -153,5 +153,30 @@ describe('Sequelize', () => {
 
       expect(config.port).to.equal(port);
     });
+
+    it('should pass query string parameters to dialectOptions', () => {
+      const sequelize = new Sequelize('mysql://example.com:9821/dbname?ssl=true');
+      const dialectOptions = sequelize.config.dialectOptions;
+
+      expect(dialectOptions.foo).to.equal('true');
+    });
+
+    it('should merge query string parameters to options', () => {
+      const sequelize = new Sequelize('mysql://example.com:9821/dbname?ssl=true&application_name=client', {
+        storage: '/completely/different/path.db',
+        dialectOptions: {
+          supportBigNumbers: true,
+          application_name: 'server',
+        }
+      });
+
+      const options = sequelize.options;
+      const dialectOptions = sequelize.config.dialectOptions;
+
+      expect(options.storage).to.equal('/completely/different/path.db');
+      expect(dialectOptions.supportBigNumbers).to.be.true;
+      expect(dialectOptions.application_name).to.equal('client');
+      expect(dialectOptions.ssl).to.equal('true');
+    });
   });
 });

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -158,7 +158,7 @@ describe('Sequelize', () => {
       const sequelize = new Sequelize('mysql://example.com:9821/dbname?ssl=true');
       const dialectOptions = sequelize.config.dialectOptions;
 
-      expect(dialectOptions.foo).to.equal('true');
+      expect(dialectOptions.ssl).to.equal('true');
     });
 
     it('should merge query string parameters to options', () => {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Added support for the ssl option to the Postgres URI. For example:
```
postgres://localhost/sequelize_test?ssl=true
```

The way I chose to support this was assigning any query parameters from the URI into `dialectOptions`. Then each dialects `ConnectionManager.connect()` can use the parameters the same as if they were used in the constructor with `options.dialectOptions`. 

Closes #10015 

Related #9712, #6932, #5891
