### PR TITLE
docs: fix minor typo

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -486,7 +486,7 @@ class Sequelize {
   }
 
   /**
-   * Execute a query on the DB, with the possibility to bypass all the sequelize goodness.
+   * Execute a query on the DB, optionally bypassing all the Sequelize goodness.
    *
    * By default, the function will return two arguments: an array of results, and a metadata object, containing number of affected rows etc.
    *

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1140,7 +1140,7 @@ export class Sequelize extends Hooks {
   ): T;
 
   /**
-   * Execute a query on the DB, with the posibility to bypass all the sequelize goodness.
+   * Execute a query on the DB, optionally bypassing all the Sequelize goodness.
    *
    * By default, the function will return two arguments: an array of results, and a metadata object,
    * containing number of affected rows etc. Use `.then(([...]))` to access the results.


### PR DESCRIPTION
I noticed a typo (`posibility` was written instead of `possibility`) and instead of just fixing it I thought of rewriting the sentence a bit.