### PR TITLE
Add support for `ON CONFLICT DO UPDATE` on SQLite 3

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -300,7 +300,7 @@ class QueryGenerator {
     }
 
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
-      if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres
+      if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);

--- a/lib/dialects/sqlite/index.js
+++ b/lib/dialects/sqlite/index.js
@@ -24,7 +24,8 @@ SqliteDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   'DEFAULT VALUES': true,
   'UNION ALL': false,
   inserts: {
-    ignoreDuplicates: ' OR IGNORE'
+    ignoreDuplicates: ' OR IGNORE',
+    updateOnDuplicate: ' ON CONFLICT DO UPDATE SET'
   },
   index: {
     using: false,

--- a/lib/model.js
+++ b/lib/model.js
@@ -2518,7 +2518,7 @@ class Model {
    * @param  {boolean}      [options.hooks=true]             Run before / after bulk create hooks?
    * @param  {boolean}      [options.individualHooks=false]  Run before / after create hooks for each individual Instance? BulkCreate hooks will still be run if options.hooks is true.
    * @param  {boolean}      [options.ignoreDuplicates=false] Ignore duplicate values for primary keys? (not supported by MSSQL or Postgres < 9.5)
-   * @param  {Array}        [options.updateOnDuplicate]      Fields to update if row key already exists (on duplicate key update)? (only supported by MySQL, MariaDB & Postgres >= 9.5). By default, all fields are updated.
+   * @param  {Array}        [options.updateOnDuplicate]      Fields to update if row key already exists (on duplicate key update)? (only supported by MySQL, MariaDB, SQLite >= 3.24.0 & Postgres >= 9.5). By default, all fields are updated.
    * @param  {Transaction}  [options.transaction]            Transaction to run query under
    * @param  {Function}     [options.logging=false]          A function that gets executed while running the query to log the sql.
    * @param  {boolean}      [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).
@@ -2566,7 +2566,7 @@ class Model {
       if (options.ignoreDuplicates && ['mssql'].includes(dialect)) {
         return Promise.reject(new Error(`${dialect} does not support the ignoreDuplicates option.`));
       }
-      if (options.updateOnDuplicate && (dialect !== 'mysql' && dialect !== 'mariadb' && dialect !== 'postgres')) {
+      if (options.updateOnDuplicate && (dialect !== 'mysql' && dialect !== 'mariadb' && dialect !== 'sqlite' && dialect !== 'postgres')) {
         return Promise.reject(new Error(`${dialect} does not support the updateOnDuplicate option.`));
       }
 

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -499,6 +499,9 @@ if (dialect === 'sqlite') {
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { ignoreDuplicates: true }],
           expectation: "INSERT OR IGNORE INTO `myTable` (`name`) VALUES ('foo'),('bar');"
+        }, {
+          arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { updateOnDuplicate: ['name'], upsertKeys: ['name'] }],
+          expectation: "INSERT INTO `myTable` (`name`) VALUES ('foo'),('bar') ON CONFLICT (`name`) DO UPDATE SET `name`=EXCLUDED.`name`;"
         }
       ],
 

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -157,7 +157,8 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           postgres: 'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\') ON CONFLICT ("user_name") DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
           mssql: 'INSERT INTO [users] ([user_name],[pass_word]) VALUES (N\'testuser\',N\'12345\');',
           mariadb: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
-          mysql: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);'
+          mysql: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
+          sqlite: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON CONFLICT (`user_name`) DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
         });
     });
   });

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -736,7 +736,7 @@ export interface BulkCreateOptions extends Logging, Transactionable {
 
   /**
    * Fields to update if row key already exists (on duplicate key update)? (only supported by MySQL,
-   * MariaDB & Postgres >= 9.5). By default, all fields are updated.
+   * MariaDB, SQLite >= 3.24.0 & Postgres >= 9.5). By default, all fields are updated.
    */
   updateOnDuplicate?: string[];
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

SQLite supports upsert from version 3.24.0 (see [docs](https://www.sqlite.org/lang_UPSERT.html)). Theses changes allow the SQLite dialect using the:
`INSERT ... ON CONFLICT DO UPDATE`

This feature allow to use the option updateOnDuplicate with SQLite like database.

This is my first attempt at a PR on a project like this, please advise on how I can improve my submission, thank you.
