### PR TITLE
Fixed(tedious) Update returning in dialect 

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -346,7 +346,7 @@ class QueryGenerator {
       }
     }
 
-    if (this._dialect.supports.returnValues) {
+    if (this._dialect.supports.returnValues && options.returning) {
       if (this._dialect.supports.returnValues.output) {
         // we always need this for mssql
         outputFragment = ' OUTPUT INSERTED.*';

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -95,7 +95,7 @@ if (dialect.match(/^mssql/)) {
       });
     });
   });
-  
+
   it('not returning in update when table include a trigger', function() {
     const TriggerTable = this.sequelize.define('TriggerTable', {
       ID: {
@@ -113,7 +113,7 @@ if (dialect.match(/^mssql/)) {
     return TriggerTable.sync({ force: true }).then(() => {
       const TriggerForTable = `
       CREATE TRIGGER [SIMPLE_TRIGGER_UPDATE] ON [TriggerTable] AFTER UPDATE
-      AS 
+      AS
       BEGIN
         -- SET NOCOUNT ON added to prevent extra result sets from
         SET NOCOUNT ON;
@@ -130,13 +130,7 @@ if (dialect.match(/^mssql/)) {
             ID: 1
           },
           returning: false
-        }).then(() => {
-          return true;
-        }).catch(error => {
-          return error.message;
         });
-      }).then(BoolUpdate => {
-        expect(BoolUpdate).to.equals(true);
       });
     });
   });

--- a/test/unit/sql/update.test.js
+++ b/test/unit/sql/update.test.js
@@ -51,7 +51,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         timestamps: false
       });
 
-      expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }), {
+      expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1, returning: true }), {
         query: {
           mssql: 'UPDATE TOP(1) [Users] SET [username]=$1 OUTPUT INSERTED.* WHERE [username] = $2',
           mariadb: 'UPDATE `Users` SET `username`=$1 WHERE `username` = $2 LIMIT 1',


### PR DESCRIPTION
This pull request solves the bug that I will explain next, only with mssql

**1. Define model InfoClientes**

```js
module.exports = (sequelize, DataType) => {

  const ModelDefinition = sequelize.define('ModelName', {
    ...fields...
  }, {
    tableName: 'TableNameInDB',
    timestamps: false,
    hasTrigger: true //this table have a trigger
  });

  ModelDefinition.associate = (models) => {
  };

  return ModelDefinition ;
};
```
**2. Using the model without persistent mode**
```js
const ModelNameResovler = function ModelNameResovler(data){
    return true;
};

const ModelNameException = function ModelNameException(ErrorUpdate){
    return false;
};

ModelName.update(UpdateValues, {
  where: {
    IdClientes: UpdateValues.IdClientes
  },
  returning: false, //This should not include the clause OUTPUT INSERTED. *
}).then(
  ModelNameResovler
).catch(
  ModelNameException
);
```
**See error**
```js
//Message: The target table 'ModelName' of the DML statement cannot have any enabled triggers if the statement contains an OUTPUT clause without INTO clause. 
//SQL Generate By Sequelize: UPDATE [ModelName] SET [Names]=@0,[OtherDate]=@1 OUTPUT INSERTED.* WHERE [Id] = @2
```

### The solution in this pull request
The generated update strings should have been. 
`UPDATE [InfoClientes] SET [Nombre]=@0,[ManejaCopago]=@1 WHERE [IdClientes] = @2`
This because clearly specified that nothing returns (`returning: false`)

https://github.com/sequelize/sequelize/blob/715a82fd0278672d665386a34d0684cdc7dbeb68/lib/dialects/abstract/query-generator.js#L349

Add option.returning
https://github.com/wilmerhmg/sequelize/blob/76dc3aa7b746367261c3e2a058eeeec54ff23b53/lib/dialects/abstract/query-generator.js#L349
