### PR TITLE
docs(data-types): separate nav menu

### DIFF
--- a/.esdoc.json
+++ b/.esdoc.json
@@ -59,6 +59,9 @@
           ]
         }
       }
+    },
+    {
+      "name": "./docs/plugins/group-data-types"
     }
   ]
 }

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -38,3 +38,9 @@ a[href^="file/lib/"] {
   box-shadow: none !important;
   max-width: 300px;
 }
+
+.navigation {
+  margin-top: 40px !important;
+  padding-top: 0;
+  height: calc(100% - 40px);
+}

--- a/docs/plugins/group-data-types.js
+++ b/docs/plugins/group-data-types.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const path = require('path');
+const cheerio = require('cheerio');
+
+function groupDataTypes($) {
+  let firstLi;
+  $('nav a').each(function() {
+    /* eslint-disable no-invalid-this */
+    if ($(this).attr('href').startsWith('class/lib/data-types.js~')) {
+      const li = $(this).closest('li');
+      if (!firstLi) {
+        firstLi = li;
+        firstLi.prepend('<a data-ice="dirPath" class="nav-dir-path" href="variable/index.html#static-variable-DataTypes">datatypes</a>');
+        firstLi.appendTo(firstLi.parent());
+      } else {
+        firstLi.after(li);
+      }
+    }
+  });
+}
+
+class GroupDataTypesPlugin {
+  onHandleContent(ev) {
+    if (path.extname(ev.data.fileName) !== '.html') return;
+
+    const $ = cheerio.load(ev.data.content);
+
+    groupDataTypes($);
+
+    $('nav li[data-ice=doc]:first-child').css('margin-top', '15px');
+
+    ev.data.content = $.html();
+  }
+}
+
+module.exports = new GroupDataTypesPlugin();


### PR DESCRIPTION
This PR groups every data type from the API reference menu into one section.

This is closely related to #10686. I personally prefer that solution, but I tried to follow [this comment](https://github.com/sequelize/sequelize/pull/10686#issuecomment-479338407). My solution only changes the menu, but the Reference Summary remains cluttered.