### PR TITLE
Added already existing options for bulkDelete to the documentation

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -1088,8 +1088,10 @@ class QueryInterface {
    * @param {string}  tableName            table name from where to delete records
    * @param {Object}  where                where conditions to find records to delete
    * @param {Object}  [options]            options
-   * @param {boolean} [options.truncate]  Use truncate table command
-   * @param {Model}   [model]             Model
+   * @param {boolean} [options.truncate]   Use truncate table command   
+   * @param {boolean} [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
+   * @param {boolean} [options.restartIdentity=false] Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table.
+   * @param {Model}   [model]              Model
    *
    * @returns {Promise}
    */


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?

 Not yet, I looked into it, and it looks like the bulkDelete take a generic(?) QueryOptions object.
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This issue adds missing documentation, thus closes #11473

<!-- Please provide a description of the change here. -->
