### PR TITLE
fix(types): add validate to CreateOptions

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -629,6 +629,13 @@ export interface CreateOptions extends BuildOptions, Logging, Silent, Transactio
    * On Duplicate
    */
   onDuplicate?: string;
+
+  /**
+   * If false, validations won't be run.
+   *
+   * @default true
+   */
+  validate?: boolean;
 }
 
 /**

--- a/types/test/usage.ts
+++ b/types/test/usage.ts
@@ -17,4 +17,7 @@ async function test(): Promise<void> {
 
     const user2 = await User.create({ firstName: 'John', groupId: 1 });
     await User.findAndCountAll({ distinct: true });
+
+    const user3 = await User.create({ firstName: 'Jane', groupId: 1 }, { validate: false });
+    await User.findAndCountAll({ distinct: true });
 }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Add missing `validate` option to `create` as mentioned here: http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-create
