### PR TITLE
Remove extra tick mark and period in Array autodoc comment

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -752,7 +752,7 @@ class ENUM extends ABSTRACT {
  * An array of `type`. Only available in Postgres.
  *
  * @example
- * DataTypes.ARRAY(DataTypes.DECIMAL)`.
+ * DataTypes.ARRAY(DataTypes.DECIMAL)
  */
 class ARRAY extends ABSTRACT {
   /**


### PR DESCRIPTION
### Description of change

Small typo fix to the `DataType.ARRAY` autodoc comment
