### PR TITLE
Update DATE precision on docs

### DIFF
--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -30,7 +30,7 @@ Sequelize.DECIMAL                     // DECIMAL
 Sequelize.DECIMAL(10, 2)              // DECIMAL(10,2)
 
 Sequelize.DATE                        // DATETIME for mysql / sqlite, TIMESTAMP WITH TIME ZONE for postgres
-Sequelize.DATE(6)                     // DATETIME(6) for mysql 5.6.4+. Fractional seconds support with up to 6 digits of precision
+Sequelize.DATE(3)                     // DATETIME(3) for mysql 5.6.4+. Fractional seconds support with up to 6 digits of precision on mysql but limited to 3 by moment library
 Sequelize.DATEONLY                    // DATE without time.
 Sequelize.BOOLEAN                     // TINYINT(1)
 


### PR DESCRIPTION
I've update the DATE max precision number to 3 on docs.
This is caused by moment library limit (https://github.com/moment/moment/issues/3196) to milliseconds affecting queries.

Issue: https://github.com/sequelize/sequelize/issues/8697