### PR TITLE
 fix(postgres): remove if not exists and cascade on create/drop db

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -26,8 +26,8 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
 
     const values = {
       database: this.quoteIdentifier(databaseName),
-      charset: options.charset ? ' DEFAULT CHARSET SET = ' + this.escape(options.charset) : '',
-      collation: options.collate ? ' DEFAULT COLLATE = ' + this.escape(options.collate) : ''
+      charset: options.charset ? ' DEFAULT CHARACTER SET ' + this.escape(options.charset) : '',
+      collation: options.collate ? ' DEFAULT COLLATE ' + this.escape(options.collate) : ''
     };
 
     return _.template(query, this._templateSettings)(values).trim() + ';';

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -21,10 +21,12 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const values = {
       database: this.quoteTable(databaseName),
       encoding: options.encoding ? ' ENCODING = ' + this.escape(options.encoding) : '',
-      collation: options.collate ? ' LC_COLLATE = ' + this.escape(options.collate) : ''
+      collation: options.collate ? ' LC_COLLATE = ' + this.escape(options.collate) : '',
+      ctype: options.ctype ? ' LC_CTYPE = ' + this.escape(options.ctype) : '',
+      template: options.template ? ' TEMPLATE = ' + this.escape(options.template) : ''
     };
 
-    return `CREATE DATABASE ${values.database}${values.encoding}${values.collation};`;
+    return `CREATE DATABASE ${values.database}${values.encoding}${values.collation}${values.ctype}${values.template};`;
   }
 
   dropDatabaseQuery(databaseName) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -24,11 +24,11 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       collation: options.collate ? ' LC_COLLATE = ' + this.escape(options.collate) : ''
     };
 
