### PR TITLE
docs: Typo and grammar fix

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -71,7 +71,7 @@ Foo.init({
    }
  },
 
- // It is possible to add coments on columns for MySQL, PostgreSQL and MSSQL only
+ // It is possible to add comments on columns for MySQL, PostgreSQL and MSSQL only
  commentMe: {
    type: Sequelize.INTEGER,
 
@@ -710,7 +710,7 @@ User.init({}, {
       }
     },
 
-    // A BTREE index with a ordered field
+    // A BTREE index with an ordered field
     {
       name: 'title_index',
       using: 'BTREE',


### PR DESCRIPTION
Found in tutorial section of documentation. Specifically, models-definition.