### PR TITLE
Add support for temporary tables in all dialects

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -132,7 +132,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
           const commentMatch = dataType.match(/^(.+) (COMMENT.*)$/);
           const commentText = commentMatch[2].replace(/COMMENT/, '').trim();
           commentStr += _.template(commentTemplate, this._templateSettings)({
-            table: this.quoteIdentifier(tableName),
+            table: this.quoteIdentifier(options.temporaryTable ? `##${tableName}` : tableName),
             comment: this.escape(commentText),
             column: this.quoteIdentifier(attr)
           });
@@ -164,7 +164,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     const values = {
-        table: this.quoteTable(tableName),
+        table: this.quoteTable(options.temporaryTable ? `##${tableName}` : tableName),
         attributes: attrStr.join(', ')
       },
       pkString = primaryKeys.map(pk => { return this.quoteIdentifier(pk); }).join(', ');

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -62,7 +62,9 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
       rowFormat: null
     }, options || {});
 
-    const query = 'CREATE TABLE IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %><%= rowFormat %>';
+    const createStatement = options.temporaryTable ? 'CREATE TEMPORARY TABLE' : 'CREATE TABLE';
+
+    const query = `${createStatement} IF NOT EXISTS <%= table %> (<%= attributes%>) ENGINE=<%= engine %><%= comment %><%= charset %><%= collation %><%= initialAutoIncrement %><%= rowFormat %>`;
     const primaryKeys = [];
     const foreignKeys = {};
     const attrStr = [];

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -106,7 +106,9 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       values.attributes += `, PRIMARY KEY (${pks})`;
     }
 
-    return `CREATE TABLE ${databaseVersion === 0 || semver.gte(databaseVersion, '9.1.0') ? 'IF NOT EXISTS ' : ''}${values.table} (${values.attributes})${values.comments}${values.columnComments};`;
+    const createStatement = options.temporaryTable ? 'CREATE TEMPORARY TABLE' : 'CREATE TABLE';
+
+    return `${createStatement} ${databaseVersion === 0 || semver.gte(databaseVersion, '9.1.0') ? 'IF NOT EXISTS ' : ''}${values.table} (${values.attributes})${values.comments}${values.columnComments};`;
   }
 
   dropTableQuery(tableName, options) {

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -68,7 +68,9 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
       attrStr += `, PRIMARY KEY (${pkString})`;
     }
 
-    const sql = `CREATE TABLE IF NOT EXISTS ${table} (${attrStr});`;
+    const createStatement = options.temporaryTable ? 'CREATE TEMPORARY TABLE' : 'CREATE TABLE';
+
+    const sql = `${createStatement} IF NOT EXISTS ${table} (${attrStr});`;
     return this.replaceBooleanDefaults(sql);
   }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -818,6 +818,7 @@ class Model {
    * @param {boolean}                 [options.paranoid=false] Calling `destroy` will not delete the model, but instead set a `deletedAt` timestamp if this is true. Needs `timestamps=true` to work
    * @param {boolean}                 [options.underscored=false] Add underscored field to all attributes, this covers user defined attributes, timestamps and foreign keys. Will not affect attributes with explicitly set `field` option
    * @param {boolean}                 [options.freezeTableName=false] If freezeTableName is true, sequelize will not try to alter the model name to get the table name. Otherwise, the model name will be pluralized
+   * @param {boolean}                 [options.temporaryTable=false] If temporaryTable is true, sequelize will create a temporary table (does not work with connection pool)
    * @param {Object}                  [options.name] An object with two attributes, `singular` and `plural`, which are used when this model is associated to others.
    * @param {string}                  [options.name.singular=Utils.singularize(modelName)] Singular name for model
    * @param {string}                  [options.name.plural=Utils.pluralize(modelName)] Plural name for model
@@ -887,7 +888,8 @@ class Model {
       schemaDelimiter: '',
       defaultScope: {},
       scopes: {},
-      indexes: []
+      indexes: [],
+      temporaryTable: false
     }, options);
 
     // if you call "define" multiple times for the same modelName, do not clutter the factory

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -195,6 +195,10 @@ class QueryInterface {
 
     options = _.clone(options) || {};
 
+    if (options.temporaryTable && this.sequelize.dialect.connectionManager.config.pool.max > 1) {
+      return Promise.reject('Temporary tables do not work with a connection pool');
+    }
+
     if (options && options.uniqueKeys) {
       _.forOwn(options.uniqueKeys, uniqueKey => {
         if (uniqueKey.customIndex === undefined) {

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -151,5 +151,28 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         });
       });
     });
+
+    describe('temporary tables', () => {
+
+      it('should not create a temporary table with connection pool', () => {
+        return expect(
+          Support.sequelize.queryInterface.createTable(
+            'TempUser',
+            {username: DataTypes.TEXT},
+            {temporaryTable: true})
+        ).to.eventually.be.rejectedWith('Temporary tables do not work with a connection pool');
+      });
+
+      it('should create a temporary table', () => {
+        const noPoolSequelize = Support.createSequelizeInstance({pool: {max: 1}});
+
+        return expect(
+          noPoolSequelize.queryInterface.createTable(
+            'TempUser',
+            {username: DataTypes.TEXT},
+            {temporaryTable: true})
+        ).to.eventually.be.fulfilled;
+      });
+    });
   });
 });

--- a/test/unit/sql/create-table.test.js
+++ b/test/unit/sql/create-table.test.js
@@ -81,6 +81,22 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
+    describe('temporary tables', () => {
+      const FooUser = current.define('user', {}, {
+        timestamps: false,
+        temporaryTable: true
+      });
+
+      it('properly uses the temporary option', () => {
+        expectsql(sql.createTableQuery(FooUser.getTableName(), sql.attributesToSQL(FooUser.rawAttributes), {temporaryTable: true}), {
+          sqlite: 'CREATE TEMPORARY TABLE IF NOT EXISTS `users` (`id` INTEGER PRIMARY KEY AUTOINCREMENT);',
+          postgres: 'CREATE TEMPORARY TABLE IF NOT EXISTS "users" ("id"   SERIAL , PRIMARY KEY ("id"));',
+          mysql: 'CREATE TEMPORARY TABLE IF NOT EXISTS `users` (`id` INTEGER NOT NULL auto_increment , PRIMARY KEY (`id`)) ENGINE=InnoDB;',
+          mssql: "IF OBJECT_ID('[##users]', 'U') IS NULL CREATE TABLE [##users] ([id] INTEGER NOT NULL IDENTITY(1,1) , PRIMARY KEY ([id]));"
+        });
+      });
+    });
+
     if (current.dialect.name === 'postgres') {
       describe('IF NOT EXISTS version check', () => {
         const modifiedSQL = _.clone(sql);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Added support for temporary tables. This is supported by all dialects. A temporary table is only available for the current session (connection). Therefore it is only supported if pooling is disabled (by setting max pool size to 1).

The new `temporaryTable` option can be set when defining a model or using `queryInterface.createTable()`. If pooling is enabled then an error is thrown.

One use case for this is simplifying integration tests in apps that use sequelize. Another use case is when creating migrations that move data around.
