### PR TITLE
chore(.github): improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report to help us improve
 title: ''
-labels: ''
+labels: 'type: bug'
 assignees: ''
 
 ---
@@ -13,7 +13,9 @@ Please note this is an issue tracker, not a support forum.
 For general questions, please use StackOverflow or Slack.
 -->
 
-## What are you doing?
+## Issue Description
+
+### What are you doing?
 
 <!--
 Post a MINIMAL, SELF-CONTAINED code that reproduces the issue. It must be runnable by simply copying and pasting into an isolated JS file, except possibly for the database connection configuration.
@@ -24,13 +26,13 @@ Check http://sscce.org/ or https://stackoverflow.com/help/minimal-reproducible-e
 // MINIMAL, SELF-CONTAINED code here (SSCCE/MCVE/reprex)
 ```
 
-## What do you expect to happen?
+### What do you expect to happen?
 
 <!-- Explain what behavior you wanted/expected. You may include an output. -->
 
 _I wanted Foo!_
 
-## What is actually happening?
+### What is actually happening?
 
 <!-- Show what happened. -->
 
@@ -40,7 +42,21 @@ _The output was Bar!_
 Output here
 ```
 
-## How does this problem relates to dialects?
+### Additional context
+Add any other context or screenshots about the feature request here.
+
+### Environment
+
+- Sequelize version: XXX <!-- run `npm list sequelize` to obtain this -->
+- Node.js version: XXX <!-- run `node -v` to obtain this -->
+- Operating System: XXX
+- If TypeScript related: TypeScript version: XXX
+
+## Issue Template Checklist
+
+<!-- Please answer the questions below. If you don't, your issue may be closed. -->
+
+### How does this problem relate to dialects?
 
 <!-- Choose one. -->
 
@@ -48,19 +64,15 @@ Output here
 - [ ] I think this problem happens only for the following dialect(s): <!-- Put dialect(s) here -->
 - [ ] I don't know, I was using PUT-YOUR-DIALECT-HERE, with connector library version XXX and database version XXX
 
-## Environment
+### Would you be willing to resolve this issue by subitting a Pull Request?
 
-Sequelize version: XXX
-Node version: XXX
-OS: XXX
-If TypeScript related: TypeScript version: XXX
+<!-- Remember that first contributors are welcome! -->
 
-## Other considerations
+- [ ] Yes, I have the time and I know how to start.
+- [ ] Yes, I have the time but I don't know how to start, I would need guidance.
+- [ ] No, I don't have the time, although I believe I could do it if I had the time...
+- [ ] No, I don't have the time and I wouldn't even know how to start.
 
