### PR TITLE
docs: add index operator option

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -477,6 +477,8 @@ class QueryGenerator {
                   - length: An integer. Optional
                   - order: 'ASC' or 'DESC'. Optional
         - parser
+        - using
+        - operator
         - concurrently: Pass CONCURRENT so other operations run while the index is created
       - rawTablename, the name of the table, without schema. Used to create the name of the index
    @private

--- a/lib/model.js
+++ b/lib/model.js
@@ -895,6 +895,7 @@ class Model {
    * @param {string}                  [options.indexes[].name] The name of the index. Defaults to model name + _ + fields concatenated
    * @param {string}                  [options.indexes[].type] Index type. Only used by mysql. One of `UNIQUE`, `FULLTEXT` and `SPATIAL`
    * @param {string}                  [options.indexes[].using] The method to create the index by (`USING` statement in SQL). BTREE and HASH are supported by mysql and postgres, and postgres additionally supports GIST and GIN.
+   * @param {string}                  [options.indexes[].operator] Specify index operator.
    * @param {boolean}                 [options.indexes[].unique=false] Should the index by unique? Can also be triggered by setting type to `UNIQUE`
    * @param {boolean}                 [options.indexes[].concurrently=false] PostgresSQL will build the index without taking any write locks. Postgres only
    * @param {Array<string|Object>}    [options.indexes[].fields] An array of the fields to index. Each field can either be a string containing the name of the field, a sequelize object (e.g `sequelize.fn`), or an object with the following attributes: `attribute` (field name), `length` (create a prefix index of length chars), `order` (the direction the column should be sorted in), `collate` (the collation (sort order) for the column)

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -567,7 +567,7 @@ class QueryInterface {
       // sqlite needs some special treatment as it cannot change a column
       return SQLiteQueryInterface.changeColumn(this, tableName, attributes, options);
     }
-    const query = this.QueryGenerator.attributesToSQL(attributes, { 
+    const query = this.QueryGenerator.attributesToSQL(attributes, {
       context: 'changeColumn',
       table: tableName
     });
@@ -632,6 +632,7 @@ class QueryInterface {
    * @param {boolean} [options.concurrently] Pass CONCURRENT so other operations run while the index is created
    * @param {boolean} [options.unique] Create a unique index
    * @param {string}  [options.using]  Useful for GIN indexes
+   * @param {string}  [options.operator] Index operator
    * @param {string}  [options.type]   Type of index, available options are UNIQUE|FULLTEXT|SPATIAL
    * @param {string}  [options.name]   Name of the index. Default is <table>_<attr1>_<attr2>
    * @param {Object}  [options.where]  Where condition on index, for partial indexes


### PR DESCRIPTION
### Description of change

Add index operator option for API Documentation.

Operator option is used here : https://github.com/sequelize/sequelize/blob/5f9d5907425ae1d86b402133718d007a52f2b39e/lib/dialects/abstract/query-generator.js#L577
