### PR TITLE
Make relations schema aware when schema is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ If you have any security issue to report, contact project maintainers privately.
 
 ### Translations
 - [English v5](http://docs.sequelizejs.com) (OFFICIAL)
-- [中文文档 v4](https://github.com/demopark/sequelize-docs-Zh-CN) (UNOFFICIAL)
+- [中文文档 v4/v5](https://github.com/demopark/sequelize-docs-Zh-CN) (UNOFFICIAL)

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -18,7 +18,7 @@ Example of a minimal TypeScript project:
 
 ```ts
 import { Sequelize, Model, DataTypes, BuildOptions } from 'sequelize';
-import { HasManyGetAssociationsMixin, HasManyAddAssociationMixin, HasManyHasAssociationMixin, Association, HasManyCountAssociationsMixin, HasManyCreateAssociationMixin } from '../../lib/associations';
+import { HasManyGetAssociationsMixin, HasManyAddAssociationMixin, HasManyHasAssociationMixin, Association, HasManyCountAssociationsMixin, HasManyCreateAssociationMixin } from 'sequelize';
 
 class User extends Model {
   public id!: number; // Note that the `null assertion` `!` is required in strict mode.
@@ -114,7 +114,7 @@ Address.init({
     allowNull: false,
   }
 }, {
-  tableName: 'users',
+  tableName: 'address',
   sequelize: sequelize, // this bit is important
 });
 

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Pool } = require('sequelize-pool');
+const { Pool, TimeoutError } = require('sequelize-pool');
 const _ = require('lodash');
 const semver = require('semver');
 const Promise = require('../../promise');
@@ -278,9 +278,11 @@ class ConnectionManager {
 
     return promise.then(() => {
       return this.pool.acquire(options.type, options.useMaster)
-        .catch(Promise.TimeoutError, err => { throw new errors.ConnectionAcquireTimeoutError(err); })
-        .tap(() => { debug('connection acquired'); });
-    });
+        .catch(error => {
+          if (error instanceof TimeoutError) throw new errors.ConnectionAcquireTimeoutError(error);
+          throw error;
+        });
+    }).tap(() => { debug('connection acquired'); });
   }
 
   /**

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -549,6 +549,12 @@ class QueryGenerator {
       options.where = this.whereQuery(options.where);
     }
 
+    if (options.schema) {
+      tableName = {
+        tableName,
+        options: options.schema
+      };
+    }
     if (typeof tableName === 'string') {
       tableName = this.quoteIdentifiers(tableName);
     } else {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -552,7 +552,7 @@ class QueryGenerator {
     if (options.schema) {
       tableName = {
         tableName,
-        options: options.schema
+        schema: options.schema
       };
     }
     if (typeof tableName === 'string') {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -510,7 +510,11 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.references) {
-      const referencesTable = this.quoteTable(attribute.references.model);
+      let referencesTable = this.quoteTable(attribute.references.model);
+      const tableDetails = this.extractTableDetails(referencesTable, options);
+      if (options.schema) {
+        referencesTable = tableDetails.schema + tableDetails.delimiter + referencesTable;
+      }
       let referencesKey;
 
       if (attribute.references.key) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1355,7 +1355,8 @@ class Model {
           Object.assign({
             logging: options.logging,
             benchmark: options.benchmark,
-            transaction: options.transaction
+            transaction: options.transaction,
+            schema: options.schema
           }, index),
           this.tableName
         ));

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -230,7 +230,10 @@ class QueryInterface {
       });
     }
 
-    attributes = this.QueryGenerator.attributesToSQL(attributes, { table: tableName, context: 'createTable' });
+    attributes = this.QueryGenerator.attributesToSQL(attributes, {
+      table: tableName,
+      context: 'createTable',
+      schema: options.schema });
     sql = this.QueryGenerator.createTableQuery(tableName, attributes, options);
 
     return promise.then(() => this.sequelize.query(sql, options));

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "moment-timezone": "^0.5.21",
     "retry-as-promised": "^3.1.0",
     "semver": "^5.6.0",
-    "sequelize-pool": "^1.0.2",
+    "sequelize-pool": "^2.1.0",
     "toposort-class": "^1.0.1",
     "uuid": "^3.2.1",
     "validator": "^10.11.0",

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -294,19 +294,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     });
 
     describe('logging', () => {
-      it('executes a query with global benchmarking option and default logger', () => {
-        const logger = sinon.stub(console, 'log');
-        const sequelize = Support.createSequelizeInstance({
-          logging: logger,
-          benchmark: true
-        });
-
-        return sequelize.query('select 1;').then(() => {
-          expect(logger.calledOnce).to.be.true;
-          expect(logger.args[0][0]).to.be.match(/Executed \((\d*|default)\): select 1; Elapsed time: \d+ms/);
-        });
-      });
-
       it('executes a query with global benchmarking option and custom logger', () => {
         const logger = sinon.spy();
         const sequelize = Support.createSequelizeInstance({
@@ -318,17 +305,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           expect(logger.calledOnce).to.be.true;
           expect(logger.args[0][0]).to.be.match(/Executed \((\d*|default)\): select 1/);
           expect(typeof logger.args[0][1] === 'number').to.be.true;
-        });
-      });
-
-      it('executes a query with benchmarking option and default logger', function() {
-        const logger = sinon.stub(console, 'log');
-        return this.sequelize.query('select 1;', {
-          logging: logger,
-          benchmark: true
-        }).then(() => {
-          expect(logger.calledOnce).to.be.true;
-          expect(logger.args[0][0]).to.be.match(/Executed \((\d*|default)\): select 1; Elapsed time: \d+ms/);
         });
       });
 

--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -40,7 +40,7 @@ export interface ModelHooks<M extends Model = Model> {
   beforeCount(options: CountOptions): HookReturn;
   beforeFindAfterExpandIncludeAll(options: FindOptions): HookReturn;
   beforeFindAfterOptions(options: FindOptions): HookReturn;
-  afterFind(instancesOrInstance: M[] | M, options: FindOptions): HookReturn;
+  afterFind(instancesOrInstance: M[] | M | null, options: FindOptions): HookReturn;
   beforeSync(options: SyncOptions): HookReturn;
   afterSync(options: SyncOptions): HookReturn;
   beforeBulkSync(options: SyncOptions): HookReturn;

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -479,7 +479,7 @@ export type FindAttributeOptions =
 
 export interface IndexHint {
   type: IndexHints;
-  value: string[];
+  values: string[];
 }
 
 export interface IndexHintable {

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2311,11 +2311,11 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   public static afterFind<M extends Model>(
     this: { new (): M } & typeof Model,
     name: string,
-    fn: (instancesOrInstance: M[] | M, options: FindOptions) => HookReturn
+    fn: (instancesOrInstance: M[] | M | null, options: FindOptions) => HookReturn
   ): void;
   public static afterFind<M extends Model>(
     this: { new (): M } & typeof Model,
-    fn: (instancesOrInstance: M[] | M, options: FindOptions) => HookReturn
+    fn: (instancesOrInstance: M[] | M | null, options: FindOptions) => HookReturn
   ): void;
 
   /**

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -647,10 +647,10 @@ export class Sequelize extends Hooks {
    */
   public static afterFind(
     name: string,
-    fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void
+    fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void
   ): void;
   public static afterFind(
-    fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void
+    fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void
   ): void;
 
   /**
@@ -953,9 +953,9 @@ export class Sequelize extends Hooks {
    */
   public afterFind(
     name: string,
-    fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void
+    fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void
   ): void;
-  public afterFind(fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void): void;
+  public afterFind(fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void): void;
 
   /**
    * A hook that is run before a define call

--- a/types/test/hooks.ts
+++ b/types/test/hooks.ts
@@ -1,4 +1,4 @@
-import {Model, SaveOptions, Sequelize} from "sequelize"
+import {Model, SaveOptions, Sequelize, FindOptions} from "sequelize"
 import { ModelHooks } from "../lib/hooks";
 
 /*
@@ -7,6 +7,8 @@ import { ModelHooks } from "../lib/hooks";
 
 Sequelize.beforeSave((t: TestModel, options: SaveOptions) => {});
 Sequelize.afterSave((t: TestModel, options: SaveOptions) => {});
+Sequelize.afterFind((t: TestModel[] | TestModel | null, options: FindOptions) => {});
+Sequelize.afterFind('namedAfterFind', (t: TestModel[] | TestModel | null, options: FindOptions) => {});
 
 /*
  * covers types/lib/hooks.d.ts
@@ -16,6 +18,7 @@ export const sequelize = new Sequelize('uri', {
   hooks: {
     beforeSave (m: Model, options: SaveOptions) {},
     afterSave (m: Model, options: SaveOptions) {},
+    afterFind (m: Model[] | Model | null, options: FindOptions) {},
   }
 });
 
@@ -25,12 +28,14 @@ class TestModel extends Model {
 const hooks: Partial<ModelHooks> = {
   beforeSave(t: TestModel, options: SaveOptions) { },
   afterSave(t: TestModel, options: SaveOptions) { },
+  afterFind(t: TestModel | TestModel[] | null, options: FindOptions) { },
 };
 
 TestModel.init({}, {sequelize, hooks })
 
 TestModel.addHook('beforeSave', (t: TestModel, options: SaveOptions) => { });
 TestModel.addHook('afterSave', (t: TestModel, options: SaveOptions) => { });
+TestModel.addHook('afterFind', (t: TestModel[] | TestModel | null, options: FindOptions) => { });
 
 /*
  * covers types/lib/model.d.ts
@@ -38,3 +43,4 @@ TestModel.addHook('afterSave', (t: TestModel, options: SaveOptions) => { });
 
 TestModel.beforeSave((t: TestModel, options: SaveOptions) => { });
 TestModel.afterSave((t: TestModel, options: SaveOptions) => { });
+TestModel.afterFind((t: TestModel | TestModel[] | null, options: FindOptions) => { });

--- a/types/test/index-hints.ts
+++ b/types/test/index-hints.ts
@@ -4,6 +4,6 @@ import { IndexHints } from '..';
 User.findAll({
   indexHints: [{
     type: IndexHints.FORCE,
-    value: ['some_index'],
+    values: ['some_index'],
   }],
-})
+});


### PR DESCRIPTION
When I have a data model using Postgres and I'm using schemas (other than the default schema) and I have relations, one need to set the schema also for `REFERENCES`. This was not the case so far. 
This PR applies the schema when provided as `options` to `sync()`.