### PR TITLE
perf: remove unnecessary cloneDeep calls

### DIFF
--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -180,7 +180,7 @@ class HasMany extends Association {
       instances = undefined;
     }
 
-    options = Utils.cloneDeep(options);
+    options = Object.assign({}, options);
 
     if (this.scope) {
       Object.assign(where, this.scope);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1689,7 +1689,6 @@ class Model {
     this.warnOnInvalidOptions(options, Object.keys(this.rawAttributes));
 
     const tableNames = {};
-    let originalOptions;
 
     tableNames[this.getTableName(options)] = true;
     options = Utils.cloneDeep(options);
@@ -1751,9 +1750,8 @@ class Model {
         return this.runHooks('beforeFindAfterOptions', options);
       }
     }).then(() => {
-      originalOptions = Utils.cloneDeep(options);
-      options.tableNames = Object.keys(tableNames);
-      return this.QueryInterface.select(this, this.getTableName(options), options);
+      const selectOptions = Object.assign({}, options, { tableNames: Object.keys(tableNames) });
+      return this.QueryInterface.select(this, this.getTableName(selectOptions), selectOptions);
     }).tap(results => {
       if (options.hooks) {
         return this.runHooks('afterFind', results, options);
@@ -1771,7 +1769,7 @@ class Model {
         throw new sequelizeErrors.EmptyResultError();
       }
 
-      return Model._findSeparate(results, originalOptions);
+      return Model._findSeparate(results, options);
     });
   }
 

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1112,10 +1112,8 @@ class QueryInterface {
     );
   }
 
-  select(model, tableName, options) {
-    options = Utils.cloneDeep(options);
-    options.type = QueryTypes.SELECT;
-    options.model = model;
+  select(model, tableName, optionsArg) {
+    const options = Object.assign({}, optionsArg, { type: QueryTypes.SELECT, model });
 
     return this.sequelize.query(
       this.QueryGenerator.selectQuery(tableName, options, model),


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

When we do many `findAll` calls, with complex options (many includes, many specific attributes etc), `deepCopy` consumes a lot of CPU. I removed some of these calls, and replaced them with a shallow copy (using `Object.assign`) when the function does not alter deep attributes.

<!-- Please provide a description of the change here. -->
