### PR TITLE
chore: bump version to 4.42.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS",
-  "version": "0.0.0-development",
+  "version": "4.42.0",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     {


### PR DESCRIPTION
Feel free to reject this since it appears v4 versions are likely being handled/bumped during the npm package publishing step.

I have a separate issue https://github.com/sequelize/sequelize/issues/10131 requesting a new v4 package release.

Thanks!