### PR TITLE
v5 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,20 +71,19 @@ jobs:
     - stage: test
       node_js: '8'
       env: DIALECT=sqlite COVERAGE=false TSC=true
-    # - stage: release
-    #   node_js: '8'
-    #   script:
-    #     - npm run semantic-release
-    #   before_deploy:
-    #     - npm run docs
-    #   deploy:
-    #     provider: surge
-    #     project: ./esdoc/
-    #     domain: docs.sequelizejs.com
-    #     skip_cleanup: true
-    #     on: v4
+    - stage: release
+      node_js: '8'
+      script:
+        - npm run docs
+      # before_deploy:
+      #   - npm run docs
+      deploy:
+        provider: surge
+        project: ./esdoc/
+        domain: docs.sequelizejs.com
+        skip_cleanup: true
 
 stages:
   - test
-  # - name: release
-  #   if: branch = master AND type = push AND fork = false
+  - name: release
+    if: branch = master AND type = push AND fork = false

--- a/CONTACT.md
+++ b/CONTACT.md
@@ -1,11 +1,10 @@
 ## Contact Us
 
-In some cases you might want to reach the maintainers privately. These can be reporting a security vulnerability or any other specific cases. 
+In some cases you might want to reach the maintainers privately. These can be reporting a security vulnerability or any other specific cases.
 You can use the information below to contact maintainers directly. We will try to get back to you as soon as possible.
 
 ### Via Email
 
-- **Mick Hansen** mick.kasper.hansen@gmail.com
 - **Jan Aagaard Meier** janzeh@gmail.com
 - **Sushant Dhiman** sushantdhiman@outlook.com
 
@@ -13,9 +12,5 @@ You can use the information below to contact maintainers directly. We will try t
 
 Maintainer's usernames for [Sequelize Slack Channel](https://sequelize.slack.com)
 
-- **Mick Hansen** @mhansen
 - **Jan Aagaard Meier** @janmeier
-- **Sushant Dhiman** @sushantdhiman 
-
-
-
+- **Sushant Dhiman** @sushantdhiman

