### PR TITLE
chore(.github): ignored issue template reply

### DIFF
--- a/.github/IssueTemplateIgnored.md
+++ b/.github/IssueTemplateIgnored.md
@@ -1,0 +1,7 @@
+Sequelize requires you to [file new issues](https://github.com/sequelize/sequelize/issues/new/choose) with specific [issue templates](https://github.com/sequelize/sequelize/blob/master/.github/ISSUE_TEMPLATE). Please don't ignore our [contribution guidelines](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md#issues) and template structure. They help us quickly triage issues. Although we would like to help everyone, our time is finite.
+
+Note that this issue will be closed for not following the issue template. You may open a new issue or update this one with correct template. You can add any additional information to your issue.
+
+----------------------------
+
+Please use Github Issue Tracker only for reporting bugs, requesting new features or discussions. Ask questions on [StackOverflow](https://stackoverflow.com/) (using the [sequelize.js tag](https://stackoverflow.com/questions/tagged/sequelize.js)) or on [Slack](https://sequelize.slack.com).


### PR DESCRIPTION
My idea is to standardize the reply we shall use for issues that don't follow the template. Just to make it easy for us to copy-paste a standard response instead of writing it down every time.

I based it on the latest one used by @sushantdhiman, with minor changes.

What do you think? @sushantdhiman @SimonSchick @eseliger 

I also plan on updating the Issue Template to clarify the need for SSCCE/MCVEs.