### PR TITLE
fix(search_path): disable bindParam in updateQuery

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -333,12 +333,18 @@ class QueryGenerator {
 
     const values = [];
     const bind = [];
-    const bindParam = options.bindParam === undefined ? this.bindParam(bind) : options.bindParam;
     const modelAttributeMap = {};
     let outputFragment ='';
     let tmpTable = '';        // tmpTable declaration for trigger
     let selectFromTmp = '';   // Select statement for trigger
     let suffix = '';
+
+    if (_.get(this, ['sequelize', 'options', 'dialectOptions', 'prependSearchPath']) || options.searchPath) {
+      // Not currently supported with search path (requires output of multiple queries)
+      options.bindParam = false;
+    }
+
+    const bindParam = options.bindParam === undefined ? this.bindParam(bind) : options.bindParam;
 
     if (this._dialect.supports['LIMIT ON UPDATE'] && options.limit) {
       if (this.dialect !== 'mssql') {

--- a/test/integration/model/searchPath.test.js
+++ b/test/integration/model/searchPath.test.js
@@ -467,6 +467,40 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             });
         });
       });
+
+      describe('Edit data via instance.update, retrieve updated instance via model.findAll', () => {
+        it('should be able to update data via instance update in both schemas, and retrieve it via findAll with where', function() {
+          const Restaurant = this.Restaurant;
+
+          return Promise.all([
+            Restaurant.create({ foo: 'one', bar: '1' }, { searchPath: SEARCH_PATH_ONE })
+              .then(rnt => rnt.update({ bar: 'x.1' }, { searchPath: SEARCH_PATH_ONE })),
+            Restaurant.create({ foo: 'one', bar: '2' }, { searchPath: SEARCH_PATH_ONE })
+              .then(rnt => rnt.update({ bar: 'x.2' }, { searchPath: SEARCH_PATH_ONE })),
+            Restaurant.create({ foo: 'two', bar: '1' }, { searchPath: SEARCH_PATH_TWO })
+              .then(rnt => rnt.update({ bar: 'x.1' }, { searchPath: SEARCH_PATH_TWO })),
+            Restaurant.create({ foo: 'two', bar: '2' }, { searchPath: SEARCH_PATH_TWO })
+              .then(rnt => rnt.update({ bar: 'x.2' }, { searchPath: SEARCH_PATH_TWO }))
+          ]).then(() => Promise.all([
+            Restaurant.findAll({
+              where: { bar: 'x.1' },
+              searchPath: SEARCH_PATH_ONE
+            }).then(restaurantsOne => {
+              expect(restaurantsOne.length).to.equal(1);
+              expect(restaurantsOne[0].foo).to.equal('one');
+              expect(restaurantsOne[0].bar).to.equal('x.1');
+            }),
+            Restaurant.findAll({
+              where: { bar: 'x.2' },
+              searchPath: SEARCH_PATH_TWO
+            }).then(restaurantsTwo => {
+              expect(restaurantsTwo.length).to.equal(1);
+              expect(restaurantsTwo[0].foo).to.equal('two');
+              expect(restaurantsTwo[0].bar).to.equal('x.2');
+            })
+          ]));
+        });
+      });
     });
   }
 });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Should close issue #10875 

Disable `bindParam` in `updateQuery` when `searchPath` is used. Similar to how [insertQuery](https://github.com/sequelize/sequelize/blob/master/lib/dialects/abstract/query-generator.js#L168) handles `searchPath`