### PR TITLE
Pass useUTC dialect option to mssql/Tedious

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -56,6 +56,10 @@ class ConnectionManager extends AbstractConnectionManager {
         Object.assign(connectionConfig.authentication, config.dialectOptions.authentication);
       }
 
+      if (config.dialectOptions.useUTC !== undefined) {
+        connectionConfig.options.useUTC = config.dialectOptions.useUTC;
+      }
+
       Object.assign(connectionConfig.options, config.dialectOptions.options);
     }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Hello,
first of all, many thanks for your great project that I am discovering. 

I struggled for hours to understand why sequelize was not returning dates from mssql according to my timezone : here is my fix.
Note that I have no local mssql to run tests, so even if first part of tests seems to pass, the second part is trying to connect to a local server that I don't have. The server I use is a production one that I use read only  and I have no admin access.
In the same subject, I commented an issue about datetimeoffset serialization and mssql there : https://github.com/sequelize/sequelize/issues/7930#issuecomment-484094201

Hope it can help