### PR TITLE
Correction for the MSSQL config

### DIFF
--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -187,17 +187,23 @@ Model.findAll({
 - Sequelize now works with `tedious >= 6.0.0`. Old `dialectOptions` has to be updated to match their new format. Please refer to tedious [documentation](http://tediousjs.github.io/tedious/api-connection.html#function_newConnection). An example of new `dialectOptions` is given below
 
 ```json
-dialectOptions: {
-  authentication: {
-    domain: 'my-domain'
-  },
-  options: {
-    requestTimeout: 60000,
-    cryptoCredentialsDetails: {
-      ciphers: "RC4-MD5"
-    }
-  }
-}
+database: 'DB_NAME',
+    host: 'DB_HOST',
+    dialect: 'mssql',
+    dialectOptions: {
+      authentication: {
+        type: 'ntlm',
+        options: {
+          userName: 'DB_USER',
+          password: 'DB_PASS',
+          domain: 'MY_COMPANY_DOMAIN',
+        },
+      },
+      options: {
+        port: 1433,
+        requestTimeout: 60000,
+      },
+    },
 ```
 
 #### MySQL


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
According to the 'tedious' documentation at http://tediousjs.github.io/tedious/api-connection.html#function_newConnection, below is the right config object 

authentication.type
Type of the authentication method, valid types are default, ntlm, azure-active-directory-password
authentication.options.userName

User name to use for authentication.
authentication.options.password

Password to use for authentication.
authentication.options.domain
Once you set domain for ntlm authentication type, driver will connect to SQL Server using domain login.

options.port
Port to connect to (default: 1433). 

Mutually exclusive with options.instanceName.
options.instanceName
The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable. 
(no default) 
Mutually exclusive with options.port.

options.database
Database to connect to (default: dependent on server configuration).
