### PR TITLE
Infer model attributes datatypes to basic types

### DIFF
--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -310,7 +310,9 @@ export interface DecimalDataTypeOptions {
   scale?: number;
 }
 
-export interface BooleanDataType extends AbstractDataType {}
+export interface BooleanDataType extends AbstractDataType {
+  __type: boolean;
+}
 
 /**
  * A boolean / tinyint column, depending on dialect
@@ -435,7 +437,9 @@ export interface RangeDataTypeOptions<T extends RangeableDataType> {
   subtype?: T;
 }
 
-export interface UuidDataType extends AbstractDataType {}
+export interface UuidDataType extends AbstractDataType {
+  __type: string
+}
 
 /**
  * A column storing a unique universal identifier. Use with `UUIDV1` or `UUIDV4` for default values.
@@ -610,3 +614,46 @@ export const CITEXT: AbstractDataTypeConstructor;
 
 // umzug compatibility
 export type DataTypeAbstract = AbstractDataTypeConstructor;
+
+
+type CastSimpleDataType<T extends DataType> = 
+  T extends 
+    | NumberDataType
+    | NumberDataTypeConstructor
+  ? number : 
+  T extends UuidDataType
+  ? string : 
+  T extends BooleanDataType
+  ? boolean : 
+  T extends 
+    | StringDataType
+    | StringDataTypeConstructor
+    | TextDataType
+    | TextDataTypeConstructor
+  ? string :
+  T extends 
+    | DateOnlyDataType
+    | DateOnlyDataTypeConstructor
+    | DateDataType
+    | DateDataTypeConstructor
+  ? Date : 
+  T extends AbstractDataTypeConstructor
+  ? any : 
+  {};
+
+
+/**
+ * Conditional type mapper
+ * From a sequelize  datatype to basic type (string, number, boolean, Date)
+ * ```typescript
+ * const date: CastDataType<DateOnlyDataType> = new Date();
+ * ```
+ */
+export type CastDataType<T extends DataType> = 
+  T extends ArrayDataType<infer ArrayType>
+  ? CastSimpleDataType<ArrayType>[]
+  : T extends EnumDataType<infer EnumType>
+  ? EnumType
+  : T extends EnumDataTypeConstructor
+  ? string[]
+  : CastSimpleDataType<T>;

--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -310,10 +310,12 @@ export interface DecimalDataTypeOptions {
   scale?: number;
 }
 
+export interface BooleanDataType extends AbstractDataType {}
+
 /**
  * A boolean / tinyint column, depending on dialect
  */
-export const BOOLEAN: AbstractDataTypeConstructor;
+export const BOOLEAN: BooleanDataType;
 
 /**
  * A time column
@@ -433,20 +435,22 @@ export interface RangeDataTypeOptions<T extends RangeableDataType> {
   subtype?: T;
 }
 
+export interface UuidDataType extends AbstractDataType {}
+
 /**
  * A column storing a unique universal identifier. Use with `UUIDV1` or `UUIDV4` for default values.
  */
-export const UUID: AbstractDataTypeConstructor;
+export const UUID: UuidDataType;
 
 /**
  * A default unique universal identifier generated following the UUID v1 standard
  */
-export const UUIDV1: AbstractDataTypeConstructor;
+export const UUIDV1: UuidDataType;
 
 /**
  * A default unique universal identifier generated following the UUID v4 standard
  */
-export const UUIDV4: AbstractDataTypeConstructor;
+export const UUIDV4: UuidDataType;
 
 /**
  * A virtual value that is not stored in the DB. This could for example be useful if you want to provide a default value in your model that is returned to the user but not stored in the DB.

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -9,7 +9,7 @@ import {
   HasOne,
   HasOneOptions,
 } from './associations/index';
-import { DataType } from './data-types';
+import { DataType, CastDataType } from './data-types';
 import { Deferrable } from './deferrable';
 import { HookReturn, Hooks, ModelHooks } from './hooks';
 import { ValidationOptions } from './instance-validator';
@@ -2531,8 +2531,54 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   public toJSON(): object;
 }
 
+/**
+ * Simple shorthand to use typeof Model
+ */
 export type ModelType = typeof Model;
 
+/**
+ * Constructor type of Model
+ * To get ModelType from a generic Model
+ */
 export type ModelCtor<M extends Model> = { new (): M } & ModelType;
 
