### PR TITLE
fix(types): add support for `model.associate` in typescript

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2496,6 +2496,19 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    */
   constructor(values?: object, options?: BuildOptions);
 
+   /**
+   * A function where asociations between different models are defined.
+   * For example:
+   * ```js
+   *  Post.associate = function(models) {
+    *    Post.belongsTo(models.Blog)
+    *    Post.hasMany(models.Comments)
+    *  }
+    * ```
+    * @param models a dictionary of models
+    */
+   public static associate(models: { [key: string]: typeof Model }): void;
+
   /**
    * Get an object representing the query for this instance, use with `options.where`
    */

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -42,6 +42,7 @@ export interface SyncOptions extends Logging {
   force?: boolean;
 
   /**
+   * Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
    * If alter is true, each DAO will do ALTER TABLE ... CHANGE ...
    */
   alter?: boolean;
@@ -56,21 +57,16 @@ export interface SyncOptions extends Logging {
    * The schema that the tables should be created in. This can be overridden for each table in sequelize.define
    */
   schema?: string;
-  
+
    /**
    * An optional parameter to specify the schema search_path (Postgres only)
    */
   searchPath?: string;
-  
+
    /**
    * If hooks is true then beforeSync, afterSync, beforeBulkSync, afterBulkSync hooks will be called
    */
   hooks?: boolean;
-  
-   /**
-   * Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
-   */
-  alter?: boolean;
 }
 
 export interface DefaultSetOptions {}

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -1,4 +1,5 @@
-import { Association, HasOne, Model, Sequelize } from 'sequelize';
+import { Association, HasOne, Model, Sequelize, DataTypes } from 'sequelize';
+import { BuildOptions } from '../lib/model';
 
 class MyModel extends Model {
   public num!: number;
@@ -18,21 +19,95 @@ const Instance: MyModel = new MyModel({ int: 10 });
 const num: number = Instance.get('num');
 
 MyModel.findOne({
-  include: [
-    { model: OtherModel, paranoid: true }
-  ]
+  include: [{ model: OtherModel, paranoid: true }]
 });
 
 const sequelize = new Sequelize('mysql://user:user@localhost:3306/mydb');
 
-MyModel.init({}, {
-  indexes: [
-    {
-      fields: ['foo'],
-      using: 'gin',
-      operator: 'jsonb_path_ops',
+MyModel.init(
+  {},
+  {
+    indexes: [
+      {
+        fields: ['foo'],
+        using: 'gin',
+        operator: 'jsonb_path_ops'
+      }
+    ],
+    sequelize,
+    tableName: 'my_model'
+  }
+);
+
+// Models defined using functions instead of classes
+function Functional1Factory(sequelize: Sequelize, dataTypes: typeof DataTypes) {
+  const Functional1 = <Functional1Static>sequelize.define('Functional1', {
+    id: {
+      type: dataTypes.INTEGER,
+      primaryKey: true
+    },
+    foo: {
+      type: dataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'bar'
     }
-  ],
-  sequelize,
-  tableName: 'my_model'
+  });
+
+  Functional1.associate = function(models: ModelDictionary) {
+    Functional1.belongsTo(models.Functional2);
+  };
+
+  return Functional1;
+}
+
+function Functional2Factory(sequelize: Sequelize, dataTypes: typeof DataTypes) {
+  const Functional2 = <Functional2Static>sequelize.define('Functional2', {
+    id: {
+      type: dataTypes.INTEGER,
+      primaryKey: true
+    },
+    foo: {
+      type: dataTypes.STRING,
+      allowNull: false,
+      defaultValue: 'bar'
+    }
+  });
+
+  Functional2.associate = function(models: ModelDictionary) {
+    Functional2.hasMany(models.Functional1);
+  };
+
+  return Functional2;
+}
+
+const models: ModelDictionary = {
+  Functional1: sequelize.import('', Functional1Factory),
+  Functional2: sequelize.import('', Functional2Factory)
+};
+
+Object.values(models).forEach((model: typeof Model) => {
+  model.associate(models);
 });
+
+interface Functional1 {
+  readonly id: number;
+  readonly foo: string;
+}
+
+interface Functional2 {
+  readonly id: number;
+  readonly bar: string;
+}
+
+type Functional1Static = typeof Model & {
+  new (values?: object, options?: BuildOptions): Functional1;
+};
+
+type Functional2Static = typeof Model & {
+  new (values?: object, options?: BuildOptions): Functional2;
+};
+
+type ModelDictionary = {
+  Functional1: Functional1Static;
+  Functional2: Functional2Static;
+};


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
A common pattern for adding associations between models is defining a `model.associate` function (see [this example](https://github.com/sequelize/express-example/blob/master/models/task.js) here). However, when using Typescript, this does not work as there is no associate function defined in the type definitions. This pull request provides the necessary type definitions so that this pattern can be used in Typescript as well.