### PR TITLE
flattenObject function throws uncaught error when it recursively flat…

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -399,7 +399,7 @@ function flattenObjectDeep(value) {
   function flattenObject(obj, subPath) {
     Object.keys(obj).forEach(key => {
       const pathToProperty = subPath ? `${subPath}.${key}` : key;
-      if (typeof obj[key] === 'object') {
+      if (typeof obj[key] === 'object' && obj[key] !== null) {
         flattenObject(obj[key], flattenedObj, pathToProperty);
       } else {
         flattenedObj[pathToProperty] = _.get(obj, key);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -400,7 +400,7 @@ function flattenObjectDeep(value) {
     Object.keys(obj).forEach(key => {
       const pathToProperty = subPath ? `${subPath}.${key}` : key;
       if (typeof obj[key] === 'object' && obj[key] !== null) {
-        flattenObject(obj[key], flattenedObj, pathToProperty);
+        flattenObject(obj[key], pathToProperty);
       } else {
         flattenedObj[pathToProperty] = _.get(obj, key);
       }

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -212,4 +212,34 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
       });
     }
   });
+
+  describe('flattenObjectDeep', () => {
+    it('should return the value if it is not an object', () => {
+      const value = 'non-object';
+      const returnedValue = Utils.flattenObjectDeep(value);
+      expect(returnedValue).to.equal(value);
+    });
+
+    it('should return correctly if values are null', () => {
+      const value = {
+        name: 'Jo',
+        address: {
+          street: 'Fake St. 123',
+          city: null,
+          coordinates: {
+            longitude: 55.6779627,
+            latitude: 12.5964313
+          }
+        }
+      };
+      const returnedValue = Utils.flattenObjectDeep(value);
+      expect(returnedValue).to.deep.equal({
+        name: 'John',
+        'address.street': 'Fake St. 123',
+        'address.city': null,
+        'address.coordinates.longitude': 55.6779627,
+        'address.coordinates.latitude': 12.5964313
+      });
+    });
+  });
 });

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -222,7 +222,7 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
 
     it('should return correctly if values are null', () => {
       const value = {
-        name: 'Jo',
+        name: 'John',
         address: {
           street: 'Fake St. 123',
           city: null,


### PR DESCRIPTION
…tens objects and a value is null. Added a check to make sure the value is not null before recursively calling the flattenObject function again.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Added an additional check for null when flattening objects in the util.js file. Since null is a `typeof` object, the function would call itself and try to use the `Object.keys` function on null, which would then throw an error that was covering a validation error.
