### PR TITLE
feat(sqlite/query-generator): support restart identity in SQLite

### DIFF
--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -260,7 +260,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
   truncateTableQuery(tableName, options = {}) {
     return [
       `DELETE FROM ${this.quoteTable(tableName)}`,
-      options.restartIdentity ? `; DELETE FROM \`sqlite_sequence\` WHERE \`name\` = '${tableName.schema}.${tableName.table}';` : ''
+      options.restartIdentity ? `; DELETE FROM ${this.quoteTable('sqlite_sequence')} WHERE ${this.quoteIdentifier('name')} = '${tableName.schema}.${tableName.table}';` : ''
     ].join('');
   }
 

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -257,8 +257,11 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     return { query, bind };
   }
 
-  truncateTableQuery(tableName) {
-    return `DELETE FROM ${this.quoteTable(tableName)}`;
+  truncateTableQuery(tableName, options = {}) {
+    return [
+      `DELETE FROM ${this.quoteTable(tableName)}`,
+      options.restartIdentity ? `; DELETE FROM \`sqlite_sequence\` WHERE \`name\` = '${tableName.schema}.${tableName.table}';` : ''
+    ].join('');
   }
 
   deleteQuery(tableName, where, options = {}, model) {

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -260,7 +260,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
   truncateTableQuery(tableName, options = {}) {
     return [
       `DELETE FROM ${this.quoteTable(tableName)}`,
-      options.restartIdentity ? `; DELETE FROM ${this.quoteTable('sqlite_sequence')} WHERE ${this.quoteIdentifier('name')} = '${tableName.schema}.${tableName.table}';` : ''
+      options.restartIdentity ? `; DELETE FROM ${this.quoteTable('sqlite_sequence')} WHERE ${this.quoteIdentifier('name')} = ${Utils.addTicks(Utils.removeTicks(this.quoteTable(tableName), '`'), "'")};` : ''
     ].join('');
   }
 

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -65,7 +65,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             mssql: 'TRUNCATE TABLE [public].[test_users]',
             mariadb: 'TRUNCATE `public`.`test_users`',
             mysql: 'TRUNCATE `public.test_users`',
-            sqlite: 'DELETE FROM `public.test_users`'
+            sqlite: 'DELETE FROM `public.test_users`; DELETE FROM `sqlite_sequence` WHERE `name` = \'public.test_users\';'
           }
         );
       });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Follow-up to #5356 adding support for SQLite.

`npm run test-sqlite` passes and I also tested the generated SQL against my DB

I believe current docs suffice?
