### PR TITLE
fix(mysql): issue with MySQL, TIMESTAMPS, and CURRENT_TIMESTAMP

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -66,6 +66,10 @@ function escape(val, timeZone, dialect, format) {
     throw new Error(`Invalid value ${util.inspect(val)}`);
   }
 
+  if (dialect === 'mysql' && val === 'CURRENT_TIMESTAMP') {
+    return val;
+  }
+
   if (dialect === 'postgres' || dialect === 'sqlite' || dialect === 'mssql') {
     // http://www.postgresql.org/docs/8.2/static/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS
     // http://stackoverflow.com/q/603572/130598

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -145,6 +145,10 @@ if (dialect === 'mysql') {
         {
           arguments: [{ id: { type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT' } }],
           expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
+        },
+        {
+          arguments: [{ createdAt: { type: 'TIMESTAMP', allowNull: false, defaultValue: 'CURRENT_TIMESTAMP' } }],
+          expectation: { createdAt: 'TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP' }
         }
       ],
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Do not quote CURRENT_TIMESTAMP when it's being used with MySQL.  I think it's safe to never do this.  If I knew where to scope this to 'defaultValue' I'd feel safer?

See #8868, attempting to fix this issue.
