### PR TITLE
fix(mssql): Virtual column checking at mssql @tmp table at v4

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -119,7 +119,7 @@ const QueryGenerator = {
 
           for (const modelKey in modelAttributes) {
             const attribute = modelAttributes[modelKey];
-            if (!attribute.references) {
+            if (!attribute.references && !(attribute.type instanceof DataTypes.VIRTUAL)) {
               if (tmpColumns.length > 0) {
                 tmpColumns += ',';
                 outputColumns += ',';
@@ -320,7 +320,7 @@ const QueryGenerator = {
 
           for (const modelKey in attributes) {
             const attribute = attributes[modelKey];
-            if (!attribute.references) {
+            if (!attribute.references && !(attribute.type instanceof DataTypes.VIRTUAL)) {
               if (tmpColumns.length > 0) {
                 tmpColumns += ',';
                 outputColumns += ',';

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -119,7 +119,7 @@ const QueryGenerator = {
 
           for (const modelKey in modelAttributes) {
             const attribute = modelAttributes[modelKey];
-            if (!(attribute.type instanceof DataTypes.VIRTUAL)) {
+            if (!attribute.references) {
               if (tmpColumns.length > 0) {
                 tmpColumns += ',';
                 outputColumns += ',';
@@ -320,7 +320,7 @@ const QueryGenerator = {
 
           for (const modelKey in attributes) {
             const attribute = attributes[modelKey];
-            if (!(attribute.type instanceof DataTypes.VIRTUAL)) {
+            if (!attribute.references) {
               if (tmpColumns.length > 0) {
                 tmpColumns += ',';
                 outputColumns += ',';


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

When using the `hasTrigger: true` option at mssql tables, sequelize creates a temporary table instead of using `OUTPUT INSERTED`, but this temp table includes the column names from relationships twice because `attribute.type` doesn't seem to have the expected `VIRTUAL` datatype. 

This fix uses the `references` attribute to check for relationship columns, since it is only set on those relationship columns that are already defined earlier without it.