### PR TITLE
fix(bind): add escsape of null character for postgres bind parameters

### DIFF
--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -20,11 +20,14 @@ class Query extends AbstractQuery {
    * @private
    */
   static formatBindParameters(sql, values, dialect) {
-    let bindParam = [];
+    const stringReplaceFunc = value => typeof value === 'string' ? value.replace(/\0/g, '\\0') : value;
+
+    let bindParam;
     if (Array.isArray(values)) {
-      bindParam = values;
+      bindParam = values.map(stringReplaceFunc);
       sql = AbstractQuery.formatBindParameters(sql, values, dialect, { skipValueReplace: true })[0];
     } else {
+      bindParam = [];
       let i = 0;
       const seen = {};
       const replacementFunc = (match, key, values) => {
@@ -33,7 +36,7 @@ class Query extends AbstractQuery {
         }
         if (values[key] !== undefined) {
           i = i + 1;
-          bindParam.push(values[key]);
+          bindParam.push(stringReplaceFunc(values[key]));
           seen[key] = `$${i}`;
           return `$${i}`;
         }

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -98,6 +98,32 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     });
   });
 
+  describe('strings', () => {
+    it('formats null characters correctly when inserting', () => {
+      const User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name'
+        }
+      }, {
+        timestamps: false
+      });
+
+      expectsql(sql.insertQuery(User.tableName, { user_name: 'null\0test' }, User.rawAttributes),
+        {
+          query: {
+            postgres: 'INSERT INTO "users" ("user_name") VALUES ($1);',
+            mssql: 'INSERT INTO [users] ([user_name]) VALUES ($1);',
+            default: 'INSERT INTO `users` (`user_name`) VALUES ($1);'
+          },
+          bind: {
+            postgres: ['null\u0000test'],
+            default: ['null\0test']
+          }
+        });
+    });
+  });
+
   describe('bulkCreate', () => {
     it('bulk create with onDuplicateKeyUpdate', () => {
       const User = Support.sequelize.define('user', {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Postgres doesn't support null characters in strings. This has generally been handled via https://github.com/sequelize/sequelize/blob/master/lib/sql-string.js#L75. However with Sequelize 5 using bind parameters for insert and update, the replacement of null characters no longer happens. This PR adds replacement of null characters in case of bind parameters being used.

I have added tests, but have not been able to run them across the other database. I think it should pass though, otherwise I would appreciate help getting them fixed.
