### PR TITLE
fix OptimistickLockError message

### DIFF
--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -92,7 +92,7 @@ class OptimisticLockError extends BaseError {
   constructor(options) {
     options = options || {};
     options.message = options.message || `Attempting to update a stale model instance: ${options.modelName}`;
-    super(options);
+    super(options.message);
     this.name = 'SequelizeOptimisticLockError';
     /**
      * The name of the model on which the update was attempted

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -52,4 +52,18 @@ describe('errors', () => {
       expect(stackParts[1]).to.match(/^    at throwError \(.*errors.test.js:\d+:\d+\)$/);
     });
   });
+
+  describe('OptimisticLockError', () => {
+    it('message is correct', () => {
+      let err;
+      try {
+        throw new errors['OptimisticLockError']({modelName: 'FakeModel'});
+      } catch (error) {
+        err = error;
+      }
+
+      expect(err.message).to.exist;
+      expect(err.message).to.equal('Attempting to update a stale model instance: FakeModel');
+    });
+  });
 });

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -52,18 +52,4 @@ describe('errors', () => {
       expect(stackParts[1]).to.match(/^    at throwError \(.*errors.test.js:\d+:\d+\)$/);
     });
   });
-
-  describe('OptimisticLockError', () => {
-    it('message is correct', () => {
-      let err;
-      try {
-        throw new errors['OptimisticLockError']({modelName: 'FakeModel'});
-      } catch (error) {
-        err = error;
-      }
-
-      expect(err.message).to.exist;
-      expect(err.message).to.equal('Attempting to update a stale model instance: FakeModel');
-    });
-  });
 });


### PR DESCRIPTION
`BaseError` expects to receive `message`, but the `options` object is being passed. 

It leads to this:
```
SequelizeOptimisticLockError: [object Object]
```

With the fix the error looks like:
```
SequelizeOptimisticLockError: Attempting to update a stale model instance: Customers
```

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
