### PR TITLE
Fix setting isolation level in MySQL and MariaDB

### DIFF
--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -30,6 +30,7 @@ AbstractDialect.prototype.supports = {
   bulkDefault: false,
   schemas: false,
   transactions: true,
+  settingIsolationLevelDuringTransaction: true,
   transactionOptions: {
     type: false
   },

--- a/lib/dialects/abstract/query-generator/transaction.js
+++ b/lib/dialects/abstract/query-generator/transaction.js
@@ -16,7 +16,7 @@ const TransactionQueries = {
       return;
     }
 
-    return `SET SESSION TRANSACTION ISOLATION LEVEL ${value};`;
+    return `SET TRANSACTION ISOLATION LEVEL ${value};`;
   },
 
   generateTransactionId() {

--- a/lib/dialects/mariadb/index.js
+++ b/lib/dialects/mariadb/index.js
@@ -25,6 +25,7 @@ MariadbDialect.prototype.supports = _.merge(
     'LIMIT ON UPDATE': true,
     lock: true,
     forShare: 'LOCK IN SHARE MODE',
+    settingIsolationLevelDuringTransaction: false,
     schemas: true,
     inserts: {
       ignoreDuplicates: ' IGNORE',

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -24,6 +24,7 @@ MysqlDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype.
   'LIMIT ON UPDATE': true,
   lock: true,
   forShare: 'LOCK IN SHARE MODE',
+  settingIsolationLevelDuringTransaction: false,
   inserts: {
     ignoreDuplicates: ' IGNORE',
     updateOnDuplicate: ' ON DUPLICATE KEY UPDATE'

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -127,9 +127,8 @@ class Transaction {
         this.connection.uuid = this.id;
       })
       .then(() => {
-        return this.begin()
+        return this.startTransactionWithIsolationLevel()
           .then(() => this.setDeferrable())
-          .then(() => this.setIsolationLevel())
           .catch(setupErr => this.rollback().finally(() => {
             throw setupErr;
           }));
@@ -142,13 +141,6 @@ class Transaction {
       });
   }
 
-  begin() {
-    return this
-      .sequelize
-      .getQueryInterface()
-      .startTransaction(this, this.options);
-  }
-
   setDeferrable() {
     if (this.options.deferrable) {
       return this
@@ -158,11 +150,18 @@ class Transaction {
     }
   }
 
-  setIsolationLevel() {
-    return this
-      .sequelize
-      .getQueryInterface()
-      .setIsolationLevel(this, this.options.isolationLevel, this.options);
+  startTransactionWithIsolationLevel() {
+    const queryInterface = this.sequelize.getQueryInterface();
+
+    if ( this.sequelize.dialect.supports.settingIsolationLevelDuringTransaction ) {
+      return queryInterface.startTransaction(this, this.options).then(() => {
+        return queryInterface.setIsolationLevel(this, this.options.isolationLevel);
+      });
+    }
+
+    return queryInterface.setIsolationLevel(this, this.options.isolationLevel).then(() => {
+      return queryInterface.startTransaction(this, this.options);
+    });
   }
 
   cleanup() {

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -527,6 +527,93 @@ if (current.dialect.supports.transactions) {
 
     }
 
+    describe('isolation levels', () => {
+      it('should read the most recent committed rows when using the READ COMMITTED isolation level', function() {
+        const User = this.sequelize.define('user', {
+          username: Support.Sequelize.STRING
+        });
+
+        return expect(
+          this.sequelize.sync({ force: true }).then(() => {
+            return this.sequelize.transaction({ isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED }, transaction => {
+              return User.findAll({ transaction }).then(users => {
+                expect( users ).to.have.lengthOf(0);
+              }).then(() => {
+                // Create a User outside of the transaction
+                return User.create({ username: 'jan' }).then(() => { 
+                  // We should see the created user inside the transaction
+                  return User.findAll({ transaction }).then(users => {
+                    expect( users ).to.have.lengthOf(1);
+                  });
+                });
+              });
+            });
+          })
+        ).to.eventually.be.fulfilled;
+      });
+
+      // mssql is excluded because it implements REPREATABLE READ using locks rather than a snapshot, and will see the new row
+      if (['mariadb', 'mysql', 'postgres', 'postgres-native'].includes(dialect)) {
+        it('should not read newly committed rows when using the REPEATABLE READ isolation level', function() {
+          const User = this.sequelize.define('user', {
+            username: Support.Sequelize.STRING
+          });
+
+          return expect(
+            this.sequelize.sync({ force: true }).then(() => {
+              return this.sequelize.transaction({ isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ }, transaction => {
+                return User.findAll({ transaction }).then(users => {
+                  expect( users ).to.have.lengthOf(0);
+                }).then(() => {
+                  // Create a User outside of the transaction
+                  return User.create({ username: 'jan' }).then(() => { 
+                    // We should NOT see the created user inside the transaction
+                    return User.findAll({ transaction }).then(users => {
+                      expect( users ).to.have.lengthOf(0);
+                    });
+                  });
+                });
+              });
+            })
+          ).to.eventually.be.fulfilled;
+        });
+      }
+
+      // PostgreSQL is excluded because it detects Serialization Failure on commit instead of acquiring locks on the read rows
+      if (['mariadb', 'mysql', 'mssql'].includes(dialect)) {
+        it('should block updates after reading a row using SERIALIZABLE', function() {
+          const User = this.sequelize.define('user', {
+              username: Support.Sequelize.STRING
+            }),
+            transactionSpy = sinon.spy();
+
+          return this.sequelize.sync({ force: true }).then(() => {
+            return User.create({ username: 'jan' });
+          }).then(() => {
+            return this.sequelize.transaction({ isolationLevel: Transaction.ISOLATION_LEVELS.SERIALIZABLE }).then(transaction => {
+              return User.findAll( { transaction } ).then(() => {
+                return Promise.join(
+                  User.update({ username: 'joe' }, {
+                    where: {
+                      username: 'jan'
+                    }
+                  }).then(() => {
+                    expect(transactionSpy).to.have.been.called; // Update should not succeed before transaction has committed
+                  }),
+
+                  Promise.delay(2000).then(() => {
+                    return transaction.commit().then(transactionSpy);
+                  })
+                );
+              });
+            });
+          });
+        });
+      }
+
+    });
+
+
     if (current.dialect.supports.lock) {
       describe('row locking', () => {
         it('supports for update', function() {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

Fixes Issue #10975 : Setting isolation level does not work in MySQL or MariaDB. For both those dialects the setIsolationLevel query must be executed before the startTransaction query. For postgres the reverse is required, but it must be set before the first query in the transaction. For other dialects, it can be set at any time before or during a transaction.

This drops `SESSION` from the `SET TRANSACTION` queries, in order to set the isolation for a just a single transaction when future transactions in the session don't specify one, and updates MySQL and MariaDB to issue the `SET TRANSACTION` statement before the `START TRANSACTION`.

Three tests are added to confirm that changes isolation level works in all dialects. All added tests fail in mysql and mariadb without this fix.