### PR TITLE
feat(query): add liberalReplace switch to query

### DIFF
--- a/docs/raw-queries.md
+++ b/docs/raw-queries.md
@@ -76,6 +76,18 @@ sequelize.query('SELECT * FROM users WHERE name LIKE :search_name ',
 })
 ```
 
+### Liberal replacement
+
+There can be used character `:` as a valid part of the query data. Default replacement behaviour throws an Error for missing replacement key. In this case there is a possibility to ignore missing replace key in replacements object via query option `liberalReplace` that returns back original value to the query.
+
+```js
+sequelize.query('SELECT * FROM user:roles WHERE status = :status ',
+  { replacements: { status: 'active' }, type: sequelize.QueryTypes.SELECT, liberalReplace: true }
+).then(projects => {
+  console.log(projects)
+})
+```
+
 ## Bind Parameter
 
 Bind parameters are like replacements. Except replacements are escaped and inserted into the query by sequelize before the query is sent to the database, while bind parameters are sent to the database outside the SQL query text. A query can have either bind parameters or replacements. Bind parameters are referred to by either $1, $2, ... (numeric) or $key (alpha-numeric). This is independent of the dialect.

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -457,6 +457,7 @@ class Sequelize {
    * @param {boolean}         [options.supportsSearchPath] If false do not prepend the query with the search_path (Postgres only)
    * @param {boolean}         [options.mapToModel=false] Map returned fields to model's fields if `options.model` or `options.instance` is present. Mapping will occur before building the model instance.
    * @param {Object}          [options.fieldMap] Map returned fields to arbitrary names for `SELECT` query type.
+   * @param {boolean}         [options.liberalReplace] If false, each missing replacement value will result in Error (Default). If true, sequelize will not require specified replacement value for each found value for replacement and forward found value, when replacement value not specified.
    *
    * @returns {Promise}
    *
@@ -539,7 +540,7 @@ class Sequelize {
         if (Array.isArray(options.replacements)) {
           sql = Utils.format([sql].concat(options.replacements), this.options.dialect);
         } else {
-          sql = Utils.formatNamedParameters(sql, options.replacements, this.options.dialect);
+          sql = Utils.formatNamedParameters(sql, options.replacements, this.options.dialect, options.liberalReplace);
         }
       }
 

--- a/lib/sql-string.js
+++ b/lib/sql-string.js
@@ -109,7 +109,7 @@ function format(sql, values, timeZone, dialect) {
 }
 exports.format = format;
 
-function formatNamedParameters(sql, values, timeZone, dialect) {
+function formatNamedParameters(sql, values, timeZone, dialect, liberalReplace) {
   return sql.replace(/:+(?!\d)(\w+)/g, (value, key) => {
     if ('postgres' === dialect && '::' === value.slice(0, 2)) {
       return value;
@@ -118,7 +118,12 @@ function formatNamedParameters(sql, values, timeZone, dialect) {
     if (values[key] !== undefined) {
       return escape(values[key], timeZone, dialect, true);
     }
-    throw new Error(`Named parameter "${value}" has no value in the given object.`);
+    {
+      if (liberalReplace) {
+        return value;
+      }
+      throw new Error(`Named parameter "${value}" has no value in the given object.`);
+    }
   });
 }
 exports.formatNamedParameters = formatNamedParameters;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -117,9 +117,9 @@ function format(arr, dialect) {
 }
 exports.format = format;
 
-function formatNamedParameters(sql, parameters, dialect) {
+function formatNamedParameters(sql, parameters, dialect, liberalReplace) {
   const timeZone = null;
-  return SqlString.formatNamedParameters(sql, parameters, timeZone, dialect);
+  return SqlString.formatNamedParameters(sql, parameters, timeZone, dialect, liberalReplace);
 }
 exports.formatNamedParameters = formatNamedParameters;
 

--- a/test/unit/sql/sql-string.test.js
+++ b/test/unit/sql/sql-string.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+
+const sqlString = require('../../../lib/sql-string'),
+  chai = require('chai'),
+  expect = chai.expect;
+
+// Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
+
+describe('Test sql-string', () => {
+  describe('function formatNamedParameters', () => {
+    it('Valid fail for missing replacement key', () => {
+      expect(() => {
+        sqlString.formatNamedParameters('SELECT * FROM "_Join:roles:_Role" WHERE "owningId" = :owningId', { owningId: 'xxx' });
+      }).to.throw(Error, 'Named parameter ":roles" has no value in the given object.');
+    });
+
+    it('Returns SQL query for liberalReplace', () => {
+      expect(sqlString.formatNamedParameters('SELECT * FROM "_Join:roles:_Role" WHERE "owningId" = :owningId', { owningId: 'xxx' }, undefined, undefined, true)).to
+        .equal('SELECT * FROM "_Join:roles:_Role" WHERE "owningId" = \'xxx\'');
+    });
+  });
+});

--- a/types/lib/sql-string.d.ts
+++ b/types/lib/sql-string.d.ts
@@ -2,4 +2,4 @@ export type Escapable = undefined | null | boolean | number | string | Date;
 export function escapeId(val: string, forbidQualified?: boolean): string;
 export function escape(val: Escapable | Escapable[], timeZone?: string, dialect?: string, format?: string): string;
 export function format(sql: string, values: unknown[], timeZone?: string, dialect?: string): string;
-export function formatNamedParameters(sql: string, values: unknown[], timeZone?: string, dialect?: string): string;
+export function formatNamedParameters(sql: string, values: unknown[], timeZone?: string, dialect?: string, liberalReplace?: boolean): string;

--- a/types/lib/utils.d.ts
+++ b/types/lib/utils.d.ts
@@ -21,7 +21,7 @@ export function camelize(str: string): string;
 export function format(arr: string[], dialect: string): string;
 export function formatNamedParameters(sql: string, parameters: {
   [key: string]: string | number | boolean;
-}, dialect: string): string;
+}, dialect: string, liberalReplace?: boolean): string;
 export function cloneDeep<T>(obj: T, fn?: (el: unknown) => unknown): T;
 
 export interface OptionsForMapping {


### PR DESCRIPTION
adds possibility to switch if missing replacement result in error or not

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

PR solves [issue](https://github.com/sequelize/sequelize/issues/9440) when query contains ':' character as a part of query data. It's solved by introducing new option called `liberalReplace`. If `liberalReplace` set true, replacement method ignores missing replacement value and pastes back origin value to the query.

