### PR TITLE
fix(typings): add missing nested to Includeable

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -377,7 +377,7 @@ export interface IncludeThroughOptions extends Filterable, Projectable {}
 /**
  * Options for eager-loading associated models, also allowing for all associations to be loaded at once
  */
-export type Includeable = typeof Model | Association | IncludeOptions | { all: true } | string;
+export type Includeable = typeof Model | Association | IncludeOptions | { all: true, nested?: true } | string;
 
 /**
  * Complex include options

--- a/types/test/include.ts
+++ b/types/test/include.ts
@@ -20,6 +20,8 @@ MyModel.findAll({
       order: [['id', 'DESC'], [ 'AssociatedModel', MyModel, 'id', 'DESC' ], [ MyModel, 'id' ] ],
       separate: true,
       where: { state: Sequelize.col('project.state') },
+      all: true,
+      nested: true,
     },
   ],
 });


### PR DESCRIPTION
Typings were missing previously.

### Description of change

Add `nested` to typings `Includeable`.
