### PR TITLE
feat(model): add order by option to destroy

### DIFF
--- a/docs/querying.md
+++ b/docs/querying.md
@@ -467,6 +467,17 @@ Subtask.findAll({
 })
 ```
 
+`order` is also supported in the `destroy` method, but will only accept an an array of attributes and directions.
+
+```js
+Subtask.destroy({
+  order: [
+    // Will escape title and age and validate DESC and ASC respectively against a list of valid direction parameters
+    ['title', 'DESC'], ['age', 'ASC']
+  ]
+})
+```
+
 ## Table Hint
 
 `tableHint` can be used to optionally pass a table hint when using mssql. The hint must be a value from `Sequelize.TableHints` and should only be used when absolutely necessary. Only a single table hint is currently supported per query.

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -492,16 +492,21 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     let whereClause = this.getWhereConditions(where, null, model, options);
     let limit = '';
+    let order = '';
 
     if (options.limit) {
       limit = ` TOP(${this.escape(options.limit)})`;
     }
 
+    if (options.order) {
+      order = ` ORDER BY ${options.order.map(x => x.join(' ')).join(', ')}`;
+    }
+    
     if (whereClause) {
       whereClause = ` WHERE ${whereClause}`;
     }
 
-    return `DELETE${limit} FROM ${table}${whereClause}; SELECT @@ROWCOUNT AS AFFECTEDROWS;`;
+    return `DELETE${limit} FROM ${table}${whereClause}${order}; SELECT @@ROWCOUNT AS AFFECTEDROWS;`;
   }
 
   showIndexesQuery(tableName) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -277,10 +277,15 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
 
   deleteQuery(tableName, where, options = {}, model) {
     let limit = '';
+    let order = '';
     let query = `DELETE FROM ${this.quoteTable(tableName)}`;
 
     if (options.limit) {
       limit = ` LIMIT ${this.escape(options.limit)}`;
+    }
+
+    if (options.order) {
+      order = ` ORDER BY ${options.order.map(x => x.join(' ')).join(', ')}`;
     }
 
     where = this.getWhereConditions(where, null, model, options);
@@ -289,7 +294,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
       query += ` WHERE ${where}`;
     }
 
-    return query + limit;
+    return query + order + limit;
   }
 
   showIndexesQuery(tableName, options) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -372,6 +372,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const table = this.quoteTable(tableName);
     let whereClause = this.getWhereConditions(where, null, model, options);
     const limit = options.limit ? ` LIMIT ${this.escape(options.limit)}` : '';
+    const order = options.order ? ` ORDER BY ${options.order.map(x => x.join(' ')).join(', ')}` : '';
     let primaryKeys = '';
     let primaryKeysSelection = '';
 
@@ -379,9 +380,9 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       whereClause = ` WHERE ${whereClause}`;
     }
 
-    if (options.limit) {
+    if (options.order || options.limit) {
       if (!model) {
-        throw new Error('Cannot LIMIT delete without a model.');
+        throw new Error('Cannot ORDER or LIMIT delete without a model.');
       }
 
       const pks = _.values(model.primaryKeys).map(pk => this.quoteIdentifier(pk.field)).join(',');
@@ -389,7 +390,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       primaryKeys = model.primaryKeyAttributes.length > 1 ? `(${pks})` : pks;
       primaryKeysSelection = pks;
 
-      return `DELETE FROM ${table} WHERE ${primaryKeys} IN (SELECT ${primaryKeysSelection} FROM ${table}${whereClause}${limit})`;
+      return `DELETE FROM ${table} WHERE ${primaryKeys} IN (SELECT ${primaryKeysSelection} FROM ${table}${whereClause}${order}${limit})`;
     }
     return `DELETE FROM ${table}${whereClause}`;
   }

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -269,10 +269,19 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     if (whereClause) {
       whereClause = `WHERE ${whereClause}`;
     }
+    if (options.limit || options.order) {
+      whereClause = `WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${whereClause}`;
 
-    if (options.limit) {
-      whereClause = `WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${whereClause} LIMIT ${this.escape(options.limit)})`;
-    }
+      if (options.order) {
+        whereClause += ` ORDER BY ${options.order.map(x => x.join(' ')).join(', ')}`;
+      }
+
+      if (options.limit) {
+        whereClause += ` LIMIT ${this.escape(options.limit)})`;
+      } else {
+        whereClause += ')';
+      }
+    }  
 
     return `DELETE FROM ${this.quoteTable(tableName)} ${whereClause}`;
   }

--- a/lib/model.js
+++ b/lib/model.js
@@ -2654,6 +2654,7 @@ class Model {
    * @param  {Object}       [options.where]                 Filter the destroy
    * @param  {boolean}      [options.hooks=true]            Run before / after bulk destroy hooks?
    * @param  {boolean}      [options.individualHooks=false] If set to true, destroy will SELECT all records matching the where parameter and will execute before / after destroy hooks on each row
+   * @param  {Array}        [options.order]                 Specifies an ordering. Using an array, you can provide several columns / functions to order by. Each element can be further wrapped in a two-element array. The first element is the column / function to order by, the second is the direction. For example: `order: [['name', 'DESC']]`. In this way the column will be escaped, but the direction will not.
    * @param  {number}       [options.limit]                 How many rows to delete
    * @param  {boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
    * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored


### PR DESCRIPTION
Adds order by option to destroy, useful when deleting hierarchical data.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Add order by option to destroy method to resolve Issue #9715 