### PR TITLE
Clarify where to get Model from

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -92,9 +92,10 @@ Sequelize will keep the connection open by default, and use the same connection 
 
 
 
-Models are defined with `Model.init(attributes, options)`:
+Models are defined with `Sequelize.Model.init(attributes, options)`:
 
 ```js
+const Model = Sequelize.Model;
 class User extends Model {}
 User.init({
   // attributes


### PR DESCRIPTION
The docs currently say Models are defined with `Model.init` but not where to import this `Model` from.
