### PR TITLE
Fixed typo in Association documentation

### DIFF
--- a/docs/associations.md
+++ b/docs/associations.md
@@ -780,7 +780,7 @@ project.setUsers([user1, user2]).then(() => {
 })
 ```
 
-## Advance Concepts
+## Advanced Concepts
 
 ### Scopes
 


### PR DESCRIPTION
The headline was 'Advance concepts' instead of 'Advanced concepts'

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list (Documentation changes only)

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
