### PR TITLE
feat(composition): add base composition support

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1052,7 +1052,7 @@ class QueryGenerator {
       }
 
       if (typeof item !== 'string') {
-        throw new sequelizeError.CompositionError(`Query item is not a slot or a string:\n${util.inspect(item)}`);
+        throw new sequelizeError.CompositionError('Item to be composed is not a slot or a string', item);
       }
 
       return item;
@@ -1077,7 +1077,7 @@ class QueryGenerator {
       }
 
       if (typeof item !== 'string') {
-        throw new sequelizeError.CompositionError(`Query item is not a slot or a string:\n${util.inspect(item)}`);
+        throw new sequelizeError.CompositionError('Query item to be composed is not a slot or a string', item);
       }
 
       return item;
@@ -2027,7 +2027,7 @@ class QueryGenerator {
 
       return value === 'NULL' ? `${key} IS NULL` : [key, value].join(` ${smth.comparator} `);
     }
-    if (smth instanceof Utils.Literal || smth instanceof Utils.Composition) {
+    if (smth instanceof Utils.Literal || smth instanceof Utils.CompositionMethod) {
       return smth.val;
     }
     if (smth instanceof Utils.Cast) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1041,7 +1041,6 @@ class QueryGenerator {
       composition = new Composition(composition);
     }
 
-    const result = {};
     const bind = [];
     const bindParam = this.bindParam(bind);
 
@@ -1059,10 +1058,8 @@ class QueryGenerator {
     });
 
     queryItems.push(';');
-    result.query = queryItems.join('');
 
-    result.bind = this.outputBind(bind);
-    return result;
+    return { query: queryItems.join(''), bind: this.outputBind(bind) };
   }
 
   composeString(composition) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2024,8 +2024,11 @@ class QueryGenerator {
 
       return value === 'NULL' ? `${key} IS NULL` : [key, value].join(` ${smth.comparator} `);
     }
