### PR TITLE
fix(scope): overwrite attributes if multiple scopes chained

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -804,7 +804,7 @@ class Model {
     } else if (key === 'attributes' && _.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
       return _.assignWith(objValue, srcValue, (objValue, srcValue) => {
         if (Array.isArray(objValue) && Array.isArray(srcValue)) {
-          return _.union(objValue, srcValue);
+          return srcValue;
         }
       });
     }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Hopefully solves #10742 
As per documentation if multiple scopes are used, later should overwrite the previous scope. For some reason ( and I might be missing the real why ) they were being unioned with (`_.union`). So please let me know if this is useless.
<!-- Please provide a description of the change here. -->
