### PR TITLE
feat(associations): add support for default referential action

### DIFF
--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -23,6 +23,11 @@ const Mixin = {
     // Since this is a mixin, we'll need a unique letiable name for hooks (since Model will override our hooks option)
     options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
     options.useHooks = options.hooks;
+    const assocOptions = this.sequelize.options.associations;
+    if(assocOptions) {
+      options.onDelete = options.onDelete || assocOptions.onDelete;
+      options.onUpdate = options.onUpdate || assocOptions.onUpdate;
+    }
 
     options = Object.assign(options, _.omit(source.options, ['hooks']));
 
@@ -55,6 +60,11 @@ const Mixin = {
     options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
     options.useHooks = options.hooks;
     options.timestamps = options.timestamps === undefined ? this.sequelize.options.timestamps : options.timestamps;
+    const assocOptions = this.sequelize.options.associations;
+    if(assocOptions) {
+      options.onDelete = options.onDelete || assocOptions.onDelete;
+      options.onUpdate = options.onUpdate || assocOptions.onUpdate;
+    }
     options = Object.assign(options, _.omit(source.options, ['hooks', 'timestamps', 'scopes', 'defaultScope']));
 
     if (options.useHooks) {
@@ -97,6 +107,11 @@ function singleLinked(Type) {
     // Since this is a mixin, we'll need a unique letiable name for hooks (since Model will override our hooks option)
     options.hooks = options.hooks === undefined ? false : Boolean(options.hooks);
     options.useHooks = options.hooks;
+    const assocOptions = this.sequelize.options.associations;
+    if(assocOptions) {
+      options.onDelete = options.onDelete || assocOptions.onDelete;
+      options.onUpdate = options.onUpdate || assocOptions.onUpdate;
+    }
 
     if (options.useHooks) {
       source.runHooks('beforeAssociate', { source, target, type: Type }, options);

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -142,6 +142,9 @@ class Sequelize {
    * @param {Object}   [options.define={}] Default options for model definitions. See {@link Model.init}.
    * @param {Object}   [options.query={}] Default options for sequelize.query
    * @param {string}   [options.schema=null] A schema to use
+   * @param {Object}   [options.associations] An object to set the default referential actions
+   * @param {string}   [options.associations.onDelete] Default referential action for `ON DELETE`. The validation options are `RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL`.
+   * @param {string}   [options.associations.onUpdate] Default referential action for `ON UPDATE`. The validation options are `RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL`.
    * @param {Object}   [options.set={}] Default options for sequelize.set
    * @param {Object}   [options.sync={}] Default options for sequelize.sync
    * @param {string}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

Closes #10824

### Description of change

It would be nice to override the "default" referential action for ON UPDATE and ON DELETE when associations are created. It can get annoying to override this behavior for every single association in the database if RESTRICT is the general rule / policy. This could be done in the options Object passed to the new Sequelize instance (see usage example below).

```js
const db = new Sequelize(config.database, config.username, config.password, {
	host: config.host,
	// New `associations` key
	associations: {
		onDelete: 'RESTRICT',
		onUpdate: 'CASCADE',
	}
})
```