### PR TITLE
Remove `test*.js` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-test*.js
 *.swp
 .idea
 .DS_STORE


### PR DESCRIPTION
Is there a reason why this pattern should still be ignored?

See https://github.com/sequelize/sequelize/issues/11107
