### PR TITLE
Add TSVECTOR and match operator (@@) for PostgreSQL

### DIFF
--- a/docs/manual/data-types.md
+++ b/docs/manual/data-types.md
@@ -50,6 +50,8 @@ Sequelize.CIDR                        // CIDR datatype for PostgreSQL
 Sequelize.INET                        // INET datatype for PostgreSQL
 Sequelize.MACADDR                     // MACADDR datatype for PostgreSQL
 
+Sequelize.TSVECTOR                    // TSVECTOR datatype for PostgreSQL
+
 Sequelize.RANGE(Sequelize.INTEGER)    // Defines int4range range. PostgreSQL only.
 Sequelize.RANGE(Sequelize.BIGINT)     // Defined int8range range. PostgreSQL only.
 Sequelize.RANGE(Sequelize.DATE)       // Defines tstzrange range. PostgreSQL only.

--- a/docs/manual/models-usage.md
+++ b/docs/manual/models-usage.md
@@ -195,7 +195,7 @@ Project.findAll({
       [Op.contains]: [1, 2],      // @> [1, 2] (PG array contains operator)
       [Op.contained]: [1, 2],     // <@ [1, 2] (PG array contained by operator)
       [Op.any]: [2,3]            // ANY ARRAY[2, 3]::INTEGER (PG only)
-      [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // math text search for strings 'fat' and 'rat'
+      [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // match text search for strings 'fat' and 'rat'
     },
     status: {
       [Op.not]: false           // status NOT FALSE

--- a/docs/manual/models-usage.md
+++ b/docs/manual/models-usage.md
@@ -195,6 +195,7 @@ Project.findAll({
       [Op.contains]: [1, 2],      // @> [1, 2] (PG array contains operator)
       [Op.contained]: [1, 2],     // <@ [1, 2] (PG array contained by operator)
       [Op.any]: [2,3]            // ANY ARRAY[2, 3]::INTEGER (PG only)
+      [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // math text search for strings 'fat' and 'rat'
     },
     status: {
       [Op.not]: false           // status NOT FALSE

--- a/docs/manual/querying.md
+++ b/docs/manual/querying.md
@@ -176,7 +176,7 @@ const Op = Sequelize.Op
 [Op.contains]: [1, 2]      // @> [1, 2] (PG array contains operator)
 [Op.contained]: [1, 2]     // <@ [1, 2] (PG array contained by operator)
 [Op.any]: [2,3]            // ANY ARRAY[2, 3]::INTEGER (PG only)
-[Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // math text search for strings 'fat' and 'rat'
+[Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // match text search for strings 'fat' and 'rat'
 
 [Op.col]: 'user.organization_id' // = "user"."organization_id", with dialect specific column identifiers, PG in this example
 [Op.gt]: { [Op.all]: literal('SELECT 1') }

--- a/docs/manual/querying.md
+++ b/docs/manual/querying.md
@@ -176,6 +176,7 @@ const Op = Sequelize.Op
 [Op.contains]: [1, 2]      // @> [1, 2] (PG array contains operator)
 [Op.contained]: [1, 2]     // <@ [1, 2] (PG array contained by operator)
 [Op.any]: [2,3]            // ANY ARRAY[2, 3]::INTEGER (PG only)
+[Op.match]: Sequelize.fn('to_tsquery', 'fat & rat') // math text search for strings 'fat' and 'rat'
 
 [Op.col]: 'user.organization_id' // = "user"."organization_id", with dialect specific column identifiers, PG in this example
 [Op.gt]: { [Op.all]: literal('SELECT 1') }
@@ -316,7 +317,8 @@ const operatorsAliases = {
   $any: Op.any,
   $all: Op.all,
   $values: Op.values,
-  $col: Op.col
+  $col: Op.col,
+  $match: Op.match
 };
 
 const connection = new Sequelize(db, user, pass, { operatorsAliases });

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -933,6 +933,19 @@ class MACADDR extends ABSTRACT {
   }
 }
 
+
+/**
+ * The TSVECTOR type stores text search vectors.
+ * 
+ * Only available for Postgres
+ * 
+ */
+class TSVECTOR extends ABSTRACT {
+  validate() {
+    return true;
+  }
+}
+
 /**
  * A convenience class holding commonly used data types. The data types are used when defining a new model using `Sequelize.define`, like this:
  * ```js
@@ -1016,7 +1029,8 @@ const DataTypes = module.exports = {
   CIDR,
   INET,
   MACADDR,
-  CITEXT
+  CITEXT,
+  TSVECTOR
 };
 
 _.each(DataTypes, (dataType, name) => {

--- a/lib/dialects/abstract/query-generator/operators.js
+++ b/lib/dialects/abstract/query-generator/operators.js
@@ -42,7 +42,8 @@ const OperatorHelpers = {
     [Op.and]: ' AND ',
     [Op.or]: ' OR ',
     [Op.col]: 'COL',
-    [Op.placeholder]: '$$PLACEHOLDER$$'
+    [Op.placeholder]: '$$PLACEHOLDER$$',
+    [Op.match]: '@@'
   },
 
   OperatorsAliasMap: {},

--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -35,6 +35,7 @@ module.exports = BaseTypes => {
   BaseTypes.CIDR.types.postgres = ['cidr'];
   BaseTypes.INET.types.postgres = ['inet'];
   BaseTypes.MACADDR.types.postgres = ['macaddr'];
+  BaseTypes.TSVECTOR.types.postgres = ['tsvector'];
   BaseTypes.JSON.types.postgres = ['json'];
   BaseTypes.JSONB.types.postgres = ['jsonb'];
   BaseTypes.TIME.types.postgres = ['time'];

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -54,6 +54,7 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
   JSON: true,
   JSONB: true,
   HSTORE: true,
+  TSVECTOR: true,
   deferrableConstraints: true,
   searchPath: true
 });

--- a/lib/operators.js
+++ b/lib/operators.js
@@ -84,7 +84,8 @@ const Op = {
   values: Symbol.for('values'),
   col: Symbol.for('col'),
   placeholder: Symbol.for('placeholder'),
-  join: Symbol.for('join')
+  join: Symbol.for('join'),
+  match: Symbol.for('match')
 };
 
 module.exports = Op;

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -361,6 +361,18 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
 
   });
 
+  if (current.dialect.supports.TSVECTOR) {
+    it('calls parse and stringify for TSVECTOR', () => {
+      const Type = new Sequelize.TSVECTOR();
+
+      if (['postgres'].includes(dialect)) {
+        return testSuccess(Type, 'swagger');
+      }
+      testFailure(Type);
+
+    });
+  }
+
   it('calls parse and stringify for ENUM', () => {
     const Type = new Sequelize.ENUM('hat', 'cat');
 

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -1185,6 +1185,16 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       }
     }
 
+    if (current.dialect.supports.TSVESCTOR) { 
+      describe('Op.match', () => {
+        testsql('username', {
+          [Op.match]: Support.sequelize.fn('to_tsvector', 'swagger')
+        }, {
+          postgres: "[username] @@ to_tsvector('swagger')"
+        });
+      });
+    }
+
     describe('fn', () => {
       it('{name: this.sequelize.fn(\'LOWER\', \'DERP\')}', function() {
         expectsql(sql.whereQuery({ name: this.sequelize.fn('LOWER', 'DERP') }), {

--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -601,6 +601,8 @@ export const INET: AbstractDataTypeConstructor;
 
 export const MACADDR: AbstractDataTypeConstructor;
 
+export const TSVECTOR: AbstractDataTypeConstructor;
+
 /**
  * Case incenstive text
  */

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -313,6 +313,12 @@ export interface WhereOperators {
    */
   [Op.noExtendRight]?: Rangable;
 
+  /**
+   * PG only
+   *
+   * Full text search
+   */
+  [Op.match]?: string | Literal;
 }
 
 /** Example: `[Op.or]: [{a: 5}, {a: 6}]` becomes `(a = 5 OR a = 6)` */

--- a/types/lib/operators.d.ts
+++ b/types/lib/operators.d.ts
@@ -467,6 +467,7 @@ declare const Op: {
    * ```
    */
   readonly values: unique symbol;
+  readonly match: unique symbol;
 };
 
 export = Op;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Added TSVECTOR datatype and @@ operator for postgresql more information about datatype here:
https://www.postgresql.org/docs/current/functions-textsearch.html

Closes #1580