### PR TITLE
Display message when passing include's model as null/undefined

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -326,6 +326,10 @@ class Model {
   static _conformInclude(include, self) {
     let model;
 
+    if (!include) {
+      throw new Error('The model object passed to "include" is undefined or null.');
+    }
+
     if (include._pseudo) return include;
 
     include = this._transformStringAssociation(include, self);

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -197,6 +197,22 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
       return this.sequelize.createSchema('account');
     });
 
+    it('should throw an error if the passed object is undefined or null', function() {
+      const User = this.sequelize.define('User', {}, { schema: 'account' });
+
+      return this.sequelize.sync({ force: true }).then(() => {
+        return User.findAll({
+          include: [
+            { model: null }
+          ]
+        }).then(() => {
+          expect(1).to.equal(0);
+        }).catch(() => {
+          expect(1).to.equal(1);
+        });
+      });
+    });
+
     it('should support an include with multiple different association types', function() {
       return this.sequelize.dropSchema('account').then(() => {
         return this.sequelize.createSchema('account').then(() => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? - no API changes here
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

For now, if you use `include` and pass the `null`/`undefined` as a parameter (for example, in case of a typo, happened to me actually) it would crash with `Cannot read property '_pseudo of undefined` error, which can be not obvious. I've changed it so it'd through the error if the passed object is not truthy and also provided a test for it.

Here's the example of the issue: https://stackoverflow.com/questions/41790321/sequelize-error-unhandled-rejection-typeerror-cannot-read-property-pseudo-of

Example:

```js
const User = sequelize.define('User', {}); // declaring the model
User.findAll({ include: [{
    model: null
]} }); // would throw an error
```

<!-- Please provide a description of the change here. -->
