### PR TITLE
Fixes create functions if the used language is sql

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -631,8 +631,9 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const expandedOptionsArray = this.expandOptions(optionsArray);
 
     const statement = options && options.force ? 'CREATE OR REPLACE FUNCTION' : 'CREATE FUNCTION';
+    const wrappedBody = language === 'sql' ? body : `BEGIN ${body} END`;
 
-    return `${statement} ${functionName}(${paramList}) RETURNS ${returnType} AS $func$ ${variableList} BEGIN ${body} END; $func$ language '${language}'${expandedOptionsArray};`;
+    return `${statement} ${functionName}(${paramList}) RETURNS ${returnType} AS $func$ ${variableList} ${wrappedBody}; $func$ language '${language}' ${expandedOptionsArray};`;
   }
 
   dropFunction(functionName, params) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This change will add the `BEGIN`/`END` keywords in postgres functions only if the language is not `sql`. Thus, this PR will close #11312.  