### PR TITLE
fix(model): respect 'underscored' and 'underscoredAll' model init options

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -774,7 +774,7 @@ class Model {
     this.associations = {};
     this._setupHooks(options.hooks);
 
-    this.underscored = this.underscored || this.underscoredAll;
+    this.underscored = this.options.underscored || this.options.underscoredAll;
 
     if (!this.options.tableName) {
       this.tableName = this.options.freezeTableName ? this.name : Utils.underscoredIf(Utils.pluralize(this.name), this.options.underscoredAll);
@@ -955,7 +955,7 @@ class Model {
       definition._modelAttribute = true;
 
       if (definition.field === undefined) {
-        definition.field = name;
+        definition.field = Utils.underscoredIf(name, this.underscored);
       }
 
       if (definition.primaryKey === true) {

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -26,6 +26,24 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(Model.rawAttributes).not.to.have.property('updated_at');
     });
 
+    it('should underscore camelCased attributes with underscored: true', () => {
+      const Model = current.define('User', { fieldName: { type: DataTypes.TEXT } }, { underscored: true });
+
+      expect(Model.rawAttributes.fieldName.field).to.equal('field_name');
+    });
+
+    it('should underscore camelCased attributes with underscoredAll: true', () => {
+      const Model = current.define('User', { fieldName: { type: DataTypes.TEXT } }, { underscoredAll: true });
+
+      expect(Model.rawAttributes.fieldName.field).to.equal('field_name');
+    });
+
+    it('should not underscore attributes where field is already set', () => {
+      const Model = current.define('User', { fieldName: { type: DataTypes.TEXT, field: 'forcedFieldName' } }, { underscoredAll: true });
+
+      expect(Model.rawAttributes.fieldName.field).to.equal('forcedFieldName');
+    });
+
     it('should throw when id is added but not marked as PK', () => {
       expect(() => {
         current.define('foo', {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Fix a regression where `underscored` and `underscoredAll` did not affect the name of the field defined in the database for sequelize model attributes.

fix #10373
