### PR TITLE
chore(probot-stale): temporarily disable

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,10 +2,12 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 90
+# daysUntilStale: 90
+daysUntilStale: 900000 # Temporarilty disable probot-stale
 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+# daysUntilClose: 7
+daysUntilClose: 70000 # Temporarilty disable probot-stale
 
 # Issues with these labels will never be considered stale
 exemptLabels:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -3,11 +3,11 @@
 
 # Number of days of inactivity before an issue becomes stale
 # daysUntilStale: 90
-daysUntilStale: 900000 # Temporarilty disable probot-stale
+daysUntilStale: 900000 # Temporarily disable
 
 # Number of days of inactivity before a stale issue is closed
 # daysUntilClose: 7
-daysUntilClose: 70000 # Temporarilty disable probot-stale
+daysUntilClose: 70000 # Temporarily disable
 
 # Issues with these labels will never be considered stale
 exemptLabels:

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -10,12 +10,12 @@ daysUntilClose: 7
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
-  - feature
-  - documentation
-  - bug
+  - type: feature
+  - type: docs
+  - type: bug
   - discussion
-  - performance
-  - semver:major
+  - type: performance
+  - breaking change
   - good first issue
   - suggestion
 


### PR DESCRIPTION
<s>Fix probot-stale config after I renamed some labels.</s>

EDIT: I think temporarily disabling is better, once the new labels are settled we can activate it again.