### PR TITLE
test(validation): throw instead of promise.reject

### DIFF
--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -477,9 +477,8 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
       validate: {
         customFn() {
           if (this.get('name') === 'error') {
-            return Promise.reject(new Error('Error from model validation promise'));
+            throw new Error('Error from model validation promise');
           }
-          return Promise.resolve();
         }
       }
     });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
The file [test/unit/model/validation.test.js](https://github.com/sequelize/sequelize/blob/9c0f0414623805136a24fc584d634b3a132e8211/test/unit/model/validation.test.js) contains among other things two `describe` blocks, one of them called ["custom validation functions"](https://github.com/sequelize/sequelize/blob/9c0f0414623805136a24fc584d634b3a132e8211/test/unit/model/validation.test.js#L460) and the other called ["custom validation functions returning promises"](https://github.com/sequelize/sequelize/blob/9c0f0414623805136a24fc584d634b3a132e8211/test/unit/model/validation.test.js#L547). Both test very similar things, and by their names one would expect that only the latter returns promises, but both do. I think this is probably a copy-paste mistake, and fixed it in this PR.
