### PR TITLE
docs(model): document skipLocked

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1663,6 +1663,7 @@ class Model {
    * @param  {number}                                                    [options.offset] Offset for result
    * @param  {Transaction}                                               [options.transaction] Transaction to run query under
    * @param  {string|Object}                                             [options.lock] Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins. See [transaction.LOCK for an example](transaction#lock)
+   * @param  {boolean}                                                   [options.skipLocked] Skip locked rows. Only supported in Postgres.
    * @param  {boolean}                                                   [options.raw] Return raw result. See sequelize.query for more information.
    * @param  {Function}                                                  [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param  {boolean}                                                   [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -545,6 +545,11 @@ export interface FindOptions extends QueryOptions, Filterable, Projectable, Para
   lock?: Transaction.LOCK | { level: Transaction.LOCK; of: typeof Model };
 
   /**
+   * Skip locked rows. Only supported in Postgres.
+   */
+  skipLocked?: boolean;
+
+  /**
    * Return raw result. See sequelize.query for more information.
    */
   raw?: boolean;


### PR DESCRIPTION
This was added in #9197 but not added to the docs for `findAll`.

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions? **N/A**
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)? 
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Document the `skipLocked` option for `findAll`.
