### PR TITLE
Fix documentation typo in the section about upgrade to v4

### DIFF
--- a/docs/upgrade-to-v4.md
+++ b/docs/upgrade-to-v4.md
@@ -195,7 +195,7 @@ are now ES6 classes. You can set class / instance level methods like this
     if (!Array.isArray(include)) include = [include];
 
     return include.reduce((isRequired, descriptor) => {
-      const hasRequiredChild = propogateRequired(descriptor);
+      const hasRequiredChild = propagateRequired(descriptor);
       if ((descriptor.where || hasRequiredChild) && descriptor.required === undefined) {
         descriptor.required = true;
       }


### PR DESCRIPTION
### Description of change
Just fixing a typo in the `upgrade-v4.md`. The original snippet throws the error below.  
```
ReferenceError: propogateRequired is not defined
```
I would be happy to make this documentation better! Thanks!
