### PR TITLE
docs(findbypk): fix document and type definition

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1856,7 +1856,7 @@ class Model {
    * @param  {string}                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    *
    * @see
-   * {@link Model.findAll}           for a full explanation of options
+   * {@link Model.findAll}           for a full explanation of options, Note that options.where is not supported.
    *
    * @returns {Promise<Model>}
    */

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -489,6 +489,8 @@ export interface IndexHintable {
   indexHints?: IndexHint[];
 }
 
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+
 /**
  * Options that are passed to any model creating a SELECT query
  *
@@ -1756,12 +1758,12 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   public static findByPk<M extends Model>(
     this: { new (): M } & typeof Model,
     identifier?: Identifier,
-    options?: FindOptions
+    options?: Omit<FindOptions, 'where'>
   ): Promise<M | null>;
   public static findByPk<M extends Model>(
     this: { new (): M } & typeof Model,
     identifier: Identifier,
-    options: NonNullFindOptions
+    options: Omit<NonNullFindOptions, 'where'>
   ): Promise<M>;
 
   /**

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -43,6 +43,7 @@ export interface SyncOptions extends Logging {
 
   /**
    * If alter is true, each DAO will do ALTER TABLE ... CHANGE ...
+   * Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
    */
   alter?: boolean;
 
@@ -66,11 +67,6 @@ export interface SyncOptions extends Logging {
    * If hooks is true then beforeSync, afterSync, beforeBulkSync, afterBulkSync hooks will be called
    */
   hooks?: boolean;
-  
-   /**
-   * Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
-   */
-  alter?: boolean;
 }
 
 export interface DefaultSetOptions {}


### PR DESCRIPTION
### Description of change
Fix issue #10925, correct the documentation and type definition of Model.findByPk()

findByPk takes the same option as findAll, except the `where` option in the implementation, so we should correct the document and type definition