### PR TITLE
fix(types): add regex operators to WhereOperators

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -236,6 +236,42 @@ export interface WhereOperators {
    * String contains value.
    */
   [Op.substring]?: string;
+
+  /**
+   * MySQL/PG only
+   * 
+   * Matches regular expression, case sensitive
+   * 
+   * Example: `[Op.regexp]: '^[h|a|t]'` becomes `REGEXP/~ '^[h|a|t]'`
+   */
+  [Op.regexp]?: string;
+
+  /**
+   * MySQL/PG only
+   * 
+   * Does not match regular expression, case sensitive
+   * 
+   * Example: `[Op.notRegexp]: '^[h|a|t]'` becomes `NOT REGEXP/!~ '^[h|a|t]'`
+   */
+  [Op.notRegexp]?: string;
+  
+  /**
+   * PG only
+   * 
+   * Matches regular expression, case insensitive
+   * 
+   * Example: `[Op.iRegexp]: '^[h|a|t]'` becomes `~* '^[h|a|t]'`
+   */
+  [Op.iRegexp]?: string;
+
+  /**
+   * PG only
+   * 
+   * Does not match regular expression, case insensitive
+   * 
+   * Example: `[Op.notIRegexp]: '^[h|a|t]'` becomes `!~* '^[h|a|t]'`
+   */
+  [Op.notIRegexp]?: string;
 }
 
 /** Example: `[Op.or]: [{a: 5}, {a: 6}]` becomes `(a = 5 OR a = 6)` */

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -41,6 +41,10 @@ let operators: WhereOperators = {
     [Op.contains]: [1, 2], // @> [1, 2] (PG array contains operator)
     [Op.contained]: [1, 2], // <@ [1, 2] (PG array contained by operator)
     [Op.any]: [2, 3], // ANY ARRAY[2, 3]::INTEGER (PG only)
+    [Op.regexp]: '^[h|a|t]', // REGEXP/~ '^[h|a|t]' (MySQL/PG only)
+    [Op.notRegexp]: '^[h|a|t]', // NOT REGEXP/!~ '^[h|a|t]' (MySQL/PG only)
+    [Op.iRegexp]: '^[h|a|t]',    // ~* '^[h|a|t]' (PG only)
+    [Op.notIRegexp]: '^[h|a|t]' // !~* '^[h|a|t]' (PG only)
 };
 
 operators = {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
At present, using the regexp operator when calling the where function produces a typescript error. As an abbreviated example, the following...
```
   where('name', {
     [Op.regexp]: '^[s|a|m]'
   })
```
would produce the error...
`Argument of type '{ [Op.regexp]: string; }' is not assignable to parameter of type 'LogicType'.`

However, when casted to an any type, it produces a valid SQL query.

Therefore, I have updated WhereOperators to support regexp, notRegexp, iRegexp and notIRegexp operators.
