### PR TITLE
Fix unit test for instance get with raw option

### DIFF
--- a/test/unit/instance/get.test.js
+++ b/test/unit/instance/get.test.js
@@ -26,7 +26,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     it('does not invoke getter if raw: true', function() {
-      expect(this.getSpy, { raw: true }).not.to.have.been.called;
+      this.User.build().get('name', { raw: true });
+
+      expect(this.getSpy).not.to.have.been.called;
     });
   });
 });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

The test previously passed the `raw` option to the `expect()` when it was intended to be passed when building the instance. The error would cause the test to always pass.

<!-- Please provide a description of the change here. -->
