### PR TITLE
fix(postgres): check and enable standard conforming strings when required

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -256,7 +256,7 @@ class ConnectionManager {
             //avoiding a useless round trip
             if (this.sequelize.options.databaseVersion === 0) {
               return this.sequelize.databaseVersion(_options).then(version => {
-                const parsedVersion = semver.coerce(version).version;
+                const parsedVersion = _.get(semver.coerce(version), 'version') || version;
                 this.sequelize.options.databaseVersion = semver.valid(parsedVersion)
                   ? parsedVersion
                   : this.defaultVersion;

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -256,7 +256,10 @@ class ConnectionManager {
             //avoiding a useless round trip
             if (this.sequelize.options.databaseVersion === 0) {
               return this.sequelize.databaseVersion(_options).then(version => {
-                this.sequelize.options.databaseVersion = semver.valid(version) ? version : this.defaultVersion;
+                const parsedVersion = semver.coerce(version).version;
+                this.sequelize.options.databaseVersion = semver.valid(parsedVersion)
+                  ? parsedVersion
+                  : this.defaultVersion;
                 this.versionPromise = null;
                 return this._disconnect(connection);
               });

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -150,14 +150,18 @@ class ConnectionManager extends AbstractConnectionManager {
       // node-postgres does not treat this as an error since no active query was ever emitted
       connection.once('end', endHandler);
 
-      // Receive various server parameters for further configuration
-      connection.connection.on('parameterStatus', parameterHandler);
+      if (!this.sequelize.config.native) {
+        // Receive various server parameters for further configuration
+        connection.connection.on('parameterStatus', parameterHandler);
+      }
 
       connection.connect(err => {
         responded = true;
 
-        // remove parameter handler
-        connection.connection.removeListener('parameterStatus', parameterHandler);
+        if (!this.sequelize.config.native) {
+          // remove parameter handler
+          connection.connection.removeListener('parameterStatus', parameterHandler);
+        }
 
         if (err) {
           if (err.code) {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -122,6 +122,20 @@ class ConnectionManager extends AbstractConnectionManager {
       let responded = false;
 
       const connection = new this.lib.Client(connectionConfig);
+
+      const parameterHandler = message => {
+        switch (message.parameterName) {
+          case 'server_version':
+            if (this.sequelize.options.databaseVersion === 0) {
+              this.sequelize.options.databaseVersion = message.parameterValue;
+            }
+            break;
+          case 'standard_conforming_strings':
+            connection['standard_conforming_strings'] = message.parameterValue;
+            break;
+        }
+      };
+
       const endHandler = () => {
         debug('connection timeout');
         if (!responded) {
@@ -133,8 +147,15 @@ class ConnectionManager extends AbstractConnectionManager {
       // node-postgres does not treat this as an error since no active query was ever emitted
       connection.once('end', endHandler);
 
+      // Receive various server parameters for further configuration
+      connection.connection.on('parameterStatus', parameterHandler);
+
       connection.connect(err => {
         responded = true;
+
+        // remove parameter handler
+        connection.connection.removeListener('parameterStatus', parameterHandler);
+
         if (err) {
           if (err.code) {
             switch (err.code) {
@@ -166,11 +187,7 @@ class ConnectionManager extends AbstractConnectionManager {
     }).tap(connection => {
       let query = '';
 
-      if (
-        this.sequelize.options.databaseVersion !== 0
-        && semver.gte(this.sequelize.options.databaseVersion, '8.2.0')
-        && semver.lt(this.sequelize.options.databaseVersion, '9.1.0')
-      ) {
+      if (connection['standard_conforming_strings'] !== 'on') {
         // Disable escape characters in strings
         // see https://github.com/sequelize/sequelize/issues/3545 (security issue)
         // see https://www.postgresql.org/docs/current/static/runtime-config-compatible.html#GUC-STANDARD-CONFORMING-STRINGS

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -127,7 +127,10 @@ class ConnectionManager extends AbstractConnectionManager {
         switch (message.parameterName) {
           case 'server_version':
             if (this.sequelize.options.databaseVersion === 0) {
-              this.sequelize.options.databaseVersion = message.parameterValue;
+              const version = semver.coerce(message.parameterValue).version;
+              this.sequelize.options.databaseVersion = semver.valid(version)
+                ? version
+                : this.defaultVersion;
             }
             break;
           case 'standard_conforming_strings':


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

1. This enable sequelize to set `standard_conforming_strings = on` whenever they are disabled regardless of postgres version. This fixes a security issue.

2. It saves one extra query for postgres version per connection, which is available with `parameterStatus` as `server_version`