### PR TITLE
refactor(cls): lazy load cls and make it entirely optional

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -54,6 +54,8 @@ return sequelize.transaction(t => {
 
 ### Automatically pass transactions to all queries
 
+In order to use CLS you must first `npm install cls-bluebird`.
+
 In the examples above, the transaction is still manually passed, by passing `{ transaction: t }` as the second argument. To automatically pass the transaction to all queries you must install the [continuation local storage](https://github.com/othiym23/node-continuation-local-storage) (CLS) module and instantiate a namespace in your own code:
 
 ```js

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -3,7 +3,6 @@
 const url = require('url');
 const path = require('path');
 const retry = require('retry-as-promised');
-const clsBluebird = require('cls-bluebird');
 const _ = require('lodash');
 
 const Utils = require('./utils');
@@ -1032,8 +1031,12 @@ class Sequelize {
    * @returns {Object} Sequelize constructor
    */
   static useCLS(ns) {
+    Utils.assertPackage('continuation-local-storage', '%PKG%@^3.2.1 is required to to use CLS');
+    const clsBluebird = Utils.assertPackage('cls-bluebird', '%PKG%@^2.1.0 is required to to use CLS');
     // check `ns` is valid CLS namespace
-    if (!ns || typeof ns !== 'object' || typeof ns.bind !== 'function' || typeof ns.run !== 'function') throw new Error('Must provide CLS namespace');
+    if (!ns || typeof ns !== 'object' || typeof ns.bind !== 'function' || typeof ns.run !== 'function') {
+      throw new Error('Must provide CLS namespace');
+    }
 
     // save namespace as `Sequelize._cls`
     this._cls = ns;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -644,4 +644,17 @@ function nameIndex(index, tableName) {
 }
 exports.nameIndex = nameIndex;
 
-
+/**
+ * Checks if a package is installed.
+ */
+function assertPackage(packageName, message) {
+  try {
+    return require(packageName);
+  } catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+      throw new Error(message.replace('%PKG%', packageName));
+    }
+    throw err;
+  }
+}
+exports.assertPackage = assertPackage;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "cls-bluebird": "^2.1.0",
     "debug": "^4.1.0",
     "depd": "^2.0.0",
     "dottie": "^2.0.0",
@@ -47,7 +46,8 @@
     "chai-as-promised": "^7.x",
     "chai-datetime": "^1.x",
     "chai-spies": "^1.x",
-    "continuation-local-storage": "^3.x",
+    "cls-bluebird": "^2.1.0",
+    "continuation-local-storage": "^3.2.1",
     "cross-env": "^5.2.0",
     "env-cmd": "^8.0.0",
     "esdoc": "^1.1.0",
@@ -138,5 +138,9 @@
     "sscce-postgres": "cross-env DIALECT=postgres npm run sscce",
     "sscce-sqlite": "cross-env DIALECT=sqlite npm run sscce",
     "sscce-mssql": "cross-env DIALECT=mssql npm run sscce"
+  },
+  "peerDependencies": {
+    "cls-bluebird": "^2.1.0",
+    "continuation-local-storage": "^3.2.1"
   }
 }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

I noticed that `cls-bluebird` is always installed even when cls is entirely optional (same as `continuation-local-storage`).

This change makes both dependencies peer dependencies and asserts them lazily when calling `.useCLS`.

Pro:
 - Less packages shipped by default.
 - Lower load time
Contra:
 - Peer dependencies generate warnings, we can just remove them however.
 - 1 More manual install