### PR TITLE
Fixed - Retrieving attributes on Find Query

### DIFF
--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -23,7 +23,7 @@ Project.findOne({ where: {title: 'aProject'} }).then(project => {
 
 Project.findOne({
   where: {title: 'aProject'},
-  attributes: ['id', ['name', 'title']]
+  attributes: ['id','name', 'title']
 }).then(project => {
   // project will be the first entry of the Projects table with the title 'aProject' || null
   // project.get('title') will contain the name of the project


### PR DESCRIPTION
In the Project.findOne Query, while declaring attributes, 
Following line is replaced by
attributes: ['id', ['name', 'title']]
this line
attributes: ['id', 'name', 'title'].

Link : http://docs.sequelizejs.com/manual/models-usage.html

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Updated link to source