### PR TITLE
fix(querying): prevent `having` clause from cascading

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -29,6 +29,9 @@ const validQueryKeywords = new Set(['where', 'attributes', 'paranoid', 'include'
   'scope', 'group', 'through', 'defaults', 'distinct', 'primary', 'exception', 'type', 'hooks', 'force',
   'name']);
 
+// List of attributes that should not be implicitly passed into subqueries/includes.
+const nonCascadingOptions = ['include', 'attributes', 'originalAttributes', 'order', 'where', 'limit', 'offset', 'plain', 'group', 'having'];
+
 /**
  * A Model represents a table in the database. Instances of this class represent a database row.
  *
@@ -1828,7 +1831,7 @@ class Model {
 
       return include.association.get(results, Object.assign(
         {},
-        _.omit(options, ['include', 'attributes', 'originalAttributes', 'order', 'where', 'limit', 'offset', 'plain', 'group']),
+        _.omit(options, nonCascadingOptions),
         _.omit(include, ['parent', 'association', 'as', 'originalAttributes'])
       )).then(map => {
         for (const result of results) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes #10856

I am unsure how to test this correctly, @PatrickGeyer can you please confirm that adding the `having` resolves the issue?