### PR TITLE
fix(postgres): schema for index and relations

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -569,6 +569,13 @@ class QueryGenerator {
       options.where = this.whereQuery(options.where);
     }
 
+    if (options.schema) {
+      tableName = {
+        tableName,
+        schema: options.schema
+      };
+    }
+
     if (typeof tableName === 'string') {
       tableName = this.quoteIdentifiers(tableName);
     } else {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -514,7 +514,19 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.references) {
-      const referencesTable = this.quoteTable(attribute.references.model);
+      let referencesTable = this.quoteTable(attribute.references.model);
+      const tableDetails = this.extractTableDetails(referencesTable, options);
+      let schema;
+      if (options.schema) {
+        schema = options.schema;
+      } else if ((!attribute.references.model || typeof attribute.references.model == 'string')
+        && options.table && options.table.schema) {
+        schema = options.table.schema;
+      }
+
+      if (schema) {
+        referencesTable = schema + tableDetails.delimiter + referencesTable;
+      }
       let referencesKey;
 
       if (attribute.references.key) {
@@ -609,7 +621,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
     const paramList = this.expandFunctionParamList(params);
     const expandedOptionsArray = this.expandOptions(optionsArray);
-    
+
     const statement = options && options.force ? 'CREATE OR REPLACE FUNCTION' : 'CREATE FUNCTION';
 
     return `${statement} ${functionName}(${paramList}) RETURNS ${returnType} AS $func$ BEGIN ${body} END; $func$ language '${language}'${expandedOptionsArray};`;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -517,16 +517,21 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       let referencesTable = this.quoteTable(attribute.references.model);
       const tableDetails = this.extractTableDetails(referencesTable, options);
       let schema;
+
       if (options.schema) {
         schema = options.schema;
-      } else if ((!attribute.references.model || typeof attribute.references.model == 'string')
-        && options.table && options.table.schema) {
+      } else if (
+        (!attribute.references.model || typeof attribute.references.model == 'string')
+        && options.table
+        && options.table.schema
+      ) {
         schema = options.table.schema;
       }
 
       if (schema) {
         referencesTable = schema + tableDetails.delimiter + referencesTable;
       }
+
       let referencesKey;
 
       if (attribute.references.key) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1362,7 +1362,8 @@ class Model {
           Object.assign({
             logging: options.logging,
             benchmark: options.benchmark,
-            transaction: options.transaction
+            transaction: options.transaction,
+            schema: options.schema
           }, index),
           this.tableName
         ));


### PR DESCRIPTION
Relations and Indexes created from models that have set a schema are not properly prefixed with the schema. This patch solves this.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

In several cases, the schema prefix was not applied for generated indexes and related tables. This PR fixes this.

Fixes #11276.