### PR TITLE
docs(sequelize): update constructor define docs

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -62,7 +62,7 @@ class Sequelize {
    * @param {Object}   [options.dialectOptions] An object of additional options, which are passed directly to the connection library
    * @param {string}   [options.storage] Only used by sqlite. Defaults to ':memory:'
    * @param {string}   [options.protocol='tcp'] The protocol of the relational database.
-   * @param {Object}   [options.define={}] Default options for model definitions. See sequelize.define for options
+   * @param {Object}   [options.define={}] Default options for model definitions. See {@link Model.init}.
    * @param {Object}   [options.query={}] Default options for sequelize.query
    * @param {string}   [options.schema=null] A schema to use
    * @param {Object}   [options.set={}] Default options for sequelize.set

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -217,7 +217,7 @@ export interface Options extends Logging {
   protocol?: string;
 
   /**
-   * Default options for model definitions. See sequelize.define for options
+   * Default options for model definitions. See Model.init.
    */
   define?: ModelOptions;
 


### PR DESCRIPTION
### Description of change

Since `sequelize.define` has started to be called "legacy" and `Model.init` has been preferred, and since the current implementation of `sequelize.define` simply calls `Model.init` internally, I think this minor change in the docs is desirable.

Question: I've added an `@link` to the `.js` documentation but I left it as plain-text in the `.d.ts` documentation, because I didn't see any other `@link` on the `.d.ts` files. Should I have done something different? Also please see #10673.