### PR TITLE
Explain options handling in tedious

### DIFF
--- a/docs/dialects.md
+++ b/docs/dialects.md
@@ -80,7 +80,7 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 
 ## MSSQL
 
-The library for MSSQL is`tedious@^6.0.0` You'll just need to define the dialect. 
+The library for MSSQL is`tedious@^6.0.0` You'll just need to define the dialect.
 Please note: `tedious@^6.0.0` requires you to nest MSSQL specific options inside an additional `options`-object inside the `dialectOptions`-object.
 
 ```js

--- a/docs/dialects.md
+++ b/docs/dialects.md
@@ -80,10 +80,17 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 
 ## MSSQL
 
-The library for MSSQL is`tedious@^6.0.0` You'll just need to define the dialect:
+The library for MSSQL is`tedious@^6.0.0` You'll just need to define the dialect. 
+Please note: `tedious@^6.0.0` requires you to nest MSSQL specific options inside an additional `options`-object inside the `dialectOptions`-object.
 
 ```js
 const sequelize = new Sequelize('database', 'username', 'password', {
-  dialect: 'mssql'
+  dialect: 'mssql',
+  dialectOptions: {
+    options: {
+      useUTC: false,
+      dateFirst: 1,
+    }
+  }
 })
 ```


### PR DESCRIPTION
Options in tedious have to be nested in additional objects underneath the dialectOptions. While this could be inferred from the tedious documentation, it is in contrast to the other dialects and might confuse others - at least it confused me :)
Perhaps it's better to be more explicit about it.