### PR TITLE
fix(postgres-bulkcreate): updateOnDuplicate uses correct PK column names

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2700,7 +2700,7 @@ class Model {
           if (options.updateOnDuplicate) {
             options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
             // Get primary keys for postgres to enable updateOnDuplicate
-            options.upsertKeys = _.chain(model.primaryKeys).values().map('fieldName').value();
+            options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
             if (Object.keys(model.uniqueKeys).length > 0) {
               options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length === 1).map('column').value();
             }


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? - no need
- [x] Did you update the typescript typings accordingly (if applicable)? - not applicable
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This pull request fixes the following issue:
https://github.com/sequelize/sequelize/issues/11432

When performing `bulkCreate` with `updateOnDuplicate` using Postgres dialect, the generated query has bad column names. The query has the Javascript model's field names instead of the column names.

