### PR TITLE
fix(import): add missing Model in Sequelize prototype

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1261,6 +1261,7 @@ Sequelize.prototype.or = Sequelize.or;
 Sequelize.prototype.json = Sequelize.json;
 Sequelize.prototype.where = Sequelize.where;
 Sequelize.prototype.validate = Sequelize.prototype.authenticate;
+Sequelize.prototype.Model = Model;
 
 /**
  * Sequelize version number.

--- a/test/integration/assets/project.js
+++ b/test/integration/assets/project.js
@@ -1,7 +1,12 @@
 'use strict';
 
-module.exports = function(sequelize, DataTypes) {
-  return sequelize.define(`Project${parseInt(Math.random() * 9999999999999999, 10)}`, {
-    name: DataTypes.STRING
-  });
+module.exports = (sequelize, DataTypes) => {
+  class Project extends sequelize.Model { }
+
+  Project.init({
+    name: DataTypes.STRING,
+    description: DataTypes.TEXT
+  }, { sequelize, modelName: `Project${parseInt(Math.random() * 9999999999999999, 10)}` });
+
+  return Project;
 };


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
According to discussion on #10622 current example for importing modules from separate files don't work. It's because instance od `Sequelize` don't have `Model` class defined in prototype. [Example of Error](https://github.com/sequelize/sequelize/issues/10622#issuecomment-500492926)

To fix this issue `Model` class was introduced in "Aliases" section of main `sequelize.js` file. It was tested manually and with mocha tests using `DIALECT=mysql npm run test-docker-integration`.

What have been done:
- Extend Sequelize Aliases with Model.
- Modify project.js asset used to test import feature.  It should detect issue if it will appear in again in future.  Also it now reflects example from [documentation](https://sequelize.org/master/manual/models-definition.html#import).
