### PR TITLE
docs: fix data-types link

### DIFF
--- a/docs/manual/data-types.md
+++ b/docs/manual/data-types.md
@@ -1,6 +1,6 @@
 # Datatypes
 
-Below are some of the datatypes supported by sequelize. For a full and updated list, see [DataTypes](/variable/index.html#static-variable-DataTypes).
+Below are some of the datatypes supported by sequelize. For a full and updated list, see [DataTypes](/master/variable/index.html#static-variable-DataTypes).
 
 ```js
 Sequelize.STRING                      // VARCHAR(255)


### PR DESCRIPTION
### Description of change

Fix `DataTypes` link at the top of the [manual](https://sequelize.org/master/manual/data-types.html)
