### PR TITLE
docs(usage): fix broken link on Basic Usage

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -349,7 +349,7 @@ sequelize.query('select 1 as `foo.bar.baz`').then(rows => {
 ```
 
 
-[0]: /docs/latest/usage#options
+[0]: /manual/installation/usage.html#options
 [1]: /manual/tutorial/models-definition.html#configuration
 [2]: /class/lib/sequelize.js~Sequelize.html
 [3]: /manual/tutorial/transactions.html


### PR DESCRIPTION
### Description of change

Fixes the broken link to options on **Basic Usage -> Dialects -> Mysql**.

This was reported on #9664
