### PR TITLE
fix(query-interface): incorrect regex escape with json querying

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -19,6 +19,8 @@ const sequelizeError = require('../../errors');
 
 const QuoteHelper = require('./query-generator/helpers/quote');
 
+const nonEscapeOperators = new Set([Op.like, Op.iLike, Op.regexp, Op.iRegexp, Op.notRegexp, Op.notIRegexp]);
+
 /**
  * Abstract Query Generator
  *
@@ -950,7 +952,7 @@ class QueryGenerator {
           // Users shouldn't have to worry about these args - just give them a function that takes a single arg
           const simpleEscape = escVal => SqlString.escape(escVal, this.options.timezone, this.dialect);
 
-          value = field.type.stringify(value, { escape: simpleEscape, field, timezone: this.options.timezone, operation: options.operation });
+          value = field.type.stringify(value, { escape: simpleEscape, field, timezone: this.options.timezone, acceptStrings: options.acceptStrings });
 
           if (field.type.escape === false) {
             // The data-type already did the required escaping
@@ -985,7 +987,7 @@ class QueryGenerator {
         this.validate(value, field, options);
 
         if (field.type.bindParam) {
-          return field.type.bindParam(value, { escape: _.identity, field, timezone: this.options.timezone, operation: options.operation, bindParam });
+          return field.type.bindParam(value, { escape: _.identity, field, timezone: this.options.timezone, bindParam });
         }
       }
     }
@@ -2391,9 +2393,8 @@ class QueryGenerator {
         comparator = this.OperatorMap[Op.like];
         return this._joinKeyValue(key, this.escape(`%${value}%`), comparator, options.prefix);
     }
-
     const escapeOptions = {
-      acceptStrings: comparator.includes(this.OperatorMap[Op.like])
+      acceptStrings: nonEscapeOperators.has(prop)
     };
 
     if (_.isPlainObject(value)) {

--- a/lib/dialects/mariadb/data-types.js
+++ b/lib/dialects/mariadb/data-types.js
@@ -105,7 +105,7 @@ module.exports = BaseTypes => {
 
   class JSONTYPE extends BaseTypes.JSON {
     _stringify(value, options) {
-      return options.operation === 'where' && typeof value === 'string' ? value
+      return options.acceptsString && typeof value === 'string' ? value
         : JSON.stringify(value);
     }
   }

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -124,7 +124,7 @@ module.exports = BaseTypes => {
 
   class JSONTYPE extends BaseTypes.JSON {
     _stringify(value, options) {
-      return options.operation === 'where' && typeof value === 'string' ? value : JSON.stringify(value);
+      return options.acceptStrings && typeof value === 'string' ? value : JSON.stringify(value);
     }
   }
 

--- a/test/integration/operators.test.js
+++ b/test/integration/operators.test.js
@@ -1,13 +1,13 @@
 'use strict';
 
-const chai = require('chai'),
-  Sequelize = require('../../index'),
-  Op = Sequelize.Op,
-  Promise = Sequelize.Promise,
-  expect = chai.expect,
-  Support = require('../support'),
-  DataTypes = require('../../lib/data-types'),
-  dialect = Support.getTestDialect();
+const { stub } = require('sinon');
+const { expect } = require('chai');
+const Sequelize = require('../../index');
+const Op = Sequelize.Op;
+const Promise = Sequelize.Promise;
+const Support = require('../support');
+const DataTypes = require('../../lib/data-types');
+const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Operators'), () => {
   describe('REGEXP', () => {
@@ -23,6 +23,9 @@ describe(Support.getTestDialectTeaser('Operators'), () => {
         name: {
           type: DataTypes.STRING,
           field: 'full_name'
+        },
+        json: {
+          type: DataTypes.JSON
         }
       }, {
         tableName: 'users',
@@ -39,6 +42,9 @@ describe(Support.getTestDialectTeaser('Operators'), () => {
           },
           full_name: {
             type: DataTypes.STRING
+          },
+          json: {
+            type: DataTypes.JSON
           }
         })
       ]);
@@ -76,6 +82,21 @@ describe(Support.getTestDialectTeaser('Operators'), () => {
           }).then(user => {
             expect(user).to.not.be.ok;
           });
+        });
+
+        it('should work with json', function() {
+          const logging = stub();
+          return this.User.findOne({
+            logging,
+            where: {
+              json: {
+                [Op.regexp]: 'test'
+              }
+            }
+          })
+            .then(() => {
+              expect(logging.firstCall.args[0]).to.not.include('\\"test\\"');
+            });
         });
 
         it('should properly escape regular expressions', function() {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes #10602
Apparently the `operation` parameter was never set anywhere, it's time for a type checker.....