### PR TITLE
refactor(package): update tedious from v3 to v4

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -31,6 +31,7 @@ class ConnectionManager extends AbstractConnectionManager {
     const connectionConfig = {
       server: config.host,
       authentication: {
+        type: 'default',
         options: {
           userName: config.username,
           password: config.password

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const _ = require('lodash');
 const AbstractConnectionManager = require('../abstract/connection-manager');
 const ResourceLock = require('./resource-lock');
 const Promise = require('../../promise');
@@ -28,9 +29,13 @@ class ConnectionManager extends AbstractConnectionManager {
 
   connect(config) {
     const connectionConfig = {
-      userName: config.username,
-      password: config.password,
       server: config.host,
+      authentication: {
+        options: {
+          userName: config.username,
+          password: config.password
+        }
+      },
       options: {
         port: config.port,
         database: config.database,
@@ -44,9 +49,9 @@ class ConnectionManager extends AbstractConnectionManager {
         delete connectionConfig.options.port;
       }
 
-      // The 'tedious' driver needs domain property to be in the main Connection config object
-      if (config.dialectOptions.domain) {
-        connectionConfig.domain = config.dialectOptions.domain;
+      // The 'tedious' driver needs authentication object to be in the main Connection config object
+      if (config.dialectOptions.authentication) {
+        connectionConfig.authentication = _.merge(connectionConfig.authentication, config.dialectOptions.authentication);
       }
       Object.assign(connectionConfig.options, config.dialectOptions);
     }

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -38,7 +38,7 @@ class ConnectionManager extends AbstractConnectionManager {
         }
       },
       options: {
-        port: config.port,
+        port: parseInt(config.port, 10),
         database: config.database,
         encrypt: false
       }

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -212,8 +212,20 @@ class Sequelize {
       dialectModule: this.options.dialectModule,
       dialectModulePath: this.options.dialectModulePath,
       keepDefaultTimezone: this.options.keepDefaultTimezone,
-      dialectOptions: this.options.dialectOptions
+      dialectOptions: this.options.dialectOptions || {}
     };
+
+    if (this.options.dialect === 'mssql') {
+      this.config.dialectOptions.authentication = this.config.dialectOptions.authentication || {};
+
+      if (typeof this.config.username !== 'undefined') {
+        this.config.dialectOptions.authentication.options = _.merge(this.config.dialectOptions.authentication.options, { userName: this.config.username });
+      }
+
+      if (typeof this.config.password !== 'undefined') {
+        this.config.dialectOptions.authentication.options = _.merge(this.config.dialectOptions.authentication.options, { password: this.config.password || '' });
+      }
+    }
 
     let Dialect;
     // Requiring the dialect in a switch-case to keep the

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "sinon": "^7.2.4",
     "sinon-chai": "^3.2.0",
     "sqlite3": "^4.0.6",
-    "tedious": "^3.0.1",
+    "tedious": "^4.2.0",
     "typescript": "^3.3.3333"
   },
   "keywords": [

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -124,7 +124,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
               expect(
                 err.message.includes('connect ECONNREFUSED') ||
                 err.message.includes('invalid port number') ||
-                err.message.match(/should be >=? 0 and < 65536/) ||
+                err.message.match(/must be >=? 0 and < 65536/) ||
                 err.message.includes('Login failed for user') ||
                 err.message.includes('Port must be > 0 and < 65536')
               ).to.be.ok;

--- a/test/unit/dialects/mssql/connection-manager.test.js
+++ b/test/unit/dialects/mssql/connection-manager.test.js
@@ -57,6 +57,7 @@ if (dialect === 'mssql') {
       return this.instance.dialect.connectionManager._connect(this.config).then(() => {
         const connectionConfig = this.connectionStub.args[0][0];
         expect(connectionConfig).to.have.property('authentication');
+        expect(connectionConfig.authentication).to.have.property('type');
         expect(connectionConfig.authentication).to.have.property('options');
 
         const authOptions = connectionConfig.authentication.options;


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

This breaking change updates the `tedious` driver for the `mssql` dialect to the current major version (4.x) and refactors how the authentication configuration is passed accordingly.

Closes #10377.