### PR TITLE
Improve basic getting-started docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,11 @@
 [![License](https://badgen.net/github/license/sequelize/sequelize)](https://github.com/sequelize/sequelize/blob/master/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.
+Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server. It features solid transaction support, relations, eager and lazy loading, read replication and more.
 
-## v5 Release
+Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use ES6 features.
 
-You can find upgrade guide and changelog [here](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md)
-
-```bash
-npm install --save sequelize # will install v5
-```
+**Version 5 was released on March 13, 2019!** You can find upgrade guide and changelog on [upgrade-to-v5.md](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md).
 
 ## Table of Contents
 - [Installation](#installation)
@@ -33,17 +29,15 @@ npm install --save sequelize # will install v5
 ## Installation
 
 ```bash
-$ npm install --save sequelize
+$ npm install --save sequelize # This will install v5
 
 # And one of the following:
-$ npm install --save pg pg-hstore
+$ npm install --save pg pg-hstore # Postgres
 $ npm install --save mysql2
 $ npm install --save mariadb
 $ npm install --save sqlite3
-$ npm install --save tedious # MSSQL
+$ npm install --save tedious # Microsoft SQL Server
 ```
-
-Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use ES6 features.
 
 ## Documentation
 - [v5 Documentation](http://docs.sequelizejs.com)
@@ -52,12 +46,13 @@ Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use
 - [Contributing](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)
 
 ## Responsible disclosure
-If you have any security issue to report, contact project maintainers privately. You can find contact information [here](https://github.com/sequelize/sequelize/blob/master/CONTACT.md)
+If you have any security issue to report, contact project maintainers privately. You can find contact information in [CONTACT.md](https://github.com/sequelize/sequelize/blob/master/CONTACT.md).
 
 ## Resources
 
 - [Changelog](https://github.com/sequelize/sequelize/releases)
 - [Slack](http://sequelize-slack.herokuapp.com/)
+- [Stack Overflow](https://stackoverflow.com/questions/tagged/sequelize.js)
 
 ### Tools
 - [Sequelize & TypeScript](https://github.com/RobinBuschmann/sequelize-typescript)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # Sequelize
 
-[![npm version](https://img.shields.io/npm/v/sequelize.svg)](https://www.npmjs.com/package/sequelize)
-[![Build Status](https://travis-ci.org/sequelize/sequelize.svg?branch=master)](https://travis-ci.org/sequelize/sequelize)
-[![Windows Build status](https://ci.appveyor.com/api/projects/status/9l1ypgwsp5ij46m3/branch/master?svg=true)](https://ci.appveyor.com/project/sushantdhiman/sequelize/branch/master)
-[![codecov](https://codecov.io/gh/sequelize/sequelize/branch/master/graph/badge.svg)](https://codecov.io/gh/sequelize/sequelize)
+[![npm version](https://badgen.net/npm/v/sequelize)](https://www.npmjs.com/package/sequelize)
+[![Travis Build Status](https://badgen.net/travis/sequelize/sequelize?icon=travis)](https://travis-ci.org/sequelize/sequelize)
+[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/9l1ypgwsp5ij46m3/branch/master?svg=true)](https://ci.appveyor.com/project/sushantdhiman/sequelize/branch/master)
+[![npm downloads](https://badgen.net/npm/dm/sequelize)](https://www.npmjs.com/package/sequelize)
+[![codecov](https://badgen.net/codecov/c/github/sequelize/sequelize?icon=codecov)](https://codecov.io/gh/sequelize/sequelize)
+[![Last commit](https://badgen.net/github/last-commit/sequelize/sequelize)](https://github.com/sequelize/sequelize)
+[![Merged PRs](https://badgen.net/github/merged-prs/sequelize/sequelize)](https://github.com/sequelize/sequelize)
+[![GitHub stars](https://badgen.net/github/stars/sequelize/sequelize)](https://github.com/sequelize/sequelize)
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=955&style=bounties_received)](https://www.bountysource.com/teams/sequelize/issues?utm_source=Sequelize&utm_medium=shield&utm_campaign=bounties_received)
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com/)
-[![npm downloads](https://img.shields.io/npm/dm/sequelize.svg?maxAge=2592000)](https://www.npmjs.com/package/sequelize)
-![node](https://img.shields.io/node/v/sequelize.svg)
-[![License](https://img.shields.io/npm/l/sequelize.svg?maxAge=2592000?style=plastic)](https://github.com/sequelize/sequelize/blob/master/LICENSE)
+[![node](https://badgen.net/npm/node/sequelize)](https://www.npmjs.com/package/sequelize)
+[![License](https://badgen.net/github/license/sequelize/sequelize)](https://github.com/sequelize/sequelize/blob/master/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server. It features solid transaction support, relations, read replication and more.

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite an
 
 Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use ES6 features.
 
-## v5 Release (March 13, 2019)
+## v5 Release
 
-You can find the upgrade guide and changelog on [upgrade-to-v5.md](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md).
+You can find the upgrade guide and changelog in [upgrade-to-v5.md](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md).
 
 ## Table of Contents
 - [Installation](#installation)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite an
 
 Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use ES6 features.
 
-**Version 5 was released on March 13, 2019!** You can find upgrade guide and changelog on [upgrade-to-v5.md](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md).
+## v5 Release (March 13, 2019)
+
+You can find the upgrade guide and changelog on [upgrade-to-v5.md](https://github.com/sequelize/sequelize/blob/master/docs/upgrade-to-v5.md).
 
 ## Table of Contents
 - [Installation](#installation)

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,10 +5,19 @@
   <div class="center sequelize">Sequelize</span>
 </div>
 
-[![Travis build](https://img.shields.io/travis/sequelize/sequelize/master.svg?style=flat-square)](https://travis-ci.org/sequelize/sequelize)
-[![npm](https://img.shields.io/npm/dm/sequelize.svg?style=flat-square)](https://npmjs.org/package/sequelize)
-[![npm](https://img.shields.io/npm/v/sequelize.svg?style=flat-square)](https://github.com/sequelize/sequelize/releases)
+[![npm version](https://badgen.net/npm/v/sequelize)](https://www.npmjs.com/package/sequelize)
+[![Travis Build Status](https://badgen.net/travis/sequelize/sequelize?icon=travis)](https://travis-ci.org/sequelize/sequelize)
+[![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/9l1ypgwsp5ij46m3/branch/master?svg=true)](https://ci.appveyor.com/project/sushantdhiman/sequelize/branch/master)
+[![npm downloads](https://badgen.net/npm/dm/sequelize)](https://www.npmjs.com/package/sequelize)
+[![codecov](https://badgen.net/codecov/c/github/sequelize/sequelize?icon=codecov)](https://codecov.io/gh/sequelize/sequelize)
+[![Last commit](https://badgen.net/github/last-commit/sequelize/sequelize)](https://github.com/sequelize/sequelize)
+[![Merged PRs](https://badgen.net/github/merged-prs/sequelize/sequelize)](https://github.com/sequelize/sequelize)
+[![GitHub stars](https://badgen.net/github/stars/sequelize/sequelize)](https://github.com/sequelize/sequelize)
+[![Bountysource](https://www.bountysource.com/badge/team?team_id=955&style=bounties_received)](https://www.bountysource.com/teams/sequelize/issues?utm_source=Sequelize&utm_medium=shield&utm_campaign=bounties_received)
 [![Slack Status](http://sequelize-slack.herokuapp.com/badge.svg)](http://sequelize-slack.herokuapp.com/)
+[![node](https://badgen.net/npm/node/sequelize)](https://www.npmjs.com/package/sequelize)
+[![License](https://badgen.net/github/license/sequelize/sequelize)](https://github.com/sequelize/sequelize/blob/master/LICENSE)
+[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
 Sequelize is a promise-based ORM for Node.js v6 and up. It supports the dialects PostgreSQL, MariaDB, MySQL, SQLite and MSSQL and features solid transaction support, relations, read replication and more.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,26 +19,19 @@
 [![License](https://badgen.net/github/license/sequelize/sequelize)](https://github.com/sequelize/sequelize/blob/master/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-Sequelize is a promise-based ORM for Node.js v6 and up. It supports the dialects PostgreSQL, MariaDB, MySQL, SQLite and MSSQL and features solid transaction support, relations, read replication and more.
+Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite and Microsoft SQL Server. It features solid transaction support, relations, eager and lazy loading, read replication and more.
 
-## Example usage
+Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use ES6 features.
+
+**Sequelize v5** was released on March 13, 2019.
+
+You are currently looking at the **Tutorials and Guides** for Sequelize. You might also be interested in the [API Reference](identifiers).
+
+## Quick example
 
 ```js
 const Sequelize = require('sequelize');
-const sequelize = new Sequelize('database', 'username', 'password', {
-  host: 'localhost',
-  dialect: 'mysql'|'mariadb'|'sqlite'|'postgres'|'mssql',
-
-  pool: {
-    max: 5,
-    min: 0,
-    acquire: 30000,
-    idle: 10000
-  },
-
-  // SQLite only
-  storage: 'path/to/database.sqlite'
-});
+const sequelize = new Sequelize('postgres://user:pass@example.com:5432/dbname');
 
 const User = sequelize.define('user', {
   username: Sequelize.STRING,
@@ -55,4 +48,4 @@ sequelize.sync()
   });
 ```
 
-Please use [Getting Started](manual/getting-started) to learn more. If you wish to learn about Sequelize API please use [API Reference](identifiers)
+To learn more about how to use Sequelize, read the tutorials available in the left menu. [Begin with Getting Started](manual/getting-started).


### PR DESCRIPTION
I've reworked the getting-started docs, improving explanations, simplifying some other things, adding more examples and adding more links, hopefully making it easier for new Sequelize users to grasp the basics.

This PR also has some changes for README.md and the index.md from docs, making both more similar to each other. I've also added more nice badges and replaced the badge provider to [badgen.net](https://badgen.net) which I've grown to like a lot - it's fast and reliable.

----------

**NOTE:** I've been wanting to help with a major rework of the sequelize tutorials for a while now, I finally had the time to make some changes, but I will probably be opening more PRs in the future to improve the rest of the tutorials/guides. IMO, they look a bit outdated and disorganized. But I am short on time currently. I will probably suggest some layout changes as well in the future (short future, hopefully).

Thanks for looking! And thanks for the v5 release :grimacing: 