### PR TITLE
Migrations doc seed have timestamp

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -139,7 +139,9 @@ module.exports = {
     return queryInterface.bulkInsert('Users', [{
         firstName: 'John',
         lastName: 'Doe',
-        email: 'demo@demo.com'
+        email: 'demo@demo.com',
+        createdAt: Date.now(),
+        updatedAt: Date.now()
       }], {});
   },
 


### PR DESCRIPTION
The seed instructions in the docs fail as they don't pass validation.
This fix adds the createdAt and updatedAt fields to the seed data.

Skipped template as per contribution instructions.