### PR TITLE
Do not omit field when same field/name in fieldMap

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -248,7 +248,7 @@ class AbstractQuery {
     if (this.options.fieldMap) {
       const fieldMap = this.options.fieldMap;
       results = results.map(result => _.reduce(fieldMap, (result, name, field) => {
-        if (result[field] !== undefined) {
+        if (result[field] !== undefined && name !== field) {
           result[name] = result[field];
           delete result[field];
         }

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -468,6 +468,18 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
     });
 
+    it('keeps field names that are mapped to the same name', function() {
+      return this.sequelize.query(this.insertQuery).then(() => {
+        return this.sequelize.query(`SELECT * FROM ${qq(this.User.tableName)};`, {
+          type: 'SELECT',
+          fieldMap: { username: 'username', email_address: 'email' }
+        });
+      }).then(users => {
+        expect(users[0].username).to.be.equal('john');
+        expect(users[0].email).to.be.equal('john@gmail.com');
+      });
+    });
+
     it('reject if `values` and `options.replacements` are both passed', function() {
       return this.sequelize.query({ query: 'select ? as foo, ? as bar', values: [1, 2] }, { raw: true, replacements: [1, 2] })
         .should.be.rejectedWith(Error, 'Both `sql.values` and `options.replacements` cannot be set at the same time');


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change

Fixes https://github.com/sequelize/sequelize/issues/11458 - the `fieldMap` code now checks that `name` is different from `field` before reassigning the value of `field` in the query result to `name` and deleting `field`. A test is included.
