### PR TITLE
fix(typings): use correct set of allowed options for addIndex

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -16,7 +16,7 @@ import { ValidationOptions } from './instance-validator';
 import { ModelManager } from './model-manager';
 import Op = require('./operators');
 import { Promise } from './promise';
-import { QueryOptions } from './query-interface';
+import { QueryOptions, IndexesOptions } from './query-interface';
 import { Config, Options, Sequelize, SyncOptions } from './sequelize';
 import { Transaction } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
@@ -1134,55 +1134,7 @@ export interface ModelValidateOptions {
 /**
  * Interface for indexes property in InitOptions
  */
-export interface ModelIndexesOptions {
-  /**
-   * The name of the index. Defaults to model name + _ + fields concatenated
-   */
-  name?: string;
-
-  /**
-   * Index type. Only used by mysql. One of `UNIQUE`, `FULLTEXT` and `SPATIAL`
-   */
-  index?: string;
-
-  /**
-   * The method to create the index by (`USING` statement in SQL). BTREE and HASH are supported by mysql and
-   * postgres, and postgres additionally supports GIST and GIN.
-   */
-  method?: string;
-
-  /**
-   * Should the index by unique? Can also be triggered by setting type to `UNIQUE`
-   *
-   * @default false
-   */
-  unique?: boolean;
-
-  /**
-   * PostgreSQL will build the index without taking any write locks. Postgres only
-   *
-   * @default false
-   */
-  concurrently?: boolean;
-
-  /**
-   * An array of the fields to index. Each field can either be a string containing the name of the field,
-   * a sequelize object (e.g `sequelize.fn`), or an object with the following attributes: `attribute`
-   * (field name), `length` (create a prefix index of length chars), `order` (the direction the column
-   * should be sorted in), `collate` (the collation (sort order) for the column)
-   */
-  fields?: (string | { attribute: string; length: number; order: string; collate: string })[];
-
-  /**
-   * Type of search index. Postgres only
-   */
-  using?: string;
-
-  /**
-   * Index operator type. Postgres only
-   */
-  operator?: string;
-}
+export type ModelIndexesOptions = IndexesOptions
 
 /**
  * Interface for name property in InitOptions

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -123,18 +123,68 @@ export interface QueryInterfaceDropAllTablesOptions extends QueryInterfaceOption
   skip?: string[];
 }
 
-export interface QueryInterfaceIndexOptions extends QueryInterfaceOptions {
-  type?: 'UNIQUE' | 'FULLTEXT' | 'SPATIAL';
+export type IndexType = 'UNIQUE' | 'FULLTEXT' | 'SPATIAL';
+export type IndexMethod = 'BTREE' | 'HASH' | 'GIST' | 'SPGIST' | 'GIN' | 'BRIN' | string;
 
-  /** The name of the index. Default is __ */
+export interface IndexesOptions {
+  /**
+   * The name of the index. Defaults to model name + _ + fields concatenated
+   */
   name?: string;
 
   /** For FULLTEXT columns set your parser */
-  parser?: string;
+  parser?: string | null;
 
-  /** Set a type for the index, e.g. BTREE. See the documentation of the used dialect */
-  using?: string;
+  /**
+   * Index type. Only used by mysql. One of `UNIQUE`, `FULLTEXT` and `SPATIAL`
+   */
+  type?: IndexType;
+
+  /**
+   * Should the index by unique? Can also be triggered by setting type to `UNIQUE`
+   *
+   * @default false
+   */
+  unique?: boolean;
+
+  /**
+   * PostgreSQL will build the index without taking any write locks. Postgres only
+   *
+   * @default false
+   */
+  concurrently?: boolean;
+
+  /**
+   * An array of the fields to index. Each field can either be a string containing the name of the field,
+   * a sequelize object (e.g `sequelize.fn`), or an object with the following attributes: `name`
+   * (field name), `length` (create a prefix index of length chars), `order` (the direction the column
+   * should be sorted in), `collate` (the collation (sort order) for the column)
+   */
+  fields?: (string | { name: string; length?: number; order?: 'ASC' | 'DESC'; collate?: string })[];
+
+  /**
+   * The method to create the index by (`USING` statement in SQL). BTREE and HASH are supported by mysql and
+   * postgres, and postgres additionally supports GIST, SPGIST, BRIN and GIN.
+   */
+  using?: IndexMethod;
+
+  /**
+   * Index operator type. Postgres only
+   */
+  operator?: string;
+
+  /**
+   * Optional where parameter for index. Can be used to limit the index to certain rows.
+   */
+  where?: WhereOptions;
+
+  /**
+   * Prefix to append to the index name.
+   */
+  prefix?: string;
 }
+
+export interface QueryInterfaceIndexOptions extends IndexesOptions, QueryInterfaceOptions {}
 
 export interface AddUniqueConstraintOptions {
   type: 'unique';

--- a/types/test/models/User.ts
+++ b/types/test/models/User.ts
@@ -61,9 +61,24 @@ User.init(
         return {}
       }
     },
+    indexes: [{
+      fields: ['firstName'],
+      using: 'BTREE',
+      name: 'firstNameIdx',
+      concurrently: true,
+    }],
     sequelize,
   }
 );
+
+User.afterSync(() => {
+  sequelize.getQueryInterface().addIndex(User.tableName, {
+      fields: ['lastName'],
+      using: 'BTREE',
+      name: 'lastNameIdx',
+      concurrently: true,
+  })
+})
 
 // Hooks
 User.afterFind((users, options) => {

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -126,7 +126,6 @@ queryInterface.addIndex('Person', ['firstname', 'lastname']);
 
 // This example will create a unique index with the name SuperDuperIndex using the optional 'options' field.
 // Possible options:
-// - indicesType: UNIQUE|FULLTEXT|SPATIAL
 // - indexName: The name of the index. Default is __
 // - parser: For FULLTEXT columns set your parser
 // - indexType: Set a type for the index, e.g. BTREE. See the documentation of the used dialect


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change
I looked up all the values that are used and valid and cleaned up the index types a bit. Also merged with the query interface to have a consistent interface (as they both call addIndexQuery anyways)