### PR TITLE
fix(query-generator): subquery handling

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -882,11 +882,14 @@ const QueryGenerator = {
       return '';
     }
 
-    let fragment = '';
-    const offset = options.offset || 0,
-      isSubQuery = options.hasIncludeWhere || options.hasIncludeRequired || options.hasMultiAssociation;
+    const offset = options.offset || 0;
+    const isSubQuery = options.subQuery === undefined
+      ? options.hasIncludeWhere || options.hasIncludeRequired || options.hasMultiAssociation
+      : options.subQuery;
 
+    let fragment = '';
     let orders = {};
+    
     if (options.order) {
       orders = this.getQueryOrders(options, model, isSubQuery);
     }

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support = require(__dirname + '/../../support'),
+  Sequelize = Support.Sequelize,
+  Op = Sequelize.Op,
+  dialect = Support.getTestDialect();
+
+if (dialect.match(/^mssql/)) {
+  describe('[MSSQL Specific] Regressions', () => {
+    it('does not duplicate columns in ORDER BY statement, #9008', function () {
+      const LoginLog = this.sequelize.define('LoginLog', {
+        ID: {
+          field: 'id',
+          type: Sequelize.INTEGER,
+          primaryKey: true,
+          autoIncrement: true
+        },
+        UserID: {
+          field: 'userid',
+          type: Sequelize.UUID,
+          allowNull: false
+        }
+      });
+
+      const User = this.sequelize.define('User', {
+        UserID: {
+          field: 'userid',
+          type: Sequelize.UUID,
+          defaultValue: Sequelize.UUIDV4,
+          primaryKey: true
+        },
+        UserName: {
+          field: 'username',
+          type: Sequelize.STRING(50),
+          allowNull: false
+        }
+      });
+
+      LoginLog.belongsTo(User, {
+        foreignKey: 'UserID'
+      });
+      User.hasMany(LoginLog, {
+        foreignKey: 'UserID'
+      });
+
+      return this.sequelize.sync({ force: true })
+        .then(() => User.bulkCreate([
+          { UserName: 'Vayom' },
+          { UserName: 'Shaktimaan' },
+          { UserName: 'Nikita' },
+          { UserName: 'Aryamaan' }
+        ], { returning: true }))
+        .spread((vyom, shakti, nikita, arya) => {
+          return Sequelize.Promise.all([
+            vyom.createLoginLog(),
+            shakti.createLoginLog(),
+            nikita.createLoginLog(),
+            arya.createLoginLog()
+          ]);
+        }).then(() => {
+          return LoginLog.findAll({
+            include: [
+              {
+                model: User,
+                where: {
+                  UserName: {
+                    [Op.like]: '%maan%'
+                  }
+                }
+              }
+            ],
+            order: [[User, 'UserName', 'DESC']],
+            offset: 0,
+            limit: 10
+          });
+        }).then(logs => {
+          expect(logs).to.have.length(2);
+          expect(logs[0].User.get('UserName')).to.equal('Shaktimaan');
+          expect(logs[1].User.get('UserName')).to.equal('Aryamaan');
+        });
+    });
+  });
+}


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? see Description.
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Closes https://github.com/sequelize/sequelize/issues/10425.
Backports https://github.com/sequelize/sequelize/commit/0cbb7b9f54fa385b233dbbef69c346c3fc369145 to v4.

Tests fail, but seems related to connection issues to the remote database. (have no local MSSQL DB to test):

```
1) [MSSQL] BelongsToMany
       getAssociations
         supports transactions:
     Error: Timeout of 30000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (test/integration/associations/belongs-to-many.test.js)
  

  2) "after each" hook for "supports transactions":
     Error: Expected 0 running queries. 1 queries still running in [MSSQL] BelongsToMany getAssociations supports transactions
      at Object.verifyNoRunningQueries (lib/sequelize.js:266:45)
      at Context.<anonymous> (test/integration/support.js:12:25)
```
