### PR TITLE
feat(postgres): support object alias in belongsTo and hasOne

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -21,7 +21,10 @@ class BelongsTo extends Association {
     this.isSingleAssociation = true;
     this.foreignKeyAttribute = {};
 
-    if (this.as) {
+    if (this.as && _.isPlainObject(this.as)) {
+      this.isAliased = true;
+      this.options.name = this.as;
+    } else if (this.as) {
       this.isAliased = true;
       this.options.name = {
         singular: this.as

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -22,7 +22,10 @@ class HasOne extends Association {
     this.isSingleAssociation = true;
     this.foreignKeyAttribute = {};
 
-    if (this.as) {
+    if (this.as && _.isPlainObject(this.as)) {
+      this.isAliased = true;
+      this.options.name = this.as;
+    } else if (this.as) {
       this.isAliased = true;
       this.options.name = {
         singular: this.as


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

belongsTo and hasOne now supports the association alias syntax:

```
as: { singular: 'task', plural: 'tasks' }
```

This functionality is already present in hasMany and belongsToMany and is counter-intuitive not to utilise it in one-to-one relationships.

It will allow a pattern where a variable can be set as the alias name:

```
const taskAlias = { singular: 'task', plural: 'taskList' };

User.belongsToMany(Project, { as: taskAlias });
ProjectPlan.belongsTo(Project, { as: taskAlias });
```