### PR TITLE
fix(createtable): pass table field name in attr

### DIFF
--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -478,7 +478,7 @@ module.exports = BaseTypes => {
 
       if (this.type instanceof BaseTypes.ENUM) {
         castKey = `${Utils.addTicks(
-          Utils.generateEnumName(options.field.Model.getTableName(), options.field.fieldName),
+          Utils.generateEnumName(options.field.tableName || options.field.Model.getTableName(), options.field.fieldName),
           '"'
         ) }[]`;
       }

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -476,6 +476,12 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
         if (attribute.type instanceof DataTypes.ARRAY) {
           type += '[]';
+
+          // Add table and field name if not exists on attributes with ARRAY(ENUM) type
+          if (!attribute.fieldName) {
+            attribute.fieldName = options.key;
+            attribute.tableName = options.table.tableName || options.table;
+          }
         }
 
       } else {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -154,6 +154,12 @@ if (dialect.startsWith('postgres')) {
           expectation: { id: 'INTEGER NOT NULL DEFAULT 1 REFERENCES "Bar" ("id") ON DELETE CASCADE ON UPDATE RESTRICT' }
         },
 
+        // When type is ARRAY(ENUM) with defaultValue
+        {
+          arguments: [{ col: { type: DataTypes.ARRAY(DataTypes.ENUM('bar', 'baz')), allowNull: false, defaultValue: ['bar'] } }, { context: 'createTable', table: { schema: 'public', tableName: 'foo' } }],
+          expectation: { col: 'ENUM(\'bar\', \'baz\')[] NOT NULL DEFAULT ARRAY[\'bar\']::"enum_foo_col"[]' }
+        },
+
         // Variants when quoteIdentifiers is false
         {
           arguments: [{ id: { type: 'INTEGER', references: { model: 'Bar' } } }],


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Closes #11285

Set `tableName` and `fieldName` on attribute with type ARRAY(ENUM)
<!-- Please provide a description of the change here. -->
