### PR TITLE
Using native promises with bluebird function replacements.

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -2,20 +2,20 @@
 
 Promise.each =  async function(arr, fn) {
    for(const item of arr) await fn(item);
-}.bind(this);
+}
 
-Promise.prototype.return = func=>{
+Promise.prototype.return = func => {
   return Promise.resolve(func);
 }
 
-Promise.prototype.tap = function(fn){
-    return this.then(function(value){
+Promise.prototype.tap = function(fn) {
+    return this.then(function(value) {
          fn(value);
          return value;
     });
 };
 
-Promise.try = func=>{
+Promise.try = func => {
   return new Promise((resolve, reject) => {
   		resolve(func());
   	});

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,6 +1,32 @@
 'use strict';
 
-const Promise = require('bluebird').getNewLibraryCopy();
+Promise.each =  async function(arr, fn) {
+   for(const item of arr) await fn(item);
+}.bind(this);
+
+Promise.prototype.return = func=>{
+  return Promise.resolve(func);
+}
+
+Promise.prototype.tap = function(fn){
+    return this.then(function(value){
+         fn(value);
+         return value;
+    });
+};
+
+Promise.try = func=>{
+  return new Promise((resolve, reject) => {
+  		resolve(func());
+  	});
+  }
+
+Promise.map = (fn, ctx) => {
+  return Promise.resolve(function(val) {
+    val = Array.isArray(val) ? val : [val]
+    return Promise.all(val.map(fn, ctx))
+  });
+}
 
 module.exports = Promise;
 module.exports.Promise = Promise;


### PR DESCRIPTION
### Description of change

Replaces bluebird promises to use native promises instead. These changes include function shims for the bluebird functions used within sequelize that are bluebird specific. The reason for this changes is higher performance with native promises. See the below load tests results as evidence. 

**Load test with promise.js updated with native promises.**
```
10 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   160.64ms   24.02ms 452.13ms   79.65%
    Req/Sec    31.40     12.67    50.00     68.94%
  9321 requests in 30.07s, 6.28MB read
Requests/sec:    309.95
Transfer/sec:    213.69KB
```

**Load test with promise.js using old bluebird promises**
```
10 threads and 50 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   476.37ms   47.71ms 882.19ms   93.22%
    Req/Sec    11.41      6.64    40.00     53.50%
  3129 requests in 30.09s, 2.11MB read
Requests/sec:    103.98
Transfer/sec:     71.69KB
```

Now if you want to keep bluebird promises for some reason, I will happily publish a fork of the sequelize package without bluebird in it. However, I believe it is to the communities benefit to remove bluebird. 