### PR TITLE
fix(types): allow specifying additional options for db.query and add missing retry

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1688,7 +1688,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    *   where: ...,
    *   limit: 12,
    *   offset: 12
-   * }).then(function (result) {
+   * }).then(result => {
    *   ...
    * })
    * ```
@@ -1776,7 +1776,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
 
   /**
    * Find a row that matches the query, or build (but don't save) the row if none is found.
-   * The successfull result of the promise will be (instance, initialized) - Make sure to use .spread()
+   * The successfull result of the promise will be (instance, initialized) - Make sure to use `.then(([...]))`
    */
   public static findOrBuild<M extends Model>(
     this: { new (): M } & typeof Model,
@@ -1785,7 +1785,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
 
   /**
    * Find a row that matches the query, or build and save the row if none is found
-   * The successful result of the promise will be (instance, created) - Make sure to use .spread()
+   * The successful result of the promise will be (instance, created) - Make sure to use `.then(([...]))`
    *
    * If no transaction is passed in the `options` object, a new transaction will be created internally, to
    * prevent the race condition where a matching row is created by another connection after the find but
@@ -2291,7 +2291,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * Similarily, when fetching through a join table with custom attributes, these attributes will be
    * available as an object with the name of the through model.
    * ```js
-   * user.getProjects().then(function (projects) {
+   * user.getProjects().then(projects => {
    *   var p1 = projects[0]
    *   p1.userprojects.started // Is this project started yet?
    * })
@@ -2340,8 +2340,8 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * Similarily, when fetching through a join table with custom attributes, these attributes will be
    * available as an object with the name of the through model.
    * ```js
-   * user.getProjects().then(function (projects) {
-   *   var p1 = projects[0]
+   * user.getProjects().then(projects => {
+   *   const p1 = projects[0]
    *   p1.userprojects.started // Is this project started yet?
    * })
    * ```

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -2,7 +2,7 @@ import { DataType } from './data-types';
 import { Logging, Model, ModelAttributeColumnOptions, ModelAttributes, Transactionable, WhereOptions, Filterable } from './model';
 import { Promise } from './promise';
 import QueryTypes = require('./query-types');
-import { Sequelize } from './sequelize';
+import { Sequelize, RetryOptions } from './sequelize';
 import { Transaction } from './transaction';
 
 /**
@@ -55,13 +55,15 @@ export interface QueryOptions extends Logging, Transactionable {
    * A sequelize instance used to build the return instance
    */
   instance?: Model;
+
+  retry?: RetryOptions;
 }
 
 export interface QueryOptionsWithWhere extends QueryOptions, Filterable {
 
 }
 
-export interface QueryOptionsWithModel {
+export interface QueryOptionsWithModel extends QueryOptions {
   /**
    * A sequelize model used to build the returned model instances (used to be called callee)
    */

--- a/types/test/connection.ts
+++ b/types/test/connection.ts
@@ -1,25 +1,38 @@
 import { QueryTypes, Sequelize, SyncOptions } from 'sequelize';
+import { User } from 'models/User';
 
 export const sequelize = new Sequelize('uri');
 
 sequelize.afterBulkSync((options: SyncOptions) => {
-    console.log('synced');
+  console.log('synced');
 });
 
 sequelize
-    .query('SELECT * FROM `test`', {
-        type: QueryTypes.SELECT,
-    })
-    .then(rows => {
-        rows.forEach(row => {
-            console.log(row);
-        });
+  .query('SELECT * FROM `test`', {
+    type: QueryTypes.SELECT,
+  })
+  .then(rows => {
+    rows.forEach(row => {
+      console.log(row);
     });
+  });
 
 sequelize
 .query('INSERT into test set test=1', {
-    type: QueryTypes.INSERT,
+  type: QueryTypes.INSERT,
 })
 .then(([aiId, affected]) => {
-    console.log(aiId, affected);
+  console.log(aiId, affected);
 });
+
+sequelize.transaction<void>(async transaction => {
+  const rows = await sequelize
+    .query('SELECT * FROM `user`', {
+      retry: {
+        max: 123,
+      },
+      model: User,
+      transaction,
+      logging: true,
+    })
+})

--- a/types/test/sequelize.ts
+++ b/types/test/sequelize.ts
@@ -5,6 +5,10 @@ export const sequelize = new Sequelize({
     afterConnect: (connection, config: Config) => {
       // noop
     }
+  },
+  retry: {
+    max: 123,
+    match: ['hurr'],
   }
 });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change

See title
fixes #10506

@sushantdhiman can you clarify if you can specify BOTH the query `type` AND `model`?
It seems that when model is specified it implicitly uses `SELECT` but what if `type` is specified?