### PR TITLE
Add support for sqlite citext data-type 

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -120,7 +120,7 @@ Sequelize.STRING(1234)                // VARCHAR(1234)
 Sequelize.STRING.BINARY               // VARCHAR BINARY
 Sequelize.TEXT                        // TEXT
 Sequelize.TEXT('tiny')                // TINYTEXT
-Sequelize.CITEXT                      // CITEXT      PostgreSQL only.
+Sequelize.CITEXT                      // CITEXT      PostgreSQL and SQLite only.
 
 Sequelize.INTEGER                     // INTEGER
 Sequelize.BIGINT                      // BIGINT

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -143,7 +143,7 @@ TEXT.prototype.validate = function validate(value) {
 /**
  * An unlimited length case-insensitive text column.
  * Original case is preserved but acts case-insensitive when comparing values (such as when finding or unique constraints).
- * Only available in Postgres.
+ * Only available in Postgres and SQLite.
  *
  * @namespace DataTypes.CITEXT
  */

--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -108,6 +108,16 @@ module.exports = BaseTypes => {
     return 'TEXT';
   };
 
+  function CITEXT() {
+    if (!(this instanceof CITEXT)) return new CITEXT();
+    BaseTypes.CITEXT.apply(this, arguments);
+  }
+  inherits(CITEXT, BaseTypes.CITEXT);
+
+  CITEXT.prototype.toSql = function toSql() {
+    return 'TEXT COLLATE NOCASE';
+  };
+
   function CHAR(length, binary) {
     if (!(this instanceof CHAR)) return new CHAR(length, binary);
     BaseTypes.CHAR.apply(this, arguments);
@@ -280,7 +290,8 @@ module.exports = BaseTypes => {
     BIGINT,
     TEXT,
     ENUM,
-    JSON: JSONTYPE
+    JSON: JSONTYPE,
+    CITEXT
   };
 
   _.forIn(exports, (DataType, key) => {

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -346,7 +346,7 @@ class InstanceValidator {
       }
     }
 
-    if (rawAttribute.type instanceof DataTypes.STRING || rawAttribute.type instanceof DataTypes.TEXT) {
+    if (rawAttribute.type instanceof DataTypes.STRING || rawAttribute.type instanceof DataTypes.TEXT || rawAttribute.type instanceof DataTypes.CITEXT) {
       if (Array.isArray(value) || _.isObject(value) && !(value instanceof Utils.SequelizeMethod) && !Buffer.isBuffer(value)) {
         this.errors.push(new sequelizeError.ValidationErrorItem(
           `${field} cannot be an array or an object`,

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -285,6 +285,11 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
   it('calls parse and stringify for CITEXT', () => {
     const Type = new Sequelize.CITEXT();
 
+    if (dialect === 'sqlite') {
+      // The "field type" sqlite returns is TEXT so is covered under TEXT test above
+      return;
+    }
+
     if (dialect === 'postgres') {
       return testSuccess(Type, 'foobar');
     } else {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -998,7 +998,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
-    if (dialect === 'postgres') {
+    if (dialect === 'postgres' || dialect === 'sqlite') {
       it("doesn't allow case-insensitive duplicated records using CITEXT", function () {
         const User = this.sequelize.define('UserWithUniqueCITEXT', {
           username: {type: Sequelize.CITEXT, unique: true}

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -475,7 +475,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
 
-      if (dialect === 'postgres') {
+      if (dialect === 'postgres' || dialect === 'sqlite') {
         it('should be able to find multiple users with case-insensitive on CITEXT type', function() {
           const User = this.sequelize.define('UsersWithCaseInsensitiveName', {
             username: Sequelize.CITEXT

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -288,7 +288,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
 
-      if (dialect === 'postgres') {
+      if (dialect === 'postgres' || dialect === 'sqlite') {
         it('should allow case-insensitive find on CITEXT type', function() {
           const User = this.sequelize.define('UserWithCaseInsensitiveName', {
             username: Sequelize.CITEXT


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

#10024 added CITETXT for Postgres.

This isn't a real data-type in SQLite but uses `COLLATE NOCASE` on the `TEXT` field. The behavior is the same as CITEXT for Postgres with the exception of SQLite only supporting ASCII characters.