+/**
+ * Conditional type mapper
+ * Get DataType from a generic ModelAttributes value T
+ * if T is a ModelAttributeColumnOptions, DataType is ModelAttributeColumnOptions["type"]
+ */
+type ExtractAttributeDataType<T extends DataType | ModelAttributeColumnOptions> = 
+  T extends DataType
+  ? T :
+  T extends ModelAttributeColumnOptions
+  ? T["type"] :
+  any;
+
+/**
+ * Get attributes "basic types" (string, number, boolean, Date, *[]) from a ModelAttributes
+ * ```typescript
+ * const productAttributes = {
+ *  sku: DataTypes.STRING,
+ *  qty: {
+ *     type: DataTypes.INTEGER,
+ *     allowNull: true
+ *  },
+ *  instock: DataTypes.BOOLEAN,
+ *  label: {
+ *     type: DataTypes.STRING(100),
+ *     allowNull: true
+ * };
+ * type TProduct = AttributesTypes<typeof productAttributes>;
+ * // {
+ * //   sku: string;
+ * //   qty: number;
+ * //   instock: boolean;
+ * //   label: string;
+ * // }
+ * ```
+ */
+export type AttributesTypes<T extends ModelAttributes> = { [P in keyof T]: CastDataType<ExtractAttributeDataType<T[P]>> };
+
 export default Model;
+
+

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1469,7 +1469,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    *  string or a type-description object, with the properties described below:
    * @param options These options are merged with the default define options provided to the Sequelize constructor
    */
-  public static init(attributes: ModelAttributes, options: InitOptions): void;
+  public static init<A extends ModelAttributes>(attributes: A, options: InitOptions): { new (...args: any[]): Model & AttributesTypes<A> } & typeof Model;
 
   /**
    * Remove attribute from model definition

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1396,6 +1396,8 @@ export interface AddScopeOptions {
   override: boolean;
 }
 
+type ModelInstance<M> = M extends Model<infer I, any>? M & I : M;
+
 export abstract class Model<T = any, T2 = any> extends Hooks {
   /** The name of the database table */
   public static readonly tableName: string;
@@ -1469,7 +1471,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    *  string or a type-description object, with the properties described below:
    * @param options These options are merged with the default define options provided to the Sequelize constructor
    */
-  public static init<A extends ModelAttributes>(attributes: A, options: InitOptions): { new (...args: any[]): Model & AttributesTypes<A> } & typeof Model;
+  public static init<A extends ModelAttributes, TInstance = AttributesTypes<A>>(attributes: A, options: InitOptions): ModelCtor<Model<TInstance>>;
 
   /**
    * Remove attribute from model definition
@@ -1639,7 +1641,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    *
    * @see {Sequelize#query}
    */
