### PR TITLE
fix(mysql): boolean TINYINT support

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -204,7 +204,7 @@ class NUMBER extends ABSTRACT {
     return true;
   }
   _stringify(number) {
-    if (typeof number === 'number' || number === null || number === undefined) {
+    if (typeof number === 'number' || typeof number === 'boolean' || number === null || number === undefined) {
       return number;
     }
     if (typeof number.toString === 'function') {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -248,6 +248,43 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     });
   });
 
+  if (dialect === 'mysql') {
+    it('should handle TINYINT booleans', function() {
+      const User = this.sequelize.define('user', {
+        id: { type: Sequelize.TINYINT, primaryKey: true },
+        isRegistered: Sequelize.TINYINT
+      });
+
+      return User.sync({ force: true }).then(() => {
+        return User.create({ id: 1, isRegistered: true });
+      }).then(registeredUser => {
+        expect(registeredUser.isRegistered).to.equal(true);
+        return User.findOne({
+          where: {
+            id: 1,
+            isRegistered: true
+          }
+        });
+      }).then(registeredUser => {
+        expect(registeredUser).to.be.ok;
+        expect(registeredUser.isRegistered).to.equal(1);
+
+        return User.create({ id: 2, isRegistered: false });
+      }).then(unregisteredUser => {
+        expect(unregisteredUser.isRegistered).to.equal(false);
+        return User.findOne({
+          where: {
+            id: 2,
+            isRegistered: false
+          }
+        });
+      }).then(unregisteredUser => {
+        expect(unregisteredUser).to.be.ok;
+        expect(unregisteredUser.isRegistered).to.equal(0);
+      });
+    });
+  }
+
   it('calls parse and bindParam for DOUBLE', () => {
     const Type = new Sequelize.DOUBLE();
 


### PR DESCRIPTION
This regressed in #10492

Fixes #10600
Fixes #10633

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Bring back support for passing booleans into `TINYINT` fields. 
