### PR TITLE
fix(docs): fix package id links in docs

### DIFF
--- a/docs/manual/upgrade-to-v5.md
+++ b/docs/manual/upgrade-to-v5.md
@@ -26,7 +26,7 @@ Sequelize now ship official typings [#10287](https://github.com/sequelize/sequel
 
 ### Pooling
 
-With v5 Sequelize now use `sequelize-pool` which is a modernized fork of `generic-pool@2.5`. You no longer need to call `sequelize.close` to shutdown pool, this helps with lambda executions. [#8468](https://github.com/sequelize/sequelize/issues/8468)
+With v5 Sequelize now use `sequelize-pool` which is a modernized fork of <code>generic-pool&#64;2.5</code>. You no longer need to call `sequelize.close` to shutdown pool, this helps with lambda executions. [#8468](https://github.com/sequelize/sequelize/issues/8468)
 
 ### Model
 
@@ -231,7 +231,7 @@ dialectOptions: {
 - fix(types): additional options for db.query and add missing retry [#10512](https://github.com/sequelize/sequelize/pull/10512)
 - fix(query): don't prepare options & sql for every retry [#10498](https://github.com/sequelize/sequelize/pull/10498)
 - feat: expose Sequelize.BaseError
-- feat: upgrade to tedious@6.0.0 [#10494](https://github.com/sequelize/sequelize/pull/10494)
+- feat: upgrade to <code>tedious&#64;6.0.0</code> [#10494](https://github.com/sequelize/sequelize/pull/10494)
 - feat(sqlite/query-generator): support restart identity for truncate-table [#10522](https://github.com/sequelize/sequelize/pull/10522)
 - feat(data-types): handle numbers passed as objects [#10492](https://github.com/sequelize/sequelize/pull/10492)
 - feat(types): enabled string association [#10481](https://github.com/sequelize/sequelize/pull/10481)


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

Documentation-only change.

### Description of change

These were previously being rendered as `mailto:` links via esdoc (which uses marked's autolink rendering); see https://sequelize.org/master/manual/upgrade-to-v5.html. 

There are some [suggestions](https://gist.github.com/alexpeattie/4729247) about how one might disable or avoid autolinking but in this case the package identifiers are in backticks, producing weird behaviour similar to https://github.com/markedjs/marked/issues/1327.  Assuming the fix for this latter issue worked to solve this issue, then a dependency upgrade of `marked` within `esdoc` might solve the problem, but there are [maintenance issues](https://github.com/esdoc/esdoc/pull/543) there preventing updates or merges.

Until that point, this is a workaround to avoiding the weird `mailto:` links on this page by using HTML and character encoded entities instead.  Various attempts like `<code>foobar@1.2.3</code>` still rendered in the inner version spec as an email address.

