### PR TITLE
fix(validations): Setting isNewRecord to false for validation in bulkUpdate

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2706,7 +2706,7 @@ class Model {
     return Promise.try(() => {
       // Validate
       if (options.validate) {
-        const build = this.build(values);
+        const build = this.build(values, {isNewRecord: false});
         build.set(this._timestampAttributes.updatedAt, values[this._timestampAttributes.updatedAt], { raw: true });
 
         if (options.sideEffects) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -3626,15 +3626,13 @@ class Model {
               options.fields = _.uniq(options.fields.concat(hookChanged));
             }
 
-            if (hookChanged) {
-              if (options.validate) {
-              // Validate again
+            if (hookChanged.length > 0 && options.validate) {
+            // Validate again
 
-                options.skip = _.difference(Object.keys(this.constructor.rawAttributes), hookChanged);
-                return this.validate(options).then(() => {
-                  delete options.skip;
-                });
-              }
+              options.skip = _.difference(Object.keys(this.constructor.rawAttributes), hookChanged);
+              return this.validate(options).then(() => {
+                delete options.skip;
+              });
             }
           });
       }
@@ -4200,35 +4198,35 @@ Model._conformOptions = Model._conformOptions;
 Model._validateIncludedElements = Model._validateIncludedElements;
 Model._expandIncludeAll = Model._expandIncludeAll;
 
-Model.findByPrimary = function () {
+Model.findByPrimary = function() {
   Utils.deprecate('Model.findByPrimary has been deprecated, please use Model.findByPk instead');
   return Model.findByPk.apply(this, arguments);
 };
-Model.findById = function () {
+Model.findById = function() {
   Utils.deprecate('Model.findById has been deprecated, please use Model.findByPk instead');
   return Model.findByPk.apply(this, arguments);
 };
-Model.find = function () {
+Model.find = function() {
   Utils.deprecate('Model.find has been deprecated, please use Model.findOne instead');
   return Model.findOne.apply(this, arguments);
 };
-Model.findAndCount = function () {
+Model.findAndCount = function() {
   Utils.deprecate('Model.findAndCount has been deprecated, please use Model.findAndCountAll instead');
   return Model.findAndCountAll.apply(this, arguments);
 };
-Model.findOrInitialize = function () {
+Model.findOrInitialize = function() {
   Utils.deprecate('Model.findOrInitialize has been deprecated, please use Model.findOrBuild instead');
   return Model.findOrBuild.apply(this, arguments);
 };
-Model.insertOrUpdate = function () {
+Model.insertOrUpdate = function() {
   Utils.deprecate('Model.insertOrUpdate has been deprecated, please use Model.upsert instead');
   return Model.upsert.apply(this, arguments);
 };
-Model.all = function () {
+Model.all = function() {
   Utils.deprecate('Model.all has been deprecated, please use Model.findAll instead');
   return Model.findAll.apply(this, arguments);
 };
-Model.prototype.updateAttributes = function () {
+Model.prototype.updateAttributes = function() {
   Utils.deprecate('Instance.updateAttributes has been deprecated, please use Instance.update instead');
   return Model.prototype.update.apply(this, arguments);
 };


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
In validation context of bulkUpdate, isNewRecord was coming true which looks not realistic since we performing an update. re#10507
