### PR TITLE
Docs: fixed typo in the model definition example

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -551,7 +551,7 @@ module.exports = (sequelize, DataTypes) => {
     name: DataTypes.STRING,
     description: DataTypes.TEXT
   }, { sequelize });
-  return Projectl
+  return Project;
 }
 ```
 


### PR DESCRIPTION
### Description of change

Copy-pasting an example into your code would make it crash. This is obvious typo mistake.