### PR TITLE
fix(upsert): createdAt config ignored

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2465,7 +2465,7 @@ class Model {
       const now = Utils.now(this.sequelize.options.dialect);
 
       // Attach createdAt
-      if (createdAtAttr && !updateValues[createdAtAttr]) {
+      if (createdAtAttr && !insertValues[createdAtAttr]) {
         const field = this.rawAttributes[createdAtAttr].field || createdAtAttr;
         insertValues[field] = this._getDefaultTimestamp(createdAtAttr) || now;
       }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

We are using milliseconds for our `createdAt` and `updatedAt` columns, by setting `defaultValue: Sequelize.fn('NOW',3)`. It works great, except when we `Upsert`, in which case only `updatedAt` has milliseconds.

This because when setting `createdAt`, it incorrectly checks for an existing value in the `updateValues` instead of the `insertValues`.

This PR changes that, and fixes the issue.
