### PR TITLE
feat(postgres): allow customizing client_min_messages

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -177,12 +177,16 @@ class ConnectionManager extends AbstractConnectionManager {
         query += 'SET standard_conforming_strings=on;';
       }
 
+      if (this.sequelize.options.clientMinMessages !== false) {
+        query += `SET client_min_messages TO ${this.sequelize.options.clientMinMessages};`;
+      }
+
       if (!this.sequelize.config.keepDefaultTimezone) {
         const isZone = !!moment.tz.zone(this.sequelize.options.timezone);
         if (isZone) {
-          query += `SET client_min_messages TO warning; SET TIME ZONE '${this.sequelize.options.timezone}';`;
+          query += `SET TIME ZONE '${this.sequelize.options.timezone}';`;
         } else {
-          query += `SET client_min_messages TO warning; SET TIME ZONE INTERVAL '${this.sequelize.options.timezone}' HOUR TO MINUTE;`;
+          query += `SET TIME ZONE INTERVAL '${this.sequelize.options.timezone}' HOUR TO MINUTE;`;
         }
       }
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -70,6 +70,7 @@ class Sequelize {
    * @param {Object}   [options.set={}] Default options for sequelize.set
    * @param {Object}   [options.sync={}] Default options for sequelize.sync
    * @param {string}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.
+   * @param {string|boolean} [options.clientMinMessages='warning'] The PostgreSQL `client_min_messages` session parameter. Set to `false` to not override the database's default.
    * @param {Function} [options.logging=console.log] A function that gets executed every time Sequelize would log something.
    * @param {boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param {boolean}  [options.omitNull=false] A flag that defines if null values should be passed to SQL queries or not.
@@ -156,6 +157,7 @@ class Sequelize {
       query: {},
       sync: {},
       timezone: '+00:00',
+      clientMinMessages: 'warning',
       logging: console.log,
       omitNull: false,
       native: false,

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -23,6 +23,30 @@ if (dialect.match(/^postgres/)) {
     it('should correctly parse the moment based timezone while fetching hstore oids', function() {
       return checkTimezoneParsing(this.sequelize.options);
     });
+
+    it('should set client_min_messages to warning by default', () => {
+      return Support.sequelize.query('SHOW client_min_messages')
+        .then(result => {
+          expect(result[0].client_min_messages).to.equal('warning');
+        });
+    });
+
+    it('should allow overriding client_min_messages', () => {
+      const sequelize = Support.createSequelizeInstance({ clientMinMessages: 'ERROR' });
+      return sequelize.query('SHOW client_min_messages')
+        .then(result => {
+          expect(result[0].client_min_messages).to.equal('error');
+        });
+    });
+
+    it('should not set client_min_messages if clientMinMessages is false', () => {
+      const sequelize = Support.createSequelizeInstance({ clientMinMessages: false });
+      return sequelize.query('SHOW client_min_messages')
+        .then(result => {
+          // `notice` is Postgres's default
+          expect(result[0].client_min_messages).to.equal('notice');
+        });
+    });
   });
 
   describe('Dynamic OIDs', () => {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

For some reason, Sequelize sets `client_min_messages` to `warning` when connecting to Postgres. This was introduced in https://github.com/sequelize/sequelize/pull/3041 with the only justification being "There is a new `SET` that increases the message level to `warning` (up from `notice`) since the upgraded pg client is now capable of bubbling these messages." 

`pg` does indeed allow you to [register an event when the server returns a message](https://node-postgres.com/api/client#client-on-39-notice-39-notice-string-gt-void-gt-void), but it doesn't follow that Sequelize needs to override the default `client_min_messages`. 

Furthermore, this behavior accidentally became coupled to the `keepDefaultTimezone` setting in https://github.com/sequelize/sequelize/commit/95a5c0d86dbdd32133a3dcb64659e98f12691b02. When `keepDefaultTimezone` is `true`, `client_min_messages` is not overridden. 

This behavior has been in place so long that it may be safest to keep `client_min_messages` set to `warning` by default. But we can at least allow users to customize it and decouple it from `keepDefaultTimezone`. 

If we want to make a riskier change, we can set `client_min_messages` to `null` by default and have Sequelize default to *not* updating the DB's setting. I have not done that in this PR, but it's an easy change if we want to make it.
