### PR TITLE
fix(mysql): deadlocks indicate a rollback

### DIFF
--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -34,10 +34,10 @@ class Query extends AbstractQuery {
 
   run(sql, parameters) {
     this.sql = sql;
-    const { connection } = this;
+    const { connection, options } = this;
 
     const showWarnings = this.sequelize.options.showWarnings
-      || this.options.showWarnings;
+      || options.showWarnings;
 
     const complete = this._logQuery(sql, debug);
 
@@ -56,6 +56,11 @@ class Query extends AbstractQuery {
           return results;
         })
         .catch(err => {
+          // MariaDB automatically rolls-back transactions in the event of a deadlock
+          if (options.transaction && err.errno === 1213) {
+            options.transaction.finished = 'rollback';
+          }
+
           complete();
 
           err.sql = sql;

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -29,10 +29,10 @@ class Query extends AbstractQuery {
 
   run(sql, parameters) {
     this.sql = sql;
-    const { connection } = this;
+    const { connection, options } = this;
 
     //do we need benchmark for this query execution
-    const showWarnings = this.sequelize.options.showWarnings || this.options.showWarnings;
+    const showWarnings = this.sequelize.options.showWarnings || options.showWarnings;
 
     const complete = this._logQuery(sql, debug);
 
@@ -41,6 +41,10 @@ class Query extends AbstractQuery {
         complete();
 
         if (err) {
+          // MySQL automatically rolls-back transactions in the event of a deadlock
+          if (options.transaction && err.errno === 1213) {
+            options.transaction.finished = 'rollback';
+          }
           err.sql = sql;
 
           reject(this.formatError(err));

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1417,7 +1417,8 @@ class QueryInterface {
 
     options = Object.assign({}, options, {
       transaction: transaction.parent || transaction,
-      supportsSearchPath: false
+      supportsSearchPath: false,
+      completesTransaction: true
     });
 
     const sql = this.QueryGenerator.commitTransactionQuery(transaction);
@@ -1435,7 +1436,8 @@ class QueryInterface {
 
     options = Object.assign({}, options, {
       transaction: transaction.parent || transaction,
-      supportsSearchPath: false
+      supportsSearchPath: false,
+      completesTransaction: true
     });
     options.transaction.name = transaction.parent ? transaction.name : undefined;
     const sql = this.QueryGenerator.rollbackTransactionQuery(transaction);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -614,17 +614,22 @@ class Sequelize {
         [sql, bindParameters] = this.dialect.Query.formatBindParameters(sql, options.bind, this.options.dialect);
       }
 
+      const checkTransaction = () => {
+        if (options.transaction && options.transaction.finished && !options.completesTransaction) {
+          const error = new Error(`${options.transaction.finished} has been called on this transaction(${options.transaction.id}), you can no longer use it. (The rejected query is attached as the 'sql' property of this error)`);
+          error.sql = sql;
+          throw error;
+        }
+      };
+
       const retryOptions = Object.assign({}, this.options.retry, options.retry || {});
 
       return Promise.resolve(retry(() => Promise.try(() => {
         if (options.transaction === undefined && Sequelize._cls) {
           options.transaction = Sequelize._cls.get('transaction');
         }
-        if (options.transaction && options.transaction.finished) {
-          const error = new Error(`${options.transaction.finished} has been called on this transaction(${options.transaction.id}), you can no longer use it. (The rejected query is attached as the 'sql' property of this error)`);
-          error.sql = sql;
-          throw error;
-        }
+
+        checkTransaction();
 
         return options.transaction
           ? options.transaction.connection
@@ -632,6 +637,7 @@ class Sequelize {
       }).then(connection => {
         const query = new this.dialect.Query(connection, this, options);
         return this.runHooks('beforeQuery', options, query)
+          .then(() => checkTransaction())
           .then(() => query.run(sql, bindParameters))
           .finally(() => this.runHooks('afterQuery', options, query))
           .finally(() => {

--- a/test/integration/dialects/mysql/errors.test.js
+++ b/test/integration/dialects/mysql/errors.test.js
@@ -70,7 +70,6 @@ if (dialect === 'mysql') {
             reltype: 'child'
           }));
       });
-
     });
   });
 }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

When MySQL or MariaDB encounter a deadlock, [the default behavior](https://dev.mysql.com/doc/refman/5.7/en/innodb-deadlock-detection.html) is to roll back the active transaction (having roughly the same effect as manually issuing the `ROLLBACK;` command). 

Currently, Sequelize does not apply any special handling to these errors.  If a query yields a deadlock error, all future queries against that "transaction" will actually be run against the default context.  This can have potentially destructive implications, as those subsequent queries cannot be rolled back.

This PR adds some code to mark any deadlocked transactions as though they've been rolled-back.  This prevents Sequelize from running any further queries against these transactions (utilizing the mechanisms that already exist for that purpose).

Mitigates #8352.