### PR TITLE
added support for non unique keys for MySQL

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -103,6 +103,16 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
         }
       });
     }
+    if (options.indexKeys) {
+      _.each(options.indexKeys, (columns, indexName) => {
+        if (columns.customIndex) {
+          if (!_.isString(indexName)) {
+            indexName = `index_${tableName}_${columns.fields.join('_')}`;
+          }
+          attributesClause += `, KEY ${this.quoteIdentifier(indexName)} (${columns.fields.map(field => this.quoteIdentifier(field)).join(', ')})`;
+        }
+      });
+    }
 
     if (pkString.length > 0) {
       attributesClause += `, PRIMARY KEY (${pkString})`;


### PR DESCRIPTION

### Description of change

added support for non unique keys for MySQL

before
```
CREATE TABLE `users_password_resets` (
  `email` varchar(255) NOT NULL,
  `token` varchar(255) NOT NULL,
  `createdAt` datetime DEFAULT NULL,
   UNIQUE KEY `users_password_resets_email_index` (`email`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

after
```
CREATE TABLE `users_password_resets` (
  `email` varchar(255) NOT NULL,
  `token` varchar(255) NOT NULL,
  `createdAt` datetime DEFAULT NULL,
   KEY `users_password_resets_email_index` (`email`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

same like Laravel ;)
