### PR TITLE
fix(typings): add missing sourceKey option in HasOneOptions association type 

### DIFF
--- a/types/lib/associations/has-many.d.ts
+++ b/types/lib/associations/has-many.d.ts
@@ -7,16 +7,21 @@ import {
   Model,
   ModelCtor,
   Transactionable,
-  WhereOptions,
 } from '../model';
 import { Promise } from '../promise';
-import { Transaction } from '../transaction';
 import { Association, ManyToManyOptions, MultiAssociationAccessors } from './base';
 
 /**
  * Options provided when associating models with hasMany relationship
  */
 export interface HasManyOptions extends ManyToManyOptions {
+
+  /**
+   * The name of the field to use as the key for the association in the source table. Defaults to the primary
+   * key of the source table
+   */
+  sourceKey?: string;
+
   /**
    * A string or a data type to represent the identifier in the table
    */

--- a/types/lib/associations/has-one.d.ts
+++ b/types/lib/associations/has-one.d.ts
@@ -7,6 +7,13 @@ import { Association, AssociationOptions, SingleAssociationAccessors } from './b
  * Options provided when associating models with hasOne relationship
  */
 export interface HasOneOptions extends AssociationOptions {
+
+  /**
+   * The name of the field to use as the key for the association in the source table. Defaults to the primary
+   * key of the source table
+   */
+  sourceKey?: string;
+
   /**
    * A string or a data type to represent the identifier in the table
    */

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -56,6 +56,12 @@ export interface QueryOptions extends Logging, Transactionable {
    */
   instance?: Model;
 
+  /**
+   * Map returned fields to model's fields if `options.model` or `options.instance` is present.
+   * Mapping will occur before building the model instance.
+   */
+  mapToModel?: boolean;
+
   retry?: RetryOptions;
 }
 

--- a/types/test/e2e/docs-example.ts
+++ b/types/test/e2e/docs-example.ts
@@ -111,6 +111,7 @@ Address.init({
 
 // Here we associate which actually populates out pre-declared `association` static and other methods.
 User.hasMany(Project, {
+  sourceKey: 'id',
   foreignKey: 'ownerId',
   as: 'projects' // this determines the name in `associations`!
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change
add missing `sourceKey` option in `HasOneOptions` association type definition
