### PR TITLE
fix(postgres): schema for index and relations

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -569,6 +569,12 @@ class QueryGenerator {
       options.where = this.whereQuery(options.where);
     }
 
+    if (options.schema) {
+      tableName = {
+        tableName,
+        schema: options.schema
+      };
+    }
     if (typeof tableName === 'string') {
       tableName = this.quoteIdentifiers(tableName);
     } else {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -514,7 +514,11 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.references) {
-      const referencesTable = this.quoteTable(attribute.references.model);
+      let referencesTable = this.quoteTable(attribute.references.model);
+      const tableDetails = this.extractTableDetails(referencesTable, options);
+      if (options.schema) {
+        referencesTable = tableDetails.schema + tableDetails.delimiter + referencesTable;
+      }
       let referencesKey;
 
       if (attribute.references.key) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1362,7 +1362,8 @@ class Model {
           Object.assign({
             logging: options.logging,
             benchmark: options.benchmark,
-            transaction: options.transaction
+            transaction: options.transaction,
+            schema: options.schema
           }, index),
           this.tableName
         ));

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -230,7 +230,10 @@ class QueryInterface {
       });
     }
 
-    attributes = this.QueryGenerator.attributesToSQL(attributes, { table: tableName, context: 'createTable' });
+    attributes = this.QueryGenerator.attributesToSQL(attributes, {
+      table: tableName,
+      context: 'createTable',
+      schema: options.schema });
     sql = this.QueryGenerator.createTableQuery(tableName, attributes, options);
 
     return promise.then(() => this.sequelize.query(sql, options));


### PR DESCRIPTION
Relations and Indexes created from models that have set a schema are not properly prefixed with the schema. This patch solves this.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Add schema prefix where needed.
