### PR TITLE
Add SMALLDATETIME type for MSSQL

### DIFF
--- a/docs/data-types.md
+++ b/docs/data-types.md
@@ -32,6 +32,7 @@ Sequelize.DECIMAL(10, 2)              // DECIMAL(10,2)
 Sequelize.DATE                        // DATETIME for mysql / sqlite, TIMESTAMP WITH TIME ZONE for postgres
 Sequelize.DATE(6)                     // DATETIME(6) for mysql 5.6.4+. Fractional seconds support with up to 6 digits of precision
 Sequelize.DATEONLY                    // DATE without time.
+Sequelize.SMALLDATETIME               // SMALLDATETIME datatype for MSSQL
 Sequelize.BOOLEAN                     // TINYINT(1)
 
 Sequelize.ENUM('value 1', 'value 2')  // An ENUM with allowed values 'value 1' and 'value 2'

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -497,6 +497,21 @@ class DATEONLY extends ABSTRACT {
 }
 
 /**
+ * A small date time column.
+ *
+ * Only available for MSSQL
+ */
+class SMALLDATETIME extends DATE {
+  toSql() {
+    return 'SMALLDATETIME';
+  }
+  _stringify(date, options) {
+    const timeZoneDate = this._applyTimezone(date, options);
+    return timeZoneDate.toISOString();
+  }
+}
+
+/**
  * A key / value store column. Only available in Postgres.
  */
 class HSTORE extends ABSTRACT {
@@ -993,6 +1008,7 @@ const DataTypes = module.exports = {
   TIME,
   DATE,
   DATEONLY,
+  SMALLDATETIME,
   BOOLEAN,
   NOW,
   BLOB,

--- a/lib/dialects/mssql/data-types.js
+++ b/lib/dialects/mssql/data-types.js
@@ -27,6 +27,7 @@ module.exports = BaseTypes => {
    */
 
   BaseTypes.DATE.types.mssql = [43];
+  BaseTypes.SMALLDATETIME.types.mssql = [58];
   BaseTypes.STRING.types.mssql = [231, 173];
   BaseTypes.CHAR.types.mssql = [175];
   BaseTypes.TEXT.types.mssql = false;

--- a/lib/model.js
+++ b/lib/model.js
@@ -1157,7 +1157,7 @@ class Model {
 
       if (definition.type instanceof DataTypes.BOOLEAN) {
         this._hasBooleanAttributes = true;
-      } else if (definition.type instanceof DataTypes.DATE || definition.type instanceof DataTypes.DATEONLY) {
+      } else if (definition.type instanceof DataTypes.DATE || definition.type instanceof DataTypes.DATEONLY || definition.type instanceof DataTypes.SMALLDATETIME) {
         this._hasDateAttributes = true;
       } else if (definition.type instanceof DataTypes.JSON) {
         this._jsonAttributes.add(name);

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -162,7 +162,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     const Type = new Sequelize.SMALLDATETIME();
 
     if (['mssql'].includes(dialect)) {
-      return testSuccess(Type, moment(new Date()).format('YYYY-MM-DD'));
+      return testSuccess(Type, new Date());
     }
     testFailure(Type);
   });

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -158,6 +158,15 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     return testSuccess(Type, moment(new Date()).format('YYYY-MM-DD'));
   });
 
+  it('calls parse and stringify for SMALLDATETIME', () => {
+    const Type = new Sequelize.SMALLDATETIME();
+
+    if (['mssql'].includes(dialect)) {
+      return testSuccess(Type, moment(new Date()).format('YYYY-MM-DD'));
+    }
+    testFailure(Type);
+  });
+
   it('calls parse and stringify for TIME', () => {
     const Type = new Sequelize.TIME();
 

--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -102,7 +102,7 @@ export interface CharDataType extends StringDataType {
 }
 
 export interface CharDataTypeOptions extends StringDataTypeOptions {}
-   
+
 export type TextLength = 'tiny' | 'medium' | 'long';
 
 /**
@@ -326,6 +326,11 @@ export const TIME: AbstractDataTypeConstructor;
  * A datetime column
  */
 export const DATE: DateDataTypeConstructor;
+
+/**
+ * A smalldatetime column
+ */
+export const SMALLDATETIME: DateDataTypeConstructor;
 
 interface DateDataTypeConstructor extends AbstractDataTypeConstructor {
   new (length?: string | number): DateDataType;


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
<!-- Please provide a description of the change here. -->
Adds a `SMALLDATETIME` type to be used by MSSQL. 

If the MSSQL database is setup to use `SMALLDATETIME`, the Sequelize `DATE` type doesn't work as expected because it includes a timezone, which gets dropped by the database. The only way `SMALLDATETIME` differs from `DATE` is that the former forces UTC on write.

Solution inspired from https://github.com/sequelize/sequelize/issues/7879#issuecomment-329971730 and a previous attempt that was done in https://github.com/sequelize/sequelize/pull/10167. The solution proposed in this PR differs slightly, though; this PR uses [`toISOString`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString) to ensure UTC, rather than specifying a specific format.

TODO:
[ ] Add additional test(s) to ensure proper `stringify`ing
