### PR TITLE
feat(docs): attributes key merging

### DIFF
--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -162,6 +162,8 @@ WHERE firstName = 'bob' AND age > 30 LIMIT 10
 
 Note how `limit` and `age` are overwritten by `scope2`, while `firstName` is preserved. The `limit`, `offset`, `order`, `paranoid`, `lock` and `raw` fields are overwritten, while `where` is shallowly merged (meaning that identical keys will be overwritten). The merge strategy for `include` will be discussed later on.
 
+Note that `attributes` keys of multiple applied scopes are merged in such a way that `attributes.exclude` are always preserved. This allows merging several scopes and never leaking sensitive fields in final scope.
+
 The same merge logic applies when passing a find object directly to `findAll` (and similar finders) on a scoped model:
 
 ```js


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Solves #10742 
<!-- Please provide a description of the change here. -->
Trying to clarify that `options.attributes.exclude` is always going to be preserved no matter how many scopes are applied.

@sushantdhiman if I wasn't clear enough let me know and I'll fix it up.