### PR TITLE
fix(types): use correct `this` value when initializing getterMethods

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1178,15 +1178,15 @@ export interface ModelNameOptions {
 /**
  * Interface for getterMethods in InitOptions
  */
-export interface ModelGetterOptions {
-  [name: string]: (this: Model) => unknown;
+export interface ModelGetterOptions<M extends Model = Model> {
+  [name: string]: (this: M) => unknown;
 }
 
 /**
  * Interface for setterMethods in InitOptions
  */
-export interface ModelSetterOptions {
-  [name: string]: (this: Model, val: any) => void;
+export interface ModelSetterOptions<M extends Model = Model> {
+  [name: string]: (this: M, val: any) => void;
 }
 
 /**
@@ -1477,12 +1477,12 @@ export interface ModelOptions<M extends Model = Model> {
   /**
    * Allows defining additional setters that will be available on model instances.
    */
-  setterMethods?: ModelSetterOptions;
+  setterMethods?: ModelSetterOptions<M>;
 
   /**
    * Allows defining additional getters that will be available on model instances.
    */
-  getterMethods?: ModelGetterOptions;
+  getterMethods?: ModelGetterOptions<M>;
 
   /**
    * Enable optimistic locking.
@@ -1498,7 +1498,7 @@ export interface ModelOptions<M extends Model = Model> {
 /**
  * Options passed to [[Model.init]]
  */
-export interface InitOptions extends ModelOptions {
+export interface InitOptions<M extends Model =  Model> extends ModelOptions<M> {
   /**
    * The sequelize connection. Required ATM.
    */
@@ -1588,7 +1588,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    *  string or a type-description object, with the properties described below:
    * @param options These options are merged with the default define options provided to the Sequelize constructor
    */
-  public static init(attributes: ModelAttributes, options: InitOptions): void;
+  public static init<M extends Model = Model>(this: ModelCtor<M>, attributes: ModelAttributes, options: InitOptions<M>): void;
 
   /**
    * Remove attribute from model definition

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -38,11 +38,16 @@ MyModel.init({}, {
     }
   ],
   sequelize,
-  tableName: 'my_model'
+  tableName: 'my_model',
+  getterMethods: {
+    multiply: function() {
+      return this.num * 2;
+    }
+  }
 });
 
 /**
- * Tests for findCreateFind() type. 
+ * Tests for findCreateFind() type.
  */
 class UserModel extends Model {}
 
@@ -56,9 +61,9 @@ UserModel.init({
 UserModel.findCreateFind({
   where: {
     username: "new user username"
-  }, 
+  },
   defaults: {
-    beta_user: true 
+    beta_user: true
   }
 })
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Currently, if I try to initialize `getterMethods` or `setterMethods` while initializing a model in a TypeScript project, TS does not infer the correct type for `this` inside of those methods (and does not allow `this` to be easily casted to the correct type):

```ts
import { Association, HasOne, Model, Sequelize, DataTypes } from 'sequelize';

class MyModel extends Model {
  public num!: number;
}

MyModel.init({}, {
  sequelize,
  tableName: 'my_model',
  getterMethods: {
    multiply: function() {
      return this.num * 2; // <-- ERROR
    }
  }
});
```