### PR TITLE
Fix toJSON to always provide copy of data (cloneDeep)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4187,7 +4187,7 @@ class Model {
    * @returns {Object}
    */
   toJSON() {
-    return _.clone(
+    return _.cloneDeep(
       this.get({
         plain: true
       })

--- a/test/unit/instance/to-json.test.js
+++ b/test/unit/instance/to-json.test.js
@@ -22,5 +22,24 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       const json2 = user.toJSON();
       expect(json2).to.have.property('name').and.be.equal('my-name');
     });
+
+    it('returns clone of JSON data-types', () => {
+      const User = current.define('User', {
+        name: DataTypes.STRING,
+        permissions: DataTypes.JSON
+      });
+      const user = User.build({ name: 'my-name', permissions: { admin: true, special: 'foobar' } });
+      const json = user.toJSON();
+
+      expect(json)
+        .to.have.property('permissions')
+        .that.does.not.equal(user.permissions);
+
+      json.permissions.admin = false;
+
+      expect(user.permissions)
+        .to.have.property('admin')
+        .that.equals(true);
+    });
   });
 });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Changes `mode.toJSON()` to always return a copy of the underlying data. This was a small change from lodash `clone()` to `cloneDeep()`.

Closes #10052 

<!-- Please provide a description of the change here. -->
