### PR TITLE
docs: tutorial improvements

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,7 +90,7 @@ Sequelize will keep the connection open by default, and use the same connection 
 
 ## Modeling a table
 
-A model is a class that extends `Sequelize.Model`. Models are defined with `Sequelize.Model.init(attributes, options)`:
+A model is a class that extends `Sequelize.Model`. Models can be defined in two equivalent ways. The first, with `Sequelize.Model.init(attributes, options)`:
 
 ```js
 const Model = Sequelize.Model;
@@ -111,7 +111,7 @@ User.init({
 });
 ```
 
-Alternatively (legacy declaration, using `sequelize.define`):
+Alternatively, using `sequelize.define`:
 
 ```js
 const User = sequelize.define('User', {
@@ -128,6 +128,8 @@ const User = sequelize.define('User', {
   // options
 });
 ```
+
+Internally, `sequelize.define` calls `Model.init`.
 
 The above code tells Sequelize to expect a table named `users` in the database with the fields `firstName` and `lastName`. The table name is automatically pluralized by default (a library called [inflection](https://www.npmjs.com/package/inflection) is used under the hood to do this). This behavior can be stopped for a specific model by using the `freezeTableName: true` option, or for all models by using the `define` option from the [Sequelize constructor](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor).
 
@@ -155,7 +157,7 @@ class Bar extends Model {}
 Bar.init({ /* ... */ }, { sequelize, timestamps: true });
 ```
 
-You can read more about creating models in the [Model.init API Reference](/class/lib/model.js~Model.html#static-method-init), or in the legacy [sequelize.define API reference](/class/lib/sequelize.js~Sequelize.html#instance-method-define).
+You can read more about creating models in the [Model.init API Reference](/class/lib/model.js~Model.html#static-method-init), or in the [sequelize.define API reference](/class/lib/sequelize.js~Sequelize.html#instance-method-define).
 
 ## Synchronizing the model with the database
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -90,9 +90,7 @@ Sequelize will keep the connection open by default, and use the same connection 
 
 ## Modeling a table
 
-
-
-Models are defined with `Sequelize.Model.init(attributes, options)`:
+A model is a class that extends `Sequelize.Model`. Models are defined with `Sequelize.Model.init(attributes, options)`:
 
 ```js
 const Model = Sequelize.Model;
@@ -113,7 +111,7 @@ User.init({
 });
 ```
 
-Alternatively (legacy):
+Alternatively (legacy declaration, using `sequelize.define`):
 
 ```js
 const User = sequelize.define('User', {
@@ -131,7 +129,7 @@ const User = sequelize.define('User', {
 });
 ```
 
-The above code tells Sequelize to expect a table named `users` in the database with the fields `firstName` and `lastName`. The table name is automatically pluralized by default (a library called [inflection](https://www.npmjs.com/package/inflection) is used under the hood to do this). This behavior can be stopped for a specific model by using the `freezeTableName: true` option, or for all models by using the `define` option from the Sequelize constructor.
+The above code tells Sequelize to expect a table named `users` in the database with the fields `firstName` and `lastName`. The table name is automatically pluralized by default (a library called [inflection](https://www.npmjs.com/package/inflection) is used under the hood to do this). This behavior can be stopped for a specific model by using the `freezeTableName: true` option, or for all models by using the `define` option from the [Sequelize constructor](http://docs.sequelizejs.com/class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor).
 
 Sequelize also defines by default the fields `id` (primary key), `createdAt` and `updatedAt` to every model. This behavior can also be changed, of course (check the API Reference to learn more about the available options).
 
@@ -157,7 +155,7 @@ class Bar extends Model {}
 Bar.init({ /* ... */ }, { sequelize, timestamps: true });
 ```
 
-You can read more about creating models in the [define API Reference](/class/lib/sequelize.js~Sequelize.html#instance-method-define) and the [Model API reference](/class/lib/model.js~Model.html).
+You can read more about creating models in the [Model.init API Reference](/class/lib/model.js~Model.html#static-method-init), or in the legacy [sequelize.define API reference](/class/lib/sequelize.js~Sequelize.html#instance-method-define).
 
 ## Synchronizing the model with the database
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ You are currently looking at the **Tutorials and Guides** for Sequelize. You mig
 
 ```js
 const Sequelize = require('sequelize');
+// const { Sequelize, Model } = require('sequelize'); // This would also work
 const sequelize = new Sequelize('postgres://user:pass@example.com:5432/dbname');
 
 class User extends Sequelize.Model {}

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ Sequelize is a promise-based Node.js ORM for Postgres, MySQL, MariaDB, SQLite an
 
 Sequelize follows [SEMVER](http://semver.org). Supports Node v6 and above to use ES6 features.
 
-**Sequelize v5** was released on March 13, 2019.
+**Sequelize v5** was released on March 13, 2019. [Official TypeScript typings are now included](manual/typescript).
 
 You are currently looking at the **Tutorials and Guides** for Sequelize. You might also be interested in the [API Reference](identifiers).
 
@@ -33,7 +33,7 @@ You are currently looking at the **Tutorials and Guides** for Sequelize. You mig
 const Sequelize = require('sequelize');
 const sequelize = new Sequelize('postgres://user:pass@example.com:5432/dbname');
 
-class User extends Model {}
+class User extends Sequelize.Model {}
 User.init({
   username: Sequelize.STRING,
   birthday: Sequelize.DATE
@@ -49,4 +49,4 @@ sequelize.sync()
   });
 ```
 
-To learn more about how to use Sequelize, read the tutorials available in the left menu. [Begin with Getting Started](manual/getting-started).
+To learn more about how to use Sequelize, read the tutorials available in the left menu. Begin with [Getting Started](manual/getting-started).

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,7 +31,6 @@ You are currently looking at the **Tutorials and Guides** for Sequelize. You mig
 
 ```js
 const Sequelize = require('sequelize');
-// const { Sequelize, Model } = require('sequelize'); // This would also work
 const sequelize = new Sequelize('postgres://user:pass@example.com:5432/dbname');
 
 class User extends Sequelize.Model {}

--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -201,7 +201,7 @@ Foo.init({
   sequelize,
 });
 
-// legacy with `sequelize.define`
+// Or with `sequelize.define`
 sequelize.define('Foo', {
   firstname: Sequelize.STRING,
   lastname: Sequelize.STRING
@@ -220,7 +220,7 @@ sequelize.define('Foo', {
       this.setDataValue('lastname', names.slice(-1).join(' '));
     }
   }
-} );
+});
 ```
 
 

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,19 +1,15 @@
 # TypeScript
 
-Since v5 Sequelize provides it's own TypeScript definitions.
-Please note that only TS >= 3.1 is supported.
+Since v5, Sequelize provides its own TypeScript definitions. Please note that only TS >= 3.1 is supported.
 
-## Installation:
+As Sequelize heavily relies on runtime property assignments, TypeScript won't be very useful out of the box. A decent amount of manual type declarations are needed to make models workable.
 
-In order to avoid installation bloat for non TS users you must install the following packages manually:
- - `@types/node` this is universally required
+## Installation
+
+In order to avoid installation bloat for non TS users, you must install the following typing packages manually:
+ - `@types/node` (this is universally required)
  - `@types/validator`
  - `@types/bluebird`
-
- ## Note
-
-As Sequelize heavily relies on runtime property assignments, TypeScript won't be very useful out of the box.
-A decent amount of manual type declarations are needed to make models workable.
 
 ## Usage
 
@@ -131,7 +127,7 @@ async function stuff() {
 ## Legacy `.define` usage
 
 TypeScript doesn't know how to generate a `class` definition when we use the legacy `.define`,
-therefor we need to do some manual work and declare an interface and a type and eventually cast 
+therefore we need to do some manual work and declare an interface and a type and eventually cast 
 the result of `.define` to the _static_ type.
 
 ```ts
@@ -146,7 +142,7 @@ type MyModelStatic = typeof Model & {
   new (values?: object, options?: BuildOptions): MyModel;
 }
 
-// TS can't derive a proper class definition from a `.define` call, therefor we need to cast here.
+// TS can't derive a proper class definition from a `.define` call, therefore we need to cast here.
 const MyDefineModel = <MyModelStatic>sequelize.define('MyDefineModel', {
   id: {
     primaryKey: true,

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -124,10 +124,9 @@ async function stuff() {
 }
 ```
 
-## Legacy `.define` usage
+## Usage of `sequelize.define`
 
-TypeScript doesn't know how to generate a `class` definition when we use the legacy `.define`,
-therefore we need to do some manual work and declare an interface and a type and eventually cast 
+TypeScript doesn't know how to generate a `class` definition when we use the `sequelize.define` method to define a Model. Therefore, we need to do some manual work and declare an interface and a type, and eventually cast 
 the result of `.define` to the _static_ type.
 
 ```ts


### PR DESCRIPTION
### Description of change

Improves a bit the tutorials:

* Quick start script now works (changed `Model` to `Sequelize.Model`)
* A few other clarifications, link updates and minor formatting changes