-  public static findAll<M extends Model>(this: { new (): M } & typeof Model, options?: FindOptions): Promise<M[]>;
+  public static findAll<M extends Model>(this: { new (): M } & typeof Model, options?: FindOptions): Promise<ModelInstance<M>[]>;
 
   /**
    * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
@@ -1649,12 +1651,12 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     this: { new (): M } & typeof Model,
     identifier?: Identifier,
     options?: FindOptions
-  ): Promise<M | null>;
+  ): Promise<ModelInstance<M> | null>;
   public static findByPk<M extends Model>(
     this: { new (): M } & typeof Model,
     identifier: Identifier,
     options: NonNullFindOptions
-  ): Promise<M>;
+  ): Promise<ModelInstance<M>>;
 
   /**
    * Search for a single instance. This applies LIMIT 1, so the listener will always be called with a single
@@ -1663,8 +1665,8 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   public static findOne<M extends Model>(
     this: { new (): M } & typeof Model,
     options?: FindOptions
-  ): Promise<M | null>;
-  public static findOne<M extends Model>(this: { new (): M } & typeof Model, options: NonNullFindOptions): Promise<M>;
+  ): Promise<ModelInstance<M> | null>;
+  public static findOne<M extends Model>(this: { new (): M } & typeof Model , options: NonNullFindOptions): Promise<ModelInstance<M>>;
 
   /**
    * Run an aggregation method on the specified field
@@ -1772,7 +1774,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     this: { new (): M } & typeof Model,
     records: object[],
     options?: BuildOptions
-  ): M[];
+  ): ModelInstance<M>[];
 
   /**
    * Builds a new model instance and calls save on it.
@@ -1781,7 +1783,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     this: { new (): M } & typeof Model,
     values?: object,
     options?: CreateOptions
-  ): Promise<M>;
+  ): Promise<ModelInstance<M>>;
   public static create(values: object, options: CreateOptions & { returning: false }): Promise<void>;
 
   /**
@@ -1849,7 +1851,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     this: { new (): M } & typeof Model,
     records: object[],
     options?: BulkCreateOptions
-  ): Promise<M[]>;
+  ): Promise<ModelInstance<M>[]>;
 
   /**
    * Truncate all instances of the model. This is a convenient method for Model.destroy({ truncate: true }).
@@ -1886,7 +1888,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     this: { new (): M },
     field: K,
     options: IncrementDecrementOptionsWithBy
-  ): Promise<M>;
+  ): Promise<ModelInstance<M>>;
 
   /**
    * Increments multiple fields by the same value.
@@ -1895,7 +1897,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     this: { new (): M },
     fields: K[],
     options: IncrementDecrementOptionsWithBy
-  ): Promise<M>;
+  ): Promise<ModelInstance<M>>;
 
   /**
    * Increments multiple fields by different values.
@@ -1904,7 +1906,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     this: { new (): M },
     fields: { [key in K]?: number },
     options: IncrementDecrementOptions
-  ): Promise<M>;
+  ): Promise<ModelInstance<M>>;
 
   /**
    * Run a describe query on the table. The result will be return to the listener as a hash of attributes and
@@ -2203,7 +2205,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * @param options Options for the association
    */
   public static hasOne<M extends Model, T extends Model>(
-    this: ModelCtor<M>, target: ModelCtor<T>, options?: HasOneOptions
+    this: { new (): M } & typeof Model, target: ModelCtor<T>, options?: HasOneOptions
   ): HasOne<M, T>;
 
   /**
@@ -2216,7 +2218,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * @param options Options for the association
    */
   public static belongsTo<M extends Model, T extends Model>(
-    this: ModelCtor<M>, target: ModelCtor<T>, options?: BelongsToOptions
+    this: { new (): M } & typeof Model, target: ModelCtor<T>, options?: BelongsToOptions
   ): BelongsTo<M, T>;
 
   /**
@@ -2273,7 +2275,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * @param options Options for the association
    */
   public static hasMany<M extends Model, T extends Model>(
-    this: ModelCtor<M>, target: ModelCtor<T>, options?: HasManyOptions
+    this: { new (): M } & typeof Model, target: ModelCtor<T>, options?: HasManyOptions
   ): HasMany<M, T>;
 
   /**
@@ -2326,7 +2328,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    *
    */
   public static belongsToMany<M extends Model, T extends Model>(
-    this: ModelCtor<M>, target: ModelCtor<T>, options: BelongsToManyOptions
+    this: { new (): M } & typeof Model, target: ModelCtor<T>, options: BelongsToManyOptions
   ): BelongsToMany<M, T>;
 
   /**
@@ -2369,9 +2371,9 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * @param options.plain If set to true, included instances will be returned as plain objects
    */
   public get(options?: { plain?: boolean; clone?: boolean }): object;
+  public get<K extends keyof this>(key: K, options?: { plain?: boolean; clone?: boolean }): Exclude<this[K], undefined>;
   public get(key: string, options?: { plain?: boolean; clone?: boolean }): unknown;
-  public get<K extends keyof this>(key: K, options?: { plain?: boolean; clone?: boolean }): this[K];
-
+  
   /**
    * Set is used to update values on the instance (the sequelize representation of the instance that is,
    * remember that nothing will be persisted before you actually call `save`). In its most basic form `set`
@@ -2531,27 +2533,39 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   public toJSON(): object;
 }
 
-/**
- * Simple shorthand to use typeof Model
- */
-export type ModelType = typeof Model;
 
 /**
  * Constructor type of Model
  * To get ModelType from a generic Model
  */
-export type ModelCtor<M extends Model> = { new (): M } & ModelType;
+export type ModelCtor<M extends Model> = { new (): M & ModelInstance<M> }& typeof Model;
+
+type NonNullable = {allowNull: false};
+
+type PickType<Base, Condition> = Pick<Base, {
+  [Key in keyof Base]: Base[Key] extends Condition ? Key : never
+}[keyof Base]>;
+
+type ExcludeType<Base, Condition> = Pick<Base, {
+  [Key in keyof Base]: Base[Key] extends Condition ? never : Key
+}[keyof Base]>;
+
+
+type RequiredAttributes<T extends ModelAttributes> = PickType<T, NonNullable>;
+
+type OptionalAttributes<T extends ModelAttributes> = ExcludeType<T, NonNullable>;
 
 /**
  * Conditional type mapper
- * Get DataType from a generic ModelAttributes value T
+ * Get "basic type"  from a generic ModelAttribute value T
  * if T is a ModelAttributeColumnOptions, DataType is ModelAttributeColumnOptions["type"]
  */
