### PR TITLE
Undocumented alter option in SyncOptions

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -42,6 +42,11 @@ export interface SyncOptions extends Logging {
   force?: boolean;
 
   /**
+   * If alter is true, each DAO will do ALTER TABLE ... CHANGE ...
+   */
+  alter?: boolean;
+
+  /**
    * Match a regex against the database name before syncing, a safety check for cases where force: true is
    * used in tests but not live code
    */


### PR DESCRIPTION
Thought it was removed, but it's still there. Just not documented.

Workaround until this is merged `await sequelize.sync({ alter: true } as SyncOptions);`