### PR TITLE
fix(types): add string to Includeable

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -376,7 +376,7 @@ export interface IncludeThroughOptions extends Filterable, Projectable {}
 /**
  * Options for eager-loading associated models, also allowing for all associations to be loaded at once
  */
-export type Includeable = typeof Model | Association | IncludeOptions | { all: true };
+export type Includeable = typeof Model | Association | IncludeOptions | { all: true } | string;
 
 /**
  * Complex include options

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -58,12 +58,12 @@ export interface SyncOptions extends Logging {
    */
   schema?: string;
 
-   /**
+  /**
    * An optional parameter to specify the schema search_path (Postgres only)
    */
   searchPath?: string;
 
-   /**
+  /**
    * If hooks is true then beforeSync, afterSync, beforeBulkSync, afterBulkSync hooks will be called
    */
   hooks?: boolean;

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -23,6 +23,10 @@ MyModel.findOne({
   ]
 });
 
+MyModel.hasOne(OtherModel, { as: 'OtherModelAlias' });
+
+MyModel.findOne({ include: ['OtherModelAlias'] });
+
 const sequelize = new Sequelize('mysql://user:user@localhost:3306/mydb');
 
 MyModel.init({}, {


### PR DESCRIPTION
This is allowable for Aliases, according to docs and lack of errors when attempting.
See Types: [options.include](http://docs.sequelizejs.com/class/lib/model.js~Model.html#static-method-findAll)

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions? (maybe?)
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (not sure if types could as docs? kinda?)
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

I tried to follow what this person did at https://github.com/sequelize/sequelize/pull/10804 as far as tests go, but, TBH I didn't look into how these typedef tests work.

This just adds `string` as a possible type for `Includeable` as is allowed for Aliases.
