### PR TITLE
disconnect hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -186,11 +186,13 @@ new Sequelize(..., {
 
 ### Connection Hooks
 
-Sequelize provides two hooks that are executed immediately before and after a database connection is obtained:
+Sequelize provides four hooks that are executed immediately before and after a database connection is obtained or released:
 
 ```text
 beforeConnect(config)
 afterConnect(connection, config)
+beforeDisconnect(connection)
+afterDisconnect(connection)
 ```
 
 These hooks can be useful if you need to asynchronously obtain database credentials, or need to directly access the low-level database connection after it has been created.

--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -320,7 +320,9 @@ class ConnectionManager {
    * @returns {Promise}
    */
   _disconnect(connection) {
-    return this.dialect.connectionManager.disconnect(connection);
+    return this.sequelize.runHooks('beforeDisconnect', connection)
+      .then(() => this.dialect.connectionManager.disconnect(connection))
+      .then(() => this.sequelize.runHooks('afterDisconnect', connection));
   }
 
   /**

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -42,6 +42,8 @@ const hookTypes = {
   afterAssociate: { params: 2, sync: true },
   beforeConnect: { params: 1, noModel: true },
   afterConnect: { params: 2, noModel: true },
+  beforeDisconnect: { params: 1, noModel: true },
+  afterDisconnect: { params: 1, noModel: true },
   beforeSync: { params: 1 },
   afterSync: { params: 1 },
   beforeBulkSync: { params: 1 },
@@ -501,8 +503,24 @@ exports.applyTo = applyTo;
 /**
  * A hook that is run after a connection is created
  * @param {string}   name
- * @param {Function} fn   A callback function that is called with the connection object and thye config passed to connection
+ * @param {Function} fn   A callback function that is called with the connection object and the config passed to connection
  * @name afterConnect
+ * @memberof Sequelize
+ */
+
+/**
+ * A hook that is run before a connection is disconnected
+ * @param {string}   name
+ * @param {Function} fn   A callback function that is called with the connection object
+ * @name beforeDisconnect
+ * @memberof Sequelize
+ */
+
+/**
+ * A hook that is run after a connection is disconnected
+ * @param {string}   name
+ * @param {Function} fn   A callback function that is called with the connection object
+ * @name afterDisconnect
  * @memberof Sequelize
  */
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -167,7 +167,7 @@ class Sequelize {
    * @param {number}   [options.retry.max] How many times a failing query is automatically retried.  Set to 0 to disable retrying on SQL_BUSY error.
    * @param {boolean}  [options.typeValidation=false] Run built in type validators on insert and update, e.g. validate that arguments passed to integer fields are integer-like.
    * @param {Object}   [options.operatorsAliases] String based operator alias. Pass object to limit set of aliased operators.
-   * @param {Object}   [options.hooks] An object of global hook functions that are called before and after certain lifecycle events. Global hooks will run after any model-specific hooks defined for the same event (See `Sequelize.Model.init()` for a list).  Additionally, `beforeConnect()` and `afterConnect()` hooks may be defined here.
+   * @param {Object}   [options.hooks] An object of global hook functions that are called before and after certain lifecycle events. Global hooks will run after any model-specific hooks defined for the same event (See `Sequelize.Model.init()` for a list).  Additionally, `beforeConnect()`, `afterConnect()`, `beforeDisconnect()`, and `afterDisconnect()` hooks may be defined here.
    */
   constructor(database, username, password, options) {
     let config;

--- a/test/unit/connection-manager.test.js
+++ b/test/unit/connection-manager.test.js
@@ -66,4 +66,42 @@ describe('connection manager', () => {
       });
     });
   });
+
+  describe('_disconnect', () => {
+    beforeEach(function() {
+      this.connection = {};
+
+      this.dialect = {
+        connectionManager: {
+          disconnect: sinon.stub().resolves(this.connection)
+        }
+      };
+
+      this.sequelize = Support.createSequelizeInstance();
+    });
+
+    it('should call beforeDisconnect', function() {
+      const spy = sinon.spy();
+      this.sequelize.beforeDisconnect(spy);
+
+      const connectionManager = new ConnectionManager(this.dialect, this.sequelize);
+
+      return connectionManager._disconnect(this.connection).then(() => {
+        expect(spy.callCount).to.equal(1);
+        expect(spy.firstCall.args[0]).to.equal(this.connection);
+      });
+    });
+
+    it('should call afterDisconnect', function() {
+      const spy = sinon.spy();
+      this.sequelize.afterDisconnect(spy);
+
+      const connectionManager = new ConnectionManager(this.dialect, this.sequelize);
+
+      return connectionManager._disconnect(this.connection).then(() => {
+        expect(spy.callCount).to.equal(1);
+        expect(spy.firstCall.args[0]).to.equal(this.connection);
+      });
+    });
+  });
 });

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -15,7 +15,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
   });
 
   it('does not expose non-model hooks', function() {
-    for (const badHook of ['beforeDefine', 'afterDefine', 'beforeConnect', 'afterConnect', 'beforeInit', 'afterInit']) {
+    for (const badHook of ['beforeDefine', 'afterDefine', 'beforeConnect', 'afterConnect', 'beforeDisconnect', 'afterDisconnect', 'beforeInit', 'afterInit']) {
       expect(this.Model).to.not.have.property(badHook);
     }
   });

--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -54,6 +54,8 @@ export interface SequelizeHooks extends ModelHooks {
   afterInit(sequelize: Sequelize): void;
   beforeConnect(config: Config): HookReturn;
   afterConnect(connection: unknown, config: Config): HookReturn;
+  beforeDisconnect(connection: unknown): HookReturn;
+  afterDisconnect(connection: unknown): HookReturn;
 }
 
 /**

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -57,12 +57,12 @@ export interface SyncOptions extends Logging {
    * The schema that the tables should be created in. This can be overridden for each table in sequelize.define
    */
   schema?: string;
-  
+
    /**
    * An optional parameter to specify the schema search_path (Postgres only)
    */
   searchPath?: string;
-  
+
    /**
    * If hooks is true then beforeSync, afterSync, beforeBulkSync, afterBulkSync hooks will be called
    */
@@ -620,6 +620,24 @@ export class Sequelize extends Hooks {
    */
   public static afterConnect(name: string, fn: (connection: unknown, options: Config) => void): void;
   public static afterConnect(fn: (connection: unknown, options: Config) => void): void;
+
+  /**
+   * A hook that is run before a connection is released
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  public static beforeDisconnect(name: string, fn: (connection: unknown) => void): void;
+  public static beforeDisconnect(fn: (connection: unknown) => void): void;
+
+  /**
+   * A hook that is run after a connection is released
+   *
+   * @param name
+   * @param fn   A callback function that is called with options
+   */
+  public static afterDisconnect(name: string, fn: (connection: unknown) => void): void;
+  public static afterDisconnect(fn: (connection: unknown) => void): void;
 
   /**
    * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Add hooks that run before and after disconnecting a connection:

- `beforeDisconnect`
- `afterDisconnect`

<!-- Please provide a description of the change here. -->