-    if (smth instanceof Utils.Literal || smth instanceof Utils.CompositionMethod) {
+    if (smth instanceof Utils.Literal) {
       return smth.val;
+    }
+    if (smth instanceof Utils.CompositionMethod) {
+      return Utils.convertComposable(smth, Composition);
     }
     if (smth instanceof Utils.Cast) {
       if (smth.val instanceof Utils.SequelizeMethod) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -19,6 +19,8 @@ const sequelizeError = require('../../errors');
 
 const QuoteHelper = require('./query-generator/helpers/quote');
 
+const { Slot, Composition } = require('./query-generator/composition');
+
 /**
  * Abstract Query Generator
  *
@@ -971,6 +973,16 @@ class QueryGenerator {
   }
 
   /*
+   * Converts an array of binded parameters to the format required by the dialect
+   *
+   * @param {array} array
+   * @private
+  */
+  outputBind(bind) {
+    return bind;
+  }
+
+  /*
     Returns a bind parameter representation of a value (e.g. a string, number or date)
     @private
   */
@@ -1022,6 +1034,54 @@ class QueryGenerator {
         throw error;
       }
     }
+  }
+
+  composeQuery(composition) {
+    if (!(composition instanceof Composition)) {
+      composition = new Composition(composition);
+    }
+
+    const result = {};
+    const bind = [];
+    const bindParam = this.bindParam(bind);
+
+    const queryItems = composition.items.map(item => {
+      if (item instanceof Slot) {
+        // Really binds, returns only acompaning sql string with bind placeholder
+        return this.format(item.value, item.field, item.options, bindParam);
+      }
+
+      if (typeof item !== 'string') {
+        throw new sequelizeError.CompositionError(`Query item is not a slot or a string:\n${util.inspect(item)}`);
+      }
+
+      return item;
+    });
+
+    queryItems.push(';');
+    result.query = queryItems.join('');
+
+    result.bind = this.outputBind(bind);
+    return result;
+  }
+
+  composeString(composition) {
+    if (!(composition instanceof Composition)) {
+      composition = new Composition(composition);
+    }
+
+    // For each query item, get sql parts and join them
+    return composition.items.map(item => {
+      if (item instanceof Slot) {
+        return this.escape(item.value, item.field, item.options);
+      }
+
+      if (typeof item !== 'string') {
+        throw new sequelizeError.CompositionError(`Query item is not a slot or a string:\n${util.inspect(item)}`);
+      }
+
+      return item;
+    }).join('');
   }
 
   isIdentifierQuoted(identifier) {
@@ -1967,7 +2027,7 @@ class QueryGenerator {
 
       return value === 'NULL' ? `${key} IS NULL` : [key, value].join(` ${smth.comparator} `);
     }
-    if (smth instanceof Utils.Literal) {
+    if (smth instanceof Utils.Literal || smth instanceof Utils.Composition) {
       return smth.val;
     }
     if (smth instanceof Utils.Cast) {

--- a/lib/dialects/abstract/query-generator/composition.js
+++ b/lib/dialects/abstract/query-generator/composition.js
@@ -1,0 +1,153 @@
+'use strict';
+
+const util = require('util');
+const { CompositionError } = require('../../../errors');
+
+/*
+ * Self contained value representation
+ *
+ * It can be converted to an escaped sql string or to a binded param. It also
+ * must be self contained, the escaper or binder should be part of the slot. It
+ * is identified for being an instace of this class, otherwise reject (reflects
+ * unsafe handling)
+ *
+ */
+class Slot {
+  constructor(value, field, options) {
+    this.value = value;
+    this.field = field;
+    this.options = options || {};
+  }
+}
+
+module.exports.Slot = Slot;
+
+/*
+ * It is a placeholder in a QueryItems instance
+ *
+ */
+class Placeholder {
+  constructor(name) {
+    this.name = name;
+  }
+}
+
+module.exports.Placeholder = Placeholder;
+
+/*
+  Buildind block for queries of any dialect
+
+  Should be simple, secure and composable. It can hold three items: (sql) strings,
+  value *slots* or placeholders. Keep this class simple, for higher abstractions
+  build something else. This should not depend on dialect or db version.
+
+  @private
+ */
+class Composition {
+  constructor(...items) {
+    // Should clone *items* array. Should not copy *items* array by reference.
+    this.items = this.constructor._processArgs(items);
+  }
+  get length() {
+    return this.items.length;
+  }
+  static _processArgs(items) {
+    // Should return new array
+    return items.reduce((a, item) => {
+      if (typeof item === 'string' || item instanceof Slot ||
+        item instanceof Placeholder) {
+        a.push(item);
+        return a;
+      }
+      if (item instanceof this) {
+        a.push(...item.items);
+        return a;
+      }
+
+      throw new CompositionError(`Invalid query item: ${util.inspect(item)}`);
+    }, []);
+  }
+  add(...items) {
+    this.items.push(...this.constructor._processArgs(items));
+
+    return this;
+  }
+  prepend(...items) {
+    this.items.unshift(...this.constructor._processArgs(items));
+
+    return this;
+  }
+  set(...items) {
+    this.items = this.constructor._processArgs(items);
+
+    return this;
+  }
+  clone() {
+    const clone = new this.constructor();
+    clone.items = this.items.slice(0);
+    return clone;
+  }
+  static from(array) {
+    const composition = new this();
+    composition.items = this._processArgs(array);
+
+    return composition;
+  }
+}
+
+module.exports.Composition = Composition;
+
+/*
+ * Holds multiple compositions or objects cohercible to compositions
+ *
+ * Useful for grouping and manipulating anonymous compositions. It
+ * holds compositions or single composition items.
+ *
+ * Concatenable methods.
+ */
+
+class CompositionGroup {
+  constructor(...args) {
+    this.compositions = args;
+  }
+  get length() {
+    return this.compositions.length;
+  }
+  add(...compositions) {
+    this.compositions.push(...compositions);
+
+    return this;
+  }
+  // Inserts a new composition(*spacer*) between existing compositions
+  space(spacer) {
+    if (this.compositions.length === 0) return this;
+
+    this.compositions = this.compositions.slice(1).reduce((a, group) => {
+      a.push(spacer, group);
+      return a;
+    }, [this.compositions[0]]);
+
+    return this;
+  }
+  merge(group) {
+    this.compositions = this.compositions.concat(group.compositions);
+
+    return this;
+  }
+  slice() {
+    const compositions = this.compositions.slice.apply(this.compositions, arguments);
+
+    return this.constructor.from(compositions);
+  }
+  toComposition() {
+    return Composition.from(this.compositions);
+  }
+  static from(array) {
+    const group = new this();
+    group.compositions = array.slice(0);
+
+    return group;
+  }
+}
+
+module.exports.CompositionGroup = CompositionGroup;

--- a/lib/dialects/abstract/query-generator/composition.js
+++ b/lib/dialects/abstract/query-generator/composition.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const util = require('util');
 const { CompositionError } = require('../../../errors');
+const Utils = require('../../../utils');
 
 /*
  * Self contained value representation
@@ -20,8 +20,6 @@ class Slot {
   }
 }
 
-module.exports.Slot = Slot;
-
 /*
  * It is a placeholder in a QueryItems instance
  *
@@ -31,8 +29,6 @@ class Placeholder {
     this.name = name;
   }
 }
-
-module.exports.Placeholder = Placeholder;
 
 /*
   Buildind block for queries of any dialect
@@ -64,7 +60,7 @@ class Composition {
         return a;
       }
 
-      throw new CompositionError(`Invalid query item: ${util.inspect(item)}`);
+      throw new CompositionError('Invalid query item', item);
     }, []);
   }
   add(...items) {
@@ -95,8 +91,6 @@ class Composition {
   }
 }
 
-module.exports.Composition = Composition;
-
 /*
  * Holds multiple compositions or objects cohercible to compositions
  *
@@ -122,10 +116,7 @@ class CompositionGroup {
   space(spacer) {
     if (this.compositions.length === 0) return this;
 
-    this.compositions = this.compositions.slice(1).reduce((a, group) => {
-      a.push(spacer, group);
-      return a;
-    }, [this.compositions[0]]);
+    this.compositions = Utils.interleave(this.compositions, spacer);
 
     return this;
   }
@@ -134,8 +125,8 @@ class CompositionGroup {
 
     return this;
   }
-  slice() {
-    const compositions = this.compositions.slice.apply(this.compositions, arguments);
+  slice(...args) {
+    const compositions = this.compositions.slice.apply(this.compositions, args);
 
     return this.constructor.from(compositions);
   }
@@ -150,4 +141,7 @@ class CompositionGroup {
   }
 }
 
-module.exports.CompositionGroup = CompositionGroup;
+exports.Slot = Slot;
+exports.Placeholder = Placeholder;
+exports.Composition = Composition;
+exports.CompositionGroup = CompositionGroup;

--- a/lib/dialects/abstract/query-generator/composition.js
+++ b/lib/dialects/abstract/query-generator/composition.js
@@ -39,8 +39,9 @@ class Placeholder {
 
   @private
  */
-class Composition {
+const composableMixin = BaseClass => class extends BaseClass {
   constructor(...items) {
+    super();
     // Should clone *items* array. Should not copy *items* array by reference.
     this.items = this.constructor._processArgs(items);
   }
@@ -89,7 +90,9 @@ class Composition {
 
     return composition;
   }
-}
+};
+
+class Composition extends composableMixin(Object) {}
 
 /*
  * Holds multiple compositions or objects cohercible to compositions
@@ -141,6 +144,7 @@ class CompositionGroup {
   }
 }
 
+exports.composableMixin = composableMixin;
 exports.Slot = Slot;
 exports.Placeholder = Placeholder;
 exports.Composition = Composition;

--- a/lib/dialects/abstract/query-generator/composition.js
+++ b/lib/dialects/abstract/query-generator/composition.js
@@ -43,12 +43,12 @@ const composableMixin = BaseClass => class extends BaseClass {
   constructor(...items) {
     super();
     // Should clone *items* array. Should not copy *items* array by reference.
-    this.items = this.constructor._processArgs(items);
+    this.items = this._processArgs(items);
   }
   get length() {
     return this.items.length;
   }
-  static _processArgs(items) {
+  _processArgs(items) {
     // Should return new array
     return items.reduce((a, item) => {
       if (typeof item === 'string' || item instanceof Slot ||
@@ -56,7 +56,7 @@ const composableMixin = BaseClass => class extends BaseClass {
         a.push(item);
         return a;
       }
-      if (item instanceof this) {
+      if (item instanceof this.constructor) {
         a.push(...item.items);
         return a;
       }
@@ -65,17 +65,17 @@ const composableMixin = BaseClass => class extends BaseClass {
     }, []);
   }
   add(...items) {
-    this.items.push(...this.constructor._processArgs(items));
+    this.items.push(...this._processArgs(items));
 
     return this;
   }
   prepend(...items) {
-    this.items.unshift(...this.constructor._processArgs(items));
+    this.items.unshift(...this._processArgs(items));
 
     return this;
   }
   set(...items) {
-    this.items = this.constructor._processArgs(items);
+    this.items = this._processArgs(items);
 
     return this;
   }
@@ -86,7 +86,7 @@ const composableMixin = BaseClass => class extends BaseClass {
   }
   static from(array) {
     const composition = new this();
-    composition.items = this._processArgs(array);
+    composition.items = this.prototype._processArgs(array);
 
     return composition;
   }

--- a/lib/dialects/abstract/query-generator/query-proto.js
+++ b/lib/dialects/abstract/query-generator/query-proto.js
@@ -54,12 +54,10 @@ class QueryProto {
   }
 }
 
-module.exports.QueryProto = QueryProto;
-
 class SelectProto extends QueryProto {
   static get partNames() {
-    return ['attributes', 'from', 'join', 'where', 'group',
-      'having', 'order', 'page', 'lock'];
+    return Object.freeze(['attributes', 'from', 'join', 'where', 'group',
+      'having', 'order', 'page', 'lock']);
   }
   toComposition() {
     const composition = new Composition();
@@ -91,12 +89,10 @@ class SelectProto extends QueryProto {
   }
 }
 
-module.exports.SelectProto = SelectProto;
-
 class InsertProto extends QueryProto {
   static get partNames() {
-    return ['preQuery', 'flags', 'table', 'ignoreDups', 'attributes',
-      'output', 'values', 'onConflict', 'return', 'postQuery'];
+    return Object.freeze(['preQuery', 'flags', 'table', 'ignoreDups', 'attributes',
+      'output', 'values', 'onConflict', 'return', 'postQuery']);
   }
   toComposition() {
     if (!this.table || !this.table.length) {
@@ -124,12 +120,10 @@ class InsertProto extends QueryProto {
   }
 }
 
-module.exports.InsertProto = InsertProto;
-
 class UpdateProto extends QueryProto {
   static get partNames() {
-    return ['preQuery', 'flags', 'table', 'output',
-      'values', 'where', 'limit', 'return', 'postQuery'];
+    return Object.freeze(['preQuery', 'flags', 'table', 'output',
+      'values', 'where', 'limit', 'return', 'postQuery']);
   }
   toComposition() {
     if (! (this.table && this.table.length)) {
@@ -157,4 +151,7 @@ class UpdateProto extends QueryProto {
   }
 }
 
-module.exports.UpdateProto = UpdateProto;
+exports.QueryProto = QueryProto;
+exports.SelectProto = SelectProto;
+exports.InsertProto = InsertProto;
+exports.UpdateProto = UpdateProto;

--- a/lib/dialects/abstract/query-generator/query-proto.js
+++ b/lib/dialects/abstract/query-generator/query-proto.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { Composition } = require('./composition');
+const { CompositionError } = require('../../../errors');
 
 /*
  * Named collections of Composition elements.
@@ -9,6 +10,7 @@ const { Composition } = require('./composition');
  * Allow disordered query building and easy substitution of query parts. Flexible,
  * non-nested and non-exahustive organization.
  */
+const QueryProtoPartNames = Object.freeze([]);
 
 class QueryProto {
   constructor(proto) {
@@ -22,7 +24,7 @@ class QueryProto {
     }
   }
   static get partNames() {
-    return [];
+    return QueryProtoPartNames;
   }
   set(proto) {
     // Should clone proto into this object, NOT copy shallow references
@@ -50,14 +52,16 @@ class QueryProto {
     return clone;
   }
   toComposition() {
-    throw new Error(`Class ${this.constructor.name} has not implemented toComposition method`);
+    throw new CompositionError(`Class ${this.constructor.name} has not implemented toComposition method`);
   }
 }
 
+const SelectProtoPartNames = Object.freeze(['attributes', 'from', 'join', 'where', 'group',
+  'having', 'order', 'page', 'lock']);
+
 class SelectProto extends QueryProto {
   static get partNames() {
-    return Object.freeze(['attributes', 'from', 'join', 'where', 'group',
-      'having', 'order', 'page', 'lock']);
+    return SelectProtoPartNames;
   }
   toComposition() {
     const composition = new Composition();
@@ -69,8 +73,8 @@ class SelectProto extends QueryProto {
       composition.add(' *');
     }
 
-    if (! (this.from && this.from.length)) {
-      throw new Error('Missing FROM clause in select proto query');
+    if (!(this.from && this.from.length)) {
+      throw new CompositionError('Missing FROM clause in select proto query');
     }
 
     composition.add(' FROM ', this.from);
@@ -89,17 +93,19 @@ class SelectProto extends QueryProto {
   }
 }
 
+const InsertProtoPartNames = Object.freeze(['preQuery', 'flags', 'table', 'ignoreDups', 'attributes',
+  'output', 'values', 'onConflict', 'return', 'postQuery']);
+
 class InsertProto extends QueryProto {
   static get partNames() {
-    return Object.freeze(['preQuery', 'flags', 'table', 'ignoreDups', 'attributes',
-      'output', 'values', 'onConflict', 'return', 'postQuery']);
+    return InsertProtoPartNames;
   }
   toComposition() {
     if (!this.table || !this.table.length) {
-      throw new Error('Missing table in INSERT query');
+      throw new CompositionError('Missing table in INSERT query');
     }
     if (!this.values || !this.values.length) {
-      throw new Error('Missing values in INSERT query');
+      throw new CompositionError('Missing values in INSERT query');
     }
 
     const composition = new Composition();
@@ -120,17 +126,19 @@ class InsertProto extends QueryProto {
   }
 }
 
+const UpdateProtoPartNames = Object.freeze(['preQuery', 'flags', 'table', 'output',
+  'values', 'where', 'limit', 'return', 'postQuery']);
+
 class UpdateProto extends QueryProto {
   static get partNames() {
-    return Object.freeze(['preQuery', 'flags', 'table', 'output',
-      'values', 'where', 'limit', 'return', 'postQuery']);
+    return UpdateProtoPartNames;
   }
   toComposition() {
     if (! (this.table && this.table.length)) {
-      throw new Error('Missing table in UPDATE query');
+      throw new CompositionError('Missing table in UPDATE query');
     }
     if (! (this.values && this.values.length)) {
-      throw new Error('Missing values in UPDATE query');
+      throw new CompositionError('Missing values in UPDATE query');
     }
 
     const composition = new Composition();

--- a/lib/dialects/abstract/query-generator/query-proto.js
+++ b/lib/dialects/abstract/query-generator/query-proto.js
@@ -1,0 +1,160 @@
+'use strict';
+
+const { Composition } = require('./composition');
+
+/*
+ * Named collections of Composition elements.
+ *
+ * Useful for organizing and manipulating the different parts of a query.
+ * Allow disordered query building and easy substitution of query parts. Flexible,
+ * non-nested and non-exahustive organization.
+ */
+
+class QueryProto {
+  constructor(proto) {
+    if (proto) {
+      this.set(proto);
+    } else {
+      // Should clone Composition, NOT copy shallow references
+      for (const key of this.constructor.partNames) {
+        this[key] = new Composition();
+      }
+    }
+  }
+  static get partNames() {
+    return [];
+  }
+  set(proto) {
+    // Should clone proto into this object, NOT copy shallow references
+
+    for (const key of this.constructor.partNames) {
+      this[key] = new Composition();
+
+      if (proto[key] && proto[key].length) {
+        this[key] = proto[key].clone();
+      } else {
+        this[key] = new Composition();
+      }
+    }
+
+    return this;
+  }
+  clone() {
+    // Should clone Composition, NOT copy shallow references
+    const clone = new this.constructor();
+
+    for (const key of this.constructor.partNames) {
+      clone[key] = this[key].clone();
+    }
+
+    return clone;
+  }
+  toComposition() {
+    throw new Error(`Class ${this.constructor.name} has not implemented toComposition method`);
+  }
+}
+
+module.exports.QueryProto = QueryProto;
+
+class SelectProto extends QueryProto {
+  static get partNames() {
+    return ['attributes', 'from', 'join', 'where', 'group',
+      'having', 'order', 'page', 'lock'];
+  }
+  toComposition() {
+    const composition = new Composition();
+    composition.add('SELECT');
+
+    if (this.attributes.length) {
+      composition.add(' ', this.attributes);
+    } else {
+      composition.add(' *');
+    }
+
+    if (! (this.from && this.from.length)) {
+      throw new Error('Missing FROM clause in select proto query');
+    }
+
+    composition.add(' FROM ', this.from);
+
+    // Each join should come with its own join linker
+    if (this.join.length) composition.add(' ', this.join);
+    if (this.where.length) composition.add(' WHERE ', this.where);
+    if (this.group.length) composition.add(' GROUP BY ', this.group);
+    if (this.having.length) composition.add(' HAVING ', this.having);
+    if (this.order.length) composition.add(' ORDER BY ', this.order);
+    // Each dialect has its own pagination and lock syntax
+    if (this.page.length) composition.add(' ', this.page);
+    if (this.lock.length) composition.add(' ', this.lock);
+
+    return composition;
+  }
+}
+
+module.exports.SelectProto = SelectProto;
+
+class InsertProto extends QueryProto {
+  static get partNames() {
+    return ['preQuery', 'flags', 'table', 'ignoreDups', 'attributes',
+      'output', 'values', 'onConflict', 'return', 'postQuery'];
+  }
+  toComposition() {
+    if (!this.table || !this.table.length) {
+      throw new Error('Missing table in INSERT query');
+    }
+    if (!this.values || !this.values.length) {
+      throw new Error('Missing values in INSERT query');
+    }
+
+    const composition = new Composition();
+
+    if (this.preQuery.length) composition.add(this.preQuery);
+    composition.add('INSERT');
+    if (this.flags.length) composition.add(' ', this.flags);
+    composition.add(' INTO ', this.table);
+    if (this.attributes.length) composition.add(' (', this.attributes, ')');
+    if (this.output.length) composition.add(' ', this.output);
+    // Can be VALUES (...) or a query
+    composition.add(' ', this.values);
+    if (this.onConflict.length) composition.add(' ', this.onConflict);
+    if (this.return.length) composition.add(' ', this.return);
+    if (this.postQuery.length) composition.add(this.postQuery);
+
+    return composition;
+  }
+}
+
+module.exports.InsertProto = InsertProto;
+
+class UpdateProto extends QueryProto {
+  static get partNames() {
+    return ['preQuery', 'flags', 'table', 'output',
+      'values', 'where', 'limit', 'return', 'postQuery'];
+  }
+  toComposition() {
+    if (! (this.table && this.table.length)) {
+      throw new Error('Missing table in UPDATE query');
+    }
+    if (! (this.values && this.values.length)) {
+      throw new Error('Missing values in UPDATE query');
+    }
+
+    const composition = new Composition();
+
+    if (this.preQuery.length) composition.add(this.preQuery);
+    composition.add('UPDATE');
+    if (this.flags.length) composition.add(' ', this.flags);
+    composition.add(' ', this.table);
+    // Can be VALUES or a SELECT statement
+    composition.add(' SET ', this.values);
+    if (this.output.length) composition.add(' ', this.output);
+    if (this.where.length) composition.add(' WHERE ', this.where);
+    if (this.limit.length) composition.add(' ', this.limit);
+    if (this.return.length) composition.add(' ', this.return);
+    if (this.postQuery.length) composition.add(this.postQuery);
+
+    return composition;
+  }
+}
+
+module.exports.UpdateProto = UpdateProto;

--- a/lib/dialects/abstract/query-generator/query-proto.js
+++ b/lib/dialects/abstract/query-generator/query-proto.js
@@ -10,8 +10,6 @@ const { CompositionError } = require('../../../errors');
  * Allow disordered query building and easy substitution of query parts. Flexible,
  * non-nested and non-exahustive organization.
  */
-const QueryProtoPartNames = Object.freeze([]);
-
 class QueryProto {
   constructor(proto) {
     if (proto) {
@@ -22,9 +20,6 @@ class QueryProto {
         this[key] = new Composition();
       }
     }
-  }
-  static get partNames() {
-    return QueryProtoPartNames;
   }
   set(proto) {
     // Should clone proto into this object, NOT copy shallow references
@@ -55,14 +50,9 @@ class QueryProto {
     throw new CompositionError(`Class ${this.constructor.name} has not implemented toComposition method`);
   }
 }
-
-const SelectProtoPartNames = Object.freeze(['attributes', 'from', 'join', 'where', 'group',
-  'having', 'order', 'page', 'lock']);
+QueryProto.partNames = Object.freeze([]);
 
 class SelectProto extends QueryProto {
-  static get partNames() {
-    return SelectProtoPartNames;
-  }
   toComposition() {
     const composition = new Composition();
     composition.add('SELECT');
@@ -92,14 +82,10 @@ class SelectProto extends QueryProto {
     return composition;
   }
 }
-
-const InsertProtoPartNames = Object.freeze(['preQuery', 'flags', 'table', 'ignoreDups', 'attributes',
-  'output', 'values', 'onConflict', 'return', 'postQuery']);
+SelectProto.partNames = Object.freeze(['attributes', 'from', 'join', 'where', 'group',
+  'having', 'order', 'page', 'lock']);
 
 class InsertProto extends QueryProto {
-  static get partNames() {
-    return InsertProtoPartNames;
-  }
   toComposition() {
     if (!this.table || !this.table.length) {
       throw new CompositionError('Missing table in INSERT query');
@@ -125,14 +111,10 @@ class InsertProto extends QueryProto {
     return composition;
   }
 }
-
-const UpdateProtoPartNames = Object.freeze(['preQuery', 'flags', 'table', 'output',
-  'values', 'where', 'limit', 'return', 'postQuery']);
+InsertProto.partNames = Object.freeze(['preQuery', 'flags', 'table', 'ignoreDups', 'attributes',
+  'output', 'values', 'onConflict', 'return', 'postQuery']);
 
 class UpdateProto extends QueryProto {
-  static get partNames() {
-    return UpdateProtoPartNames;
-  }
   toComposition() {
     if (! (this.table && this.table.length)) {
       throw new CompositionError('Missing table in UPDATE query');
@@ -158,6 +140,8 @@ class UpdateProto extends QueryProto {
     return composition;
   }
 }
+UpdateProto.partNames = Object.freeze(['preQuery', 'flags', 'table', 'output',
+  'values', 'where', 'limit', 'return', 'postQuery']);
 
 exports.QueryProto = QueryProto;
 exports.SelectProto = SelectProto;

--- a/lib/errors/composition-error.js
+++ b/lib/errors/composition-error.js
@@ -6,7 +6,7 @@ const BaseError = require('./base-error');
  * Thrown when a Composition encounters invalid elements.
  *
  * @param {Error}  error   Error description
- * @param {Object} item    Invalid item
+ * @param {*}      item    Invalid item
  *
  * @extends BaseError
  */
@@ -15,6 +15,10 @@ class CompositionError extends BaseError {
   constructor(message, item) {
     super(message);
     this.name = 'SequelizeCompositionError';
+    /**
+     * The item was provided
+     * @type {*}
+     */
     this.item = item;
     Error.captureStackTrace(this, this.constructor);
   }

--- a/lib/errors/composition-error.js
+++ b/lib/errors/composition-error.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const BaseError = require('./base-error');
+
+/**
+ * Thrown when a Composition encounters invalid elements.
+ *
+ * @param {Error}  error   Error description
+ * @param {Object} item    Invalid item
+ *
+ * @extends BaseError
+ */
+
+class CompositionError extends BaseError {
+  constructor(message, item) {
+    super(message);
+    this.name = 'SequelizeCompositionError';
+    this.item = item;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+module.exports = CompositionError;

--- a/lib/errors/composition-error.js
+++ b/lib/errors/composition-error.js
@@ -3,12 +3,10 @@
 const BaseError = require('./base-error');
 
 /**
- * Thrown when a Composition encounters invalid elements.
+ * Thrown when a Composition fails to be created or transformed.
  *
  * @param {Error}  error   Error description
- * @param {*}      item    Invalid item
- *
- * @extends BaseError
+ * @param {*}      [item]  Invalid item
  */
 
 class CompositionError extends BaseError {
@@ -16,7 +14,7 @@ class CompositionError extends BaseError {
     super(message);
     this.name = 'SequelizeCompositionError';
     /**
-     * The item was provided
+     * Invalid item
      * @type {*}
      */
     this.item = item;

--- a/lib/errors/index.js
+++ b/lib/errors/index.js
@@ -29,3 +29,5 @@ exports.TimeoutError = require('./database/timeout-error');
 exports.UnknownConstraintError = require('./database/unknown-constraint-error');
 
 exports.UniqueConstraintError = require('./validation/unique-constraint-error');
+
+exports.CompositionError = require('./composition-error');

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -508,7 +508,9 @@ class Sequelize {
 
     return Promise.try(() => {
       if (typeof sql === 'object') {
-        if (sql instanceof Utils.CompositionMethod) sql = sql.val;
+        if (sql instanceof Utils.CompositionMethod) {
+          sql = Utils.convertComposable(sql, Composition);
+        }
         if (sql instanceof Composition) {
           const query = this.dialect.QueryGenerator.composeQuery(sql);
           sql = query.query;
@@ -930,10 +932,7 @@ class Sequelize {
    * @returns {Sequelize.composition}
    */
   static composition(...items) {
-    return new Utils.CompositionMethod(...items.map(item => {
-      if (item instanceof Utils.CompositionMethod) return item.val;
-      return item;
-    }));
+    return Utils.CompositionMethod.from(items);
   }
 
   /**

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -508,7 +508,7 @@ class Sequelize {
 
     return Promise.try(() => {
       if (typeof sql === 'object') {
-        if (sql instanceof Utils.Composition) sql = sql.val;
+        if (sql instanceof Utils.CompositionMethod) sql = sql.val;
         if (sql instanceof Composition) {
           const query = this.dialect.QueryGenerator.composeQuery(sql);
           sql = query.query;
@@ -930,8 +930,8 @@ class Sequelize {
    * @returns {Sequelize.composition}
    */
   static composition(...items) {
-    return new Utils.Composition(...items.map(item => {
-      if (item instanceof Utils.Composition) return item.val;
+    return new Utils.CompositionMethod(...items.map(item => {
+      if (item instanceof Utils.CompositionMethod) return item.val;
       return item;
     }));
   }
@@ -943,7 +943,7 @@ class Sequelize {
    * @param {*} value Value
    * @param {Object} [field] Model field or data type
    * @param {Object} [options] Options
-   * @returns {Sequelize.Composition}
+   * @returns {Sequelize.composition}
    */
   slot(value, field, options) {
     // dataType instead of field
@@ -951,7 +951,7 @@ class Sequelize {
       field = { type: this.normalizeDataType(field) };
     }
 
-    return new Utils.Composition(new Slot(value, field, options));
+    return new Utils.CompositionMethod(new Slot(value, field, options));
   }
 
   /**
@@ -960,10 +960,10 @@ class Sequelize {
    * @private
    * @param {string} [name] Name for placeholder
    *
-   * @returns {Sequelize.Composition}
+   * @returns {Sequelize.composition}
    */
   static placeholder(name) {
-    return new Utils.Composition(new Placeholder(name));
+    return new Utils.CompositionMethod(new Placeholder(name));
   }
 
   /**

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -22,6 +22,7 @@ const Association = require('./associations/index');
 const Validator = require('./utils/validator-extras').validator;
 const Op = require('./operators');
 const deprecations = require('./utils/deprecations');
+const { Slot, Composition, Placeholder } = require('./dialects/abstract/query-generator/composition');
 
 /**
  * This is the main class, the entry point to sequelize.
@@ -507,22 +508,29 @@ class Sequelize {
 
     return Promise.try(() => {
       if (typeof sql === 'object') {
-        if (sql.values !== undefined) {
-          if (options.replacements !== undefined) {
-            throw new Error('Both `sql.values` and `options.replacements` cannot be set at the same time');
+        if (sql instanceof Utils.Composition) sql = sql.val;
+        if (sql instanceof Composition) {
+          const query = this.dialect.QueryGenerator.composeQuery(sql);
+          sql = query.query;
+          options.bind = query.bind;
+        } else {
+          if (sql.values !== undefined) {
+            if (options.replacements !== undefined) {
+              throw new Error('Both `sql.values` and `options.replacements` cannot be set at the same time');
+            }
+            options.replacements = sql.values;
           }
-          options.replacements = sql.values;
-        }
 
-        if (sql.bind !== undefined) {
-          if (options.bind !== undefined) {
-            throw new Error('Both `sql.bind` and `options.bind` cannot be set at the same time');
+          if (sql.bind !== undefined) {
+            if (options.bind !== undefined) {
+              throw new Error('Both `sql.bind` and `options.bind` cannot be set at the same time');
+            }
+            options.bind = sql.bind;
           }
-          options.bind = sql.bind;
-        }
 
-        if (sql.query !== undefined) {
-          sql = sql.query;
+          if (sql.query !== undefined) {
+            sql = sql.query;
+          }
         }
       }
 
@@ -912,6 +920,53 @@ class Sequelize {
   }
 
   /**
+   * Creates an object representing sql strings and slots. Slots are values
+   * that will be binded or escaped. Strings and slots will be joined without
+   * spaces.
+   *
+   * @param {...string|Object} items String or slot to be part of the query
+   * @memberof Sequelize
+   *
+   * @returns {Sequelize.composition}
+   */
+  static composition(...items) {
+    return new Utils.Composition(...items.map(item => {
+      if (item instanceof Utils.Composition) return item.val;
+      return item;
+    }));
+  }
+
+  /**
+   * Slot to be included into a composition
+   *
+   * @private
+   * @param {*} value Value
+   * @param {Object} [field] Model field or data type
+   * @param {Object} [options] Options
+   * @returns {Sequelize.Composition}
+   */
+  slot(value, field, options) {
+    // dataType instead of field
+    if (typeof field === 'function' || field instanceof DataTypes.ABSTRACT) {
+      field = { type: this.normalizeDataType(field) };
+    }
+
+    return new Utils.Composition(new Slot(value, field, options));
+  }
+
+  /**
+   * Returns a placeholder as a SequelizeMethod.
+   *
+   * @private
+   * @param {string} [name] Name for placeholder
+   *
+   * @returns {Sequelize.Composition}
+   */
+  static placeholder(name) {
+    return new Utils.Composition(new Placeholder(name));
+  }
+
+  /**
    * An AND query
    *
    * @see
@@ -1192,6 +1247,8 @@ Sequelize.prototype.fn = Sequelize.fn;
 Sequelize.prototype.col = Sequelize.col;
 Sequelize.prototype.cast = Sequelize.cast;
 Sequelize.prototype.literal = Sequelize.literal;
+Sequelize.prototype.composition = Sequelize.composition;
+Sequelize.prototype.placeholder = Sequelize.placeholder;
 Sequelize.prototype.and = Sequelize.and;
 Sequelize.prototype.or = Sequelize.or;
 Sequelize.prototype.json = Sequelize.json;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,6 +9,10 @@ const Promise = require('./promise');
 const operators  = require('./operators');
 const operatorsSet = new Set(_.values(operators));
 
+const {
+  Composition: QueryComposition
+} = require('./dialects/abstract/query-generator/composition');
+
 let inflection = require('inflection');
 
 exports.classToInvokable = require('./utils/classToInvokable').classToInvokable;
@@ -451,6 +455,15 @@ class Literal extends SequelizeMethod {
   }
 }
 exports.Literal = Literal;
+
+class Composition extends SequelizeMethod {
+  constructor(...items) {
+    super();
+    // Cannot inherit from both SequelizeMethod and Composition, wrap
+    this.val = QueryComposition.from(items);
+  }
+}
+exports.Composition = Composition;
 
 class Json extends SequelizeMethod {
   constructor(conditionsOrPath, value) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -658,6 +658,10 @@ exports.intersects = intersects;
  * @private
  */
 function interleave(arr, delimiter) {
+  if (!arr.length) {
+    return arr.slice(0);
+  }
+
   const out = new Array(arr.length * 2 - 1);
   out[0] = arr[0];
 
@@ -666,6 +670,7 @@ function interleave(arr, delimiter) {
     out[writeIdx++] = delimiter;
     out[writeIdx++] = arr[readIdx];
   }
+
   return out;
 }
 exports.interleave = interleave;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -659,7 +659,7 @@ exports.intersects = intersects;
  */
 function interleave(arr, delimiter) {
   if (!arr.length) {
-    return arr.slice(0);
+    return [];
   }
 
   const out = new Array(arr.length * 2 - 1);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,7 @@ const Promise = require('./promise');
 const operators  = require('./operators');
 const operatorsSet = new Set(_.values(operators));
 
-const { Composition } = require('./dialects/abstract/query-generator/composition');
+const { composableMixin } = require('./dialects/abstract/query-generator/composition');
 
 let inflection = require('inflection');
 
@@ -454,13 +454,7 @@ class Literal extends SequelizeMethod {
 }
 exports.Literal = Literal;
 
-class CompositionMethod extends SequelizeMethod {
-  constructor(...items) {
-    super();
-    // Cannot inherit from both SequelizeMethod and Composition, wrap
-    this.val = Composition.from(items);
-  }
-}
+class CompositionMethod extends composableMixin(SequelizeMethod) {}
 exports.CompositionMethod = CompositionMethod;
 
 class Json extends SequelizeMethod {
@@ -492,6 +486,15 @@ class Where extends SequelizeMethod {
   }
 }
 exports.Where = Where;
+
+function convertComposable(composable, ToClass) {
+  const output = new ToClass();
+  // skips _processArgs validation for increased performance
+  output.items = composable.items.slice(0);
+  return output;
+}
+
+exports.convertComposable = convertComposable;
 
 //Collection of helper methods to make it easier to work with symbol operators
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,9 +9,7 @@ const Promise = require('./promise');
 const operators  = require('./operators');
 const operatorsSet = new Set(_.values(operators));
 
-const {
-  Composition: QueryComposition
-} = require('./dialects/abstract/query-generator/composition');
+const { Composition } = require('./dialects/abstract/query-generator/composition');
 
 let inflection = require('inflection');
 
@@ -456,14 +454,14 @@ class Literal extends SequelizeMethod {
 }
 exports.Literal = Literal;
 
-class Composition extends SequelizeMethod {
+class CompositionMethod extends SequelizeMethod {
   constructor(...items) {
     super();
     // Cannot inherit from both SequelizeMethod and Composition, wrap
-    this.val = QueryComposition.from(items);
+    this.val = Composition.from(items);
   }
 }
-exports.Composition = Composition;
+exports.CompositionMethod = CompositionMethod;
 
 class Json extends SequelizeMethod {
   constructor(conditionsOrPath, value) {
@@ -647,3 +645,27 @@ function intersects(arr1, arr2) {
   return arr1.some(v => arr2.includes(v));
 }
 exports.intersects = intersects;
+
+/**
+ * Interleaves an array of elements with another element.
+ *
+ * @example
+ * interleave(['a', 'b', 'c'], 'd')
+ * // returns ['a', 'd', 'b', 'd', 'c']
+ *
+ * @param {Array} arr
+ * @param {*} delimiter
+ * @private
+ */
+function interleave(arr, delimiter) {
+  const out = new Array(arr.length * 2 - 1);
+  out[0] = arr[0];
+
+  let writeIdx = 1;
+  for (let readIdx = 1; readIdx < arr.length; readIdx++) {
+    out[writeIdx++] = delimiter;
+    out[writeIdx++] = arr[readIdx];
+  }
+  return out;
+}
+exports.interleave = interleave;

--- a/test/integration/raw-queries.test.js
+++ b/test/integration/raw-queries.test.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const chai = require('chai'),
-  expect = chai.expect,
-  Support = require('./support'),
-  DataTypes = require('../../lib/data-types'),
-  sequelize = Support.sequelize,
-  dialect = Support.getTestDialect();
+const { expect } = require('chai');
+const Support = require('./support');
+const DataTypes = require('../../lib/data-types');
+const sequelize = Support.sequelize;
+const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Custom Queries'), () => {
 
@@ -57,7 +56,7 @@ describe(Support.getTestDialectTeaser('Custom Queries'), () => {
           replacements: ['abc\'"\n\r\b\t\\\x1a']
         });
       }).then(instances => {
-        expect(instances.length).to.equal(1);
+        expect(instances).to.have.lengthOf(1);
         expect(instances[0].get({ plain: true })).to.deep.equal({
           id: 20,
           name: 'abc\'"\n\r\b\t\\\x1a'
@@ -91,7 +90,7 @@ describe(Support.getTestDialectTeaser('Custom Queries'), () => {
           }
         });
       }).then(instances => {
-        expect(instances.length).to.equal(1);
+        expect(instances).to.have.lengthOf(1);
         expect(instances[0].get({ plain: true })).to.deep.equal({
           id: 20,
           name: 'abc\'"\n\r\b\t\\\x1a'
@@ -125,7 +124,7 @@ describe(Support.getTestDialectTeaser('Custom Queries'), () => {
           bind: ['abc\'"\n\r\b\t\\\x1a']
         });
       }).then(instances => {
-        expect(instances.length).to.equal(1);
+        expect(instances).to.have.lengthOf(1);
         expect(instances[0].get({ plain: true })).to.deep.equal({
           id: 20,
           name: 'abc\'"\n\r\b\t\\\x1a'
@@ -159,7 +158,7 @@ describe(Support.getTestDialectTeaser('Custom Queries'), () => {
           }
         });
       }).then(instances => {
-        expect(instances.length).to.equal(1);
+        expect(instances).to.have.lengthOf(1);
         expect(instances[0].get({ plain: true })).to.deep.equal({
           id: 20,
           name: 'abc\'"\n\r\b\t\\\x1a'
@@ -192,7 +191,7 @@ describe(Support.getTestDialectTeaser('Custom Queries'), () => {
           }
         });
       }).then(instances => {
-        expect(instances.length).to.equal(1);
+        expect(instances).to.have.lengthOf(1);
         expect(instances[0].get({ plain: true })).to.deep.equal({
           id: 20,
           name: 'abc$'
@@ -225,7 +224,7 @@ describe(Support.getTestDialectTeaser('Custom Queries'), () => {
           type: sequelize.QueryTypes.SELECT
         });
       }).then(instances => {
-        expect(instances.length).to.equal(1);
+        expect(instances).to.have.lengthOf(1);
         expect(instances[0].get({ plain: true })).to.deep.equal({
           id: 20,
           name: 'abc\'"\n\r\b\t\\\x1a'
@@ -253,7 +252,7 @@ describe(Support.getTestDialectTeaser('Custom Queries'), () => {
           type: sequelize.QueryTypes.SELECT
         });
       }).then(instances => {
-        expect(instances.length).to.equal(1);
+        expect(instances).to.have.lengthOf(1);
         expect(instances[0].get({ plain: true })).to.deep.equal({
           id: 20,
           name: 'abc$'

--- a/test/integration/raw-queries.test.js
+++ b/test/integration/raw-queries.test.js
@@ -1,0 +1,266 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support = require('./support'),
+  DataTypes = require('../../lib/data-types'),
+  sequelize = Support.sequelize,
+  dialect = Support.getTestDialect();
+
+describe(Support.getTestDialectTeaser('Custom Queries'), () => {
+
+  function createModel() {
+    return sequelize.define('Dummies', {
+      name: {
+        type: DataTypes.STRING
+      }
+    }, {
+      tableName: 'dummies',
+      timestamps: false
+    });
+  }
+
+  function createTable() {
+    return sequelize.sync({ force: true }).then(() => {
+      let query = 'INSERT INTO dummies (id, name) VALUES(10, \'evil\');';
+
+      if (dialect === 'mssql') {
+        query = `SET IDENTITY_INSERT dummies ON; ${query}; SET IDENTITY_INSERT dummies OFF;`;
+      }
+
+      return sequelize.query(query, {
+        type: sequelize.QueryTypes.INSERT
+      });
+    });
+  }
+
+  describe('Interpolated replacementes', () => {
+
+    it('can interpolate unnamed replacements', () => {
+      const Model = createModel();
+
+      return createTable().then(() => {
+        let query = 'INSERT INTO dummies (id, name) VALUES(?, ?);';
+
+        if (dialect === 'mssql') {
+          query = `SET IDENTITY_INSERT dummies ON; ${query}; SET IDENTITY_INSERT dummies OFF;`;
+        }
+
+        return sequelize.query(query, {
+          type: sequelize.QueryTypes.INSERT,
+          replacements: [20, 'abc\'"\n\r\b\t\\\x1a']
+        });
+      }).then(() => {
+        return sequelize.query('SELECT * FROM dummies WHERE name = ?;', {
+          model: Model,
+          type: sequelize.QueryTypes.SELECT,
+          replacements: ['abc\'"\n\r\b\t\\\x1a']
+        });
+      }).then(instances => {
+        expect(instances.length).to.equal(1);
+        expect(instances[0].get({ plain: true })).to.deep.equal({
+          id: 20,
+          name: 'abc\'"\n\r\b\t\\\x1a'
+        });
+      });
+    });
+
+    it('can interpolate named replacements', () => {
+      const Model = createModel();
+
+      return createTable().then(() => {
+        let query = 'INSERT INTO dummies (id, name) VALUES(:id, :name);';
+
+        if (dialect === 'mssql') {
+          query = `SET IDENTITY_INSERT dummies ON; ${query}; SET IDENTITY_INSERT dummies OFF;`;
+        }
+
+        return sequelize.query(query, {
+          type: sequelize.QueryTypes.INSERT,
+          replacements: {
+            id: 20,
+            name: 'abc\'"\n\r\b\t\\\x1a'
+          }
+        });
+      }).then(() => {
+        return sequelize.query('SELECT * FROM dummies WHERE name = :name;', {
+          model: Model,
+          type: sequelize.QueryTypes.SELECT,
+          replacements: {
+            name: 'abc\'"\n\r\b\t\\\x1a'
+          }
+        });
+      }).then(instances => {
+        expect(instances.length).to.equal(1);
+        expect(instances[0].get({ plain: true })).to.deep.equal({
+          id: 20,
+          name: 'abc\'"\n\r\b\t\\\x1a'
+        });
+      });
+    });
+
+  });
+
+
+  describe('Binded parameters', () => {
+
+    it('can bind unnamed parameters', () => {
+      const Model = createModel();
+
+      return createTable().then(() => {
+        let query = 'INSERT INTO dummies (id, name) VALUES($1, $2);';
+
+        if (dialect === 'mssql') {
+          query = `SET IDENTITY_INSERT dummies ON; ${query}; SET IDENTITY_INSERT dummies OFF;`;
+        }
+
+        return sequelize.query(query, {
+          type: sequelize.QueryTypes.INSERT,
+          bind: [20, 'abc\'"\n\r\b\t\\\x1a']
+        });
+      }).then(() => {
+        return sequelize.query('SELECT * FROM dummies WHERE name = $1;', {
+          model: Model,
+          type: sequelize.QueryTypes.SELECT,
+          bind: ['abc\'"\n\r\b\t\\\x1a']
+        });
+      }).then(instances => {
+        expect(instances.length).to.equal(1);
+        expect(instances[0].get({ plain: true })).to.deep.equal({
+          id: 20,
+          name: 'abc\'"\n\r\b\t\\\x1a'
+        });
+      });
+    });
+
+    it('can bind named parameters', () => {
+      const Model = createModel();
+
+      return createTable().then(() => {
+        let query = 'INSERT INTO dummies (id, name) VALUES($id, $name);';
+
+        if (dialect === 'mssql') {
+          query = `SET IDENTITY_INSERT dummies ON; ${query}; SET IDENTITY_INSERT dummies OFF;`;
+        }
+
+        return sequelize.query(query, {
+          type: sequelize.QueryTypes.INSERT,
+          bind: {
+            id: 20,
+            name: 'abc\'"\n\r\b\t\\\x1a'
+          }
+        });
+      }).then(() => {
+        return sequelize.query('SELECT * FROM dummies WHERE name = $name;', {
+          model: Model,
+          type: sequelize.QueryTypes.SELECT,
+          bind: {
+            name: 'abc\'"\n\r\b\t\\\x1a'
+          }
+        });
+      }).then(instances => {
+        expect(instances.length).to.equal(1);
+        expect(instances[0].get({ plain: true })).to.deep.equal({
+          id: 20,
+          name: 'abc\'"\n\r\b\t\\\x1a'
+        });
+      });
+    });
+
+    it('can escape $', () => {
+      const Model = createModel();
+
+      return createTable().then(() => {
+        let query = 'INSERT INTO dummies (id, name) VALUES($id, \'abc$$\');';
+
+        if (dialect === 'mssql') {
+          query = `SET IDENTITY_INSERT dummies ON; ${query}; SET IDENTITY_INSERT dummies OFF;`;
+        }
+
+        return sequelize.query(query, {
+          type: sequelize.QueryTypes.INSERT,
+          bind: {
+            id: 20
+          }
+        });
+      }).then(() => {
+        return sequelize.query('SELECT * FROM dummies WHERE id = $id AND name = \'abc$$\';', {
+          model: Model,
+          type: sequelize.QueryTypes.SELECT,
+          bind: {
+            id: 20
+          }
+        });
+      }).then(instances => {
+        expect(instances.length).to.equal(1);
+        expect(instances[0].get({ plain: true })).to.deep.equal({
+          id: 20,
+          name: 'abc$'
+        });
+      });
+    });
+
+  });
+
+
+  describe('Compositions', () => {
+
+    it('can use compositions', () => {
+      const Model = createModel();
+
+      return createTable().then(() => {
+        // Nested composition just for testing, otherwise it is unneeded
+        let query = sequelize.composition('INSERT INTO dummies (id, name) ', sequelize.composition('VALUES(', sequelize.slot(20)), ', ', sequelize.slot('abc\'"\n\r\b\t\\\x1a'), ');');
+
+        if (dialect === 'mssql') {
+          query = sequelize.composition('SET IDENTITY_INSERT dummies ON; ', query, '; SET IDENTITY_INSERT dummies OFF;');
+        }
+
+        return sequelize.query(query, {
+          type: sequelize.QueryTypes.INSERT
+        });
+      }).then(() => {
+        return sequelize.query(sequelize.composition('SELECT * FROM dummies WHERE name = ', sequelize.slot('abc\'"\n\r\b\t\\\x1a'), ';'), {
+          model: Model,
+          type: sequelize.QueryTypes.SELECT
+        });
+      }).then(instances => {
+        expect(instances.length).to.equal(1);
+        expect(instances[0].get({ plain: true })).to.deep.equal({
+          id: 20,
+          name: 'abc\'"\n\r\b\t\\\x1a'
+        });
+      });
+    });
+
+    it('do not need to escape $', () => {
+      const Model = createModel();
+
+      return createTable().then(() => {
+        // Nested composition just for testing, otherwise it is unneeded
+        let query = sequelize.composition('INSERT INTO dummies (id, name) ', sequelize.composition('VALUES(', sequelize.slot(20)), ', \'abc$\');');
+
+        if (dialect === 'mssql') {
+          query = sequelize.composition('SET IDENTITY_INSERT dummies ON; ', query, '; SET IDENTITY_INSERT dummies OFF;');
+        }
+        
+        return sequelize.query(query, {
+          type: sequelize.QueryTypes.INSERT
+        });
+      }).then(() => {
+        return sequelize.query(sequelize.composition('SELECT * FROM dummies WHERE id = ', sequelize.slot(20), ' AND name = \'abc$\';'), {
+          model: Model,
+          type: sequelize.QueryTypes.SELECT
+        });
+      }).then(instances => {
+        expect(instances.length).to.equal(1);
+        expect(instances[0].get({ plain: true })).to.deep.equal({
+          id: 20,
+          name: 'abc$'
+        });
+      });
+    });
+
+  });
+
+});

--- a/test/support.js
+++ b/test/support.js
@@ -258,11 +258,9 @@ const Support = {
       expect(query.query || query).to.equal(expectation);
 
       if (assertions.bind) {
-        let bind = assertions.bind[Support.sequelize.dialect.name] || assertions.bind['default'] || assertions.bind;
-        if (Support.sequelize.dialect.name === 'mssql' && Array.isArray(bind)) {
-          bind = Support.sequelize.dialect.QueryGenerator.outputBind(bind);
-        }
-        expect(query.bind).to.deep.equal(bind);
+        const stdBind = assertions.bind[Support.sequelize.dialect.name] || assertions.bind['default'] || assertions.bind;
+        const dialectBind = Support.sequelize.dialect.QueryGenerator.outputBind(stdBind);
+        expect(query.bind).to.deep.equal(dialectBind);
       }
     }
   }

--- a/test/unit/composition.test.js
+++ b/test/unit/composition.test.js
@@ -1,0 +1,383 @@
+'use strict';
+
+const Support = require('../support'),
+  chai = require('chai'),
+  expect = chai.expect,
+  Sequelize = Support.Sequelize,
+  expectsql = Support.expectsql;
+
+const {
+  Slot,
+  Placeholder,
+  Composition,
+  CompositionGroup
+} = require('../../lib/dialects/abstract/query-generator/composition');
+
+const {
+  QueryProto,
+  SelectProto,
+  InsertProto,
+  UpdateProto
+} = require('../../lib/dialects/abstract/query-generator/query-proto');
+
+describe('Composition', () => {
+
+  it('validates input', () => {
+    expect(() => new Composition('foo ', new Slot(new Date(), { type: Sequelize.DATE }), ' bar')).to.not.throw();
+    expect(() => new Composition('bar', new Placeholder())).to.not.throw();
+    expect(() => new Composition('numbers not allowed', 8008)).to.throw('Invalid query item: 8008');
+    expect(() => new Composition('Only allows strings, slots and placholders', new Date(Date.UTC(2000, 0, 1)))).to.throw('Invalid query item: 2000-01-01T00:00:00.000Z');
+    expect(() => new Composition('Otherwise, throw', {})).to.throw('Invalid query item: {}');
+    expect(() => new Composition('bad', [])).to.throw('Invalid query item: []');
+  });
+
+  it('should have *set* method', () => {
+    const items = ['foo ', new Slot(5), ' bar'];
+
+    const compositionEmpty = new Composition();
+    expect(compositionEmpty.set(...items)).to.deep.equal(new Composition(...items));
+
+    // *set* cleans previous values
+    const composition = new Composition('start ');
+    expect(composition.set(...items)).to.deep.equal(new Composition(...items));
+
+    // *set* modifies instace without need to reassign
+    expect(composition).to.deep.equal(new Composition(...items));
+
+    // *set* returns same object
+    expect(composition === composition.set(...items)).to.be.ok;
+  });
+
+  it('should have *add* method', () => {
+    const items = ['foo ', new Slot(5), ' bar'];
+
+    const compositionEmpty = new Composition();
+    expect(compositionEmpty.add(...items)).to.deep.equal(new Composition(...items));
+
+    // *add* puts items towards the end
+    const composition = new Composition('start ');
+    expect(composition.add(...items).items).to.deep.equal(['start '].concat(items));
+
+    // *add* modifies instace without need to reassign
+    expect(composition.items).to.deep.equal(['start '].concat(items));
+
+    // *add* returns same object
+    expect(composition === composition.add(...items)).to.be.ok;
+  });
+
+  it('should have *prepend* method', () => {
+    const items = ['foo ', new Slot(5), ' bar'];
+
+    const compositionEmpty = new Composition();
+    expect(compositionEmpty.prepend(...items)).to.deep.equal(new Composition(...items));
+
+    // *prepend* puts items towards the beginning
+    const composition = new Composition(' end');
+    expect(composition.prepend(...items).items).to.deep.equal(items.concat([' end']));
+
+    // *prepend* modifies instace without need to reassign
+    expect(composition.items).to.deep.equal(items.concat([' end']));
+
+    // *prepend* returns same object
+    expect(composition === composition.prepend(...items)).to.be.ok;
+  });
+
+  it('should have *clone* method', () => {
+    const items = ['foo ', new Slot(5), ' bar'];
+    const originalComposition = new Composition(...items);
+
+    // *clone* should return a different object
+    expect(originalComposition.clone() === originalComposition).to.not.be.ok;
+
+    // But the returned object must have the same items
+    expect(originalComposition.clone().items).to.deep.equal(items);
+  });
+
+  it('should have *from* method', () => {
+    const items = ['foo ', new Slot(5), ' bar'];
+    const composition = Composition.from(items);
+
+    expect(composition.items).to.deep.equal(['foo ', new Slot(5), ' bar']);
+
+    // *from* should create a *Composition* instance
+    expect(composition instanceof Composition).to.be.ok;
+  });
+
+});
+
+describe('Composition Group', () => {
+
+  it('accepts composition elements', () => {
+    expect(() => new CompositionGroup('foo ',  new Slot(5),
+      ' bar', new Composition())).to.not.throw();
+    // validation is done when using method toComposiiton()
+  });
+
+  it('should have *add* method', () => {
+    const compositions = ['foo ', new Slot(5), ' bar', new Composition()];
+
+    const groupEmpty = new CompositionGroup();
+    expect(groupEmpty.add(...compositions)).to.deep.equal(CompositionGroup.from(compositions));
+
+    // *add* puts compositions towards the end
+    const group = new CompositionGroup('start ');
+    expect(group.add(...compositions)).to.deep.equal(new CompositionGroup('start ', ...compositions));
+
+    // *add* modifies instace without need to reassign
+    expect(group).to.deep.equal(new CompositionGroup('start ', ...compositions));
+
+    // *add* returns same object
+    expect(group === group.add(...compositions)).to.be.ok;
+  });
+
+  it('should have *space* method', () => {
+    const compositions = ['foo ', new Slot(5), ' bar', new Composition()];
+
+    const group = CompositionGroup.from(compositions);
+    expect(group.space(', ').compositions).to.deep.equal(['foo ', ', ',
+      new Slot(5), ', ', ' bar', ', ', new Composition()]);
+
+    // *space* modifies instace without need to reassign
+    expect(group.compositions).to.deep.equal(['foo ', ', ',
+      new Slot(5), ', ', ' bar', ', ', new Composition()]);
+
+    // *space* returns same object
+    const group2 = CompositionGroup.from(compositions);
+    expect(group2 === group2.space(', ')).to.be.ok;
+  });
+
+  it('should have *merge* method', () => {
+    const group1 = new CompositionGroup('foo ', new Slot(5), ' bar');
+    const group2 = new CompositionGroup(new Composition('oof', new Slot(5), 'rab'));
+
+    expect(group1.merge(group2).compositions).to.deep.equal(['foo ',
+      new Slot(5), ' bar', new Composition('oof',
+        new Slot(5), 'rab')]);
+
+    // *merge* should return a different object
+    expect(group1.merge(group2) === group1).to.be.ok;
+    expect(group1.merge(group2) === group2).to.not.be.ok;
+  });
+
+  it('should have *slice* method', () => {
+    const group = new CompositionGroup('foo ', new Slot(5), ' bar',
+      new Composition('oof', new Slot(5), 'rab'), 'end');
+
+    expect(group.slice(1, 3).compositions).to.deep.equal([new Slot(5), ' bar']);
+
+    // *slice* should return a different object
+    expect(group.slice() === group).to.not.be.ok;
+  });
+
+  it('should have *toComposition* method', () => {
+    const group = new CompositionGroup('foo ', new Slot(5),
+      new Composition('oof', 'rab'), ' bar');
+
+    expect(group.toComposition() instanceof Composition).to.be.ok;
+
+    // *toComposition* should return a different object
+    expect(group.toComposition().items).to.deep.equal(['foo ', new Slot(5),
+      'oof', 'rab', ' bar']);
+
+  });
+
+  it('should have *from* method', () => {
+    const compositions = ['foo ', new Slot(5), ' bar',
+      new Composition('oof', new Slot(5), 'rab')];
+    const group = CompositionGroup.from(compositions);
+
+    expect(group.compositions).to.deep.equal([
+      'foo ', new Slot(5), ' bar', new Composition('oof', new Slot(5), 'rab')
+    ]);
+
+    // *from* should create a *CompositionGroup* instance
+    expect(group instanceof CompositionGroup).to.be.ok;
+  });
+
+});
+
+describe('Query proto', () => {
+
+  const partNames = ['foo', 'bar'];
+  class TestProto extends QueryProto {
+    static get partNames() { return partNames; }
+  }
+
+  it('constructor should accept QueryProto instances or similar objects', () => {
+    const similar = { foo: new Composition('abc'), extrange: new Composition('def') };
+    const testProto = new TestProto(similar);
+    const otherTestProto = new TestProto(testProto);
+
+    // *foo* should have been copied, but not *extrange*
+    expect(testProto).to.deep.equal({ foo: { items: ['abc'] }, bar: { items: [] } });
+    expect(otherTestProto).to.deep.equal({ foo: { items: ['abc'] }, bar: { items: [] } });
+
+    // deep copy of instance up to Composition level
+    expect(testProto !== otherTestProto).to.be.ok;
+    expect(testProto.foo !== otherTestProto.foo).to.be.ok;
+  });
+
+  it('should have *set* method', () => {
+    const originalTestProto = new TestProto();
+    const testProto = new TestProto();
+
+    originalTestProto.foo.add('abc', new Slot(5));
+    originalTestProto.bar.add('def');
+
+    testProto.foo.add('bar');
+
+    // *set* cleans previous values
+    expect(testProto.set(originalTestProto)).to.deep.equal({
+      foo: { items: ['abc', new Slot(5)] },
+      bar: { items: ['def'] }
+    });
+
+    // *set* modifies instace without need to reassign
+    expect(testProto).to.deep.equal({
+      foo: { items: ['abc', new Slot(5)] },
+      bar: { items: ['def'] }
+    });
+
+    // *set* returns same object
+    expect(testProto === testProto.set(originalTestProto)).to.be.ok;
+  });
+
+  it('should have *clone* method', () => {
+    const testProto = new TestProto();
+
+    testProto.foo.add('abc', new Slot(5));
+    testProto.bar.add('def');
+
+    // *clone* should return a different object
+    expect(testProto.clone() === testProto).to.not.be.ok;
+
+    // But the returned object must have the same items
+    expect(testProto.clone()).to.deep.equal({
+      foo: { items: ['abc', new Slot(5)] },
+      bar: { items: ['def'] }
+    });
+  });
+
+  it('should error if subclasses do not implement toComposition method', () => {
+    const testProto = new TestProto();
+    testProto.foo.add('abc');
+
+    expect(() => testProto.toComposition()).to.throw('Class TestProto has not implemented toComposition method');
+  });
+});
+
+describe('Select proto', () => {
+
+  it('should implement toComposition method', () => {
+    const selectProto = new SelectProto({
+      attributes: new Composition('SUM("apples") AS "totalApples", "color"'),
+      from: new Composition('"mytable"'),
+      join: new Composition('INNER JOIN "childtable"'),
+      where: new Composition('"color" IN (', new Slot('green'), ', ', new Slot('red'), ')'),
+      group: new Composition('"color"'),
+      having: new Composition('"totalApples" > ', new Slot(5)),
+      order: new Composition('"totalApples" DESC'),
+      page: new Composition('LIMIT ', new Slot(10), ' OFFSET ', new Slot(10)),
+      lock: new Composition('FOR UPDATE')
+    });
+
+    expectsql(selectProto.toComposition(), {
+      query: {
+        default: 'SELECT SUM("apples") AS "totalApples", "color" FROM "mytable" INNER JOIN "childtable" WHERE "color" IN ($1, $2) GROUP BY "color" HAVING "totalApples" > $3 ORDER BY "totalApples" DESC LIMIT $4 OFFSET $5 FOR UPDATE;'
+      },
+      bind: {
+        default: ['green', 'red', 5, 10, 10]
+      }
+    });
+  });
+
+  it('toComposition() should require from clause', () => {
+    expect(() => new SelectProto().toComposition()).to.throw('Missing FROM clause in select proto query');
+    expect(() => new SelectProto({ from: new Composition('"mytable"') }).toComposition()).not.to.throw();
+  });
+
+  it('should use \'*\' if values are missing', () => {
+    const selectProto = new SelectProto({ from: new Composition('"mytable"') });
+
+    expectsql(selectProto.toComposition(), {
+      query: {
+        default: 'SELECT * FROM "mytable";'
+      },
+      bind: {
+        default: []
+      }
+    });
+  });
+});
+
+describe('Insert proto', () => {
+
+  it('should implement toComposition method', () => {
+    const insertProto = new InsertProto({
+      preQuery: new Composition('set "foo" = \'bar\'; '),
+      flags: new Composition('IGNORE'),
+      table: new Composition('"mytable"'),
+      attributes: new Composition('"apples", "color"'),
+      output: new Composition('OUTPUT *'),
+      values: new Composition('SELECT ', new Slot(5), ', ', new Slot('green')),
+      onConflict: new Composition('ON CONFLICT DO NOTHING'),
+      return: new Composition('RETURNING *'),
+      postQuery: new Composition('; set "foo" = \'foo\'')
+    });
+
+    expectsql(insertProto.toComposition(), {
+      query: {
+        default: 'set "foo" = \'bar\'; INSERT IGNORE INTO "mytable" ("apples", "color") OUTPUT * SELECT $1, $2 ON CONFLICT DO NOTHING RETURNING *; set "foo" = \'foo\';'
+      },
+      bind: {
+        default: [5, 'green']
+      }
+    });
+  });
+
+  it('toComposition() should require a table', () => {
+    expect(() => new InsertProto({ values: new Composition('1') }).toComposition()).to.throw('Missing table in INSERT query');
+    expect(() => new InsertProto({ table: new Composition('"mytable"'), values: new Composition('1') }).toComposition()).not.to.throw();
+  });
+
+  it('toComposition() should require values', () => {
+    expect(() => new InsertProto({ table: new Composition('"mytable"') }).toComposition()).to.throw('Missing values in INSERT query');
+    expect(() => new InsertProto({ table: new Composition('"mytable"'), values: new Composition('1') }).toComposition()).not.to.throw();
+  });
+});
+
+describe('Update proto', () => {
+
+  it('should implement toComposition method', () => {
+    const updateProto = new UpdateProto({
+      preQuery: new Composition('set "foo" = \'bar\'; '),
+      flags: new Composition('IGNORE'),
+      table: new Composition('"mytable"'),
+      values: new Composition('"apples" = ', new Slot(5), ', "color" = ', new Slot('red')),
+      output: new Composition('OUTPUT *'),
+      where: new Composition('"id" = ', new Slot(21)),
+      limit: new Composition('LIMIT ', new Slot(10)),
+      return: new Composition('RETURNING *'),
+      postQuery: new Composition('; set "foo" = \'foo\'')
+    });
+
+    expectsql(updateProto.toComposition(), {
+      query: {
+        default: 'set "foo" = \'bar\'; UPDATE IGNORE "mytable" SET "apples" = $1, "color" = $2 OUTPUT * WHERE "id" = $3 LIMIT $4 RETURNING *; set "foo" = \'foo\';'
+      },
+      bind: {
+        default: [5, 'red', 21, 10]
+      }
+    });
+  });
+
+  it('toComposition() should require a table', () => {
+    expect(() => new UpdateProto({ values: new Composition('1') }).toComposition()).to.throw('Missing table in UPDATE query');
+    expect(() => new UpdateProto({ table: new Composition('"mytable"'), values: new Composition('1') }).toComposition()).not.to.throw();
+  });
+
+  it('toComposition() should require values', () => {
+    expect(() => new UpdateProto({ table: new Composition('"mytable"') }).toComposition()).to.throw('Missing values in UPDATE query');
+    expect(() => new UpdateProto({ table: new Composition('"mytable"'), values: new Composition('1') }).toComposition()).not.to.throw();
+  });
+});

--- a/test/unit/composition.test.js
+++ b/test/unit/composition.test.js
@@ -34,75 +34,75 @@ describe('Composition', () => {
     expect(() => new Composition('bad', array)).to.throw('Invalid query item').with.property('item', array);
   });
 
-  it('should have *set* method', () => {
+  it('should have set method', () => {
     const items = ['foo ', new Slot(5), ' bar'];
 
     const compositionEmpty = new Composition();
     expect(compositionEmpty.set(...items)).to.deep.equal(new Composition(...items));
 
-    // *set* cleans previous values
+    // set cleans previous values
     const composition = new Composition('start ');
     expect(composition.set(...items)).to.deep.equal(new Composition(...items));
 
-    // *set* modifies instace without need to reassign
+    // set modifies instace without need to reassign
     expect(composition).to.deep.equal(new Composition(...items));
 
-    // *set* returns same object
+    // set returns same object
     expect(composition).to.equal(composition.set(...items));
   });
 
-  it('should have *add* method', () => {
+  it('should have add method', () => {
     const items = ['foo ', new Slot(5), ' bar'];
 
     const compositionEmpty = new Composition();
     expect(compositionEmpty.add(...items)).to.deep.equal(new Composition(...items));
 
-    // *add* puts items towards the end
+    // add puts items towards the end
     const composition = new Composition('start ');
     expect(composition.add(...items).items).to.deep.equal(['start ', ...items]);
 
-    // *add* modifies instace without need to reassign
+    // add modifies instace without need to reassign
     expect(composition.items).to.deep.equal(['start ', ...items]);
 
-    // *add* returns same object
+    // add returns same object
     expect(composition).to.equal(composition.add(...items));
   });
 
-  it('should have *prepend* method', () => {
+  it('should have prepend method', () => {
     const items = ['foo ', new Slot(5), ' bar'];
 
     const compositionEmpty = new Composition();
     expect(compositionEmpty.prepend(...items)).to.deep.equal(new Composition(...items));
 
-    // *prepend* puts items towards the beginning
+    // prepend puts items towards the beginning
     const composition = new Composition(' end');
     expect(composition.prepend(...items).items).to.deep.equal([...items, ' end']);
 
-    // *prepend* modifies instace without need to reassign
+    // prepend modifies instace without need to reassign
     expect(composition.items).to.deep.equal([...items, ' end']);
 
-    // *prepend* returns same object
+    // prepend returns same object
     expect(composition).to.equal(composition.prepend(...items));
   });
 
-  it('should have *clone* method', () => {
+  it('should have clone method', () => {
     const items = ['foo ', new Slot(5), ' bar'];
     const originalComposition = new Composition(...items);
 
-    // *clone* should return a different object
+    // clone should return a different object
     expect(originalComposition.clone()).to.not.equal(originalComposition);
 
     // But the returned object must have the same items
     expect(originalComposition.clone().items).to.deep.equal(items);
   });
 
-  it('should have *from* method', () => {
+  it('should have from method', () => {
     const items = ['foo ', new Slot(5), ' bar'];
     const composition = Composition.from(items);
 
     expect(composition.items).to.deep.equal(['foo ', new Slot(5), ' bar']);
 
-    // *from* should create a *Composition* instance
+    // from should create a Composition instance
     expect(composition instanceof Composition).to.be.ok;
   });
 
@@ -116,40 +116,40 @@ describe('Composition Group', () => {
     // validation is done when using method toComposiiton()
   });
 
-  it('should have *add* method', () => {
+  it('should have add method', () => {
     const compositions = ['foo ', new Slot(5), ' bar', new Composition()];
 
     const groupEmpty = new CompositionGroup();
     expect(groupEmpty.add(...compositions)).to.deep.equal(CompositionGroup.from(compositions));
 
-    // *add* puts compositions towards the end
+    // add puts compositions towards the end
     const group = new CompositionGroup('start ');
     expect(group.add(...compositions)).to.deep.equal(new CompositionGroup('start ', ...compositions));
 
-    // *add* modifies instace without need to reassign
+    // add modifies instace without need to reassign
     expect(group).to.deep.equal(new CompositionGroup('start ', ...compositions));
 
-    // *add* returns same object
+    // add returns same object
     expect(group).to.equal(group.add(...compositions));
   });
 
-  it('should have *space* method', () => {
+  it('should have space method', () => {
     const compositions = ['foo ', new Slot(5), ' bar', new Composition()];
 
     const group = CompositionGroup.from(compositions);
     expect(group.space(', ').compositions).to.deep.equal(['foo ', ', ',
       new Slot(5), ', ', ' bar', ', ', new Composition()]);
 
-    // *space* modifies instace without need to reassign
+    // space modifies instace without need to reassign
     expect(group.compositions).to.deep.equal(['foo ', ', ',
       new Slot(5), ', ', ' bar', ', ', new Composition()]);
 
-    // *space* returns same object
+    // space returns same object
     const group2 = CompositionGroup.from(compositions);
     expect(group2).to.equal(group2.space(', '));
   });
 
-  it('should have *merge* method', () => {
+  it('should have merge method', () => {
     const group1 = new CompositionGroup('foo ', new Slot(5), ' bar');
     const group2 = new CompositionGroup(new Composition('oof', new Slot(5), 'rab'));
 
@@ -157,22 +157,22 @@ describe('Composition Group', () => {
       new Slot(5), ' bar', new Composition('oof',
         new Slot(5), 'rab')]);
 
-    // *merge* should return same object
+    // merge should return same object
     expect(group1.merge(group2)).to.equal(group1);
     expect(group1.merge(group2)).to.not.equal(group2);
   });
 
-  it('should have *slice* method', () => {
+  it('should have slice method', () => {
     const group = new CompositionGroup('foo ', new Slot(5), ' bar',
       new Composition('oof', new Slot(5), 'rab'), 'end');
 
     expect(group.slice(1, 3).compositions).to.deep.equal([new Slot(5), ' bar']);
 
-    // *slice* should return a different object
+    // slice should return a different object
     expect(group.slice()).to.not.equal(group);
   });
 
-  it('should have *toComposition* method', () => {
+  it('should have toComposition method', () => {
     const group = new CompositionGroup('foo ', new Slot(5),
       new Composition('oof', 'rab'), ' bar');
 
@@ -183,7 +183,7 @@ describe('Composition Group', () => {
 
   });
 
-  it('should have *from* method', () => {
+  it('should have from method', () => {
     const compositions = ['foo ', new Slot(5), ' bar',
       new Composition('oof', new Slot(5), 'rab')];
     const group = CompositionGroup.from(compositions);
@@ -192,7 +192,7 @@ describe('Composition Group', () => {
       'foo ', new Slot(5), ' bar', new Composition('oof', new Slot(5), 'rab')
     ]);
 
-    // *from* should create a *CompositionGroup* instance
+    // from should create a CompositionGroup instance
     expect(group instanceof CompositionGroup).to.be.ok;
   });
 
@@ -210,7 +210,7 @@ describe('Query proto', () => {
     const testProto = new TestProto(similar);
     const otherTestProto = new TestProto(testProto);
 
-    // *foo* should have been copied, but not *extrange*
+    // foo should have been copied, but not extrange
     expect(testProto).to.deep.equal({ foo: { items: ['abc'] }, bar: { items: [] } });
     expect(otherTestProto).to.deep.equal({ foo: { items: ['abc'] }, bar: { items: [] } });
 
@@ -219,7 +219,7 @@ describe('Query proto', () => {
     expect(testProto.foo !== otherTestProto.foo).to.be.ok;
   });
 
-  it('should have *set* method', () => {
+  it('should have set method', () => {
     const originalTestProto = new TestProto();
     const testProto = new TestProto();
 
@@ -228,29 +228,29 @@ describe('Query proto', () => {
 
     testProto.foo.add('bar');
 
-    // *set* cleans previous values
+    // set cleans previous values
     expect(testProto.set(originalTestProto)).to.deep.equal({
       foo: { items: ['abc', new Slot(5)] },
       bar: { items: ['def'] }
     });
 
-    // *set* modifies instace without need to reassign
+    // set modifies instace without need to reassign
     expect(testProto).to.deep.equal({
       foo: { items: ['abc', new Slot(5)] },
       bar: { items: ['def'] }
     });
 
-    // *set* returns same object
+    // set returns same object
     expect(testProto).to.equal(testProto.set(originalTestProto));
   });
 
-  it('should have *clone* method', () => {
+  it('should have clone method', () => {
     const testProto = new TestProto();
 
     testProto.foo.add('abc', new Slot(5));
     testProto.bar.add('def');
 
-    // *clone* should return a different object
+    // clone should return a different object
     expect(testProto.clone()).to.not.equal(testProto);
 
     // But the returned object must have the same items

--- a/test/unit/sql/composed-query.test.js
+++ b/test/unit/sql/composed-query.test.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const Support = require('../support'),
+  util = require('util'),
+  _ = require('lodash'),
+  chai = require('chai'),
+  expect = chai.expect,
+  Sequelize = Support.Sequelize,
+  expectsql = Support.expectsql,
+  current = Support.sequelize,
+  QG = current.dialect.QueryGenerator;
+
+const {
+  Composition,
+  Placeholder
+} = require('../../../lib/dialects/abstract/query-generator/composition');
+
+describe('Composed queries', () => {
+  const testsql = function(arg, expectation) {
+    it(util.inspect(arg, { depth: 3 }), () => {
+      const sqlOrError = _.attempt(() => QG.composeQuery(QG.handleSequelizeMethod(arg)), arg);
+      return expectsql(sqlOrError, expectation);
+    });
+  };
+
+  describe('process value slots with data types', () => {
+    testsql(current.composition('SELECT ', current.slot(5, Sequelize.INTEGER), ', ', current.slot(new Date(Date.UTC(2011, 2, 27, 10, 1, 55)), Sequelize.DATE)), {
+      query: {
+        default: 'SELECT $1, $2;'
+      },
+      bind: {
+        default: [5, '2011-03-27 10:01:55.000 +00:00'],
+        mysql: [5, '2011-03-27 10:01:55'],
+        mariadb: [5, '2011-03-27 10:01:55.000']
+      }
+    });
+  });
+
+  describe('composeQuery method disallows unreplaced placeholders', () => {
+    testsql(current.composition('SELECT ', current.slot(5, Sequelize.INTEGER), ', ', current.placeholder()), {
+      default: new Error('Query item is not a slot or a string:\nPlaceholder { name: undefined }')
+    });
+  });
+
+  describe('composeString method disallows unreplaced placeholders', () => {
+    expect(() => QG.composeString(new Composition('SELECT ', QG.handleSequelizeMethod(current.placeholder())))).to.throw('Query item is not a slot or a string:\nPlaceholder { name: undefined }');
+  });
+
+  describe('handle Slot as a sequelize method', () => {
+    testsql(current.slot(5, Sequelize.INTEGER), {
+      query: {
+        default: '$1;'
+      },
+      bind: {
+        default: [5]
+      }
+    });
+  });
+
+  it('handle placeholder as a sequelize method', () => {
+    const result = QG.handleSequelizeMethod(current.placeholder());
+    expect(result).to.be.instanceof(Composition);
+    expect(result.items[0]).to.be.instanceof(Placeholder);
+  });
+});

--- a/test/unit/sql/composed-query.test.js
+++ b/test/unit/sql/composed-query.test.js
@@ -35,13 +35,13 @@ describe('Composed queries', () => {
   describe('composeQuery method disallows unreplaced placeholders', () => {
     const placeholderFromMethod = current.placeholder();
     testsql(current.composition('SELECT ', current.slot(5, Sequelize.INTEGER), ', ', placeholderFromMethod), {
-      default: new Sequelize.CompositionError('Item to be composed is not a slot or a string', placeholderFromMethod.val.items[0])
+      default: new Sequelize.CompositionError('Item to be composed is not a slot or a string', placeholderFromMethod.items[0])
     });
   });
 
   describe('composeString method disallows unreplaced placeholders', () => {
-    const placeholderCompositon = QG.handleSequelizeMethod(current.placeholder());
-    expect(() => QG.composeString(new Composition('SELECT ', placeholderCompositon)))
+    const placeholderCompositon = current.placeholder();
+    expect(() => QG.composeString(QG.handleSequelizeMethod(current.composition('SELECT ', placeholderCompositon))))
       .to.throw(Sequelize.CompositionError).with.property('item', placeholderCompositon.items[0]);
   });
 

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -255,12 +255,12 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
       expect(Utils.interleave(['a', 'b', 'c'], ',')).to.deep.equal(['a', ',', 'b', ',', 'c']);
     });
 
-    it('Returns new array', () => {
+    it('returns new array', () => {
       const arr = ['a', 'b', 'c'];
-      expect(Utils.interleave(['a', 'b', 'c'], ',')).not.to.equal(arr);
+      expect(Utils.interleave(arr, ',')).not.to.equal(arr);
     });
 
-    it('Works for input length of 0 and 1', () => {
+    it('works for input length of 0 and 1', () => {
       const arr0 = [];
       expect(Utils.interleave(arr0, ',')).to.deep.equal(arr0);
       expect(Utils.interleave(arr0, ',')).to.not.equal(arr0);

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -250,6 +250,27 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
+  describe('Interleave', () => {
+    it('interleaves',  () => {
+      expect(Utils.interleave(['a', 'b', 'c'], ',')).to.deep.equal(['a', ',', 'b', ',', 'c']);
+    });
+
+    it('Returns new array', () => {
+      const arr = ['a', 'b', 'c'];
+      expect(Utils.interleave(['a', 'b', 'c'], ',')).not.to.equal(arr);
+    });
+
+    it('Works for input length of 0 and 1', () => {
+      const arr0 = [];
+      expect(Utils.interleave(arr0, ',')).to.deep.equal(arr0);
+      expect(Utils.interleave(arr0, ',')).to.not.equal(arr0);
+
+      const arr1 = ['a'];
+      expect(Utils.interleave(arr1, ',')).to.deep.equal(arr1);
+      expect(Utils.interleave(arr1, ',')).to.not.equal(arr1);
+    });
+  });
+
   describe('Sequelize.cast', () => {
     const sql = Support.sequelize;
     const generator = sql.queryInterface.QueryGenerator;

--- a/types/lib/composition.d.ts
+++ b/types/lib/composition.d.ts
@@ -1,0 +1,32 @@
+import { AbstractDataType, AbstractDataTypeConstructor } from './data-types'
+
+export class Slot {
+    public value: any
+    public field?: AbstractDataType | AbstractDataTypeConstructor
+    public options?: object
+    constructor(value: any, field?: AbstractDataType | AbstractDataTypeConstructor, options?: object)
+}
+
+export class Placeholder {
+    public name: string
+    constructor(name?: string)
+}
+
+export interface Composable<T> {
+    items: (string | Slot | Placeholder)[]
+    length(): number
+    add(...items: (string | Slot | Placeholder | T)[]): this
+    prepend(...items: (string | Slot | Placeholder | T)[]): this
+    set(...items: (string | Slot | Placeholder | T)[]): this
+    clone(): T
+}
+
+export class Composition implements Composable<Composition> {
+    public items: (string | Slot | Placeholder)[]
+    public length(): number
+    public add(...items: (string | Slot | Placeholder | Composition)[]): this
+    public prepend(...items: (string | Slot | Placeholder | Composition)[]): this
+    public set(...items: (string | Slot | Placeholder | Composition)[]): this
+    public clone(): Composition
+    constructor(...items: (string | Slot | Placeholder | Composition)[])
+}

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1,3 +1,4 @@
+import { Composition } from './composition'
 import * as DataTypes from './data-types';
 import * as Deferrable from './deferrable';
 import { HookReturn, Hooks, SequelizeHooks } from './hooks';
@@ -26,7 +27,7 @@ import { Promise } from './promise';
 import { QueryInterface, QueryOptions, QueryOptionsWithModel, QueryOptionsWithType } from './query-interface';
 import QueryTypes = require('./query-types');
 import { Transaction, TransactionOptions } from './transaction';
-import { Cast, Col, Fn, Json, Literal, Where } from './utils';
+import { Cast, Col, CompositionMethod, Fn, Json, Literal, Where } from './utils';
 // tslint:disable-next-line:no-duplicate-imports
 import * as Utils from './utils';
 import { validator } from './utils/validator-extras';
@@ -374,6 +375,31 @@ export class Sequelize extends Hooks {
    * @param val
    */
   public static literal: typeof literal;
+
+  /**
+   * Creates an object representing sql strings and slots. Slots are values
+   * that will be binded or escaped. Strings and slots will be joined without
+   * spaces.
+   *
+   * @param items String or slot to be part of the query
+   */
+  public static composition: typeof composition
+
+  /**
+   * Slot to be included into a composition
+   *
+   * @param value Value
+   * @param [field] Model field or data type
+   * @param [options] Options
+   */
+  public slot: typeof slot
+
+  /**
+   * Returns a placeholder as a SequelizeMethod.
+   *
+ * @param [name] Name for placeholder
+   */
+  public static placeholder: typeof placeholder
 
   /**
    * An AND query
@@ -1087,14 +1113,14 @@ export class Sequelize extends Hooks {
    * @param sql
    * @param options Query options
    */
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.UPDATE>): Promise<[undefined, number]>;
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.BULKUPDATE>): Promise<number>;
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.INSERT>): Promise<[number, number]>;
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.UPSERT>): Promise<number>;
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.DELETE>): Promise<void>;
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SHOWTABLES>): Promise<string[]>;
-  public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.DESCRIBE>): Promise<{
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.UPDATE>): Promise<[undefined, number]>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.BULKUPDATE>): Promise<number>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.INSERT>): Promise<[number, number]>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.UPSERT>): Promise<number>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.DELETE>): Promise<void>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.SHOWTABLES>): Promise<string[]>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.DESCRIBE>): Promise<{
     [key: string]: {
       type: string;
       allowNull: boolean;
@@ -1105,11 +1131,11 @@ export class Sequelize extends Hooks {
     }
   }>;
   public query<M extends Model>(
-    sql: string | { query: string; values: unknown[] },
+    sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod,
     options: QueryOptionsWithModel
   ): Promise<M[]>;
-  public query<T extends object>(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SELECT>): Promise<T[]>;
-  public query(sql: string | { query: string; values: unknown[] }, options?: QueryOptions | QueryOptionsWithType<QueryTypes.RAW>): Promise<unknown[]>;
+  public query<T extends object>(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options: QueryOptionsWithType<QueryTypes.SELECT>): Promise<T[]>;
+  public query(sql: string | { query: string; values: unknown[] } | Composition | CompositionMethod, options?: QueryOptions | QueryOptionsWithType<QueryTypes.RAW>): Promise<unknown[]>;
 
   /**
    * Execute a query which would set an environment or user variable. The variables are set per connection,
@@ -1310,6 +1336,31 @@ export function cast(val: unknown, type: string): Cast;
  * @param val
  */
 export function literal(val: string): Literal;
+
+/**
+ * Creates an object representing sql strings and slots. Slots are values
+ * that will be binded or escaped. Strings and slots will be joined without
+ * spaces.
+ *
+ * @param items String or slot to be part of the query
+ */
+export function composition(...items: (string | CompositionMethod)[]): CompositionMethod
+
+/**
+ * Slot to be included into a composition
+ *
+ * @param value Value
+ * @param [field] Model field or data type
+ * @param [options] Options
+ */
+ export function slot<D extends DataTypes.AbstractDataType, DC extends DataTypes.AbstractDataTypeConstructor>(value: any, field?: D | DC, options?: object): CompositionMethod
+
+/**
+ * Returns a placeholder as a SequelizeMethod.
+ *
+ * @param [name] Name for placeholder
+ */
+export function placeholder(name?: string): CompositionMethod
 
 /**
  * An AND query

--- a/types/lib/utils.d.ts
+++ b/types/lib/utils.d.ts
@@ -1,3 +1,4 @@
+import { Composable, Placeholder, Slot } from './composition'
 import { DataType } from './data-types';
 import { Model, WhereOptions } from './model';
 
@@ -99,6 +100,19 @@ export class Cast extends SequelizeMethod {
 export class Literal extends SequelizeMethod {
   public val: unknown;
   constructor(val: unknown);
+}
+
+export class CompositionMethod implements Composable<CompositionMethod> {
+    private _isSequelizeMethod: boolean
+
+    public items: (string | Slot | Placeholder)[]
+    public length(): number
+    public add(...items: (string | Slot | Placeholder | CompositionMethod)[]): this
+    public prepend(...items: (string | Slot | Placeholder | CompositionMethod)[]): this
+    public set(...items: (string | Slot | Placeholder | CompositionMethod)[]): this
+    public clone(): CompositionMethod
+
+    constructor(...items: (string | Slot | Placeholder | CompositionMethod)[])
 }
 
 export class Json extends SequelizeMethod {

--- a/types/test/composition.ts
+++ b/types/test/composition.ts
@@ -1,0 +1,6 @@
+import { composition, DataTypes, Sequelize } from 'sequelize'
+
+declare const sequelize: Sequelize
+
+sequelize.query(composition('SELECT ', sequelize.slot(1)))
+sequelize.query(composition('SELECT ', sequelize.slot(1, DataTypes.NUMBER, {})))


### PR DESCRIPTION
This patch provides the base for building binded parameters. It defined the composition elements, their sequelize interface and the basic rules about processing them.

Related to issues #10284 #10285