### PR TITLE
support floats in mssql

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "mysql2": "^1.6.4",
     "pg": "^7.5.0",
     "pg-hstore": "^2.x",
-    "pg-types": "^1.x",
+    "pg-types": "^2.0.0",
     "rimraf": "^2.x",
     "sinon": "^6.3.5",
     "sinon-chai": "^3.2.0",


### PR DESCRIPTION
When trying to insert numbers with decimals it the number gets parsed and 22.22 ends up being 2222000000000000000 which is out of range. this detects if the parameter has decimals and sets it to be treated like a float, i dont know if this is perfect but it is definitely better than what was there which was unusable for decimals

### Pull Request check-list
_Please make sure to review and check all of these items:_

* [x]  Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
* [x]  Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
* [ ]  Have you added new tests to prevent regressions?
* [ ]  Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
* [ ]  Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?