### PR TITLE
docs: fix Typescript example import and table name

### DIFF
--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -18,7 +18,7 @@ Example of a minimal TypeScript project:
 
 ```ts
 import { Sequelize, Model, DataTypes, BuildOptions } from 'sequelize';
-import { HasManyGetAssociationsMixin, HasManyAddAssociationMixin, HasManyHasAssociationMixin, Association, HasManyCountAssociationsMixin, HasManyCreateAssociationMixin } from '../../lib/associations';
+import { HasManyGetAssociationsMixin, HasManyAddAssociationMixin, HasManyHasAssociationMixin, Association, HasManyCountAssociationsMixin, HasManyCreateAssociationMixin } from 'sequelize';
 
 class User extends Model {
   public id!: number; // Note that the `null assertion` `!` is required in strict mode.
@@ -114,7 +114,7 @@ Address.init({
     allowNull: false,
   }
 }, {
-  tableName: 'users',
+  tableName: 'address',
   sequelize: sequelize, // this bit is important
 });
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Fix errors in typescript docs example.

When running `sequelize.sync()` using the typescript documentation I had the following issues:
1.
```
Cannot find module '../../lib/associations'
```
the change I made is to update the import import from `../../lib/associations` to `sequelize`.

2.
```
UnhandledPromiseRejectionWarning: SequelizeDatabaseError: column "name" of relation "users" does not exist
```
The `Address` should be in it's own table by the looks of it so I changed the table from `users` to `address`.

These two fixes mean the example runs fine against the latest postgres image https://hub.docker.com/_/postgres (11.3)
