### PR TITLE
docs(hooks): add documentation for connection hooks

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -90,6 +90,7 @@ class Sequelize {
    * @param {number}   [options.retry.max] How many times a failing query is automatically retried.  Set to 0 to disable retrying on SQL_BUSY error.
    * @param {boolean}  [options.typeValidation=false] Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like.
    * @param {Object}   [options.operatorsAliases] String based operator alias. Pass object to limit set of aliased operators.
+   * @param {Object}   [options.hooks] An object of global hook functions that are called before and after certain lifecycle events. Global hooks will run after any model-specific hooks defined for the same event (See `Sequelize.Model.init()` for a list).  Additionally, `beforeConnect()` and `afterConnect()` hooks may be defined here.
    */
   constructor(database, username, password, options) {
     let config;

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -302,7 +302,12 @@ export interface Options extends Logging {
    *
    * @default all aliases
    */
-  operatorsAliases: OperatorsAliases | false;
+  operatorsAliases?: OperatorsAliases | false;
+
+  /**
+   * Sets global permanent hooks.
+   */
+  hooks?: Partial<SequelizeHooks>
 }
 
 export interface QueryOptionsTransactionRequired {}

--- a/types/test/sequelize.ts
+++ b/types/test/sequelize.ts
@@ -1,6 +1,12 @@
 import { Config, Sequelize } from 'sequelize';
 
-export const sequelize = new Sequelize('uri');
+export const sequelize = new Sequelize({
+  hooks: {
+    afterConnect: (connection, config: Config) => {
+      // noop
+    }
+  }
+});
 
 const conn = sequelize.connectionManager;
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Adds documentation for the `beforeConnect()` and `afterConnect()` hooks, API documentation for providing global hook definitions when constructing a Sequelize instance, and the corresponding TypeScript types.

Additionally, this corrects the TypeScript types to make `operatorsAliases` an _optional_ configuration property (which was discovered when writing tests for the new types).