### PR TITLE
fix(describetable): support string length for char in mssql

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -173,7 +173,7 @@ class Query extends AbstractQuery {
         };
 
         if (
-          result[_result.Name].type.includes('VARCHAR')
+          result[_result.Name].type.includes('CHAR')
           && _result.Length
         ) {
           if (_result.Length === -1) {

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -95,4 +95,17 @@ if (dialect.match(/^mssql/)) {
       });
     });
   });
+
+  it('sets the char(10) length correctly on describeTable', function() {
+    const Users = this.sequelize.define('_Users', {
+      username: Sequelize.CHAR(10)
+    }, { freezeTableName: true });
+
+    return Users.sync({ force: true }).then(() => {
+      return this.sequelize.getQueryInterface().describeTable('_Users').then(metadata => {
+        const username = metadata.username;
+        expect(username.type).to.include('(10)');
+      });
+    });
+  });
 }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Add length to `CHAR` and `NCHAR` fields in MSSQL's `describeTable` function.

<!-- Please provide a description of the change here. -->
