### PR TITLE
fix(types): add join and values operators

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -128,6 +128,11 @@ export interface AllOperator {
   [Op.all]: (string | number)[];
 }
 
+/** Undocumented? */
+export interface ValuesOperator {
+  [Op.values]: (string | number)[];
+}
+
 /**
  * Operators that can be used in WhereOptions
  *
@@ -170,14 +175,14 @@ export interface WhereOperators {
    *  - `[Op.like]: '%hat',` becomes `LIKE '%hat'`
    *  - `[Op.like]: { [Op.any]: ['cat', 'hat']}` becomes `LIKE ANY ARRAY['cat', 'hat']`
    */
-  [Op.like]?: string | Literal | AnyOperator | AllOperator;
+  [Op.like]?: string | Literal | AnyOperator | AllOperator | ValuesOperator;
 
   /**
    * Examples:
    *  - `[Op.notLike]: '%hat'` becomes `NOT LIKE '%hat'`
    *  - `[Op.notLike]: { [Op.any]: ['cat', 'hat']}` becomes `NOT LIKE ANY ARRAY['cat', 'hat']`
    */
-  [Op.notLike]?: string | Literal | AnyOperator | AllOperator;
+  [Op.notLike]?: string | Literal | AnyOperator | AllOperator | ValuesOperator;
 
   /**
    * case insensitive PG only
@@ -186,7 +191,7 @@ export interface WhereOperators {
    *  - `[Op.iLike]: '%hat'` becomes `ILIKE '%hat'`
    *  - `[Op.iLike]: { [Op.any]: ['cat', 'hat']}` becomes `ILIKE ANY ARRAY['cat', 'hat']`
    */
-  [Op.iLike]?: string | Literal | AnyOperator | AllOperator;
+  [Op.iLike]?: string | Literal | AnyOperator | AllOperator | ValuesOperator;
 
   /**
    * PG array overlap operator
@@ -219,7 +224,7 @@ export interface WhereOperators {
    *  - `[Op.notILike]: '%hat'` becomes `NOT ILIKE '%hat'`
    *  - `[Op.notLike]: ['cat', 'hat']` becomes `LIKE ANY ARRAY['cat', 'hat']`
    */
-  [Op.notILike]?: string | Literal | AnyOperator | AllOperator;
+  [Op.notILike]?: string | Literal | AnyOperator | AllOperator | ValuesOperator;
 
   /** Example: `[Op.notBetween]: [11, 15],` becomes `NOT BETWEEN 11 AND 15` */
   [Op.notBetween]?: [number, number];

--- a/types/lib/operators.d.ts
+++ b/types/lib/operators.d.ts
@@ -18,7 +18,6 @@ declare const Op: {
   readonly in: unique symbol;
   readonly iRegexp: unique symbol;
   readonly is: unique symbol;
-  readonly join: unique symbol;
   readonly like: unique symbol;
   readonly lt: unique symbol;
   readonly lte: unique symbol;

--- a/types/lib/operators.d.ts
+++ b/types/lib/operators.d.ts
@@ -18,6 +18,7 @@ declare const Op: {
   readonly in: unique symbol;
   readonly iRegexp: unique symbol;
   readonly is: unique symbol;
+  readonly join: unique symbol;
   readonly like: unique symbol;
   readonly lt: unique symbol;
   readonly lte: unique symbol;
@@ -39,5 +40,6 @@ declare const Op: {
   readonly strictLeft: unique symbol;
   readonly strictRight: unique symbol;
   readonly substring: unique symbol;
+  readonly values: unique symbol;
 };
 export = Op;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Add TypeScript typings for the `Op.join` and `Op.values` operators.

Typings currently don't reflect the [source code](https://github.com/sequelize/sequelize/blob/master/lib/operators.js) and [documentation](https://github.com/sequelize/sequelize/blob/master/docs/querying.md).