### PR TITLE
docs(typescript): correct misspelling of `associations`

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -43,7 +43,7 @@ class User extends Model {
   // actively include a relation.
   public readonly projects?: Project[];
 
-  public static associtations: {
+  public static associations: {
     projects: Association<User, Project>;
   };
 }

--- a/types/test/e2e/docs-example.ts
+++ b/types/test/e2e/docs-example.ts
@@ -133,7 +133,7 @@ async function stuff() {
   });
 
   const ourUser = await User.findByPk(1, {
-    include: [User.associations.Project],
+    include: [User.associations.projects],
     rejectOnEmpty: true, // Specifying true here removes `null` from the return type!
   });
   console.log(ourUser.projects![0].name); // Note the `!` null assertion since TS can't know if we included

--- a/types/test/e2e/docs-example.ts
+++ b/types/test/e2e/docs-example.ts
@@ -34,7 +34,7 @@ class User extends Model {
   // actively include a relation.
   public readonly projects?: Project[];
 
-  public static associtations: {
+  public static associations: {
     projects: Association<User, Project>;
   };
 }


### PR DESCRIPTION
### Description of change

This changes two occurrences of `associtations` (note the extra `t`).

I figure if this isn't corrected, this typo will slowly seep into the
various implementations (like end-users like myself) who are copying and
pasting examples from the documentation into their own projects. 😄 
