### PR TITLE
docs: Keeping consistency around the spacing inside of curly brackets

### DIFF
--- a/docs/models-usage.md
+++ b/docs/models-usage.md
@@ -133,7 +133,7 @@ Suppose you want to find all users who have a profile attached:
 ```js
 User.findAndCountAll({
   include: [
-     { model: Profile, required: true}
+     { model: Profile, required: true }
   ],
   limit: 3
 });


### PR DESCRIPTION
Included one space between the value and curly brackets