### PR TITLE
fix(describeTable): MAX string length for mssql

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -176,7 +176,11 @@ class Query extends AbstractQuery {
           result[_result.Name].type.includes('VARCHAR')
           && _result.Length
         ) {
-          result[_result.Name].type += `(${_result.Length})`;
+          if (_result.Length === -1) {
+            result[_result.Name].type += '(MAX)';
+          } else {
+            result[_result.Name].type += `(${_result.Length})`;
+          }
         }
 
       }

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -82,4 +82,17 @@ if (dialect.match(/^mssql/)) {
         });
     });
   });
+
+  it('sets the varchar(max) length correctly on describeTable', function() {
+    const Users = this.sequelize.define('_Users', {
+      username: Sequelize.STRING('MAX')
+    }, { freezeTableName: true });
+
+    return Users.sync({ force: true }).then(() => {
+      return this.sequelize.getQueryInterface().describeTable('_Users').then(metadata => {
+        const username = metadata.username;
+        expect(username.type).to.include('(MAX)');
+      });
+    });
+  });
 }


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

MSSQL got support for varchar lengths in #9896 but if the length is `MAX` in the database the length === `-1`

This PR will check for that case and change the length to `MAX`
