### PR TITLE
fix(types): enhance having parameters

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -447,9 +447,9 @@ export interface FindOptions extends Logging, Transactionable, Filterable, Proje
   raw?: boolean;
 
   /**
-   * having ?!?
+   * Select group rows after groups and aggregates are computed.
    */
-  having?: WhereAttributeHash;
+  having?: WhereOptions;
 
   /**
    * Use sub queries (internal)

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -256,3 +256,8 @@ where = {
 where = whereFn('test', {
   [Op.gt]: new Date(),
 });
+
+// Where as having option
+MyModel.findAll({
+  having: where
+});


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
At present, using the where function to build a having parameter for FindOptions produces a typescript error. As an abbreviated example, the following...
```
Model.findAll({
   having: where(fn('max', col('"Model".created_at')), {
     [Op.lt]: subYears(new Date(), 1)
   }),
});
```
would produce the error...
`Type 'Where' is not assignable to type 'WhereAttributeHash'.`

However, when casted to an any type, it produces a valid SQL query.

Therefore, I have updated the supported types for the having parameter to accept the Where type.