### PR TITLE
fix(model): prevent version number from being interpreted as string

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3731,7 +3731,7 @@ class Model {
         where = this.where(true);
         where = Utils.mapValueFieldNames(where, Object.keys(where), this.constructor);
         if (versionAttr) {
-          values[versionFieldName] += 1;
+          values[versionFieldName] = parseInt(values[versionFieldName], 10) + 1;
         }
         query = 'update';
         args = [this, this.constructor.getTableName(options), values, where, options];


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? --> not applicable
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

While testing with CockroachDB as backend database, I encountered a strange situation where the version number used by Sequelize for optimistic locking is (correctly) stored as INT in the table, but is incremented as string, and ends up becoming "1111...". Eventually the version number becomes too large to fit an integer. The exact same code does not show the issue when using MySQL or SQLite as backend store.

This fix ensures that the version number is incremented as a number. It merely makes the existing desired behaviour explicit and should not change the behaviour for backends where it is already working correctly.

I am not sure about how I would go about adding tests for this - more research would be needed to see whether this is CockroachDB or maybe also PostgreSQL-specific. Adding a test suite for Cockroach would be a good idea but out of my reach for now (I barely know the Sequelize source code at this point).

