### PR TITLE
feat(types): adding upsert with returning: true

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -239,36 +239,36 @@ export interface WhereOperators {
 
   /**
    * MySQL/PG only
-   * 
+   *
    * Matches regular expression, case sensitive
-   * 
+   *
    * Example: `[Op.regexp]: '^[h|a|t]'` becomes `REGEXP/~ '^[h|a|t]'`
    */
   [Op.regexp]?: string;
 
   /**
    * MySQL/PG only
-   * 
+   *
    * Does not match regular expression, case sensitive
-   * 
+   *
    * Example: `[Op.notRegexp]: '^[h|a|t]'` becomes `NOT REGEXP/!~ '^[h|a|t]'`
    */
   [Op.notRegexp]?: string;
-  
+
   /**
    * PG only
-   * 
+   *
    * Matches regular expression, case insensitive
-   * 
+   *
    * Example: `[Op.iRegexp]: '^[h|a|t]'` becomes `~* '^[h|a|t]'`
    */
   [Op.iRegexp]?: string;
 
   /**
    * PG only
-   * 
+   *
    * Does not match regular expression, case insensitive
-   * 
+   *
    * Example: `[Op.notIRegexp]: '^[h|a|t]'` becomes `!~* '^[h|a|t]'`
    */
   [Op.notIRegexp]?: string;
@@ -1909,8 +1909,14 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   public static upsert<M extends Model>(
     this: { new (): M } & typeof Model,
     values: object,
-    options?: UpsertOptions
+    options?: UpsertOptions & { returning?: false | undefined }
   ): Promise<boolean>;
+
+  public static upsert<M extends Model> (
+    this: { new (): M } & typeof Model,
+    values: object,
+    options?: UpsertOptions & { returning: true }
+  ): Promise<[ M, boolean ]>;
 
   /**
    * Create and insert multiple instances in bulk.

--- a/types/test/upsert.ts
+++ b/types/test/upsert.ts
@@ -7,7 +7,7 @@ class TestModel extends Model {
 TestModel.init({}, {sequelize})
 
 sequelize.transaction(trx => {
-  return TestModel.upsert({}, {
+  TestModel.upsert<TestModel>({}, {
     benchmark: true,
     fields: ['testField'],
     hooks: true,
@@ -16,5 +16,26 @@ sequelize.transaction(trx => {
     searchPath: 'DEFAULT',
     transaction: trx,
     validate: true,
-  })
+  }).then((res: [ TestModel, boolean ]) => {});
+
+  TestModel.upsert<TestModel>({}, {
+    benchmark: true,
+    fields: ['testField'],
+    hooks: true,
+    logging: true,
+    returning: false,
+    searchPath: 'DEFAULT',
+    transaction: trx,
+    validate: true,
+  }).then((created: boolean) => {});
+
+  return TestModel.upsert<TestModel>({}, {
+    benchmark: true,
+    fields: ['testField'],
+    hooks: true,
+    logging: true,
+    searchPath: 'DEFAULT',
+    transaction: trx,
+    validate: true,
+  }).then((created: boolean) => {});
 })


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? **No**
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **No**
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Added correct return type to `upsert` when `{ returning: true }`

<!-- Please provide a description of the change here. -->
