### PR TITLE
refactor(query-generation): remove lodash string templates

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -111,9 +111,9 @@ class QueryGenerator {
     const quotedTable = this.quoteTable(table);
     const bindParam = options.bindParam === undefined ? this.bindParam(bind) : options.bindParam;
     let query;
-    let valueQuery = `<%= tmpTable %>INSERT<%= ignoreDuplicates %> INTO ${quotedTable} (<%= attributes %>)<%= output %> VALUES (<%= values %>)<%= onConflictDoNothing %>`;
-    let emptyQuery = `<%= tmpTable %>INSERT<%= ignoreDuplicates %> INTO ${quotedTable}<%= output %><%= onConflictDoNothing %>`;
-    let outputFragment;
+    let valueQuery = '';
+    let emptyQuery = '';
+    let outputFragment = '';
     let identityWrapperRequired = false;
     let tmpTable = '';         //tmpTable declaration for trigger
 
@@ -176,25 +176,6 @@ class QueryGenerator {
     if (this._dialect.supports.EXCEPTION && options.exception) {
       // Not currently supported with bind parameters (requires output of multiple queries)
       options.bindParam = false;
-      // Mostly for internal use, so we expect the user to know what he's doing!
-      // pg_temp functions are private per connection, so we never risk this function interfering with another one.
-      if (semver.gte(this.sequelize.options.databaseVersion, '9.2.0')) {
-        // >= 9.2 - Use a UUID but prefix with 'func_' (numbers first not allowed)
-        const delimiter = `$func_${uuidv4().replace(/-/g, '')}$`;
-
-        options.exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
-        valueQuery = `${`CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response ${quotedTable}, OUT sequelize_caught_exception text) RETURNS RECORD AS ${delimiter}` +
-          ' BEGIN '}${valueQuery} INTO response; EXCEPTION ${options.exception} END ${delimiter
-        } LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()`;
-      } else {
-        options.exception = 'WHEN unique_violation THEN NULL;';
-        valueQuery = `CREATE OR REPLACE FUNCTION pg_temp.testfunc() RETURNS SETOF ${quotedTable} AS $body$ BEGIN RETURN QUERY ${valueQuery}; EXCEPTION ${options.exception} END; $body$ LANGUAGE plpgsql; SELECT * FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc();`;
-      }
-    }
-
-    if (this._dialect.supports['ON DUPLICATE KEY'] && options.onDuplicate) {
-      valueQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
-      emptyQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
     }
 
     valueHash = Utils.removeNullValuesFromHash(valueHash, this.options.omitNull);
@@ -235,12 +216,36 @@ class QueryGenerator {
       tmpTable
     };
 
+    valueQuery = `${tmpTable}INSERT${replacements.ignoreDuplicates} INTO ${quotedTable} (${replacements.attributes})${replacements.output} VALUES (${replacements.values})${replacements.onConflictDoNothing}${valueQuery}`;
+    emptyQuery = `${tmpTable}INSERT${replacements.ignoreDuplicates} INTO ${quotedTable}${replacements.output}${replacements.onConflictDoNothing}${emptyQuery}`;
+
+    if (this._dialect.supports.EXCEPTION && options.exception) {
+      // Mostly for internal use, so we expect the user to know what he's doing!
+      // pg_temp functions are private per connection, so we never risk this function interfering with another one.
+      if (semver.gte(this.sequelize.options.databaseVersion, '9.2.0')) {
+        // >= 9.2 - Use a UUID but prefix with 'func_' (numbers first not allowed)
+        const delimiter = `$func_${uuidv4().replace(/-/g, '')}$`;
+
+        options.exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
+        valueQuery = `${`CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response ${quotedTable}, OUT sequelize_caught_exception text) RETURNS RECORD AS ${delimiter}` +
+        ' BEGIN '}${valueQuery} INTO response; EXCEPTION ${options.exception} END ${delimiter
+        } LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()`;
+      } else {
+        options.exception = 'WHEN unique_violation THEN NULL;';
+        valueQuery = `CREATE OR REPLACE FUNCTION pg_temp.testfunc() RETURNS SETOF ${quotedTable} AS $body$ BEGIN RETURN QUERY ${valueQuery}; EXCEPTION ${options.exception} END; $body$ LANGUAGE plpgsql; SELECT * FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc();`;
+      }
+    }
+
+    if (this._dialect.supports['ON DUPLICATE KEY'] && options.onDuplicate) {
+      valueQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
+      emptyQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
+    }
+
     query = `${replacements.attributes.length ? valueQuery : emptyQuery};`;
     if (identityWrapperRequired && this._dialect.supports.autoIncrement.identityInsert) {
       query = `SET IDENTITY_INSERT ${quotedTable} ON; ${query} SET IDENTITY_INSERT ${quotedTable} OFF;`;
     }
 
-    query = _.template(query, this._templateSettings)(replacements);
     // Used by Postgres upsertQuery and calls to here with options.exception set to true
     const result = { query };
     if (options.bindParam !== false) {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Our production app has been experiencing memory leaks in sequelize that seem to be happening in lodash templates. It appears some other users are also experiencing this issue here #9276. It was thought that #10047 would resolve the issue but that PR still left some lodash template usages in the query generator. This PR removes the last calls to lodash templates.

I have tried to create a small sample case to reproduce the memory leak and have not been able to. However this change seems to resolve this issue in production for us.
