### PR TITLE
fix(mysql): backport boolean TINYINT support to v4

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -147,7 +147,7 @@ NUMBER.prototype.validate = function(value) {
   return true;
 };
 NUMBER.prototype._stringify = function _stringify(number) {
-  if (typeof number === 'number' || number === null || number === undefined) {
+  if (typeof number === 'number' || typeof number === 'boolean' || number === null || number === undefined) {
     return number;
   }
 

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -228,6 +228,43 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     });
   });
 
+  if (dialect === 'mysql') {
+    it('should handle TINYINT booleans', function() {
+      const User = this.sequelize.define('user', {
+        id: { type: Sequelize.TINYINT, primaryKey: true },
+        isRegistered: Sequelize.TINYINT
+      });
+
+      return User.sync({ force: true }).then(() => {
+        return User.create({ id: 1, isRegistered: true });
+      }).then(registeredUser => {
+        expect(registeredUser.isRegistered).to.equal(true);
+        return User.findOne({
+          where: {
+            id: 1,
+            isRegistered: true
+          }
+        });
+      }).then(registeredUser => {
+        expect(registeredUser).to.be.ok;
+        expect(registeredUser.isRegistered).to.equal(1);
+
+        return User.create({ id: 2, isRegistered: false });
+      }).then(unregisteredUser => {
+        expect(unregisteredUser.isRegistered).to.equal(false);
+        return User.findOne({
+          where: {
+            id: 2,
+            isRegistered: false
+          }
+        });
+      }).then(unregisteredUser => {
+        expect(unregisteredUser).to.be.ok;
+        expect(unregisteredUser.isRegistered).to.equal(0);
+      });
+    });
+  }
+
   it('calls parse and stringify for DOUBLE', () => {
     const Type = new Sequelize.DOUBLE();
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **N/A**
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Backports #10644 to v4. Since the original feature that broke this was backported to v4, it's only fair to backport the fix too. 

Fixes #10600 
