### PR TITLE
feat(database-error): add 'parameters' property

### DIFF
--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -64,6 +64,7 @@ class Query extends AbstractQuery {
           complete();
 
           err.sql = sql;
+          err.parameters = parameters;
           throw this.formatError(err);
         })
     )

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -70,6 +70,7 @@ class Query extends AbstractQuery {
 
         if (err) {
           err.sql = sql;
+          err.parameters = parameters;
           reject(this.formatError(err));
         } else {
           resolve(this.formatResults(results, rowCount));

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -46,6 +46,7 @@ class Query extends AbstractQuery {
             options.transaction.finished = 'rollback';
           }
           err.sql = sql;
+          err.parameters = parameters;
 
           reject(this.formatError(err));
         } else {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -68,6 +68,7 @@ class Query extends AbstractQuery {
       }
 
       err.sql = sql;
+      err.parameters = parameters;
       throw this.formatError(err);
     })
       .then(queryResult => {

--- a/lib/errors/database-error.js
+++ b/lib/errors/database-error.js
@@ -22,6 +22,11 @@ class DatabaseError extends BaseError {
      * @type {string}
      */
     this.sql = parent.sql;
+    /**
+     * The parameters for the sql that triggered the error
+     * @type {Array<any>}
+     */
+    this.parameters = parent.parameters;
     Error.captureStackTrace(this, this.constructor);
   }
 }

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -171,6 +171,18 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       expect(databaseError.message).to.equal('original database error message');
     });
 
+    it('SequelizeDatabaseError should keep the original sql and the parameters', () => {
+      const orig = new Error();
+      orig.sql = 'SELECT * FROM table WHERE id = $1';
+      orig.parameters = ['1'];
+      const databaseError = new Sequelize.DatabaseError(orig);
+
+      expect(databaseError).to.have.property('sql');
+      expect(databaseError).to.have.property('parameters');
+      expect(databaseError.sql).to.equal(orig.sql);
+      expect(databaseError.parameters).to.equal(orig.parameters);
+    });
+
     it('ConnectionError should keep original message', () => {
       const orig = new Error('original connection error message');
       const connectionError = new Sequelize.ConnectionError(orig);

--- a/types/lib/errors.d.ts
+++ b/types/lib/errors.d.ts
@@ -79,6 +79,7 @@ export class DatabaseError extends BaseError implements CommonErrorProperties {
   public readonly parent: Error;
   public readonly original: Error;
   public readonly sql: string;
+  public readonly parameters: Array<any>;
   /**
    * A base class for all database related errors.
    * @param parent The database specific error which triggered this one


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Added a new property name 'parameters' on the DatabaseError class.
It's purpose is to hold the array of parameters for the sql query that's already defined on the error so that the complete sql query could be reconstructed based on the information offered by the error.

The issue solved by this PR is the absence of the complete information about an sql query that triggers an error. For example, if an error is thrown with the message 'invalid input syntax for integer: "220.00000000000003"' for a table with multiple integer columns, it is impossible to figure out, from the contents of the error, the exact column in which the query attempted to insert the value. With this change it should be possible to match the the value and the column using the index of the value in the newly added parameter.