### PR TITLE
fix(mssql): filter tables only in mssql+mysql showTablesQuery

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -222,7 +222,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
   }
 
   showTablesQuery() {
-    return 'SELECT TABLE_NAME, TABLE_SCHEMA FROM INFORMATION_SCHEMA.TABLES;';
+    return "SELECT TABLE_NAME, TABLE_SCHEMA FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';";
   }
 
   dropTableQuery(tableName) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -149,7 +149,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
   }
 
   showTablesQuery() {
-    return 'SHOW TABLES;';
+    return "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';";
   }
 
   addColumnQuery(table, key, dataType) {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -44,6 +44,10 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   describe('showAllTables', () => {
     it('should not contain views', function() {
       const cleanup = () => {
+        // NOTE: The syntax "DROP VIEW [IF EXISTS]"" is not part of the standard
+        // and might not be available on all RDBMSs. Therefore "DROP VIEW" is
+        // the compatible option, which can throw an error in case the VIEW does
+        // not exist. In case of error, it is ignored by reflect()+tap().
         return this.sequelize.query('DROP VIEW V_Fail').reflect();
       };
       return this.queryInterface

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -41,6 +41,28 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     });
   });
 
+  describe('showAllTables', () => {
+    it('should contain only tables', function() {
+      const cleanup = r => {
+        return this.sequelize.query('DROP VIEW V_Fail').then(() => r, () => r);
+      };
+      return this.queryInterface
+        .createTable('my_test_table', { name: DataTypes.STRING })
+        .then(cleanup)
+        .then(() => this.sequelize.query('CREATE VIEW V_Fail AS SELECT 1 Id'))
+        .then(() => this.queryInterface.showAllTables())
+        .then(cleanup)
+        .then(tableNames => {
+          if (tableNames[0] && tableNames[0].tableName) {
+            tableNames = tableNames.map(v => v.tableName);
+          }
+          expect(tableNames).to.have.length(1);
+          expect(tableNames).to.contain('my_test_table');
+          expect(tableNames).to.not.contain('V_Fail');
+        });
+    });
+  });
+
   describe('renameTable', () => {
     it('should rename table', function() {
       return this.queryInterface

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -42,23 +42,21 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   });
 
   describe('showAllTables', () => {
-    it('should contain only tables', function() {
-      const cleanup = r => {
-        return this.sequelize.query('DROP VIEW V_Fail').then(() => r, () => r);
+    it('should not contain views', function() {
+      const cleanup = () => {
+        return this.sequelize.query('DROP VIEW V_Fail').reflect();
       };
       return this.queryInterface
         .createTable('my_test_table', { name: DataTypes.STRING })
-        .then(cleanup)
+        .tap(cleanup)
         .then(() => this.sequelize.query('CREATE VIEW V_Fail AS SELECT 1 Id'))
         .then(() => this.queryInterface.showAllTables())
-        .then(cleanup)
+        .tap(cleanup)
         .then(tableNames => {
           if (tableNames[0] && tableNames[0].tableName) {
             tableNames = tableNames.map(v => v.tableName);
           }
-          expect(tableNames).to.have.length(1);
-          expect(tableNames).to.contain('my_test_table');
-          expect(tableNames).to.not.contain('V_Fail');
+          expect(tableNames).to.deep.equal(['my_test_table']);
         });
     });
   });

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -183,7 +183,7 @@ if (current.dialect.name === 'mssql') {
 
     it('showTablesQuery', function() {
       expectsql(this.queryGenerator.showTablesQuery(), {
-        mssql: 'SELECT TABLE_NAME, TABLE_SCHEMA FROM INFORMATION_SCHEMA.TABLES;'
+        mssql: "SELECT TABLE_NAME, TABLE_SCHEMA FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE';"
       });
     });
 


### PR DESCRIPTION
Closes #11438

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Filter tables by 'BASE TABLE' in `MSSQLQueryGenerator.showTablesQuery`.
Added tests.
