### PR TITLE
test: fix running query count in test suite

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -571,14 +571,11 @@ class Sequelize {
 
         return query.run(sql, bindParameters)
           .finally(() => {
+            if (this.test._trackRunningQueries) this.test._runningQueries--;
             if (!options.transaction) {
               return this.connectionManager.releaseConnection(connection);
             }
           });
-      }).finally(() => {
-        if (this.test._trackRunningQueries) {
-          this.test._runningQueries--;
-        }
       }), retryOptions));
     });
   }

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -266,7 +266,7 @@ class Sequelize {
         this._trackRunningQueries = true;
       },
       verifyNoRunningQueries() {
-        if (this._runningQueries > 0) throw new Error(`Expected 0 running queries. ${this._runningQueries} queries still running`);
+        if (this._runningQueries !== 0) throw new Error(`Expected 0 running queries. ${this._runningQueries} queries still running`);
       }
     };
 
@@ -351,7 +351,7 @@ class Sequelize {
     options.modelName = modelName;
     options.sequelize = this;
 
-    const model = class extends Model {};
+    const model = class extends Model { };
 
     model.init(attributes, options);
 
@@ -548,10 +548,8 @@ class Sequelize {
 
       const retryOptions = Object.assign({}, this.options.retry, options.retry || {});
 
-      return Promise.resolve(retry(retryParameters => Promise.try(() => {
-        const isFirstTry = retryParameters.current === 1;
-
-        if (isFirstTry && this.test._trackRunningQueries) {
+      return Promise.resolve(retry(() => Promise.try(() => {
+        if (this.test._trackRunningQueries) {
           this.test._runningQueries++;
         }
 
@@ -577,11 +575,11 @@ class Sequelize {
               return this.connectionManager.releaseConnection(connection);
             }
           });
-      }), retryOptions)).finally(() => {
+      }).finally(() => {
         if (this.test._trackRunningQueries) {
           this.test._runningQueries--;
         }
-      });
+      }), retryOptions));
     });
   }
 
@@ -605,7 +603,7 @@ class Sequelize {
     if (this.options.dialect !== 'mysql') {
       throw new Error('sequelize.set is only supported for mysql');
     }
-    if (!options.transaction || !(options.transaction instanceof Transaction) ) {
+    if (!options.transaction || !(options.transaction instanceof Transaction)) {
       throw new TypeError('options.transaction is required');
     }
 
@@ -616,8 +614,7 @@ class Sequelize {
 
     // Generate SQL Query
     const query =
-      `SET ${
-        _.map(variables, (v, k) => `@${k} := ${typeof v === 'string' ? `"${v}"` : v}`).join(', ')}`;
+      `SET ${_.map(variables, (v, k) => `@${k} := ${typeof v === 'string' ? `"${v}"` : v}`).join(', ')}`;
 
     return this.query(query, options);
   }
@@ -1040,7 +1037,7 @@ class Sequelize {
           // Rollback transaction if not already finished (commit, rollback, etc)
           // and reject with original error (ignore any error in rollback)
           return Promise.try(() => {
-            if (!transaction.finished) return transaction.rollback().catch(() => {});
+            if (!transaction.finished) return transaction.rollback().catch(() => { });
           }).throw(err);
         });
     });
@@ -1096,7 +1093,7 @@ class Sequelize {
       // remove options from set of logged arguments if options.logging is equal to console.log
       // eslint-disable-next-line no-console
       if (options.logging === console.log) {
-        args.splice(args.length-1, 1);
+        args.splice(args.length - 1, 1);
       }
     } else {
       options = this.options;
@@ -1163,8 +1160,8 @@ class Sequelize {
     if (attribute.hasOwnProperty('defaultValue')) {
       if (typeof attribute.defaultValue === 'function' && (
         attribute.defaultValue === DataTypes.NOW ||
-          attribute.defaultValue === DataTypes.UUIDV1 ||
-          attribute.defaultValue === DataTypes.UUIDV4
+        attribute.defaultValue === DataTypes.UUIDV1 ||
+        attribute.defaultValue === DataTypes.UUIDV4
       )) {
         attribute.defaultValue = new attribute.defaultValue();
       }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change

This should (hopefully) fix all the errors in the test-suite that were thrown when runningQueries was not 0. This was bc the counter was increased every try (retries included), but only decreased once for each query call.