### PR TITLE
feat(model): unbound method call error

### DIFF
--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const sequelizeErrors = require('./../errors');
+
 function checkNamingCollision(association) {
   if (association.source.rawAttributes.hasOwnProperty(association.as)) {
     throw new Error(
@@ -61,6 +63,7 @@ function mixinMethods(association, obj, methods, aliases) {
       const realMethod = aliases[method] || method;
 
       obj[association.accessors[method]] = function() {
+        if (!this) throw new sequelizeErrors.UnboundMethodCallError(`Model#${association.accessors[method]}`);
         return association[realMethod].apply(association, [this, ...Array.from(arguments)]);
       };
     }

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -12,6 +12,7 @@ exports.InstanceError = require('./instance-error');
 exports.OptimisticLockError = require('./optimistic-lock-error');
 exports.QueryError = require('./query-error');
 exports.SequelizeScopeError = require('./sequelize-scope-error');
+exports.UnboundMethodCallError = require('./unbound-method-call-error');
 exports.ValidationError = require('./validation-error');
 exports.ValidationErrorItem = exports.ValidationError.ValidationErrorItem;
 

--- a/lib/errors/unbound-method-call-error.js
+++ b/lib/errors/unbound-method-call-error.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const BaseError = require('./base-error');
+
+/**
+ * Thrown when a sequelize method is called unbounded. This is done to give something better
+ * than `TypeError: cannot read property 'foo' of undefined` that would happen anyway.
+ * 
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
+ * 
+ * @example
+ * 
+ * ```js
+ * // Not OK:
+ * someInitialSetupAsync().then(sequelize.sync) // UnboundMethodCallError: Sequelize#sync was called unbounded
+ * doSomethingAsync().then(Foo.findAll) // UnboundMethodCallError: Model.findAll was called unbounded
+ * Bar.findAll().then(foo.addBars) // UnboundMethodCallError: Model#addBars was called unbounded
+ * 
+ * // OK:
+ * someInitialSetupAsync().then(sequelize.sync.bind(sequelize));
+ * someInitialSetupAsync().then(() => sequelize.sync());
+ * doSomethingAsync().then(Foo.findAll.bind(Foo));
+ * doSomethingAsync().then(() => Foo.findAll());
+ * Bar.findAll().then(foo.addBars.bind(foo));
+ * Bar.findAll().then(bars => foo.addBars(bars));
+ * ```
+ * 
+ * @extends BaseError
+ */
+class UnboundMethodCallError extends BaseError {
+  constructor(methodName) {
+    super(`${methodName} was called unbounded`);
+    this.name = 'SequelizeUnboundMethodCallError';
+    this.methodName = methodName;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = UnboundMethodCallError;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1244,6 +1244,8 @@ class Model {
    * @returns {Promise<Model>}
    */
   static sync(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.sync');
+
     options = Object.assign({}, this.options, options);
     options.hooks = options.hooks === undefined ? true : !!options.hooks;
 
@@ -1354,6 +1356,7 @@ class Model {
    * @returns {Promise}
    */
   static drop(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.drop');
     return this.QueryInterface.dropTable(this.getTableName(options), options);
   }
 
@@ -1406,6 +1409,7 @@ class Model {
    * @returns {string|Object}
    */
   static getTableName() { // testhint options:none
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.getTableName');
     return this.QueryGenerator.addSchema(this);
   }
 
@@ -1415,6 +1419,7 @@ class Model {
    * @returns {Model}
    */
   static unscoped() {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.unscoped');
     return this.scope();
   }
 
@@ -1490,6 +1495,8 @@ class Model {
    * @returns {Model} A reference to the model, with the scope(s) applied. Calling scope again on the returned model will clear the previous scope.
    */
   static scope(option) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.scope');
+
     const self = class extends this {};
     let scope;
     let scopeName;
@@ -1641,6 +1648,8 @@ class Model {
    * @returns {Promise<Array<Model>>}
    */
   static findAll(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.findAll');
+
     if (options !== undefined && !_.isPlainObject(options)) {
       throw new sequelizeErrors.QueryError('The argument passed to findAll must be an options object, use findByPk if you wish to pass a single primary key value');
     }
@@ -1872,6 +1881,8 @@ class Model {
    * @returns {Promise<Model>}
    */
   static findOne(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.findOne');
+
     if (options !== undefined && !_.isPlainObject(options)) {
       throw new Error('The argument passed to findOne must be an options object, use findByPk if you wish to pass a single primary key value');
     }
@@ -1976,6 +1987,8 @@ class Model {
    * @returns {Promise<number>}
    */
   static count(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.count');
+
     return Promise.try(() => {
       options = _.defaults(Utils.cloneDeep(options), { hooks: true });
       if (options.hooks) {
@@ -2036,6 +2049,8 @@ class Model {
    * @returns {Promise<{count: number, rows: Model[]}>}
    */
   static findAndCountAll(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.findAndCountAll');
+
     if (options !== undefined && !_.isPlainObject(options)) {
       throw new Error('The argument passed to findAndCountAll must be an options object, use findByPk if you wish to pass a single primary key value');
     }
@@ -2642,6 +2657,8 @@ class Model {
    * @see {@link Model.destroy} for more information
    */
   static truncate(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.truncate');
+
     options = Utils.cloneDeep(options) || {};
     options.truncate = true;
     return this.destroy(options);
@@ -3036,6 +3053,7 @@ class Model {
    * @returns {Promise} hash of attributes and their types
    */
   static describe(schema, options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Model.describe');
     return this.QueryInterface.describeTable(this.tableName, Object.assign({ schema: schema || this._schema || undefined }, options));
   }
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -656,6 +656,7 @@ class Sequelize {
    * @returns {Promise}
    */
   showAllSchemas(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#showAllSchemas');
     return this.getQueryInterface().showAllSchemas(options);
   }
 
@@ -687,6 +688,7 @@ class Sequelize {
    * @returns {Promise}
    */
   dropAllSchemas(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#dropAllSchemas');
     return this.getQueryInterface().dropAllSchemas(options);
   }
 
@@ -705,6 +707,8 @@ class Sequelize {
    * @returns {Promise}
    */
   sync(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#sync');
+
     options = _.clone(options) || {};
     options.hooks = options.hooks === undefined ? true : !!options.hooks;
     options = _.defaults(options, this.options.sync, this.options);
@@ -758,6 +762,8 @@ class Sequelize {
    * @see {@link Model.truncate} for more information
    */
   truncate(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#truncate');
+
     const models = [];
 
     this.modelManager.forEachModel(model => {
@@ -786,6 +792,8 @@ class Sequelize {
    * @returns {Promise}
    */
   drop(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#drop');
+
     const models = [];
 
     this.modelManager.forEachModel(model => {
@@ -805,6 +813,8 @@ class Sequelize {
    * @returns {Promise}
    */
   authenticate(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#authenticate');
+  
     options = Object.assign({
       raw: true,
       plain: true,
@@ -815,6 +825,7 @@ class Sequelize {
   }
 
   databaseVersion(options) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#databaseVersion');
     return this.getQueryInterface().databaseVersion(options);
   }
 
@@ -824,6 +835,7 @@ class Sequelize {
    * @returns {Sequelize.fn}
    */
   random() {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#random');
     const dia = this.getDialect();
     if (dia === 'postgres' || dia === 'sqlite') {
       return this.fn('RANDOM');
@@ -1004,6 +1016,8 @@ class Sequelize {
    * @returns {Promise}
    */
   transaction(options, autoCallback) {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#transaction');
+
     if (typeof options === 'function') {
       autoCallback = options;
       options = undefined;
@@ -1107,6 +1121,7 @@ class Sequelize {
    * @returns {Promise}
    */
   close() {
+    if (!this) throw new sequelizeErrors.UnboundMethodCallError('Sequelize#close');
     return this.connectionManager.close();
   }
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Sometimes I forget that some sequelize methods rely internally on the `this` object reference, and end up calling them unbounded and getting bad error messages. Some examples:

```js
someInitialSetupAsync().then(sequelize.sync) // TypeError: Cannot read property 'options' of undefined
doSomethingAsync().then(Foo.findAll) // TypeError: Cannot read property 'warnOnInvalidOptions' of undefined
Bar.findAll().then(foo.addBars) // TypeError: Cannot read property 'get' of undefined
```

Now, with experience, as soon as I see such errors I immediately think that I probably forgot to call [bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind). But at the first time, it took me a long time.

This PR adds a new error type in sequelize, `UnboundMethodCallError`, and the new behavior is as follows:

```js
someInitialSetupAsync().then(sequelize.sync) // UnboundMethodCallError: Sequelize#sync was called unbounded
doSomethingAsync().then(Foo.findAll) // UnboundMethodCallError: Model.findAll was called unbounded
Bar.findAll().then(foo.addBars) // UnboundMethodCallError: Model#addBars was called unbounded
```

This works by adding a one-line check (`if (!this)`) to each method. I didn't add this check on all methods, because that would be too much work, so I did it only for the public documented methods which can be called without parameters (i.e. have no required parameter) - the rationale being that if a method requires one or more parameters it is unlikely that it will be called unbounded. I also did it for the association mixins, because I made the mistake with them more than once (see the example above), so I thought it might happen to others too.

I also made some performance checks and I am confident to say that one single extra `if (!this)` is super negligible.