### PR TITLE
refactor: use template strings, unify testing, remove dottie

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -99,7 +99,8 @@
     "one-var-declaration-per-line": "warn",
     "comma-dangle": "warn",
     "no-shadow": "warn",
-    "camelcase": "warn"
+    "camelcase": "warn",
+    "prefer-template": "error"
   },
   "parserOptions": {
     "ecmaVersion": 6,

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -205,16 +205,16 @@ class BelongsToMany extends Association {
     const singular = _.upperFirst(this.options.name.singular);
 
     this.accessors = {
-      get: 'get' + plural,
-      set: 'set' + plural,
-      addMultiple: 'add' + plural,
-      add: 'add' + singular,
-      create: 'create' + singular,
-      remove: 'remove' + singular,
-      removeMultiple: 'remove' + plural,
-      hasSingle: 'has' + singular,
-      hasAll: 'has' + plural,
-      count: 'count' + plural
+      get: `get${plural}`,
+      set: `set${plural}`,
+      addMultiple: `add${plural}`,
+      add: `add${singular}`,
+      create: `create${singular}`,
+      remove: `remove${singular}`,
+      removeMultiple: `remove${plural}`,
+      hasSingle: `has${singular}`,
+      hasAll: `has${plural}`,
+      count: `count${plural}`
     };
   }
 

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -71,9 +71,9 @@ class BelongsTo extends Association {
     const singular = _.upperFirst(this.options.name.singular);
 
     this.accessors = {
-      get: 'get' + singular,
-      set: 'set' + singular,
-      create: 'create' + singular
+      get: `get${singular}`,
+      set: `set${singular}`,
+      create: `create${singular}`
     };
   }
 

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -96,16 +96,16 @@ class HasMany extends Association {
 
     this.associationAccessor = this.as;
     this.accessors = {
-      get: 'get' + plural,
-      set: 'set' + plural,
-      addMultiple: 'add' + plural,
-      add: 'add' + singular,
-      create: 'create' + singular,
-      remove: 'remove' + singular,
-      removeMultiple: 'remove' + plural,
-      hasSingle: 'has' + singular,
-      hasAll: 'has' + plural,
-      count: 'count' + plural
+      get: `get${plural}`,
+      set: `set${plural}`,
+      addMultiple: `add${plural}`,
+      add: `add${singular}`,
+      create: `create${singular}`,
+      remove: `remove${singular}`,
+      removeMultiple: `remove${plural}`,
+      hasSingle: `has${singular}`,
+      hasAll: `has${plural}`,
+      count: `count${plural}`
     };
   }
 

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -70,9 +70,9 @@ class HasOne extends Association {
     const singular = _.upperFirst(this.options.name.singular);
 
     this.accessors = {
-      get: 'get' + singular,
-      set: 'set' + singular,
-      create: 'create' + singular
+      get: `get${singular}`,
+      set: `set${singular}`,
+      create: `create${singular}`
     };
   }
 

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -63,7 +63,7 @@ inherits(STRING, ABSTRACT);
 
 STRING.prototype.key = STRING.key = 'STRING';
 STRING.prototype.toSql = function toSql() {
-  return 'VARCHAR(' + this._length + ')' + (this._binary ? ' BINARY' : '');
+  return `VARCHAR(${this._length})${this._binary ? ' BINARY' : ''}`;
 };
 STRING.prototype.validate = function validate(value) {
   if (Object.prototype.toString.call(value) !== '[object String]') {
@@ -101,7 +101,7 @@ inherits(CHAR, STRING);
 
 CHAR.prototype.key = CHAR.key = 'CHAR';
 CHAR.prototype.toSql = function toSql() {
-  return 'CHAR(' + this._length + ')' + (this._binary ? ' BINARY' : '');
+  return `CHAR(${this._length})${this._binary ? ' BINARY' : ''}`;
 };
 
 /**
@@ -193,9 +193,9 @@ NUMBER.prototype.key = NUMBER.key = 'NUMBER';
 NUMBER.prototype.toSql = function toSql() {
   let result = this.key;
   if (this._length) {
-    result += '(' + this._length;
+    result += `(${this._length}`;
     if (typeof this._decimals === 'number') {
-      result += ',' + this._decimals;
+      result += `,${this._decimals}`;
     }
     result += ')';
   }
@@ -209,7 +209,7 @@ NUMBER.prototype.toSql = function toSql() {
 };
 NUMBER.prototype.validate = function(value) {
   if (!Validator.isFloat(String(value))) {
-    throw new sequelizeErrors.ValidationError(util.format('%j is not a valid ' + _.toLower(this.key), value));
+    throw new sequelizeErrors.ValidationError(util.format(`%j is not a valid ${_.toLower(this.key)}`, value));
   }
 
   return true;
@@ -246,7 +246,7 @@ inherits(INTEGER, NUMBER);
 INTEGER.prototype.key = INTEGER.key = 'INTEGER';
 INTEGER.prototype.validate = function validate(value) {
   if (!Validator.isInt(String(value))) {
-    throw new sequelizeErrors.ValidationError(util.format('%j is not a valid ' + _.toLower(this.key), value));
+    throw new sequelizeErrors.ValidationError(util.format(`%j is not a valid ${_.toLower(this.key)}`, value));
   }
 
   return true;
@@ -393,7 +393,7 @@ DECIMAL.prototype.key = DECIMAL.key = 'DECIMAL';
 DECIMAL.prototype.toSql = function toSql() {
 
   if (this._precision || this._scale) {
-    return 'DECIMAL(' + [this._precision, this._scale].filter(_.identity).join(',') + ')';
+    return `DECIMAL(${[this._precision, this._scale].filter(_.identity).join(',')})`;
   }
 
   return 'DECIMAL';
@@ -413,13 +413,13 @@ for (const floating of [FLOAT, DOUBLE, REAL]) {
       return 'NaN';
     } else if (!isFinite(value)) {
       const sign = value < 0 ? '-' : '';
-      return sign + 'Infinity';
+      return `${sign}Infinity`;
     }
 
     return value;
   };
   floating.prototype._stringify = function _stringify(value) {
-    return "'" + this._value(value) + "'";
+    return `'${this._value(value)}'`;
   };
   floating.prototype._bindParam = function _bindParam(value, options) {
     return options.bindParam(this._value(value));
@@ -716,7 +716,7 @@ BLOB.prototype._stringify = function _stringify(value) {
 };
 
 BLOB.prototype._hexify = function _hexify(hex) {
-  return "X'" + hex + "'";
+  return `X'${hex}'`;
 };
 
 BLOB.prototype._bindParam = function _bindParam(value, options) {
@@ -960,7 +960,7 @@ inherits(ARRAY, ABSTRACT);
 
 ARRAY.prototype.key = ARRAY.key = 'ARRAY';
 ARRAY.prototype.toSql = function toSql() {
-  return this.type.toSql() + '[]';
+  return `${this.type.toSql()}[]`;
 };
 ARRAY.prototype.validate = function validate(value) {
   if (!Array.isArray(value)) {
@@ -1038,10 +1038,10 @@ GEOMETRY.prototype.key = GEOMETRY.key = 'GEOMETRY';
 
 GEOMETRY.prototype.escape = false;
 GEOMETRY.prototype._stringify = function _stringify(value, options) {
-  return 'GeomFromText(' + options.escape(wkx.Geometry.parseGeoJSON(value).toWkt()) + ')';
+  return `GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
 };
 GEOMETRY.prototype._bindParam = function _bindParam(value, options) {
-  return 'GeomFromText(' + options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt()) + ')';
+  return `GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
 };
 
 /**
@@ -1085,10 +1085,10 @@ GEOGRAPHY.prototype.key = GEOGRAPHY.key = 'GEOGRAPHY';
 
 GEOGRAPHY.prototype.escape = false;
 GEOGRAPHY.prototype._stringify = function _stringify(value, options) {
-  return 'GeomFromText(' + options.escape(wkx.Geometry.parseGeoJSON(value).toWkt()) + ')';
+  return `GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
 };
 GEOGRAPHY.prototype._bindParam = function _bindParam(value, options) {
-  return 'GeomFromText(' + options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt()) + ')';
+  return `GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
 };
 
 /**

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -52,7 +52,7 @@ class ConnectionManager {
         if (dataType.types[this.dialectName]) {
           this._refreshTypeParser(dataType);
         } else {
-          throw new Error('Parse function not supported for type ' + dataType.key + ' in dialect ' + this.dialectName);
+          throw new Error(`Parse function not supported for type ${dataType.key} in dialect ${this.dialectName}`);
         }
       }
     });

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1045,7 +1045,7 @@ class QueryGenerator {
          * https://bugs.mysql.com/bug.php?id=81896
          */
         paths = paths.map(subPath => Utils.addTicks(subPath, '"'));
-        pathStr = `${['$'].concat(paths).join('.')}`;
+        pathStr = ['$'].concat(paths).join('.');
         quotedColumn = this.isIdentifierQuoted(column)
           ? column
           : this.quoteIdentifier(column);

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2,7 +2,6 @@
 
 const util = require('util');
 const _ = require('lodash');
-const Dottie = require('dottie');
 const uuidv4 = require('uuid/v4');
 const semver = require('semver');
 
@@ -153,13 +152,13 @@ class QueryGenerator {
                 outputColumns += ',';
               }
 
-              tmpColumns += this.quoteIdentifier(attribute.field) + ' ' + attribute.type.toSql();
-              outputColumns += 'INSERTED.' + this.quoteIdentifier(attribute.field);
+              tmpColumns += `${this.quoteIdentifier(attribute.field)} ${attribute.type.toSql()}`;
+              outputColumns += `INSERTED.${this.quoteIdentifier(attribute.field)}`;
             }
           }
 
           tmpTable = `declare @tmp table (${tmpColumns});`;
-          outputFragment = ' OUTPUT ' + outputColumns + ' into @tmp';
+          outputFragment = ` OUTPUT ${outputColumns} into @tmp`;
           const selectFromTmp = ';select * from @tmp';
 
           valueQuery += selectFromTmp;
@@ -180,12 +179,12 @@ class QueryGenerator {
       // pg_temp functions are private per connection, so we never risk this function interfering with another one.
       if (semver.gte(this.sequelize.options.databaseVersion, '9.2.0')) {
         // >= 9.2 - Use a UUID but prefix with 'func_' (numbers first not allowed)
-        const delimiter = '$func_' + uuidv4().replace(/-/g, '') + '$';
+        const delimiter = `$func_${uuidv4().replace(/-/g, '')}$`;
 
         options.exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
-        valueQuery = `CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response ${quotedTable}, OUT sequelize_caught_exception text) RETURNS RECORD AS ${delimiter}` +
-          ' BEGIN ' + valueQuery + ' INTO response; EXCEPTION ' + options.exception + ' END ' + delimiter +
-          ' LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()';
+        valueQuery = `${`CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response ${quotedTable}, OUT sequelize_caught_exception text) RETURNS RECORD AS ${delimiter}` +
+          ' BEGIN '}${valueQuery} INTO response; EXCEPTION ${options.exception} END ${delimiter
+        } LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()`;
       } else {
         options.exception = 'WHEN unique_violation THEN NULL;';
         valueQuery = `CREATE OR REPLACE FUNCTION pg_temp.testfunc() RETURNS SETOF ${quotedTable} AS $body$ BEGIN RETURN QUERY ${valueQuery}; EXCEPTION ${options.exception} END; $body$ LANGUAGE plpgsql; SELECT * FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc();`;
@@ -193,8 +192,8 @@ class QueryGenerator {
     }
 
     if (this._dialect.supports['ON DUPLICATE KEY'] && options.onDuplicate) {
-      valueQuery += ' ON DUPLICATE KEY ' + options.onDuplicate;
-      emptyQuery += ' ON DUPLICATE KEY ' + options.onDuplicate;
+      valueQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
+      emptyQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
     }
 
     valueHash = Utils.removeNullValuesFromHash(valueHash, this.options.omitNull);
@@ -235,7 +234,7 @@ class QueryGenerator {
       tmpTable
     };
 
-    query = (replacements.attributes.length ? valueQuery : emptyQuery) + ';';
+    query = `${replacements.attributes.length ? valueQuery : emptyQuery};`;
     if (identityWrapperRequired && this._dialect.supports.autoIncrement.identityInsert) {
       query = `SET IDENTITY_INSERT ${quotedTable} ON; ${query} SET IDENTITY_INSERT ${quotedTable} OFF;`;
     }
@@ -298,10 +297,10 @@ class QueryGenerator {
     }
 
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
-      onDuplicateKeyUpdate = ' ON DUPLICATE KEY UPDATE ' + options.updateOnDuplicate.map(attr => {
+      onDuplicateKeyUpdate = ` ON DUPLICATE KEY UPDATE ${options.updateOnDuplicate.map(attr => {
         const key = this.quoteIdentifier(attr);
-        return key + '=VALUES(' + key + ')';
-      }).join(',');
+        return `${key}=VALUES(${key})`;
+      }).join(',')}`;
     }
 
     const ignoreDuplicates = options.ignoreDuplicates ? this._dialect.supports.inserts.ignoreDuplicates : '';
@@ -340,7 +339,7 @@ class QueryGenerator {
 
     if (this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
       if (this.dialect !== 'mssql') {
-        suffix = ' LIMIT ' + this.escape(options.limit) + ' ';
+        suffix = ` LIMIT ${this.escape(options.limit)} `;
       }
     }
 
@@ -362,13 +361,13 @@ class QueryGenerator {
                 outputColumns += ',';
               }
 
-              tmpColumns += this.quoteIdentifier(attribute.field) + ' ' + attribute.type.toSql();
-              outputColumns += 'INSERTED.' + this.quoteIdentifier(attribute.field);
+              tmpColumns += `${this.quoteIdentifier(attribute.field)} ${attribute.type.toSql()}`;
+              outputColumns += `INSERTED.${this.quoteIdentifier(attribute.field)}`;
             }
           }
 
           tmpTable = `declare @tmp table (${tmpColumns}); `;
-          outputFragment = ' OUTPUT ' + outputColumns + ' into @tmp';
+          outputFragment = ` OUTPUT ${outputColumns} into @tmp`;
           selectFromTmp = ';select * from @tmp';
 
           suffix += selectFromTmp;
@@ -400,9 +399,9 @@ class QueryGenerator {
       const value = attrValueHash[key];
 
       if (value instanceof Utils.SequelizeMethod || options.bindParam === false) {
-        values.push(this.quoteIdentifier(key) + '=' + this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE' }));
+        values.push(`${this.quoteIdentifier(key)}=${this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE'})}`);
       } else {
-        values.push(this.quoteIdentifier(key) + '=' + this.format(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE' }, bindParam));
+        values.push(`${this.quoteIdentifier(key)}=${this.format(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE'}, bindParam)}`);
       }
     }
 
@@ -452,13 +451,13 @@ class QueryGenerator {
 
     for (const key in attrValueHash) {
       const value = attrValueHash[key];
-      values.push(this.quoteIdentifier(key) + '=' + this.quoteIdentifier(key) + operator + ' ' + this.escape(value));
+      values.push(`${this.quoteIdentifier(key)}=${this.quoteIdentifier(key)}${operator} ${this.escape(value)}`);
     }
 
     attributes = attributes || {};
     for (const key in attributes) {
       const value = attributes[key];
-      values.push(this.quoteIdentifier(key) + '=' + this.escape(value));
+      values.push(`${this.quoteIdentifier(key)}=${this.escape(value)}`);
     }
 
     return `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')}${outputFragment} ${this.whereQuery(where)} ${returningFragment}`.trim();
@@ -509,21 +508,21 @@ class QueryGenerator {
         }
 
         if (!field.name) {
-          throw new Error('The following index field has no name: ' + util.inspect(field));
+          throw new Error(`The following index field has no name: ${util.inspect(field)}`);
         }
 
         result += this.quoteIdentifier(field.name);
 
         if (this._dialect.supports.index.collate && field.collate) {
-          result += ' COLLATE ' + this.quoteIdentifier(field.collate);
+          result += ` COLLATE ${this.quoteIdentifier(field.collate)}`;
         }
 
         if (this._dialect.supports.index.length && field.length) {
-          result += '(' + field.length + ')';
+          result += `(${field.length})`;
         }
 
         if (field.order) {
-          result += ' ' + field.order;
+          result += ` ${field.order}`;
         }
 
         return result;
@@ -570,11 +569,11 @@ class QueryGenerator {
       options.type, 'INDEX',
       !this._dialect.supports.indexViaAlter ? concurrently : undefined,
       this.quoteIdentifiers(options.name),
-      this._dialect.supports.index.using === 1 && options.using ? 'USING ' + options.using : '',
-      !this._dialect.supports.indexViaAlter ? 'ON ' + tableName : undefined,
-      this._dialect.supports.index.using === 2 && options.using ? 'USING ' + options.using : '',
-      '(' + fieldsSql.join(', ') + (options.operator ? ' '+options.operator : '') + ')',
-      this._dialect.supports.index.parser && options.parser ? 'WITH PARSER ' + options.parser : undefined,
+      this._dialect.supports.index.using === 1 && options.using ? `USING ${options.using}` : '',
+      !this._dialect.supports.indexViaAlter ? `ON ${tableName}` : undefined,
+      this._dialect.supports.index.using === 2 && options.using ? `USING ${options.using}` : '',
+      `(${fieldsSql.join(', ')}${options.operator ? ` ${options.operator}` : ''})`,
+      this._dialect.supports.index.parser && options.parser ? `WITH PARSER ${options.parser}` : undefined,
       this._dialect.supports.index.where && options.where ? options.where : undefined
     );
 
@@ -610,7 +609,7 @@ class QueryGenerator {
         }
 
         if (!field.name) {
-          throw new Error('The following index field has no name: ' + field);
+          throw new Error(`The following index field has no name: ${field}`);
         }
 
         result += this.quoteIdentifier(field.name);
@@ -779,7 +778,7 @@ class QueryGenerator {
 
           // see if this is an order
           if (index > 0 && orderIndex !== -1) {
-            item = this.sequelize.literal(' ' + validOrderOptions[orderIndex]);
+            item = this.sequelize.literal(` ${validOrderOptions[orderIndex]}`);
           } else if (previousModel && previousModel.prototype instanceof Model) {
             // only go down this path if we have preivous model and check only once
             if (previousModel.associations !== undefined && previousModel.associations[item]) {
@@ -796,7 +795,7 @@ class QueryGenerator {
 
               if (previousModel.rawAttributes[itemSplit[0]].type instanceof DataTypes.JSON) {
                 // just quote identifiers for now
-                const identifier = this.quoteIdentifiers(previousModel.name  + '.' + previousModel.rawAttributes[itemSplit[0]].field);
+                const identifier = this.quoteIdentifiers(`${previousModel.name}.${previousModel.rawAttributes[itemSplit[0]].field}`);
 
                 // get path
                 const path = itemSplit.slice(1);
@@ -833,9 +832,9 @@ class QueryGenerator {
       let sql = '';
 
       if (i > 0) {
-        sql += this.quoteIdentifier(tableNames.join(connector)) + '.';
+        sql += `${this.quoteIdentifier(tableNames.join(connector))}.`;
       } else if (typeof collection[0] === 'string' && parent) {
-        sql += this.quoteIdentifier(parent.name) + '.';
+        sql += `${this.quoteIdentifier(parent.name)}.`;
       }
 
       // loop through everything past i and append to the sql
@@ -845,14 +844,14 @@ class QueryGenerator {
 
       return sql;
     } else if (collection._modelAttribute) {
-      return this.quoteTable(collection.Model.name) + '.' + this.quoteIdentifier(collection.fieldName);
+      return `${this.quoteTable(collection.Model.name)}.${this.quoteIdentifier(collection.fieldName)}`;
     } else if (collection instanceof Utils.SequelizeMethod) {
       return this.handleSequelizeMethod(collection);
     } else if (_.isPlainObject(collection) && collection.raw) {
       // simple objects with raw is no longer supported
       throw new Error('The `{raw: "..."}` syntax is no longer supported.  Use `sequelize.literal` instead.');
     } else {
-      throw new Error('Unknown structure passed to order / group: ' + util.inspect(collection));
+      throw new Error(`Unknown structure passed to order / group: ${util.inspect(collection)}`);
     }
   }
 
@@ -881,7 +880,7 @@ class QueryGenerator {
       const head = identifiers.slice(0, identifiers.length - 1).join('.');
       const tail = identifiers[identifiers.length - 1];
 
-      return this.quoteIdentifier(head) + '.' + this.quoteIdentifier(tail);
+      return `${this.quoteIdentifier(head)}.${this.quoteIdentifier(tail)}`;
     }
 
     return this.quoteIdentifier(identifiers);
@@ -905,7 +904,7 @@ class QueryGenerator {
     if (_.isObject(param)) {
       if (this._dialect.supports.schemas) {
         if (param.schema) {
-          table += this.quoteIdentifier(param.schema) + '.';
+          table += `${this.quoteIdentifier(param.schema)}.`;
         }
 
         table += this.quoteIdentifier(param.tableName);
@@ -922,7 +921,7 @@ class QueryGenerator {
     }
 
     if (alias) {
-      table += ' AS ' + this.quoteIdentifier(alias);
+      table += ` AS ${this.quoteIdentifier(alias)}`;
     }
 
     return table;
@@ -963,7 +962,7 @@ class QueryGenerator {
   bindParam(bind) {
     return value => {
       bind.push(value);
-      return '$' + bind.length;
+      return `$${bind.length}`;
     };
   }
 
@@ -1141,7 +1140,7 @@ class QueryGenerator {
     if (subQuery || options.groupedLimit) {
       // We need primary keys
       attributes.subQuery = attributes.main;
-      attributes.main = [(mainTable.as || mainTable.quotedName) + '.*'];
+      attributes.main = [`${mainTable.as || mainTable.quotedName}.*`];
     }
 
     if (options.include) {
@@ -1235,7 +1234,7 @@ class QueryGenerator {
 
         // Caching the base query and splicing the where part into it is consistently > twice
         // as fast than generating from scratch each time for values.length >= 5
-        const baseQuery = 'SELECT * FROM (' + this.selectQuery(
+        const baseQuery = `SELECT * FROM (${this.selectQuery(
           tableName,
           {
             attributes: options.attributes,
@@ -1247,11 +1246,11 @@ class QueryGenerator {
             model
           },
           model
-        ).replace(/;$/, '') + ') AS sub'; // Every derived table must have its own alias
+        ).replace(/;$/, '')  }) AS sub`; // Every derived table must have its own alias
         const placeHolder = this.whereItemQuery(Op.placeholder, true, { model });
         const splicePos = baseQuery.indexOf(placeHolder);
 
-        mainQueryItems.push(this.selectFromTableFragment(options, mainTable.model, attributes.main, '(' +
+        mainQueryItems.push(this.selectFromTableFragment(options, mainTable.model, attributes.main, `(${
           options.groupedLimit.values.map(value => {
             let groupWhere;
             if (whereKey) {
@@ -1269,7 +1268,7 @@ class QueryGenerator {
           }).join(
             this._dialect.supports['UNION ALL'] ? ' UNION ALL ' : ' UNION '
           )
-          + ')', mainTable.as));
+        })`, mainTable.as));
       } else {
         mainQueryItems.push(this.selectFromTableFragment(options, mainTable.model, attributes.main, mainTable.quotedName, mainTable.as));
       }
@@ -1282,9 +1281,9 @@ class QueryGenerator {
       options.where = this.getWhereConditions(options.where, mainTable.as || tableName, model, options);
       if (options.where) {
         if (subQuery) {
-          subQueryItems.push(' WHERE ' + options.where);
+          subQueryItems.push(` WHERE ${options.where}`);
         } else {
-          mainQueryItems.push(' WHERE ' + options.where);
+          mainQueryItems.push(` WHERE ${options.where}`);
           // Walk the main query to update all selects
           mainQueryItems.forEach((value, key) => {
             if (value.startsWith('SELECT')) {
@@ -1299,9 +1298,9 @@ class QueryGenerator {
     if (options.group) {
       options.group = Array.isArray(options.group) ? options.group.map(t => this.quote(t, model)).join(', ') : this.quote(options.group, model);
       if (subQuery) {
-        subQueryItems.push(' GROUP BY ' + options.group);
+        subQueryItems.push(` GROUP BY ${options.group}`);
       } else {
-        mainQueryItems.push(' GROUP BY ' + options.group);
+        mainQueryItems.push(` GROUP BY ${options.group}`);
       }
     }
 
@@ -1310,9 +1309,9 @@ class QueryGenerator {
       options.having = this.getWhereConditions(options.having, tableName, model, options, false);
       if (options.having) {
         if (subQuery) {
-          subQueryItems.push(' HAVING ' + options.having);
+          subQueryItems.push(` HAVING ${options.having}`);
         } else {
-          mainQueryItems.push(' HAVING ' + options.having);
+          mainQueryItems.push(` HAVING ${options.having}`);
         }
       }
     }
@@ -1321,10 +1320,10 @@ class QueryGenerator {
     if (options.order) {
       const orders = this.getQueryOrders(options, model, subQuery);
       if (orders.mainQueryOrder.length) {
-        mainQueryItems.push(' ORDER BY ' + orders.mainQueryOrder.join(', '));
+        mainQueryItems.push(` ORDER BY ${orders.mainQueryOrder.join(', ')}`);
       }
       if (orders.subQueryOrder.length) {
-        subQueryItems.push(' ORDER BY ' + orders.subQueryOrder.join(', '));
+        subQueryItems.push(` ORDER BY ${orders.subQueryOrder.join(', ')}`);
       }
     }
 
@@ -1350,14 +1349,14 @@ class QueryGenerator {
         lock = options.lock.level;
       }
       if (this._dialect.supports.lockKey && (lock === 'KEY SHARE' || lock === 'NO KEY UPDATE')) {
-        query += ' FOR ' + lock;
+        query += ` FOR ${lock}`;
       } else if (lock === 'SHARE') {
-        query += ' ' + this._dialect.supports.forShare;
+        query += ` ${this._dialect.supports.forShare}`;
       } else {
         query += ' FOR UPDATE';
       }
       if (this._dialect.supports.lockOf && options.lock.of && options.lock.of.prototype instanceof Model) {
-        query += ' OF ' + this.quoteTable(options.lock.of.name);
+        query += ` OF ${this.quoteTable(options.lock.of.name)}`;
       }
       if (this._dialect.supports.skipLocked && options.skipLocked) {
         query += ' SKIP LOCKED';
@@ -1376,7 +1375,7 @@ class QueryGenerator {
       }
       if (Array.isArray(attr)) {
         if (attr.length !== 2) {
-          throw new Error(JSON.stringify(attr) + ' is not a valid attribute definition. Please use the following format: [\'attribute definition\', \'alias\']');
+          throw new Error(`${JSON.stringify(attr)} is not a valid attribute definition. Please use the following format: ['attribute definition', 'alias']`);
         }
         attr = attr.slice();
 
@@ -1395,7 +1394,7 @@ class QueryGenerator {
           : this.escape(attr);
       }
       if (!_.isEmpty(options.include) && !attr.includes('.') && addTable) {
-        attr = mainTableAs + '.' + attr;
+        attr = `${mainTableAs}.${attr}`;
       }
 
       return attr;
@@ -1636,9 +1635,9 @@ class QueryGenerator {
     const throughAs = `${includeAs.internalAs}->${through.as}`;
     const externalThroughAs = `${includeAs.externalAs}.${through.as}`;
     const throughAttributes = through.attributes.map(attr =>
-      this.quoteIdentifier(throughAs) + '.' + this.quoteIdentifier(Array.isArray(attr) ? attr[0] : attr)
-      + ' AS '
-      + this.quoteIdentifier(externalThroughAs + '.' + (Array.isArray(attr) ? attr[1] : attr))
+      `${this.quoteIdentifier(throughAs)}.${this.quoteIdentifier(Array.isArray(attr) ? attr[0] : attr)
+      } AS ${
+        this.quoteIdentifier(`${externalThroughAs}.${Array.isArray(attr) ? attr[1] : attr}`)}`
     );
     const association = include.association;
     const parentIsTop = !include.parent.association && include.parent.model.name === topLevelInfo.options.model.name;
@@ -1788,8 +1787,8 @@ class QueryGenerator {
         where: {
           [Op.and]: [
             this.sequelize.literal([
-              this.quoteTable(topParent.model.name) + '.' + this.quoteIdentifier(topParent.model.primaryKeyField),
-              this.quoteIdentifier(topInclude.through.model.name) + '.' + this.quoteIdentifier(topAssociation.identifierField)
+              `${this.quoteTable(topParent.model.name)}.${this.quoteIdentifier(topParent.model.primaryKeyField)}`,
+              `${this.quoteIdentifier(topInclude.through.model.name)}.${this.quoteIdentifier(topAssociation.identifierField)}`
             ].join(' = ')),
             topInclude.through.where
           ]
@@ -1803,8 +1802,8 @@ class QueryGenerator {
       const targetField = isBelongsTo ? topAssociation.sourceKeyField || topInclude.model.primaryKeyField : topAssociation.identifierField;
 
       const join = [
-        this.quoteIdentifier(topInclude.as) + '.' + this.quoteIdentifier(targetField),
-        this.quoteTable(topParent.as || topParent.model.name) + '.' + this.quoteIdentifier(sourceField)
+        `${this.quoteIdentifier(topInclude.as)}.${this.quoteIdentifier(targetField)}`,
+        `${this.quoteTable(topParent.as || topParent.model.name)}.${this.quoteIdentifier(sourceField)}`
       ].join(' = ');
 
       query = this.selectQuery(topInclude.model.getTableName(), {
@@ -1899,10 +1898,10 @@ class QueryGenerator {
   }
 
   selectFromTableFragment(options, model, attributes, tables, mainTableAs) {
-    let fragment = 'SELECT ' + attributes.join(', ') + ' FROM ' + tables;
+    let fragment = `SELECT ${attributes.join(', ')} FROM ${tables}`;
 
     if (mainTableAs) {
-      fragment += ' AS ' + mainTableAs;
+      fragment += ` AS ${mainTableAs}`;
     }
 
     return fragment;
@@ -1948,13 +1947,13 @@ class QueryGenerator {
       if (smth.attribute instanceof Utils.SequelizeMethod) {
         key = this.getWhereConditions(smth.attribute, tableName, factory, options, prepend);
       } else {
-        key = this.quoteTable(smth.attribute.Model.name) + '.' + this.quoteIdentifier(smth.attribute.field || smth.attribute.fieldName);
+        key = `${this.quoteTable(smth.attribute.Model.name)}.${this.quoteIdentifier(smth.attribute.field || smth.attribute.fieldName)}`;
       }
 
       if (value && value instanceof Utils.SequelizeMethod) {
         value = this.getWhereConditions(value, tableName, factory, options, prepend);
 
-        result = value === 'NULL' ? key + ' IS NULL' : [key, value].join(' ' + smth.comparator + ' ');
+        result = value === 'NULL' ? `${key} IS NULL` : [key, value].join(` ${smth.comparator} `);
       } else if (_.isPlainObject(value)) {
         result = this.whereItemQuery(smth.attribute, value, {
           model: factory
@@ -1966,7 +1965,7 @@ class QueryGenerator {
           value = this.escape(value);
         }
 
-        result = value === 'NULL' ? key + ' IS NULL' : [key, value].join(' ' + smth.comparator + ' ');
+        result = value === 'NULL' ? `${key} IS NULL` : [key, value].join(` ${smth.comparator} `);
       }
     } else if (smth instanceof Utils.Literal) {
       result = smth.val;
@@ -1979,9 +1978,9 @@ class QueryGenerator {
         result = this.escape(smth.val);
       }
 
-      result = 'CAST(' + result + ' AS ' + smth.type.toUpperCase() + ')';
+      result = `CAST(${result} AS ${smth.type.toUpperCase()})`;
     } else if (smth instanceof Utils.Fn) {
-      result = smth.fn + '(' + smth.args.map(arg => {
+      result = `${smth.fn}(${smth.args.map(arg => {
         if (arg instanceof Utils.SequelizeMethod) {
           return this.handleSequelizeMethod(arg, tableName, factory, options, prepend);
         } else if (_.isPlainObject(arg)) {
@@ -1989,7 +1988,7 @@ class QueryGenerator {
         } else {
           return this.escape(arg);
         }
-      }).join(', ') + ')';
+      }).join(', ')  })`;
     } else if (smth instanceof Utils.Col) {
       if (Array.isArray(smth.col)) {
         if (!factory) {
@@ -2009,7 +2008,7 @@ class QueryGenerator {
   whereQuery(where, options) {
     const query = this.whereItemsQuery(where, options);
     if (query && query.length) {
-      return 'WHERE '+query;
+      return `WHERE ${query}`;
     }
     return '';
   }
@@ -2031,7 +2030,7 @@ class QueryGenerator {
     const items = [];
 
     binding = binding || 'AND';
-    if (binding.substr(0, 1) !== ' ') binding = ' '+binding+' ';
+    if (binding.substr(0, 1) !== ' ') binding = ` ${binding} `;
 
     if (_.isPlainObject(where)) {
       Utils.getComplexKeys(where).forEach(prop => {
@@ -2055,7 +2054,7 @@ class QueryGenerator {
       if (options.model.rawAttributes[keyParts[0]] && options.model.rawAttributes[keyParts[0]].type instanceof DataTypes.JSON) {
         const tmp = {};
         const field = options.model.rawAttributes[keyParts[0]];
-        Dottie.set(tmp, keyParts.slice(1), value);
+        _.set(tmp, keyParts.slice(1), value);
         return this.whereItemQuery(field.field || keyParts[0], tmp, Object.assign({field}, options));
       }
     }
@@ -2173,7 +2172,7 @@ class QueryGenerator {
       value = value.map(item => {
         let itemQuery = this.whereItemsQuery(item, options, this.OperatorMap[Op.and]);
         if (itemQuery && itemQuery.length && (Array.isArray(item) || _.isPlainObject(item)) && Utils.getComplexSize(item) > 1) {
-          itemQuery = '('+itemQuery+')';
+          itemQuery = `(${itemQuery})`;
         }
         return itemQuery;
       }).filter(item => item && item.length);
@@ -2188,7 +2187,7 @@ class QueryGenerator {
       return '0 = 1';
     }
 
-    return value ? outerBinding + '('+value+')' : undefined;
+    return value ? `${outerBinding}(${value})` : undefined;
   }
 
   _whereBind(binding, key, value, options) {
@@ -2203,7 +2202,7 @@ class QueryGenerator {
 
     value = value.filter(item => item && item.length);
 
-    return value.length ? '('+value.join(binding)+')' : undefined;
+    return value.length ? `(${value.join(binding)})` : undefined;
   }
 
   _whereJSON(key, value, options) {
@@ -2228,7 +2227,7 @@ class QueryGenerator {
     });
 
     const result = items.join(this.OperatorMap[Op.and]);
-    return items.length > 1 ? '('+result+')' : result;
+    return items.length > 1 ? `(${result})` : result;
   }
 
   _traverseJSON(items, baseKey, prop, item, path) {
@@ -2292,7 +2291,7 @@ class QueryGenerator {
       throw new Error(`${key} and ${value} has no comparator`);
     }
     key = this._getSafeKey(key, prefix);
-    return [key, value].join(' '+comparator+' ');
+    return [key, value].join(` ${comparator} `);
   }
 
   _getSafeKey(key, prefix) {

--- a/lib/dialects/abstract/query-generator/helpers/quote.js
+++ b/lib/dialects/abstract/query-generator/helpers/quote.js
@@ -68,7 +68,7 @@ function quoteIdentifier(dialect, identifier, options) {
       }
 
     case 'mssql':
-      return '[' + identifier.replace(/[\[\]']+/g, '') + ']';
+      return `[${identifier.replace(/[\[\]']+/g, '')}]`;
 
     default:
       throw new Error(`Dialect "${dialect}" is not supported`);

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -247,8 +247,9 @@ class AbstractQuery {
           if (result.hasOwnProperty(key)) {
             if (this.options.nest) {
               _.set(o, key, result[key]);
+            } else {
+              o[key] = result[key];
             }
-            o[key] = result[key];
           }
         }
 

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const logger = require('../../utils/logger');
 const SqlString = require('../../sql-string');
 const QueryTypes = require('../../query-types');
+const Dot = require('dottie');
 
 class AbstractQuery {
 
@@ -241,16 +242,16 @@ class AbstractQuery {
     // Raw queries
     if (this.options.raw) {
       result = results.map(result => {
-        const o = {};
+        let o = {};
 
         for (const key in result) {
           if (result.hasOwnProperty(key)) {
-            if (this.options.nest) {
-              _.set(o, key, result[key]);
-            } else {
-              o[key] = result[key];
-            }
+            o[key] = result[key];
           }
+        }
+
+        if (this.options.nest) {
+          o = Dot.transform(o);
         }
 
         return o;

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -3,7 +3,6 @@
 const _ = require('lodash');
 const logger = require('../../utils/logger');
 const SqlString = require('../../sql-string');
-const Dot = require('dottie');
 const QueryTypes = require('../../query-types');
 
 class AbstractQuery {
@@ -81,7 +80,7 @@ class AbstractQuery {
         }
       }
       if (replVal === undefined) {
-        throw new Error('Named bind parameter "' + match + '" has no value in the given object.');
+        throw new Error(`Named bind parameter "${match}" has no value in the given object.`);
       }
       return replVal;
     });
@@ -126,7 +125,7 @@ class AbstractQuery {
   }
 
   getUniqueConstraintErrorMessage(field) {
-    let message = field ? field + ' must be unique' : 'Must be unique';
+    let message = field ? `${field} must be unique` : 'Must be unique';
 
     if (field && this.model) {
       for (const key of Object.keys(this.model.uniqueKeys)) {
@@ -242,16 +241,15 @@ class AbstractQuery {
     // Raw queries
     if (this.options.raw) {
       result = results.map(result => {
-        let o = {};
+        const o = {};
 
         for (const key in result) {
           if (result.hasOwnProperty(key)) {
+            if (this.options.nest) {
+              _.set(o, key, result[key]);
+            }
             o[key] = result[key];
           }
-        }
-
-        if (this.options.nest) {
-          o = Dot.transform(o);
         }
 
         return o;
@@ -399,7 +397,7 @@ class AbstractQuery {
       if ($current.includeMap.hasOwnProperty(piece)) {
         includeMap[key] = $current = $current.includeMap[piece];
         if (previousPiece) {
-          previousPiece = previousPiece+'.'+piece;
+          previousPiece = `${previousPiece}.${piece}`;
         } else {
           previousPiece = piece;
         }
@@ -450,7 +448,7 @@ class AbstractQuery {
     const getUniqueKeyAttributes = model => {
       let uniqueKeyAttributes = _.chain(model.uniqueKeys);
       uniqueKeyAttributes = uniqueKeyAttributes
-        .result(uniqueKeyAttributes.findKey() + '.fields')
+        .result(`${uniqueKeyAttributes.findKey()}.fields`)
         .map(field => _.findKey(model.attributes, chr => chr.field === field))
         .value();
 
@@ -524,22 +522,22 @@ class AbstractQuery {
 
             if (length) {
               for (i = 0; i < length; i++) {
-                prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
+                prefix = $parent ? `${$parent}.${$prevKeyPrefix[i]}` : $prevKeyPrefix[i];
                 primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
                 $length = primaryKeyAttributes.length;
                 itemHash = prefix;
                 if ($length === 1) {
-                  itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[0]]);
+                  itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[0]}`]);
                 }
                 else if ($length > 1) {
                   for ($i = 0; $i < $length; $i++) {
-                    itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[$i]]);
+                    itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
                   }
                 }
                 else if (!_.isEmpty(includeMap[prefix].model.uniqueKeys)) {
                   uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
                   for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
-                    itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
+                    itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];
                   }
                 }
                 if (!parentHash) {
@@ -613,22 +611,22 @@ class AbstractQuery {
 
         if (length) {
           for (i = 0; i < length; i++) {
-            prefix = $parent ? $parent+'.'+$prevKeyPrefix[i] : $prevKeyPrefix[i];
+            prefix = $parent ? `${$parent}.${$prevKeyPrefix[i]}` : $prevKeyPrefix[i];
             primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
             $length = primaryKeyAttributes.length;
             itemHash = prefix;
             if ($length === 1) {
-              itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[0]]);
+              itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[0]}`]);
             }
             else if ($length > 0) {
               for ($i = 0; $i < $length; $i++) {
-                itemHash += stringify(row[prefix+'.'+primaryKeyAttributes[$i]]);
+                itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
               }
             }
             else if (!_.isEmpty(includeMap[prefix].model.uniqueKeys)) {
               uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
               for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
-                itemHash += row[prefix+'.'+uniqueKeyAttributes[$i]];
+                itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];
               }
             }
             if (!parentHash) {

--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -68,7 +68,7 @@ module.exports = BaseTypes => {
   };
 
   BLOB.prototype._hexify = function _hexify(hex) {
-    return '0x' + hex;
+    return `0x${hex}`;
   };
 
   function STRING(length, binary) {
@@ -79,9 +79,9 @@ module.exports = BaseTypes => {
 
   STRING.prototype.toSql = function toSql() {
     if (!this._binary) {
-      return 'NVARCHAR(' + this._length + ')';
+      return `NVARCHAR(${this._length})`;
     } else {
-      return 'BINARY(' + this._length + ')';
+      return `BINARY(${this._length})`;
     }
   };
 

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -11,7 +11,7 @@ const Op = require('../../operators');
 
 /* istanbul ignore next */
 const throwMethodUndefined = function(methodName) {
-  throw new Error('The method "' + methodName + '" is not defined! Please add it to your sql dialect.');
+  throw new Error(`The method "${methodName}" is not defined! Please add it to your sql dialect.`);
 };
 
 class MSSQLQueryGenerator extends AbstractQueryGenerator {
@@ -20,7 +20,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
       collate: null
     }, options || {});
 
-    const collation = options.collate ? 'COLLATE ' + this.escape(options.collate) : '';
+    const collation = options.collate ? `COLLATE ${this.escape(options.collate)}` : '';
 
     return [
       'IF NOT EXISTS (SELECT * FROM sys.databases WHERE name =', wrapSingleQuote(databaseName), ')',
@@ -138,18 +138,18 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
           if (dataType.includes('REFERENCES')) {
             // MSSQL doesn't support inline REFERENCES declarations: move to the end
             match = dataType.match(/^(.+) (REFERENCES.*)$/);
-            attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1].replace('PRIMARY KEY', ''));
+            attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace('PRIMARY KEY', '')}`);
             foreignKeys[attr] = match[2];
           } else {
-            attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType.replace('PRIMARY KEY', ''));
+            attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`);
           }
         } else if (dataType.includes('REFERENCES')) {
           // MSSQL doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
-          attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1]);
+          attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
           foreignKeys[attr] = match[2];
         } else {
-          attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
+          attrStr.push(`${this.quoteIdentifier(attr)} ${dataType}`);
         }
       }
     }
@@ -162,7 +162,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
       _.each(options.uniqueKeys, (columns, indexName) => {
         if (columns.customIndex) {
           if (!_.isString(indexName)) {
-            indexName = 'uniq_' + tableName + '_' + columns.fields.join('_');
+            indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
           }
           attributesClause += `, CONSTRAINT ${this.quoteIdentifier(indexName)} UNIQUE (${columns.fields.map(field => this.quoteIdentifier(field)).join(', ')})`;
         }
@@ -175,7 +175,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     for (const fkey in foreignKeys) {
       if (foreignKeys.hasOwnProperty(fkey)) {
-        attributesClause += ', FOREIGN KEY (' + this.quoteIdentifier(fkey) + ') ' + foreignKeys[fkey];
+        attributesClause += `, FOREIGN KEY (${this.quoteIdentifier(fkey)}) ${foreignKeys[fkey]}`;
       }
     }
 
@@ -216,7 +216,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     ].join(' ');
 
     if (schema) {
-      sql += 'AND t.TABLE_SCHEMA =' + wrapSingleQuote(schema);
+      sql += `AND t.TABLE_SCHEMA =${wrapSingleQuote(schema)}`;
     }
 
     return sql;
@@ -266,11 +266,11 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     let finalQuery = '';
     if (attrString.length) {
-      finalQuery += 'ALTER COLUMN ' + attrString.join(', ');
+      finalQuery += `ALTER COLUMN ${attrString.join(', ')}`;
       finalQuery += constraintString.length ? ' ' : '';
     }
     if (constraintString.length) {
-      finalQuery += 'ADD ' + constraintString.join(', ');
+      finalQuery += `ADD ${constraintString.join(', ')}`;
     }
 
     return `ALTER TABLE ${this.quoteTable(tableName)} ${finalQuery};`;
@@ -327,10 +327,10 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     if (allAttributes.length > 0) {
       attrValueHashes.forEach(attrValueHash => {
-        tuples.push('(' +
+        tuples.push(`(${
           allAttributes.map(key =>
-            this.escape(attrValueHash[key])).join(',') +
-        ')');
+            this.escape(attrValueHash[key])).join(',')
+        })`);
       });
 
       const quotedAttributes = allAttributes.map(attr => this.quoteIdentifier(attr)).join(',');
@@ -482,11 +482,11 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     let limit = '';
 
     if (options.limit) {
-      limit = ' TOP(' + this.escape(options.limit) + ')';
+      limit = ` TOP(${this.escape(options.limit)})`;
     }
 
     if (whereClause) {
-      whereClause = ' WHERE ' + whereClause;
+      whereClause = ` WHERE ${whereClause}`;
     }
 
     return `DELETE${limit} FROM ${table}${whereClause}; SELECT @@ROWCOUNT AS AFFECTEDROWS;`;
@@ -504,7 +504,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
     }
 
     return `DROP INDEX ${this.quoteIdentifiers(indexName)} ON ${this.quoteIdentifiers(tableName)}`;
@@ -535,9 +535,9 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
       // enums are a special case
       template = attribute.type.toSql();
-      template += ' CHECK (' + this.quoteIdentifier(attribute.field) + ' IN(' + attribute.values.map(value => {
+      template += ` CHECK (${this.quoteIdentifier(attribute.field)} IN(${attribute.values.map(value => {
         return this.escape(value);
-      }).join(', ') + '))';
+      }).join(', ')  }))`;
       return template;
     } else {
       template = attribute.type.toString();
@@ -556,7 +556,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     // Blobs/texts cannot have a defaultValue
     if (attribute.type !== 'TEXT' && attribute.type._binary !== true &&
         Utils.defaultValueSchemable(attribute.defaultValue)) {
-      template += ' DEFAULT ' + this.escape(attribute.defaultValue);
+      template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
     }
 
     if (attribute.unique === true) {
@@ -568,25 +568,25 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.references) {
-      template += ' REFERENCES ' + this.quoteTable(attribute.references.model);
+      template += ` REFERENCES ${this.quoteTable(attribute.references.model)}`;
 
       if (attribute.references.key) {
-        template += ' (' + this.quoteIdentifier(attribute.references.key) + ')';
+        template += ` (${this.quoteIdentifier(attribute.references.key)})`;
       } else {
-        template += ' (' + this.quoteIdentifier('id') + ')';
+        template += ` (${this.quoteIdentifier('id')})`;
       }
 
       if (attribute.onDelete) {
-        template += ' ON DELETE ' + attribute.onDelete.toUpperCase();
+        template += ` ON DELETE ${attribute.onDelete.toUpperCase()}`;
       }
 
       if (attribute.onUpdate) {
-        template += ' ON UPDATE ' + attribute.onUpdate.toUpperCase();
+        template += ` ON UPDATE ${attribute.onUpdate.toUpperCase()}`;
       }
     }
 
     if (attribute.comment && _.isString(attribute.comment)) {
-      template += ' COMMENT ' + attribute.comment;
+      template += ` COMMENT ${attribute.comment}`;
     }
 
     return template;
@@ -654,18 +654,18 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
    * @returns {string}
    */
   _getForeignKeysQueryPrefix(catalogName) {
-    return 'SELECT ' +
+    return `${'SELECT ' +
         'constraint_name = OBJ.NAME, ' +
-        'constraintName = OBJ.NAME, ' +
-        (catalogName ? `constraintCatalog = '${catalogName}', ` : '') +
-        'constraintSchema = SCHEMA_NAME(OBJ.SCHEMA_ID), ' +
+        'constraintName = OBJ.NAME, '}${
+      catalogName ? `constraintCatalog = '${catalogName}', ` : ''
+    }constraintSchema = SCHEMA_NAME(OBJ.SCHEMA_ID), ` +
         'tableName = TB.NAME, ' +
-        'tableSchema = SCHEMA_NAME(TB.SCHEMA_ID), ' +
-        (catalogName ? `tableCatalog = '${catalogName}', ` : '') +
-        'columnName = COL.NAME, ' +
-        'referencedTableSchema = SCHEMA_NAME(RTB.SCHEMA_ID), ' +
-        (catalogName ? `referencedCatalog = '${catalogName}', ` : '') +
-        'referencedTableName = RTB.NAME, ' +
+        `tableSchema = SCHEMA_NAME(TB.SCHEMA_ID), ${
+          catalogName ? `tableCatalog = '${catalogName}', ` : ''
+        }columnName = COL.NAME, ` +
+        `referencedTableSchema = SCHEMA_NAME(RTB.SCHEMA_ID), ${
+          catalogName ? `referencedCatalog = '${catalogName}', ` : ''
+        }referencedTableName = RTB.NAME, ` +
         'referencedColumnName = RCOL.NAME ' +
       'FROM sys.foreign_key_columns FKC ' +
         'INNER JOIN sys.objects OBJ ON OBJ.OBJECT_ID = FKC.CONSTRAINT_OBJECT_ID ' +
@@ -683,23 +683,23 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
    */
   getForeignKeysQuery(table, catalogName) {
     const tableName = table.tableName || table;
-    let sql = this._getForeignKeysQueryPrefix(catalogName) +
-      ' WHERE TB.NAME =' + wrapSingleQuote(tableName);
+    let sql = `${this._getForeignKeysQueryPrefix(catalogName)
+    } WHERE TB.NAME =${wrapSingleQuote(tableName)}`;
 
     if (table.schema) {
-      sql += ' AND SCHEMA_NAME(TB.SCHEMA_ID) =' + wrapSingleQuote(table.schema);
+      sql += ` AND SCHEMA_NAME(TB.SCHEMA_ID) =${wrapSingleQuote(table.schema)}`;
     }
     return sql;
   }
 
   getForeignKeyQuery(table, attributeName) {
     const tableName = table.tableName || table;
-    let sql = this._getForeignKeysQueryPrefix() +
-      ' WHERE TB.NAME =' + wrapSingleQuote(tableName) +
-      ' AND COL.NAME =' + wrapSingleQuote(attributeName);
+    let sql = `${this._getForeignKeysQueryPrefix()
+    } WHERE TB.NAME =${wrapSingleQuote(tableName)
+    } AND COL.NAME =${wrapSingleQuote(attributeName)}`;
 
     if (table.schema) {
-      sql += ' AND SCHEMA_NAME(TB.SCHEMA_ID) =' + wrapSingleQuote(table.schema);
+      sql += ` AND SCHEMA_NAME(TB.SCHEMA_ID) =${wrapSingleQuote(table.schema)}`;
     }
 
     return sql;
@@ -749,7 +749,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
   startTransactionQuery(transaction) {
     if (transaction.parent) {
-      return 'SAVE TRANSACTION ' + this.quoteIdentifier(transaction.name) + ';';
+      return `SAVE TRANSACTION ${this.quoteIdentifier(transaction.name)};`;
     }
 
     return 'BEGIN TRANSACTION;';
@@ -765,7 +765,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
   rollbackTransactionQuery(transaction) {
     if (transaction.parent) {
-      return 'ROLLBACK TRANSACTION ' + this.quoteIdentifier(transaction.name) + ';';
+      return `ROLLBACK TRANSACTION ${this.quoteIdentifier(transaction.name)};`;
     }
 
     return 'ROLLBACK TRANSACTION;';
@@ -773,12 +773,12 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
   selectFromTableFragment(options, model, attributes, tables, mainTableAs, where) {
     let topFragment = '';
-    let mainFragment = 'SELECT ' + attributes.join(', ') + ' FROM ' + tables;
+    let mainFragment = `SELECT ${attributes.join(', ')} FROM ${tables}`;
 
     // Handle SQL Server 2008 with TOP instead of LIMIT
     if (semver.valid(this.sequelize.options.databaseVersion) && semver.lt(this.sequelize.options.databaseVersion, '11.0.0')) {
       if (options.limit) {
-        topFragment = 'TOP ' + options.limit + ' ';
+        topFragment = `TOP ${options.limit} `;
       }
       if (options.offset) {
         const offset = options.offset || 0,
@@ -793,7 +793,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
         }
 
         const tmpTable = mainTableAs ? mainTableAs : 'OffsetTable';
-        const whereFragment = where ? ' WHERE ' + where : '';
+        const whereFragment = where ? ` WHERE ${where}` : '';
 
         /*
          * For earlier versions of SQL server, we need to nest several queries
@@ -806,20 +806,20 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
          *    the TOP N rows of the query where the row number is > OFFSET
          * 3. The innermost query is the actual set we want information from
          */
-        const fragment = 'SELECT TOP 100 PERCENT ' + attributes.join(', ') + ' FROM ' +
-                        '(SELECT ' + topFragment + '*' +
-                          ' FROM (SELECT ROW_NUMBER() OVER (ORDER BY ' + orders.mainQueryOrder.join(', ') + ') as row_num, * ' +
-                            ' FROM ' + tables + ' AS ' + tmpTable + whereFragment + ')' +
-                          ' AS ' + tmpTable + ' WHERE row_num > ' + offset + ')' +
-                        ' AS ' + tmpTable;
+        const fragment = `SELECT TOP 100 PERCENT ${attributes.join(', ')} FROM ` +
+                        `(SELECT ${topFragment}*` +
+                          ` FROM (SELECT ROW_NUMBER() OVER (ORDER BY ${orders.mainQueryOrder.join(', ')}) as row_num, * ` +
+                            ` FROM ${tables} AS ${tmpTable}${whereFragment})` +
+                          ` AS ${tmpTable} WHERE row_num > ${offset})` +
+                        ` AS ${tmpTable}`;
         return fragment;
       } else {
-        mainFragment = 'SELECT ' + topFragment + attributes.join(', ') + ' FROM ' + tables;
+        mainFragment = `SELECT ${topFragment}${attributes.join(', ')} FROM ${tables}`;
       }
     }
 
     if (mainTableAs) {
-      mainFragment += ' AS ' + mainTableAs;
+      mainFragment += ` AS ${mainTableAs}`;
     }
 
     if (options.tableHint && TableHints[options.tableHint]) {
@@ -850,15 +850,15 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     if (options.limit || options.offset) {
       if (!options.order || options.include && !orders.subQueryOrder.length) {
         fragment += options.order && !isSubQuery ? ', ' : ' ORDER BY ';
-        fragment += this.quoteTable(options.tableAs || model.name) + '.' + this.quoteIdentifier(model.primaryKeyField);
+        fragment += `${this.quoteTable(options.tableAs || model.name)}.${this.quoteIdentifier(model.primaryKeyField)}`;
       }
 
       if (options.offset || options.limit) {
-        fragment += ' OFFSET ' + this.escape(offset) + ' ROWS';
+        fragment += ` OFFSET ${this.escape(offset)} ROWS`;
       }
 
       if (options.limit) {
-        fragment += ' FETCH NEXT ' + this.escape(options.limit) + ' ROWS ONLY';
+        fragment += ` FETCH NEXT ${this.escape(options.limit)} ROWS ONLY`;
       }
     }
 

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -55,7 +55,7 @@ class Query extends AbstractQuery {
     if (benchmark) {
       queryBegin = Date.now();
     } else {
-      this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
+      this.sequelize.log(`Executing (${this.connection.uuid || 'default'}): ${this.sql}`, this.options);
     }
 
     debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
@@ -101,7 +101,7 @@ class Query extends AbstractQuery {
           debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
           if (benchmark) {
-            this.sequelize.log('Executed (' + (this.connection.uuid || 'default') + '): ' + this.sql, Date.now() - queryBegin, this.options);
+            this.sequelize.log(`Executed (${this.connection.uuid || 'default'}): ${this.sql}`, Date.now() - queryBegin, this.options);
           }
 
           if (err) {
@@ -149,7 +149,7 @@ class Query extends AbstractQuery {
     const replacementFunc = (match, key, values) => {
       if (values[key] !== undefined) {
         bindParam[key] = values[key];
-        return '@' + key;
+        return `@${key}`;
       }
       return undefined;
     };

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -63,7 +63,7 @@ module.exports = BaseTypes => {
   inherits(DATE, BaseTypes.DATE);
 
   DATE.prototype.toSql = function toSql() {
-    return 'DATETIME' + (this._length ? '(' + this._length + ')' : '');
+    return `DATETIME${this._length ? `(${this._length})` : ''}`;
   };
 
   DATE.prototype._stringify = function _stringify(date, options) {
@@ -86,7 +86,7 @@ module.exports = BaseTypes => {
     if (moment.tz.zone(options.timezone)) {
       value = moment.tz(value, options.timezone).toDate();
     } else {
-      value = new Date(value + ' ' + options.timezone);
+      value = new Date(`${value} ${options.timezone}`);
     }
 
     return value;
@@ -124,7 +124,7 @@ module.exports = BaseTypes => {
     } else if (SUPPORTED_GEOMETRY_TYPES.includes(this.type)) {
       this.sqlType = this.type;
     } else {
-      throw new Error('Supported geometry types are: ' + SUPPORTED_GEOMETRY_TYPES.join(', '));
+      throw new Error(`Supported geometry types are: ${SUPPORTED_GEOMETRY_TYPES.join(', ')}`);
     }
   }
   inherits(GEOMETRY, BaseTypes.GEOMETRY);
@@ -159,7 +159,7 @@ module.exports = BaseTypes => {
   inherits(ENUM, BaseTypes.ENUM);
 
   ENUM.prototype.toSql = function toSql(options) {
-    return 'ENUM(' + this.values.map(value => options.escape(value)).join(', ') + ')';
+    return `ENUM(${this.values.map(value => options.escape(value)).join(', ')})`;
   };
 
   function JSONTYPE() {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -23,10 +23,10 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     }, options || {});
 
     const database = this.quoteIdentifier(databaseName);
-    const charset = options.charset ? ' DEFAULT CHARACTER SET ' + this.escape(options.charset) : '';
-    const collate = options.collate ? ' DEFAULT COLLATE ' + this.escape(options.collate) : '';
+    const charset = options.charset ? ` DEFAULT CHARACTER SET ${this.escape(options.charset)}` : '';
+    const collate = options.collate ? ` DEFAULT COLLATE ${this.escape(options.collate)}` : '';
 
-    return `CREATE DATABASE IF NOT EXISTS ${database}${charset}${collate}`.trim() + ';';
+    return `${`CREATE DATABASE IF NOT EXISTS ${database}${charset}${collate}`.trim()};`;
   }
 
   dropDatabaseQuery(databaseName) {
@@ -67,37 +67,37 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
           if (dataType.includes('REFERENCES')) {
             // MySQL doesn't support inline REFERENCES declarations: move to the end
             match = dataType.match(/^(.+) (REFERENCES.*)$/);
-            attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1].replace('PRIMARY KEY', ''));
+            attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace('PRIMARY KEY', '')}`);
             foreignKeys[attr] = match[2];
           } else {
-            attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType.replace('PRIMARY KEY', ''));
+            attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`);
           }
         } else if (dataType.includes('REFERENCES')) {
           // MySQL doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
-          attrStr.push(this.quoteIdentifier(attr) + ' ' + match[1]);
+          attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
           foreignKeys[attr] = match[2];
         } else {
-          attrStr.push(this.quoteIdentifier(attr) + ' ' + dataType);
+          attrStr.push(`${this.quoteIdentifier(attr)} ${dataType}`);
         }
       }
     }
 
     const table = this.quoteTable(tableName);
     let attributesClause = attrStr.join(', ');
-    const comment = options.comment && _.isString(options.comment) ? ' COMMENT ' + this.escape(options.comment) : '';
+    const comment = options.comment && _.isString(options.comment) ? ` COMMENT ${this.escape(options.comment)}` : '';
     const engine = options.engine;
-    const charset = options.charset ? ' DEFAULT CHARSET=' + options.charset : '';
-    const collation = options.collate ? ' COLLATE ' + options.collate : '';
-    const rowFormat = options.rowFormat ? ' ROW_FORMAT=' + options.rowFormat : '';
-    const initialAutoIncrement = options.initialAutoIncrement ? ' AUTO_INCREMENT=' + options.initialAutoIncrement : '';
+    const charset = options.charset ? ` DEFAULT CHARSET=${options.charset}` : '';
+    const collation = options.collate ? ` COLLATE ${options.collate}` : '';
+    const rowFormat = options.rowFormat ? ` ROW_FORMAT=${options.rowFormat}` : '';
+    const initialAutoIncrement = options.initialAutoIncrement ? ` AUTO_INCREMENT=${options.initialAutoIncrement}` : '';
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
 
     if (options.uniqueKeys) {
       _.each(options.uniqueKeys, (columns, indexName) => {
         if (columns.customIndex) {
           if (!_.isString(indexName)) {
-            indexName = 'uniq_' + tableName + '_' + columns.fields.join('_');
+            indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
           }
           attributesClause += `, UNIQUE ${this.quoteIdentifier(indexName)} (${columns.fields.map(field => this.quoteIdentifier(field)).join(', ')})`;
         }
@@ -110,7 +110,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
 
     for (const fkey in foreignKeys) {
       if (foreignKeys.hasOwnProperty(fkey)) {
-        attributesClause += ', FOREIGN KEY (' + this.quoteIdentifier(fkey) + ') ' + foreignKeys[fkey];
+        attributesClause += `, FOREIGN KEY (${this.quoteIdentifier(fkey)}) ${foreignKeys[fkey]}`;
       }
     }
 
@@ -159,17 +159,17 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
         constraintString.push(`FOREIGN KEY (${attrName}) ${definition}`);
       } else {
-        attrString.push('`' + attributeName + '` `' + attributeName + '` ' + definition);
+        attrString.push(`\`${attributeName}\` \`${attributeName}\` ${definition}`);
       }
     }
 
     let finalQuery = '';
     if (attrString.length) {
-      finalQuery += 'CHANGE ' + attrString.join(', ');
+      finalQuery += `CHANGE ${attrString.join(', ')}`;
       finalQuery += constraintString.length ? ' ' : '';
     }
     if (constraintString.length) {
-      finalQuery += 'ADD ' + constraintString.join(', ');
+      finalQuery += `ADD ${constraintString.join(', ')}`;
     }
 
     return `ALTER TABLE ${this.quoteTable(tableName)} ${finalQuery};`;
@@ -180,7 +180,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
 
     for (const attrName in attributes) {
       const definition = attributes[attrName];
-      attrString.push('`' + attrBefore + '` `' + attrName + '` ' + definition);
+      attrString.push(`\`${attrBefore}\` \`${attrName}\` ${definition}`);
     }
 
     return `ALTER TABLE ${this.quoteTable(tableName)} CHANGE ${attrString.join(', ')};`;
@@ -264,7 +264,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
 
     options.onDuplicate += Object.keys(updateValues).map(key => {
       key = this.quoteIdentifier(key);
-      return key + '=VALUES(' + key +')';
+      return `${key}=VALUES(${key})`;
     }).join(', ');
 
     return this.insertQuery(tableName, insertValues, model.rawAttributes, options);
@@ -276,23 +276,23 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
 
   deleteQuery(tableName, where, options = {}, model) {
     let limit = '';
-    let query = 'DELETE FROM ' + this.quoteTable(tableName);
+    let query = `DELETE FROM ${this.quoteTable(tableName)}`;
 
     if (options.limit) {
-      limit = ' LIMIT ' + this.escape(options.limit);
+      limit = ` LIMIT ${this.escape(options.limit)}`;
     }
 
     where = this.getWhereConditions(where, null, model, options);
 
     if (where) {
-      query += ' WHERE ' + where;
+      query += ` WHERE ${where}`;
     }
 
     return query + limit;
   }
 
   showIndexesQuery(tableName, options) {
-    return 'SHOW INDEX FROM ' + this.quoteTable(tableName) + ((options || {}).database ? ' FROM `' + options.database + '`' : '');
+    return `SHOW INDEX FROM ${this.quoteTable(tableName)}${(options || {}).database ? ` FROM \`${options.database}\`` : ''}`;
   }
 
   showConstraintsQuery(table, constraintName) {
@@ -318,14 +318,14 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
       sql += ` AND TABLE_SCHEMA = '${schemaName}'`;
     }
 
-    return sql + ';';
+    return `${sql};`;
   }
 
   removeIndexQuery(tableName, indexNameOrAttributes) {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
     }
 
     return `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteTable(tableName)}`;
@@ -351,7 +351,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
 
     // BLOB/TEXT/GEOMETRY/JSON cannot have a default value
     if (!['BLOB', 'TEXT', 'GEOMETRY', 'JSON'].includes(attributeString) && attribute.type._binary !== true && Utils.defaultValueSchemable(attribute.defaultValue)) {
-      template += ' DEFAULT ' + this.escape(attribute.defaultValue);
+      template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
     }
 
     if (attribute.unique === true) {
@@ -363,14 +363,14 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.comment) {
-      template += ' COMMENT ' + this.escape(attribute.comment);
+      template += ` COMMENT ${this.escape(attribute.comment)}`;
     }
 
     if (attribute.first) {
       template += ' FIRST';
     }
     if (attribute.after) {
-      template += ' AFTER ' + this.quoteIdentifier(attribute.after);
+      template += ` AFTER ${this.quoteIdentifier(attribute.after)}`;
     }
 
     if (attribute.references) {
@@ -382,20 +382,20 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
         template += `, ADD CONSTRAINT ${fkName} FOREIGN KEY (${attrName})`;
       }
 
-      template += ' REFERENCES ' + this.quoteTable(attribute.references.model);
+      template += ` REFERENCES ${this.quoteTable(attribute.references.model)}`;
 
       if (attribute.references.key) {
-        template += ' (' + this.quoteIdentifier(attribute.references.key) + ')';
+        template += ` (${this.quoteIdentifier(attribute.references.key)})`;
       } else {
-        template += ' (' + this.quoteIdentifier('id') + ')';
+        template += ` (${this.quoteIdentifier('id')})`;
       }
 
       if (attribute.onDelete) {
-        template += ' ON DELETE ' + attribute.onDelete.toUpperCase();
+        template += ` ON DELETE ${attribute.onDelete.toUpperCase()}`;
       }
 
       if (attribute.onUpdate) {
-        template += ' ON UPDATE ' + attribute.onUpdate.toUpperCase();
+        template += ` ON UPDATE ${attribute.onUpdate.toUpperCase()}`;
       }
     }
 
@@ -473,7 +473,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     // Check invalid json statement
     hasInvalidToken |= openingBrackets !== closingBrackets;
     if (hasJsonFunction && hasInvalidToken) {
-      throw new Error('Invalid json statement: ' + stmt);
+      throw new Error(`Invalid json statement: ${stmt}`);
     }
 
     // return true if the statement has valid json function
@@ -511,8 +511,8 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
    * @private
    */
   getForeignKeysQuery(tableName, schemaName) {
-    return 'SELECT ' + this._getForeignKeysQueryFields() + ' FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE where TABLE_NAME = \'' + tableName + /* jshint ignore: line */
-      '\' AND CONSTRAINT_NAME!=\'PRIMARY\' AND CONSTRAINT_SCHEMA=\'' + schemaName + '\' AND REFERENCED_TABLE_NAME IS NOT NULL;'; /* jshint ignore: line */
+    return `SELECT ${this._getForeignKeysQueryFields()} FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE where TABLE_NAME = '${tableName  /* jshint ignore: line */
+    }' AND CONSTRAINT_NAME!='PRIMARY' AND CONSTRAINT_SCHEMA='${schemaName}' AND REFERENCED_TABLE_NAME IS NOT NULL;`; /* jshint ignore: line */
   }
 
   /**
@@ -527,15 +527,15 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     const tableName = table.tableName || table;
     const schemaName = table.schema;
 
-    return 'SELECT ' + this._getForeignKeysQueryFields()
-      + ' FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE'
-      + ' WHERE (REFERENCED_TABLE_NAME = ' + wrapSingleQuote(tableName)
-      + (schemaName ? ' AND REFERENCED_TABLE_SCHEMA = ' + wrapSingleQuote(schemaName): '')
-      + ' AND REFERENCED_COLUMN_NAME = ' + wrapSingleQuote(columnName)
-      + ') OR (TABLE_NAME = ' + wrapSingleQuote(tableName)
-      + (schemaName ? ' AND TABLE_SCHEMA = ' + wrapSingleQuote(schemaName): '')
-      + ' AND COLUMN_NAME = ' + wrapSingleQuote(columnName)
-      + ' AND REFERENCED_TABLE_NAME IS NOT NULL'
+    return `SELECT ${this._getForeignKeysQueryFields()
+    } FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE`
+      + ` WHERE (REFERENCED_TABLE_NAME = ${wrapSingleQuote(tableName)
+      }${schemaName ? ` AND REFERENCED_TABLE_SCHEMA = ${wrapSingleQuote(schemaName)}`: ''
+      } AND REFERENCED_COLUMN_NAME = ${wrapSingleQuote(columnName)
+      }) OR (TABLE_NAME = ${wrapSingleQuote(tableName)
+      }${schemaName ? ` AND TABLE_SCHEMA = ${wrapSingleQuote(schemaName)}`: ''
+      } AND COLUMN_NAME = ${wrapSingleQuote(columnName)
+      } AND REFERENCED_TABLE_NAME IS NOT NULL`
       + ')';
   }
 
@@ -548,7 +548,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
    * @private
    */
   dropForeignKeyQuery(tableName, foreignKey) {
-    return 'ALTER TABLE ' + this.quoteTable(tableName) + ' DROP FOREIGN KEY ' + this.quoteIdentifier(foreignKey) + ';';
+    return `ALTER TABLE ${this.quoteTable(tableName)} DROP FOREIGN KEY ${this.quoteIdentifier(foreignKey)};`;
   }
 };
 

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -535,8 +535,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
       }) OR (TABLE_NAME = ${wrapSingleQuote(tableName)
       }${schemaName ? ` AND TABLE_SCHEMA = ${wrapSingleQuote(schemaName)}`: ''
       } AND COLUMN_NAME = ${wrapSingleQuote(columnName)
-      } AND REFERENCED_TABLE_NAME IS NOT NULL`
-      + ')';
+      } AND REFERENCED_TABLE_NAME IS NOT NULL)`;
   }
 
   /**

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -50,7 +50,7 @@ class Query extends AbstractQuery {
     if (benchmark) {
       queryBegin = Date.now();
     } else {
-      this.sequelize.log('Executing (' + (this.connection.uuid || 'default') + '): ' + this.sql, this.options);
+      this.sequelize.log(`Executing (${this.connection.uuid || 'default'}): ${this.sql}`, this.options);
     }
 
     debug(`executing(${this.connection.uuid || 'default'}) : ${this.sql}`);
@@ -60,7 +60,7 @@ class Query extends AbstractQuery {
         debug(`executed(${this.connection.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
-          this.sequelize.log('Executed (' + (this.connection.uuid || 'default') + '): ' + this.sql, Date.now() - queryBegin, this.options);
+          this.sequelize.log(`Executed (${this.connection.uuid || 'default'}): ${this.sql}`, Date.now() - queryBegin, this.options);
         }
 
         if (err) {
@@ -175,7 +175,7 @@ class Query extends AbstractQuery {
 
   logWarnings(results) {
     return this.run('SHOW WARNINGS').then(warningResults => {
-      const warningMessage = 'MySQL Warnings (' + (this.connection.uuid||'default') + '): ';
+      const warningMessage = `MySQL Warnings (${this.connection.uuid||'default'}): `;
       const messages = [];
       for (const _warningRow of warningResults) {
         if (typeof _warningRow ==='undefined' || typeof _warningRow[Symbol.iterator] !== 'function') continue;

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -153,9 +153,9 @@ class ConnectionManager extends AbstractConnectionManager {
       if (!this.sequelize.config.keepDefaultTimezone) {
         const isZone = !!moment.tz.zone(this.sequelize.options.timezone);
         if (isZone) {
-          query += 'SET client_min_messages TO warning; SET TIME ZONE \'' + this.sequelize.options.timezone + '\';';
+          query += `SET client_min_messages TO warning; SET TIME ZONE '${this.sequelize.options.timezone}';`;
         } else {
-          query += 'SET client_min_messages TO warning; SET TIME ZONE INTERVAL \'' + this.sequelize.options.timezone + '\' HOUR TO MINUTE;';
+          query += `SET client_min_messages TO warning; SET TIME ZONE INTERVAL '${this.sequelize.options.timezone}' HOUR TO MINUTE;`;
         }
       }
 

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -406,7 +406,7 @@ module.exports = BaseTypes => {
 
   BLOB.prototype._hexify = function _hexify(hex) {
     // bytea hex format http://www.postgresql.org/docs/current/static/datatype-binary.html
-    return 'E\'\\\\x' + hex + '\'';
+    return `E'\\\\x${hex}'`;
   };
 
   BaseTypes.BLOB.types.postgres = {
@@ -424,10 +424,10 @@ module.exports = BaseTypes => {
     let result = this.key;
 
     if (this.type) {
-      result += '(' + this.type;
+      result += `(${this.type}`;
 
       if (this.srid) {
-        result += ',' + this.srid;
+        result += `,${this.srid}`;
       }
 
       result += ')';
@@ -447,10 +447,10 @@ module.exports = BaseTypes => {
   };
 
   GEOMETRY.prototype._stringify = function _stringify(value, options) {
-    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+    return `ST_GeomFromGeoJSON(${options.escape(JSON.stringify(value))})`;
   };
   GEOMETRY.prototype._bindParam = function _bindParam(value, options) {
-    return 'ST_GeomFromGeoJSON(' + options.bindParam(value) + ')';
+    return `ST_GeomFromGeoJSON(${options.bindParam(value)})`;
   };
 
   function GEOGRAPHY(type, srid) {
@@ -463,10 +463,10 @@ module.exports = BaseTypes => {
     let result = 'GEOGRAPHY';
 
     if (this.type) {
-      result += '(' + this.type;
+      result += `(${this.type}`;
 
       if (this.srid) {
-        result += ',' + this.srid;
+        result += `,${this.srid}`;
       }
 
       result += ')';
@@ -486,10 +486,10 @@ module.exports = BaseTypes => {
   };
 
   GEOGRAPHY.prototype._stringify = function _stringify(value, options) {
-    return 'ST_GeomFromGeoJSON(' + options.escape(JSON.stringify(value)) + ')';
+    return `ST_GeomFromGeoJSON(${options.escape(JSON.stringify(value))})`;
   };
   GEOGRAPHY.prototype.bindParam = function bindParam(value, options) {
-    return 'ST_GeomFromGeoJSON(' + options.bindParam(value) + ')';
+    return `ST_GeomFromGeoJSON(${options.bindParam(value)})`;
   };
 
   let hstore;
@@ -522,7 +522,7 @@ module.exports = BaseTypes => {
     return hstore.stringify(value);
   };
   HSTORE.prototype._stringify = function _stringify(value) {
-    return "'" + this._value(value) + "'";
+    return `'${this._value(value)}'`;
   };
   HSTORE.prototype._bindParam = function _bindParam(value, options) {
     return options.bindParam(this._value(value));
@@ -593,14 +593,14 @@ module.exports = BaseTypes => {
   RANGE.prototype._stringify = function _stringify(values, options) {
     const value = this._value(values, options);
     if (!Array.isArray(values)) {
-      return `'${value}'::` + this.toCastType();
+      return `'${value}'::${this.toCastType()}`;
     }
     return `'${value}'`;
   };
   RANGE.prototype._bindParam = function _bindParam(values, options) {
     const value = this._value(values, options);
     if (!Array.isArray(values)) {
-      return options.bindParam(value) + '::' + this.toCastType();
+      return `${options.bindParam(value)}::${this.toCastType()}`;
     }
     return options.bindParam(value);
   };
@@ -627,20 +627,20 @@ module.exports = BaseTypes => {
     }, this);
   };
   BaseTypes.ARRAY.prototype._stringify = function _stringify(values, options) {
-    let str = 'ARRAY[' + this._value(values, options).join(',') + ']';
+    let str = `ARRAY[${this._value(values, options).join(',')}]`;
 
     if (this.type) {
       const Utils = require('../../utils');
       let castKey = this.toSql();
 
       if (this.type instanceof BaseTypes.ENUM) {
-        castKey = Utils.addTicks(
+        castKey = `${Utils.addTicks(
           Utils.generateEnumName(options.field.Model.getTableName(), options.field.fieldName),
           '"'
-        ) + '[]';
+        )  }[]`;
       }
 
-      str += '::' + castKey;
+      str += `::${castKey}`;
     }
 
     return str;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -20,10 +20,10 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
     const values = {
       database: this.quoteTable(databaseName),
-      encoding: options.encoding ? ' ENCODING = ' + this.escape(options.encoding) : '',
-      collation: options.collate ? ' LC_COLLATE = ' + this.escape(options.collate) : '',
-      ctype: options.ctype ? ' LC_CTYPE = ' + this.escape(options.ctype) : '',
-      template: options.template ? ' TEMPLATE = ' + this.escape(options.template) : ''
+      encoding: options.encoding ? ` ENCODING = ${this.escape(options.encoding)}` : '',
+      collation: options.collate ? ` LC_COLLATE = ${this.escape(options.collate)}` : '',
+      ctype: options.ctype ? ` LC_CTYPE = ${this.escape(options.ctype)}` : '',
+      template: options.template ? ` TEMPLATE = ${this.escape(options.template)}` : ''
     };
 
     return `CREATE DATABASE ${values.database}${values.encoding}${values.collation}${values.ctype}${values.template};`;
@@ -67,7 +67,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const quotedTable = this.quoteTable(tableName);
 
     if (options.comment && _.isString(options.comment)) {
-      comments += `; COMMENT ON TABLE ${quotedTable} IS ` + this.escape(options.comment);
+      comments += `; COMMENT ON TABLE ${quotedTable} IS ${this.escape(options.comment)}`;
     }
 
     for (const attr in attributes) {
@@ -81,7 +81,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       }
 
       const dataType = this.dataTypeMapping(tableName, attr, attributes[attr]);
-      attrStr.push(quotedAttr + ' ' + dataType);
+      attrStr.push(`${quotedAttr} ${dataType}`);
     }
 
 
@@ -203,7 +203,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     // Check invalid json statement
     hasInvalidToken |= openingBrackets !== closingBrackets;
     if (hasJsonFunction && hasInvalidToken) {
-      throw new Error('Invalid json statement: ' + stmt);
+      throw new Error(`Invalid json statement: ${stmt}`);
     }
 
     // return true if the statement has valid json function
@@ -273,37 +273,37 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       let attrSql = '';
 
       if (definition.includes('NOT NULL')) {
-        attrSql += query(this.quoteIdentifier(attributeName) + ' SET NOT NULL');
+        attrSql += query(`${this.quoteIdentifier(attributeName)} SET NOT NULL`);
 
         definition = definition.replace('NOT NULL', '').trim();
       } else if (!definition.includes('REFERENCES')) {
-        attrSql += query(this.quoteIdentifier(attributeName) + ' DROP NOT NULL');
+        attrSql += query(`${this.quoteIdentifier(attributeName)} DROP NOT NULL`);
       }
 
       if (definition.includes('DEFAULT')) {
-        attrSql += query(this.quoteIdentifier(attributeName) + ' SET DEFAULT ' + definition.match(/DEFAULT ([^;]+)/)[1]);
+        attrSql += query(`${this.quoteIdentifier(attributeName)} SET DEFAULT ${definition.match(/DEFAULT ([^;]+)/)[1]}`);
 
         definition = definition.replace(/(DEFAULT[^;]+)/, '').trim();
       } else if (!definition.includes('REFERENCES')) {
-        attrSql += query(this.quoteIdentifier(attributeName) + ' DROP DEFAULT');
+        attrSql += query(`${this.quoteIdentifier(attributeName)} DROP DEFAULT`);
       }
 
       if (attributes[attributeName].startsWith('ENUM(')) {
         attrSql += this.pgEnum(tableName, attributeName, attributes[attributeName]);
         definition = definition.replace(/^ENUM\(.+\)/, this.pgEnumName(tableName, attributeName, { schema: false }));
-        definition += ' USING (' + this.quoteIdentifier(attributeName) + '::' + this.pgEnumName(tableName, attributeName) + ')';
+        definition += ` USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(tableName, attributeName)})`;
       }
 
       if (definition.match(/UNIQUE;*$/)) {
         definition = definition.replace(/UNIQUE;*$/, '');
-        attrSql += query('ADD UNIQUE (' + this.quoteIdentifier(attributeName) + ')').replace('ALTER COLUMN', '');
+        attrSql += query(`ADD UNIQUE (${this.quoteIdentifier(attributeName)})`).replace('ALTER COLUMN', '');
       }
 
       if (definition.includes('REFERENCES')) {
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
-        attrSql += query('ADD FOREIGN KEY (' + this.quoteIdentifier(attributeName) + ') ' + definition).replace('ALTER COLUMN', '');
+        attrSql += query(`ADD FOREIGN KEY (${this.quoteIdentifier(attributeName)}) ${definition}`).replace('ALTER COLUMN', '');
       } else {
-        attrSql += query(this.quoteIdentifier(attributeName) + ' TYPE ' + definition);
+        attrSql += query(`${this.quoteIdentifier(attributeName)} TYPE ${definition}`);
       }
 
       sql.push(attrSql);
@@ -370,12 +370,12 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   deleteQuery(tableName, where, options = {}, model) {
     const table = this.quoteTable(tableName);
     let whereClause = this.getWhereConditions(where, null, model, options);
-    const limit = options.limit ? ' LIMIT ' + this.escape(options.limit) : '';
+    const limit = options.limit ? ` LIMIT ${this.escape(options.limit)}` : '';
     let primaryKeys = '';
     let primaryKeysSelection = '';
 
     if (whereClause) {
-      whereClause = ' WHERE ' + whereClause;
+      whereClause = ` WHERE ${whereClause}`;
     }
 
     if (options.limit) {
@@ -385,7 +385,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
       const pks = _.values(model.primaryKeys).map(pk => this.quoteIdentifier(pk.field)).join(',');
 
-      primaryKeys = model.primaryKeyAttributes.length > 1 ? '(' + pks + ')' : pks;
+      primaryKeys = model.primaryKeyAttributes.length > 1 ? `(${pks})` : pks;
       primaryKeysSelection = pks;
 
       return `DELETE FROM ${table} WHERE ${primaryKeys} IN (SELECT ${primaryKeysSelection} FROM ${table}${whereClause}${limit})`;
@@ -432,7 +432,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
     }
 
     return `DROP INDEX IF EXISTS ${this.quoteIdentifiers(indexName)}`;
@@ -472,7 +472,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       }
 
       if (Array.isArray(values) && values.length > 0) {
-        type = 'ENUM(' + values.map(value => this.escape(value)).join(', ') + ')';
+        type = `ENUM(${values.map(value => this.escape(value)).join(', ')})`;
 
         if (attribute.type instanceof DataTypes.ARRAY) {
           type += '[]';
@@ -487,7 +487,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       type = attribute.type;
     }
 
-    let sql = type + '';
+    let sql = `${type}`;
 
     if (attribute.hasOwnProperty('allowNull') && !attribute.allowNull) {
       sql += ' NOT NULL';
@@ -498,7 +498,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (Utils.defaultValueSchemable(attribute.defaultValue)) {
-      sql += ' DEFAULT ' + this.escape(attribute.defaultValue, attribute);
+      sql += ` DEFAULT ${this.escape(attribute.defaultValue, attribute)}`;
     }
 
     if (attribute.unique === true) {
@@ -522,20 +522,20 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       sql += ` REFERENCES ${referencesTable} (${referencesKey})`;
 
       if (attribute.onDelete) {
-        sql += ' ON DELETE ' + attribute.onDelete.toUpperCase();
+        sql += ` ON DELETE ${attribute.onDelete.toUpperCase()}`;
       }
 
       if (attribute.onUpdate) {
-        sql += ' ON UPDATE ' + attribute.onUpdate.toUpperCase();
+        sql += ` ON UPDATE ${attribute.onUpdate.toUpperCase()}`;
       }
 
       if (attribute.references.deferrable) {
-        sql += ' ' + attribute.references.deferrable.toString(this);
+        sql += ` ${attribute.references.deferrable.toString(this)}`;
       }
     }
 
     if (attribute.comment && _.isString(attribute.comment)) {
-      sql += ' COMMENT ' + attribute.comment;
+      sql += ` COMMENT ${attribute.comment}`;
     }
 
     return sql;
@@ -552,7 +552,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       columnFragment = columns.map(column => this.quoteIdentifier(column)).join(', ');
     }
 
-    return 'SET CONSTRAINTS ' + columnFragment + ' ' + type;
+    return `SET CONSTRAINTS ${columnFragment} ${type}`;
   }
 
   setDeferredQuery(columns) {
@@ -624,13 +624,13 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   }
 
   databaseConnectionUri(config) {
-    let uri = config.protocol + '://' + config.user + ':' + config.password + '@' + config.host;
+    let uri = `${config.protocol}://${config.user}:${config.password}@${config.host}`;
     if (config.port) {
-      uri += ':' + config.port;
+      uri += `:${config.port}`;
     }
-    uri += '/' + config.database;
+    uri += `/${config.database}`;
     if (config.ssl) {
-      uri += '?ssl=' + config.ssl;
+      uri += `?ssl=${config.ssl}`;
     }
     return uri;
   }
@@ -665,7 +665,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
   expandOptions(options) {
     return _.isUndefined(options) || _.isEmpty(options) ?
-      '' : '\n\t' + options.join('\n\t');
+      '' : `\n\t${options.join('\n\t')}`;
   }
 
   decodeTriggerEventType(eventSpecifier) {
@@ -677,7 +677,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     };
 
     if (!_.has(EVENT_DECODER, eventSpecifier)) {
-      throw new Error('Invalid trigger event specified: ' + eventSpecifier);
+      throw new Error(`Invalid trigger event specified: ${eventSpecifier}`);
     }
 
     return EVENT_DECODER[eventSpecifier];
@@ -701,13 +701,13 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       };
 
       if (!_.has(EVENT_MAP, fireValue)) {
-        throw new Error('parseTriggerEventSpec: undefined trigger event ' + fireKey);
+        throw new Error(`parseTriggerEventSpec: undefined trigger event ${fireKey}`);
       }
 
       let eventSpec = EVENT_MAP[fireValue];
       if (eventSpec === 'UPDATE') {
         if (Array.isArray(fireValue) && fireValue.length > 0) {
-          eventSpec += ' OF ' + fireValue.join(', ');
+          eventSpec += ` OF ${fireValue.join(', ')}`;
         }
       }
 
@@ -734,7 +734,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const tableDetails = this.extractTableDetails(tableName, options);
 
     if (tableDetails.tableName && attrName) {
-      enumName = ' AND t.typname=' + this.pgEnumName(tableDetails.tableName, attrName, { schema: false }).replace(/"/g, "'");
+      enumName = ` AND t.typname=${this.pgEnumName(tableDetails.tableName, attrName, { schema: false}).replace(/"/g, "'")}`;
     }
 
     return 'SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t ' +
@@ -748,12 +748,12 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     let values;
 
     if (dataType.values) {
-      values = "ENUM('" + dataType.values.join("', '") + "')";
+      values = `ENUM('${dataType.values.join("', '")}')`;
     } else {
       values = dataType.toString().match(/^ENUM\(.+\)/)[0];
     }
 
-    let sql = 'CREATE TYPE ' + enumName + ' AS ' + values + ';';
+    let sql = `CREATE TYPE ${enumName} AS ${values};`;
     if (!!options && options.force === true) {
       sql = this.pgEnumDrop(tableName, attr) + sql;
     }
@@ -762,7 +762,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
   pgEnumAdd(tableName, attr, value, options) {
     const enumName = this.pgEnumName(tableName, attr);
-    let sql = 'ALTER TYPE ' + enumName + ' ADD VALUE ';
+    let sql = `ALTER TYPE ${enumName} ADD VALUE `;
 
     if (semver.gte(this.sequelize.options.databaseVersion, '9.3.0')) {
       sql += 'IF NOT EXISTS ';
@@ -770,9 +770,9 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     sql += this.escape(value);
 
     if (options.before) {
-      sql += ' BEFORE ' + this.escape(options.before);
+      sql += ` BEFORE ${this.escape(options.before)}`;
     } else if (options.after) {
-      sql += ' AFTER ' + this.escape(options.after);
+      sql += ` AFTER ${this.escape(options.after)}`;
     }
 
     return sql;
@@ -780,7 +780,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
   pgEnumDrop(tableName, attr, enumName) {
     enumName = enumName || this.pgEnumName(tableName, attr);
-    return 'DROP TYPE IF EXISTS ' + enumName + '; ';
+    return `DROP TYPE IF EXISTS ${enumName}; `;
   }
 
   fromArray(text) {
@@ -797,7 +797,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   }
 
   padInt(i) {
-    return i < 10 ? '0' + i.toString() : i.toString();
+    return i < 10 ? `0${i.toString()}` : i.toString();
   }
 
   dataTypeMapping(tableName, attr, dataType) {
@@ -870,18 +870,18 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
    * @param {string} schemaName
    */
   getForeignKeyReferencesQuery(tableName, catalogName, schemaName) {
-    return this._getForeignKeyReferencesQueryPrefix() +
-      `WHERE constraint_type = 'FOREIGN KEY' AND tc.table_name = '${tableName}'` +
-      (catalogName ? ` AND tc.table_catalog = '${catalogName}'` : '') +
-      (schemaName ? ` AND tc.table_schema = '${schemaName}'` : '');
+    return `${this._getForeignKeyReferencesQueryPrefix()
+    }WHERE constraint_type = 'FOREIGN KEY' AND tc.table_name = '${tableName}'${
+      catalogName ? ` AND tc.table_catalog = '${catalogName}'` : ''
+    }${schemaName ? ` AND tc.table_schema = '${schemaName}'` : ''}`;
   }
 
   getForeignKeyReferenceQuery(table, columnName) {
     const tableName = table.tableName || table;
     const schema = table.schema;
-    return this._getForeignKeyReferencesQueryPrefix() +
-      `WHERE constraint_type = 'FOREIGN KEY' AND tc.table_name='${tableName}' AND  kcu.column_name = '${columnName}'` +
-      (schema ? ` AND tc.table_schema = '${schema}'` : '');
+    return `${this._getForeignKeyReferencesQueryPrefix()
+    }WHERE constraint_type = 'FOREIGN KEY' AND tc.table_name='${tableName}' AND  kcu.column_name = '${columnName}'${
+      schema ? ` AND tc.table_schema = '${schema}'` : ''}`;
   }
 
   /**
@@ -893,7 +893,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
    * @private
    */
   dropForeignKeyQuery(tableName, foreignKey) {
-    return 'ALTER TABLE ' + this.quoteTable(tableName) + ' DROP CONSTRAINT ' + this.quoteIdentifier(foreignKey) + ';';
+    return `ALTER TABLE ${this.quoteTable(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(foreignKey)};`;
   }
 };
 

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -582,7 +582,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const paramList = this.expandFunctionParamList(functionParams);
 
     return `CREATE ${this.triggerEventTypeIsConstraint(eventType)}TRIGGER ${triggerName} ${decodedEventType} ${
-      eventSpec} ON ${tableName} ${expandedOptions} EXECUTE PROCEDURE ${functionName}(${paramList});`;
+      eventSpec} ON ${tableName}${expandedOptions ? ` ${expandedOptions}` : ''} EXECUTE PROCEDURE ${functionName}(${paramList});`;
   }
 
   dropTrigger(tableName, triggerName) {
@@ -656,7 +656,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
   expandOptions(options) {
     return _.isUndefined(options) || _.isEmpty(options) ?
-      '' : `\n\t${options.join('\n\t')}`;
+      '' : options.join(' ');
   }
 
   decodeTriggerEventType(eventSpecifier) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -487,7 +487,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       type = attribute.type;
     }
 
-    let sql = `${type}`;
+    let sql = type.toString();
 
     if (attribute.hasOwnProperty('allowNull') && !attribute.allowNull) {
       sql += ' NOT NULL';
@@ -581,11 +581,8 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const expandedOptions = this.expandOptions(optionsArray);
     const paramList = this.expandFunctionParamList(functionParams);
 
-    return `CREATE ${this.triggerEventTypeIsConstraint(eventType)}TRIGGER ${triggerName}\n`
-      + `\t${decodedEventType} ${eventSpec}\n`
-      + `\tON ${tableName}\n`
-      + `\t${expandedOptions}\n`
-      + `\tEXECUTE PROCEDURE ${functionName}(${paramList});`;
+    return `CREATE ${this.triggerEventTypeIsConstraint(eventType)}TRIGGER ${triggerName} ${decodedEventType} ${
+      eventSpec} ON ${tableName} ${expandedOptions} EXECUTE PROCEDURE ${functionName}(${paramList});`;
   }
 
   dropTrigger(tableName, triggerName) {
@@ -600,15 +597,9 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     if (!functionName || !returnType || !language || !body) throw new Error('createFunction missing some parameters. Did you pass functionName, returnType, language and body?');
 
     const paramList = this.expandFunctionParamList(params);
-    const indentedBody = body.replace('\n', '\n\t');
     const expandedOptions = this.expandOptions(options);
 
-    return `CREATE FUNCTION ${functionName}(${paramList})\n`
-      + `RETURNS ${returnType} AS $func$\n`
-      + 'BEGIN\n'
-      + `\t${indentedBody}\n`
-      + 'END;\n'
-      + `$func$ language '${language}'${expandedOptions};`;
+    return `CREATE FUNCTION ${functionName}(${paramList}) RETURNS ${returnType} AS $func$ BEGIN ${body} END; $func$ language '${language}'${expandedOptions};`;
   }
 
   dropFunction(functionName, params) {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -43,8 +43,8 @@ class Query extends AbstractQuery {
         if (values[key] !== undefined) {
           i = i + 1;
           bindParam.push(values[key]);
-          seen[key] = '$'+i;
-          return '$'+i;
+          seen[key] = `$${i}`;
+          return `$${i}`;
         }
         return undefined;
       };
@@ -71,7 +71,7 @@ class Query extends AbstractQuery {
     if (benchmark) {
       queryBegin = Date.now();
     } else {
-      this.sequelize.log('Executing (' + (this.client.uuid || 'default') + '): ' + this.sql, this.options);
+      this.sequelize.log(`Executing (${this.client.uuid || 'default'}): ${this.sql}`, this.options);
     }
 
     debug(`executing(${this.client.uuid || 'default'}) : ${this.sql}`);
@@ -89,7 +89,7 @@ class Query extends AbstractQuery {
         debug(`executed(${this.client.uuid || 'default'}) : ${this.sql}`);
 
         if (benchmark) {
-          this.sequelize.log('Executed (' + (this.client.uuid || 'default') + '): ' + this.sql, Date.now() - queryBegin, this.options);
+          this.sequelize.log(`Executed (${this.client.uuid || 'default'}): ${this.sql}`, Date.now() - queryBegin, this.options);
         }
 
         return queryResult;
@@ -175,7 +175,7 @@ class Query extends AbstractQuery {
               let i;
               for (i=5;i<=8;i+=3) {
                 if (/(UPDATE|DELETE)/.test(defParts[i])) {
-                  row['on_'+defParts[i].toLowerCase()] = defParts[i+1];
+                  row[`on_${defParts[i].toLowerCase()}`] = defParts[i+1];
                 }
               }
             }

--- a/lib/dialects/postgres/range.js
+++ b/lib/dialects/postgres/range.js
@@ -49,7 +49,7 @@ function stringify(data) {
   const lowerBound = stringifyRangeBound(data[0]);
   const upperBound = stringifyRangeBound(data[1]);
 
-  return (data.inclusive[0] ? '[' : '(') + lowerBound + ',' + upperBound + (data.inclusive[1] ? ']' : ')');
+  return `${(data.inclusive[0] ? '[' : '(') + lowerBound},${upperBound}${data.inclusive[1] ? ']' : ')'}`;
 }
 exports.stringify = stringify;
 

--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -69,7 +69,7 @@ class ConnectionManager extends AbstractConnectionManager {
     }).tap(connection => {
       if (this.sequelize.config.password) {
         // Make it possible to define and use password for sqlite encryption plugin like sqlcipher
-        connection.run('PRAGMA KEY=' + this.sequelize.escape(this.sequelize.config.password));
+        connection.run(`PRAGMA KEY=${this.sequelize.escape(this.sequelize.config.password)}`);
       }
       if (this.sequelize.options.foreignKeys !== false) {
         // Make it possible to define and use foreign key constraints unless

--- a/lib/dialects/sqlite/data-types.js
+++ b/lib/dialects/sqlite/data-types.js
@@ -87,7 +87,7 @@ module.exports = BaseTypes => {
 
   STRING.prototype.toSql = function toSql() {
     if (this._binary) {
-      return 'VARCHAR BINARY(' + this._length + ')';
+      return `VARCHAR BINARY(${this._length})`;
     } else {
       return BaseTypes.STRING.prototype.toSql.call(this);
     }
@@ -125,7 +125,7 @@ module.exports = BaseTypes => {
 
   CHAR.prototype.toSql = function toSql() {
     if (this._binary) {
-      return 'CHAR BINARY(' + this._length + ')';
+      return `CHAR BINARY(${this._length})`;
     } else {
       return BaseTypes.CHAR.prototype.toSql.call(this);
     }
@@ -148,9 +148,9 @@ module.exports = BaseTypes => {
     }
 
     if (this._length) {
-      result += '(' + this._length;
+      result += `(${this._length}`;
       if (typeof this._decimals === 'number') {
-        result += ',' + this._decimals;
+        result += `,${this._decimals}`;
       }
       result += ')';
     }

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -48,7 +48,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
             dataTypeString = dataType.replace('PRIMARY KEY', 'NOT NULL');
           }
         }
-        attrArray.push(this.quoteIdentifier(attr) + ' ' + dataTypeString);
+        attrArray.push(`${this.quoteIdentifier(attr)} ${dataTypeString}`);
       }
     }
 
@@ -128,7 +128,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     // Check invalid json statement
     hasInvalidToken |= openingBrackets !== closingBrackets;
     if (hasJsonFunction && hasInvalidToken) {
-      throw new Error('Invalid json statement: ' + stmt);
+      throw new Error(`Invalid json statement: ${stmt}`);
     }
 
     // return true if the statement has valid json function
@@ -187,7 +187,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     const attributes = {};
     attributes[key] = dataType;
     const fields = this.attributesToSQL(attributes, { context: 'addColumn' });
-    const attribute = this.quoteIdentifier(key) + ' ' + fields[key];
+    const attribute = `${this.quoteIdentifier(key)} ${fields[key]}`;
 
     const sql = `ALTER TABLE ${this.quoteTable(table)} ADD ${attribute};`;
 
@@ -208,7 +208,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, upsertOptions);
     const update = this.updateQuery(tableName, updateValues, where, upsertOptions, model.rawAttributes);
 
-    const query = insert.query + ' ' + update.query;
+    const query = `${insert.query} ${update.query}`;
 
     return { query, bind };
   }
@@ -237,9 +237,9 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
       const value = attrValueHash[key];
 
       if (value instanceof Utils.SequelizeMethod || options.bindParam === false) {
-        values.push(this.quoteIdentifier(key) + '=' + this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE' }));
+        values.push(`${this.quoteIdentifier(key)}=${this.escape(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE'})}`);
       } else {
-        values.push(this.quoteIdentifier(key) + '=' + this.format(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE' }, bindParam));
+        values.push(`${this.quoteIdentifier(key)}=${this.format(value, modelAttributeMap && modelAttributeMap[key] || undefined, { context: 'UPDATE'}, bindParam)}`);
       }
     }
 
@@ -293,7 +293,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
           // TODO thoroughly check that DataTypes.NOW will properly
           // get populated on all databases as DEFAULT value
           // i.e. mysql requires: DEFAULT CURRENT_TIMESTAMP
-          sql += ' DEFAULT ' + this.escape(dataType.defaultValue, dataType);
+          sql += ` DEFAULT ${this.escape(dataType.defaultValue, dataType)}`;
         }
 
         if (dataType.unique === true) {
@@ -321,11 +321,11 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
           sql += ` REFERENCES ${referencesTable} (${referencesKey})`;
 
           if (dataType.onDelete) {
-            sql += ' ON DELETE ' + dataType.onDelete.toUpperCase();
+            sql += ` ON DELETE ${dataType.onDelete.toUpperCase()}`;
           }
 
           if (dataType.onUpdate) {
-            sql += ' ON UPDATE ' + dataType.onUpdate.toUpperCase();
+            sql += ` ON UPDATE ${dataType.onUpdate.toUpperCase()}`;
           }
 
         }
@@ -350,14 +350,14 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
       sql += ` AND sql LIKE '%${constraintName}%'`;
     }
 
-    return sql + ';';
+    return `${sql};`;
   }
 
   removeIndexQuery(tableName, indexNameOrAttributes) {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.underscore(tableName + '_' + indexNameOrAttributes.join('_'));
+      indexName = Utils.underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
     }
 
     return `DROP INDEX IF EXISTS ${this.quoteIdentifier(indexName)}`;
@@ -383,11 +383,11 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     let backupTableName;
     if (typeof tableName === 'object') {
       backupTableName = {
-        tableName: tableName.tableName + '_backup',
+        tableName: `${tableName.tableName}_backup`,
         schema: tableName.schema
       };
     } else {
-      backupTableName = tableName + '_backup';
+      backupTableName = `${tableName}_backup`;
     }
 
     const quotedTableName = this.quoteTable(tableName);
@@ -395,11 +395,11 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     const attributeNames = Object.keys(attributes).map(attr => this.quoteIdentifier(attr)).join(', ');
 
     // Temporary table cannot work for foreign keys.
-    return this.createTableQuery(backupTableName, attributes)
-      + `INSERT INTO ${quotedBackupTableName} SELECT ${attributeNames} FROM ${quotedTableName};`
-      + `DROP TABLE ${quotedTableName};`
-      + this.createTableQuery(tableName, attributes)
-      + `INSERT INTO ${quotedTableName} SELECT ${attributeNames} FROM ${quotedBackupTableName};`
+    return `${this.createTableQuery(backupTableName, attributes)
+    }INSERT INTO ${quotedBackupTableName} SELECT ${attributeNames} FROM ${quotedTableName};`
+      + `DROP TABLE ${quotedTableName};${
+        this.createTableQuery(tableName, attributes)
+      }INSERT INTO ${quotedTableName} SELECT ${attributeNames} FROM ${quotedBackupTableName};`
       + `DROP TABLE ${quotedBackupTableName};`;
   }
 
@@ -410,18 +410,18 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
 
     if (typeof tableName === 'object') {
       backupTableName = {
-        tableName: tableName.tableName + '_backup',
+        tableName: `${tableName.tableName}_backup`,
         schema: tableName.schema
       };
     } else {
-      backupTableName = tableName + '_backup';
+      backupTableName = `${tableName}_backup`;
     }
     const quotedTableName = this.quoteTable(tableName);
     const quotedBackupTableName = this.quoteTable(backupTableName);
     const attributeNames = Object.keys(attributes).map(attr => this.quoteIdentifier(attr)).join(', ');
 
-    return createTableSql.replace(`CREATE TABLE ${quotedTableName}`, `CREATE TABLE ${quotedBackupTableName}`)
-      + `INSERT INTO ${quotedBackupTableName} SELECT ${attributeNames} FROM ${quotedTableName};`
+    return `${createTableSql.replace(`CREATE TABLE ${quotedTableName}`, `CREATE TABLE ${quotedBackupTableName}`)
+    }INSERT INTO ${quotedBackupTableName} SELECT ${attributeNames} FROM ${quotedTableName};`
       + `DROP TABLE ${quotedTableName};`
       + `ALTER TABLE ${quotedBackupTableName} RENAME TO ${quotedTableName};`;
   }
@@ -434,34 +434,34 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
 
     if (typeof tableName === 'object') {
       backupTableName = {
-        tableName: tableName.tableName + '_backup',
+        tableName: `${tableName.tableName}_backup`,
         schema: tableName.schema
       };
     } else {
-      backupTableName = tableName + '_backup';
+      backupTableName = `${tableName}_backup`;
     }
 
     const quotedTableName = this.quoteTable(tableName);
     const quotedBackupTableName = this.quoteTable(backupTableName);
     const attributeNamesImport = Object.keys(attributes).map(attr =>
-      attrNameAfter === attr ? this.quoteIdentifier(attrNameBefore) + ' AS ' + this.quoteIdentifier(attr) : this.quoteIdentifier(attr)
+      attrNameAfter === attr ? `${this.quoteIdentifier(attrNameBefore)} AS ${this.quoteIdentifier(attr)}` : this.quoteIdentifier(attr)
     ).join(', ');
     const attributeNamesExport = Object.keys(attributes).map(attr => this.quoteIdentifier(attr)).join(', ');
 
-    return this.createTableQuery(backupTableName, attributes).replace('CREATE TABLE', 'CREATE TEMPORARY TABLE')
-      + `INSERT INTO ${quotedBackupTableName} SELECT ${attributeNamesImport} FROM ${quotedTableName};`
-      + `DROP TABLE ${quotedTableName};`
-      + this.createTableQuery(tableName, attributes)
-      + `INSERT INTO ${quotedTableName} SELECT ${attributeNamesExport} FROM ${quotedBackupTableName};`
+    return `${this.createTableQuery(backupTableName, attributes).replace('CREATE TABLE', 'CREATE TEMPORARY TABLE')
+    }INSERT INTO ${quotedBackupTableName} SELECT ${attributeNamesImport} FROM ${quotedTableName};`
+      + `DROP TABLE ${quotedTableName};${
+        this.createTableQuery(tableName, attributes)
+      }INSERT INTO ${quotedTableName} SELECT ${attributeNamesExport} FROM ${quotedBackupTableName};`
       + `DROP TABLE ${quotedBackupTableName};`;
   }
 
   startTransactionQuery(transaction) {
     if (transaction.parent) {
-      return 'SAVEPOINT ' + this.quoteIdentifier(transaction.name) + ';';
+      return `SAVEPOINT ${this.quoteIdentifier(transaction.name)};`;
     }
 
-    return 'BEGIN ' + transaction.options.type + ' TRANSACTION;';
+    return `BEGIN ${transaction.options.type} TRANSACTION;`;
   }
 
   setIsolationLevelQuery(value) {
@@ -475,7 +475,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
       case Transaction.ISOLATION_LEVELS.SERIALIZABLE:
         return '-- SQLite\'s default isolation level is SERIALIZABLE. Nothing to do.';
       default:
-        throw new Error('Unknown isolation level: ' + value);
+        throw new Error(`Unknown isolation level: ${value}`);
     }
   }
 

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -35,7 +35,7 @@ function removeColumn(tableName, attributeName, options) {
     const sql = this.QueryGenerator.removeColumnQuery(tableName, fields);
     const subQueries = sql.split(';').filter(q => q !== '');
 
-    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
+    return Promise.each(subQueries, subQuery => this.sequelize.query(`${subQuery};`, Object.assign({raw: true}, options)));
   });
 }
 exports.removeColumn = removeColumn;
@@ -63,7 +63,7 @@ function changeColumn(tableName, attributes, options) {
     const sql = this.QueryGenerator.removeColumnQuery(tableName, fields);
     const subQueries = sql.split(';').filter(q => q !== '');
 
-    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
+    return Promise.each(subQueries, subQuery => this.sequelize.query(`${subQuery};`, Object.assign({raw: true}, options)));
   });
 }
 exports.changeColumn = changeColumn;
@@ -92,7 +92,7 @@ function renameColumn(tableName, attrNameBefore, attrNameAfter, options) {
     const sql = this.QueryGenerator.renameColumnQuery(tableName, attrNameBefore, attrNameAfter, fields);
     const subQueries = sql.split(';').filter(q => q !== '');
 
-    return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
+    return Promise.each(subQueries, subQuery => this.sequelize.query(`${subQuery};`, Object.assign({raw: true}, options)));
   });
 }
 exports.renameColumn = renameColumn;
@@ -134,7 +134,7 @@ function removeConstraint(tableName, constraintName, options) {
       const sql = this.QueryGenerator._alterConstraintQuery(tableName, fields, createTableSql);
       const subQueries = sql.split(';').filter(q => q !== '');
 
-      return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
+      return Promise.each(subQueries, subQuery => this.sequelize.query(`${subQuery};`, Object.assign({raw: true}, options)));
     });
 }
 exports.removeConstraint = removeConstraint;
@@ -150,7 +150,7 @@ function addConstraint(tableName, options) {
       const index = sql.length - 1;
       //Replace ending ')' with constraint snippet - Simulates String.replaceAt
       //http://stackoverflow.com/questions/1431094
-      createTableSql = sql.substr(0, index) +  `, ${constraintSnippet})` + sql.substr(index + 1) + ';';
+      createTableSql = `${sql.substr(0, index)}, ${constraintSnippet})${sql.substr(index + 1)};`;
 
       return this.describeTable(tableName, options);
     })
@@ -158,7 +158,7 @@ function addConstraint(tableName, options) {
       const sql = this.QueryGenerator._alterConstraintQuery(tableName, fields, createTableSql);
       const subQueries = sql.split(';').filter(q => q !== '');
 
-      return Promise.each(subQueries, subQuery => this.sequelize.query(subQuery + ';', Object.assign({raw: true}, options)));
+      return Promise.each(subQueries, subQuery => this.sequelize.query(`${subQuery};`, Object.assign({raw: true}, options)));
     });
 }
 exports.addConstraint = addConstraint;

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -40,14 +40,14 @@ class Query extends AbstractQuery {
     if (Array.isArray(values)) {
       bindParam = {};
       values.forEach((v, i) => {
-        bindParam['$'+(i+1)] = v;
+        bindParam[`$${i+1}`] = v;
       });
       sql = AbstractQuery.formatBindParameters(sql, values, dialect, { skipValueReplace: true })[0];
     } else {
       bindParam = {};
       if (typeof values === 'object') {
         for (const k of Object.keys(values)) {
-          bindParam['$'+k] = values[k];
+          bindParam[`$${k}`] = values[k];
         }
       }
       sql = AbstractQuery.formatBindParameters(sql, values, dialect, { skipValueReplace: true })[0];
@@ -64,7 +64,7 @@ class Query extends AbstractQuery {
         if (!prefix) {
           key = _include.as;
         } else {
-          key = prefix + '.' + _include.as;
+          key = `${prefix}.${_include.as}`;
         }
         ret[key] = _include.model;
 
@@ -93,7 +93,7 @@ class Query extends AbstractQuery {
     if (benchmark) {
       queryBegin = Date.now();
     } else {
-      this.sequelize.log('Executing (' + (this.database.uuid || 'default') + '): ' + this.sql, this.options);
+      this.sequelize.log(`Executing (${this.database.uuid || 'default'}): ${this.sql}`, this.options);
     }
 
     debug(`executing(${this.database.uuid || 'default'}) : ${this.sql}`);
@@ -112,7 +112,7 @@ class Query extends AbstractQuery {
                 debug(`executed(${query.database.uuid || 'default'}) : ${query.sql}`);
 
                 if (benchmark) {
-                  query.sequelize.log('Executed (' + (query.database.uuid || 'default') + '): ' + query.sql, Date.now() - queryBegin, query.options);
+                  query.sequelize.log(`Executed (${query.database.uuid || 'default'}): ${query.sql}`, Date.now() - queryBegin, query.options);
                 }
 
                 if (err) {
@@ -281,7 +281,7 @@ class Query extends AbstractQuery {
                 tableName = tableName.replace(/`/g, '');
                 columnTypes[tableName] = {};
 
-                this.database.all('PRAGMA table_info(`' + tableName + '`)', (err, results) => {
+                this.database.all(`PRAGMA table_info(\`${tableName}\`)`, (err, results) => {
                   if (!err) {
                     for (const result of results) {
                       columnTypes[tableName][result.name] = result.type;
@@ -429,7 +429,7 @@ class Query extends AbstractQuery {
       item.primary = false;
       item.unique = !!item.unique;
       item.constraintName = item.name;
-      return this.run('PRAGMA INDEX_INFO(`' + item.name + '`)').then(columns => {
+      return this.run(`PRAGMA INDEX_INFO(\`${item.name}\`)`).then(columns => {
         for (const column of columns) {
           item.fields[column.seqno] = {
             attribute: column.name,

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -60,7 +60,7 @@ class ValidationError extends BaseError {
 
       // ... otherwise create a concatenated message out of existing errors.
     } else if (this.errors.length > 0 && this.errors[0].message) {
-      this.message = this.errors.map(err => (err.type || err.origin) + ': ' + err.message).join(',\n');
+      this.message = this.errors.map(err => `${err.type || err.origin}: ${err.message}`).join(',\n');
     }
     Error.captureStackTrace(this, this.constructor);
   }
@@ -91,7 +91,7 @@ exports.ValidationError = ValidationError;
 class OptimisticLockError extends BaseError {
   constructor(options) {
     options = options || {};
-    options.message = options.message || 'Attempting to update a stale model instance: ' + options.modelName;
+    options.message = options.message || `Attempting to update a stale model instance: ${options.modelName}`;
     super(options);
     this.name = 'SequelizeOptimisticLockError';
     /**
@@ -327,7 +327,7 @@ class ValidationErrorItem {
       if (ValidationErrorItem.Origins[ type ]) {
         this.origin = type;
       } else {
-        const lowercaseType = (type + '').toLowerCase().trim();
+        const lowercaseType = (`${type}`).toLowerCase().trim();
         const realType  = ValidationErrorItem.TypeStringMap[ lowercaseType ];
 
         if (realType && ValidationErrorItem.Origins[ realType ]) {

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -281,13 +281,13 @@ class InstanceValidator {
       const valueString = String(value);
       // check if Validator knows that kind of validation test
       if (typeof validator[validatorType] !== 'function') {
-        throw new Error('Invalid validator function: ' + validatorType);
+        throw new Error(`Invalid validator function: ${validatorType}`);
       }
 
       const validatorArgs = this._extractValidatorArgs(test, validatorType, field);
 
       if (!validator[validatorType].apply(validator, [valueString, ...validatorArgs])) {
-        throw Object.assign(new Error(test.msg || `Validation ${validatorType} on ${field} failed`), { validatorName: validatorType, validatorArgs });
+        throw Object.assign(new Error(test.msg || `Validation ${validatorType} on ${field} failed`), { validatorName: validatorType, validatorArgs});
       }
     });
   }

--- a/lib/model-manager.js
+++ b/lib/model-manager.js
@@ -59,7 +59,7 @@ class ModelManager {
       let tableName = model.getTableName();
 
       if (_.isObject(tableName)) {
-        tableName = tableName.schema + '.' + tableName.tableName;
+        tableName = `${tableName.schema}.${tableName.tableName}`;
       }
 
       models[tableName] = model;
@@ -72,7 +72,7 @@ class ModelManager {
             dep = attribute.references.model;
 
             if (_.isObject(dep)) {
-              dep = dep.schema + '.' + dep.tableName;
+              dep = `${dep.schema}.${dep.tableName}`;
             }
 
             deps.push(dep);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2,6 +2,7 @@
 
 const assert = require('assert');
 const _ = require('lodash');
+const Dottie = require('dottie');
 
 const Utils = require('./utils');
 const logger = require('./utils/logger');
@@ -3458,9 +3459,9 @@ class Model {
             // If attribute is not in model definition, return
             if (!this._isAttribute(key)) {
               if (key.includes('.') && this.constructor._isJsonAttribute(key.split('.')[0])) {
-                const previousNestedValue = _.get(this.dataValues, key);
+                const previousNestedValue = Dottie.get(this.dataValues, key);
                 if (!_.isEqual(previousNestedValue, value)) {
-                  _.set(this.dataValues, key, value);
+                  Dottie.set(this.dataValues, key, value);
                   this.changed(key.split('.')[0], true);
                 }
               }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-const Dottie = require('dottie');
 const _ = require('lodash');
 
 const Utils = require('./utils');
@@ -317,7 +316,7 @@ class Model {
   static _transformStringAssociation(include, self) {
     if (self && typeof include === 'string') {
       if (!self.associations.hasOwnProperty(include)) {
-        throw new Error('Association with alias "' + include + '" does not exists');
+        throw new Error(`Association with alias "${include}" does not exists`);
       }
       return self.associations[include];
     }
@@ -398,7 +397,7 @@ class Model {
 
         const types = validTypes[type];
         if (!types) {
-          throw new sequelizeErrors.EagerLoadingError('include all \'' + type + '\' is not valid - must be BelongsTo, HasOne, HasMany, One, Has, Many or All');
+          throw new sequelizeErrors.EagerLoadingError(`include all '${type}' is not valid - must be BelongsTo, HasOne, HasMany, One, Has, Many or All`);
         }
 
         if (types !== true) {
@@ -913,11 +912,11 @@ class Model {
     // error check options
     _.each(options.validate, (validator, validatorType) => {
       if (attributes.hasOwnProperty(validatorType)) {
-        throw new Error('A model validator function must not have the same name as a field. Model: ' + this.name + ', field/validation name: ' + validatorType);
+        throw new Error(`A model validator function must not have the same name as a field. Model: ${this.name}, field/validation name: ${validatorType}`);
       }
 
       if (!_.isFunction(validator)) {
-        throw new Error('Members of the validate option must be functions. Model: ' + this.name + ', error with validate member ' + validatorType);
+        throw new Error(`Members of the validate option must be functions. Model: ${this.name}, error with validate member ${validatorType}`);
       }
     });
 
@@ -1003,7 +1002,7 @@ class Model {
     this.prototype._customSetters = {};
 
     _.each(['get', 'set'], type => {
-      const opt = type + 'terMethods';
+      const opt = `${type}terMethods`;
       const funcs = _.clone(_.isObject(this.options[opt]) ? this.options[opt] : {});
       const _custom = type === 'get' ? this.prototype._customGetters : this.prototype._customSetters;
 
@@ -1123,7 +1122,7 @@ class Model {
         } else if (typeof definition.unique === 'string') {
           idxName = definition.unique;
         } else {
-          idxName = this.tableName + '_' + name + '_unique';
+          idxName = `${this.tableName}_${name}_unique`;
         }
 
         const idx = this.uniqueKeys[idxName] || { fields: [] };
@@ -1194,7 +1193,7 @@ class Model {
 
     for (const key of Object.keys(attributeManipulation)) {
       if (Model.prototype.hasOwnProperty(key)) {
-        this.sequelize.log('Not overriding built-in method from model attribute: ' + key);
+        this.sequelize.log(`Not overriding built-in method from model attribute: ${key}`);
         continue;
       }
       Object.defineProperty(this.prototype, key, attributeManipulation[key]);
@@ -1425,7 +1424,7 @@ class Model {
     }, options);
 
     if ((name === 'defaultScope' && Object.keys(this.options.defaultScope).length > 0 || name in this.options.scopes) && options.override === false) {
-      throw new Error('The scope ' + name + ' already exists. Pass { override: true } as options to silence this error');
+      throw new Error(`The scope ${name} already exists. Pass { override: true } as options to silence this error`);
     }
 
     this._conformOptions(scope, this);
@@ -1550,7 +1549,7 @@ class Model {
 
         self._scopeNames.push(scopeName ? scopeName : 'defaultScope');
       } else {
-        throw new sequelizeErrors.SequelizeScopeError('Invalid scope ' + scopeName + ' called.');
+        throw new sequelizeErrors.SequelizeScopeError(`Invalid scope ${scopeName} called.`);
       }
     }
 
@@ -1863,7 +1862,7 @@ class Model {
       options.where = {};
       options.where[this.primaryKeyAttribute] = param;
     } else {
-      throw new Error('Argument passed to findByPk is invalid: '+param);
+      throw new Error(`Argument passed to findByPk is invalid: ${param}`);
     }
 
     // Bypass a possible overloaded findOne
@@ -1996,7 +1995,7 @@ class Model {
     }).then(() => {
       let col = options.col || '*';
       if (options.include) {
-        col = this.name + '.' + (options.col || this.primaryKeyField);
+        col = `${this.name}.${options.col || this.primaryKeyField}`;
       }
 
       options.plain = !options.group;
@@ -3248,7 +3247,7 @@ class Model {
   }
 
   toString() {
-    return '[object SequelizeInstance:'+this.constructor.name+']';
+    return `[object SequelizeInstance:${this.constructor.name}]`;
   }
 
   /**
@@ -3459,9 +3458,9 @@ class Model {
             // If attribute is not in model definition, return
             if (!this._isAttribute(key)) {
               if (key.includes('.') && this.constructor._isJsonAttribute(key.split('.')[0])) {
-                const previousDottieValue = Dottie.get(this.dataValues, key);
-                if (!_.isEqual(previousDottieValue, value)) {
-                  Dottie.set(this.dataValues, key, value);
+                const previousNestedValue = _.get(this.dataValues, key);
+                if (!_.isEqual(previousNestedValue, value)) {
+                  _.set(this.dataValues, key, value);
                   this.changed(key.split('.')[0], true);
                 }
               }
@@ -3703,7 +3702,7 @@ class Model {
           ignoreChanged = _.without(ignoreChanged, updatedAtAttr);
         }
 
-        return this.constructor.runHooks('before' + hook, this, options)
+        return this.constructor.runHooks(`before${hook}`, this, options)
           .then(() => {
             if (options.defaultFields && !this.isNewRecord) {
               afterHookValues = _.pick(this.dataValues, _.difference(this.changed(), ignoreChanged));
@@ -3846,7 +3845,7 @@ class Model {
         .tap(result => {
           // Run after hook
           if (options.hooks) {
-            return this.constructor.runHooks('after' + hook, result, options);
+            return this.constructor.runHooks(`after${hook}`, result, options);
           }
         })
         .then(result => {

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -261,7 +261,7 @@ class QueryInterface {
         const instanceTable = this.sequelize.modelManager.getModel(tableName, { attribute: 'tableName' });
 
         if (instanceTable) {
-          const getTableName = (!options || !options.schema || options.schema === 'public' ? '' : options.schema + '_') + tableName;
+          const getTableName = (!options || !options.schema || options.schema === 'public' ? '' : `${options.schema}_`) + tableName;
 
           const keys = Object.keys(instanceTable.rawAttributes);
           const keyLen = keys.length;
@@ -319,7 +319,7 @@ class QueryInterface {
           tableNames.forEach(tableName => {
             let normalizedTableName = tableName;
             if (_.isObject(tableName)) {
-              normalizedTableName = tableName.schema + '.' + tableName.tableName;
+              normalizedTableName = `${tableName.schema}.${tableName.tableName}`;
             }
 
             foreignKeys[normalizedTableName].forEach(foreignKey => {
@@ -478,7 +478,7 @@ class QueryInterface {
       // Query generators that use information_schema for retrieving table info will just return an empty result set,
       // it will not throw an error like built-ins do (e.g. DESCRIBE on MySql).
       if (_.isEmpty(data)) {
-        return Promise.reject('No description found for "' + tableName + '" table. Check the table name and schema; remember, they _are_ case sensitive.');
+        return Promise.reject(`No description found for "${tableName}" table. Check the table name and schema; remember, they _are_ case sensitive.`);
       } else {
         return Promise.resolve(data);
       }
@@ -584,7 +584,7 @@ class QueryInterface {
     options = options || {};
     return this.describeTable(tableName, options).then(data => {
       if (!data[attrNameBefore]) {
-        throw new Error('Table ' + tableName + ' doesn\'t have the column ' + attrNameBefore);
+        throw new Error(`Table ${tableName} doesn't have the column ${attrNameBefore}`);
       }
 
       data = data[attrNameBefore] || {};
@@ -681,7 +681,7 @@ class QueryInterface {
 
       tableNames.forEach((tableName, i) => {
         if (_.isObject(tableName)) {
-          tableName = tableName.schema + '.' + tableName.tableName;
+          tableName = `${tableName.schema}.${tableName.tableName}`;
         }
 
         result[tableName] = Array.isArray(results[i])

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -230,7 +230,7 @@ class Sequelize {
         Dialect = require('./dialects/sqlite');
         break;
       default:
-        throw new Error('The dialect ' + this.getDialect() + ' is not supported. Supported dialects: mssql, mysql, postgres, and sqlite.');
+        throw new Error(`The dialect ${this.getDialect()} is not supported. Supported dialects: mssql, mysql, postgres, and sqlite.`);
     }
 
     this.dialect = new Dialect(this);
@@ -261,7 +261,7 @@ class Sequelize {
         this._trackRunningQueries = true;
       },
       verifyNoRunningQueries() {
-        if (this._runningQueries > 0) throw new Error('Expected 0 running queries. '+this._runningQueries+' queries still running');
+        if (this._runningQueries > 0) throw new Error(`Expected 0 running queries. ${this._runningQueries} queries still running`);
       }
     };
 
@@ -361,7 +361,7 @@ class Sequelize {
    */
   model(modelName) {
     if (!this.isDefined(modelName)) {
-      throw new Error(modelName + ' has not been defined');
+      throw new Error(`${modelName} has not been defined`);
     }
 
     return this.modelManager.getModel(modelName);
@@ -432,7 +432,7 @@ class Sequelize {
    * @param {boolean}         [options.raw] If true, sequelize will not try to format the results of the query, or build an instance of a model from the result
    * @param {Transaction}     [options.transaction=null] The transaction that the query should be executed under
    * @param {QueryTypes}      [options.type='RAW'] The type of query you are executing. The query type affects how results are formatted before they are passed back. The type is a string, but `Sequelize.QueryTypes` is provided as convenience shortcuts.
-   * @param {boolean}         [options.nest=false] If true, transforms objects with `.` separated property names into nested objects using [dottie.js](https://github.com/mickhansen/dottie.js). For example { 'user.username': 'john' } becomes { user: { username: 'john' }}. When `nest` is true, the query type is assumed to be `'SELECT'`, unless otherwise specified
+   * @param {boolean}         [options.nest=false] If true, transforms objects with `.` separated property names into nested objects using [lodashs](https://lodash.com/docs/4.17.10#set). For example { 'user.username': 'john' } becomes { user: { username: 'john' }}. When `nest` is true, the query type is assumed to be `'SELECT'`, unless otherwise specified
    * @param {boolean}         [options.plain=false] Sets the query type to `SELECT` and return a single row
    * @param {Object|Array}    [options.replacements] Either an object of named parameter replacements in the format `:param` or an array of unnamed replacements to replace `?` in your SQL.
    * @param {Object|Array}    [options.bind] Either an object of named bind parameter in the format `_param` or an array of unnamed bind parameter to replace `$1, $2, ...` in your SQL.
@@ -607,8 +607,8 @@ class Sequelize {
 
     // Generate SQL Query
     const query =
-      'SET '+
-      _.map(variables, (v, k) => '@'+k +' := '+ (typeof v === 'string' ? '"'+v+'"' : v)).join(', ');
+      `SET ${
+        _.map(variables, (v, k) => `@${k} := ${typeof v === 'string' ? `"${v}"` : v}`).join(', ')}`;
 
     return this.query(query, options);
   }
@@ -1088,7 +1088,7 @@ class Sequelize {
 
       // second argument is sql-timings, when benchmarking option enabled
       if ((this.options.benchmark || options.benchmark) && options.logging === console.log) {
-        args = [args[0] + ' Elapsed time: ' + args[1] + 'ms'];
+        args = [`${args[0]} Elapsed time: ${args[1]}ms`];
       }
 
       options.logging.apply(null, args);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -432,7 +432,7 @@ class Sequelize {
    * @param {boolean}         [options.raw] If true, sequelize will not try to format the results of the query, or build an instance of a model from the result
    * @param {Transaction}     [options.transaction=null] The transaction that the query should be executed under
    * @param {QueryTypes}      [options.type='RAW'] The type of query you are executing. The query type affects how results are formatted before they are passed back. The type is a string, but `Sequelize.QueryTypes` is provided as convenience shortcuts.
-   * @param {boolean}         [options.nest=false] If true, transforms objects with `.` separated property names into nested objects using [lodashs](https://lodash.com/docs/4.17.10#set). For example { 'user.username': 'john' } becomes { user: { username: 'john' }}. When `nest` is true, the query type is assumed to be `'SELECT'`, unless otherwise specified
+   * @param {boolean}         [options.nest=false] If true, transforms objects with `.` separated property names into nested objects using [dottie.js](https://github.com/mickhansen/dottie.js). For example { 'user.username': 'john' } becomes { user: { username: 'john' }}. When `nest` is true, the query type is assumed to be `'SELECT'`, unless otherwise specified
    * @param {boolean}         [options.plain=false] Sets the query type to `SELECT` and return a single row
    * @param {Object|Array}    [options.replacements] Either an object of named parameter replacements in the format `:param` or an array of unnamed replacements to replace `?` in your SQL.
    * @param {Object|Array}    [options.bind] Either an object of named bind parameter in the format `_param` or an array of unnamed bind parameter to replace `$1, $2, ...` in your SQL.

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -32,9 +32,9 @@ function escape(val, timeZone, dialect, format) {
       if (dialect === 'sqlite' || dialect === 'mssql') {
         return +!!val;
       }
-      return '' + !!val;
+      return `${!!val}`;
     case 'number':
-      return val + '';
+      return `${val}`;
     case 'string':
     // In mssql, prepend N to all quoted vals which are originally a string (for
     // unicode compatibility)
@@ -63,7 +63,7 @@ function escape(val, timeZone, dialect, format) {
   }
 
   if (!val.replace) {
-    throw new Error('Invalid value ' + util.inspect(val));
+    throw new Error(`Invalid value ${util.inspect(val)}`);
   }
 
   if (dialect === 'postgres' || dialect === 'sqlite' || dialect === 'mssql') {
@@ -84,11 +84,11 @@ function escape(val, timeZone, dialect, format) {
         case '\b': return '\\b';
         case '\t': return '\\t';
         case '\x1a': return '\\Z';
-        default: return '\\' + s;
+        default: return `\\${s}`;
       }
     });
   }
-  return (prependN ? "N'" : "'") + val + "'";
+  return `${(prependN ? "N'" : "'") + val}'`;
 }
 exports.escape = escape;
 
@@ -96,7 +96,7 @@ function format(sql, values, timeZone, dialect) {
   values = [].concat(values);
 
   if (typeof sql !== 'string') {
-    throw new Error('Invalid SQL string provided: ' + sql);
+    throw new Error(`Invalid SQL string provided: ${sql}`);
   }
 
   return sql.replace(/\?/g, match => {
@@ -118,7 +118,7 @@ function formatNamedParameters(sql, values, timeZone, dialect) {
     if (values[key] !== undefined) {
       return escape(values[key], timeZone, dialect, true);
     } else {
-      throw new Error('Named parameter "' + value + '" has no value in the given object.');
+      throw new Error(`Named parameter "${value}" has no value in the given object.`);
     }
   });
 }

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -32,9 +32,9 @@ function escape(val, timeZone, dialect, format) {
       if (dialect === 'sqlite' || dialect === 'mssql') {
         return +!!val;
       }
-      return `${!!val}`;
+      return (!!val).toString();
     case 'number':
-      return `${val}`;
+      return val.toString();
     case 'string':
     // In mssql, prepend N to all quoted vals which are originally a string (for
     // unicode compatibility)

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -40,7 +40,7 @@ class Transaction {
     if (this.parent) {
       this.id = this.parent.id;
       this.parent.savepoints.push(this);
-      this.name = this.id + '-sp-' + this.parent.savepoints.length;
+      this.name = `${this.id}-sp-${this.parent.savepoints.length}`;
     } else {
       this.id = this.name = generateTransactionId();
     }
@@ -55,7 +55,7 @@ class Transaction {
    */
   commit() {
     if (this.finished) {
-      return Promise.reject(new Error('Transaction cannot be committed because it has been finished with state: ' + this.finished));
+      return Promise.reject(new Error(`Transaction cannot be committed because it has been finished with state: ${this.finished}`));
     }
 
     this._clearCls();
@@ -84,7 +84,7 @@ class Transaction {
    */
   rollback() {
     if (this.finished) {
-      return Promise.reject(new Error('Transaction cannot be rolled back because it has been finished with state: ' + this.finished));
+      return Promise.reject(new Error(`Transaction cannot be rolled back because it has been finished with state: ${this.finished}`));
     }
 
     if (!this.connection) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -403,7 +403,7 @@ function flattenObjectDeep(value) {
 
   function flattenObject(obj, subPath) {
     Object.keys(obj).forEach(key => {
-      const pathToProperty = subPath ? `${subPath}.${key}` : `${key}`;
+      const pathToProperty = subPath ? `${subPath}.${key}` : key;
       if (typeof obj[key] === 'object') {
         flattenObject(obj[key], flattenedObj, pathToProperty);
       } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -552,7 +552,7 @@ exports.isWhereEmpty = isWhereEmpty;
  * @private
  */
 function generateEnumName(tableName, columnName) {
-  return 'enum_' + tableName + '_' + columnName;
+  return `enum_${tableName}_${columnName}`;
 }
 exports.generateEnumName = generateEnumName;
 
@@ -637,7 +637,7 @@ function nameIndex(index, tableName) {
     const fields = index.fields.map(
       field => typeof field === 'string' ? field : field.name || field.attribute
     );
-    index.name = underscore(tableName + '_' + fields.join('_'));
+    index.name = underscore(`${tableName}_${fields.join('_')}`);
   }
 
   return index;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "cls-bluebird": "^2.1.0",
     "debug": "^4.1.0",
     "depd": "^1.1.0",
+    "dottie": "^2.0.0",
     "generic-pool": "^3.4.0",
     "inflection": "1.12.0",
     "lodash": "^4.17.11",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "cls-bluebird": "^2.1.0",
     "debug": "^4.1.0",
     "depd": "^1.1.0",
-    "dottie": "^2.0.0",
     "generic-pool": "^3.4.0",
     "inflection": "1.12.0",
     "lodash": "^4.17.11",

--- a/test/config/config.js
+++ b/test/config/config.js
@@ -3,7 +3,7 @@
 const fs = require('fs');
 let mssqlConfig;
 try {
-  mssqlConfig = JSON.parse(fs.readFileSync(__dirname + '/mssql.json', 'utf8'));
+  mssqlConfig = JSON.parse(fs.readFileSync(`${__dirname}/mssql.json`, 'utf8'));
 } catch (e) {
   // ignore
 }

--- a/test/integration/assets/es6project.js
+++ b/test/integration/assets/es6project.js
@@ -1,6 +1,6 @@
 'use strict';
 exports.default = function(sequelize, DataTypes) {
-  return sequelize.define('Project' + parseInt(Math.random() * 9999999999999999), {
+  return sequelize.define(`Project${parseInt(Math.random() * 9999999999999999)}`, {
     name: DataTypes.STRING
   });
 };

--- a/test/integration/assets/project.js
+++ b/test/integration/assets/project.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function(sequelize, DataTypes) {
-  return sequelize.define('Project' + parseInt(Math.random() * 9999999999999999), {
+  return sequelize.define(`Project${parseInt(Math.random() * 9999999999999999)}`, {
     name: DataTypes.STRING
   });
 };

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -887,7 +887,7 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
         Tasks = {};
 
       dataTypes.forEach(dataType => {
-        const tableName = 'TaskXYZ_' + dataType.key;
+        const tableName = `TaskXYZ_${dataType.key}`;
         Tasks[dataType] = this.sequelize.define(tableName, { title: DataTypes.STRING });
 
         Tasks[dataType].belongsTo(User, { foreignKey: 'userId', keyType: dataType, constraints: false });

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -858,7 +858,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
 
         const ctx = {};
         return this.sequelize.sync({ force: true }).then(() => {
-          const users = _.range(1000).map(i => ({username: 'user' + i, num: i, status: 'live'}));
+          const users = _.range(1000).map(i => ({username: `user${i}`, num: i, status: 'live'}));
           return User.bulkCreate(users);
         }).then(() => {
           return Task.create({ title: 'task' });
@@ -1337,7 +1337,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         Tasks = {};
 
       return Promise.each(dataTypes, dataType => {
-        const tableName = 'TaskXYZ_' + dataType.key;
+        const tableName = `TaskXYZ_${dataType.key}`;
         Tasks[dataType] = this.sequelize.define(tableName, { title: DataTypes.STRING });
 
         User.hasMany(Tasks[dataType], { foreignKey: 'userId', keyType: dataType, constraints: false });

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -765,7 +765,7 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
         Tasks = {};
 
       return Promise.map(dataTypes, dataType => {
-        const tableName = 'TaskXYZ_' + dataType.key;
+        const tableName = `TaskXYZ_${dataType.key}`;
         Tasks[dataType] = this.sequelize.define(tableName, { title: Sequelize.STRING });
 
         User.hasOne(Tasks[dataType], { foreignKey: 'userId', keyType: dataType, constraints: false });

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -26,7 +26,7 @@ describe(Support.getTestDialectTeaser('associations'), () => {
       });
 
       this.Comment.prototype.getItem = function() {
-        return this['get' + this.get('commentable').substr(0, 1).toUpperCase() + this.get('commentable').substr(1)]();
+        return this[`get${this.get('commentable').substr(0, 1).toUpperCase()}${this.get('commentable').substr(1)}`]();
       };
 
       this.Post.addScope('withComments', {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -108,7 +108,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
 
     expect(() => {
       current.refreshTypes();
-    }).to.throw('Parse function not supported for type ' + Type.key + ' in dialect ' + dialect);
+    }).to.throw(`Parse function not supported for type ${Type.key} in dialect ${dialect}`);
 
     delete Type.constructor.parse;
   };

--- a/test/integration/dialects/mysql/associations.test.js
+++ b/test/integration/dialects/mysql/associations.test.js
@@ -46,8 +46,8 @@ if (dialect === 'mysql') {
     describe('HasMany', () => {
       beforeEach(function() {
         //prevent periods from occurring in the table name since they are used to delimit (table.column)
-        this.User = this.sequelize.define('User' + Math.ceil(Math.random() * 10000000), { name: DataTypes.STRING });
-        this.Task = this.sequelize.define('Task' + Math.ceil(Math.random() * 10000000), { name: DataTypes.STRING });
+        this.User = this.sequelize.define(`User${Math.ceil(Math.random() * 10000000)}`, { name: DataTypes.STRING});
+        this.Task = this.sequelize.define(`Task${Math.ceil(Math.random() * 10000000)}`, { name: DataTypes.STRING});
         this.users = null;
         this.tasks = null;
 
@@ -58,11 +58,11 @@ if (dialect === 'mysql') {
           tasks = [];
 
         for (let i = 0; i < 5; ++i) {
-          users[users.length] = {name: 'User' + Math.random()};
+          users[users.length] = {name: `User${Math.random()}`};
         }
 
         for (let x = 0; x < 5; ++x) {
-          tasks[tasks.length] = {name: 'Task' + Math.random()};
+          tasks[tasks.length] = {name: `Task${Math.random()}`};
         }
 
         return this.sequelize.sync({ force: true }).then(() => {

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -11,7 +11,7 @@ if (dialect === 'mysql') {
   describe('[MYSQL Specific] DAOFactory', () => {
     describe('constructor', () => {
       it('handles extended attributes (unique)', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: { type: DataTypes.STRING, unique: true }
         }, { timestamps: false });
 
@@ -19,58 +19,58 @@ if (dialect === 'mysql') {
       });
 
       it('handles extended attributes (default)', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: {type: DataTypes.STRING, defaultValue: 'foo'}
         }, { timestamps: false });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({username: "VARCHAR(255) DEFAULT 'foo'", id: 'INTEGER NOT NULL auto_increment PRIMARY KEY'});
       });
 
       it('handles extended attributes (null)', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: {type: DataTypes.STRING, allowNull: false}
         }, { timestamps: false });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({username: 'VARCHAR(255) NOT NULL', id: 'INTEGER NOT NULL auto_increment PRIMARY KEY'});
       });
 
       it('handles extended attributes (primaryKey)', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           username: {type: DataTypes.STRING, primaryKey: true}
         }, { timestamps: false });
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({username: 'VARCHAR(255) PRIMARY KEY'});
       });
 
       it('adds timestamps', function() {
-        const User1 = this.sequelize.define('User' + config.rand(), {});
-        const User2 = this.sequelize.define('User' + config.rand(), {}, { timestamps: true });
+        const User1 = this.sequelize.define(`User${config.rand()}`, {});
+        const User2 = this.sequelize.define(`User${config.rand()}`, {}, { timestamps: true});
 
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User1.rawAttributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', updatedAt: 'DATETIME NOT NULL', createdAt: 'DATETIME NOT NULL'});
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User2.rawAttributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', updatedAt: 'DATETIME NOT NULL', createdAt: 'DATETIME NOT NULL'});
       });
 
       it('adds deletedAt if paranoid', function() {
-        const User = this.sequelize.define('User' + config.rand(), {}, { paranoid: true });
+        const User = this.sequelize.define(`User${config.rand()}`, {}, { paranoid: true});
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', deletedAt: 'DATETIME', updatedAt: 'DATETIME NOT NULL', createdAt: 'DATETIME NOT NULL'});
       });
 
       it('underscores timestamps if underscored', function() {
-        const User = this.sequelize.define('User' + config.rand(), {}, { paranoid: true, underscored: true });
+        const User = this.sequelize.define(`User${config.rand()}`, {}, { paranoid: true, underscored: true});
         expect(this.sequelize.getQueryInterface().QueryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({id: 'INTEGER NOT NULL auto_increment PRIMARY KEY', deleted_at: 'DATETIME', updated_at: 'DATETIME NOT NULL', created_at: 'DATETIME NOT NULL'});
       });
 
       it('omits text fields with defaultValues', function() {
-        const User = this.sequelize.define('User' + config.rand(), {name: {type: DataTypes.TEXT, defaultValue: 'helloworld'}});
+        const User = this.sequelize.define(`User${config.rand()}`, {name: {type: DataTypes.TEXT, defaultValue: 'helloworld'}});
         expect(User.rawAttributes.name.type.toString()).to.equal('TEXT');
       });
 
       it('omits blobs fields with defaultValues', function() {
-        const User = this.sequelize.define('User' + config.rand(), {name: {type: DataTypes.STRING.BINARY, defaultValue: 'helloworld'}});
+        const User = this.sequelize.define(`User${config.rand()}`, {name: {type: DataTypes.STRING.BINARY, defaultValue: 'helloworld'}});
         expect(User.rawAttributes.name.type.toString()).to.equal('VARCHAR(255) BINARY');
       });
     });
 
     describe('primaryKeys', () => {
       it('determines the correct primaryKeys', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           foo: {type: DataTypes.STRING, primaryKey: true},
           bar: DataTypes.STRING
         });

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -45,8 +45,8 @@ if (dialect.match(/^postgres/)) {
       describe('addDAO / getModel', () => {
         beforeEach(function() {
           //prevent periods from occurring in the table name since they are used to delimit (table.column)
-          this.User = this.sequelize.define('User' + config.rand(), { name: DataTypes.STRING });
-          this.Task = this.sequelize.define('Task' + config.rand(), { name: DataTypes.STRING });
+          this.User = this.sequelize.define(`User${config.rand()}`, { name: DataTypes.STRING});
+          this.Task = this.sequelize.define(`Task${config.rand()}`, { name: DataTypes.STRING});
           this.users = null;
           this.tasks = null;
 
@@ -57,11 +57,11 @@ if (dialect.match(/^postgres/)) {
             tasks = [];
 
           for (let i = 0; i < 5; ++i) {
-            users[users.length] = {name: 'User' + Math.random()};
+            users[users.length] = {name: `User${Math.random()}`};
           }
 
           for (let x = 0; x < 5; ++x) {
-            tasks[tasks.length] = {name: 'Task' + Math.random()};
+            tasks[tasks.length] = {name: `Task${Math.random()}`};
           }
 
           return this.sequelize.sync({ force: true }).then(() => {
@@ -96,8 +96,8 @@ if (dialect.match(/^postgres/)) {
             tasks = [];
 
           //prevent periods from occurring in the table name since they are used to delimit (table.column)
-          this.User = this.sequelize.define('User' + config.rand(), { name: DataTypes.STRING });
-          this.Task = this.sequelize.define('Task' + config.rand(), { name: DataTypes.STRING });
+          this.User = this.sequelize.define(`User${config.rand()}`, { name: DataTypes.STRING});
+          this.Task = this.sequelize.define(`Task${config.rand()}`, { name: DataTypes.STRING});
           this.users = null;
           this.tasks = null;
 
@@ -105,11 +105,11 @@ if (dialect.match(/^postgres/)) {
           this.Task.belongsToMany(this.User, {as: 'Users', through: 'usertasks'});
 
           for (let i = 0; i < 5; ++i) {
-            users[users.length] = {id: i + 1, name: 'User' + Math.random()};
+            users[users.length] = {id: i + 1, name: `User${Math.random()}`};
           }
 
           for (let x = 0; x < 5; ++x) {
-            tasks[tasks.length] = {id: x + 1, name: 'Task' + Math.random()};
+            tasks[tasks.length] = {id: x + 1, name: `Task${Math.random()}`};
           }
 
           return this.sequelize.sync({ force: true }).then(() => {

--- a/test/integration/dialects/sqlite/connection-manager.test.js
+++ b/test/integration/dialects/sqlite/connection-manager.test.js
@@ -8,7 +8,7 @@ const Support = require('../../support');
 const dialect = Support.getTestDialect();
 const DataTypes = require('../../../../lib/data-types');
 
-const fileName = Math.random() + '_test.sqlite';
+const fileName = `${Math.random()}_test.sqlite`;
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] Connection Manager', () => {
@@ -35,14 +35,14 @@ if (dialect === 'sqlite') {
           expect(fs.existsSync(path.join(__dirname, fileName))).to.be.true;
           expect(fs.existsSync(path.join(__dirname, `${fileName}-shm`)), 'shm file should exists').to.be.true;
           expect(fs.existsSync(path.join(__dirname, `${fileName}-wal`)), 'wal file should exists').to.be.true;
-        
+
           return sequelize.close();
         })
         .then(() => {
           expect(fs.existsSync(path.join(__dirname, fileName))).to.be.true;
           expect(fs.existsSync(path.join(__dirname, `${fileName}-shm`)), 'shm file exists').to.be.false;
           expect(fs.existsSync(path.join(__dirname, `${fileName}-wal`)), 'wal file exists').to.be.false;
-          
+
           return this.sequelize.query('PRAGMA journal_mode = DELETE');
         });
     });

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -25,7 +25,7 @@ if (dialect === 'sqlite') {
     });
 
     storages.forEach(storage => {
-      describe('with storage "' + storage + '"', () => {
+      describe(`with storage "${storage}"`, () => {
         after(() => {
           if (storage === dbFile) {
             require('fs').writeFileSync(dbFile, '');

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -254,7 +254,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       }
     ].forEach(constraintTest => {
 
-      it('Can be intercepted as ' + constraintTest.type + ' using .catch', function() {
+      it(`Can be intercepted as ${constraintTest.type} using .catch`, function() {
         const spy = sinon.spy(),
           User = this.sequelize.define('user', {
             first_name: {

--- a/test/integration/hooks/bulkOperation.test.js
+++ b/test/integration/hooks/bulkOperation.test.js
@@ -117,13 +117,13 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         this.User.afterCreate(user => {
-          user.username = 'User' + user.id;
+          user.username = `User${user.id}`;
           return Promise.resolve();
         });
 
         return this.User.bulkCreate([{aNumber: 5}, {aNumber: 7}, {aNumber: 3}], { fields: ['aNumber'], individualHooks: true }).then(records => {
           records.forEach(record => {
-            expect(record.username).to.equal('User' + record.id);
+            expect(record.username).to.equal(`User${record.id}`);
             expect(record.beforeHookTest).to.be.true;
           });
           expect(beforeBulkCreate).to.be.true;
@@ -150,7 +150,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         this.User.afterCreate(user => {
-          user.username = 'User' + user.id;
+          user.username = `User${user.id}`;
           return Promise.resolve();
         });
 
@@ -246,7 +246,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         this.User.afterUpdate(user => {
-          user.username = 'User' + user.id;
+          user.username = `User${user.id}`;
         });
 
         return this.User.bulkCreate([
@@ -254,7 +254,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         ]).then(() => {
           return this.User.update({aNumber: 10}, {where: {aNumber: 1}, individualHooks: true}).then(([, records]) => {
             records.forEach(record => {
-              expect(record.username).to.equal('User' + record.id);
+              expect(record.username).to.equal(`User${record.id}`);
               expect(record.beforeHookTest).to.be.true;
             });
             expect(beforeBulk).to.have.been.calledOnce;
@@ -295,7 +295,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         });
 
         this.User.afterUpdate(user => {
-          user.username = 'User' + user.id;
+          user.username = `User${user.id}`;
         });
 
         return this.User.bulkCreate([{aNumber: 1}, {aNumber: 1}, {aNumber: 1}], { fields: ['aNumber'] }).then(() => {

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -511,7 +511,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               promise = promise.then(() => {
                 return model.create({}).then(instance => {
                   if (previousInstance) {
-                    return previousInstance['set'+ _.upperFirst(model.name)](instance).then(() => {
+                    return previousInstance[`set${_.upperFirst(model.name)}`](instance).then(() => {
                       previousInstance = instance;
                     });
                   } else {
@@ -610,7 +610,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               promise = promise.then(() => {
                 return model.create(values).then(instance => {
                   if (previousInstance) {
-                    return previousInstance['set'+ _.upperFirst(model.name)](instance).then(() => {
+                    return previousInstance[`set${_.upperFirst(model.name)}`](instance).then(() => {
                       previousInstance = instance;
                     });
                   } else {
@@ -1386,7 +1386,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
           ],
           limit: 3,
           order: [
-            [this.sequelize.col(this.models.Product.name + '.id'), 'ASC']
+            [this.sequelize.col(`${this.models.Product.name}.id`), 'ASC']
           ]
         }).then(products => {
           expect(products.length).to.equal(3);
@@ -1535,11 +1535,11 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         for (let i = 1; i <= memberCount; i++) {
           members.push({
             id: i,
-            email: 'email' + i + '@lmu.com',
-            password: 'testing' + i
+            email: `email${i}@lmu.com`,
+            password: `testing${i}`
           });
           albums.push({
-            title: 'Album' + i,
+            title: `Album${i}`,
             MemberId: i
           });
         }

--- a/test/integration/include/findOne.test.js
+++ b/test/integration/include/findOne.test.js
@@ -310,7 +310,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
               promise = promise.then(() => {
                 return model.create(values).then(instance => {
                   if (previousInstance) {
-                    return previousInstance['set'+ _.upperFirst(model.name)](instance).then(() => {
+                    return previousInstance[`set${_.upperFirst(model.name)}`](instance).then(() => {
                       previousInstance = instance;
                     });
                   } else {

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -380,7 +380,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
           return Promise.each(singles, model => {
             return model.create({}).then(instance => {
               if (previousInstance) {
-                return previousInstance['set'+ _.upperFirst(model.name)](instance).then(() => {
+                return previousInstance[`set${_.upperFirst(model.name)}`](instance).then(() => {
                   previousInstance = instance;
                 });
               }

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -63,7 +63,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('is done properly for special characters', function() {
       // Ideally we should test more: "\0\n\r\b\t\\\'\"\x1a"
       // But this causes sqlite to fail and exits the entire test suite immediately
-      const bio = dialect + "'\"\n"; // Need to add the dialect here so in case of failure I know what DB it failed for
+      const bio = `${dialect}'"\n`; // Need to add the dialect here so in case of failure I know what DB it failed for
 
       return this.User.create({ username: bio }).then(u1 => {
         return this.User.findByPk(u1.id).then(u2 => {
@@ -967,7 +967,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     describe('hooks', () => {
       it('should update attributes added in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: DataTypes.STRING
@@ -998,7 +998,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should update attributes changed in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: DataTypes.STRING
@@ -1030,7 +1030,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should validate attributes added in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: {
@@ -1063,7 +1063,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should validate attributes changed in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: {
@@ -1225,7 +1225,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should not throw ER_EMPTY_QUERY if changed only virtual fields', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           name: DataTypes.STRING,
           bio: {
             type: DataTypes.VIRTUAL,

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -380,7 +380,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   });
 
   it('correctly validates using custom validation methods', function() {
-    const User = this.sequelize.define('User' + config.rand(), {
+    const User = this.sequelize.define(`User${config.rand()}`, {
       name: {
         type: Sequelize.STRING,
         validate: {
@@ -407,7 +407,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   });
 
   it('supports promises with custom validation methods', function() {
-    const User = this.sequelize.define('User' + config.rand(), {
+    const User = this.sequelize.define(`User${config.rand()}`, {
       name: {
         type: Sequelize.STRING,
         validate: {
@@ -434,7 +434,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   });
 
   it('skips other validations if allowNull is true and the value is null', function() {
-    const User = this.sequelize.define('User' + config.rand(), {
+    const User = this.sequelize.define(`User${config.rand()}`, {
       age: {
         type: Sequelize.INTEGER,
         allowNull: true,
@@ -454,7 +454,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   });
 
   it('validates a model with custom model-wide validation methods', function() {
-    const Foo = this.sequelize.define('Foo' + config.rand(), {
+    const Foo = this.sequelize.define(`Foo${config.rand()}`, {
       field1: {
         type: Sequelize.INTEGER,
         allowNull: true
@@ -488,7 +488,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   });
 
   it('validates model with a validator whose arg is an Array successfully twice in a row', function() {
-    const Foo = this.sequelize.define('Foo' + config.rand(), {
+    const Foo = this.sequelize.define(`Foo${config.rand()}`, {
         bar: {
           type: Sequelize.STRING,
           validate: {
@@ -505,7 +505,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   it('validates enums', function() {
     const values = ['value1', 'value2'];
 
-    const Bar = this.sequelize.define('Bar' + config.rand(), {
+    const Bar = this.sequelize.define(`Bar${config.rand()}`, {
       field: {
         type: Sequelize.ENUM,
         values,
@@ -526,7 +526,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   it('skips validations for the given fields', function() {
     const values = ['value1', 'value2'];
 
-    const Bar = this.sequelize.define('Bar' + config.rand(), {
+    const Bar = this.sequelize.define(`Bar${config.rand()}`, {
       field: {
         type: Sequelize.ENUM,
         values,
@@ -544,7 +544,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   it('skips validations for fields with value that is SequelizeMethod', function() {
     const values = ['value1', 'value2'];
 
-    const Bar = this.sequelize.define('Bar' + config.rand(), {
+    const Bar = this.sequelize.define(`Bar${config.rand()}`, {
       field: {
         type: Sequelize.ENUM,
         values,

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -86,7 +86,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     }
 
     it('should update fields that are not specified on create', function() {
-      const User = this.sequelize.define('User' + config.rand(), {
+      const User = this.sequelize.define(`User${  config.rand()}`, {
         name: DataTypes.STRING,
         bio: DataTypes.TEXT,
         email: DataTypes.STRING
@@ -111,7 +111,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('should succeed in updating when values are unchanged (without timestamps)', function() {
-      const User = this.sequelize.define('User' + config.rand(), {
+      const User = this.sequelize.define(`User${  config.rand()}`, {
         name: DataTypes.STRING,
         bio: DataTypes.TEXT,
         email: DataTypes.STRING
@@ -140,7 +140,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('should update timestamps with milliseconds', function() {
-      const User = this.sequelize.define('User' + config.rand(), {
+      const User = this.sequelize.define(`User${  config.rand()}`, {
         name: DataTypes.STRING,
         bio: DataTypes.TEXT,
         email: DataTypes.STRING,
@@ -200,7 +200,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     describe('hooks', () => {
       it('should update attributes added in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${  config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: DataTypes.STRING
@@ -231,7 +231,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should update attributes changed in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${  config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: DataTypes.STRING
@@ -263,7 +263,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should validate attributes added in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${  config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: {
@@ -296,7 +296,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should validate attributes changed in hooks when default fields are used', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${  config.rand()}`, {
           name: DataTypes.STRING,
           bio: DataTypes.TEXT,
           email: {
@@ -331,7 +331,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('should not set attributes that are not specified by fields', function() {
-      const User = this.sequelize.define('User' + config.rand(), {
+      const User = this.sequelize.define(`User${  config.rand()}`, {
         name: DataTypes.STRING,
         bio: DataTypes.TEXT,
         email: DataTypes.STRING
@@ -385,7 +385,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('doesn\'t update primary keys or timestamps', function() {
-      const User = this.sequelize.define('User' + config.rand(), {
+      const User = this.sequelize.define(`User${  config.rand()}`, {
         name: DataTypes.STRING,
         bio: DataTypes.TEXT,
         identifier: {type: DataTypes.STRING, primaryKey: true}

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -508,7 +508,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         price: {
           type: Sequelize.INTEGER,
           get() {
-            return 'answer = ' + this.getDataValue('price');
+            return `answer = ${this.getDataValue('price')}`;
           },
           set(v) {
             return this.setDataValue('price', v + 42);
@@ -536,7 +536,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         },
         getterMethods: {
           price() {
-            return '$' + this.getDataValue('priceInCents') / 100;
+            return `$${this.getDataValue('priceInCents') / 100}`;
           },
 
           priceInCents() {
@@ -546,7 +546,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       expect(Product.build({price: 20}).priceInCents).to.equal(20 * 100);
-      expect(Product.build({priceInCents: 30 * 100}).price).to.equal('$' + 30);
+      expect(Product.build({priceInCents: 30 * 100}).price).to.equal(`$${30}`);
     });
 
     it('attaches getter and setter methods from options only if not defined in attribute', function() {
@@ -564,7 +564,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           price1(v) { this.setDataValue('price1', v * 100); }
         },
         getterMethods: {
-          price2() { return '$' + this.getDataValue('price2'); }
+          price2() { return `$${this.getDataValue('price2')}`;}
         }
       });
 
@@ -1430,7 +1430,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(users.length).to.equal(1);
         expect(users[0].username).to.equal('Bob');
 
-        return this.sequelize.query('SELECT * FROM ' + qi('ParanoidUsers') + ' WHERE ' + qi('deletedAt') + ' IS NOT NULL ORDER BY ' + qi('id'));
+        return this.sequelize.query(`SELECT * FROM ${qi('ParanoidUsers')} WHERE ${qi('deletedAt')} IS NOT NULL ORDER BY ${qi('id')}`);
       }).then(([users]) => {
         expect(users[0].username).to.equal('Peter');
         expect(users[1].username).to.equal('Paul');
@@ -2632,7 +2632,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('should not fail with an include', function() {
       return this.User.findAll({
-        where: this.sequelize.literal(this.sequelize.queryInterface.QueryGenerator.quoteIdentifiers('Projects.title') + ' = ' + this.sequelize.queryInterface.QueryGenerator.escape('republic')),
+        where: this.sequelize.literal(`${this.sequelize.queryInterface.QueryGenerator.quoteIdentifiers('Projects.title')} = ${this.sequelize.queryInterface.QueryGenerator.escape('republic')}`),
         include: [
           {model: this.Project}
         ]
@@ -2645,11 +2645,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     it('should not overwrite a specified deletedAt by setting paranoid: false', function() {
       let tableName = '';
       if (this.User.name) {
-        tableName = this.sequelize.queryInterface.QueryGenerator.quoteIdentifier(this.User.name) + '.';
+        tableName = `${this.sequelize.queryInterface.QueryGenerator.quoteIdentifier(this.User.name)}.`;
       }
       return this.User.findAll({
         paranoid: false,
-        where: this.sequelize.literal(tableName + this.sequelize.queryInterface.QueryGenerator.quoteIdentifier('deletedAt') + ' IS NOT NULL '),
+        where: this.sequelize.literal(`${tableName + this.sequelize.queryInterface.QueryGenerator.quoteIdentifier('deletedAt')} IS NOT NULL `),
         include: [
           {model: this.Project}
         ]
@@ -2826,7 +2826,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             if (val.includes('!')) {
               throw new Error('val should not include a "!"');
             }
-            this.setDataValue('username', val + '!');
+            this.setDataValue('username', `${val}!`);
           }
         }
       });

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -204,7 +204,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return Promise.map(_.range(50), i => {
             return User.findOrCreate({
               where: {
-                email: 'unique.email.'+i+'@sequelizejs.com',
+                email: `unique.email.${i}@sequelizejs.com`,
                 companyId: Math.floor(Math.random() * 5)
               }
             });
@@ -228,7 +228,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           return Promise.map(_.range(50), i => {
             return User.findOrCreate({
               where: {
-                email: 'unique.email.'+i+'@sequelizejs.com',
+                email: `unique.email.${i}@sequelizejs.com`,
                 companyId: 2
               }
             });
@@ -236,7 +236,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             return Promise.map(_.range(50), i => {
               return User.findOrCreate({
                 where: {
-                  email: 'unique.email.'+i+'@sequelizejs.com',
+                  email: `unique.email.${i}@sequelizejs.com`,
                   companyId: 2
                 }
               });
@@ -804,7 +804,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         intVal: this.sequelize.cast('1', type)
       }, {
         logging(sql) {
-          expect(sql).to.match(new RegExp("CAST\\(N?'1' AS " + type.toUpperCase() + '\\)'));
+          expect(sql).to.match(new RegExp(`CAST\\(N?'1' AS ${type.toUpperCase()}\\)`));
           match = true;
         }
       }).then(user => {
@@ -844,7 +844,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     it('is possible to just use .literal() to bypass escaping', function() {
       return this.User.create({
-        intVal: this.sequelize.literal('CAST(1-2 AS ' + (dialect === 'mysql' ? 'SIGNED' : 'INTEGER') + ')')
+        intVal: this.sequelize.literal(`CAST(1-2 AS ${dialect === 'mysql' ? 'SIGNED' : 'INTEGER'})`)
       }).then(user => {
         return this.User.findByPk(user.id).then(user => {
           expect(user.intVal).to.equal(-1);
@@ -911,10 +911,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                   if (number > 9) {
                     return number;
                   }
-                  return '0' + number;
+                  return `0${number}`;
                 };
 
-              expect(user.year).to.equal(now.getUTCFullYear() + '-' + pad(now.getUTCMonth() + 1) + '-' + pad(now.getUTCDate()));
+              expect(user.year).to.equal(`${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}`);
             });
           });
         });
@@ -1007,7 +1007,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         return User.sync({force: true}).then(() => {
           const tableName = User.getTableName();
-          return this.sequelize.query('CREATE UNIQUE INDEX lower_case_username ON "' + tableName + '" ((lower(username)))');
+          return this.sequelize.query(`CREATE UNIQUE INDEX lower_case_username ON "${tableName}" ((lower(username)))`);
         }).then(() => {
           return User.create({username: 'foo'});
         }).then(() => {
@@ -1185,7 +1185,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         books = [];
 
       dataTypes.forEach((dataType, index) => {
-        books[index] = this.sequelize.define('Book' + index, {
+        books[index] = this.sequelize.define(`Book${index}`, {
           id: { type: dataType, primaryKey: true, autoIncrement: true },
           title: Sequelize.TEXT
         });

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1393,7 +1393,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should allow us to find IDs using capital letters', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           ID: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
           Login: { type: Sequelize.STRING }
         });

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -25,7 +25,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         if (current.dialect.name !== 'mssql') {
           it('should work with order: literal()', function() {
             return this.User.findAll({
-              order: this.sequelize.literal('email = ' + this.sequelize.escape('test@sequelizejs.com'))
+              order: this.sequelize.literal(`email = ${this.sequelize.escape('test@sequelizejs.com')}`)
             }).then(users => {
               expect(users.length).to.equal(1);
               users.forEach(user => {
@@ -36,7 +36,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
           it('should work with order: [literal()]', function() {
             return this.User.findAll({
-              order: [this.sequelize.literal('email = ' + this.sequelize.escape('test@sequelizejs.com'))]
+              order: [this.sequelize.literal(`email = ${this.sequelize.escape('test@sequelizejs.com')}`)]
             }).then(users => {
               expect(users.length).to.equal(1);
               users.forEach(user => {
@@ -48,7 +48,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           it('should work with order: [[literal()]]', function() {
             return this.User.findAll({
               order: [
-                [this.sequelize.literal('email = ' + this.sequelize.escape('test@sequelizejs.com'))]
+                [this.sequelize.literal(`email = ${this.sequelize.escape('test@sequelizejs.com')}`)]
               ]
             }).then(users => {
               expect(users.length).to.equal(1);

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -132,7 +132,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('returns a single dao given a string id', function() {
-        return this.User.findByPk(`${this.user.id}`).then(user => {
+        return this.User.findByPk(this.user.id.toString()).then(user => {
           expect(Array.isArray(user)).to.not.be.ok;
           expect(user.id).to.equal(this.user.id);
           expect(user.id).to.equal(1);

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -132,7 +132,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('returns a single dao given a string id', function() {
-        return this.User.findByPk(this.user.id + '').then(user => {
+        return this.User.findByPk(`${this.user.id}`).then(user => {
           expect(Array.isArray(user)).to.not.be.ok;
           expect(user.id).to.equal(this.user.id);
           expect(user.id).to.equal(1);
@@ -266,7 +266,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('should allow us to find IDs using capital letters', function() {
-        const User = this.sequelize.define('User' + config.rand(), {
+        const User = this.sequelize.define(`User${config.rand()}`, {
           ID: { type: Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
           Login: { type: Sequelize.STRING }
         });

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -385,7 +385,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         } else if (dialect === 'mysql' || dialect === 'mssql') {
           expect(keys).to.have.length(12);
         } else {
-          console.log('This test doesn\'t support ' + dialect);
+          console.log(`This test doesn't support ${dialect}`);
         }
         return fks;
       }).then(fks => {

--- a/test/integration/sequelize/deferrable.test.js
+++ b/test/integration/sequelize/deferrable.test.js
@@ -17,9 +17,9 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       this.run = function(deferrable, options) {
         options = options || {};
 
-        const taskTableName      = options.taskTableName || 'tasks_' + config.rand();
+        const taskTableName      = options.taskTableName || `tasks_${config.rand()}`;
         const transactionOptions = Object.assign({}, { deferrable: Sequelize.Deferrable.SET_DEFERRED }, options);
-        const userTableName      = 'users_' + config.rand();
+        const userTableName      = `users_${config.rand()}`;
 
         const User = this.sequelize.define(
           'User', { name: Sequelize.STRING }, { tableName: userTableName }
@@ -83,11 +83,11 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       it('allows the violation of the foreign key constraint if the transaction deferres only the foreign key constraint', function() {
-        const taskTableName = 'tasks_' + config.rand();
+        const taskTableName = `tasks_${config.rand()}`;
 
         return this
           .run(Sequelize.Deferrable.INITIALLY_IMMEDIATE, {
-            deferrable: Sequelize.Deferrable.SET_DEFERRED([taskTableName + '_user_id_fkey']),
+            deferrable: Sequelize.Deferrable.SET_DEFERRED([`${taskTableName}_user_id_fkey`]),
             taskTableName
           })
           .then(task => {

--- a/test/integration/support.js
+++ b/test/integration/support.js
@@ -11,7 +11,7 @@ afterEach(function() {
   try {
     this.sequelize.test.verifyNoRunningQueries();
   } catch (err) {
-    err.message += ' in '+this.currentTest.fullTitle();
+    err.message += ` in ${this.currentTest.fullTitle()}`;
     throw err;
   }
 });

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -28,7 +28,7 @@ if (dialect !== 'sqlite') {
         now = 'GETDATE()';
       }
 
-      const query = 'SELECT ' + now + ' as now';
+      const query = `SELECT ${now} as now`;
       return Promise.all([
         this.sequelize.query(query, { type: this.sequelize.QueryTypes.SELECT }),
         this.sequelizeWithTimezone.query(query, { type: this.sequelize.QueryTypes.SELECT })

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -417,7 +417,7 @@ if (current.dialect.supports.transactions) {
         });
 
         Object.keys(Transaction.TYPES).forEach(key => {
-          it('should allow specification of ' + key + ' type', function() {
+          it(`should allow specification of ${key} type`, function() {
             return this.sequelize.transaction({
               type: key
             }).then(t => {
@@ -461,7 +461,7 @@ if (current.dialect.supports.transactions) {
               return sequelize.transaction({type: Support.Sequelize.Transaction.TYPES.EXCLUSIVE, retry: {match: ['NO_MATCH']}}).then(t => {
               // introduce delay to force the busy state race condition to fail
                 return Promise.delay(1000).then(() => {
-                  return User.create({id: null, username: 'test ' + t.id}, {transaction: t}).then(() => {
+                  return User.create({id: null, username: `test ${t.id}`}, {transaction: t}).then(() => {
                     return t.commit();
                   });
                 });

--- a/test/support.js
+++ b/test/support.js
@@ -142,7 +142,7 @@ const Support = {
   },
 
   getSupportedDialects() {
-    return fs.readdirSync(__dirname + '/../lib/dialects')
+    return fs.readdirSync(`${__dirname}/../lib/dialects`)
       .filter(file => !file.includes('.js') && !file.includes('abstract'));
   },
 
@@ -150,7 +150,7 @@ const Support = {
     if (expectations[dialect]) {
       expect(value).to.match(expectations[dialect]);
     } else {
-      throw new Error('Undefined expectation for "' + dialect + '"!');
+      throw new Error(`Undefined expectation for "${dialect}"!`);
     }
   },
 
@@ -177,7 +177,7 @@ const Support = {
     }
 
     if (!this.getSupportedDialects().includes(envDialect)) {
-      throw new Error('The dialect you have passed is unknown. Did you really mean: ' + envDialect);
+      throw new Error(`The dialect you have passed is unknown. Did you really mean: ${envDialect}`);
     }
 
     return envDialect;
@@ -190,7 +190,7 @@ const Support = {
       dialect = 'postgres-native';
     }
 
-    return '[' + dialect.toUpperCase() + '] ' + moduleName;
+    return `[${dialect.toUpperCase()}] ${moduleName}`;
   },
 
   getTestUrl(config) {
@@ -198,16 +198,16 @@ const Support = {
     const dbConfig = config[config.dialect];
 
     if (config.dialect === 'sqlite') {
-      url = 'sqlite://' + dbConfig.storage;
+      url = `sqlite://${dbConfig.storage}`;
     } else {
 
       let credentials = dbConfig.username;
       if (dbConfig.password) {
-        credentials += ':' + dbConfig.password;
+        credentials += `:${dbConfig.password}`;
       }
 
-      url = config.dialect + '://' + credentials
-      + '@' + dbConfig.host + ':' + dbConfig.port + '/' + dbConfig.database;
+      url = `${config.dialect}://${credentials
+      }@${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`;
     }
     return url;
   },
@@ -225,7 +225,7 @@ const Support = {
             .replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT);
         }
       } else {
-        throw new Error('Undefined expectation for "' + Support.sequelize.dialect.name + '"!');
+        throw new Error(`Undefined expectation for "${Support.sequelize.dialect.name}"!`);
       }
     }
 

--- a/test/supportShim.js
+++ b/test/supportShim.js
@@ -17,7 +17,7 @@ module.exports = function(Sequelize) {
   shimAll(QueryInterface.prototype, 'QueryInterface#');
   shimAll(Sequelize.Association.prototype, 'Association#');
   _.forIn(Sequelize.Association, (Association, name) => {
-    shimAll(Association.prototype, 'Association.' + name + '#');
+    shimAll(Association.prototype, `Association.${name}#`);
   });
 
   // Shim Model static methods to then shim getter/setter methods
@@ -28,7 +28,7 @@ module.exports = function(Sequelize) {
           association = original.apply(this, arguments);
 
         _.forIn(association.accessors, (accessor, accessorName) => {
-          shim(model.prototype, accessor, model.prototype[accessor].length, null, 'Model#' + accessorName);
+          shim(model.prototype, accessor, model.prototype[accessor].length, null, `Model#${accessorName}`);
         });
 
         return association;
@@ -164,7 +164,7 @@ module.exports = function(Sequelize) {
 
           if (!(result instanceof Sequelize.Promise)) {
             result = Sequelize.Promise.resolve(result);
-            err = new Error('Promise returned by ' + debugName + ' is not instance of Sequelize.Promise');
+            err = new Error(`Promise returned by ${debugName} is not instance of Sequelize.Promise`);
           }
 
           result = result.finally(() => {
@@ -219,7 +219,7 @@ module.exports = function(Sequelize) {
       const logger = originalLogging !== undefined ? originalLogging : sequelize.options.logging;
       if (logger) {
         if ((sequelize.options.benchmark || options.benchmark) && logger === console.log) {
-          return logger.call(this, arguments[0] + ' Elapsed time: ' + arguments[1] + 'ms');
+          return logger.call(this, `${arguments[0]} Elapsed time: ${arguments[1]}ms`);
         } else {
           return logger.apply(this, arguments);
         }
@@ -253,7 +253,7 @@ module.exports = function(Sequelize) {
    * @throws {Error} - Throws if `options.logging` is not a shimmed logging function
    */
   function testLogger(options, name) {
-    if (!options || !options.logging || !options.logging.__testLoggingFn) throw new Error('options.logging has been lost in method ' + name);
+    if (!options || !options.logging || !options.logging.__testLoggingFn) throw new Error(`options.logging has been lost in method ${name}`);
   }
 
   /**
@@ -263,7 +263,7 @@ module.exports = function(Sequelize) {
    * @returns {boolean} - true if this method called from within the tests
    */
   const pathRegStr = _.escapeRegExp(''),
-    regExp = new RegExp('^\\s+at\\s+(' + pathRegStr + '|.+ \\(' + pathRegStr + ')');
+    regExp = new RegExp(`^\\s+at\\s+(${pathRegStr}|.+ \\(${pathRegStr})`);
 
   function calledFromTests() {
     return !!(new Error()).stack.split(/[\r\n]+/)[3].match(regExp);
@@ -300,8 +300,8 @@ function forOwn(obj, fn) {
 function getFunctionCode(fn) {
   let code = fn.toString();
   if (code.match(/^function[\s\*\(]/) || code.match(/^class[\s\{]/)) return code;
-  if (code.match(/^(import|delete)[\s\*\(]/)) code = '_' + code.substr(1);
-  return 'function ' + code;
+  if (code.match(/^(import|delete)[\s\*\(]/)) code = `_${code.substr(1)}`;
+  return `function ${code}`;
 }
 
 /**
@@ -339,7 +339,7 @@ function getArgumentsConformFn(method, args, hints, tree) {
     body = getFunctionCode(method).slice(start, hints.end.start);
 
   // create function that conforms arguments
-  return new Function(args, body + ';return [' + args + '];');
+  return new Function(args, `${body};return [${args}];`);
 }
 
 /**
@@ -361,7 +361,7 @@ function cloneOptions(options) {
  * @throws {Error} - Throws if options and original are not identical
  */
 function checkOptions(options, original, name) {
-  if (!optionsEqual(options, original)) throw new Error('options modified in ' + name + ', input: ' + util.inspect(original) + ' output: ' + util.inspect(options));
+  if (!optionsEqual(options, original)) throw new Error(`options modified in ${name}, input: ${util.inspect(original)} output: ${util.inspect(options)}`);
 }
 
 /**

--- a/test/unit/dialect-module-configuration.test.js
+++ b/test/unit/dialect-module-configuration.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai'),
   expect = chai.expect,
   path = require('path'),
-  Support = require(__dirname + '/support'),
+  Support = require(`${__dirname}/support`),
   Sequelize = Support.Sequelize,
   dialect = Support.getTestDialect();
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -716,7 +716,7 @@ if (dialect === 'mysql') {
 
         tests.forEach(test => {
           const query = test.expectation.query || test.expectation;
-          const title = test.title || 'MySQL correctly returns ' + query + ' for ' + JSON.stringify(test.arguments);
+          const title = test.title || `MySQL correctly returns ${query} for ${JSON.stringify(test.arguments)}`;
           it(title, function() {
             if (test.needsSequelize) {
               if (_.isFunction(test.arguments[1])) test.arguments[1] = test.arguments[1](this.sequelize);

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -1145,19 +1145,19 @@ if (dialect.startsWith('postgres')) {
       createTrigger: [
         {
           arguments: ['myTable', 'myTrigger', 'after', ['insert'],  'myFunction', [], []],
-          expectation: 'CREATE TRIGGER myTrigger\n\tAFTER INSERT\n\tON myTable\n\t\n\tEXECUTE PROCEDURE myFunction();'
+          expectation: 'CREATE TRIGGER myTrigger AFTER INSERT ON myTable EXECUTE PROCEDURE myFunction();'
         },
         {
           arguments: ['myTable', 'myTrigger', 'before', ['insert', 'update'],  'myFunction', [{name: 'bar', type: 'INTEGER'}], []],
-          expectation: 'CREATE TRIGGER myTrigger\n\tBEFORE INSERT OR UPDATE\n\tON myTable\n\t\n\tEXECUTE PROCEDURE myFunction(bar INTEGER);'
+          expectation: 'CREATE TRIGGER myTrigger BEFORE INSERT OR UPDATE ON myTable EXECUTE PROCEDURE myFunction(bar INTEGER);'
         },
         {
           arguments: ['myTable', 'myTrigger', 'instead_of', ['insert', 'update'],  'myFunction', [], ['FOR EACH ROW']],
-          expectation: 'CREATE TRIGGER myTrigger\n\tINSTEAD OF INSERT OR UPDATE\n\tON myTable\n\t\n\tFOR EACH ROW\n\tEXECUTE PROCEDURE myFunction();'
+          expectation: 'CREATE TRIGGER myTrigger INSTEAD OF INSERT OR UPDATE ON myTable FOR EACH ROW EXECUTE PROCEDURE myFunction();'
         },
         {
           arguments: ['myTable', 'myTrigger', 'after_constraint', ['insert', 'update'],  'myFunction', [{name: 'bar', type: 'INTEGER'}], ['FOR EACH ROW']],
-          expectation: 'CREATE CONSTRAINT TRIGGER myTrigger\n\tAFTER INSERT OR UPDATE\n\tON myTable\n\t\n\tFOR EACH ROW\n\tEXECUTE PROCEDURE myFunction(bar INTEGER);'
+          expectation: 'CREATE CONSTRAINT TRIGGER myTrigger AFTER INSERT OR UPDATE ON myTable FOR EACH ROW EXECUTE PROCEDURE myFunction(bar INTEGER);'
         }
       ],
       getForeignKeyReferenceQuery: [

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -1218,7 +1218,7 @@ if (dialect.startsWith('postgres')) {
 
         tests.forEach(test => {
           const query = test.expectation.query || test.expectation;
-          const title = test.title || 'Postgres correctly returns ' + query + ' for ' + JSON.stringify(test.arguments);
+          const title = test.title || `Postgres correctly returns ${query} for ${JSON.stringify(test.arguments)}`;
           it(title, function() {
             if (test.needsSequelize) {
               if (_.isFunction(test.arguments[1])) test.arguments[1] = test.arguments[1](this.sequelize);

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -634,7 +634,7 @@ if (dialect === 'sqlite') {
 
         tests.forEach(test => {
           const query = test.expectation.query || test.expectation;
-          const title = test.title || 'SQLite correctly returns ' + query + ' for ' + JSON.stringify(test.arguments);
+          const title = test.title || `SQLite correctly returns ${query} for ${JSON.stringify(test.arguments)}`;
           it(title, function() {
             if (test.needsSequelize) {
               if (_.isFunction(test.arguments[1])) test.arguments[1] = test.arguments[1](this.sequelize);

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -22,8 +22,8 @@ describe('errors', () => {
       }
       expect(err).to.exist;
       const stackParts = err.stack.split('\n');
-      const fullErrorName = 'Sequelize' + errorName;
-      expect(stackParts[0]).to.equal(fullErrorName + ': this is a message');
+      const fullErrorName = `Sequelize${errorName}`;
+      expect(stackParts[0]).to.equal(`${fullErrorName}: this is a message`);
       expect(stackParts[1]).to.match(/^    at throwError \(.*errors.test.js:\d+:\d+\)$/);
     });
   });
@@ -47,7 +47,7 @@ describe('errors', () => {
       expect(err).to.exist;
       const stackParts = err.stack.split('\n');
 
-      const fullErrorName = 'Sequelize' + errorName;
+      const fullErrorName = `Sequelize${errorName}`;
       expect(stackParts[0]).to.equal(fullErrorName);
       expect(stackParts[1]).to.match(/^    at throwError \(.*errors.test.js:\d+:\d+\)$/);
     });

--- a/test/unit/model/schema.test.js
+++ b/test/unit/model/schema.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support   = require('../support'),
   current   = Support.sequelize;
 
-describe(Support.getTestDialectTeaser('Model') + 'Schemas', () => {
+describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
   if (current.dialect.supports.schemas) {
     const Project = current.define('project'),
       Company = current.define('company', {}, {

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -15,7 +15,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   const scopes = {
     complexFunction(value) {
       return {
-        where: [value + ' IN (SELECT foobar FROM some_sql_function(foo.bar))']
+        where: [`${value} IN (SELECT foobar FROM some_sql_function(foo.bar))`]
       };
     },
     somethingTrue: {

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -182,14 +182,14 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
 
     const applyFailTest = function applyFailTest(validatorDetails, i, validator) {
         const failingValue = validatorDetails.fail[i];
-        it('correctly specifies an instance as invalid using a value of "' + failingValue + '" for the validation "' + validator + '"', function() {
+        it(`correctly specifies an instance as invalid using a value of "${failingValue}" for the validation "${validator}"`, function() {
           const validations = {},
-            message = validator + '(' + failingValue + ')';
+            message = `${validator}(${failingValue})`;
 
           validations[validator] = validatorDetails.spec || {};
           validations[validator].msg = message;
 
-          const UserFail = this.sequelize.define('User' + config.rand(), {
+          const UserFail = this.sequelize.define(`User${config.rand()}`, {
             name: {
               type: Sequelize.STRING,
               validate: validations
@@ -206,9 +206,9 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       },
       applyPassTest = function applyPassTest(validatorDetails, j, validator, type) {
         const succeedingValue = validatorDetails.pass[j];
-        it('correctly specifies an instance as valid using a value of "' + succeedingValue + '" for the validation "' + validator + '"', function() {
+        it(`correctly specifies an instance as valid using a value of "${succeedingValue}" for the validation "${validator}"`, function() {
           const validations = {},
-            message = validator + '(' + succeedingValue + ')';
+            message = `${validator}(${succeedingValue})`;
 
           validations[validator] = validatorDetails.spec || {};
 
@@ -221,7 +221,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
             validations[validator] = true;
           }
 
-          const UserSuccess = this.sequelize.define('User' + config.rand(), {
+          const UserSuccess = this.sequelize.define(`User${config.rand()}`, {
             name: {
               type: Sequelize.STRING,
               validate: validations

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -13,15 +13,15 @@ const Support = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
-suite(Support.getTestDialectTeaser('SQL'), () => {
-  suite('DataTypes', () => {
+describe(Support.getTestDialectTeaser('SQL'), () => {
+  describe('DataTypes', () => {
     const testsql = function(description, dataType, expectation) {
-      test(description, () => {
+      it(description, () => {
         return expectsql(current.normalizeDataType(dataType).toSql(), expectation);
       });
     };
 
-    suite('STRING', () => {
+    describe('STRING', () => {
       testsql('STRING', DataTypes.STRING, {
         default: 'VARCHAR(255)',
         mssql: 'NVARCHAR(255)'
@@ -51,8 +51,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         postgres: 'BYTEA'
       });
 
-      suite('validate', () => {
-        test('should return `true` if `value` is a string', () => {
+      describe('validate', () => {
+        it('should return `true` if `value` is a string', () => {
           const type = DataTypes.STRING();
 
           expect(type.validate('foobar')).to.equal(true);
@@ -62,7 +62,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('TEXT', () => {
+    describe('TEXT', () => {
       testsql('TEXT', DataTypes.TEXT, {
         default: 'TEXT',
         mssql: 'NVARCHAR(MAX)' // in mssql text is actually representing a non unicode text field
@@ -92,8 +92,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         mysql: 'LONGTEXT'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.TEXT();
 
           expect(() => {
@@ -101,7 +101,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '12345 is not a valid string');
         });
 
-        test('should return `true` if `value` is a string', () => {
+        it('should return `true` if `value` is a string', () => {
           const type = DataTypes.TEXT();
 
           expect(type.validate('foobar')).to.equal(true);
@@ -109,7 +109,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('CHAR', () => {
+    describe('CHAR', () => {
       testsql('CHAR', DataTypes.CHAR, {
         default: 'CHAR(255)'
       });
@@ -135,7 +135,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('BOOLEAN', () => {
+    describe('BOOLEAN', () => {
       testsql('BOOLEAN', DataTypes.BOOLEAN, {
         postgres: 'BOOLEAN',
         mssql: 'BIT',
@@ -143,8 +143,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         sqlite: 'TINYINT(1)'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.BOOLEAN();
 
           expect(() => {
@@ -152,7 +152,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '12345 is not a valid boolean');
         });
 
-        test('should return `true` if `value` is a boolean', () => {
+        it('should return `true` if `value` is a boolean', () => {
           const type = DataTypes.BOOLEAN();
 
           expect(type.validate(true)).to.equal(true);
@@ -165,7 +165,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('DATE', () => {
+    describe('DATE', () => {
       testsql('DATE', DataTypes.DATE, {
         postgres: 'TIMESTAMP WITH TIME ZONE',
         mssql: 'DATETIMEOFFSET',
@@ -180,8 +180,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         sqlite: 'DATETIME'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.DATE();
 
           expect(() => {
@@ -189,7 +189,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid date');
         });
 
-        test('should return `true` if `value` is a date', () => {
+        it('should return `true` if `value` is a date', () => {
           const type = DataTypes.DATE();
 
           expect(type.validate(new Date())).to.equal(true);
@@ -198,9 +198,9 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
 
     if (current.dialect.supports.HSTORE) {
-      suite('HSTORE', () => {
-        suite('validate', () => {
-          test('should throw an error if `value` is invalid', () => {
+      describe('HSTORE', () => {
+        describe('validate', () => {
+          it('should throw an error if `value` is invalid', () => {
             const type = DataTypes.HSTORE();
 
             expect(() => {
@@ -208,7 +208,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid hstore');
           });
 
-          test('should return `true` if `value` is an hstore', () => {
+          it('should return `true` if `value` is an hstore', () => {
             const type = DataTypes.HSTORE();
 
             expect(type.validate({ foo: 'bar' })).to.equal(true);
@@ -217,7 +217,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     }
 
-    suite('UUID', () => {
+    describe('UUID', () => {
       testsql('UUID', DataTypes.UUID, {
         postgres: 'UUID',
         mssql: 'CHAR(36)',
@@ -225,8 +225,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         sqlite: 'UUID'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.UUID();
 
           expect(() => {
@@ -238,13 +238,13 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '["foobar"] is not a valid uuid');
         });
 
-        test('should return `true` if `value` is an uuid', () => {
+        it('should return `true` if `value` is an uuid', () => {
           const type = DataTypes.UUID();
 
           expect(type.validate(uuid.v4())).to.equal(true);
         });
 
-        test('should return `true` if `value` is a string and we accept strings', () => {
+        it('should return `true` if `value` is a string and we accept strings', () => {
           const type = DataTypes.UUID();
 
           expect(type.validate('foobar', { acceptStrings: true })).to.equal(true);
@@ -252,13 +252,13 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('UUIDV1', () => {
+    describe('UUIDV1', () => {
       testsql('UUIDV1', DataTypes.UUIDV1, {
         default: 'UUIDV1'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.UUIDV1();
 
           expect(() => {
@@ -270,13 +270,13 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '["foobar"] is not a valid uuid');
         });
 
-        test('should return `true` if `value` is an uuid', () => {
+        it('should return `true` if `value` is an uuid', () => {
           const type = DataTypes.UUIDV1();
 
           expect(type.validate(uuid.v1())).to.equal(true);
         });
 
-        test('should return `true` if `value` is a string and we accept strings', () => {
+        it('should return `true` if `value` is a string and we accept strings', () => {
           const type = DataTypes.UUIDV1();
 
           expect(type.validate('foobar', { acceptStrings: true })).to.equal(true);
@@ -284,13 +284,13 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('UUIDV4', () => {
+    describe('UUIDV4', () => {
       testsql('UUIDV4', DataTypes.UUIDV4, {
         default: 'UUIDV4'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.UUIDV4();
           const value = uuid.v1();
 
@@ -303,13 +303,13 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '["foobar"] is not a valid uuidv4');
         });
 
-        test('should return `true` if `value` is an uuid', () => {
+        it('should return `true` if `value` is an uuid', () => {
           const type = DataTypes.UUIDV4();
 
           expect(type.validate(uuid.v4())).to.equal(true);
         });
 
-        test('should return `true` if `value` is a string and we accept strings', () => {
+        it('should return `true` if `value` is a string and we accept strings', () => {
           const type = DataTypes.UUIDV4();
 
           expect(type.validate('foobar', { acceptStrings: true })).to.equal(true);
@@ -317,14 +317,14 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('NOW', () => {
+    describe('NOW', () => {
       testsql('NOW', DataTypes.NOW, {
         default: 'NOW',
         mssql: 'GETDATE()'
       });
     });
 
-    suite('INTEGER', () => {
+    describe('INTEGER', () => {
       testsql('INTEGER', DataTypes.INTEGER, {
         default: 'INTEGER'
       });
@@ -383,8 +383,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         mssql: 'INTEGER'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.INTEGER();
 
           expect(() => {
@@ -400,7 +400,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '123.45 is not a valid integer');
         });
 
-        test('should return `true` if `value` is a valid integer', () => {
+        it('should return `true` if `value` is a valid integer', () => {
           const type = DataTypes.INTEGER();
 
           expect(type.validate('12345')).to.equal(true);
@@ -409,7 +409,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('TINYINT', () => {
+    describe('TINYINT', () => {
       const cases = [
         {
           title: 'TINYINT',
@@ -521,8 +521,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         testsql(row.title, row.dataType, row.expect);
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.TINYINT();
 
           expect(() => {
@@ -534,7 +534,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '123.45 is not a valid tinyint');
         });
 
-        test('should return `true` if `value` is an integer', () => {
+        it('should return `true` if `value` is an integer', () => {
           const type = DataTypes.TINYINT();
 
           expect(type.validate(-128)).to.equal(true);
@@ -543,7 +543,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('SMALLINT', () => {
+    describe('SMALLINT', () => {
       const cases = [
         {
           title: 'SMALLINT',
@@ -655,8 +655,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         testsql(row.title, row.dataType, row.expect);
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.SMALLINT();
 
           expect(() => {
@@ -668,7 +668,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '123.45 is not a valid smallint');
         });
 
-        test('should return `true` if `value` is an integer', () => {
+        it('should return `true` if `value` is an integer', () => {
           const type = DataTypes.SMALLINT();
 
           expect(type.validate(-32768)).to.equal(true);
@@ -677,7 +677,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('MEDIUMINT', () => {
+    describe('MEDIUMINT', () => {
       const cases = [
         {
           title: 'MEDIUMINT',
@@ -769,8 +769,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         testsql(row.title, row.dataType, row.expect);
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.MEDIUMINT();
 
           expect(() => {
@@ -782,7 +782,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '123.45 is not a valid mediumint');
         });
 
-        test('should return `true` if `value` is an integer', () => {
+        it('should return `true` if `value` is an integer', () => {
           const type = DataTypes.MEDIUMINT();
 
           expect(type.validate(-8388608)).to.equal(true);
@@ -791,7 +791,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('BIGINT', () => {
+    describe('BIGINT', () => {
       testsql('BIGINT', DataTypes.BIGINT, {
         default: 'BIGINT'
       });
@@ -850,8 +850,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         mssql: 'BIGINT'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.BIGINT();
 
           expect(() => {
@@ -863,7 +863,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '123.45 is not a valid bigint');
         });
 
-        test('should return `true` if `value` is an integer', () => {
+        it('should return `true` if `value` is an integer', () => {
           const type = DataTypes.BIGINT();
 
           expect(type.validate('9223372036854775807')).to.equal(true);
@@ -871,7 +871,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('REAL', () => {
+    describe('REAL', () => {
       testsql('REAL', DataTypes.REAL, {
         default: 'REAL'
       });
@@ -964,7 +964,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('DOUBLE PRECISION', () => {
+    describe('DOUBLE PRECISION', () => {
       testsql('DOUBLE', DataTypes.DOUBLE, {
         default: 'DOUBLE PRECISION'
       });
@@ -1039,7 +1039,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('FLOAT', () => {
+    describe('FLOAT', () => {
       testsql('FLOAT', DataTypes.FLOAT, {
         default: 'FLOAT',
         postgres: 'FLOAT'
@@ -1133,8 +1133,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         mssql: 'FLOAT'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.FLOAT();
 
           expect(() => {
@@ -1142,7 +1142,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid float');
         });
 
-        test('should return `true` if `value` is a float', () => {
+        it('should return `true` if `value` is a float', () => {
           const type = DataTypes.FLOAT();
 
           expect(type.validate(1.2)).to.equal(true);
@@ -1164,7 +1164,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     }
 
-    suite('DECIMAL', () => {
+    describe('DECIMAL', () => {
       testsql('DECIMAL', DataTypes.DECIMAL, {
         default: 'DECIMAL'
       });
@@ -1200,8 +1200,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         default: 'DECIMAL(10,2)'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.DECIMAL(10);
 
           expect(() => {
@@ -1217,7 +1217,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, 'null is not a valid decimal');
         });
 
-        test('should return `true` if `value` is a decimal', () => {
+        it('should return `true` if `value` is a decimal', () => {
           const type = DataTypes.DECIMAL(10);
 
           expect(type.validate(123)).to.equal(true);
@@ -1232,14 +1232,14 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('ENUM', () => {
+    describe('ENUM', () => {
       // TODO: Fix Enums and add more tests
       // testsql('ENUM("value 1", "value 2")', DataTypes.ENUM('value 1', 'value 2'), {
       //   default: 'ENUM'
       // });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.ENUM('foo');
 
           expect(() => {
@@ -1247,7 +1247,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid choice in ["foo"]');
         });
 
-        test('should return `true` if `value` is a valid choice', () => {
+        it('should return `true` if `value` is a valid choice', () => {
           const type = DataTypes.ENUM('foobar', 'foobiz');
 
           expect(type.validate('foobar')).to.equal(true);
@@ -1256,7 +1256,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('BLOB', () => {
+    describe('BLOB', () => {
       testsql('BLOB', DataTypes.BLOB, {
         default: 'BLOB',
         mssql: 'VARBINARY(MAX)',
@@ -1287,8 +1287,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         postgres: 'BYTEA'
       });
 
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.BLOB();
 
           expect(() => {
@@ -1296,7 +1296,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '12345 is not a valid blob');
         });
 
-        test('should return `true` if `value` is a blob', () => {
+        it('should return `true` if `value` is a blob', () => {
           const type = DataTypes.BLOB();
 
           expect(type.validate('foobar')).to.equal(true);
@@ -1305,9 +1305,9 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('RANGE', () => {
-      suite('validate', () => {
-        test('should throw an error if `value` is invalid', () => {
+    describe('RANGE', () => {
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
           const type = DataTypes.RANGE();
 
           expect(() => {
@@ -1315,7 +1315,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid range');
         });
 
-        test('should throw an error if `value` is not an array with two elements', () => {
+        it('should throw an error if `value` is not an array with two elements', () => {
           const type = DataTypes.RANGE();
 
           expect(() => {
@@ -1323,7 +1323,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           }).to.throw(Sequelize.ValidationError, 'A range must be an array with two elements');
         });
 
-        test('should return `true` if `value` is a range', () => {
+        it('should return `true` if `value` is a range', () => {
           const type = DataTypes.RANGE();
 
           expect(type.validate([1, 2])).to.equal(true);
@@ -1332,7 +1332,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
 
     if (current.dialect.supports.ARRAY) {
-      suite('ARRAY', () => {
+      describe('ARRAY', () => {
         testsql('ARRAY(VARCHAR)', DataTypes.ARRAY(DataTypes.STRING), {
           postgres: 'VARCHAR(255)[]'
         });
@@ -1403,8 +1403,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         }
 
-        suite('validate', () => {
-          test('should throw an error if `value` is invalid', () => {
+        describe('validate', () => {
+          it('should throw an error if `value` is invalid', () => {
             const type = DataTypes.ARRAY();
 
             expect(() => {
@@ -1412,7 +1412,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             }).to.throw(Sequelize.ValidationError, '"foobar" is not a valid array');
           });
 
-          test('should return `true` if `value` is an array', () => {
+          it('should return `true` if `value` is an array', () => {
             const type = DataTypes.ARRAY();
 
             expect(type.validate(['foo', 'bar'])).to.equal(true);
@@ -1422,7 +1422,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.supports.GEOMETRY) {
-      suite('GEOMETRY', () => {
+      describe('GEOMETRY', () => {
         testsql('GEOMETRY', DataTypes.GEOMETRY, {
           default: 'GEOMETRY'
         });

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -11,14 +11,14 @@ const Support   = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
-suite(Support.getTestDialectTeaser('SQL'), () => {
-  suite('delete', () => {
+describe(Support.getTestDialectTeaser('SQL'), () => {
+  describe('delete', () => {
     const User = current.define('test_user', {}, {
       timestamps: false,
       schema: 'public'
     });
 
-    suite('truncate #4306', () => {
+    describe('truncate #4306', () => {
       const options = {
         table: User.getTableName(),
         where: {},
@@ -28,7 +28,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         type: QueryTypes.BULKDELETE
       };
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         return expectsql(
           sql.truncateTableQuery(
             options.table,
@@ -43,7 +43,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('truncate with cascade and restartIdentity', () => {
+    describe('truncate with cascade and restartIdentity', () => {
       const options = {
         table: User.getTableName(),
         where: {},
@@ -54,7 +54,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         type: QueryTypes.BULKDELETE
       };
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         return expectsql(
           sql.truncateTableQuery(
             options.table,
@@ -69,7 +69,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('delete without limit', () => {
+    describe('delete without limit', () => {
       const options = {
         table: User.getTableName(),
         where: {name: 'foo' },
@@ -77,7 +77,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         type: QueryTypes.BULKDELETE
       };
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         return expectsql(
           sql.deleteQuery(
             options.table,
@@ -94,7 +94,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('delete with limit', () => {
+    describe('delete with limit', () => {
       const options = {
         table: User.getTableName(),
         where: {name: "foo';DROP TABLE mySchema.myTable;"},
@@ -102,7 +102,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         type: QueryTypes.BULKDELETE
       };
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         return expectsql(
           sql.deleteQuery(
             options.table,
@@ -119,7 +119,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('delete with limit and without model', () => {
+    describe('delete with limit and without model', () => {
       const options = {
         table: User.getTableName(),
         where: {name: "foo';DROP TABLE mySchema.myTable;"},
@@ -127,7 +127,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         type: QueryTypes.BULKDELETE
       };
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         let query;
         try {
           query = sql.deleteQuery(
@@ -151,7 +151,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('delete when the primary key has a different field name', () => {
+    describe('delete when the primary key has a different field name', () => {
       const User = current.define('test_user', {
         id: {
           type: Sequelize.INTEGER,
@@ -169,7 +169,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         type: QueryTypes.BULKDELETE
       };
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         return expectsql(
           sql.deleteQuery(
             options.table,
@@ -186,7 +186,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('delete with undefined parameter in where', () => {
+    describe('delete with undefined parameter in where', () => {
       const options = {
         table: User.getTableName(),
         type: QueryTypes.BULKDELETE,
@@ -194,7 +194,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         limit: null
       };
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         const sqlOrError = _.attempt(
           sql.deleteQuery.bind(sql),
           options.table,

--- a/test/unit/sql/generateJoin.test.js
+++ b/test/unit/sql/generateJoin.test.js
@@ -12,18 +12,18 @@ const Support = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
-suite(Support.getTestDialectTeaser('SQL'), () => {
-  suite('generateJoin', () => {
+describe(Support.getTestDialectTeaser('SQL'), () => {
+  describe('generateJoin', () => {
     const testsql = function(path, options, expectation) {
 
-      const name = `${path}, ${util.inspect(options, { depth: 10 })}`;
+      const name = `${path}, ${util.inspect(options, { depth: 10})}`;
 
       Sequelize.Model._conformOptions(options);
       options = Sequelize.Model._validateIncludedElements(options);
 
       const include = _.at(options, path)[0];
 
-      test(name, () => {
+      it(name, () => {
 
         const join = sql.generateJoin(include,
           {

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -8,9 +8,9 @@ const Support = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
-suite(Support.getTestDialectTeaser('SQL'), () => {
-  suite('addIndex', () => {
-    test('naming', () => {
+describe(Support.getTestDialectTeaser('SQL'), () => {
+  describe('addIndex', () => {
+    it('naming', () => {
       expectsql(sql.addIndexQuery('table', ['column1', 'column2'], {}, 'table'), {
         default: 'CREATE INDEX [table_column1_column2] ON [table] ([column1], [column2])',
         mysql: 'ALTER TABLE `table` ADD INDEX `table_column1_column2` (`column1`, `column2`)'
@@ -37,7 +37,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       }
     });
 
-    test('type and using', () => {
+    it('type and using', () => {
       expectsql(sql.addIndexQuery('User', ['fieldC'], {
         type: 'FULLTEXT',
         concurrently: true
@@ -61,7 +61,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    test('POJO field', () => {
+    it('POJO field', () => {
       expectsql(sql.addIndexQuery('table', [{ attribute: 'column', collate: 'BINARY', length: 5, order: 'DESC'}], {}, 'table'), {
         default: 'CREATE INDEX [table_column] ON [table] ([column] COLLATE [BINARY] DESC)',
         mssql: 'CREATE INDEX [table_column] ON [table] ([column] DESC)',
@@ -69,7 +69,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    test('function', () => {
+    it('function', () => {
       expectsql(sql.addIndexQuery('table', [current.fn('UPPER', current.col('test'))], { name: 'myindex'}), {
         default: 'CREATE INDEX [myindex] ON [table] (UPPER([test]))',
         mysql: 'ALTER TABLE `table` ADD INDEX `myindex` (UPPER(`test`))'
@@ -77,7 +77,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
 
     if (current.dialect.supports.index.using === 2) {
-      test('USING', () => {
+      it('USING', () => {
         expectsql(sql.addIndexQuery('table', {
           fields: ['event'],
           using: 'gin'
@@ -88,7 +88,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.supports.index.where) {
-      test('WHERE', () => {
+      it('WHERE', () => {
         expectsql(sql.addIndexQuery('table', {
           fields: ['type'],
           where: {
@@ -132,7 +132,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.supports.JSONB) {
-      test('operator', () => {
+      it('operator', () => {
         expectsql(sql.addIndexQuery('table', {
           fields: ['event'],
           using: 'gin',
@@ -144,7 +144,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.name === 'postgres') {
-      test('show indexes', () => {
+      it('show indexes', () => {
         expectsql(sql.showIndexesQuery('table'), {
           postgres: 'SELECT i.relname AS name, ix.indisprimary AS primary, ix.indisunique AS unique, ix.indkey AS indkey, ' +
           'array_agg(a.attnum) as column_indexes, array_agg(a.attname) AS column_names, pg_get_indexdef(ix.indexrelid) ' +
@@ -165,8 +165,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
   });
 
-  suite('removeIndex', () => {
-    test('naming', () => {
+  describe('removeIndex', () => {
+    it('naming', () => {
       expectsql(sql.removeIndexQuery('table', ['column1', 'column2'], {}, 'table'), {
         mysql: 'DROP INDEX `table_column1_column2` ON `table`',
         mssql: 'DROP INDEX [table_column1_column2] ON [table]',

--- a/test/unit/sql/json.test.js
+++ b/test/unit/sql/json.test.js
@@ -10,17 +10,17 @@ const Support = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 if (current.dialect.supports.JSON) {
-  suite(Support.getTestDialectTeaser('SQL'), () => {
-    suite('JSON', () => {
-      suite('escape', () => {
-        test('plain string', () => {
+  describe(Support.getTestDialectTeaser('SQL'), () => {
+    describe('JSON', () => {
+      describe('escape', () => {
+        it('plain string', () => {
           expectsql(sql.escape('string', { type: new DataTypes.JSON() }), {
             default: '\'"string"\'',
             mysql: '\'\\"string\\"\''
           });
         });
 
-        test('plain int', () => {
+        it('plain int', () => {
           expectsql(sql.escape(0, { type: new DataTypes.JSON() }), {
             default: '\'0\''
           });
@@ -29,7 +29,7 @@ if (current.dialect.supports.JSON) {
           });
         });
 
-        test('boolean', () => {
+        it('boolean', () => {
           expectsql(sql.escape(true, { type: new DataTypes.JSON() }), {
             default: '\'true\''
           });
@@ -38,13 +38,13 @@ if (current.dialect.supports.JSON) {
           });
         });
 
-        test('NULL', () => {
+        it('NULL', () => {
           expectsql(sql.escape(null, { type: new DataTypes.JSON() }), {
             default: 'NULL'
           });
         });
 
-        test('nested object', () => {
+        it('nested object', () => {
           expectsql(sql.escape({ some: 'nested', more: { nested: true }, answer: 42 }, { type: new DataTypes.JSON() }), {
             default: '\'{"some":"nested","more":{"nested":true},"answer":42}\'',
             mysql: '\'{\\"some\\":\\"nested\\",\\"more\\":{\\"nested\\":true},\\"answer\\":42}\''
@@ -52,7 +52,7 @@ if (current.dialect.supports.JSON) {
         });
 
         if (current.dialect.supports.ARRAY) {
-          test('array of JSON', () => {
+          it('array of JSON', () => {
             expectsql(sql.escape([
               { some: 'nested', more: { nested: true }, answer: 42 },
               43,
@@ -63,7 +63,7 @@ if (current.dialect.supports.JSON) {
           });
 
           if (current.dialect.supports.JSONB) {
-            test('array of JSONB', () => {
+            it('array of JSONB', () => {
               expectsql(sql.escape([
                 { some: 'nested', more: { nested: true }, answer: 42 },
                 43,
@@ -76,8 +76,8 @@ if (current.dialect.supports.JSON) {
         }
       });
 
-      suite('path extraction', () => {
-        test('condition object', () => {
+      describe('path extraction', () => {
+        it('condition object', () => {
           expectsql(sql.whereItemQuery(undefined, Sequelize.json({ id: 1 })), {
             postgres: '("id"#>>\'{}\') = \'1\'',
             sqlite: "json_extract(`id`, '$') = '1'",
@@ -85,7 +85,7 @@ if (current.dialect.supports.JSON) {
           });
         });
 
-        test('nested condition object', () => {
+        it('nested condition object', () => {
           expectsql(sql.whereItemQuery(undefined, Sequelize.json({ profile: { id: 1 } })), {
             postgres: '("profile"#>>\'{id}\') = \'1\'',
             sqlite: "json_extract(`profile`, '$.id') = '1'",
@@ -93,7 +93,7 @@ if (current.dialect.supports.JSON) {
           });
         });
 
-        test('multiple condition object', () => {
+        it('multiple condition object', () => {
           expectsql(sql.whereItemQuery(undefined, Sequelize.json({ property: { value: 1 }, another: { value: 'string' } })), {
             postgres: '("property"#>>\'{value}\') = \'1\' AND ("another"#>>\'{value}\') = \'string\'',
             sqlite: "json_extract(`property`, '$.value') = '1' AND json_extract(`another`, '$.value') = 'string'",
@@ -101,7 +101,7 @@ if (current.dialect.supports.JSON) {
           });
         });
 
-        test('dot notation', () => {
+        it('dot notation', () => {
           expectsql(sql.whereItemQuery(Sequelize.json('profile.id'), '1'), {
             postgres: '("profile"#>>\'{id}\') = \'1\'',
             sqlite: "json_extract(`profile`, '$.id') = '1'",
@@ -109,7 +109,7 @@ if (current.dialect.supports.JSON) {
           });
         });
 
-        test('column named "json"', () => {
+        it('column named "json"', () => {
           expectsql(sql.whereItemQuery(Sequelize.json('json'), '{}'), {
             postgres: '("json"#>>\'{}\') = \'{}\'',
             sqlite: "json_extract(`json`, '$') = '{}'",
@@ -118,39 +118,39 @@ if (current.dialect.supports.JSON) {
         });
       });
 
-      suite('raw json query', () => {
+      describe('raw json query', () => {
         if (current.dialect.name === 'postgres') {
-          test('#>> operator', () => {
+          it('#>> operator', () => {
             expectsql(sql.whereItemQuery(Sequelize.json('("data"#>>\'{id}\')'), 'id'), {
               postgres: '("data"#>>\'{id}\') = \'id\''
             });
           });
         }
 
-        test('json function', () => {
+        it('json function', () => {
           expectsql(sql.handleSequelizeMethod(Sequelize.json('json(\'{"profile":{"name":"david"}}\')')), {
             default: 'json(\'{"profile":{"name":"david"}}\')'
           });
         });
 
-        test('nested json functions', () => {
+        it('nested json functions', () => {
           expectsql(sql.handleSequelizeMethod(Sequelize.json('json_extract(json_object(\'{"profile":null}\'), "profile")')), {
             default: 'json_extract(json_object(\'{"profile":null}\'), "profile")'
           });
         });
 
-        test('escaped string argument', () => {
+        it('escaped string argument', () => {
           expectsql(sql.handleSequelizeMethod(Sequelize.json('json(\'{"quote":{"single":"\'\'","double":""""},"parenthesis":"())("}\')')), {
             default: 'json(\'{"quote":{"single":"\'\'","double":""""},"parenthesis":"())("}\')'
           });
         });
 
-        test('unbalnced statement', () => {
+        it('unbalnced statement', () => {
           expect(() => sql.handleSequelizeMethod(Sequelize.json('json())'))).to.throw();
           expect(() => sql.handleSequelizeMethod(Sequelize.json('json_extract(json()'))).to.throw();
         });
 
-        test('separator injection', () => {
+        it('separator injection', () => {
           expect(() => sql.handleSequelizeMethod(Sequelize.json('json(; DELETE YOLO INJECTIONS; -- )'))).to.throw();
           expect(() => sql.handleSequelizeMethod(Sequelize.json('json(); DELETE YOLO INJECTIONS; -- '))).to.throw();
         });

--- a/test/unit/sql/offset-limit.test.js
+++ b/test/unit/sql/offset-limit.test.js
@@ -8,12 +8,12 @@ const Support   = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
-suite(Support.getTestDialectTeaser('SQL'), () => {
-  suite('offset/limit', () => {
+describe(Support.getTestDialectTeaser('SQL'), () => {
+  describe('offset/limit', () => {
     const testsql = function(options, expectation) {
       const model = options.model;
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         return expectsql(
           sql.addLimitAndOffset(
             options,

--- a/test/unit/sql/remove-column.test.js
+++ b/test/unit/sql/remove-column.test.js
@@ -8,9 +8,9 @@ const Support   = require('../support'),
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
 if (current.dialect.name !== 'sqlite') {
-  suite(Support.getTestDialectTeaser('SQL'), () => {
-    suite('removeColumn', () => {
-      test('schema', () => {
+  describe(Support.getTestDialectTeaser('SQL'), () => {
+    describe('removeColumn', () => {
+      it('schema', () => {
         expectsql(sql.removeColumnQuery({
           schema: 'archive',
           tableName: 'user'

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -13,12 +13,12 @@ const Support = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
-suite(Support.getTestDialectTeaser('SQL'), () => {
-  suite('select', () => {
+describe(Support.getTestDialectTeaser('SQL'), () => {
+  describe('select', () => {
     const testsql = function(options, expectation) {
       const model = options.model;
 
-      test(util.inspect(options, {depth: 2}), () => {
+      it(util.inspect(options, {depth: 2}), () => {
         return expectsql(
           sql.selectQuery(
             options.table || model && model.getTableName(),
@@ -67,12 +67,12 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         ]
       }
     }, {
-      default: 'SELECT [User].* FROM ('+
+      default: `SELECT [User].* FROM (${
         [
-          'SELECT * FROM (SELECT [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [User] WHERE [User].[companyId] = 1 ORDER BY [last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub',
-          'SELECT * FROM (SELECT [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [User] WHERE [User].[companyId] = 5 ORDER BY [last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub'
+          `SELECT * FROM (SELECT [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [User] WHERE [User].[companyId] = 1 ORDER BY [last_name] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`,
+          `SELECT * FROM (SELECT [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [User] WHERE [User].[companyId] = 5 ORDER BY [last_name] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`
         ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-      +') AS [User];'
+      }) AS [User];`
     });
 
     (function() {
@@ -120,12 +120,12 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           ]
         }
       }, {
-        default: 'SELECT [user].* FROM ('+
+        default: `SELECT [user].* FROM (${
           [
-            'SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 1 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub',
-            'SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 5 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub'
+            `SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 1 ORDER BY [subquery_order_0] ASC${ current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`,
+            `SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 5 ORDER BY [subquery_order_0] ASC${ current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user] ORDER BY [subquery_order_0] ASC;'
+        }) AS [user] ORDER BY [subquery_order_0] ASC;`
       });
 
       testsql({
@@ -151,12 +151,12 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           ]
         }
       }, {
-        default: 'SELECT [user].* FROM ('+
-        [
-          'SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 1 AND [project_users].[status] = 1 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub',
-          'SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 5 AND [project_users].[status] = 1 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub'
-        ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user] ORDER BY [subquery_order_0] ASC;'
+        default: `SELECT [user].* FROM (${
+          [
+            `SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 1 AND [project_users].[status] = 1 ORDER BY [subquery_order_0] ASC${ current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`,
+            `SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 5 AND [project_users].[status] = 1 ORDER BY [subquery_order_0] ASC${ current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`
+          ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
+        }) AS [user] ORDER BY [subquery_order_0] ASC;`
       });
 
 
@@ -183,12 +183,12 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           ]
         }
       }, {
-        default: 'SELECT [user].* FROM ('+
+        default: `SELECT [user].* FROM (${
           [
-            'SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 1 WHERE [user].[age] >= 21 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') + sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub',
-            'SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 5 WHERE [user].[age] >= 21 ORDER BY [subquery_order_0] ASC'+ (current.dialect.name === 'mssql' ? ', [user].[id_user]' : '') +sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub'
+            `SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 1 WHERE [user].[age] >= 21 ORDER BY [subquery_order_0] ASC${ current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`,
+            `SELECT * FROM (SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_users].[user_id] AS [project_users.userId], [project_users].[project_id] AS [project_users.projectId] FROM [users] AS [user] INNER JOIN [project_users] AS [project_users] ON [user].[id_user] = [project_users].[user_id] AND [project_users].[project_id] = 5 WHERE [user].[age] >= 21 ORDER BY [subquery_order_0] ASC${ current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user] ORDER BY [subquery_order_0] ASC;'
+        }) AS [user] ORDER BY [subquery_order_0] ASC;`
       });
     }());
 
@@ -269,12 +269,12 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           ]
         }
       }, {
-        default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM ('+
+        default: `SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (${
           [
-            'SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 1 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: [['last_name', 'ASC']] })+') AS sub',
-            'SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 5 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: [['last_name', 'ASC']] })+') AS sub'
+            `SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 1 ORDER BY [user].[last_name] ASC${sql.addLimitAndOffset({ limit: 3, order: [['last_name', 'ASC']]})}) AS sub`,
+            `SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 5 ORDER BY [user].[last_name] ASC${sql.addLimitAndOffset({ limit: 3, order: [['last_name', 'ASC']]})}) AS sub`
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id];'
+        }) AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id];`
       });
 
       testsql({
@@ -293,10 +293,10 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         hasMultiAssociation: true, //must be set only for mssql dialect here
         subQuery: true
       }, {
-        default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +
-                       'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC' +
-                       sql.addLimitAndOffset({ limit: 30, offset: 10, order: [['`user`.`last_name`', 'ASC']]}) +
-                   ') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;'
+        default: `${'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM (' +
+                       'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC'}${
+          sql.addLimitAndOffset({ limit: 30, offset: 10, order: [['`user`.`last_name`', 'ASC']]})
+        }) AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;`
       });
 
       const nestedInclude = Model._validateIncludedElements({
@@ -333,12 +333,12 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           ]
         }
       }, {
-        default: 'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title], [POSTS->COMMENTS].[id] AS [POSTS.COMMENTS.id], [POSTS->COMMENTS].[title] AS [POSTS.COMMENTS.title] FROM ('+
+        default: `SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title], [POSTS->COMMENTS].[id] AS [POSTS.COMMENTS.id], [POSTS->COMMENTS].[title] AS [POSTS.COMMENTS.title] FROM (${
           [
-            'SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 1 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub',
-            'SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 5 ORDER BY [user].[last_name] ASC'+sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })+') AS sub'
+            `SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 1 ORDER BY [user].[last_name] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`,
+            `SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 5 ORDER BY [user].[last_name] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC']})}) AS sub`
           ].join(current.dialect.supports['UNION ALL'] ?' UNION ALL ' : ' UNION ')
-        +') AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id] LEFT OUTER JOIN [comment] AS [POSTS->COMMENTS] ON [POSTS].[id] = [POSTS->COMMENTS].[post_id];'
+        }) AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id] LEFT OUTER JOIN [comment] AS [POSTS->COMMENTS] ON [POSTS].[id] = [POSTS->COMMENTS].[post_id];`
       });
     })();
 
@@ -439,8 +439,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('attribute escaping', () => {
-      test('plain attributes (1)', () => {
+    describe('attribute escaping', () => {
+      it('plain attributes (1)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: ['* FROM [User]; DELETE FROM [User];SELECT [id]'.replace(/\[/g, Support.sequelize.dialect.TICK_CHAR_LEFT).replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT)]
         }), {
@@ -449,7 +449,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      test('plain attributes (2)', () => {
+      it('plain attributes (2)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: ['* FROM User; DELETE FROM User;SELECT id']
         }), {
@@ -457,7 +457,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      test('plain attributes (3)', () => {
+      it('plain attributes (3)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: ['a\', * FROM User; DELETE FROM User;SELECT id']
         }), {
@@ -466,7 +466,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      test('plain attributes (4)', () => {
+      it('plain attributes (4)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: ['*, COUNT(*) FROM User; DELETE FROM User;SELECT id']
         }), {
@@ -474,7 +474,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      test('aliased attributes (1)', () => {
+      it('aliased attributes (1)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: [
             ['* FROM [User]; DELETE FROM [User];SELECT [id]'.replace(/\[/g, Support.sequelize.dialect.TICK_CHAR_LEFT).replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT), 'myCol']
@@ -484,7 +484,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      test('aliased attributes (2)', () => {
+      it('aliased attributes (2)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: [
             ['* FROM User; DELETE FROM User;SELECT id', 'myCol']
@@ -494,7 +494,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      test('aliased attributes (3)', () => {
+      it('aliased attributes (3)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: [
             ['id', '* FROM User; DELETE FROM User;SELECT id']
@@ -504,7 +504,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      test('attributes from includes', () => {
+      it('attributes from includes', () => {
         const User = Support.sequelize.define('User', {
           name: DataTypes.STRING,
           age: DataTypes.INTEGER
@@ -570,22 +570,22 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
   });
 
-  suite('queryIdentifiers: false', () => {
-    suiteSetup(() => {
+  describe('queryIdentifiers: false', () => {
+    beforeEach(() => {
       sql.options.quoteIdentifiers = false;
     });
-    suiteTeardown(() => {
+    afterEach(() => {
       sql.options.quoteIdentifiers = true;
     });
 
-    test('*', () => {
+    it('*', () => {
       expectsql(sql.selectQuery('User'), {
         default: 'SELECT * FROM [User];',
         postgres: 'SELECT * FROM "User";'
       });
     });
 
-    test('with attributes', () => {
+    it('with attributes', () => {
       expectsql(sql.selectQuery('User', {
         attributes: ['name', 'age']
       }), {
@@ -594,7 +594,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    test('include (left outer join)', () => {
+    it('include (left outer join)', () => {
       const User = Support.sequelize.define('User', {
         name: DataTypes.STRING,
         age: DataTypes.INTEGER
@@ -628,7 +628,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
 
 
-    test('nested include (left outer join)', () => {
+    it('nested include (left outer join)', () => {
       const User = Support.sequelize.define('User', {
         name: DataTypes.STRING,
         age: DataTypes.INTEGER
@@ -675,8 +675,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
 
   });
 
-  suite('raw query', () => {
-    test('raw replacements for where', () => {
+  describe('raw query', () => {
+    it('raw replacements for where', () => {
       expect(() => {
         sql.selectQuery('User', {
           attributes: ['*'],
@@ -685,7 +685,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       }).to.throw(Error, 'Support for literal replacements in the `where` object has been removed.');
     });
 
-    test('raw replacements for nested where', () => {
+    it('raw replacements for nested where', () => {
       expect(() => {
         sql.selectQuery('User', {
           attributes: ['*'],
@@ -694,7 +694,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       }).to.throw(Error, 'Support for literal replacements in the `where` object has been removed.');
     });
 
-    test('raw replacements for having', () => {
+    it('raw replacements for having', () => {
       expect(() => {
         sql.selectQuery('User', {
           attributes: ['*'],
@@ -703,7 +703,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       }).to.throw(Error, 'Support for literal replacements in the `where` object has been removed.');
     });
 
-    test('raw replacements for nested having', () => {
+    it('raw replacements for nested having', () => {
       expect(() => {
         sql.selectQuery('User', {
           attributes: ['*'],
@@ -712,7 +712,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       }).to.throw(Error, 'Support for literal replacements in the `where` object has been removed.');
     });
 
-    test('raw string from where', () => {
+    it('raw string from where', () => {
       expect(() => {
         sql.selectQuery('User', {
           attributes: ['*'],
@@ -721,7 +721,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       }).to.throw(Error, 'Support for `{where: \'raw query\'}` has been removed.');
     });
 
-    test('raw string from having', () => {
+    it('raw string from having', () => {
       expect(() => {
         sql.selectQuery('User', {
           attributes: ['*'],

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -12,15 +12,15 @@ const Support = require('../support'),
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
-suite(Support.getTestDialectTeaser('SQL'), () => {
-  suite('whereQuery', () => {
+describe(Support.getTestDialectTeaser('SQL'), () => {
+  describe('whereQuery', () => {
     const testsql = function(params, options, expectation) {
       if (expectation === undefined) {
         expectation = options;
         options = undefined;
       }
 
-      test(util.inspect(params, {depth: 10})+(options && ', '+util.inspect(options) || ''), () => {
+      it(util.inspect(params, {depth: 10})+(options && `, ${util.inspect(options)}` || ''), () => {
         const sqlOrError = _.attempt(sql.whereQuery.bind(sql), params, options);
         return expectsql(sqlOrError, expectation);
       });
@@ -54,7 +54,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       default: 'WHERE [User].[id] = 1'
     });
 
-    test("{ id: 1 }, { prefix: current.literal(sql.quoteTable.call(current.dialect.QueryGenerator, {schema: 'yolo', tableName: 'User'})) }", () => {
+    it("{ id: 1 }, { prefix: current.literal(sql.quoteTable.call(current.dialect.QueryGenerator, {schema: 'yolo', tableName: 'User'})) }", () => {
       expectsql(sql.whereQuery({id: 1}, {prefix: current.literal(sql.quoteTable.call(current.dialect.QueryGenerator, {schema: 'yolo', tableName: 'User'}))}), {
         default: 'WHERE [yolo.User].[id] = 1',
         postgres: 'WHERE "yolo"."User"."id" = 1',
@@ -95,14 +95,14 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
   });
 
-  suite('whereItemQuery', () => {
+  describe('whereItemQuery', () => {
     const testsql = function(key, value, options, expectation) {
       if (expectation === undefined) {
         expectation = options;
         options = undefined;
       }
 
-      test(String(key)+': '+util.inspect(value, {depth: 10})+(options && ', '+util.inspect(options) || ''), () => {
+      it(`${String(key)}: ${util.inspect(value, {depth: 10})}${options && `, ${util.inspect(options)}` || ''}`, () => {
         return expectsql(sql.whereItemQuery(key, value, options), expectation);
       });
     };
@@ -117,7 +117,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       mssql: '[deleted] IS NULL'
     });
 
-    suite('$in', () => {
+    describe('$in', () => {
       testsql('equipment', {
         [Op.in]: [1, 3]
       }, {
@@ -145,7 +145,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('Buffer', () => {
+    describe('Buffer', () => {
       testsql('field', new Buffer('Sequelize'), {
         postgres: '"field" = E\'\\\\x53657175656c697a65\'',
         sqlite: "`field` = X'53657175656c697a65'",
@@ -154,7 +154,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$not', () => {
+    describe('$not', () => {
       testsql('deleted', {
         [Op.not]: true
       }, {
@@ -176,7 +176,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$notIn', () => {
+    describe('$notIn', () => {
       testsql('equipment', {
         [Op.notIn]: []
       }, {
@@ -198,7 +198,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$ne', () => {
+    describe('$ne', () => {
       testsql('email', {
         [Op.ne]: 'jack.bauer@gmail.com'
       }, {
@@ -207,8 +207,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$and/$or/$not', () => {
-      suite('$or', () => {
+    describe('$and/$or/$not', () => {
+      describe('$or', () => {
         testsql('email', {
           [Op.or]: ['maker@mhansen.io', 'janzeh@gmail.com']
         }, {
@@ -262,13 +262,13 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           mssql: "([roleName] = N'NEW' OR ([roleName] = N'CLIENT' AND [type] = N'CLIENT'))"
         });
 
-        test('sequelize.or({group_id: 1}, {user_id: 2})', function() {
+        it('sequelize.or({group_id: 1}, {user_id: 2})', function() {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.or({group_id: 1}, {user_id: 2})), {
             default: '([group_id] = 1 OR [user_id] = 2)'
           });
         });
 
-        test("sequelize.or({group_id: 1}, {user_id: 2, role: 'admin'})", function() {
+        it("sequelize.or({group_id: 1}, {user_id: 2, role: 'admin'})", function() {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.or({group_id: 1}, {user_id: 2, role: 'admin'})), {
             default: "([group_id] = 1 OR ([user_id] = 2 AND [role] = 'admin'))",
             mssql: "([group_id] = 1 OR ([user_id] = 2 AND [role] = N'admin'))"
@@ -283,14 +283,14 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           default: '0 = 1'
         });
 
-        test('sequelize.or()', function() {
+        it('sequelize.or()', function() {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.or()), {
             default: '0 = 1'
           });
         });
       });
 
-      suite('$and', () => {
+      describe('$and', () => {
         testsql(Op.and, {
           [Op.or]: {
             group_id: 1,
@@ -336,14 +336,14 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           mssql: "([name] LIKE N'%someValue1%' AND [name] LIKE N'%someValue2%')"
         });
 
-        test('sequelize.and({shared: 1, sequelize.or({group_id: 1}, {user_id: 2}))', function() {
+        it('sequelize.and({shared: 1, sequelize.or({group_id: 1}, {user_id: 2}))', function() {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.and({shared: 1}, this.sequelize.or({group_id: 1}, {user_id: 2}))), {
             default: '([shared] = 1 AND ([group_id] = 1 OR [user_id] = 2))'
           });
         });
       });
 
-      suite('$not', () => {
+      describe('$not', () => {
         testsql(Op.not, {
           [Op.or]: {
             group_id: 1,
@@ -364,7 +364,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$col', () => {
+    describe('$col', () => {
       testsql('userId', {
         [Op.col]: 'user.id'
       }, {
@@ -407,7 +407,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$gt', () => {
+    describe('$gt', () => {
       testsql('rank', {
         [Op.gt]: 2
       }, {
@@ -423,7 +423,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$like', () => {
+    describe('$like', () => {
       testsql('username', {
         [Op.like]: '%swagger'
       }, {
@@ -432,7 +432,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$startsWith', () => {
+    describe('$startsWith', () => {
       testsql('username', {
         [Op.startsWith]: 'swagger'
       }, {
@@ -441,7 +441,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$endsWith', () => {
+    describe('$endsWith', () => {
       testsql('username', {
         [Op.endsWith]: 'swagger'
       }, {
@@ -450,7 +450,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$substring', () => {
+    describe('$substring', () => {
       testsql('username', {
         [Op.substring]: 'swagger'
       }, {
@@ -459,7 +459,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$between', () => {
+    describe('$between', () => {
       testsql('date', {
         [Op.between]: ['2013-01-01', '2013-01-11']
       }, {
@@ -476,7 +476,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    suite('$notBetween', () => {
+    describe('$notBetween', () => {
       testsql('date', {
         [Op.notBetween]: ['2013-01-01', '2013-01-11']
       }, {
@@ -486,8 +486,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
 
     if (current.dialect.supports.ARRAY) {
-      suite('ARRAY', () => {
-        suite('$contains', () => {
+      describe('ARRAY', () => {
+        describe('$contains', () => {
           testsql('muscles', {
             [Op.contains]: [2, 3]
           }, {
@@ -511,7 +511,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        suite('$overlap', () => {
+        describe('$overlap', () => {
           testsql('muscles', {
             [Op.overlap]: [3, 11]
           }, {
@@ -519,7 +519,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        suite('$any', () => {
+        describe('$any', () => {
           testsql('userId', {
             [Op.any]: [4, 5, 6]
           }, {
@@ -536,7 +536,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             postgres: '"userId" = ANY (ARRAY[2,5]::INTEGER[])'
           });
 
-          suite('$values', () => {
+          describe('$values', () => {
             testsql('userId', {
               [Op.any]: {
                 [Op.values]: [4, 5, 6]
@@ -559,7 +559,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        suite('$all', () => {
+        describe('$all', () => {
           testsql('userId', {
             [Op.all]: [4, 5, 6]
           }, {
@@ -576,7 +576,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             postgres: '"userId" = ALL (ARRAY[2,5]::INTEGER[])'
           });
 
-          suite('$values', () => {
+          describe('$values', () => {
             testsql('userId', {
               [Op.all]: {
                 [Op.values]: [4, 5, 6]
@@ -599,7 +599,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        suite('$like', () => {
+        describe('$like', () => {
           testsql('userId', {
             [Op.like]: {
               [Op.any]: ['foo', 'bar', 'baz']
@@ -668,7 +668,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.supports.RANGE) {
-      suite('RANGE', () => {
+      describe('RANGE', () => {
 
         testsql('range', {
           [Op.contains]: new Date(Date.UTC(2000, 1, 1))
@@ -795,8 +795,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.supports.JSON) {
-      suite('JSON', () => {
-        test('sequelize.json("profile.id"), sequelize.cast(2, \'text\')")', function() {
+      describe('JSON', () => {
+        it('sequelize.json("profile.id"), sequelize.cast(2, \'text\')")', function() {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.json('profile.id', this.sequelize.cast('12346-78912', 'text'))), {
             postgres: "(\"profile\"#>>'{id}') = CAST('12346-78912' AS TEXT)",
             sqlite: "json_extract(`profile`, '$.id') = CAST('12346-78912' AS TEXT)",
@@ -804,7 +804,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        test('sequelize.json({profile: {id: "12346-78912", name: "test"}})', function() {
+        it('sequelize.json({profile: {id: "12346-78912", name: "test"}})', function() {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.json({profile: {id: '12346-78912', name: 'test'}})), {
             postgres: "(\"profile\"#>>'{id}') = '12346-78912' AND (\"profile\"#>>'{name}') = 'test'",
             sqlite: "json_extract(`profile`, '$.id') = '12346-78912' AND json_extract(`profile`, '$.name') = 'test'",
@@ -992,9 +992,9 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
             type: new DataTypes.JSONB()
           }
         }, {
-          mysql: "CAST((`data`->>'$.\"nested\".\"attribute\"') AS DATETIME) > "+sql.escape(dt),
-          postgres: "CAST((\"data\"#>>'{nested,attribute}') AS TIMESTAMPTZ) > "+sql.escape(dt),
-          sqlite: "json_extract(`data`, '$.nested.attribute') > " + sql.escape(dt.toISOString())
+          mysql: `CAST((\`data\`->>'$."nested"."attribute"') AS DATETIME) > ${sql.escape(dt)}`,
+          postgres: `CAST(("data"#>>'{nested,attribute}') AS TIMESTAMPTZ) > ${sql.escape(dt)}`,
+          sqlite: `json_extract(\`data\`, '$.nested.attribute') > ${sql.escape(dt.toISOString())}`
         });
 
         testsql('data', {
@@ -1030,7 +1030,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.supports.JSONB) {
-      suite('JSONB', () => {
+      describe('JSONB', () => {
         testsql('data', {
           [Op.contains]: {
             company: 'Magnafone'
@@ -1046,7 +1046,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     if (current.dialect.supports.REGEXP) {
-      suite('$regexp', () => {
+      describe('$regexp', () => {
         testsql('username', {
           [Op.regexp]: '^sw.*r$'
         }, {
@@ -1055,7 +1055,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      suite('$regexp', () => {
+      describe('$regexp', () => {
         testsql('newline', {
           [Op.regexp]: '^new\nline$'
         }, {
@@ -1064,7 +1064,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      suite('$notRegexp', () => {
+      describe('$notRegexp', () => {
         testsql('username', {
           [Op.notRegexp]: '^sw.*r$'
         }, {
@@ -1073,7 +1073,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
-      suite('$notRegexp', () => {
+      describe('$notRegexp', () => {
         testsql('newline', {
           [Op.notRegexp]: '^new\nline$'
         }, {
@@ -1083,7 +1083,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       });
 
       if (current.dialect.name === 'postgres') {
-        suite('$iRegexp', () => {
+        describe('$iRegexp', () => {
           testsql('username', {
             [Op.iRegexp]: '^sw.*r$'
           }, {
@@ -1091,7 +1091,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        suite('$iRegexp', () => {
+        describe('$iRegexp', () => {
           testsql('newline', {
             [Op.iRegexp]: '^new\nline$'
           }, {
@@ -1099,7 +1099,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        suite('$notIRegexp', () => {
+        describe('$notIRegexp', () => {
           testsql('username', {
             [Op.notIRegexp]: '^sw.*r$'
           }, {
@@ -1107,7 +1107,7 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
           });
         });
 
-        suite('$notIRegexp', () => {
+        describe('$notIRegexp', () => {
           testsql('newline', {
             [Op.notIRegexp]: '^new\nline$'
           }, {
@@ -1117,8 +1117,8 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
       }
     }
 
-    suite('fn', () => {
-      test('{name: this.sequelize.fn(\'LOWER\', \'DERP\')}', function() {
+    describe('fn', () => {
+      it('{name: this.sequelize.fn(\'LOWER\', \'DERP\')}', function() {
         expectsql(sql.whereQuery({name: this.sequelize.fn('LOWER', 'DERP')}), {
           default: "WHERE [name] = LOWER('DERP')",
           mssql: "WHERE [name] = LOWER(N'DERP')"
@@ -1127,11 +1127,11 @@ suite(Support.getTestDialectTeaser('SQL'), () => {
     });
   });
 
-  suite('getWhereConditions', () => {
+  describe('getWhereConditions', () => {
     const testsql = function(value, expectation) {
       const User = current.define('user', {});
 
-      test(util.inspect(value, {depth: 10}), () => {
+      it(util.inspect(value, {depth: 10}), () => {
         return expectsql(sql.getWhereConditions(value, User.tableName, User), expectation);
       });
     };

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -8,9 +8,9 @@ const Utils = require('../../lib/utils');
 const logger = require('../../lib/utils/logger').getLogger();
 const Op = Support.Sequelize.Op;
 
-suite(Support.getTestDialectTeaser('Utils'), () => {
-  suite('merge', () => {
-    test('does not clone sequelize models', () => {
+describe(Support.getTestDialectTeaser('Utils'), () => {
+  describe('merge', () => {
+    it('does not clone sequelize models', () => {
       const User = Support.sequelize.define('user');
       const merged = Utils.merge({}, { include: [{model: User }]});
       const merged2 = Utils.merge({}, { user: User });
@@ -20,29 +20,29 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
-  suite('toDefaultValue', () => {
-    test('return plain data types', () => {
+  describe('toDefaultValue', () => {
+    it('return plain data types', () => {
       expect(Utils.toDefaultValue(DataTypes.UUIDV4)).to.equal('UUIDV4');
     });
-    test('return uuid v1', () => {
+    it('return uuid v1', () => {
       expect(/^[a-z0-9\-]{36}$/.test(Utils.toDefaultValue(DataTypes.UUIDV1()))).to.be.equal(true);
     });
-    test('return uuid v4', () => {
+    it('return uuid v4', () => {
       expect(/^[a-z0-9\-]{36}/.test(Utils.toDefaultValue(DataTypes.UUIDV4()))).to.be.equal(true);
     });
-    test('return now', () => {
+    it('return now', () => {
       expect(Object.prototype.toString.call(Utils.toDefaultValue(DataTypes.NOW()))).to.be.equal('[object Date]');
     });
-    test('return plain string', () => {
+    it('return plain string', () => {
       expect(Utils.toDefaultValue('Test')).to.equal('Test');
     });
-    test('return plain object', () => {
+    it('return plain object', () => {
       chai.assert.deepEqual({}, Utils.toDefaultValue({}));
     });
   });
 
-  suite('defaults', () => {
-    test('defaults normal object', () => {
+  describe('defaults', () => {
+    it('defaults normal object', () => {
       expect(Utils.defaults(
         { a: 1, c: 3},
         { b: 2 },
@@ -55,7 +55,7 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
       });
     });
 
-    test('defaults symbol keys', () => {
+    it('defaults symbol keys', () => {
       expect(Utils.defaults(
         { a: 1, [Symbol.for('c')]: 3},
         { b: 2 },
@@ -69,8 +69,8 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
-  suite('mapFinderOptions', () => {
-    test('virtual attribute dependencies', () => {
+  describe('mapFinderOptions', () => {
+    it('virtual attribute dependencies', () => {
       expect(Utils.mapFinderOptions({
         attributes: [
           'active'
@@ -91,7 +91,7 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
       ]);
     });
 
-    test('multiple calls', () => {
+    it('multiple calls', () => {
       const Model = Support.sequelize.define('User', {
         createdAt: {
           type: DataTypes.DATE,
@@ -120,8 +120,8 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
-  suite('mapOptionFieldNames', () => {
-    test('plain where', () => {
+  describe('mapOptionFieldNames', () => {
+    it('plain where', () => {
       expect(Utils.mapOptionFieldNames({
         where: {
           firstName: 'Paul',
@@ -144,7 +144,7 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
       });
     });
 
-    test('$or where', () => {
+    it('$or where', () => {
       expect(Utils.mapOptionFieldNames({
         where: {
           [Op.or]: {
@@ -171,7 +171,7 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
       });
     });
 
-    test('$or[] where', () => {
+    it('$or[] where', () => {
       expect(Utils.mapOptionFieldNames({
         where: {
           [Op.or]: [
@@ -198,7 +198,7 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
       });
     });
 
-    test('$and where', () => {
+    it('$and where', () => {
       expect(Utils.mapOptionFieldNames({
         where: {
           [Op.and]: {
@@ -226,8 +226,8 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
-  suite('stack', () => {
-    test('stack trace starts after call to Util.stack()', function this_here_test() { // eslint-disable-line
+  describe('stack', () => {
+    it('stack trace starts after call to Util.stack()', function this_here_test() { // eslint-disable-line
       // We need a named function to be able to capture its trace
       function a() {
         return b();
@@ -250,13 +250,13 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
-  suite('Sequelize.cast', () => {
+  describe('Sequelize.cast', () => {
     const sql = Support.sequelize;
     const generator = sql.queryInterface.QueryGenerator;
     const run = generator.handleSequelizeMethod.bind(generator);
     const expectsql = Support.expectsql;
 
-    test('accepts condition object (auto casting)', () => {
+    it('accepts condition object (auto casting)', () => {
       expectsql(run(sql.fn('SUM', sql.cast({
         [Op.or]: {
           foo: 'foo',
@@ -269,23 +269,23 @@ suite(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
-  suite('Logger', () => {
-    test('deprecate', () => {
+  describe('Logger', () => {
+    it('deprecate', () => {
       expect(logger.deprecate).to.be.a('function');
       logger.deprecate('test deprecation');
     });
 
-    test('debug', () => {
+    it('debug', () => {
       expect(logger.debug).to.be.a('function');
       logger.debug('test debug');
     });
 
-    test('warn', () => {
+    it('warn', () => {
       expect(logger.warn).to.be.a('function');
       logger.warn('test warning');
     });
 
-    test('debugContext',  () => {
+    it('debugContext',  () => {
       expect(logger.debugContext).to.be.a('function');
       const testLogger = logger.debugContext('test');
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Last big PR for a while.

1) Used eslint to convert all string concat to template strings, see https://stackoverflow.com/questions/29055518/are-es6-template-literals-faster-than-string-concatenation
2) Moved all usage of `suite` and `test` within tests to use the `describe` and `it` functions.
3) Replaced dottie with _.set/get (one less dependency 🎉)