### PR TITLE
fix(mssql): save number bigger than 2147483647

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -19,7 +19,11 @@ class Query extends AbstractQuery {
     paramType.type = TYPES.NVarChar;
     if (typeof value === 'number') {
       if (Number.isInteger(value)) {
-        paramType.type = TYPES.Int;
+        if (value >= -2147483648 && value <= 2147483647) {
+          paramType.type = TYPES.Int;
+        } else {
+          paramType.type = TYPES.BigInt;
+        }
       } else {
         paramType.type = TYPES.Numeric;
         //Default to a reasonable numeric precision/scale pending more sophisticated logic

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -108,4 +108,33 @@ if (dialect.match(/^mssql/)) {
       });
     });
   });
+
+  it('saves value bigger than 2147483647, #11245', function() {
+    const BigIntTable =  this.sequelize.define('BigIntTable', {
+      business_id: {
+        type: Sequelize.BIGINT,
+        allowNull: false
+      }
+    }, {
+      freezeTableName: true
+    });
+
+    const bigIntValue = 2147483648;
+
+    return BigIntTable.sync({ force: true })
+      .then(() => {
+        return BigIntTable.create({
+          business_id: bigIntValue
+        });
+      })
+      .then(() => {
+        return BigIntTable.findAll({
+          where: {}
+        });
+      })
+      .then(records => {
+        expect(records).to.have.lengthOf(1);
+        expect(Number(records[0].business_id)).to.equals(bigIntValue);
+      });
+  });
 }

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -127,14 +127,9 @@ if (dialect.match(/^mssql/)) {
           business_id: bigIntValue
         });
       })
-      .then(() => {
-        return BigIntTable.findAll({
-          where: {}
-        });
-      })
-      .then(records => {
-        expect(records).to.have.lengthOf(1);
-        expect(Number(records[0].business_id)).to.equals(bigIntValue);
+      .then(() => BigIntTable.findOne())
+      .then(record => {
+        expect(Number(record.business_id)).to.equals(bigIntValue);
       });
   });
 }


### PR DESCRIPTION
 <!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Pull request to address issue #11245 . This change fixes issue in mssql dialect allowing to save a number bigger than 2147483647 into a column with BIGINT type.
<!-- Please provide a description of the change here. -->
