### PR TITLE
fix: throw on undefined where parameters

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -15,7 +15,6 @@ const Association = require('../../associations/base');
 const BelongsTo = require('../../associations/belongs-to');
 const BelongsToMany = require('../../associations/belongs-to-many');
 const HasMany = require('../../associations/has-many');
-const QueryTypes = require('../../query-types');
 const Op = require('../../operators');
 const sequelizeError = require('../../errors');
 
@@ -2080,16 +2079,11 @@ class QueryGenerator {
     return items.length && items.filter(item => item && item.length).join(binding) || '';
   }
 
-  whereItemQuery(key, value, options) {
-    options = options || {};
+  whereItemQuery(key, value, options = {}) {
     if (value === undefined) {
-      // protection from stuff like User.delete({where: {id: undefined}})
-      if ([QueryTypes.BULKDELETE, QueryTypes.BULKUPDATE].includes(options.type)) {
-        throw new Error(`WHERE parameter "${key}" of ${options.type} query has value of undefined`);
-      }
-      // for other query types, ignore all where parameters with undefined value
-      return;
+      throw new Error(`WHERE parameter "${key}" has invalid "undefined" value`);
     }
+
     if (typeof key === 'string' && key.includes('.') && options.model) {
       const keyParts = key.split('.');
       if (options.model.rawAttributes[keyParts[0]] && options.model.rawAttributes[keyParts[0]].type instanceof DataTypes.JSON) {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -935,7 +935,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           throw new Error('Update should throw an error if where has a key with undefined value');
         }, err => {
           expect(err).to.be.an.instanceof(Error);
-          expect(err.message).to.equal('WHERE parameter "username" of BULKUPDATE query has value of undefined');
+          expect(err.message).to.equal('WHERE parameter "username" has invalid "undefined" value');
         });
       });
     });
@@ -1304,7 +1304,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         throw new Error('Destroy should throw an error if where has a key with undefined value');
       }, err => {
         expect(err).to.be.an.instanceof(Error);
-        expect(err.message).to.equal('WHERE parameter "username" of BULKDELETE query has value of undefined');
+        expect(err.message).to.equal('WHERE parameter "username" has invalid "undefined" value');
       });
     });
 

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -164,7 +164,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         }));
     });
 
-    it('should work with undefined uuid primary key in where', function() {
+    it('should work with empty uuid primary key in where', function() {
       const User = this.sequelize.define('User', {
         id: {
           type: DataTypes.UUID,
@@ -179,9 +179,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       return User.sync({force: true}).then(() => {
         return User.findOrCreate({
-          where: {
-            id: undefined
-          },
+          where: {},
           defaults: {
             name: Math.random().toString()
           }

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1444,9 +1444,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
 
-      it('should ignore undefined in where parameters', function() {
-        return this.User.findAll({where: {username: undefined}}).then(users => {
-          expect(users.length).to.equal(2);
+      it('should throw for undefined where parameters', function() {
+        return this.User.findAll({where: {username: undefined}}).then(() => {
+          throw new Error('findAll should throw an error if where has a key with undefined value');
+        }, err => {
+          expect(err).to.be.an.instanceof(Error);
+          expect(err.message).to.equal('WHERE parameter "username" has invalid "undefined" value');
         });
       });
     });

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -203,7 +203,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           User
         );
         return expectsql(sqlOrError, {
-          default: new Error('WHERE parameter "name" of BULKDELETE query has value of undefined')
+          default: new Error('WHERE parameter "name" has invalid "undefined" value')
         });
       });
     });

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -33,22 +33,22 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       default: ''
     });
     testsql({id: undefined}, {
-      default: ''
+      default: new Error('WHERE parameter "id" has invalid "undefined" value')
     });
     testsql({id: 1}, {
       default: 'WHERE [id] = 1'
     });
     testsql({id: 1, user: undefined}, {
-      default: 'WHERE [id] = 1'
+      default: new Error('WHERE parameter "user" has invalid "undefined" value')
     });
     testsql({id: 1, user: undefined}, {type: QueryTypes.SELECT}, {
-      default: 'WHERE [id] = 1'
+      default: new Error('WHERE parameter "user" has invalid "undefined" value')
     });
     testsql({id: 1, user: undefined}, {type: QueryTypes.BULKDELETE}, {
-      default: new Error('WHERE parameter "user" of BULKDELETE query has value of undefined')
+      default: new Error('WHERE parameter "user" has invalid "undefined" value')
     });
     testsql({id: 1, user: undefined}, {type: QueryTypes.BULKUPDATE}, {
-      default: new Error('WHERE parameter "user" of BULKUPDATE query has value of undefined')
+      default: new Error('WHERE parameter "user" has invalid "undefined" value')
     });
     testsql({id: 1}, {prefix: 'User'}, {
       default: 'WHERE [User].[id] = 1'


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Follow up from https://github.com/sequelize/sequelize/pull/9548, Now Sequelize will throw for any `undefined` where keys