-type ExtractAttributeDataType<T extends DataType | ModelAttributeColumnOptions> = 
+type ExtractBaseType<T> = 
   T extends DataType
-  ? T :
+  ? CastDataType<T> :
   T extends ModelAttributeColumnOptions
-  ? T["type"] :
+  ? CastDataType<T["type"]> :
+  T extends never ? never :
   any;
 
 /**
@@ -2566,18 +2580,20 @@ type ExtractAttributeDataType<T extends DataType | ModelAttributeColumnOptions> 
  *  instock: DataTypes.BOOLEAN,
  *  label: {
  *     type: DataTypes.STRING(100),
- *     allowNull: true
+ *     allowNull: false
  * };
  * type TProduct = AttributesTypes<typeof productAttributes>;
  * // {
- * //   sku: string;
- * //   qty: number;
- * //   instock: boolean;
+ * //   sku?: string;
+ * //   qty?: number;
+ * //   instock?: boolean;
  * //   label: string;
  * // }
  * ```
  */
-export type AttributesTypes<T extends ModelAttributes> = { [P in keyof T]: CastDataType<ExtractAttributeDataType<T[P]>> };
+export type AttributesTypes<T extends ModelAttributes, R = RequiredAttributes<T>, O = OptionalAttributes<T>> = 
+  { [P in keyof R]: ExtractBaseType<R[P]> } & Partial<{ [P in keyof O]: ExtractBaseType<O[P]> }>;
+
 
 export default Model;
 

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -3,6 +3,7 @@ import * as Deferrable from './deferrable';
 import { HookReturn, Hooks, SequelizeHooks } from './hooks';
 import { ValidationOptions } from './instance-validator';
 import {
+  AttributesTypes,
   AndOperator,
   BulkCreateOptions,
   CreateOptions,
@@ -1019,7 +1020,7 @@ export class Sequelize extends Hooks {
    * @param options  These options are merged with the default define options provided to the Sequelize
    *           constructor
    */
-  public define(modelName: string, attributes: ModelAttributes, options?: ModelOptions): typeof Model;
+  public define<A extends ModelAttributes>(modelName: string, attributes: A, options?: ModelOptions): { new (...args: any[]): Model & AttributesTypes<A> } & typeof Model;
 
   /**
    * Fetch a Model which is already defined

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -15,6 +15,7 @@ import {
   Model,
   ModelAttributeColumnOptions,
   ModelAttributes,
+  ModelCtor,
   ModelOptions,
   OrOperator,
   UpdateOptions,
@@ -1020,8 +1021,8 @@ export class Sequelize extends Hooks {
    * @param options  These options are merged with the default define options provided to the Sequelize
    *           constructor
    */
-  public define<A extends ModelAttributes>(modelName: string, attributes: A, options?: ModelOptions): { new (...args: any[]): Model & AttributesTypes<A> } & typeof Model;
-
+  public define<A extends ModelAttributes, TInstance = AttributesTypes<A>>(modelName: string, attributes: A, options?: ModelOptions): ModelCtor<Model<TInstance>>;
+  
   /**
    * Fetch a Model which is already defined
    *

--- a/types/test/define.ts
+++ b/types/test/define.ts
@@ -30,3 +30,27 @@ async function test() {
 
     await user2.save();
 }
+
+
+// Instance types are infered from the model attributes
+
+const Product = sequelize.define('Product', 
+    { 
+        sku: DataTypes.STRING(3),
+        availableOn: DataTypes.DATE,
+        price: DataTypes.DECIMAL(7,2),
+        instock: DataTypes.BOOLEAN
+    }, 
+    { tableName: 'users' }
+);
+
+async function test2() {
+    const p = await Product.findOne();
+    if (p) {
+        p.instock = true;
+        p.availableOn = new Date();
+        p.price = 10;
+        p.sku = 'P1000';
+        await p.save();
+    }
+}

--- a/types/test/define.ts
+++ b/types/test/define.ts
@@ -1,4 +1,4 @@
-import { DataTypes, Model } from 'sequelize';
+import { DataTypes, Model, AttributesTypes, IntanceAttributesTypes } from 'sequelize';
 import { sequelize } from './connection';
 
 // I really wouldn't recommend this, but if you want you can still use define() and interfaces
@@ -32,11 +32,22 @@ async function test() {
 }
 
 
-// Instance types are infered from the model attributes
+// Types are infered from the model attributes
 
 const Product = sequelize.define('Product', 
-    { 
-        sku: DataTypes.STRING(3),
+    {
+        id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true
+        }, 
+        sku: {
+            type: DataTypes.STRING(3),
+            /**
+             * "as false" is needed for typescript v < 3.4
+             * typescript 3.4 will allow to declare object "as const"
+             */
+            allowNull: false as false 
+        },
         availableOn: DataTypes.DATE,
         price: DataTypes.DECIMAL(7,2),
         instock: DataTypes.BOOLEAN
@@ -45,12 +56,29 @@ const Product = sequelize.define('Product',
 );
 
 async function test2() {
-    const p = await Product.findOne();
-    if (p) {
+   const p = await Product.findOne();
+
+    
+    if (p !== null) {
         p.instock = true;
-        p.availableOn = new Date();
+        
         p.price = 10;
+        p.price = undefined; // ok
+
         p.sku = 'P1000';
+        // p.sku = undefined; // error, sku does not allow null
+
+        // let availableOn: Date = p.availableOn;
+        let sku: string = p.get("sku");
+        let instock: boolean = p.get("instock");
+
         await p.save();
     }
+
+
+    const p2 = new Product();
+    // p2.id = 'NOPE'; // error
+    p2.price = 2.67;
+    await p2.save();
+    
 }


### PR DESCRIPTION
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

I've added some utility conditional types to extract/get  attributes "basic types" (string, number, boolean, Date) from a ModelAttributes

So : 
```typescript
const productAttributes = {
  sku: DataTypes.STRING,
  qty: {
     type: DataTypes.INTEGER,
     allowNull: true
  },
  instock: DataTypes.BOOLEAN,
  label: {
     type: DataTypes.STRING(100),
     allowNull: true
};
type TProduct = AttributesTypes<typeof productAttributes>;
// {
//   sku: string;
//   qty: number;
//   instock: boolean;
//   label: string;
// }
```

`sequelize.define` now return a model typed with all the attributes used, without the need to declare an interface

```typescript
const Product = sequelize.define('Product', 
    { 
        sku: DataTypes.STRING(3),
        availableOn: DataTypes.DATE,
        price: DataTypes.DECIMAL(7,2),
        instock: DataTypes.BOOLEAN
    }, 
    { tableName: 'users' }
);

async function test2() {
    const p = await Product.findOne();
    if (p) {
        p.instock = true;
        p.availableOn = new Date();
        p.price = 10;
        p.sku = 'P1000';
        await p.save();
    }
}
```


Some "creative" use of these new types

```typescript
export function defineModel<A extends ModelAttributes = ModelAttributes>(
    attributes: A,
    modelOptions: Partial<InitOptions> = {}
): { new (...args: any[]): Model & AttributesTypes<A> } & typeof Model & { connect: (sequelize: Sequelize) => void } {
    return class extends Model {
        static readonly associations: {
            [key: string]: Association;
        };
        public static connect(sequelize: Sequelize) {
            this.init(attributes, {
                ...modelOptions,
                sequelize
            });
        }
    } as any;
}

class ProductModel extends defineModel({
    productId: DataTypes.INTEGER,
    qty: {
        type: DataTypes.INTEGER,
        allowNull: true
    },
    sku: {
        type: DataTypes.STRING,
        allowNull: true
    },
    description: DataTypes.BLOB,
    instock: DataTypes.BOOLEAN
}) {
    categoryId: number;

    isAvailable() {
        return this.instock && this.qty > 0;
    }

    static associate() {
        return {
            Category: this.belongsTo(CategoryModel, {
                as: "Category",
                foreignKey: "categoryId"
            })
        };
    }
    static associations: ReturnType<typeof ProductModel.associate>;
}

class CategoryModel extends defineModel({
    categoryId: DataTypes.INTEGER,
    name: DataTypes.STRING
}) {
    static associate() {
        return {
            Products: this.hasMany(ProductModel, {
                as: "Products",
                foreignKey: "categoryId"
            })
        };
    }

    static associations: ReturnType<typeof CategoryModel.associate>;
}

export function connect(sequelize: Sequelize) {
    // Connect all models
    ProductModel.connect(sequelize);
    CategoryModel.connect(sequelize);

    // Create associations
    ProductModel.associate();
    CategoryModel.associate();
}

//  ... ... 

ProductModel.findOne().then(p => {
    if (p && p.isAvailable()) {
        return p;
    }
});

```