### PR TITLE
fix(query-generator): adding offset in unioned queries

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1101,6 +1101,7 @@ const QueryGenerator = {
           {
             attributes: options.attributes,
             limit: options.groupedLimit.limit,
+            offset: options.offset,
             order: groupedLimitOrder,
             where,
             include,


### PR DESCRIPTION
fixed an issue when passing limit/offset inside of a subquery

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ x ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ - ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ - ] Have you added new tests to prevent regressions?
- [ - ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ x ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
<!-- Please provide a description of the change here. -->
When executing a query like the following, the offset value would not get passed to the UNION ALL Generated query.

```js
models.tblLeague.findAll({
      include: [
        {
          model: models.tblPost,
          order: [['createdDate', 'DESC']],
          offset: 5,
          limit: 10,
          where: { isActive: state.active },
        },
      ],
      where: { leagueId: [1,2,3] },
    });
```

In a nutshell, adds same code (addition of offset) from #9577  from v5 to v4