-    return `CREATE DATABASE IF NOT EXISTS ${values.database}${values.encoding}${values.collation};`;
+    return `CREATE DATABASE ${values.database}${values.encoding}${values.collation};`;
   }
 
   dropDatabaseQuery(databaseName) {
-    return `DROP DATABASE IF EXISTS ${this.quoteTable(databaseName)} CASCADE;`;
+    return `DROP DATABASE IF EXISTS ${this.quoteTable(databaseName)};`;
   }
 
   createSchema(schema) {

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -32,6 +32,8 @@ class QueryInterface {
    * @param {string} [options.charset] Database default character set, MYSQL only
    * @param {string} [options.collate] Database default collation
    * @param {string} [options.encoding] Database default character set, PostgreSQL only
+   * @param {string} [options.ctype] Database character classification, PostgreSQL only
+   * @param {string} [options.template] The name of the template from which to create the new database, PostgreSQL only
    *
    * @returns {Promise}
    */

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -27,31 +27,31 @@ class QueryInterface {
   /**
    * Creates a database
    *
-   * @param {string} schema    Schema name to create
+   * @param {string} database  Database name to create
    * @param {Object} [options] Query options
    * @param {string} [options.charset] Database default character set, MYSQL only
-   * @param {string} [options.encoding] Database default character set, PostgreSQL only
    * @param {string} [options.collate] Database default collation
+   * @param {string} [options.encoding] Database default character set, PostgreSQL only
    *
    * @returns {Promise}
    */
-  createDatabase(schema, options) {
+  createDatabase(database, options) {
     options = options || {};
-    const sql = this.QueryGenerator.createDatabaseQuery(schema, options);
+    const sql = this.QueryGenerator.createDatabaseQuery(database, options);
     return this.sequelize.query(sql, options);
   }
 
   /**
    * Drops a database
    *
-   * @param {string} schema    Schema name to drop
+   * @param {string} database  Database name to drop
    * @param {Object} [options] Query options
    *
    * @returns {Promise}
    */
-  dropDatabase(schema, options) {
+  dropDatabase(database, options) {
     options = options || {};
-    const sql = this.QueryGenerator.dropDatabaseQuery(schema);
+    const sql = this.QueryGenerator.dropDatabaseQuery(database);
     return this.sequelize.query(sql, options);
   }
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -18,15 +18,15 @@ if (dialect === 'mysql') {
         },
         {
           arguments: ['myDatabase', {charset: 'utf8mb4'}],
-          expectation: 'CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT CHARSET SET = \'utf8mb4\';'
+          expectation: 'CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT CHARACTER SET \'utf8mb4\';'
         },
         {
           arguments: ['myDatabase', {collate: 'utf8mb4_unicode_ci'}],
-          expectation: 'CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT COLLATE = \'utf8mb4_unicode_ci\';'
+          expectation: 'CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT COLLATE \'utf8mb4_unicode_ci\';'
         },
         {
           arguments: ['myDatabase', {charset: 'utf8mb4', collate: 'utf8mb4_unicode_ci'}],
-          expectation: 'CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT CHARSET SET = \'utf8mb4\' DEFAULT COLLATE = \'utf8mb4_unicode_ci\';'
+          expectation: 'CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT CHARACTER SET \'utf8mb4\' DEFAULT COLLATE \'utf8mb4_unicode_ci\';'
         }
       ],
       dropDatabaseQuery: [

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -17,25 +17,25 @@ if (dialect.match(/^postgres/)) {
       createDatabaseQuery: [
         {
           arguments: ['myDatabase'],
-          expectation: 'CREATE DATABASE IF NOT EXISTS "myDatabase";'
+          expectation: 'CREATE DATABASE "myDatabase";'
         },
         {
           arguments: ['myDatabase', {encoding: 'UTF8'}],
-          expectation: 'CREATE DATABASE IF NOT EXISTS "myDatabase" ENCODING = \'UTF8\';'
+          expectation: 'CREATE DATABASE "myDatabase" ENCODING = \'UTF8\';'
         },
         {
           arguments: ['myDatabase', {collate: 'en_US.UTF-8'}],
-          expectation: 'CREATE DATABASE IF NOT EXISTS "myDatabase" LC_COLLATE = \'en_US.UTF-8\';'
+          expectation: 'CREATE DATABASE "myDatabase" LC_COLLATE = \'en_US.UTF-8\';'
         },
         {
           arguments: ['myDatabase', {encoding: 'UTF8', collate: 'en_US.UTF-8'}],
-          expectation: 'CREATE DATABASE IF NOT EXISTS "myDatabase" ENCODING = \'UTF8\' LC_COLLATE = \'en_US.UTF-8\';'
+          expectation: 'CREATE DATABASE "myDatabase" ENCODING = \'UTF8\' LC_COLLATE = \'en_US.UTF-8\';'
         }
       ],
       dropDatabaseQuery: [
         {
           arguments: ['myDatabase'],
-          expectation: 'DROP DATABASE IF EXISTS "myDatabase" CASCADE;'
+          expectation: 'DROP DATABASE IF EXISTS "myDatabase";'
         }
       ],
       arithmeticQuery: [

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -28,8 +28,20 @@ if (dialect.match(/^postgres/)) {
           expectation: 'CREATE DATABASE "myDatabase" LC_COLLATE = \'en_US.UTF-8\';'
         },
         {
-          arguments: ['myDatabase', {encoding: 'UTF8', collate: 'en_US.UTF-8'}],
-          expectation: 'CREATE DATABASE "myDatabase" ENCODING = \'UTF8\' LC_COLLATE = \'en_US.UTF-8\';'
+          arguments: ['myDatabase', {encoding: 'UTF8'}],
+          expectation: 'CREATE DATABASE "myDatabase" ENCODING = \'UTF8\';'
+        },
+        {
+          arguments: ['myDatabase', {ctype: 'zh_TW.UTF-8'}],
+          expectation: 'CREATE DATABASE "myDatabase" LC_CTYPE = \'zh_TW.UTF-8\';'
+        },
+        {
+          arguments: ['myDatabase', {template: 'template0'}],
+          expectation: 'CREATE DATABASE "myDatabase" TEMPLATE = \'template0\';'
+        },
+        {
+          arguments: ['myDatabase', {encoding: 'UTF8', collate: 'en_US.UTF-8', ctype: 'zh_TW.UTF-8', template: 'template0'}],
+          expectation: 'CREATE DATABASE "myDatabase" ENCODING = \'UTF8\' LC_COLLATE = \'en_US.UTF-8\' LC_CTYPE = \'zh_TW.UTF-8\' TEMPLATE = \'template0\';'
         }
       ],
       dropDatabaseQuery: [


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Resolved #10030 

Postgresql doesn't support `CREATE DATABASE IF NOT EXISTS...`. So remove words `IF NOT EXISTS`.

Add more options on postgresql  `CREATE DATABASE`:
- template
- ctype

refs:
- https://www.postgresql.org/docs/9.5/static/sql-createdatabase.html
- https://www.postgresql.org/docs/9.5/static/sql-dropdatabase.html