### PR TITLE
fix: store options in array

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -761,6 +761,7 @@ class ARRAY extends ABSTRACT {
   constructor(type) {
     super();
     const options = _.isPlainObject(type) ? type : { type };
+    this.options = options;
     this.type = typeof options.type === 'function' ? new options.type() : options.type;
   }
   toSql() {


### PR DESCRIPTION
### Pull Request check-list
_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This change will store the options of `ARRAY` in the class. I stumbled across this when I tried to extend the `ARRAY` type and the options were not set.
