### PR TITLE
fix(types): allow functions in projection

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -383,7 +383,7 @@ export type Order = string | Fn | Col | Literal | OrderItem[];
  * Please note if this is used the aliased property will not be available on the model instance
  * as a property but only via `instance.get('alias')`.
  */
-export type ProjectionAlias = [string | Literal | Fn, string];
+export type ProjectionAlias = [string | Literal | Fn, string | Fn];
 
 export type FindAttributeOptions =
   | (string | ProjectionAlias)[]


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Something like this was not possible before:
```ts
      attributes: {
        include: [['count', fn('count', col('id'))]],
      },
```
