### PR TITLE
docs(types): update comment for options.operatorsAliases

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -325,8 +325,9 @@ export interface Options extends Logging {
   typeValidation?: boolean;
 
   /**
-   * Sets available operator aliases. See (https://sequelize.org/master/manual/tutorial/querying.html#operators)
-   * for more information. Set to false to disable operator aliases completely (recommended)
+   * Sets available operator aliases.
+   * See (https://sequelize.org/master/manual/querying.html#operators) for more information.
+   * WARNING: Setting this to boolean value was deprecated and is no-op.
    *
    * @default all aliases
    */


### PR DESCRIPTION
# Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change
 Updated comment in  `sequelize.d.ts` since `Sequelize` constructor's `operatorsAliases` option is deprecated. Please let me know if comment's grammar is awkward.