### PR TITLE
docs: add note for find*create functions

### DIFF
--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -36,7 +36,7 @@ The method `findOrCreate` can be used to check if a certain element already exis
 
 Let's assume we have an empty database with a `User` model which has a `username` and a `job`.
 
-*Note:* `where` option will be appended to `defaults` if create query runs.
+`where` option will be appended to `defaults` for create case. 
 
 ```js
 User

--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -36,6 +36,8 @@ The method `findOrCreate` can be used to check if a certain element already exis
 
 Let's assume we have an empty database with a `User` model which has a `username` and a `job`.
 
+*Note:* `where` option will be appended to `defaults` if create query runs.
+
 ```js
 User
   .findOrCreate({where: {username: 'sdepold'}, defaults: {job: 'Technical Lead JavaScript'}})

--- a/lib/model.js
+++ b/lib/model.js
@@ -2221,7 +2221,7 @@ class Model {
    * The successful result of the promise will be (instance, built)
    *
    * @param {Object}   options find options
-   * @param {Object}   options.where A hash of search attributes.
+   * @param {Object}   options.where A hash of search attributes. Will be appended to defaults if create runs.
    * @param {Object}   [options.defaults] Default values to use if building a new instance
    * @param {Object}   [options.transaction] Transaction to run query under
    *
@@ -2265,7 +2265,7 @@ class Model {
    * {@link Model.findAll} for a full specification of find and options
    *
    * @param {Object}      options find and create options
-   * @param {Object}      options.where where A hash of search attributes.
+   * @param {Object}      options.where where A hash of search attributes. Will be appended to defaults if create runs. 
    * @param {Object}      [options.defaults] Default values to use if creating a new instance
    * @param {Transaction} [options.transaction] Transaction to run query under
    *
@@ -2375,7 +2375,7 @@ class Model {
    * {@link Model.findAll} for a full specification of find and options
    *
    * @param {Object} options find options
-   * @param {Object} options.where A hash of search attributes.
+   * @param {Object} options.where A hash of search attributes. Will be appended to defaults if create runs. 
    * @param {Object} [options.defaults] Default values to use if creating a new instance
    *
    * @returns {Promise<Model,boolean>}

--- a/lib/model.js
+++ b/lib/model.js
@@ -2221,7 +2221,7 @@ class Model {
    * The successful result of the promise will be (instance, built)
    *
    * @param {Object}   options find options
-   * @param {Object}   options.where A hash of search attributes. Will be appended to defaults if create runs.
+   * @param {Object}   options.where A hash of search attributes. If `where` is a plain object it will be appended with defaults to build a new instance.
    * @param {Object}   [options.defaults] Default values to use if building a new instance
    * @param {Object}   [options.transaction] Transaction to run query under
    *
@@ -2265,7 +2265,7 @@ class Model {
    * {@link Model.findAll} for a full specification of find and options
    *
    * @param {Object}      options find and create options
-   * @param {Object}      options.where where A hash of search attributes. Will be appended to defaults if create runs. 
+   * @param {Object}      options.where where A hash of search attributes. If `where` is a plain object it will be appended with defaults to build a new instance.
    * @param {Object}      [options.defaults] Default values to use if creating a new instance
    * @param {Transaction} [options.transaction] Transaction to run query under
    *
@@ -2375,7 +2375,7 @@ class Model {
    * {@link Model.findAll} for a full specification of find and options
    *
    * @param {Object} options find options
-   * @param {Object} options.where A hash of search attributes. Will be appended to defaults if create runs. 
+   * @param {Object} options.where A hash of search attributes. If `where` is a plain object it will be appended with defaults to build a new instance.
    * @param {Object} [options.defaults] Default values to use if creating a new instance
    *
    * @returns {Promise<Model,boolean>}


### PR DESCRIPTION
I spent a few days this week pounding my head against the wall wondering why when I would run any of the `Model.find*Create()` functions, whatever I was putting into the `where` options parameter, it was getting inserted into the database. 

From reading the docs and also assuming that `where` is only used for the "WHERE" query generation, I finally dug into the source code of sequelize and realized my issue. 

I thought it would be helpful for others to realize when they use any of these functions that the `where` option will be used in the create query. 