### PR TITLE
fix(types): relax order typing

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -441,14 +441,22 @@ export interface IncludeOptions extends Filterable, Projectable, Paranoid {
   subQuery?: boolean;
 }
 
+type OrderItemModel = typeof Model | { model: typeof Model; as: string } | string
+type OrderItemColumn = string | Col | Fn | Literal
 export type OrderItem =
   | string
   | Fn
   | Col
   | Literal
-  | [string | Col | Fn | Literal, string]
-  | [typeof Model | { model: typeof Model; as: string }, string, string]
-  | [typeof Model, typeof Model, string, string];
+  | [OrderItemColumn, string]
+  | [OrderItemModel, OrderItemColumn]
+  | [OrderItemModel, OrderItemColumn, string]
+  | [OrderItemModel, OrderItemModel, OrderItemColumn]
+  | [OrderItemModel, OrderItemModel, OrderItemColumn, string]
+  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn]
+  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn, string]
+  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn]
+  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn, string]
 export type Order = string | Fn | Col | Literal | OrderItem[];
 
 /**

--- a/types/test/include.ts
+++ b/types/test/include.ts
@@ -17,7 +17,7 @@ MyModel.findAll({
       on: {
         a: 1,
       },
-      order: [['id', 'DESC']],
+      order: [['id', 'DESC'], [ 'AssociatedModel', MyModel, 'id', 'DESC' ], [ MyModel, 'id' ] ],
       separate: true,
       where: { state: Sequelize.col('project.state') },
     },
@@ -32,7 +32,7 @@ MyModel.findAll({
   include: [{
     limit: 1,
     association: 'relation',
-    order: [['id', 'DESC']],
+    order: [['id', 'DESC'], 'id', [ AssociatedModel, MyModel, 'id', 'ASC' ]],
     separate: true,
     where: { state: Sequelize.col('project.state') },
   }]


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? **yes**
- [x] Have you added new tests to prevent regressions? **no**
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **no**
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Relax type `order` checking in queries, because we can have multiple nester models and or strings etc. I'm not sure we can do better than this.

Closes https://github.com/sequelize/sequelize/issues/10780

<!-- Please provide a description of the change here. -->
