### PR TITLE
fix(connection-manager): correctly assign default port

### DIFF
--- a/lib/dialects/mariadb/connection-manager.js
+++ b/lib/dialects/mariadb/connection-manager.js
@@ -23,8 +23,8 @@ const parserStore = require('../parserStore')('mariadb');
 
 class ConnectionManager extends AbstractConnectionManager {
   constructor(dialect, sequelize) {
+    sequelize.config.port = sequelize.config.port || 3306;
     super(dialect, sequelize);
-    this.sequelize.config.port = this.sequelize.config.port || 3306;
     this.lib = this._loadDialectModule('mariadb');
     this.refreshTypeParser(DataTypes);
   }

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -12,8 +12,8 @@ const debugTedious = logger.getLogger().debugContext('connection:mssql:tedious')
 
 class ConnectionManager extends AbstractConnectionManager {
   constructor(dialect, sequelize) {
+    sequelize.config.port = sequelize.config.port || 1433;
     super(dialect, sequelize);
-    this.sequelize.config.port = this.sequelize.config.port || 1433;
     this.lib = this._loadDialectModule('tedious');
     this.refreshTypeParser(DataTypes);
   }

--- a/lib/dialects/mysql/connection-manager.js
+++ b/lib/dialects/mysql/connection-manager.js
@@ -23,8 +23,8 @@ const parserStore = require('../parserStore')('mysql');
 
 class ConnectionManager extends AbstractConnectionManager {
   constructor(dialect, sequelize) {
+    sequelize.config.port = sequelize.config.port || 3306;
     super(dialect, sequelize);
-    this.sequelize.config.port = this.sequelize.config.port || 3306;
     this.lib = this._loadDialectModule('mysql2');
     this.refreshTypeParser(DataTypes);
   }

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -12,8 +12,8 @@ const moment = require('moment-timezone');
 
 class ConnectionManager extends AbstractConnectionManager {
   constructor(dialect, sequelize) {
+    sequelize.config.port = sequelize.config.port || 5432;
     super(dialect, sequelize);
-    this.sequelize.config.port = this.sequelize.config.port || 5432;
 
     const pgLib = this._loadDialectModule('pg');
     this.lib = this.sequelize.config.native ? pgLib.native : pgLib;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Fixes https://github.com/sequelize/sequelize/issues/10556

It seems default ports were never used by pool because connection manager keep a cloned copy of config. Now we assign default port before initializing connection manager 