### PR TITLE
Don't look up sourceKey on fieldRawAttributesMap

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -79,16 +79,12 @@ class HasMany extends Association {
     }
 
     this.sourceKey = this.options.sourceKey || this.source.primaryKeyAttribute;
-    if (this.target.rawAttributes[this.sourceKey]) {
+    if (this.source.rawAttributes[this.sourceKey]) {
+      this.sourceKeyAttribute = this.sourceKey;
       this.sourceKeyField = this.source.rawAttributes[this.sourceKey].field || this.sourceKey;
     } else {
-      this.sourceKeyField = this.sourceKey;
-    }
-
-    if (this.source.fieldRawAttributesMap[this.sourceKey]) {
-      this.sourceKeyAttribute = this.source.fieldRawAttributesMap[this.sourceKey].fieldName;
-    } else {
       this.sourceKeyAttribute = this.source.primaryKeyAttribute;
+      this.sourceKeyField = this.source.primaryKeyField;
     }
     this.sourceIdentifier = this.sourceKey;
     this.associationAccessor = this.as;


### PR DESCRIPTION
This PR applies a bugfix from https://github.com/sequelize/sequelize/commit/5941bfe78573e63c70bdb8d1f8aee94019edb04b onto the v4 branch

V4's has-many currently does this to determine sourceKeyAttribute

```ts
    if (this.source.fieldRawAttributesMap[this.sourceKey]) {
      this.sourceKeyAttribute = this.source.fieldRawAttributesMap[this.sourceKey].fieldName;
    } else {
      this.sourceKeyAttribute = this.source.primaryKeyAttribute;
    }
```
It should be looking it up using `rawAttributes` instead
`fieldRawAttributesMap` has the `field` as keys (the name of the column on the actual db), `rawAttributes` has the `names` as keys (the name of the column we set on sequelize)

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
