### PR TITLE
chore: replace lodash and es5 constructs to use es6

### DIFF
--- a/docs/instances.md
+++ b/docs/instances.md
@@ -181,8 +181,7 @@ Task.bulkCreate([
     { status: 'inactive' }, /* set attributes' value */
     { where: { subject: 'programming' }} /* where criteria */
   );
-}).spread((affectedCount, affectedRows) => {
-  // .update returns two values in an array, therefore we use .spread
+}).then(([affectedCount, affectedRows]) => {
   // Notice that affectedRows will only be defined in dialects which support returning: true
 
   // affectedCount will be 2

--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -793,4 +793,3 @@ sequelize.define('user', {}, {
 [0]: /manual/tutorial/models-definition.html#configuration
 [3]: https://github.com/chriso/validator.js
 [5]: /docs/final/misc#asynchronicity
-[6]: http://bluebirdjs.com/docs/api/spread.html

--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -38,7 +38,7 @@ Let's assume we have an empty database with a `User` model which has a `username
 ```js
 User
   .findOrCreate({where: {username: 'sdepold'}, defaults: {job: 'Technical Lead JavaScript'}})
-  .spread((user, created) => {
+  .then(([user, created]) => {
     console.log(user.get({
       plain: true
     }))
@@ -65,7 +65,7 @@ The code created a new instance. So when we already have an instance ...
 ```js
 User.create({ username: 'fnord', job: 'omnomnom' })
   .then(() => User.findOrCreate({where: {username: 'fnord'}, defaults: {job: 'something else'}}))
-  .spread((user, created) => {
+  .then(([user, created]) => {
     console.log(user.get({
       plain: true
     }))

--- a/docs/raw-queries.md
+++ b/docs/raw-queries.md
@@ -5,7 +5,7 @@ As there are often use cases in which it is just easier to execute raw / already
 By default the function will return two arguments - a results array, and an object containing metadata (affected rows etc.). Note that since this is a raw query, the metadata (property names etc.) is dialect specific. Some dialects return the metadata "within" the results object (as properties on an array). However, two arguments will always be returned, but for MSSQL and MySQL it will be two references to the same object.
 
 ```js
-sequelize.query("UPDATE users SET y = 42 WHERE x = 12").spread((results, metadata) => {
+sequelize.query("UPDATE users SET y = 42 WHERE x = 12").then(([results, metadata]) => {
   // Results will be an empty array and metadata will contain the number of affected rows.
 })
 ```

--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -121,7 +121,7 @@ Project.scope('defaultScope', 'deleted').findAll();
 SELECT * FROM projects WHERE active = true AND deleted = true
 ```
 
-When invoking several scopes, keys from subsequent scopes will overwrite previous ones (similar to [_.assign](https://lodash.com/docs#assign)). Consider two scopes:
+When invoking several scopes, keys from subsequent scopes will overwrite previous ones (similar to [Object.assign](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign). Consider two scopes:
 
 ```js
 {

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -73,7 +73,7 @@ class BelongsToMany extends Association {
     this.associationType = 'BelongsToMany';
     this.targetAssociation = null;
     this.sequelize = source.sequelize;
-    this.through = _.assign({}, this.options.through);
+    this.through = Object.assign({}, this.options.through);
     this.isMultiAssociation = true;
     this.doubleLinked = false;
 
@@ -162,7 +162,7 @@ class BelongsToMany extends Association {
 
     if (typeof this.through.model === 'string') {
       if (!this.sequelize.isDefined(this.through.model)) {
-        this.through.model = this.sequelize.define(this.through.model, {}, _.extend(this.options, {
+        this.through.model = this.sequelize.define(this.through.model, {}, Object.assign(this.options, {
           tableName: this.through.model,
           indexes: [], //we don't want indexes here (as referenced in #2416)
           paranoid: false,  // A paranoid join table does not make sense
@@ -297,8 +297,8 @@ class BelongsToMany extends Association {
       if (!targetAttribute.onUpdate) targetAttribute.onUpdate = 'CASCADE';
     }
 
-    this.through.model.rawAttributes[this.foreignKey] = _.extend(this.through.model.rawAttributes[this.foreignKey], sourceAttribute);
-    this.through.model.rawAttributes[this.otherKey] = _.extend(this.through.model.rawAttributes[this.otherKey], targetAttribute);
+    this.through.model.rawAttributes[this.foreignKey] = Object.assign(this.through.model.rawAttributes[this.foreignKey], sourceAttribute);
+    this.through.model.rawAttributes[this.otherKey] = Object.assign(this.through.model.rawAttributes[this.otherKey], targetAttribute);
 
     this.through.model.refreshAttributes();
 
@@ -396,7 +396,7 @@ class BelongsToMany extends Association {
       throughWhere[association.foreignKey] = instance.get(association.source.primaryKeyAttribute);
 
       if (through.scope) {
-        _.assign(throughWhere, through.scope);
+        Object.assign(throughWhere, through.scope);
       }
 
       //If a user pass a where on the options through options, make an "and" with the current throughWhere
@@ -474,7 +474,7 @@ class BelongsToMany extends Association {
       instances = [instances];
     }
 
-    options = _.assign({
+    options = Object.assign({
       raw: true
     }, options, {
       scope: false
@@ -562,7 +562,7 @@ class BelongsToMany extends Association {
           where[foreignIdentifier] = newObj.get(targetKey);
 
           if (Object.keys(attributes).length) {
-            promises.push(association.through.model.update(attributes, _.extend(options, {where})));
+            promises.push(association.through.model.update(attributes, Object.assign(options, {where})));
           }
         }
       }
@@ -584,13 +584,13 @@ class BelongsToMany extends Association {
 
           attributes = _.defaults(attributes, unassociatedObject[association.through.model.name], defaultAttributes);
 
-          _.assign(attributes, association.through.scope);
+          Object.assign(attributes, association.through.scope);
           attributes = Object.assign(attributes, association.through.scope);
 
           return attributes;
         });
 
-        promises.push(association.through.model.bulkCreate(bulk, _.assign({ validate: true }, options)));
+        promises.push(association.through.model.bulkCreate(bulk, Object.assign({ validate: true }, options)));
       }
 
       return Utils.Promise.all(promises);
@@ -635,7 +635,7 @@ class BelongsToMany extends Association {
     where[identifier] = sourceInstance.get(sourceKey);
     where[foreignIdentifier] = newInstances.map(newInstance => newInstance.get(targetKey));
 
-    _.assign(where, association.through.scope);
+    Object.assign(where, association.through.scope);
 
     const updateAssociations = currentRows => {
       const promises = [];
@@ -664,12 +664,12 @@ class BelongsToMany extends Association {
           attributes[identifier] = sourceInstance.get(sourceKey);
           attributes[foreignIdentifier] = unassociatedObject.get(targetKey);
 
-          _.assign(attributes, association.through.scope);
+          Object.assign(attributes, association.through.scope);
 
           return attributes;
         });
 
-        promises.push(association.through.model.bulkCreate(bulk, _.assign({ validate: true }, options)));
+        promises.push(association.through.model.bulkCreate(bulk, Object.assign({ validate: true }, options)));
       }
 
       for (const assoc of changedAssociations) {
@@ -684,7 +684,7 @@ class BelongsToMany extends Association {
         where[identifier] = sourceInstance.get(sourceKey);
         where[foreignIdentifier] = assoc.get(targetKey);
 
-        promises.push(association.through.model.update(attributes, _.extend(options, {where})));
+        promises.push(association.through.model.update(attributes, Object.assign(options, {where})));
       }
 
       return Utils.Promise.all(promises);
@@ -692,7 +692,7 @@ class BelongsToMany extends Association {
 
     return association.through.model.findAll(_.defaults({where, raw: true}, options))
       .then(currentRows => updateAssociations(currentRows))
-      .spread(associations => associations)
+      .then(([associations]) => associations)
       .catch(error => {
         if (error instanceof EmptyResultError) return updateAssociations();
         throw error;
@@ -745,7 +745,7 @@ class BelongsToMany extends Association {
     }
 
     if (association.scope) {
-      _.assign(values, association.scope);
+      Object.assign(values, association.scope);
       if (options.fields) {
         Array.prototype.push.apply(options.fields, Object.keys(association.scope));
       }

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -202,7 +202,7 @@ class BelongsTo extends Association {
 
     if (options.save === false) return;
 
-    options = _.extend({
+    options = Object.assign({
       fields: [this.foreignKey],
       allowNull: [this.foreignKey],
       association: true

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -182,7 +182,7 @@ class HasMany extends Association {
     options = Utils.cloneDeep(options);
 
     if (this.scope) {
-      _.assign(where, this.scope);
+      Object.assign(where, this.scope);
     }
 
     if (instances) {
@@ -282,7 +282,7 @@ class HasMany extends Association {
       targetInstances = [targetInstances];
     }
 
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       scope: false,
       raw: true
     });
@@ -363,7 +363,7 @@ class HasMany extends Association {
         update = {};
         update[this.foreignKey] = sourceInstance.get(this.sourceKey);
 
-        _.assign(update, this.scope);
+        Object.assign(update, this.scope);
         updateWhere[this.target.primaryKeyAttribute] = unassociatedObjects.map(unassociatedObject =>
           unassociatedObject[this.target.primaryKeyAttribute]
         );
@@ -399,7 +399,7 @@ class HasMany extends Association {
     targetInstances = this.toInstanceArray(targetInstances);
 
     update[this.foreignKey] = sourceInstance.get(this.sourceKey);
-    _.assign(update, this.scope);
+    Object.assign(update, this.scope);
 
     where[this.target.primaryKeyAttribute] = targetInstances.map(unassociatedObject =>
       unassociatedObject.get(this.target.primaryKeyAttribute)

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -155,7 +155,7 @@ class HasOne extends Association {
     }
 
     if (this.scope) {
-      _.assign(where, this.scope);
+      Object.assign(where, this.scope);
     }
 
     options.where = options.where ?
@@ -192,7 +192,7 @@ class HasOne extends Association {
   set(sourceInstance, associatedInstance, options) {
     let alreadyAssociated;
 
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       scope: false
     });
 
@@ -204,7 +204,7 @@ class HasOne extends Association {
 
       if (oldInstance && !alreadyAssociated) {
         oldInstance[this.foreignKey] = null;
-        return oldInstance.save(_.extend({}, options, {
+        return oldInstance.save(Object.assign({}, options, {
           fields: [this.foreignKey],
           allowNull: [this.foreignKey],
           association: true
@@ -220,7 +220,7 @@ class HasOne extends Association {
           });
         }
 
-        _.assign(associatedInstance, this.scope);
+        Object.assign(associatedInstance, this.scope);
         associatedInstance.set(this.foreignKey, sourceInstance.get(this.sourceKeyAttribute));
 
         return associatedInstance.save(options);

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -24,7 +24,7 @@ const Mixin = {
     options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
     options.useHooks = options.hooks;
 
-    options = _.extend(options, _.omit(source.options, ['hooks']));
+    options = Object.assign(options, _.omit(source.options, ['hooks']));
 
     if (options.useHooks) {
       this.runHooks('beforeAssociate', {source, target, type: HasMany}, options);
@@ -55,7 +55,7 @@ const Mixin = {
     options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
     options.useHooks = options.hooks;
     options.timestamps = options.timestamps === undefined ? this.sequelize.options.timestamps : options.timestamps;
-    options = _.extend(options, _.omit(source.options, ['hooks', 'timestamps', 'scopes', 'defaultScope']));
+    options = Object.assign(options, _.omit(source.options, ['hooks', 'timestamps', 'scopes', 'defaultScope']));
 
     if (options.useHooks) {
       this.runHooks('beforeAssociate', {source, target, type: BelongsToMany}, options);
@@ -109,7 +109,7 @@ function singleLinked(Type) {
       this.runHooks('beforeAssociate', {source, target, type: Type}, options);
     }
     // the id is in the foreign table
-    const association = new Type(source, target, _.extend(options, source.options));
+    const association = new Type(source, target, Object.assign(options, source.options));
     source.associations[association.associationAccessor] = association;
 
     association._injectAttributes();

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -780,7 +780,7 @@ RANGE.prototype.toCastType = function toCastType() {
   return pgRangeCastTypes[this._subtype.toLowerCase()];
 };
 RANGE.prototype.validate = function validate(value) {
-  if (!_.isArray(value)) {
+  if (!Array.isArray(value)) {
     throw new sequelizeErrors.ValidationError(util.format('%j is not a valid range', value));
   }
 
@@ -963,7 +963,7 @@ ARRAY.prototype.toSql = function toSql() {
   return this.type.toSql() + '[]';
 };
 ARRAY.prototype.validate = function validate(value) {
-  if (!_.isArray(value)) {
+  if (!Array.isArray(value)) {
     throw new sequelizeErrors.ValidationError(util.format('%j is not a valid array', value));
   }
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1799,7 +1799,7 @@ class QueryGenerator {
         return;
       }
 
-      nestedIncludes = [_.extend({}, child, { include: nestedIncludes, attributes: [] })];
+      nestedIncludes = [Object.assign({}, child, { include: nestedIncludes, attributes: [] })];
       child = parent;
     }
 
@@ -1876,7 +1876,7 @@ class QueryGenerator {
    * are preserved.
    */
   _getRequiredClosure(include) {
-    const copy = _.extend({}, include, {attributes: [], include: []});
+    const copy = Object.assign({}, include, {attributes: [], include: []});
 
     if (Array.isArray(include.include)) {
       copy.include = include.include
@@ -2261,7 +2261,7 @@ class QueryGenerator {
     Utils.getOperators(value).forEach(op => {
       const where = {};
       where[op] = value[op];
-      items.push(this.whereItemQuery(key, where, _.assign({}, options, {json: false})));
+      items.push(this.whereItemQuery(key, where, Object.assign({}, options, {json: false})));
     });
 
     _.forOwn(value, (item, prop) => {
@@ -2550,7 +2550,7 @@ class QueryGenerator {
   }
 }
 
-_.assignIn(QueryGenerator.prototype, require('./query-generator/operators'));
-_.assignIn(QueryGenerator.prototype, require('./query-generator/transaction'));
+Object.assign(QueryGenerator.prototype, require('./query-generator/operators'));
+Object.assign(QueryGenerator.prototype, require('./query-generator/transaction'));
 
 module.exports = QueryGenerator;

--- a/lib/dialects/abstract/query-generator/operators.js
+++ b/lib/dialects/abstract/query-generator/operators.js
@@ -51,7 +51,7 @@ const OperatorHelpers = {
     if (!aliases || _.isEmpty(aliases)) {
       this.OperatorsAliasMap = false;
     } else {
-      this.OperatorsAliasMap = _.assign({}, aliases);
+      this.OperatorsAliasMap = Object.assign({}, aliases);
     }
   },
 

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -16,7 +16,7 @@ const throwMethodUndefined = function(methodName) {
 
 class MSSQLQueryGenerator extends AbstractQueryGenerator {
   createDatabaseQuery(databaseName, options) {
-    options = _.extend({
+    options = Object.assign({
       collate: null
     }, options || {});
 

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -24,7 +24,7 @@ const removeColumn = function(tableName, attributeName, options) {
 
   const findConstraintSql = this.QueryGenerator.getDefaultConstraintQuery(tableName, attributeName);
   return this.sequelize.query(findConstraintSql, options)
-    .spread(results => {
+    .then(([results]) => {
       if (!results.length) {
         // No default constraint found -- we can cleanly remove the column
         return;
@@ -36,7 +36,7 @@ const removeColumn = function(tableName, attributeName, options) {
       const findForeignKeySql = this.QueryGenerator.getForeignKeyQuery(tableName, attributeName);
       return this.sequelize.query(findForeignKeySql, options);
     })
-    .spread(results => {
+    .then(([results]) => {
       if (!results.length) {
         // No foreign key constraints found, so we can remove the column
         return;
@@ -49,7 +49,7 @@ const removeColumn = function(tableName, attributeName, options) {
       const primaryKeyConstraintSql = this.QueryGenerator.getPrimaryKeyConstraintQuery(tableName, attributeName);
       return this.sequelize.query(primaryKeyConstraintSql, options);
     })
-    .spread(result => {
+    .then(([result]) => {
       if (!result.length) {
         return;
       }

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -15,7 +15,7 @@ class Query extends AbstractQuery {
     this.instance = options.instance;
     this.model = options.model;
     this.sequelize = sequelize;
-    this.options = _.extend({
+    this.options = Object.assign({
       logging: console.log,
       plain: false,
       raw: false

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -17,7 +17,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
   }
 
   createDatabaseQuery(databaseName, options) {
-    options = _.extend({
+    options = Object.assign({
       charset: null,
       collate: null
     }, options || {});
@@ -56,7 +56,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
   }
 
   createTableQuery(tableName, attributes, options) {
-    options = _.extend({
+    options = Object.assign({
       engine: 'InnoDB',
       charset: null,
       rowFormat: null
@@ -204,7 +204,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
       // Parse nested object
       if (smth.conditions) {
         const conditions = _.map(this.parseConditionObject(smth.conditions), condition =>
-          `${this.quoteIdentifier(_.first(condition.path))}->>'\$.${_.tail(condition.path).join('.')}' = '${condition.value}'`
+          `${this.quoteIdentifier(condition.path[0])}->>'\$.${_.tail(condition.path).join('.')}' = '${condition.value}'`
         );
 
         return conditions.join(' and ');

--- a/lib/dialects/mysql/query-interface.js
+++ b/lib/dialects/mysql/query-interface.js
@@ -8,7 +8,6 @@
  @private
  */
 
-const _ = require('lodash');
 const Promise = require('../../promise');
 const sequelizeErrors = require('../../errors');
 
@@ -29,9 +28,9 @@ function removeColumn(tableName, columnName, options) {
       tableName,
       schema: this.sequelize.config.database
     }, columnName),
-    _.assign({ raw: true }, options)
+    Object.assign({ raw: true }, options)
   )
-    .spread(results => {
+    .then(([results]) => {
       //Exclude primary key constraint
       if (!results.length || results[0].constraint_name === 'PRIMARY') {
         // No foreign key constraints found, so we can remove the column
@@ -39,12 +38,12 @@ function removeColumn(tableName, columnName, options) {
       }
       return Promise.map(results, constraint => this.sequelize.query(
         this.QueryGenerator.dropForeignKeyQuery(tableName, constraint.constraint_name),
-        _.assign({ raw: true }, options)
+        Object.assign({ raw: true }, options)
       ));
     })
     .then(() => this.sequelize.query(
       this.QueryGenerator.removeColumnQuery(tableName, columnName),
-      _.assign({ raw: true }, options)
+      Object.assign({ raw: true }, options)
     ));
 }
 

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -16,7 +16,7 @@ class Query extends AbstractQuery {
     this.model = options.model;
     this.sequelize = sequelize;
     this.uuid = uuidv4();
-    this.options = _.extend({
+    this.options = Object.assign({
       logging: console.log,
       plain: false,
       raw: false,

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -13,7 +13,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   }
 
   createDatabaseQuery(databaseName, options) {
-    options = _.extend({
+    options = Object.assign({
       encoding: null,
       collate: null
     }, options || {});
@@ -56,7 +56,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   }
 
   createTableQuery(tableName, attributes, options) {
-    options = _.extend({}, options || {});
+    options = Object.assign({}, options || {});
 
     //Postgres 9.0 does not support CREATE TABLE IF NOT EXISTS, 9.1 and above do
     const databaseVersion = _.get(this, 'sequelize.options.databaseVersion', 0);
@@ -122,7 +122,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
   describeTableQuery(tableName, schema) {
     if (!schema) schema = 'public';
-    
+
     return 'SELECT ' +
       'pk.constraint_type as "Constraint",' +
       'c.column_name as "Field", ' +
@@ -217,7 +217,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       // Parse nested object
       if (smth.conditions) {
         const conditions = _.map(this.parseConditionObject(smth.conditions), condition =>
-          `${this.jsonPathExtractionQuery(_.first(condition.path), _.tail(condition.path))} = '${condition.value}'`
+          `${this.jsonPathExtractionQuery(condition.path[0], _.tail(condition.path))} = '${condition.value}'`
         );
 
         return conditions.join(' AND ');
@@ -672,7 +672,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   }
 
   expandFunctionParamList(params) {
-    if (_.isUndefined(params) || !_.isArray(params)) {
+    if (_.isUndefined(params) || !Array.isArray(params)) {
       throw new Error('expandFunctionParamList: function parameters array required, including an empty one for no arguments');
     }
 
@@ -738,7 +738,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
       let eventSpec = EVENT_MAP[fireValue];
       if (eventSpec === 'UPDATE') {
-        if (_.isArray(fireValue) && fireValue.length > 0) {
+        if (Array.isArray(fireValue) && fireValue.length > 0) {
           eventSpec += ' OF ' + fireValue.join(', ');
         }
       }

--- a/lib/dialects/postgres/query-interface.js
+++ b/lib/dialects/postgres/query-interface.js
@@ -44,7 +44,7 @@ function ensureEnums(tableName, attributes, options, model) {
       sql = this.QueryGenerator.pgListEnums(tableName, attribute.field || keys[i], options);
       promises.push(this.sequelize.query(
         sql,
-        _.assign({}, options, { plain: true, raw: true, type: QueryTypes.SELECT })
+        Object.assign({}, options, { plain: true, raw: true, type: QueryTypes.SELECT })
       ));
     }
   }
@@ -67,7 +67,7 @@ function ensureEnums(tableName, attributes, options, model) {
           sql = this.QueryGenerator.pgEnum(tableName, attribute.field || keys[i], enumType, options);
           promises.push(this.sequelize.query(
             sql,
-            _.assign({}, options, { raw: true })
+            Object.assign({}, options, { raw: true })
           ));
         } else if (!!results[enumIdx] && !!model) {
           const enumVals = this.QueryGenerator.fromArray(results[enumIdx].enum_value);

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -15,7 +15,7 @@ class Query extends AbstractQuery {
     this.sequelize = sequelize;
     this.instance = options.instance;
     this.model = options.model;
-    this.options = _.extend({
+    this.options = Object.assign({
       logging: console.log,
       plain: false,
       raw: false

--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -27,7 +27,7 @@ function parseRangeBound(bound, parseType) {
 function stringify(data) {
   if (data === null) return null;
 
-  if (!_.isArray(data)) throw new Error('range must be an array');
+  if (!Array.isArray(data)) throw new Error('range must be an array');
   if (!data.length) return 'empty';
   if (data.length !== 2) throw new Error('range array length must be 0 (empty) or 2 (lower and upper bounds)');
 

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -151,7 +151,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
       // Parse nested object
       if (smth.conditions) {
         const conditions = this.parseConditionObject(smth.conditions).map(condition =>
-          `${this.jsonPathExtractionQuery(_.first(condition.path), _.tail(condition.path))} = '${condition.value}'`
+          `${this.jsonPathExtractionQuery(condition.path[0], _.tail(condition.path))} = '${condition.value}'`
         );
 
         return conditions.join(' AND ');

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -35,7 +35,7 @@ function removeColumn(tableName, attributeName, options) {
     const sql = this.QueryGenerator.removeColumnQuery(tableName, fields);
     const subQueries = sql.split(';').filter(q => q !== '');
 
-    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', _.assign({raw: true}, options)));
+    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
   });
 }
 exports.removeColumn = removeColumn;
@@ -63,7 +63,7 @@ function changeColumn(tableName, attributes, options) {
     const sql = this.QueryGenerator.removeColumnQuery(tableName, fields);
     const subQueries = sql.split(';').filter(q => q !== '');
 
-    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', _.assign({raw: true}, options)));
+    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
   });
 }
 exports.changeColumn = changeColumn;
@@ -92,7 +92,7 @@ function renameColumn(tableName, attrNameBefore, attrNameAfter, options) {
     const sql = this.QueryGenerator.renameColumnQuery(tableName, attrNameBefore, attrNameAfter, fields);
     const subQueries = sql.split(';').filter(q => q !== '');
 
-    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', _.assign({raw: true}, options)));
+    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
   });
 }
 exports.renameColumn = renameColumn;
@@ -134,7 +134,7 @@ function removeConstraint(tableName, constraintName, options) {
       const sql = this.QueryGenerator._alterConstraintQuery(tableName, fields, createTableSql);
       const subQueries = sql.split(';').filter(q => q !== '');
 
-      return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', _.assign({raw: true}, options)));
+      return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
     });
 }
 exports.removeConstraint = removeConstraint;
@@ -144,7 +144,7 @@ function addConstraint(tableName, options) {
   const describeCreateTableSql = this.QueryGenerator.describeCreateTableQuery(tableName);
   let createTableSql;
 
-  return this.sequelize.query(describeCreateTableSql, _.assign({}, options, { type: QueryTypes.SELECT, raw: true }))
+  return this.sequelize.query(describeCreateTableSql, Object.assign({}, options, { type: QueryTypes.SELECT, raw: true }))
     .then(constraints => {
       const sql = constraints[0].sql;
       const index = sql.length - 1;
@@ -158,7 +158,7 @@ function addConstraint(tableName, options) {
       const sql = this.QueryGenerator._alterConstraintQuery(tableName, fields, createTableSql);
       const subQueries = sql.split(';').filter(q => q !== '');
 
-      return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', _.assign({raw: true}, options)));
+      return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
     });
 }
 exports.addConstraint = addConstraint;

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -18,11 +18,11 @@ class Query extends AbstractQuery {
     this.sequelize = sequelize;
     this.instance = options.instance;
     this.model = options.model;
-    this.options = _.extend({
+    this.options = Object.assign({
       logging: console.log,
       plain: false,
       raw: false
-    }, options || {});
+    }, options);
 
     this.checkLoggingOption();
   }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -81,7 +81,7 @@ const Hooks = {
   _setupHooks(hooks) {
     this.options.hooks = {};
     _.map(hooks || {}, (hooksArray, hookName) => {
-      if (!_.isArray(hooksArray)) hooksArray = [hooksArray];
+      if (!Array.isArray(hooksArray)) hooksArray = [hooksArray];
       hooksArray.forEach(hookFn => this.addHook(hookName, hookFn));
     });
   },

--- a/lib/model.js
+++ b/lib/model.js
@@ -70,7 +70,7 @@ class Model {
    * @param {Array}   [options.include] an array of include options - Used to build prefetched/included model instances. See `set`
    */
   constructor(values = {}, options = {}) {
-    options = _.extend({
+    options = Object.assign({
       isNewRecord: true,
       _schema: this.constructor._schema,
       _schemaDelimiter: this.constructor._schemaDelimiter
@@ -912,7 +912,7 @@ class Model {
 
     // error check options
     _.each(options.validate, (validator, validatorType) => {
-      if (_.includes(_.keys(attributes), validatorType)) {
+      if (_.includes(Object.keys(attributes), validatorType)) {
         throw new Error('A model validator function must not have the same name as a field. Model: ' + this.name + ', field/validation name: ' + validatorType);
       }
 
@@ -1234,7 +1234,7 @@ class Model {
    * @returns {Promise<Model>}
    */
   static sync(options) {
-    options = _.extend({}, this.options, options);
+    options = Object.assign({}, this.options, options);
     options.hooks = options.hooks === undefined ? true : !!options.hooks;
 
     const attributes = this.tableAttributes;
@@ -1318,7 +1318,7 @@ class Model {
 
         return Promise.map(indexes, index => this.QueryInterface.addIndex(
           this.getTableName(options),
-          _.assign({
+          Object.assign({
             logging: options.logging,
             benchmark: options.benchmark,
             transaction: options.transaction
@@ -1420,7 +1420,7 @@ class Model {
    * @param {boolean}         [options.override=false] override old scope if already defined
    */
   static addScope(name, scope, options) {
-    options = _.assign({
+    options = Object.assign({
       override: false
     }, options);
 
@@ -1815,7 +1815,7 @@ class Model {
             }
             return memo;
           }, []),
-          _.assign(
+          Object.assign(
             {},
             _.omit(options, 'include', 'attributes', 'order', 'where', 'limit', 'offset', 'plain', 'scope'),
             {include: include.include || []}
@@ -1823,7 +1823,7 @@ class Model {
         );
       }
 
-      return include.association.get(results, _.assign(
+      return include.association.get(results, Object.assign(
         {},
         _.omit(options, ['include', 'attributes', 'originalAttributes', 'order', 'where', 'limit', 'offset', 'plain', 'group']),
         _.omit(include, ['parent', 'association', 'as', 'originalAttributes'])
@@ -2061,10 +2061,11 @@ class Model {
     return Promise.all([
       this.count(countOptions),
       this.findAll(options)
-    ]).spread((count, rows) => ({
-      count,
-      rows: count === 0 ? [] : rows
-    }));
+    ])
+      .then(([count, rows]) => ({
+        count,
+        rows: count === 0 ? [] : rows
+      }));
   }
 
   /**
@@ -2129,7 +2130,7 @@ class Model {
   }
 
   static bulkBuild(valueSets, options) { // testhint options:none
-    options = _.extend({
+    options = Object.assign({
       isNewRecord: true
     }, options || {});
 
@@ -2187,7 +2188,7 @@ class Model {
 
   /**
    * Find a row that matches the query, or build (but don't save) the row if none is found.
-   * The successful result of the promise will be (instance, built) - Make sure to use .spread()
+   * The successful result of the promise will be (instance, built)
    *
    * @param {Object}   options find options
    * @param {Object}   options.where A hash of search attributes.
@@ -2224,7 +2225,7 @@ class Model {
 
   /**
    * Find a row that matches the query, or build and save the row if none is found
-   * The successful result of the promise will be (instance, created) - Make sure to use .spread()
+   * The successful result of the promise will be (instance, created)
    *
    * If no transaction is passed in the `options` object, a new transaction will be created internally, to prevent the race condition where a matching row is created by another connection after the find but before the insert call.
    * However, it is not always possible to handle this case in SQLite, specifically if one transaction inserts and another tries to select before the first one has committed. In this case, an instance of sequelize. TimeoutError will be thrown instead.
@@ -2247,7 +2248,7 @@ class Model {
       );
     }
 
-    options = _.assign({}, options);
+    options = Object.assign({}, options);
 
     if (options.defaults) {
       const defaults = Object.keys(options.defaults);
@@ -2296,7 +2297,7 @@ class Model {
         return [instance, true];
       }).catch(sequelizeErrors.UniqueConstraintError, err => {
         const flattenedWhere = Utils.flattenObjectDeep(options.where);
-        const flattenedWhereKeys = _.map(_.keys(flattenedWhere), name => _.last(_.split(name, '.')));
+        const flattenedWhereKeys = _.map(Object.keys(flattenedWhere), name => _.last(_.split(name, '.')));
         const whereFields = flattenedWhereKeys.map(name => _.get(this.rawAttributes, `${name}.field`, name));
         const defaultFields = options.defaults && Object.keys(options.defaults)
           .filter(name => this.rawAttributes[name])
@@ -2443,19 +2444,22 @@ class Model {
         if (options.hooks) {
           return this.runHooks('beforeUpsert', values, options);
         }
-      }).then(() => {
-        return this.QueryInterface.upsert(this.getTableName(options), insertValues, updateValues, instance.where(), this, options);
-      }).spread((created, primaryKey) => {
-        if (options.returning === true && primaryKey) {
-          return this.findByPk(primaryKey, options).then(record => [record, created]);
-        }
+      })
+        .then(() => {
+          return this.QueryInterface.upsert(this.getTableName(options), insertValues, updateValues, instance.where(), this, options);
+        })
+        .then(([created, primaryKey]) => {
+          if (options.returning === true && primaryKey) {
+            return this.findByPk(primaryKey, options).then(record => [record, created]);
+          }
 
-        return created;
-      }).tap(result => {
-        if (options.hooks) {
-          return this.runHooks('afterUpsert', result, options);
-        }
-      });
+          return created;
+        })
+        .tap(result => {
+          if (options.hooks) {
+            return this.runHooks('afterUpsert', result, options);
+          }
+        });
     });
   }
 
@@ -2489,7 +2493,7 @@ class Model {
       return Promise.resolve([]);
     }
 
-    options = _.extend({
+    options = Object.assign({
       validate: false,
       hooks: true,
       individualHooks: false,
@@ -2508,7 +2512,7 @@ class Model {
     }
 
     if (options.updateOnDuplicate !== undefined) {
-      if (_.isArray(options.updateOnDuplicate) && options.updateOnDuplicate.length) {
+      if (Array.isArray(options.updateOnDuplicate) && options.updateOnDuplicate.length) {
         options.updateOnDuplicate = _.intersection(
           _.without(Object.keys(this.tableAttributes), this._timestampAttributes.createdAt),
           options.updateOnDuplicate
@@ -2679,7 +2683,7 @@ class Model {
       throw new Error('Missing where or truncate attribute in the options parameter of model.destroy.');
     }
 
-    if (!options.truncate && !_.isPlainObject(options.where) && !_.isArray(options.where) && !(options.where instanceof Utils.SequelizeMethod)) {
+    if (!options.truncate && !_.isPlainObject(options.where) && !Array.isArray(options.where) && !(options.where instanceof Utils.SequelizeMethod)) {
       throw new Error('Expected plain object, array or sequelize method in the options.where parameter of model.destroy.');
     }
 
@@ -2760,7 +2764,7 @@ class Model {
   static restore(options) {
     if (!this._timestampAttributes.deletedAt) throw new Error('Model is not paranoid');
 
-    options = _.extend({
+    options = Object.assign({
       hooks: true,
       individualHooks: false
     }, options || {});
@@ -2883,7 +2887,7 @@ class Model {
         build.set(this._timestampAttributes.updatedAt, values[this._timestampAttributes.updatedAt], { raw: true });
 
         if (options.sideEffects) {
-          values = _.assign(values, _.pick(build.get(), build.changed()));
+          values = Object.assign(values, _.pick(build.get(), build.changed()));
           options.fields = _.union(options.fields, Object.keys(values));
         }
 
@@ -2925,7 +2929,7 @@ class Model {
 
           return Promise.map(instances, instance => {
             // Record updates in instances dataValues
-            _.extend(instance.dataValues, values);
+            Object.assign(instance.dataValues, values);
             // Set the changed fields on the instance
             _.forIn(valuesUse, (newValue, attr) => {
               if (newValue !== instance._previousDataValues[attr]) {
@@ -3028,7 +3032,7 @@ class Model {
    * @returns {Promise} hash of attributes and their types
    */
   static describe(schema, options) {
-    return this.QueryInterface.describeTable(this.tableName, _.assign({schema: schema || this._schema || undefined}, options));
+    return this.QueryInterface.describeTable(this.tableName, Object.assign({schema: schema || this._schema || undefined}, options));
   }
 
   static _getDefaultTimestamp(attr) {
@@ -3139,12 +3143,12 @@ class Model {
 
     Utils.mapOptionFieldNames(options, this);
 
-    const where = _.extend({}, options.where);
+    const where = Object.assign({}, options.where);
     let values = {};
 
     if (_.isString(fields)) {
       values[fields] = options.by;
-    } else if (_.isArray(fields)) {
+    } else if (Array.isArray(fields)) {
       _.each(fields, field => {
         values[field] = options.by;
       });
@@ -3216,7 +3220,7 @@ class Model {
 
   static _optionsMustContainWhere(options) {
     assert(options && options.where, 'Missing where attribute in the options parameter');
-    assert(_.isPlainObject(options.where) || _.isArray(options.where) || options.where instanceof Utils.SequelizeMethod,
+    assert(_.isPlainObject(options.where) || Array.isArray(options.where) || options.where instanceof Utils.SequelizeMethod,
       'Expected plain object, array or sequelize method in the options.where parameter');
   }
 
@@ -3392,7 +3396,7 @@ class Model {
       // If raw, and we're not dealing with includes or special attributes, just set it straight on the dataValues object
       if (options.raw && !(this._options && this._options.include) && !(options && options.attributes) && !this.constructor._hasBooleanAttributes && !this.constructor._hasDateAttributes) {
         if (Object.keys(this.dataValues).length) {
-          this.dataValues = _.extend(this.dataValues, values);
+          this.dataValues = Object.assign(this.dataValues, values);
         } else {
           this.dataValues = values;
         }
@@ -3771,10 +3775,7 @@ class Model {
       }
 
       return this.constructor.QueryInterface[query].apply(this.constructor.QueryInterface, args)
-        .then(results => {
-          const result = _.head(results);
-          const rowsUpdated = results[1];
-
+        .then(([result, rowsUpdated])=> {
           if (versionAttr) {
             // Check to see that a row was updated, otherwise it's an optimistic locking error.
             if (rowsUpdated < 1) {
@@ -3798,9 +3799,9 @@ class Model {
               delete values[this.constructor.rawAttributes[attr].field];
             }
           }
-          values = _.extend(values, result.dataValues);
+          values = Object.assign(values, result.dataValues);
 
-          result.dataValues = _.extend(result.dataValues, values);
+          result.dataValues = Object.assign(result.dataValues, values);
           return result;
         })
         .tap(() => {
@@ -3831,12 +3832,12 @@ class Model {
                   values[include.association.foreignKey] = this.get(this.constructor.primaryKeyAttribute, {raw: true});
                   values[include.association.otherKey] = instance.get(instance.constructor.primaryKeyAttribute, {raw: true});
                   // Include values defined in the scope of the association
-                  _.assign(values, include.association.through.scope);
+                  Object.assign(values, include.association.through.scope);
                   return include.association.throughModel.create(values, includeOptions);
                 });
               } else {
                 instance.set(include.association.foreignKey, this.get(include.association.sourceKey || this.constructor.primaryKeyAttribute, {raw: true}));
-                _.assign(instance, include.association.scope);
+                Object.assign(instance, include.association.scope);
                 return instance.save(includeOptions);
               }
             });
@@ -3963,7 +3964,7 @@ class Model {
    * @returns {Promise}
    */
   destroy(options) {
-    options = _.extend({
+    options = Object.assign({
       hooks: true,
       force: false
     }, options);
@@ -3988,8 +3989,7 @@ class Model {
 
         return this.constructor.QueryInterface.update(
           this, this.constructor.getTableName(options), values, where, _.defaults({ hooks: false, model: this.constructor }, options)
-        ).then(results => {
-          const rowsUpdated = results[1];
+        ).then(([results, rowsUpdated]) => {
           if (this.constructor._versionAttribute && rowsUpdated < 1) {
             throw new sequelizeErrors.OptimisticLockError({
               modelName: this.constructor.name,
@@ -3997,10 +3997,10 @@ class Model {
               where
             });
           }
-          return _.head(results);
+          return results;
         });
       } else {
-        return this.constructor.QueryInterface.delete(this, this.constructor.getTableName(options), where, _.assign({ type: QueryTypes.DELETE, limit: null }, options));
+        return this.constructor.QueryInterface.delete(this, this.constructor.getTableName(options), where, Object.assign({ type: QueryTypes.DELETE, limit: null }, options));
       }
     }).tap(() => {
       // Run after hook
@@ -4042,7 +4042,7 @@ class Model {
   restore(options) {
     if (!this.constructor._timestampAttributes.deletedAt) throw new Error('Model is not paranoid');
 
-    options = _.extend({
+    options = Object.assign({
       hooks: true,
       force: false
     }, options);
@@ -4058,7 +4058,7 @@ class Model {
       const deletedAtDefaultValue = deletedAtAttribute.hasOwnProperty('defaultValue') ? deletedAtAttribute.defaultValue : null;
 
       this.setDataValue(deletedAtCol, deletedAtDefaultValue);
-      return this.save(_.extend({}, options, {hooks: false, omitNull: false}));
+      return this.save(Object.assign({}, options, {hooks: false, omitNull: false}));
     }).tap(() => {
       // Run after hook
       if (options.hooks) {
@@ -4101,7 +4101,7 @@ class Model {
     const identifier = this.where();
 
     options = Utils.cloneDeep(options);
-    options.where = _.extend({}, options.where, identifier);
+    options.where = Object.assign({}, options.where, identifier);
     options.instance = this;
 
     return this.constructor.increment(fields, options).return(this);
@@ -4293,7 +4293,7 @@ class Model {
   static belongsTo(target, options) {} // eslint-disable-line
 }
 
-_.extend(Model, associationsMixin);
+Object.assign(Model, associationsMixin);
 Hooks.applyTo(Model);
 
 module.exports = Model;

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -110,7 +110,7 @@ class QueryInterface {
    * @returns {Promise<Array>}
    */
   showAllSchemas(options) {
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       raw: true,
       type: this.sequelize.QueryTypes.SELECT
     });
@@ -134,7 +134,7 @@ class QueryInterface {
   databaseVersion(options) {
     return this.sequelize.query(
       this.QueryGenerator.versionQuery(),
-      _.assign({}, options, { type: QueryTypes.VERSION })
+      Object.assign({}, options, { type: QueryTypes.VERSION })
     );
   }
 
@@ -270,7 +270,7 @@ class QueryInterface {
             if (instanceTable.rawAttributes[keys[i]].type instanceof DataTypes.ENUM) {
               sql = this.QueryGenerator.pgEnumDrop(getTableName, keys[i]);
               options.supportsSearchPath = false;
-              promises.push(this.sequelize.query(sql, _.assign({}, options, { raw: true })));
+              promises.push(this.sequelize.query(sql, Object.assign({}, options, { raw: true })));
             }
           }
         }
@@ -295,7 +295,7 @@ class QueryInterface {
     const dropAllTables = tableNames => Promise.each(tableNames, tableName => {
       // if tableName is not in the Array of tables names then don't drop it
       if (skip.indexOf(tableName.tableName || tableName) === -1) {
-        return this.dropTable(tableName, _.assign({}, options, { cascade: true }) );
+        return this.dropTable(tableName, Object.assign({}, options, { cascade: true }) );
       }
     });
 
@@ -352,7 +352,7 @@ class QueryInterface {
 
     return this.sequelize.query(
       this.QueryGenerator.pgEnumDrop(null, null, this.QueryGenerator.pgEscapeAndQuote(enumName)),
-      _.assign({}, options, { raw: true })
+      Object.assign({}, options, { raw: true })
     );
   }
 
@@ -373,7 +373,7 @@ class QueryInterface {
 
     return this.pgListEnums(null, options).map(result => this.sequelize.query(
       this.QueryGenerator.pgEnumDrop(null, null, this.QueryGenerator.pgEscapeAndQuote(result.enum_name)),
-      _.assign({}, options, { raw: true })
+      Object.assign({}, options, { raw: true })
     ));
   }
 
@@ -389,7 +389,7 @@ class QueryInterface {
   pgListEnums(tableName, options) {
     options = options || {};
     const sql = this.QueryGenerator.pgListEnums(tableName);
-    return this.sequelize.query(sql, _.assign({}, options, { plain: false, raw: true, type: QueryTypes.SELECT }));
+    return this.sequelize.query(sql, Object.assign({}, options, { plain: false, raw: true, type: QueryTypes.SELECT }));
   }
 
   /**
@@ -418,7 +418,7 @@ class QueryInterface {
    * @private
    */
   showAllTables(options) {
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       raw: true,
       type: QueryTypes.SHOWTABLES
     });
@@ -472,7 +472,7 @@ class QueryInterface {
 
     return this.sequelize.query(
       sql,
-      _.assign({}, options, { type: QueryTypes.DESCRIBE })
+      Object.assign({}, options, { type: QueryTypes.DESCRIBE })
     ).then(data => {
       // If no data is returned from the query, then the table name may be wrong.
       // Query generators that use information_schema for retrieving table info will just return an empty result set,
@@ -650,7 +650,7 @@ class QueryInterface {
     options = Utils.cloneDeep(options);
     options.fields = attributes;
     const sql = this.QueryGenerator.addIndexQuery(tableName, options, rawTablename);
-    return this.sequelize.query(sql, _.assign({}, options, { supportsSearchPath: false }));
+    return this.sequelize.query(sql, Object.assign({}, options, { supportsSearchPath: false }));
   }
 
   /**
@@ -664,7 +664,7 @@ class QueryInterface {
    */
   showIndex(tableName, options) {
     const sql = this.QueryGenerator.showIndexesQuery(tableName, options);
-    return this.sequelize.query(sql, _.assign({}, options, { type: QueryTypes.SHOWINDEXES }));
+    return this.sequelize.query(sql, Object.assign({}, options, { type: QueryTypes.SHOWINDEXES }));
   }
 
   getForeignKeysForTables(tableNames, options) {
@@ -672,7 +672,7 @@ class QueryInterface {
       return Promise.resolve({});
     }
 
-    options = _.assign({}, options || {}, { type: QueryTypes.FOREIGNKEYS });
+    options = Object.assign({}, options || {}, { type: QueryTypes.FOREIGNKEYS });
 
     return Promise.map(tableNames, tableName =>
       this.sequelize.query(this.QueryGenerator.getForeignKeysQuery(tableName, this.sequelize.config.database), options)
@@ -684,7 +684,7 @@ class QueryInterface {
           tableName = tableName.schema + '.' + tableName.tableName;
         }
 
-        result[tableName] = _.isArray(results[i])
+        result[tableName] = Array.isArray(results[i])
           ? results[i].map(r => r.constraint_name)
           : [results[i] && results[i].constraint_name];
 
@@ -1010,7 +1010,7 @@ class QueryInterface {
    * @example
    * queryInterface.bulkUpdate('roles', {
    *     label: 'admin',
-   *   }, { 
+   *   }, {
    *     userType: 3,
    *   },
    * );
@@ -1369,7 +1369,7 @@ class QueryInterface {
       return Promise.resolve();
     }
 
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       transaction: transaction.parent || transaction
     });
 
@@ -1387,7 +1387,7 @@ class QueryInterface {
       throw new Error('Unable to start a transaction without transaction object!');
     }
 
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       transaction: transaction.parent || transaction
     });
     options.transaction.name = transaction.parent ? transaction.name : undefined;
@@ -1397,7 +1397,7 @@ class QueryInterface {
   }
 
   deferConstraints(transaction, options) {
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       transaction: transaction.parent || transaction
     });
 
@@ -1419,7 +1419,7 @@ class QueryInterface {
       return Promise.resolve();
     }
 
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       transaction: transaction.parent || transaction,
       supportsSearchPath: false
     });
@@ -1437,7 +1437,7 @@ class QueryInterface {
       throw new Error('Unable to rollback a transaction without transaction object!');
     }
 
-    options = _.assign({}, options, {
+    options = Object.assign({}, options, {
       transaction: transaction.parent || transaction,
       supportsSearchPath: false
     });

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -134,7 +134,7 @@ class Sequelize {
 
       if (urlParts.query) {
         if (options.dialectOptions)
-          _.assign(options.dialectOptions, urlParts.query);
+          Object.assign(options.dialectOptions, urlParts.query);
         else
           options.dialectOptions = urlParts.query;
       }
@@ -413,12 +413,12 @@ class Sequelize {
   /**
    * Execute a query on the DB, with the possibility to bypass all the sequelize goodness.
    *
-   * By default, the function will return two arguments: an array of results, and a metadata object, containing number of affected rows etc. Use `.spread` to access the results.
+   * By default, the function will return two arguments: an array of results, and a metadata object, containing number of affected rows etc.
    *
    * If you are running a type of query where you don't need the metadata, for example a `SELECT` query, you can pass in a query type to make sequelize format the results:
    *
    * ```js
-   * sequelize.query('SELECT...').spread((results, metadata) => {
+   * sequelize.query('SELECT...').then(([results, metadata]) => {
    *   // Raw query - use spread
    * });
    *
@@ -454,8 +454,8 @@ class Sequelize {
    */
 
   query(sql, options) {
-    options = _.assign({}, this.options.query, options);
-    const retryOptions = _.assignIn({}, this.options.retry, options.retry || {});
+    options = Object.assign({}, this.options.query, options);
+    const retryOptions = Object.assign({}, this.options.retry, options.retry || {});
 
     let bindParameters;
 
@@ -591,7 +591,7 @@ class Sequelize {
   set(variables, options) {
 
     // Prepare options
-    options = _.extend({}, this.options.set, typeof options === 'object' && options || {});
+    options = Object.assign({}, this.options.set, typeof options === 'object' && options);
 
     if (this.options.dialect !== 'mysql') {
       throw new Error('sequelize.set is only supported for mysql');
@@ -801,7 +801,7 @@ class Sequelize {
    * @returns {Promise}
    */
   authenticate(options) {
-    options = _.assign({
+    options = Object.assign({
       raw: true,
       plain: true,
       type: QueryTypes.SELECT

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const Promise = require('./promise');
 
 /**
@@ -29,7 +28,7 @@ class Transaction {
     // get dialect specific transaction options
     const generateTransactionId = this.sequelize.dialect.QueryGenerator.generateTransactionId;
 
-    this.options = _.extend({
+    this.options = Object.assign({
       type: sequelize.options.transactionType,
       isolationLevel: sequelize.options.isolationLevel,
       readOnly: false

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -265,7 +265,7 @@ function toDefaultValue(value, dialect) {
     return uuidv4();
   } else if (value instanceof DataTypes.NOW) {
     return now(dialect);
-  } else if (_.isPlainObject(value) || _.isArray(value)) {
+  } else if (_.isPlainObject(value) || Array.isArray(value)) {
     return _.clone(value);
   } else {
     return value;
@@ -516,7 +516,7 @@ exports.getOperators = getOperators;
  * @private
  */
 function getComplexKeys(obj) {
-  return getOperators(obj).concat(_.keys(obj));
+  return getOperators(obj).concat(Object.keys(obj));
 }
 exports.getComplexKeys = getComplexKeys;
 
@@ -596,10 +596,10 @@ function defaults(object) {
       getComplexKeys(source).forEach(key => {
         const value = object[key];
         if (
-          value === undefined || 
+          value === undefined ||
             _.eq(value, Object.prototype[key]) &&
             !Object.prototype.hasOwnProperty.call(object, key)
-          
+
         ) {
           object[key] = source[key];
         }

--- a/lib/utils/inherits.js
+++ b/lib/utils/inherits.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const util = require('util');
-const _ = require('lodash');
 
 /**
  * like util.inherits, but also copies over static properties. Inherit child constructor
@@ -14,7 +13,7 @@ const _ = require('lodash');
  */
 function inherits(constructor, superConstructor) {
   util.inherits(constructor, superConstructor); // Instance (prototype) methods
-  _.extend(constructor, superConstructor); // Static methods
+  Object.assign(constructor, superConstructor); // Static methods
 }
 
 module.exports = inherits;

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -10,15 +10,14 @@
 
 const depd = require('depd');
 const debug = require('debug');
-const _ = require('lodash');
 
 class Logger {
   constructor(config) {
 
-    this.config = _.extend({
+    this.config = Object.assign({
       context: 'sequelize',
       debug: true
-    }, config || {});
+    }, config);
 
     this.depd = depd(this.config.context);
     this.debug = debug(this.config.context);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Moved all usage of `_.assign/extend` to use `Object.assign`
Moved all usage of `.spread(` to `.then` with spread syntax.
Moved all usage of `_.first/head` to use `[0]`
Moved all usage of `_.isArray` to `Array.isArray`