### PR TITLE
docs(association): Name model that association is missing from

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -329,7 +329,7 @@ class Model {
   static _transformStringAssociation(include, self) {
     if (self && typeof include === 'string') {
       if (!Object.prototype.hasOwnProperty.call(self.associations, include)) {
-        throw new Error(`Association with alias "${include}" does not exist`);
+        throw new Error(`Association with alias "${include}" does not exist on ${self.name}`);
       }
       return self.associations[include];
     }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? N/A
- [ ] Did you update the typescript typings accordingly (if applicable)? N/A
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
As the missing include error comes up in async code, it can be hard to trace the caller and source of the issue.
Propose adding the name of the model that the association cannot be found on so as to give more context for debugging.