### PR TITLE
fix(options): add 'requestTimeout' to dialect:mssql

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -39,7 +39,8 @@ class ConnectionManager extends AbstractConnectionManager {
       options: {
         port: parseInt(config.port, 10),
         database: config.database,
-        encrypt: false
+        encrypt: false,
+        requestTimeout: config.dialectOptions.requestTimeout
       }
     };
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ NA] Have you added new tests to prevent regressions?
- [NA ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

This Pull request addresses issue: #11305 - https://github.com/sequelize/sequelize/issues/11035.

Issue is: unable to set requestTimeout with configuration parameter for "mssql" dilect.

requestTimeout was added so that config.dialectOptions.requestTimeout is now being passed to tedious. 

