### PR TITLE
fix(query-generator): handle virtual column on associations with scopes

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1449,7 +1449,7 @@ class QueryGenerator {
     // includeIgnoreAttributes is used by aggregate functions
     if (topLevelInfo.options.includeIgnoreAttributes !== false) {
       include.model._expandAttributes(include);
-      Utils.mapOptionFieldNames(include, include.model);
+      Utils.mapFinderOptions(include, include.model);
 
       const includeAttributes = include.attributes.map(attr => {
         let attrAs = attr;

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -142,4 +142,40 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
   });
+
+  describe('scope in associations', () => {
+    it('should work when association with a virtual column queried with default scope', function() {
+      const Game = this.sequelize.define('Game', {
+        name: Sequelize.TEXT
+      });
+    
+      const User = this.sequelize.define('User', {
+        login: Sequelize.TEXT,
+        session: {
+          type: Sequelize.VIRTUAL,
+          get() {
+            return 'New';
+          }
+        }
+      }, {
+        defaultScope: {
+          attributes: {
+            exclude: ['login']
+          }
+        }
+      });
+      
+      Game.hasMany(User);
+
+      return this.sequelize.sync({ force: true }).then(() => {
+        return Game.findAll({
+          include: [{
+            model: User
+          }]
+        });
+      }).then(games => {
+        expect(games).to.have.lengthOf(0);
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Resolves issue described in #11316. When compiling list of attributes to be included as part of SQL query the initial list is cleaned up from virtual column and then updated with column aliases. Before this change only column aliases worked correctly. Pull request doesn't include new test but there is a change to test/integration/model/scope/find.test.js file that adds a virtual column to `DefaultScopeExclude` model that has scope with `attributes` config already defined.
I think the test case `should work when included with default scope` works to prevent regression here.
