### PR TITLE
chore: use native deprecations

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -6,7 +6,7 @@ const uuidv4 = require('uuid/v4');
 const semver = require('semver');
 
 const Utils = require('../../utils');
-const logger = require('../../utils/logger');
+const deprecations = require('../../utils/deprecations');
 const SqlString = require('../../sql-string');
 const DataTypes = require('../../data-types');
 const Model = require('../../model');
@@ -1382,7 +1382,7 @@ class QueryGenerator {
         } else if (!attr[0].includes('(') && !attr[0].includes(')')) {
           attr[0] = this.quoteIdentifier(attr[0]);
         } else {
-          logger.deprecate('Use sequelize.fn / sequelize.literal to construct attributes');
+          deprecations.noRawAttributes();
         }
         attr = [attr[0], this.quoteIdentifier(attr[1])].join(' AS ');
       } else {

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -1,10 +1,10 @@
 'use strict';
 
 const _ = require('lodash');
-const logger = require('../../utils/logger');
 const SqlString = require('../../sql-string');
 const QueryTypes = require('../../query-types');
 const Dot = require('dottie');
+const deprecations = require('../../utils/deprecations');
 
 class AbstractQuery {
 
@@ -125,7 +125,7 @@ class AbstractQuery {
    */
   checkLoggingOption() {
     if (this.options.logging === true) {
-      logger.deprecate('The logging-option should be either a function or false. Default: console.log');
+      deprecations.noTrueLogging();
       // eslint-disable-next-line no-console
       this.options.logging = console.log;
     }

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -7,7 +7,6 @@ const clsBluebird = require('cls-bluebird');
 const _ = require('lodash');
 
 const Utils = require('./utils');
-const logger = require('./utils/logger');
 const Model = require('./model');
 const DataTypes = require('./data-types');
 const Deferrable = require('./deferrable');
@@ -22,6 +21,7 @@ const Hooks = require('./hooks');
 const Association = require('./associations/index');
 const Validator = require('./utils/validator-extras').validator;
 const Op = require('./operators');
+const deprecations = require('./utils/deprecations');
 
 /**
  * This is the main class, the entry point to sequelize.
@@ -191,7 +191,7 @@ class Sequelize {
     }
 
     if (this.options.logging === true) {
-      logger.deprecate('The logging-option should be either a function or false. Default: console.log');
+      deprecations.noTrueLogging();
       // eslint-disable-next-line no-console
       this.options.logging = console.log;
     }
@@ -242,10 +242,10 @@ class Sequelize {
     this.dialect.QueryGenerator.typeValidation = options.typeValidation;
 
     if (_.isPlainObject(this.options.operatorsAliases)) {
-      logger.deprecate('String based operators are deprecated. Please use Symbol based operators for better security, read more at http://docs.sequelizejs.com/manual/querying.html#operators');
+      deprecations.noStringOperators();
       this.dialect.QueryGenerator.setOperatorsAliases(this.options.operatorsAliases);
     } else if (typeof this.options.operatorsAliases === 'boolean') {
-      logger.warn('A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.');
+      deprecations.noBoolOperatorAliases();
     }
 
     this.queryInterface = new QueryInterface(this);
@@ -1104,7 +1104,7 @@ class Sequelize {
 
     if (options.logging) {
       if (options.logging === true) {
-        logger.deprecate('The logging-option should be either a function or false. Default: console.log');
+        deprecations.noTrueLogging();
         // eslint-disable-next-line no-console
         options.logging = console.log;
       }

--- a/lib/utils/deprecations.js
+++ b/lib/utils/deprecations.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const { deprecate } = require('util');
+
+const noop = () => {};
+
+exports.noRawAttributes = deprecate(noop, 'Use sequelize.fn / sequelize.literal to construct attributes', 'SEQUELIZE0001');
+exports.noTrueLogging = deprecate(noop, 'The logging-option should be either a function or false. Default: console.log', 'SEQUELIZE0002');
+exports.noStringOperators = deprecate(noop, 'String based operators are deprecated. Please use Symbol based operators for better security, read more at http://docs.sequelizejs.com/manual/querying.html#operators', 'SEQUELIZE0003');
+exports.noBoolOperatorAliases = deprecate(noop, 'A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.', 'SEQUELIZE0004');

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -8,7 +8,6 @@
  * @private
  */
 
-const depd = require('depd');
 const debug = require('debug');
 
 class Logger {
@@ -19,12 +18,7 @@ class Logger {
       debug: true
     }, config);
 
-    this.depd = depd(this.config.context);
     this.debug = debug(this.config.context);
-  }
-
-  deprecate(message) {
-    this.depd(message);
   }
 
   debug(message) {
@@ -50,6 +44,5 @@ exports.Logger = Logger;
 
 const logger = new Logger();
 
-exports.deprecate = logger.deprecate.bind(logger);
 exports.warn = logger.warn.bind(logger);
 exports.getLogger = () =>  logger ;

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "bluebird": "^3.5.0",
     "cls-bluebird": "^2.1.0",
     "debug": "^4.1.1",
-    "depd": "^2.0.0",
     "dottie": "^2.0.0",
     "inflection": "1.12.0",
     "lodash": "^4.17.11",

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -1,19 +1,16 @@
 'use strict';
 
-const chai = require('chai'),
-  expect = chai.expect,
-  assert = chai.assert,
-  Support = require('./support'),
-  DataTypes = require('../../lib/data-types'),
-  dialect = Support.getTestDialect(),
-  _ = require('lodash'),
-  Sequelize = require('../../index'),
-  config = require('../config/config'),
-  moment = require('moment'),
-  Transaction = require('../../lib/transaction'),
-  logger = require('../../lib/utils/logger'),
-  sinon = require('sinon'),
-  current = Support.sequelize;
+const { expect, assert } = require('chai');
+const Support = require('./support');
+const DataTypes = require('../../lib/data-types');
+const dialect = Support.getTestDialect();
+const _ = require('lodash');
+const Sequelize = require('../../index');
+const config = require('../config/config');
+const moment = require('moment');
+const Transaction = require('../../lib/transaction');
+const sinon = require('sinon');
+const current = Support.sequelize;
 
 const qq = str => {
   if (dialect === 'postgres' || dialect === 'mssql') {
@@ -27,10 +24,6 @@ const qq = str => {
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {
   describe('constructor', () => {
-    afterEach(() => {
-      logger.deprecate.restore && logger.deprecate.restore();
-    });
-
     it('should pass the global options correctly', () => {
       const sequelize = Support.createSequelizeInstance({ logging: false, define: { underscored: true } }),
         DAO = sequelize.define('dao', { name: DataTypes.STRING });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -270,11 +270,6 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
   });
 
   describe('Logger', () => {
-    it('deprecate', () => {
-      expect(logger.deprecate).to.be.a('function');
-      logger.deprecate('test deprecation');
-    });
-
     it('debug', () => {
       expect(logger.debug).to.be.a('function');
       logger.debug('test debug');

--- a/types/lib/utils/logger.d.ts
+++ b/types/lib/utils/logger.d.ts
@@ -11,12 +11,10 @@ export interface LoggerConfig {
 
 export class Logger {
   constructor(config: LoggerConfig)
-  public deprecate(message: string): void;
   public debug(message: string): void;
   public warn(message: string): void;
   public debugContext(message: string): (message: string) => void;
 }
 
-export function deprecate(message: string): void;
 export function warn(message: string): void;
 export function getLogger(): Logger;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Removes `depd` in favour of `util.deprecate`.
I am unsure if this should be considered breaking since `.deprecate` was more internal.

Pro:
 - Centralised place for deprecations
 - Deprecation codes
 - Less dependencies
Contra:
 - API slightly different but `depd` was never *officially* in the docs