### PR TITLE
feat(postgres): allow use table aliases in locks

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1217,7 +1217,9 @@ const QueryGenerator = {
       } else {
         query += ' FOR UPDATE';
       }
-      if (this._dialect.supports.lockOf && options.lock.of && options.lock.of.prototype instanceof Model) {
+      if (this._dialect.supports.lockAs && options.lock.as) {
+        query += ' OF ' + this.quoteTable(options.lock.as);
+      } else if (this._dialect.supports.lockOf && options.lock.of && options.lock.of.prototype instanceof Model) {
         query += ' OF ' + this.quoteTable(options.lock.of.name);
       }
     }

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -32,6 +32,7 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
   schemas: true,
   lock: true,
   lockOf: true,
+  lockAs: true,
   lockKey: true,
   lockOuterJoinFailure: true,
   forShare: 'FOR SHARE',


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Postgres only
Added `as` option to the lock, which allows use of lock with aliases. This solved my initial problem, described here:
https://github.com/sequelize/sequelize/issues/11319

