### PR TITLE
Remove the static .toString from the 'ABSTRACT' class.

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -30,9 +30,6 @@ class ABSTRACT {
     }
     return options.bindParam(this.stringify(value, options));
   }
-  static toString() {
-    return this.name;
-  }
   static warn(link, text) {
     if (!warnings[text]) {
       warnings[text] = true;

--- a/lib/utils/classToInvokable.js
+++ b/lib/utils/classToInvokable.js
@@ -9,7 +9,7 @@
  * @private
  */
 function classToInvokable(Class) {
-  return new Proxy(Class, {
+  const proxy = new Proxy(Class, {
     apply(Target, thisArg, args) {
       return new Target(...args);
     },
@@ -20,5 +20,7 @@ function classToInvokable(Class) {
       return target[p];
     }
   });
+  proxy.toString = Function.prototype.toString.bind(Class);
+  return proxy;
 }
 exports.classToInvokable = classToInvokable;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes: https://github.com/pulumi/pulumi/issues/3310

For those who don't know, `@pulumi/pulumi` contains a serialization framework that allows someone to take normal JS functions and serialize them into a form that can be run in a cloud provider (like AWS Lambda, Azure Functions, etc.).  This serialization involves deep introspection of the original function code to determine what needs to be 'captured' and converted into the final code that runs in the cloud.

One of our customers wanted to use Pulumi along with the great sequelize library.  However, they ran into a problem due to an inability to serialize out some of the sequelize types due to some quirky stuff your library does.

So what happens in sequelize that causes problems here?  Well, in order to serialize a user's function we must `toString` it (getting the original source code from nodejs).  We then analyze the function body, finding out what values have been captured and serializing htem as well.  When we hit other function instances we recurse into them performing the same logic.  In this case the user wanted to serialize `sequelize.UUID`.  However, this fails because `pulumi` is unable to `toString` this function instance.  It's unable to, because in https://github.com/sequelize/sequelize/pull/10495 `sequelize` moved over from this being a normal function to a `class` that **also** supplies a **static** `toString` method.  This `toString` then intercepts the call to get the normal `Function.prototype.toString` implementation.

Normally, we could fix this by just calling `Function.prototype.toString.call(the_user_func)`.  However, that doesn't work here because `sequelize` **also** then wraps the class constructor function in a `Proxy` here: https://github.com/sequelize/sequelize/blob/6b3ccd81158d522fb6afe6580e0c751426795b50/lib/data-types.js#L1048-L1052

Because the class constructor function is wrapped in a Proxy, it is impossible to get at the underlying target to then pass to `Function.prototype.toString`.   Because of the combination of these two behaviors, it is effectively impossible to now get at the originating source code of this function in order to serialize it to a cloud-function.

I'm opening this PR up with what is hopefully a very minor and non-contentious change to help support this scenario.  Specifically, this just removes the **static** `toString` method on the class (not the **instance** method).  Looking at the PR that introduced this change, I have a guess that thsi addition was unintentional.  i.e. The previous code that was function-based did not do this https://github.com/sequelize/sequelize/pull/10495/files#diff-696825d45557dfe5b68972fd6f69587bL15.  It only overrode the instance `toString` and left the `ABSTRACT` function as something that would `toString` itself using normal JS semantics.  

I hope this is something you can take.  Thanks much!