### PR TITLE
Fix: postgresql's ensureEnums (#11053)

### DIFF
--- a/lib/dialects/postgres/query-interface.js
+++ b/lib/dialects/postgres/query-interface.js
@@ -74,6 +74,20 @@ function ensureEnums(qi, tableName, attributes, options, model) {
           const enumVals = qi.QueryGenerator.fromArray(results[enumIdx].enum_value);
           const vals = enumType.values;
 
+          console.log('already exists', enumVals)
+          console.log('new values', vals)
+
+          enumVals.forEach((value, idx) => {
+            const index = vals.indexOf(value);
+            if (idx === 0) {
+              // first value in existing enum array
+              if (index > 0) {
+                // this value isn't first anymore, we need to append values before this one in reverse order
+              }
+            } else {
+            }
+          })
+
           vals.forEach((value, idx) => {
             // reset out after/before options since it's for every enum value
             const valueOptions = _.clone(options);

--- a/lib/dialects/postgres/query-interface.js
+++ b/lib/dialects/postgres/query-interface.js
@@ -63,11 +63,11 @@ function ensureEnums(qi, tableName, attributes, options, model) {
       switch (position) {
         case 'after':
           valueOptions.after = relativeValue;
-          break
+          break;
         case 'before':
         default:
           valueOptions.before = relativeValue;
-          break
+          break;
       }
 
       promises.splice(spliceStart, 0, () => {
@@ -75,7 +75,7 @@ function ensureEnums(qi, tableName, attributes, options, model) {
           tableName, field, value, valueOptions
         ), valueOptions);
       });
-    }
+    };
 
     for (i = 0; i < keyLen; i++) {
       const attribute = attributes[keys[i]];
@@ -89,8 +89,9 @@ function ensureEnums(qi, tableName, attributes, options, model) {
       ) {
         // If the enum type doesn't exist then create it
         if (!results[enumIdx]) {
-          sql = qi.QueryGenerator.pgEnum(tableName, field, enumType, options);
-          promises.push(() => qi.sequelize.query(sql, Object.assign({}, options, { raw: true })));
+          promises.push(() => {
+            return qi.sequelize.query(qi.QueryGenerator.pgEnum(tableName, field, enumType, options), Object.assign({}, options, { raw: true }));
+          });
         } else if (!!results[enumIdx] && !!model) {
           const enumVals = qi.QueryGenerator.fromArray(results[enumIdx].enum_value);
           const vals = enumType.values;
@@ -103,27 +104,29 @@ function ensureEnums(qi, tableName, attributes, options, model) {
           // E.g.: [1] -> [0,2,3] ==> [1,0,2,3]
           let lastOldEnumValue;
           let rightestPosition = -1;
-          for (let enumIdx = 0; enumIdx < enumVals.length; enumIdx++) {
-            const enumVal = enumVals[enumIdx];
+          for (let oldIndex = 0; oldIndex < enumVals.length; oldIndex++) {
+            const enumVal = enumVals[oldIndex];
             const newIdx = vals.indexOf(enumVal);
             lastOldEnumValue = enumVal;
 
-            if (newIdx > -1) {
-              const newValuesBefore = vals.slice(0, newIdx);
-              const promisesLength = promises.length;
-              // we go in reverse order so we could stop when we meet old value
-              for (let reverseIdx = newValuesBefore.length - 1; reverseIdx >= 0; reverseIdx--) {
-                if (~enumVals.indexOf(newValuesBefore[reverseIdx])) {
-                  break
-                }
+            if (newIdx === -1) {
+              continue;
+            }
 
-                addEnumValue(field, newValuesBefore[reverseIdx], lastOldEnumValue, 'before', promisesLength);
+            const newValuesBefore = vals.slice(0, newIdx);
+            const promisesLength = promises.length;
+            // we go in reverse order so we could stop when we meet old value
+            for (let reverseIdx = newValuesBefore.length - 1; reverseIdx >= 0; reverseIdx--) {
+              if (~enumVals.indexOf(newValuesBefore[reverseIdx])) {
+                break;
               }
 
-              // we detect the most 'right' position of old value in new enum array so we can append new values to it
-              if (newIdx > rightestPosition) {
-                rightestPosition = newIdx;
-              }
+              addEnumValue(field, newValuesBefore[reverseIdx], lastOldEnumValue, 'before', promisesLength);
+            }
+
+            // we detect the most 'right' position of old value in new enum array so we can append new values to it
+            if (newIdx > rightestPosition) {
+              rightestPosition = newIdx;
             }
           }
 

--- a/lib/dialects/postgres/query-interface.js
+++ b/lib/dialects/postgres/query-interface.js
@@ -54,10 +54,34 @@ function ensureEnums(qi, tableName, attributes, options, model) {
     promises = [];
     let enumIdx = 0;
 
+    // This little function allows us to re-use the same code that prepends or appends new value to enum array
+    const addEnumValue = (field, value, relativeValue, position = 'before', spliceStart = promises.length) => {
+      const valueOptions = _.clone(options);
+      valueOptions.before = null;
+      valueOptions.after = null;
+
+      switch (position) {
+        case 'after':
+          valueOptions.after = relativeValue;
+          break
+        case 'before':
+        default:
+          valueOptions.before = relativeValue;
+          break
+      }
+
+      promises.splice(spliceStart, 0, () => {
+        return qi.sequelize.query(qi.QueryGenerator.pgEnumAdd(
+          tableName, field, value, valueOptions
+        ), valueOptions);
+      });
+    }
+
     for (i = 0; i < keyLen; i++) {
       const attribute = attributes[keys[i]];
       const type = attribute.type;
       const enumType = type.type || type;
+      const field = attribute.field || keys[i];
 
       if (
         type instanceof DataTypes.ENUM ||
@@ -65,52 +89,58 @@ function ensureEnums(qi, tableName, attributes, options, model) {
       ) {
         // If the enum type doesn't exist then create it
         if (!results[enumIdx]) {
-          sql = qi.QueryGenerator.pgEnum(tableName, attribute.field || keys[i], enumType, options);
-          promises.push(qi.sequelize.query(
-            sql,
-            Object.assign({}, options, { raw: true })
-          ));
+          sql = qi.QueryGenerator.pgEnum(tableName, field, enumType, options);
+          promises.push(() => qi.sequelize.query(sql, Object.assign({}, options, { raw: true })));
         } else if (!!results[enumIdx] && !!model) {
           const enumVals = qi.QueryGenerator.fromArray(results[enumIdx].enum_value);
           const vals = enumType.values;
 
-          console.log('already exists', enumVals)
-          console.log('new values', vals)
+          // Going through already existing values allows us to make queries that depend on those values
+          // We will prepend all new values between the old ones, but keep in mind - we can't change order of already existing values
+          // Then we append the rest of new values AFTER the latest already existing value
+          // E.g.: [1,2] -> [0,2,1] ==> [1,0,2]
+          // E.g.: [1,2,3] -> [2,1,3,4] ==> [1,2,3,4]
+          // E.g.: [1] -> [0,2,3] ==> [1,0,2,3]
+          let lastOldEnumValue;
+          let rightestPosition = -1;
+          for (let enumIdx = 0; enumIdx < enumVals.length; enumIdx++) {
+            const enumVal = enumVals[enumIdx];
+            const newIdx = vals.indexOf(enumVal);
+            lastOldEnumValue = enumVal;
 
-          enumVals.forEach((value, idx) => {
-            const index = vals.indexOf(value);
-            if (idx === 0) {
-              // first value in existing enum array
-              if (index > 0) {
-                // this value isn't first anymore, we need to append values before this one in reverse order
+            if (newIdx > -1) {
+              const newValuesBefore = vals.slice(0, newIdx);
+              const promisesLength = promises.length;
+              // we go in reverse order so we could stop when we meet old value
+              for (let reverseIdx = newValuesBefore.length - 1; reverseIdx >= 0; reverseIdx--) {
+                if (~enumVals.indexOf(newValuesBefore[reverseIdx])) {
+                  break
+                }
+
+                addEnumValue(field, newValuesBefore[reverseIdx], lastOldEnumValue, 'before', promisesLength);
               }
-            } else {
+
+              // we detect the most 'right' position of old value in new enum array so we can append new values to it
+              if (newIdx > rightestPosition) {
+                rightestPosition = newIdx;
+              }
             }
-          })
+          }
 
-          vals.forEach((value, idx) => {
-            // reset out after/before options since it's for every enum value
-            const valueOptions = _.clone(options);
-            valueOptions.before = null;
-            valueOptions.after = null;
-
-            if (!enumVals.includes(value)) {
-              if (vals[idx + 1]) {
-                valueOptions.before = vals[idx + 1];
-              }
-              else if (vals[idx - 1]) {
-                valueOptions.after = vals[idx - 1];
-              }
-              valueOptions.supportsSearchPath = false;
-              promises.push(qi.sequelize.query(qi.QueryGenerator.pgEnumAdd(tableName, attribute.field || keys[i], value, valueOptions), valueOptions));
+          if (lastOldEnumValue && rightestPosition < vals.length - 1) {
+            const remainingEnumValues = vals.slice(rightestPosition + 1);
+            for (let reverseIdx = remainingEnumValues.length - 1; reverseIdx >= 0; reverseIdx--) {
+              addEnumValue(field, remainingEnumValues[reverseIdx], lastOldEnumValue, 'after');
             }
-          });
+          }
+
           enumIdx++;
         }
       }
     }
 
-    return Promise.all(promises)
+    return promises
+      .reduce((promise, asyncFunction) => promise.then(asyncFunction), Promise.resolve())
       .tap(() => {
         // If ENUM processed, then refresh OIDs
         if (promises.length) {

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -367,6 +367,25 @@ if (dialect.match(/^postgres/)) {
         });
       });
 
+      it('should be able to add multiple values with different order', function() {
+        let User = this.sequelize.define('UserEnums', {
+          priority: DataTypes.ENUM('1', '2', '6')
+        });
+
+        return User.sync({ force: true }).then(() => {
+          User = this.sequelize.define('UserEnums', {
+            priority: DataTypes.ENUM('0', '1', '2', '3', '4', '5', '6', '7')
+          });
+
+          return User.sync();
+        }).then(() => {
+          return this.sequelize.getQueryInterface().pgListEnums(User.getTableName());
+        }).then(enums => {
+          expect(enums).to.have.length(1);
+          expect(enums[0].enum_value).to.equal('{0,1,2,3,4,5,6,7}');
+        });
+      });
+
       describe('ARRAY(ENUM)', () => {
         it('should be able to ignore enum types that already exist', function() {
           const User = this.sequelize.define('UserEnums', {

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -92,52 +92,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       });
     });
 
-    it('should work with enums (1)', function() {
-      return this.queryInterface.createTable('SomeTable', {
-        someEnum: DataTypes.ENUM('value1', 'value2', 'value3')
-      });
-    });
-
-    it('should work with enums (2)', function() {
-      return this.queryInterface.createTable('SomeTable', {
-        someEnum: {
-          type: DataTypes.ENUM,
-          values: ['value1', 'value2', 'value3']
-        }
-      });
-    });
-
-    it('should work with enums (3)', function() {
-      return this.queryInterface.createTable('SomeTable', {
-        someEnum: {
-          type: DataTypes.ENUM,
-          values: ['value1', 'value2', 'value3'],
-          field: 'otherName'
-        }
-      });
-    });
-
-    it('should work with enums (4)', function() {
-      return this.queryInterface.createSchema('archive').then(() => {
-        return this.queryInterface.createTable('SomeTable', {
-          someEnum: {
-            type: DataTypes.ENUM,
-            values: ['value1', 'value2', 'value3'],
-            field: 'otherName'
-          }
-        }, { schema: 'archive' });
-      });
-    });
-
-    it('should work with enums (5)', function() {
-      return this.queryInterface.createTable('SomeTable', {
-        someEnum: {
-          type: DataTypes.ENUM(['COMMENT']),
-          comment: 'special enum col'
-        }
-      });
-    });
-
     it('should work with schemas', function() {
       return this.sequelize.createSchema('hero').then(() => {
         return this.queryInterface.createTable('User', {
@@ -146,6 +100,85 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           }
         }, {
           schema: 'hero'
+        });
+      });
+    });
+
+    describe('enums', () => {
+      it('should work with enums (1)', function() {
+        return this.queryInterface.createTable('SomeTable', {
+          someEnum: DataTypes.ENUM('value1', 'value2', 'value3')
+        }).then(() => {
+          return this.queryInterface.describeTable('SomeTable');
+        }).then(table => {
+          if (dialect.includes('postgres')) {
+            expect(table.someEnum.special).to.deep.equal(['value1', 'value2', 'value3']);
+          }
+        });
+      });
+
+      it('should work with enums (2)', function() {
+        return this.queryInterface.createTable('SomeTable', {
+          someEnum: {
+            type: DataTypes.ENUM,
+            values: ['value1', 'value2', 'value3']
+          }
+        }).then(() => {
+          return this.queryInterface.describeTable('SomeTable');
+        }).then(table => {
+          if (dialect.includes('postgres')) {
+            expect(table.someEnum.special).to.deep.equal(['value1', 'value2', 'value3']);
+          }
+        });
+      });
+
+      it('should work with enums (3)', function() {
+        return this.queryInterface.createTable('SomeTable', {
+          someEnum: {
+            type: DataTypes.ENUM,
+            values: ['value1', 'value2', 'value3'],
+            field: 'otherName'
+          }
+        }).then(() => {
+          return this.queryInterface.describeTable('SomeTable');
+        }).then(table => {
+          if (dialect.includes('postgres')) {
+            expect(table.otherName.special).to.deep.equal(['value1', 'value2', 'value3']);
+          }
+        });
+      });
+
+      it('should work with enums (4)', function() {
+        return this.queryInterface.createSchema('archive').then(() => {
+          return this.queryInterface.createTable('SomeTable', {
+            someEnum: {
+              type: DataTypes.ENUM,
+              values: ['value1', 'value2', 'value3'],
+              field: 'otherName'
+            }
+          }, { schema: 'archive' });
+        }).then(() => {
+          return this.queryInterface.describeTable('SomeTable', { schema: 'archive' });
+        }).then(table => {
+          if (dialect.includes('postgres')) {
+            expect(table.otherName.special).to.deep.equal(['value1', 'value2', 'value3']);
+          }
+        });
+      });
+
+      it('should work with enums (5)', function() {
+        return this.queryInterface.createTable('SomeTable', {
+          someEnum: {
+            type: DataTypes.ENUM(['COMMENT']),
+            comment: 'special enum col'
+          }
+        }).then(() => {
+          return this.queryInterface.describeTable('SomeTable');
+        }).then(table => {
+          if (dialect.includes('postgres')) {
+            expect(table.someEnum.special).to.deep.equal(['COMMENT']);
+            expect(table.someEnum.comment).to.equal('special enum col');
+          }
         });
       });
     });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

*I am sorry, I wasn't able to run `npm run test` or `npm run test-DIALECT` on my local machine, nor did I added any new tests or even followed 'commit message conventions'. My bad.*

*I tested this solution locally on two arrays with various values, all got me right results. I also tested it on my local postgres database on real project, which also worked just fine.*

**Please, feel free to help me make this Pull Request look good and be merged**

---

### Description of change

Fixes #11053

The following is an attempt to explain how my solution works:

General idea is to use already existing values of enum type as a reference for new values. Previous (and currently active) version has some flaws, like referring non-existent values and some sort of 'race condition' from using Promise.all. You may check issue #11053 for more details.

Current implementation intent is to avoid those flaws by:
1. Going through already existing values
2. Using waterfall-like promise resolving

**Going through already existing values:**  

Let us have an existing enum array `[1,2]` and we want to make it look like `[4,3,2,6,1,0,5]`.  
Assuming we cannot change order of already existing values, ideal result should look like this: `[6,1,4,3,2,0,5]`  
To achieve this result, we must go through values `[1,2]` and find every new value that prepends it. 

We find position in new array for each old value, which is idx `4` for `1` and `2` for `2`. Then we get as many values on the left side as we can and going through them in reverse to find only *new* values that prepends current.

For value `1` its `[4,3,2,6]`, reversed `[6,2,3,4]` and new value is `[6]`
For value `2` its `[4,3]` which gives us `[3,4]` as result

Next trick is to add SQL query for each new value in right order, so we use `promises.splice(capturedPromiseLength, 0, asyncFunction)` to 'reverse-push' values.  
That way we added all 'left-side' values using BEFORE and referring already existing values.

For the rest of new values on the right side, we just use `slice(indexOfDextralOldValueInNewArray)` and then going through resulting array in reverse order we push values in `promise` array. The reverse order is needed because we use AFTER, so appending `[1,2]` to `0` needs to be a sequence of `ADD 2 AFTER 0` and `ADD 1 AFTER 0`.

**Using waterfall-like promise resolving**

Since `Promise.all` does not guarantee execution order and creates a 'race condition' for ENUM altering, we switch to 'waterfall' system, where we attach a function that returns Promise (basically, an async function) to previous Promise, using `then` method.  
As a result we're getting something like this:
`Promise.resolve().then(() => sequelize.query()).then(() => sequelize.query()) ... .tap(...)`