-<!-- You may include extra information that you consider relevant. -->
-
-## Issue Template Checklist
-
-<!-- If you don't check all the boxes below, your issue may be closed. -->
+### SSCCE declaration
 
 - [ ] The code I posted above is a true [SSCCE](http://sscce.org/) (also known as [MCVE/reprex](https://stackoverflow.com/help/minimal-reproducible-example)). It is runnable by simply copying and pasting into an isolated JS file, except possibly for the database connection configuration.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Create a bug report to help us improve
 title: ''
 labels: ''
 assignees: ''
@@ -8,43 +8,59 @@ assignees: ''
 ---
 
 <!--
+If you don't follow the issue template, your issue may be closed.
 Please note this is an issue tracker, not a support forum.
 For general questions, please use StackOverflow or Slack.
 -->
 
 ## What are you doing?
-<!-- Post a minimal, self-contained code sample that reproduces the issue, including models and associations -->
+
+<!--
+Post a MINIMAL, SELF-CONTAINED code that reproduces the issue. It must be runnable by simply copying and pasting into an isolated JS file, except possibly for the database connection configuration.
+Check http://sscce.org/ or https://stackoverflow.com/help/minimal-reproducible-example to learn more about SSCCE/MCVE/reprex.
+-->
 
 ```js
-// code here
+// MINIMAL, SELF-CONTAINED code here (SSCCE/MCVE/reprex)
 ```
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Define models X, Y, ...
-2. Run the following
-3. See error
 
 ## What do you expect to happen?
+
+<!-- Explain what behavior you wanted/expected. You may include an output. -->
+
 _I wanted Foo!_
 
 ## What is actually happening?
-_But the output was bar!_
 
-_Output, either JSON or SQL_
+<!-- Show what happened. -->
+
+_The output was Bar!_
+
+```
+Output here
+```
+
+## How does this problem relates to dialects?
+
+<!-- Choose one. -->
+
+- [ ] I think this problem happens regardless of the dialect.
+- [ ] I think this problem happens only for the following dialect(s): <!-- Put dialect(s) here -->
+- [ ] I don't know, I was using PUT-YOUR-DIALECT-HERE, with connector library version XXX and database version XXX
 
 ## Environment
-Dialect:
-- [ ] mysql
-- [ ] postgres
-- [ ] sqlite
-- [ ] mssql
-- [ ] any
-Dialect **library** version: XXX
-Database version: XXX
+
 Sequelize version: XXX
-Node Version: XXX
+Node version: XXX
 OS: XXX
 If TypeScript related: TypeScript version: XXX
-Tested with latest release:
-- [ ] No
-- [ ] Yes, specify that version: 
+
+## Other considerations
+
+<!-- You may include extra information that you consider relevant. -->
+
+## Issue Template Checklist
+
+<!-- If you don't check all the boxes below, your issue may be closed. -->
+
+- [ ] The code I posted above is a true [SSCCE](http://sscce.org/) (also known as [MCVE/reprex](https://stackoverflow.com/help/minimal-reproducible-example)). It is runnable by simply copying and pasting into an isolated JS file, except possibly for the database connection configuration.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a bug report to help us improve
 title: ''
-labels: 'type: bug'
+labels: ''
 assignees: ''
 
 ---
@@ -64,7 +64,7 @@ Add any other context or screenshots about the feature request here.
 - [ ] I think this problem happens only for the following dialect(s): <!-- Put dialect(s) here -->
 - [ ] I don't know, I was using PUT-YOUR-DIALECT-HERE, with connector library version XXX and database version XXX
 
-### Would you be willing to resolve this issue by subitting a Pull Request?
+### Would you be willing to resolve this issue by submitting a Pull Request?
 
 <!-- Remember that first contributors are welcome! -->
 
@@ -72,7 +72,3 @@ Add any other context or screenshots about the feature request here.
 - [ ] Yes, I have the time but I don't know how to start, I would need guidance.
 - [ ] No, I don't have the time, although I believe I could do it if I had the time...
 - [ ] No, I don't have the time and I wouldn't even know how to start.
-
-### SSCCE declaration
-
-- [ ] The code I posted above is a true [SSCCE](http://sscce.org/) (also known as [MCVE/reprex](https://stackoverflow.com/help/minimal-reproducible-example)). It is runnable by simply copying and pasting into an isolated JS file, except possibly for the database connection configuration.

--- a/.github/ISSUE_TEMPLATE/documentational-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentational-issue.md
@@ -1,5 +1,5 @@
 ---
-name: Documentational issue
+name: Docs issue
 about: Documentation is unclear, or otherwise insufficient/misleading
 title: ''
 labels: 'type: docs'
@@ -7,6 +7,37 @@ assignees: ''
 
 ---
 
-## What was unclear/insufficient/not covered in the documentation
+<!--
+If you don't follow the issue template, your issue may be closed.
+Please note this is an issue tracker, not a support forum.
+For general questions, please use StackOverflow or Slack.
+-->
+
+## Issue Description
+
+### What was unclear/insufficient/not covered in the documentation
 
 ### If possible: Provide some suggestion on how we can enhance the docs
+
+### Additional context
+Add any other context or screenshots about the issue here.
+
+## Issue Template Checklist
+
+<!-- Please answer the questions below. If you don't, your issue may be closed. -->
+
+### Is this issue dialect-specific?
+
+- [ ] No. This issue is relevant to Sequelize as a whole.
+- [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
+
+### Would you be willing to resolve this issue by subitting a Pull Request?
+
+<!-- Remember that first contributors are welcome! -->
+
+- [ ] Yes, I have the time and I know how to start.
+- [ ] Yes, I have the time but I don't know how to start, I would need guidance.
+- [ ] No, I don't have the time, although I believe I could do it if I had the time...
+- [ ] No, I don't have the time and I wouldn't even know how to start.
+
+

--- a/.github/ISSUE_TEMPLATE/documentational-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentational-issue.md
@@ -2,13 +2,11 @@
 name: Documentational issue
 about: Documentation is unclear, or otherwise insufficient/misleading
 title: ''
-labels: documentation
+labels: 'type: docs'
 assignees: ''
 
 ---
 
 ## What was unclear/insufficient/not covered in the documentation
 
-### If possible: Provide some suggestion how we can enhance the docs
-
-> Text goes here
+### If possible: Provide some suggestion on how we can enhance the docs

--- a/.github/ISSUE_TEMPLATE/documentational-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentational-issue.md
@@ -36,7 +36,7 @@ Add any other context or screenshots about the issue here.
 - [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
 - [ ] I don't know.
 
-### Would you be willing to resolve this issue by subitting a Pull Request?
+### Would you be willing to resolve this issue by submitting a Pull Request?
 
 <!-- Remember that first contributors are welcome! -->
 

--- a/.github/ISSUE_TEMPLATE/documentational-issue.md
+++ b/.github/ISSUE_TEMPLATE/documentational-issue.md
@@ -17,7 +17,11 @@ For general questions, please use StackOverflow or Slack.
 
 ### What was unclear/insufficient/not covered in the documentation
 
+Write here.
+
 ### If possible: Provide some suggestion on how we can enhance the docs
+
+Write here.
 
 ### Additional context
 Add any other context or screenshots about the issue here.
@@ -30,6 +34,7 @@ Add any other context or screenshots about the issue here.
 
 - [ ] No. This issue is relevant to Sequelize as a whole.
 - [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
+- [ ] I don't know.
 
 ### Would you be willing to resolve this issue by subitting a Pull Request?
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,25 +2,46 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: feature
+labels: 'type: feature'
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+## Description
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+### Is your feature request related to a problem? Please describe.
+A clear and concise description of what the problem is. Example: I'm always frustrated when [...]
 
-**Why should this be in Sequelize**
+### Describe the solution you'd like
+A clear and concise description of what you want to happen. How can the requested feature be used to approach the problem it's supposed to solve?
+
+```js
+// If applicable, add a code snippet showing how your feature would be used in a real use-case
+```
+
+### Why should this be in Sequelize
 Short explanation why this should be part of Sequelize rather than a separate package.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+### Describe alternatives/workarounds you've considered
+A clear and concise description of any alternative solutions or features you've considered. If any workaround exists to the best of your knowledge, include it here.
 
-**Usage example**
-How can the requested feature be used to approach the problem it's supposed to solve.
-
-**Additional context**
+### Additional context
 Add any other context or screenshots about the feature request here.
+
+## Feature Request Issue Template Checklist
+
+<!-- Please answer the questions below. If you don't, your issue may be closed. -->
+
+### Is your feature request dialect-specific?
+
+- [ ] No. This request is relevant to Sequelize as a whole.
+- [ ] Yes. This request only applies to the following dialect(s): XXX, YYY, ZZZ
+
+### Would you be willing to implement this feature by subitting a Pull Request?
+
+<!-- Remember that first contributors are welcome! -->
+
+- [ ] Yes, I have the time and I know how to start.
+- [ ] Yes, I have the time but I don't know how to start, I would need guidance.
+- [ ] No, I don't have the time, although I believe I could do it if I had the time...
+- [ ] No, I don't have the time and I wouldn't even know how to start.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,7 +7,13 @@ assignees: ''
 
 ---
 
-## Description
+<!--
+If you don't follow the issue template, your issue may be closed.
+Please note this is an issue tracker, not a support forum.
+For general questions, please use StackOverflow or Slack.
+-->
+
+## Issue Description
 
 ### Is your feature request related to a problem? Please describe.
 A clear and concise description of what the problem is. Example: I'm always frustrated when [...]
@@ -28,16 +34,16 @@ A clear and concise description of any alternative solutions or features you've 
 ### Additional context
 Add any other context or screenshots about the feature request here.
 
-## Feature Request Issue Template Checklist
+## Issue Template Checklist
 
 <!-- Please answer the questions below. If you don't, your issue may be closed. -->
 
-### Is your feature request dialect-specific?
+### Is this issue dialect-specific?
 
-- [ ] No. This request is relevant to Sequelize as a whole.
-- [ ] Yes. This request only applies to the following dialect(s): XXX, YYY, ZZZ
+- [ ] No. This issue is relevant to Sequelize as a whole.
+- [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
 
-### Would you be willing to implement this feature by subitting a Pull Request?
+### Would you be willing to resolve this issue by subitting a Pull Request?
 
 <!-- Remember that first contributors are welcome! -->
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'type: feature'
+labels: ''
 assignees: ''
 
 ---
@@ -43,7 +43,7 @@ Add any other context or screenshots about the feature request here.
 - [ ] No. This issue is relevant to Sequelize as a whole.
 - [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
 
-### Would you be willing to resolve this issue by subitting a Pull Request?
+### Would you be willing to resolve this issue by submitting a Pull Request?
 
 <!-- Remember that first contributors are welcome! -->
 

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -2,7 +2,7 @@
 name: Other
 about: Open an issue that does not fall directly into the other categories
 title: ''
-labels: 'type: other'
+labels: ''
 assignees: ''
 
 ---
@@ -40,7 +40,7 @@ Add any other context or screenshots about the issue here.
 - [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
 - [ ] I don't know.
 
-### Would you be willing to resolve this issue by subitting a Pull Request?
+### Would you be willing to resolve this issue by submitting a Pull Request?
 
 <!-- Remember that first contributors are welcome! -->
 

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -1,0 +1,49 @@
+---
+name: Other
+about: Open an issue that does not fall directly into the other categories
+title: ''
+labels: 'type: other'
+assignees: ''
+
+---
+
+<!--
+If you don't follow the issue template, your issue may be closed.
+Please note this is an issue tracker, not a support forum.
+For general questions, please use StackOverflow or Slack.
+-->
+
+## Issue Description
+
+A clear and concise description of what is this issue about.
+
+If applicable, you can add some code. In this case, an SSCCE/MCVE/reprex is much better than just an isolated code snippet.
+
+<!--
+Check http://sscce.org/ or https://stackoverflow.com/help/minimal-reproducible-example to learn more about SSCCE/MCVE/reprex.
+-->
+
+### StackOverflow / Slack attempts
+
+If you have tried asking on StackOverflow / Slack about this, add a link to that here.
+
+### Additional context
+Add any other context or screenshots about the issue here.
+
+## Issue Template Checklist
+
+<!-- Please answer the questions below. If you don't, your issue may be closed. -->
+
+### Is this issue dialect-specific?
+
+- [ ] No. This issue is relevant to Sequelize as a whole.
+- [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
+
+### Would you be willing to resolve this issue by subitting a Pull Request?
+
+<!-- Remember that first contributors are welcome! -->
+
+- [ ] Yes, I have the time and I know how to start.
+- [ ] Yes, I have the time but I don't know how to start, I would need guidance.
+- [ ] No, I don't have the time, although I believe I could do it if I had the time...
+- [ ] No, I don't have the time and I wouldn't even know how to start.

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -38,6 +38,7 @@ Add any other context or screenshots about the issue here.
 
 - [ ] No. This issue is relevant to Sequelize as a whole.
 - [ ] Yes. This issue only applies to the following dialect(s): XXX, YYY, ZZZ
+- [ ] I don't know.
 
 ### Would you be willing to resolve this issue by subitting a Pull Request?
 


### PR DESCRIPTION
I have made some changes to the issue templates and added a 'other' issue template for issues that don't fit into the other categories. I think it is a good idea to have this 'other' issue template because users can open generic issues anyway, so it is better if they have at least a general template to follow to help us.

I think this will help us a lot to triage issues!