### PR TITLE
fix(types): add basic support for `bind` in Sequelize.query() method

### DIFF
--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -5,6 +5,8 @@ import QueryTypes = require('./query-types');
 import { Sequelize, RetryOptions } from './sequelize';
 import { Transaction } from './transaction';
 
+type BindOrReplacements = { [key: string]: unknown } | unknown[];
+
 /**
  * Interface for query options
  */
@@ -40,9 +42,13 @@ export interface QueryOptions extends Logging, Transactionable {
    * Either an object of named parameter replacements in the format `:param` or an array of unnamed
    * replacements to replace `?` in your SQL.
    */
-  replacements?: {
-    [key: string]: string | number | string[] | number[];
-  } | string[];
+  replacements?: BindOrReplacements;
+
+  /**
+   * Either an object of named parameter bindings in the format `$param` or an array of unnamed
+   * values to bind to `$1`, `$2`, etc in your SQL.
+   */
+  bind?: BindOrReplacements;
 
   /**
    * Force the query to use the write pool, regardless of the query type.

--- a/types/test/connection.ts
+++ b/types/test/connection.ts
@@ -35,4 +35,12 @@ sequelize.transaction<void>(async transaction => {
       transaction,
       logging: true,
     })
-})
+});
+
+sequelize.query('SELECT * FROM `user` WHERE status = $1',
+  { bind: ['active'], type: QueryTypes.SELECT }
+);
+
+sequelize.query('SELECT * FROM `user` WHERE status = $status',
+  { bind: { status: 'active' }, type: QueryTypes.SELECT }
+);


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

The `bind` property described in the [docs](http://docs.sequelizejs.com/manual/raw-queries.html#bind-parameter) was missing in the type definitions.