### PR TITLE
Fix incorrect option name in docs/model-definition

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -713,7 +713,7 @@ User.init({}, {
     // A BTREE index with a ordered field
     {
       name: 'title_index',
-      method: 'BTREE',
+      using: 'BTREE',
       fields: ['author', {attribute: 'title', collate: 'en_US', order: 'DESC', length: 5}]
     }
   ],


### PR DESCRIPTION
### Description of change

Replace `method: 'BTREE'` with `using: 'BTREE'` in `docs/models-definition.html#indexes`.

Tested locally with `queryInterface.addIndex()` and `sequelize.sync()`.