### PR TITLE
fix(types): add null to afterFind hook

### DIFF
--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -40,7 +40,7 @@ export interface ModelHooks<M extends Model = Model> {
   beforeCount(options: CountOptions): HookReturn;
   beforeFindAfterExpandIncludeAll(options: FindOptions): HookReturn;
   beforeFindAfterOptions(options: FindOptions): HookReturn;
-  afterFind(instancesOrInstance: M[] | M, options: FindOptions): HookReturn;
+  afterFind(instancesOrInstance: M[] | M | null, options: FindOptions): HookReturn;
   beforeSync(options: SyncOptions): HookReturn;
   afterSync(options: SyncOptions): HookReturn;
   beforeBulkSync(options: SyncOptions): HookReturn;

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2311,11 +2311,11 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   public static afterFind<M extends Model>(
     this: { new (): M } & typeof Model,
     name: string,
-    fn: (instancesOrInstance: M[] | M, options: FindOptions) => HookReturn
+    fn: (instancesOrInstance: M[] | M | null, options: FindOptions) => HookReturn
   ): void;
   public static afterFind<M extends Model>(
     this: { new (): M } & typeof Model,
-    fn: (instancesOrInstance: M[] | M, options: FindOptions) => HookReturn
+    fn: (instancesOrInstance: M[] | M | null, options: FindOptions) => HookReturn
   ): void;
 
   /**

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -647,10 +647,10 @@ export class Sequelize extends Hooks {
    */
   public static afterFind(
     name: string,
-    fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void
+    fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void
   ): void;
   public static afterFind(
-    fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void
+    fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void
   ): void;
 
   /**
@@ -953,9 +953,9 @@ export class Sequelize extends Hooks {
    */
   public afterFind(
     name: string,
-    fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void
+    fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void
   ): void;
-  public afterFind(fn: (instancesOrInstance: Model[] | Model, options: FindOptions) => void): void;
+  public afterFind(fn: (instancesOrInstance: Model[] | Model | null, options: FindOptions) => void): void;
 
   /**
    * A hook that is run before a define call

--- a/types/test/hooks.ts
+++ b/types/test/hooks.ts
@@ -1,4 +1,4 @@
-import {Model, SaveOptions, Sequelize} from "sequelize"
+import {Model, SaveOptions, Sequelize, FindOptions} from "sequelize"
 import { ModelHooks } from "../lib/hooks";
 
 /*
@@ -7,6 +7,8 @@ import { ModelHooks } from "../lib/hooks";
 
 Sequelize.beforeSave((t: TestModel, options: SaveOptions) => {});
 Sequelize.afterSave((t: TestModel, options: SaveOptions) => {});
+Sequelize.afterFind((t: TestModel[] | TestModel | null, options: FindOptions) => {});
+Sequelize.afterFind('namedAfterFind', (t: TestModel[] | TestModel | null, options: FindOptions) => {});
 
 /*
  * covers types/lib/hooks.d.ts
@@ -16,6 +18,7 @@ export const sequelize = new Sequelize('uri', {
   hooks: {
     beforeSave (m: Model, options: SaveOptions) {},
     afterSave (m: Model, options: SaveOptions) {},
+    afterFind (m: Model[] | Model | null, options: FindOptions) {},
   }
 });
 
@@ -25,12 +28,14 @@ class TestModel extends Model {
 const hooks: Partial<ModelHooks> = {
   beforeSave(t: TestModel, options: SaveOptions) { },
   afterSave(t: TestModel, options: SaveOptions) { },
+  afterFind(t: TestModel | TestModel[] | null, options: FindOptions) { },
 };
 
 TestModel.init({}, {sequelize, hooks })
 
 TestModel.addHook('beforeSave', (t: TestModel, options: SaveOptions) => { });
 TestModel.addHook('afterSave', (t: TestModel, options: SaveOptions) => { });
+TestModel.addHook('afterFind', (t: TestModel[] | TestModel | null, options: FindOptions) => { });
 
 /*
  * covers types/lib/model.d.ts
@@ -38,3 +43,4 @@ TestModel.addHook('afterSave', (t: TestModel, options: SaveOptions) => { });
 
 TestModel.beforeSave((t: TestModel, options: SaveOptions) => { });
 TestModel.afterSave((t: TestModel, options: SaveOptions) => { });
+TestModel.afterFind((t: TestModel | TestModel[] | null, options: FindOptions) => { });


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

It is not obvious from types that `afterFind` hook can be fired with `null` as first argument (instead of model instance or instances). So this PR adds `null` explicitly.