### PR TITLE
fix(model/update): propagate paranoid to individualHooks query

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2907,7 +2907,13 @@ class Model {
 
       // Get instances and run beforeUpdate hook on each record individually
       if (options.individualHooks) {
-        return this.findAll({ where: options.where, transaction: options.transaction, logging: options.logging, benchmark: options.benchmark }).then(_instances => {
+        return this.findAll({
+          where: options.where,
+          transaction: options.transaction,
+          logging: options.logging,
+          benchmark: options.benchmark,
+          paranoid: options.paranoid
+        }).then(_instances => {
           instances = _instances;
           if (!instances.length) {
             return [];


### PR DESCRIPTION
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

I was testing some scenarios and noticed that when:
 1. Have a model with `paranoid: true` set
 2. Have `beforeUpdate` hook defined in the model
 3. Use the static `<Model>.update` method with `individualHooks: true`

The hook does not get called and therefore update statement is not executed. After a bit of investigation, I found the root cause - the `paranoid` option was not propagated to the select statement.

As it was quite straightforward change, I decided to give it a go and created PR directly :)