### PR TITLE
feat(postgres): native updateOnConflict for upsert

### DIFF
--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -7,7 +7,6 @@ AbstractDialect.prototype.supports = {
   'DEFAULT VALUES': false,
   'VALUES ()': false,
   'LIMIT ON UPDATE': false,
-  'ON DUPLICATE KEY': true,
   'ORDER NULLS': false,
   'UNION': true,
   'UNION ALL': true,

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -3,7 +3,6 @@
 const util = require('util');
 const _ = require('lodash');
 const uuidv4 = require('uuid/v4');
-const semver = require('semver');
 
 const Utils = require('../../utils');
 const deprecations = require('../../utils/deprecations');
@@ -170,11 +169,6 @@ class QueryGenerator {
       options.bindParam = false;
     }
 
-    if (this._dialect.supports.EXCEPTION && options.exception) {
-      // Not currently supported with bind parameters (requires output of multiple queries)
-      options.bindParam = false;
-    }
-
     valueHash = Utils.removeNullValuesFromHash(valueHash, this.options.omitNull);
     for (const key in valueHash) {
       if (Object.prototype.hasOwnProperty.call(valueHash, key)) {
@@ -203,6 +197,10 @@ class QueryGenerator {
         }
       }
     }
+    let updateOnDuplicate ='';
+    if (!options.ignoreDuplicates && options.onDuplicate && this._dialect.supports.inserts.updateOnDuplicate) {
+      updateOnDuplicate = options.onDuplicate;
+    }
 
     const replacements = {
       ignoreDuplicates: options.ignoreDuplicates ? this._dialect.supports.inserts.ignoreDuplicates : '',
@@ -210,32 +208,21 @@ class QueryGenerator {
       attributes: fields.join(','),
       output: outputFragment,
       values: values.join(','),
-      tmpTable
+      tmpTable,
+      updateOnDuplicate
     };
 
-    valueQuery = `${tmpTable}INSERT${replacements.ignoreDuplicates} INTO ${quotedTable} (${replacements.attributes})${replacements.output} VALUES (${replacements.values})${replacements.onConflictDoNothing}${valueQuery}`;
-    emptyQuery = `${tmpTable}INSERT${replacements.ignoreDuplicates} INTO ${quotedTable}${replacements.output}${replacements.onConflictDoNothing}${emptyQuery}`;
 
-    if (this._dialect.supports.EXCEPTION && options.exception) {
-      // Mostly for internal use, so we expect the user to know what he's doing!
-      // pg_temp functions are private per connection, so we never risk this function interfering with another one.
-      if (semver.gte(this.sequelize.options.databaseVersion, '9.2.0')) {
-        // >= 9.2 - Use a UUID but prefix with 'func_' (numbers first not allowed)
-        const delimiter = `$func_${uuidv4().replace(/-/g, '')}$`;
+    valueQuery = `${tmpTable}INSERT${replacements.ignoreDuplicates} INTO ${quotedTable} (${replacements.attributes})${replacements.output} VALUES (${replacements.values})${replacements.onConflictDoNothing}${replacements.updateOnDuplicate}${valueQuery}`;
+    emptyQuery = `${tmpTable}INSERT${replacements.ignoreDuplicates} INTO ${quotedTable}${replacements.output}${replacements.onConflictDoNothing}${replacements.updateOnDuplicate}${emptyQuery}`;
 
-        options.exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
-        valueQuery = `${`CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response ${quotedTable}, OUT sequelize_caught_exception text) RETURNS RECORD AS ${delimiter}` +
-        ' BEGIN '}${valueQuery} INTO response; EXCEPTION ${options.exception} END ${delimiter
-        } LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()`;
-      } else {
-        options.exception = 'WHEN unique_violation THEN NULL;';
-        valueQuery = `CREATE OR REPLACE FUNCTION pg_temp.testfunc() RETURNS SETOF ${quotedTable} AS $body$ BEGIN RETURN QUERY ${valueQuery}; EXCEPTION ${options.exception} END; $body$ LANGUAGE plpgsql; SELECT * FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc();`;
-      }
-    }
+    if (options.customizePostgresUniqueErrorWithTempFunction) {
+      const delimiter = `$func_${uuidv4().replace(/-/g, '')}$`;
 
-    if (this._dialect.supports['ON DUPLICATE KEY'] && options.onDuplicate) {
-      valueQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
-      emptyQuery += ` ON DUPLICATE KEY ${options.onDuplicate}`;
+      const exception = 'WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL;';
+      valueQuery = `${`CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response ${quotedTable}, OUT sequelize_caught_exception text) RETURNS RECORD AS ${delimiter}` +
+      ' BEGIN '}${valueQuery} INTO response; EXCEPTION ${exception} END ${delimiter
+      } LANGUAGE plpgsql; SELECT (testfunc.response).*, testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc()`;
     }
 
     query = `${replacements.attributes.length ? valueQuery : emptyQuery};`;
@@ -243,7 +230,6 @@ class QueryGenerator {
       query = `SET IDENTITY_INSERT ${quotedTable} ON; ${query} SET IDENTITY_INSERT ${quotedTable} OFF;`;
     }
 
-    // Used by Postgres upsertQuery and calls to here with options.exception set to true
     const result = { query };
     if (options.bindParam !== false) {
       result.bind = bind;
@@ -300,7 +286,7 @@ class QueryGenerator {
     }
 
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
-      if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres
+      if (this._dialect.name === 'postgres') {
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
@@ -433,7 +419,6 @@ class QueryGenerator {
     }
 
     const query = `${tmpTable}UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')}${outputFragment} ${this.whereQuery(where, whereOptions)}${suffix}`.trim();
-    // Used by Postgres upsertQuery and calls to here with options.exception set to true
     const result = { query };
     if (options.bindParam !== false) {
       result.bind = bind;

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -279,7 +279,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
   }
 
   upsertQuery(tableName, insertValues, updateValues, where, model, options) {
-    options.onDuplicate = 'UPDATE ';
+    options.onDuplicate = ' ON DUPLICATE KEY UPDATE ';
 
     options.onDuplicate += Object.keys(updateValues).map(key => {
       key = this.quoteIdentifier(key);

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -21,8 +21,6 @@ class PostgresDialect extends AbstractDialect {
 
 PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype.supports), {
   'DEFAULT VALUES': true,
-  'EXCEPTION': true,
-  'ON DUPLICATE KEY': false,
   'ORDER NULLS': true,
   returnValues: {
     returning: true
@@ -58,7 +56,7 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
   searchPath: true
 });
 
-ConnectionManager.prototype.defaultVersion = '9.4.0';
+ConnectionManager.prototype.defaultVersion = '9.5.0';
 PostgresDialect.prototype.Query = Query;
 PostgresDialect.prototype.DataTypes = DataTypes;
 PostgresDialect.prototype.name = 'postgres';

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -332,31 +332,29 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     return `CREATE OR REPLACE FUNCTION pg_temp.${fnName}(${parameters}) ${returns} AS $func$ BEGIN ${body} END; $func$ LANGUAGE ${language}; SELECT * FROM pg_temp.${fnName}();`;
   }
 
-  exceptionFn(fnName, tableName, parameters, main, then, when, returns, language) {
-    when = when || 'unique_violation';
-
-    const body = `${main} EXCEPTION WHEN ${when} THEN ${then};`;
-
-    return this.fn(fnName, tableName, parameters, body, returns, language);
-  }
-
   upsertQuery(tableName, insertValues, updateValues, where, model, options) {
     const primaryField = this.quoteIdentifier(model.primaryKeyField);
+    // TODO use where for on conflict ?
+    //      [ { user_id: 42 }, { foo: 'first' } ]
+    let upsertKeys = _.chain(model.primaryKeys).values().map('fieldName').value();
+    if (Object.keys(model.primaryKeys).length === 0 && Object.keys(model.uniqueKeys).length > 0) {
+      upsertKeys = _.chain(model.uniqueKeys).values().map('fields').value();
+    }
+    options.onDuplicate = ` ON CONFLICT (${upsertKeys.map(attr => this.quoteIdentifier(attr)).join(', ')}) DO UPDATE SET `;
 
-    const upsertOptions = _.defaults({ bindParam: false }, options);
-    const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, upsertOptions);
-    const update = this.updateQuery(tableName, updateValues, where, upsertOptions, model.rawAttributes);
+    options.onDuplicate += Object.keys(updateValues)
+      .filter(key => !upsertKeys.includes(`${key}`))
+      .map(key => {
+        key = this.quoteIdentifier(key);
+        return `${key}=EXCLUDED.${key}`;
+      })
+      .join(', ');
 
-    insert.query = insert.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
-    update.query = update.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
+    options.returning = true;
+    const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, options);
+    insert.query = insert.query.replace('RETURNING *', `RETURNING ${primaryField} AS primary_key`);
 
-    return this.exceptionFn(
-      'sequelize_upsert',
-      tableName,
-      'OUT created boolean, OUT primary_key text',
-      `${insert.query} created := true;`,
-      `${update.query}; created := false`
-    );
+    return insert;
   }
 
   truncateTableQuery(tableName, options = {}) {
@@ -612,7 +610,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const expandedOptionsArray = this.expandOptions(optionsArray);
     const statement = options && options.force ? 'CREATE OR REPLACE FUNCTION' : 'CREATE FUNCTION';
 
-    return `${statement} ${functionName}(${paramList}) RETURNS ${returnType} AS $func$ ${variableList} BEGIN ${body} END; $func$ language '${language}'${expandedOptionsArray};`;
+    return `${statement} ${functionName}(${paramList}) RETURNS ${returnType} AS $func$ BEGIN ${body} END; $func$ language '${language}'${expandedOptionsArray};`;
   }
 
   dropFunction(functionName, params) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -2324,7 +2324,10 @@ class Model {
         values = Utils.defaults(values, options.where);
       }
 
-      options.exception = true;
+      if (this.sequelize.options.dialect === 'postgres') {
+        options.customizePostgresUniqueErrorWithTempFunction = true;
+        options.bindParam = false;
+      }
 
       return this.create(values, options).then(instance => {
         if (instance.get(this.primaryKeyAttribute, { raw: true }) === null) {
@@ -2415,7 +2418,7 @@ class Model {
    * **Implementation details:**
    *
    * * MySQL - Implemented as a single query `INSERT values ON DUPLICATE KEY UPDATE values`
-   * * PostgreSQL - Implemented as a temporary function with exception handling: INSERT EXCEPTION WHEN unique_constraint UPDATE
+   * * PostgreSQL - Implemented INSERT values ON CONFLICT (Pk) DO UPDATE updated_fields
    * * SQLite - Implemented as two queries `INSERT; UPDATE`. This means that the update is executed regardless of whether the row already existed or not
    * * MSSQL - Implemented as a single query using `MERGE` and `WHEN (NOT) MATCHED THEN`
    * **Note** that SQLite returns undefined for created, no matter if the row was created or updated. This is because SQLite always runs INSERT OR IGNORE + UPDATE, in a single query, so there is no way to know whether the row was inserted or not.
@@ -2491,7 +2494,6 @@ class Model {
           if (options.returning === true && primaryKey) {
             return this.findByPk(primaryKey, options).then(record => [record, created]);
           }
-
           return created;
         })
         .tap(result => {

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -949,7 +949,8 @@ class QueryInterface {
     return this.sequelize.query(sql, options).then(result => {
       switch (this.sequelize.options.dialect) {
         case 'postgres':
-          return [result.created, result.primary_key];
+          // With ON CONFLICT UPDATE, it always insert
+          return [true, result.primary_key];
 
         case 'mssql':
           return [


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

replace the function to catch exception on existing element for upsert method with Postgres by the native method ON CONFLICT () UPDATE SET, it is supported by postgres >= 9.5, is this blocking ?

Closes #4132