### PR TITLE
Intersect addConstraint options instead of union

### DIFF
--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -345,7 +345,7 @@ export class QueryInterface {
   public addConstraint(
     tableName: string,
     attributes: string[],
-    options?: AddConstraintOptions | QueryInterfaceOptions
+    options?: AddConstraintOptions & QueryInterfaceOptions
   ): Promise<void>;
 
   /**

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -142,10 +142,11 @@ queryInterface.removeIndex('Person', 'SuperDuperIndex');
 
 queryInterface.removeIndex('Person', ['firstname', 'lastname']);
 
-queryInterface.addConstraint('Person', ['firstname', 'lastname'], {
+queryInterface.sequelize.transaction(trx => queryInterface.addConstraint('Person', ['firstname', 'lastname'], {
   name: 'firstnamexlastname',
   type: 'unique',
-});
+  transaction: trx,
+}))
 
 queryInterface.removeConstraint('Person', 'firstnamexlastname');
 


### PR DESCRIPTION
`QueryInterface`'s `addConstraint` allows a `transaction` as part of its options.
Currently the TS definition for `addConstraint` is a *union* type of:
```
  public addConstraint(
    ...
    options?: AddConstraintOptions | QueryInterfaceOptions
  ): Promise<void>;
```

When using a `transaction` in options, this results in a TS error of:
```
Argument of type '{ type: "foreign key"; references: { table: string; field: string; }; transaction: Transaction; onDelete: string; onUpdate: string; }' is not assignable to parameter of type 'QueryInterfaceOptions | AddUniqueConstraintOptions | AddDefaultConstraintOptions | AddCheckConstraintOptions | AddPrimaryKeyConstraintOptions | AddForeignKeyConstraintOptions'.
  Object literal may only specify known properties, and 'transaction' does not exist in type 'AddForeignKeyConstraintOptions'.
```

Since the `transaction` property should be "`AddConstraintOptions` ***and*** `QueryInterfaceOptions`" as opposed to ***or***, this PR changes it to an *intersection*: 
```
  public addConstraint(
    ...
    options?: AddConstraintOptions & QueryInterfaceOptions
  ): Promise<void>;
```

More info about Intersection vs Union types here:
https://www.typescriptlang.org/docs/handbook/advanced-types.html)