### PR TITLE
feat(connection): deprecate sql server 2008

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -6,6 +6,7 @@ const semver = require('semver');
 const Promise = require('../../promise');
 const errors = require('../../errors');
 const { logger } = require('../../utils/logger');
+const { noUnsupportedVersion } = require('../../utils/deprecations');
 const debug = logger.debugContext('pool');
 
 /**
@@ -40,6 +41,11 @@ class ConnectionManager {
     });
 
     this.initPools();
+
+    // Check version support, if set through options
+    if (this.versionSupport) {
+      this.versionSupport();
+    }
   }
 
   refreshTypeParser(dataTypes) {
@@ -241,10 +247,8 @@ class ConnectionManager {
 
     let promise;
     if (this.sequelize.options.databaseVersion === 0) {
-      if (this.versionPromise) {
-        promise = this.versionPromise;
-      } else {
-        promise = this.versionPromise = this._connect(this.config.replication.write || this.config)
+      if (!this.versionPromise) {
+        this.versionPromise = this._connect(this.config.replication.write || this.config)
           .then(connection => {
             const _options = {};
 
@@ -267,11 +271,17 @@ class ConnectionManager {
 
             this.versionPromise = null;
             return this._disconnect(connection);
+          }).then(() => {
+            // Check version support, if autodetected
+            if (this.versionSupport) {
+              return this.versionSupport();
+            }
           }).catch(err => {
             this.versionPromise = null;
             throw err;
           });
       }
+      promise = this.versionPromise;
     } else {
       promise = Promise.resolve();
     }
@@ -334,6 +344,15 @@ class ConnectionManager {
     }
 
     return this.dialect.connectionManager.validate(connection);
+  }
+
+  versionSupport() {
+    const version = _.get(this.sequelize, 'options.databaseVersion', 0);
+    const minVer = this.dialect.supports.minimumSupportedVersion;
+
+    if (minVer && semver.valid(version) && semver.lt(version, minVer)) {
+      noUnsupportedVersion(this.dialectName, version, minVer);
+    }
   }
 }
 

--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -3,6 +3,7 @@
 class AbstractDialect {}
 
 AbstractDialect.prototype.supports = {
+  minimumSupportedVersion: undefined,
   'DEFAULT': true,
   'DEFAULT VALUES': false,
   'VALUES ()': false,

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -20,6 +20,7 @@ class MssqlDialect extends AbstractDialect {
 }
 
 MssqlDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype.supports), {
+  minimumSupportedVersion: '11.0.0',
   'DEFAULT': true,
   'DEFAULT VALUES': true,
   'LIMIT ON UPDATE': true,

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -5,6 +5,7 @@ const path = require('path');
 const retry = require('retry-as-promised');
 const clsBluebird = require('cls-bluebird');
 const _ = require('lodash');
+const semver = require('semver');
 
 const Utils = require('./utils');
 const Model = require('./model');
@@ -180,6 +181,11 @@ class Sequelize {
       typeValidation: false,
       benchmark: false
     }, options || {});
+
+    // Coherce databaseVersion to valid semver format
+    if (this.options.databaseVersion) {
+      this.options.databaseVersion = semver.valid(semver.coerce(this.options.databaseVersion)) || 0;
+    }
 
     if (!this.options.dialect) {
       throw new Error('Dialect needs to be explicitly supplied as of v4.0.0');

--- a/lib/utils/deprecations.js
+++ b/lib/utils/deprecations.js
@@ -9,3 +9,4 @@ exports.noTrueLogging = deprecate(noop, 'The logging-option should be either a f
 exports.noStringOperators = deprecate(noop, 'String based operators are deprecated. Please use Symbol based operators for better security, read more at http://docs.sequelizejs.com/manual/querying.html#operators', 'SEQUELIZE0003');
 exports.noBoolOperatorAliases = deprecate(noop, 'A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.', 'SEQUELIZE0004');
 exports.noDoubleNestedGroup = deprecate(noop, 'Passing a double nested nested array to `group` is unsupported and will be removed in v6.', 'SEQUELIZE0005');
+exports.noUnsupportedVersion = (dialect, version, minVer) => deprecate(noop, `(${dialect}) Database version ${version} is unsupported. Only ${minVer} and higher are supported.`, 'SEQUELIZE0006')();

--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -6,6 +6,7 @@ const chai = require('chai'),
   sinon = require('sinon'),
   Config = require('../../../config/config'),
   ConnectionManager = require('../../../../lib/dialects/abstract/connection-manager'),
+  AbstractDialect = require('../../../../lib/dialects/abstract/index'),
   Pool = require('sequelize-pool').Pool,
   _ = require('lodash');
 
@@ -33,7 +34,7 @@ describe('Connection Manager', () => {
       replication: null
     };
     const sequelize = Support.createSequelizeInstance(options);
-    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const connectionManager = new ConnectionManager(new AbstractDialect(), sequelize);
 
     connectionManager.initPools();
     expect(connectionManager.pool).to.be.instanceOf(Pool);
@@ -49,7 +50,7 @@ describe('Connection Manager', () => {
       }
     };
     const sequelize = Support.createSequelizeInstance(options);
-    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const connectionManager = new ConnectionManager(new AbstractDialect(), sequelize);
 
     connectionManager.initPools();
     expect(connectionManager.pool.read).to.be.instanceOf(Pool);
@@ -73,7 +74,7 @@ describe('Connection Manager', () => {
       }
     };
     const sequelize = Support.createSequelizeInstance(options);
-    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const connectionManager = new ConnectionManager(new AbstractDialect(), sequelize);
 
     const res = {
       queryType: 'read'
@@ -117,7 +118,7 @@ describe('Connection Manager', () => {
       }
     };
     const sequelize = Support.createSequelizeInstance(options);
-    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const connectionManager = new ConnectionManager(new AbstractDialect(), sequelize);
 
     const res = {
       queryType: 'read'
@@ -146,7 +147,7 @@ describe('Connection Manager', () => {
       replication: null
     };
     const sequelize = Support.createSequelizeInstance(options);
-    const connectionManager = new ConnectionManager(Support.getTestDialect(), sequelize);
+    const connectionManager = new ConnectionManager(new AbstractDialect(), sequelize);
 
     connectionManager.initPools();
 

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const chai = require('chai');
-const expect = chai.expect;
+const { expect } = require('chai');
 const Support = require('../../support');
 const Sequelize = Support.Sequelize;
 const dialect = Support.getTestDialect();
@@ -29,5 +28,6 @@ if (dialect.match(/^mssql/)) {
         return expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(Sequelize.AccessDeniedError);
       });
     });
+
   });
 }

--- a/test/integration/pool.test.js
+++ b/test/integration/pool.test.js
@@ -240,7 +240,7 @@ describe(Support.getTestDialectTeaser('Pooling'), () => {
     it('should reject with ConnectionAcquireTimeoutError when unable to acquire connection', function() {
       this.testInstance = new Sequelize('localhost', 'ffd', 'dfdf', {
         dialect,
-        databaseVersion: '1.2.3',
+        databaseVersion: '9999.2.3',
         pool: {
           acquire: 10
         }
@@ -256,7 +256,7 @@ describe(Support.getTestDialectTeaser('Pooling'), () => {
     it('should reject with ConnectionAcquireTimeoutError when unable to acquire connection for transaction', function() {
       this.testInstance = new Sequelize('localhost', 'ffd', 'dfdf', {
         dialect,
-        databaseVersion: '1.2.3',
+        databaseVersion: '9999.2.3',
         pool: {
           acquire: 10,
           max: 1

--- a/test/unit/connection-manager.test.js
+++ b/test/unit/connection-manager.test.js
@@ -14,7 +14,8 @@ describe('connection manager', () => {
       this.dialect = {
         connectionManager: {
           connect: sinon.stub().resolves(this.connection)
-        }
+        },
+        supports: {}
       };
 
       this.sequelize = Support.createSequelizeInstance();


### PR DESCRIPTION
Deprecate sql server 2008 which will become completely unsupported by Microsoft in July 9, 2019. This will helps us clean sequelize code by removing some mssql specific hacks in the future.

The `versionSupport` method can be easily extended to other dialects. Additionally, use `semver.coherce` for robustness. Some DBs that report incomplete non-conforming semver versions (e.g. 9.5 instead of 9.5.0).

Related to issues #10284 #10285