### PR TITLE
docs: fix typo on belongs-to-many.js

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -608,7 +608,7 @@ class BelongsToMany extends Association {
   }
 
   /**
-   * Associate one ore several rows with source instance. It will not un-associate any already assoicated instance
+   * Associate one or several rows with source instance. It will not un-associate any already assoicated instance
    * that may be missing from `newInstances`.
    *
    * @param {Model} sourceInstance source instance to associate new instances with


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you long time!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Just fixed the typo on `lib\associations\belongs-to-many.js`
