### PR TITLE
feat(comments): allow altering comments

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -265,10 +265,18 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
   changeColumnQuery(tableName, attributes) {
     const attrString = [],
       constraintString = [];
+    let commentString = '';
 
     for (const attributeName in attributes) {
       const quotedAttrName = this.quoteIdentifier(attributeName);
-      const definition = attributes[attributeName];
+      let definition = attributes[attributeName];
+      if (definition.includes('COMMENT ')) {
+        const commentMatch = definition.match(/^(.+) (COMMENT.*)$/);
+        const commentText = commentMatch[2].replace('COMMENT', '').trim();
+        commentString += this.commentTemplate(commentText, tableName, attributeName);
+        // remove comment related substring from dataType
+        definition = commentMatch[1];
+      }
       if (definition.includes('REFERENCES')) {
         constraintString.push(`FOREIGN KEY (${quotedAttrName}) ${definition.replace(/.+?(?=REFERENCES)/, '')}`);
       } else {
@@ -285,7 +293,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
       finalQuery += `ADD ${constraintString.join(', ')}`;
     }
 
-    return `ALTER TABLE ${this.quoteTable(tableName)} ${finalQuery};`;
+    return `ALTER TABLE ${this.quoteTable(tableName)} ${finalQuery};${commentString}`;
   }
 
   renameColumnQuery(tableName, attrBefore, attributes) {
@@ -522,7 +530,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     return `DROP INDEX ${this.quoteIdentifiers(indexName)} ON ${this.quoteIdentifiers(tableName)}`;
   }
 
-  attributeToSQL(attribute, options) {
+  attributeToSQL(attribute) {
     if (!_.isPlainObject(attribute)) {
       attribute = {
         type: attribute
@@ -597,7 +605,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.comment && typeof attribute.comment === 'string') {
-      template += `; ${this.commentTemplate(attribute.comment, options.table, attribute.field)}`;
+      template += ` COMMENT ${attribute.comment}`;
     }
 
     return template;

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -522,7 +522,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     return `DROP INDEX ${this.quoteIdentifiers(indexName)} ON ${this.quoteIdentifiers(tableName)}`;
   }
 
-  attributeToSQL(attribute) {
+  attributeToSQL(attribute, options) {
     if (!_.isPlainObject(attribute)) {
       attribute = {
         type: attribute
@@ -597,7 +597,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.comment && typeof attribute.comment === 'string') {
-      template += ` COMMENT ${attribute.comment}`;
+      template += `; ${this.commentTemplate(attribute.comment, options.table, attribute.field)}`;
     }
 
     return template;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -268,7 +268,6 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   changeColumnQuery(tableName, attributes) {
     const query = subQuery => `ALTER TABLE ${this.quoteTable(tableName)} ALTER COLUMN ${subQuery};`;
     const sql = [];
-
     for (const attributeName in attributes) {
       let definition = this.dataTypeMapping(tableName, attributeName, attributes[attributeName]);
       let attrSql = '';
@@ -536,12 +535,12 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.comment && typeof attribute.comment === 'string') {
-      if (options && options.context === 'addColumn') {
-        const quotedAttr = this.quoteIdentifier(options.key);
-        const escapedCommentText = this.escape(attribute.comment);
-        sql += `; COMMENT ON COLUMN ${this.quoteTable(options.table)}.${quotedAttr} IS ${escapedCommentText}`;
-      } else {
-        sql += ` COMMENT ${attribute.comment}`;
+      if (options) {
+        if (options.context === 'addColumn' || options.context == 'changeColumn') {
+          const quotedAttr = this.quoteIdentifier(options.key);
+          const escapedCommentText = this.escape(attribute.comment);
+          sql += `; COMMENT ON COLUMN ${this.quoteTable(options.table)}.${quotedAttr} IS ${escapedCommentText}`;
+        }
       }
     }
 
@@ -575,7 +574,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
     for (const key in attributes) {
       const attribute = attributes[key];
-      result[attribute.field || key] = this.attributeToSQL(attribute, options);
+      result[attribute.field || key] = this.attributeToSQL(attribute, Object.assign({ key }, options || {}));
     }
 
     return result;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -535,12 +535,14 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.comment && typeof attribute.comment === 'string') {
-      if (options) {
-        if (options.context === 'addColumn' || options.context == 'changeColumn') {
-          const quotedAttr = this.quoteIdentifier(options.key);
-          const escapedCommentText = this.escape(attribute.comment);
-          sql += `; COMMENT ON COLUMN ${this.quoteTable(options.table)}.${quotedAttr} IS ${escapedCommentText}`;
-        }
+      if (options && (options.context === 'addColumn' || options.context === 'changeColumn')) {
+        const quotedAttr = this.quoteIdentifier(options.key);
+        const escapedCommentText = this.escape(attribute.comment);
+        sql += `; COMMENT ON COLUMN ${this.quoteTable(options.table)}.${quotedAttr} IS ${escapedCommentText}`;
+      } else {
+        // for createTable event which does it's own parsing
+        // TODO: centralize creation of comment statements here
+        sql += ` COMMENT ${attribute.comment}`;
       }
     }
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -567,7 +567,10 @@ class QueryInterface {
       // sqlite needs some special treatment as it cannot change a column
       return SQLiteQueryInterface.changeColumn(this, tableName, attributes, options);
     }
-    const query = this.QueryGenerator.attributesToSQL(attributes);
+    const query = this.QueryGenerator.attributesToSQL(attributes, { 
+      context: 'changeColumn',
+      table: tableName
+    });
     const sql = this.QueryGenerator.changeColumnQuery(tableName, query);
 
     return this.sequelize.query(sql, options);

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -230,7 +230,7 @@ class QueryInterface {
       });
     }
 
-    attributes = this.QueryGenerator.attributesToSQL(attributes, { context: 'createTable' });
+    attributes = this.QueryGenerator.attributesToSQL(attributes, { table: tableName, context: 'createTable' });
     sql = this.QueryGenerator.createTableQuery(tableName, attributes, options);
 
     return promise.then(() => this.sequelize.query(sql, options));

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -219,7 +219,23 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
             expect(describedTable.level_id.allowNull).to.be.equal(true);
           });
         });
-        
+
+        it('should change the comment of column', function() {
+          return this.queryInterface.describeTable({
+            tableName: 'users'
+          }).then( describedTable => {
+            expect(describedTable.level_id.comment).to.be.equal(null);
+            return this.queryInterface.changeColumn('users', 'level_id', {
+              type: DataTypes.INTEGER,
+              comment: 'FooBar'
+            });
+          }).then( () => {
+            return this.queryInterface.describeTable({ tableName: 'users' })
+              .then( describedTable2 => {
+                expect(describedTable2.level_id.comment).to.be.equal('FooBar');
+              });
+          });
+        });
       });
     }
   });

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -223,15 +223,15 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         it('should change the comment of column', function() {
           return this.queryInterface.describeTable({
             tableName: 'users'
-          }).then( describedTable => {
+          }).then(describedTable => {
             expect(describedTable.level_id.comment).to.be.equal(null);
             return this.queryInterface.changeColumn('users', 'level_id', {
               type: DataTypes.INTEGER,
               comment: 'FooBar'
             });
-          }).then( () => {
+          }).then(() => {
             return this.queryInterface.describeTable({ tableName: 'users' });
-          }).then( describedTable2 => {
+          }).then(describedTable2 => {
             expect(describedTable2.level_id.comment).to.be.equal('FooBar');
           });
         });

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -230,10 +230,9 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
               comment: 'FooBar'
             });
           }).then( () => {
-            return this.queryInterface.describeTable({ tableName: 'users' })
-              .then( describedTable2 => {
-                expect(describedTable2.level_id.comment).to.be.equal('FooBar');
-              });
+            return this.queryInterface.describeTable({ tableName: 'users' });
+          }).then( describedTable2 => {
+            expect(describedTable2.level_id.comment).to.be.equal('FooBar');
           });
         });
       });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Solves #10720 
Adds ability to use `changeColumn` to alter comments. It wasn't implemented initially. Works for all dialects except sqlite.