### PR TITLE
fix describeTable reject with non-error

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -475,7 +475,7 @@ class QueryInterface {
       // Query generators that use information_schema for retrieving table info will just return an empty result set,
       // it will not throw an error like built-ins do (e.g. DESCRIBE on MySql).
       if (_.isEmpty(data)) {
-        return Promise.reject(`No description found for "${tableName}" table. Check the table name and schema; remember, they _are_ case sensitive.`);
+        return Promise.reject(new Error(`No description found for "${tableName}" table. Check the table name and schema; remember, they _are_ case sensitive.`));
       }
       return data;
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Avoid `(node:120) Warning: a promise was rejected with a non-error: [object String]` by rejecting with an error, like your other Promise.reject calls.