### PR TITLE
[PostgreSQL] Fix problem with creating ENUM when addColumn is used with ARRAY(ENUM)

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -243,17 +243,19 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     return super.handleSequelizeMethod.call(this, smth, tableName, factory, options, prepend);
   }
 
-  addColumnQuery(table, key, dataType) {
+  addColumnQuery(table, key, attribute) {
 
-    const dbDataType = this.attributeToSQL(dataType, { context: 'addColumn', table, key });
+    const dbDataType = this.attributeToSQL(attribute, { context: 'addColumn', table, key });
+    const dataType = attribute.type;
     const definition = this.dataTypeMapping(table, key, dbDataType);
     const quotedKey = this.quoteIdentifier(key);
     const quotedTable = this.quoteTable(this.extractTableDetails(table));
 
     let query = `ALTER TABLE ${quotedTable} ADD COLUMN ${quotedKey} ${definition};`;
-
-    if (dataType.type && dataType.type instanceof DataTypes.ENUM || dataType instanceof DataTypes.ENUM) {
+    if (dataType instanceof DataTypes.ENUM) {
       query = this.pgEnum(table, key, dataType) + query;
+    } else if (dataType.type && dataType.type instanceof DataTypes.ENUM) {
+      query = this.pgEnum(table, key, dataType.type) + query;
     }
 
     return query;

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -289,6 +289,21 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       });
     });
 
+    it('should be able to add a column of type of array of enums', function() {
+      return this.queryInterface.addColumn('users', 'tags', {
+        allowNull: false,
+        type: Sequelize.ARRAY(Sequelize.ENUM(
+          'Value1',
+          'Value2',
+          'Value3'
+        ))
+      }).then(() => {
+        return this.queryInterface.describeTable('users');
+      }).then(table => {
+        expect(table).to.have.property('tags');
+      });
+    });
+
     it('should be able to add a foreign key reference', function() {
       return this.queryInterface.createTable('level', {
         id: {


### PR DESCRIPTION
It fixes the problem when adding column to existing table with array of enum.
Before this fix the following:
```es6
await queryInterface.addColumn('users', 'tags', {
      allowNull: false,
      type: Sequelize.ARRAY(Sequelize.ENUM(
        'Value1',
        'Value2',
        'Value3'
      ))
    });
```
would fail with
```Unhandled rejection SequelizeDatabaseError: type "public.enum_users_tags[]" does not exist```

I am sorry, I do not have time to fill out the template - I just want to show the problem with solution

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
