### PR TITLE
docs(scopes): fix sql example for merging deleted projects and projects with active users

### DIFF
--- a/docs/scopes.md
+++ b/docs/scopes.md
@@ -117,6 +117,7 @@ Project.scope(['deleted', 'activeUsers']).findAll();
 ```sql
 SELECT * FROM projects
 INNER JOIN users ON projects.userId = users.id
+WHERE projects.deleted = true
 AND users.active = true
 ```
 


### PR DESCRIPTION
### Description of change
Adds a `where` clause to the SQL example provided in the **Scopes** documentation under **Merging**, which showcases merging the **Project** `deleted` scope with the **Project** `activeUsers` scope.
