### PR TITLE
fix(log): output query is not bind parameters #11151

### DIFF
--- a/docs/models-definition.md
+++ b/docs/models-definition.md
@@ -71,7 +71,7 @@ Foo.init({
    }
  },
 
- // It is possible to add coments on columns for MySQL, PostgreSQL and MSSQL only
+ // It is possible to add comments on columns for MySQL, PostgreSQL and MSSQL only
  commentMe: {
    type: Sequelize.INTEGER,
 
@@ -710,7 +710,7 @@ User.init({}, {
       }
     },
 
-    // A BTREE index with a ordered field
+    // A BTREE index with an ordered field
     {
       name: 'title_index',
       using: 'BTREE',

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -32,11 +32,34 @@ class Query extends AbstractQuery {
     return paramType;
   }
 
+  formatQuery(_sql, _parameters) {
+    if (!_parameters || !_parameters.length) {
+      return _sql;
+    }
+
+    const [sql, bindParam] = Query.formatBindParameters(_sql, _parameters, 'postgres');
+
+    let bindCount = 0;
+
+    return sql.replace(/\$[0-9]+/g, () => {
+      const parameter = bindParam[bindCount];
+      bindCount++;
+
+      if (typeof parameter === 'number') {
+        return parameter;
+      }
+      if (typeof parameter === 'string') {
+        return `'${parameter}'`;
+      }
+      return `'${JSON.stringify(parameter)}'`;
+    });
+  }
+
   _run(connection, sql, parameters) {
     this.sql = sql;
     const { options } = this;
 
-    const complete = this._logQuery(sql, debug);
+    const complete = this._logQuery(this.formatQuery(sql, parameters), debug);
 
     return new Promise((resolve, reject) => {
       const handleTransaction = err => {

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -5,6 +5,7 @@ const AbstractQuery = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
 const _ = require('lodash');
 const { logger } = require('../../utils/logger');
+const sqlstring = require('sqlstring');
 
 const debug = logger.debugContext('sql:mysql');
 
@@ -27,6 +28,14 @@ class Query extends AbstractQuery {
     return [sql, bindParam.length > 0 ? bindParam : undefined];
   }
 
+  formatQuery(sql, parameters) {
+    if (!parameters || !parameters.length) {
+      return sql;
+    }
+
+    return sqlstring.format(sql, parameters);
+  }
+
   run(sql, parameters) {
     this.sql = sql;
     const { connection } = this;
@@ -34,7 +43,7 @@ class Query extends AbstractQuery {
     //do we need benchmark for this query execution
     const showWarnings = this.sequelize.options.showWarnings || this.options.showWarnings;
 
-    const complete = this._logQuery(parameters ? connection.format(sql, parameters) : sql, debug);
+    const complete = this._logQuery(this.formatQuery(sql, parameters), debug);
 
     return new Utils.Promise((resolve, reject) => {
       const handler = (err, results) => {

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -34,7 +34,7 @@ class Query extends AbstractQuery {
     //do we need benchmark for this query execution
     const showWarnings = this.sequelize.options.showWarnings || this.options.showWarnings;
 
-    const complete = this._logQuery(sql, debug);
+    const complete = this._logQuery(parameters ? connection.format(sql, parameters) : sql, debug);
 
     return new Utils.Promise((resolve, reject) => {
       const handler = (err, results) => {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -47,6 +47,29 @@ class Query extends AbstractQuery {
     return [sql, bindParam];
   }
 
+  formatQuery(_sql, _parameters) {
+    if (!_parameters || !_parameters.length) {
+      return _sql;
+    }
+
+    const [sql, bindParam] = Query.formatBindParameters(_sql, _parameters, 'postgres');
+
+    let bindCount = 0;
+
+    return sql.replace(/\$[0-9]+/g, () => {
+      const parameter = bindParam[bindCount];
+      bindCount++;
+
+      if (typeof parameter === 'number') {
+        return parameter;
+      }
+      if (typeof parameter === 'string') {
+        return `'${parameter}'`;
+      }
+      return `'${JSON.stringify(parameter)}'`;
+    });
+  }
+
   run(sql, parameters) {
     const { connection } = this;
 
@@ -59,7 +82,7 @@ class Query extends AbstractQuery {
       ? new Promise((resolve, reject) => connection.query(sql, parameters, (error, result) => error ? reject(error) : resolve(result)))
       : new Promise((resolve, reject) => connection.query(sql, (error, result) => error ? reject(error) : resolve(result)));
 
-    const complete = this._logQuery(sql, debug);
+    const complete = this._logQuery(this.formatQuery(sql, parameters), debug);
 
     return query.catch(err => {
       // set the client so that it will be reaped if the connection resets while executing

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "retry-as-promised": "^3.1.0",
     "semver": "^6.1.1",
     "sequelize-pool": "^2.3.0",
+    "sqlstring": "^2.3.1",
     "toposort-class": "^1.0.1",
     "uuid": "^3.2.1",
     "validator": "^10.11.0",

--- a/test/integration/dialects/mariadb/query.test.js
+++ b/test/integration/dialects/mariadb/query.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require('../../../../lib/data-types');
+
+if (dialect.match(/^mariadb/)) {
+  describe('[MARIADB] Query', () => {
+    it('should output query log if execute findAll method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.findAll({
+            attributes: [
+              'id'
+            ],
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+SELECT\s+`id`\s+FROM\s+`users`\s+AS\s+`User`;/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute create method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.create({
+            name: 'test'
+          }, {
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+INSERT\s+INTO\s+`users`\s+\(`id`,`name`,`created_at`,`updated_at`\)\s+VALUES\s+\(DEFAULT,'test','[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}','[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}'\);/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute update method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.update({
+            name: 'test'
+          }, {
+            where: {
+              id: 1
+            },
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+UPDATE\s+`users`\s+SET\s+`name`='test',`updated_at`='[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}'\s+WHERE\s+`id`\s+=\s+1/);
+            }
+          });
+        });
+    });
+  });
+}

--- a/test/integration/dialects/mssql/query.test.js
+++ b/test/integration/dialects/mssql/query.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require('../../../../lib/data-types');
+
+if (dialect.match(/^mssql/)) {
+  describe('[POSTGRES] Query', () => {
+    it('should output query log if execute findAll method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.findAll({
+            attributes: [
+              'id'
+            ],
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+SELECT\s+"id"\s+FROM\s+"users"\s+AS\s+"User";/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute create method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.create({
+            name: 'test'
+          }, {
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+INSERT\s+INTO\s+"users"\s+\("id","name","created_at","updated_at"\)\s+VALUES\s+\(DEFAULT,\\'test\\',\\'[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s+\+[0-9][0-9]:[0-9][0-9]\\',\\'[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s+\+[0-9]{2}:[0-9]{2}\\'\);/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute update method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.update({
+            name: 'test'
+          }, {
+            where: {
+              id: 1
+            },
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+UPDATE\s+"users"\s+SET\s+"name"=\\'test\\',"updated_at"=\\'[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s+\+[0-9]{2}:[0-9]{2}\\'\s+WHERE\s+"id"\s+=\s+1/);
+            }
+          });
+        });
+    });
+  });
+}

--- a/test/integration/dialects/mysql/query.test.js
+++ b/test/integration/dialects/mysql/query.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require('../../../../lib/data-types');
+
+if (dialect.match(/^mysql/)) {
+  describe('[MYSQL] Query', () => {
+    it('should output query log if execute findAll method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.findAll({
+            attributes: [
+              'id'
+            ],
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+SELECT\s+`id`\s+FROM\s+`users`\s+AS\s+`User`;/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute create method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.create({
+            name: 'test'
+          }, {
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+INSERT\s+INTO\s+`users`\s+\(`id`,`name`,`created_at`,`updated_at`\)\s+VALUES\s+\(DEFAULT,'test','[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}','[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}'\);/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute update method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.update({
+            name: 'test'
+          }, {
+            where: {
+              id: 1
+            },
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+UPDATE\s+`users`\s+SET\s+`name`='test',`updated_at`='[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}'\s+WHERE\s+`id`\s+=\s+1/);
+            }
+          });
+        });
+    });
+  });
+}

--- a/test/integration/dialects/postgres/query.test.js
+++ b/test/integration/dialects/postgres/query.test.js
@@ -1,0 +1,76 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('../../support');
+const dialect = Support.getTestDialect();
+const DataTypes = require('../../../../lib/data-types');
+
+if (dialect.match(/^postgres/)) {
+  describe('[POSTGRES] Query', () => {
+    it('should output query log if execute findAll method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.findAll({
+            attributes: [
+              'id'
+            ],
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+SELECT\s+"id"\s+FROM\s+"users"\s+AS\s+"User";/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute create method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.create({
+            name: 'test'
+          }, {
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+INSERT\s+INTO\s+"users"\s+\("id","name","created_at","updated_at"\)\s+VALUES\s+\(DEFAULT,\\'test\\',\\'[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s+\+[0-9][0-9]:[0-9][0-9]\\',\\'[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s+\+[0-9]{2}:[0-9]{2}\\'\);/);
+            }
+          });
+        });
+    });
+    it('should output query bound parameters log if execute update method.', function() {
+      const sequelize = Support.createSequelizeInstance(this.sequelize.options);
+      const UserModel= {
+        name: DataTypes.STRING,
+        createdAt: DataTypes.DATE,
+        updatedAt: DataTypes.DATE
+      };
+      const User = sequelize.define('User', UserModel, { underscored: true });
+
+      return User.sync({ force: true })
+        .then(() => {
+          return User.update({
+            name: 'test'
+          }, {
+            where: {
+              id: 1
+            },
+            logging: sql => {
+              expect(sql).to.match(/Executing\s+\(default\):\s+UPDATE\s+"users"\s+SET\s+"name"=\\'test\\',"updated_at"=\\'[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}\s+\+[0-9]{2}:[0-9]{2}\\'\s+WHERE\s+"id"\s+=\s+1/);
+            }
+          });
+        });
+    });
+  });
+}

--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -43,7 +43,7 @@ describe('model', () => {
             if (dialect === 'mysql') {
               expect(sql).to.not.include('?');
             } else if (dialect === 'mariadb') {
-              expect(sql).to.include('$1');
+              expect(sql).to.include('?');
             } else {
               expect(sql).to.include('$1');
             }

--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -40,8 +40,10 @@ describe('model', () => {
         }, {
           fields: ['id', 'username', 'document', 'emergency_contact'],
           logging: sql => {
-            if (dialect.match(/^mysql|mariadb/)) {
-              expect(sql).to.include('?');
+            if (dialect === 'mysql') {
+              expect(sql).to.not.include('?');
+            } else if (dialect === 'mariadb') {
+              expect(sql).to.include('$1');
             } else {
               expect(sql).to.include('$1');
             }

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -934,7 +934,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               if (dialect === 'mssql') {
                 expect(sql).to.not.contain('createdAt');
               } else {
-                expect(sql).to.match(/UPDATE\s+[`"]+User1s[`"]+\s+SET\s+[`"]+secretValue[`"]=(\$1|\?),[`"]+updatedAt[`"]+=(\$2|\?)\s+WHERE [`"]+id[`"]+\s=\s(\$3|\?)/);
+                expect(sql).to.match(/UPDATE\s+`User1s`\s+SET\s+`secretValue`='43',`updatedAt`='[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}'\s+WHERE\s+`id`\s+=\s+1/);
               }
             }
           });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -933,8 +933,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               test = true;
               if (dialect === 'mssql') {
                 expect(sql).to.not.contain('createdAt');
-              } else {
+              } else if (dialect === 'mysql') {
                 expect(sql).to.match(/UPDATE\s+`User1s`\s+SET\s+`secretValue`='43',`updatedAt`='[0-9]{4}-[0-9]{2}-[0-9]{2}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}'\s+WHERE\s+`id`\s+=\s+1/);
+              } else {
+                expect(sql).to.match(/UPDATE\s+[`"]+User1s[`"]+\s+SET\s+[`"]+secretValue[`"]=(\$1|\?),[`"]+updatedAt[`"]+=(\$2|\?)\s+WHERE [`"]+id[`"]+\s=\s(\$3|\?)/);
               }
             }
           });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -513,7 +513,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           expect(logSql).to.include('@0');
           expect(logSql).to.include('@1');
         } else if (dialect === 'mysql') {
-          expect(logSql.match(/\?/g).length).to.equal(2);
+          expect(logSql).to.not.include('?');
         }
       });
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change
pass query string bound parameters to this._logQuery