### PR TITLE
fix(types): allow string and number arrays for contains operator

### DIFF
--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -535,6 +535,28 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           }, {
             postgres: '"muscles" @> ARRAY[2,5]::INTEGER[]'
           });
+
+          testsql('muscles', {
+            [Op.contains]: ['stringValue1', 'stringValue2', 'stringValue3']
+          }, {
+            postgres: '"muscles" @> ARRAY[\'stringValue1\',\'stringValue2\',\'stringValue3\']'
+          });
+
+          testsql('muscles', {
+            [Op.contained]: ['stringValue1', 'stringValue2', 'stringValue3']
+          }, {
+            postgres: '"muscles" <@ ARRAY[\'stringValue1\',\'stringValue2\',\'stringValue3\']'
+          });
+
+          testsql('muscles', {
+            [Op.contains]: ['stringValue1', 'stringValue2']
+          }, {
+            field: {
+              type: DataTypes.ARRAY(DataTypes.STRING)
+            }
+          }, {
+            postgres: '"muscles" @> ARRAY[\'stringValue1\',\'stringValue2\']::VARCHAR(255)[]'
+          });
         });
 
         describe('Op.overlap', () => {

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -211,14 +211,14 @@ export interface WhereOperators {
    *
    * Example: `[Op.contains]: [1, 2]` becomes `@> [1, 2]`
    */
-  [Op.contains]?: Rangable;
+  [Op.contains]?: (string | number)[] | Rangable;
 
   /**
    * PG array contained by operator
    *
    * Example: `[Op.contained]: [1, 2]` becomes `<@ [1, 2]`
    */
-  [Op.contained]?: Rangable;
+  [Op.contained]?: (string | number)[] | Rangable;
 
   /** Example: `[Op.gt]: 6,` becomes `> 6` */
   [Op.gt]?: number | string | Date | Literal;

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -114,6 +114,12 @@ where = {
             },
         },
     },
+    meta2: {
+      [Op.contains]: ['stringValue1', 'stringValue2', 'stringValue3']
+    },
+    meta3: {
+      [Op.contains]: [1, 2, 3, 4]
+    },
 };
 
 // Relations / Associations


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Types for string and number arrays are missing for `Op.contains` & `Op.contained` operator.
