### PR TITLE
fix(model): handle virtual attributes in includes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -584,10 +584,9 @@ class Model {
     if (include.attributes && !options.raw) {
       include.model._expandAttributes(include);
 
-      // Need to make sure virtuals are mapped before setting originalAttributes
-      include = Utils.mapFinderOptions(include, include.model);
+      include.originalAttributes = this._injectDependentVirtualAttributes(include.attributes);
 
-      include.originalAttributes = include.attributes.slice(0);
+      include = Utils.mapFinderOptions(include, include.model);
 
       if (include.attributes.length) {
         _.each(include.model.primaryKeys, (attr, key) => {
@@ -699,7 +698,7 @@ class Model {
 
     // Validate child includes
     if (include.hasOwnProperty('include')) {
-      this._validateIncludedElements.call(include.model, include, tableNames, options);
+      this._validateIncludedElements.call(include.model, include, tableNames);
     }
 
     return include;

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -40,6 +40,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           this.Project = this.sequelize.define('project', {});
 
           this.Task.belongsTo(this.User);
+          this.User.hasMany(this.Task);
           this.Project.belongsToMany(this.User, { through: 'project_user' });
           this.User.belongsToMany(this.Project, { through: 'project_user' });
 
@@ -171,6 +172,23 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(user.storage).to.equal('something');
             expect(user).not.to.include.all.keys(['field1']);
             expect(user).to.include.all.keys(['field2']);
+          });
+        });
+
+        it('should be able to include model with virtual attributes', function() {
+          return this.User.create({}).then(user => {
+            return user.createTask();
+          }).then(() => {
+            return this.Task.findAll({
+              include: [{
+                attributes: ['field2', 'id'],
+                model: this.User
+              }]
+            });
+          }).then(tasks => {
+            const user = tasks[0].user.get();
+
+            expect(user.field2).to.equal(42);
           });
         });
       });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Fix virtual attributes used in includes to be returned by `get` after the model is loaded https://github.com/sequelize/sequelize/issues/10552

`originalAttributes` wasn't being set before calling `Utils.mapFinderOptions` like it is in other places
