### PR TITLE
fix(types): return a usable type when using the sequelize.models lookup

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -19,6 +19,7 @@ import {
   UpdateOptions,
   WhereAttributeHash,
   WhereOperators,
+  ModelCtor,
 } from './model';
 import { ModelManager } from './model-manager';
 import * as Op from './operators';
@@ -767,7 +768,7 @@ export class Sequelize extends Hooks {
    * Dictionary of all models linked with this instance.
    */
   public readonly models: {
-    [key: string]: typeof Model;
+    [key: string]: ModelCtor<Model>;
   };
 
   /**
@@ -1109,7 +1110,7 @@ export class Sequelize extends Hooks {
    *
    * @param modelName The name of a model defined with Sequelize.define
    */
-  public model(modelName: string): typeof Model;
+  public model(modelName: string): ModelCtor<Model>;
 
   /**
    * Checks whether a model with the given name is defined

--- a/types/test/sequelize.ts
+++ b/types/test/sequelize.ts
@@ -49,4 +49,8 @@ Sequelize.afterConnect(() => {
 
 const rnd: Fn = sequelize.random();
 
-const myModel: typeof Model = sequelize.models.asd;
+class Model1 extends Model{}
+class Model2 extends Model{}
+const myModel: typeof Model1 = sequelize.models.asd;
+myModel.hasOne(Model2)
+myModel.findAll();


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Currently, looking up model classes via the `sequelize.models` interface does not yield an object with a usable type signature (for reasons that I admittedly do not entirely understand).

Static functions such as `findAll` and `belongsTo` do not work on the values pulled off of `sequelize.models`, presumably because these methods use the `ModelCtor` "hack" to infer the correct return type.

```ts
class Model1 extends Model {}

const M1 = sequelize.models.model1;
m1.findAll({});  // <-- ERROR

/**
The 'this' context of type 'typeof Model' is not assignable to method's 'this' of type 'ModelCtor<Model<unknown, unknown>>'.
  Type 'typeof Model' is not assignable to type 'new () => Model<unknown, unknown>'.
    Cannot assign an abstract constructor type to a non-abstract constructor type.ts(2684)
/**
```

It appears that these methods _can_ be called if `sequelize.models` is redefined to contain `ModelCtor`s instead of `typeof Model`. 
