### PR TITLE
feat(types): handle Numbers passed as Objects

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,7 @@
     "new-cap": [
       "error",
       {
+        "capIsNewExceptionPattern": "^BigInt",
         "properties": false
       }
     ],

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -214,6 +214,17 @@ NUMBER.prototype.validate = function(value) {
 
   return true;
 };
+NUMBER.prototype._stringify = function _stringify(number) {
+  if (typeof number === 'number' || number === null || number === undefined) {
+    return number;
+  }
+
+  if (typeof number.toString === 'function') {
+    return number.toString();
+  }
+
+  return number;
+};
 Object.defineProperty(NUMBER.prototype, 'UNSIGNED', {
   get() {
     this._unsigned = true;

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@types/bluebird": "^3.5.26",
     "@types/node": "^10.12.27",
     "@types/validator": "^10.9.0",
+    "big-integer": "^1.6.42",
     "chai": "^4.x",
     "chai-as-promised": "^7.x",
     "chai-datetime": "^1.x",

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -12,6 +12,7 @@ const chai = require('chai'),
   uuid = require('uuid'),
   DataTypes = require('../../lib/data-types'),
   dialect = Support.getTestDialect(),
+  BigInt = require('big-integer'),
   semver = require('semver');
 
 describe(Support.getTestDialectTeaser('DataTypes'), () => {
@@ -225,6 +226,26 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     } else {
       return testSuccess(Type, 1);
     }
+  });
+
+  it('should handle JS BigInt type', function() {
+    const User = this.sequelize.define('user', {
+      age: Sequelize.BIGINT
+    });
+
+    const age = BigInt(Number.MAX_SAFE_INTEGER).add(Number.MAX_SAFE_INTEGER);
+
+    return User.sync({ force: true }).then(() => {
+      return User.create({ age });
+    }).then(user => {
+      expect(BigInt(user.age).toString()).to.equal(age.toString());
+      return User.findAll({
+        where: { age }
+      });
+    }).then(users => {
+      expect(users).to.have.lengthOf(1);
+      expect(BigInt(users[0].age).toString()).to.equal(age.toString());
+    });
   });
 
   it('calls parse and bindParam for DOUBLE', () => {


### PR DESCRIPTION
This adds support for Number types that aren't represented as actual Javascript Number instances. For example, [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt) (new in Node 10), [Decimal.js](https://github.com/MikeMcl/decimal.js/), etc. Anything with a `.toString` should work.

Fixes #10491

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes #10491
