### PR TITLE
fix(mariadb): named timezone connection bug

### DIFF
--- a/lib/dialects/mariadb/connection-manager.js
+++ b/lib/dialects/mariadb/connection-manager.js
@@ -54,13 +54,18 @@ class ConnectionManager extends AbstractConnectionManager {
    * @private
    */
   connect(config) {
+    // Named timezone is not supported in mariadb, convert to offset
+    let tzOffset = this.sequelize.options.timezone;
+    tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z')
+      : tzOffset;
+
     const connectionConfig = {
       host: config.host,
       port: config.port,
       user: config.username,
       password: config.password,
       database: config.database,
-      timezone: this.sequelize.options.timezone,
+      timezone: tzOffset,
       typeCast: ConnectionManager._typecast.bind(this),
       bigNumberStrings: false,
       supportBigNumbers: true,
@@ -73,10 +78,6 @@ class ConnectionManager extends AbstractConnectionManager {
 
     if (!this.sequelize.config.keepDefaultTimezone) {
       // set timezone for this connection
-      // but named timezone are not directly supported in mariadb, so get its offset first
-      let tzOffset = this.sequelize.options.timezone;
-      tzOffset = /\//.test(tzOffset) ? momentTz.tz(tzOffset).format('Z')
-        : tzOffset;
       if (connectionConfig.initSql) {
         if (!Array.isArray(
           connectionConfig.initSql)) {

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -38,7 +38,7 @@ if (dialect !== 'sqlite') {
       });
     });
 
-    if (dialect === 'mysql') {
+    if (dialect === 'mysql' || dialect === 'mariadb') {
       it('handles existing timestamps', function() {
         const NormalUser = this.sequelize.define('user', {}),
           TimezonedUser = this.sequelizeWithTimezone.define('user', {});


### PR DESCRIPTION
Mariadb doesn't support named timezones. Previous workaround missed `connectionConfig.timezone`. It didn't show on online tests, because they use UTC.