--- a/README.md
+++ b/README.md
@@ -24,10 +24,8 @@ npm install --save sequelize # will install v5
 ## Table of Contents
 - [Installation](#installation)
 - [Documentation](#documentation)
-- [Resources](#resources)
-- [Tools](#tools)
-- [Learning](#learning)
 - [Responsible disclosure](#responsible-disclosure)
+- [Resources](#resources)
 
 ## Installation
 
@@ -50,7 +48,11 @@ Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use
 - [v3 Documentation](https://sequelize.readthedocs.io/en/v3/)
 - [Contributing](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)
 
+## Responsible disclosure
+If you have any security issue to report, contact project maintainers privately. You can find contact information [here](https://github.com/sequelize/sequelize/blob/master/CONTACT.md)
+
 ## Resources
+
 - [Changelog](https://github.com/sequelize/sequelize/releases)
 - [Slack](http://sequelize-slack.herokuapp.com/)
 
@@ -67,6 +69,3 @@ Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use
 ### Translations
 - [English v5](http://docs.sequelizejs.com) (OFFICIAL)
 - [中文文档 v4](https://github.com/demopark/sequelize-docs-Zh-CN) (UNOFFICIAL)
-
-## Responsible disclosure
-If you have any security issue to report, contact project maintainers privately. You can find contact information [here](https://github.com/sequelize/sequelize/blob/master/CONTACT.md)

--- a/README.md
+++ b/README.md
@@ -10,25 +10,24 @@
 ![node](https://img.shields.io/node/v/sequelize.svg)
 [![License](https://img.shields.io/npm/l/sequelize.svg?maxAge=2592000?style=plastic)](https://github.com/sequelize/sequelize/blob/master/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![Greenkeeper badge](https://badges.greenkeeper.io/sequelize/sequelize.svg)](https://greenkeeper.io/)
 
 Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.
 
-## v5 Beta Release
+## v5 Release
 
-We have started v5 beta release process. Hopefully this will cover full [v5 milestone](https://github.com/sequelize/sequelize/milestone/18). You can find upgrade guide and changelog [here](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md)
+You can find upgrade guide and changelog [here](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md)
 
 ```bash
-npm install --save sequelize # will install v4
-npm install --save sequelize@next # will install v5-beta
+npm install --save sequelize # will install v5
 ```
 
 ## Table of Contents
 - [Installation](#installation)
-- [Features](#features)
-- [Responsible disclosure](#responsible-disclosure)
 - [Documentation](#documentation)
 - [Resources](#resources)
+- [Tools](#tools)
+- [Learning](#learning)
+- [Responsible disclosure](#responsible-disclosure)
 
 ## Installation
 
@@ -43,46 +42,31 @@ $ npm install --save sqlite3
 $ npm install --save tedious # MSSQL
 ```
 
-Sequelize follows [SEMVER](http://semver.org). Supports Node v4 and above to use ES6 features.
-
-## Features
-
-- Schema definition
-- Schema synchronization/dropping
-- 1:1, 1:M & N:M Associations
-- Through models
-- Promises
-- Hooks/lifecycle events
-- Prefetching/association including
-- Transactions
-- Migrations
-- CLI ([sequelize-cli](https://github.com/sequelize/cli))
-
-## Responsible disclosure
-If you have any security issue to report, contact project maintainers privately. You can find contact information [here](https://github.com/sequelize/sequelize/blob/master/CONTACT.md)
+Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use ES6 features.
 
 ## Documentation
-- [v4 Documentation](http://docs.sequelizejs.com)
+- [v5 Documentation](http://docs.sequelizejs.com)
+- [v4 Documentation](https://github.com/sequelize/sequelize/blob/v4/docs)
 - [v3 Documentation](https://sequelize.readthedocs.io/en/v3/)
-- [v3 to v4 Upgrade Guide](http://docs.sequelizejs.com/manual/tutorial/upgrade-to-v4.html)
-- [v4 to v5(beta) Upgrade Guide](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md)
+- [Contributing](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)
 
 ## Resources
-- [Contributing](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)
 - [Changelog](https://github.com/sequelize/sequelize/releases)
 - [Slack](http://sequelize-slack.herokuapp.com/)
-- [Google Groups](https://groups.google.com/forum/#!forum/sequelize)
 
 ### Tools
 - [Sequelize & TypeScript](https://github.com/RobinBuschmann/sequelize-typescript)
 - [Sequelize & GraphQL](https://github.com/mickhansen/graphql-sequelize)
 - [Add-ons & Plugins](https://github.com/sequelize/sequelize/wiki/Add-ons-&-Plugins)
+- [Sequelize CLI](https://github.com/sequelize/cli)
 
 ### Learning
-- [Getting Started](http://docs.sequelizejs.com/manual/installation/getting-started)
+- [Getting Started](http://docs.sequelizejs.com/manual/getting-started)
 - [Express Example](https://github.com/sequelize/express-example)
 
 ### Translations
-- [English v4](http://docs.sequelizejs.com) (OFFICIAL)
+- [English v5](http://docs.sequelizejs.com) (OFFICIAL)
 - [中文文档 v4](https://github.com/demopark/sequelize-docs-Zh-CN) (UNOFFICIAL)
 
+## Responsible disclosure
+If you have any security issue to report, contact project maintainers privately. You can find contact information [here](https://github.com/sequelize/sequelize/blob/master/CONTACT.md)

--- a/docs/ROUTER
+++ b/docs/ROUTER
@@ -24,3 +24,6 @@
 301 /en/latest/api/errors/ /class/lib/errors/index.js~BaseError.html
 
 302 /manual/tutorial/:section.html /manual/:section.html
+302 /manual/installation/:section.html /manual/:section.html
+302 /manual/faq/:section.html /manual/:section.html
+302 /manual/advanced/:section.html /manual/:section.html

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 [![npm](https://img.shields.io/npm/v/sequelize.svg?style=flat-square)](https://github.com/sequelize/sequelize/releases)
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com/)
 
-Sequelize is a promise-based ORM for Node.js v4 and up. It supports the dialects PostgreSQL, MariaDB, MySQL, SQLite and MSSQL and features solid transaction support, relations, read replication and more.
+Sequelize is a promise-based ORM for Node.js v6 and up. It supports the dialects PostgreSQL, MariaDB, MySQL, SQLite and MSSQL and features solid transaction support, relations, read replication and more.
 
 ## Example usage
 
@@ -46,4 +46,4 @@ sequelize.sync()
   });
 ```
 
-Please use [Getting Started](manual/installation/getting-started) to learn more. If you wish to learn about Sequelize API please use [API Reference](identifiers)
+Please use [Getting Started](manual/getting-started) to learn more. If you wish to learn about Sequelize API please use [API Reference](identifiers)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -349,7 +349,7 @@ sequelize.query('select 1 as `foo.bar.baz`').then(rows => {
 ```
 
 
-[0]: /manual/installation/usage.html#options
+[0]: /manual/usage.html#options
 [1]: /manual/models-definition.html#configuration
 [2]: /class/lib/sequelize.js~Sequelize.html
 [3]: /manual/transactions.html


### PR DESCRIPTION
This PR covers all changes related to v5 release, these are mostly documentation updates. Full changelog is available [here](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md)

- [x] README.md
- [x] Documentation links
- [x] Travis `release` step