### PR TITLE
fix(postgres): continuously support schemas for postgres

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -44,7 +44,7 @@ class QueryGenerator {
     options = options || {};
     tableName = tableName || {};
     return {
-      schema: tableName.schema || options.schema || 'public',
+      schema: tableName.schema || options.schema,
       tableName: _.isPlainObject(tableName) ? tableName.tableName : tableName,
       delimiter: tableName.delimiter || options.delimiter || '.'
     };

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -50,6 +50,14 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   showSchemasQuery() {
     return "SELECT schema_name FROM information_schema.schemata WHERE schema_name <> 'information_schema' AND schema_name != 'public' AND schema_name !~ E'^pg_';";
   }
+  renameTableQuery(before, after) {
+    return super.renameTableQuery(
+      this.extractTableDetails(before, this.options),
+      // This is not allowed!: this.extractTableDetails(after, this.options)
+      // Target must be given without schema!
+      after
+    );
+  }
 
   versionQuery() {
     return 'SHOW SERVER_VERSION';
@@ -64,7 +72,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     let comments = '';
     let columnComments = '';
 
-    const quotedTable = this.quoteTable(tableName);
+    const quotedTable = this.quoteTable(this.extractTableDetails(tableName, this.options));
 
     if (options.comment && typeof options.comment === 'string') {
       comments += `; COMMENT ON TABLE ${quotedTable} IS ${this.escape(options.comment)}`;
@@ -111,15 +119,15 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
   dropTableQuery(tableName, options) {
     options = options || {};
-    return `DROP TABLE IF EXISTS ${this.quoteTable(tableName)}${options.cascade ? ' CASCADE' : ''};`;
+    return `DROP TABLE IF EXISTS ${this.quoteTable(this.extractTableDetails(tableName, this.options))}${options.cascade ? ' CASCADE' : ''};`;
   }
 
   showTablesQuery() {
-    return "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_type LIKE '%TABLE' AND table_name != 'spatial_ref_sys';";
+    return `SELECT table_name FROM information_schema.tables WHERE table_schema = '${this.options.schema || 'public' }' AND table_type LIKE '%TABLE' AND table_name != 'spatial_ref_sys';`;
   }
 
   describeTableQuery(tableName, schema) {
-    if (!schema) schema = 'public';
+    if (!schema) schema = this.options.schema || 'public';
 
     return 'SELECT ' +
       'pk.constraint_type as "Constraint",' +
@@ -248,7 +256,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const dbDataType = this.attributeToSQL(dataType, { context: 'addColumn', table, key });
     const definition = this.dataTypeMapping(table, key, dbDataType);
     const quotedKey = this.quoteIdentifier(key);
-    const quotedTable = this.quoteTable(this.extractTableDetails(table));
+    const quotedTable = this.quoteTable(this.extractTableDetails(table, this.options));
 
     let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${quotedKey} ${definition};`;
 
@@ -260,13 +268,13 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   }
 
   removeColumnQuery(tableName, attributeName) {
-    const quotedTableName = this.quoteTable(this.extractTableDetails(tableName));
+    const quotedTableName = this.quoteTable(this.extractTableDetails(tableName, this.options));
     const quotedAttributeName = this.quoteIdentifier(attributeName);
     return `ALTER TABLE ${quotedTableName} DROP COLUMN ${quotedAttributeName};`;
   }
 
   changeColumnQuery(tableName, attributes) {
-    const query = subQuery => `ALTER TABLE ${this.quoteTable(tableName)} ALTER COLUMN ${subQuery};`;
+    const query = subQuery => `ALTER TABLE ${this.quoteTable(this.extractTableDetails(tableName, this.options))} ALTER COLUMN ${subQuery};`;
     const sql = [];
 
     for (const attributeName in attributes) {
@@ -321,7 +329,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       attrString.push(`${this.quoteIdentifier(attrBefore)} TO ${this.quoteIdentifier(attributeName)}`);
     }
 
-    return `ALTER TABLE ${this.quoteTable(tableName)} RENAME COLUMN ${attrString.join(', ')};`;
+    return `ALTER TABLE ${this.quoteTable(this.extractTableDetails(tableName, this.options))} RENAME COLUMN ${attrString.join(', ')};`;
   }
 
   fn(fnName, tableName, parameters, body, returns, language) {
@@ -362,14 +370,14 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
   truncateTableQuery(tableName, options = {}) {
     return [
-      `TRUNCATE ${this.quoteTable(tableName)}`,
+      `TRUNCATE ${this.quoteTable(this.extractTableDetails(tableName, this.options))}`,
       options.restartIdentity ? ' RESTART IDENTITY' : '',
       options.cascade ? ' CASCADE' : ''
     ].join('');
   }
 
   deleteQuery(tableName, where, options = {}, model) {
-    const table = this.quoteTable(tableName);
+    const table = this.quoteTable(this.extractTableDetails(tableName, this.options));
     let whereClause = this.getWhereConditions(where, null, model, options);
     const limit = options.limit ? ` LIMIT ${this.escape(options.limit)}` : '';
     let primaryKeys = '';
@@ -738,7 +746,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     return 'SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t ' +
       'JOIN pg_enum e ON t.oid = e.enumtypid ' +
       'JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace ' +
-      `WHERE n.nspname = '${tableDetails.schema}'${enumName} GROUP BY 1`;
+      `WHERE n.nspname = '${tableDetails.schema || this.options.schema || 'public' }'${enumName} GROUP BY 1`;
   }
 
   pgEnum(tableName, attr, dataType, options) {
@@ -891,7 +899,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
    * @private
    */
   dropForeignKeyQuery(tableName, foreignKey) {
-    return `ALTER TABLE ${this.quoteTable(tableName)} DROP CONSTRAINT ${this.quoteIdentifier(foreignKey)};`;
+    return `ALTER TABLE ${this.quoteTable(this.extractTableDetails(tableName, this.options))} DROP CONSTRAINT ${this.quoteIdentifier(foreignKey)};`;
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "Jan Aagaard Meier <janzeh@gmail.com>",
     "Daniel Durante <me@danieldurante.com>",
     "Mick Hansen <mick.kasper.hansen@gmail.com>",
-    "Sushant Dhiman <sushantdhiman@outlook.com>"
+    "Sushant Dhiman <sushantdhiman@outlook.com>",
+    "Arne Schubert <atd.schubert@gmail.com>"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Sequelize was not supporting schema continuously in postgres. It will now use the schema strictly in the following order:
1. provide as schema property in tableObject
2. provide as schema property in sequelize options
3. provided searchPath
4. in database configured searchPath


#### Note on tests

I already tried to write tests, but it seems that some (before / beforeEach) tasks are always dropping the configured test-schema. In addition I have also some problems to use an other Sequelize instance configured with schema option for the tests. Maybe someone can give me a hint, so I can complete the PR with tests.