### PR TITLE
fix(transaction): prevent nested savepoints from having the same name

### DIFF
--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -35,7 +35,7 @@ class Transaction {
     }, options || {});
 
     this.parent = this.options.transaction;
-    this.id = this.parent ? this.parent.id : generateTransactionId();
+    if (this.parent && this.parent.parent) this.parent = this.parent.parent;
 
     if (this.parent) {
       this.id = this.parent.id;

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -375,6 +375,20 @@ if (current.dialect.supports.transactions) {
       });
     });
 
+    it('should provide different name to nested savepoints', function() {
+      return this.sequelize.transaction().then(transaction => {
+        return this.sequelize.transaction({ transaction }).then(savepoint1 => {
+          return this.sequelize.transaction({ transaction: savepoint1 }).then(savepoint2 => {
+            expect(savepoint2.name).to.not.equal(transaction.name);
+            expect(savepoint2.name).to.not.equal(savepoint1.name);
+
+            expect(savepoint1.name).to.not.equal(transaction.name);
+            expect(savepoint1.name).to.not.equal(savepoint2.name);
+          });
+        });
+      });
+    });
+
     if (dialect === 'sqlite') {
       it('provides persistent transactions', () => {
         const sequelize = new Support.Sequelize('database', 'username', 'password', {dialect: 'sqlite'}),


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?

### Description of change

Fix a bug where nested savepoints have the name. This result in a critical bug where calling `rollback` on a preceding savepoint only `rollback` to the latest one.

```js
const transaction = await sails.sequelize.transaction();

const event = await Event.create({
    type: 'test',
    data: {}
}, {
    transaction
});

const savepoint1 = await sails.sequelize.transaction({ transaction });

event.type = 'test2';
await event.save({ transaction: savepoint1 });

const savepoint2 = await sails.sequelize.transaction({ transaction: savepoint1 });

event.type = 'test3';
await event.save({ transaction: savepoint2 });

await savepoint1.rollback();
await event.reload({ transaction });

// before the fix: event.type === 'test2'
// after the fix: event.type === 'test'
```