### PR TITLE
fix(types): modify Abstract export type to extending datatypes(#11072)

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -1045,7 +1045,7 @@ for (const dataTypes of dialectList) {
 // Wrap all data types to not require `new`
 for (const dataTypes of [DataTypes, ...dialectList]) {
   _.each(dataTypes, (DataType, key) => {
-    dataTypes[key] = classToInvokable(DataType);
+    dataTypes[key] = key === 'ABSTRACT' ? DataType : classToInvokable(DataType);
   });
 }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
**YES, but I need some help** 
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? **YES**
- [x] Have you added new tests to prevent regressions? **NO**
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **NO**
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)? **YES**
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
I want to solve this issue [#11072](https://github.com/sequelize/sequelize/issues/11072).
database: mysql.
Current ABSTRACT type is a proxy, it's can not inherit, so I change it to class type when exporting.

And in fact, when run text, it's throw some err.
I'm so sorry becauseI I don't know how to do, please give me some help?
very thanks!


