### PR TITLE
feat(log): configurable inspector

### DIFF
--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const dataTypes = require('./data-types');
-const util = require('util');
+const { logger } = require('./utils/logger');
 
 function arrayToList(array, timeZone, dialect, format) {
   return array.reduce((sql, val, i) => {
@@ -62,7 +62,7 @@ function escape(val, timeZone, dialect, format) {
   }
 
   if (!val.replace) {
-    throw new Error(`Invalid value ${util.inspect(val)}`);
+    throw new Error(`Invalid value ${logger.inspect(val)}`);
   }
 
   if (dialect === 'postgres' || dialect === 'sqlite' || dialect === 'mssql') {

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -9,6 +9,7 @@
  */
 
 const debug = require('debug');
+const util = require('util');
 
 class Logger {
   constructor(config) {
@@ -22,6 +23,10 @@ class Logger {
   warn(message) {
     // eslint-disable-next-line no-console
     console.warn(`(${this.config.context}) Warning: ${message}`);
+  }
+
+  inspect(value) {
+    return util.inspect(value, false, 3);
   }
 
   debugContext(name) {


### PR DESCRIPTION
Provides a configurable `logger.inspector` that will format non-string JS elements in logs and errors. This will be useful for configuring how binded parameters are logged, once that functionality is merged into sequelize.

Related to issues #10284 #10285 