### PR TITLE
fix(types): change Sequelize.prototype.close type

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1252,7 +1252,7 @@ export class Sequelize extends Hooks {
    * Normally this is done on process exit, so you only need to call this method if you are creating multiple
    * instances, and want to garbage collect some of them.
    */
-  public close(): void;
+  public close(): Promise<void>;
 
   /**
    * Returns the database version


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

The return type of Sequelize.prototype.close is currently `void`, but it should be `Promise<void>` instead. Under the hood, it calls [connectionManager.close](https://github.com/sequelize/sequelize/blob/master/lib/sequelize.js#L1131), which returns a [Promise](https://github.com/sequelize/sequelize/blob/master/lib/dialects/abstract/connection-manager.js#L110). Therefore Sequelize.prototype.close returns a Promise itself.
