### PR TITLE
add table prefix to unique index in postgres

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -306,7 +306,7 @@ const QueryGenerator = {
 
         attrSql += _.template(query.replace('ALTER COLUMN', ''), this._templateSettings)({
           tableName: this.quoteTable(tableName),
-          query: 'ADD CONSTRAINT ' + this.quoteIdentifier(attributeName + '_unique_idx') + ' UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
+          query: 'ADD CONSTRAINT ' + this.quoteIdentifier(tableName + '_' + attributeName + '_unique_idx') + ' UNIQUE (' + this.quoteIdentifier(attributeName) + ')'
         });
       }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
duplicate indexs when sync two table has fields of the same name.  it will failed when sync as `"fieldname_unique_idx" already exists`, add table prefix like `"tablename_fieldname_unique_idx"` can avoid the error.
<!-- Please provide a description of the change here. -->
