### PR TITLE
fix(postgres): update upsert regex to match the last `RETURNING *`

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -347,8 +347,12 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, upsertOptions);
     const update = this.updateQuery(tableName, updateValues, where, upsertOptions, model.rawAttributes);
 
-    insert.query = insert.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
-    update.query = update.query.replace('RETURNING *', `RETURNING ${primaryField} INTO primary_key`);
+    if (options.returning) {
+      const returningRegex = /RETURNING \*(?![\s\S]*RETURNING \*)/;
+
+      insert.query = insert.query.replace(returningRegex, `RETURNING ${primaryField} INTO primary_key`);
+      update.query = update.query.replace(returningRegex, `RETURNING ${primaryField} INTO primary_key`);
+    }
 
     return this.exceptionFn(
       'sequelize_upsert',

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -44,12 +44,14 @@ if (dialect.startsWith('postgres')) {
           expectation: 'CREATE DATABASE "myDatabase" ENCODING = \'UTF8\' LC_COLLATE = \'en_US.UTF-8\' LC_CTYPE = \'zh_TW.UTF-8\' TEMPLATE = \'template0\';'
         }
       ],
+
       dropDatabaseQuery: [
         {
           arguments: ['myDatabase'],
           expectation: 'DROP DATABASE IF EXISTS "myDatabase";'
         }
       ],
+
       arithmeticQuery: [
         {
           title: 'Should use the plus operator',
@@ -87,6 +89,7 @@ if (dialect.startsWith('postgres')) {
           expectation: 'UPDATE "myTable" SET "foo"="foo"- \'bar\''
         }
       ],
+
       attributesToSQL: [
         {
           arguments: [{ id: 'INTEGER' }],
@@ -1088,6 +1091,53 @@ if (dialect.startsWith('postgres')) {
             bind: ["foo';DROP TABLE mySchema.myTable;", 'foo']
           },
           context: { options: { quoteIdentifiers: false } }
+        }
+      ],
+
+      upsertQuery: [
+        {
+          arguments: [
+            'myTable',
+            { name: 'foo' },
+            { name: 'foo' },
+            { id: 2 },
+            { primaryKeyField: 'id' },
+            { returning: false }
+          ],
+          expectation: 'CREATE OR REPLACE FUNCTION pg_temp.sequelize_upsert(OUT created boolean, OUT primary_key text)  AS $func$ BEGIN INSERT INTO "myTable" ("name") VALUES (\'foo\'); created := true; EXCEPTION WHEN unique_violation THEN UPDATE "myTable" SET "name"=\'foo\' WHERE "id" = 2; created := false; END; $func$ LANGUAGE plpgsql; SELECT * FROM pg_temp.sequelize_upsert();'
+        },
+        {
+          arguments: [
+            'myTable',
+            { name: 'RETURNING *', json: '{"foo":"RETURNING *"}' },
+            { name: 'RETURNING *', json: '{"foo":"RETURNING *"}' },
+            { id: 2 },
+            { primaryKeyField: 'id' },
+            { returning: false }
+          ],
+          expectation: 'CREATE OR REPLACE FUNCTION pg_temp.sequelize_upsert(OUT created boolean, OUT primary_key text)  AS $func$ BEGIN INSERT INTO "myTable" ("name","json") VALUES (\'RETURNING *\',\'{"foo":"RETURNING *"}\'); created := true; EXCEPTION WHEN unique_violation THEN UPDATE "myTable" SET "name"=\'RETURNING *\',"json"=\'{"foo":"RETURNING *"}\' WHERE "id" = 2; created := false; END; $func$ LANGUAGE plpgsql; SELECT * FROM pg_temp.sequelize_upsert();'
+        },
+        {
+          arguments: [
+            'myTable',
+            { name: 'foo' },
+            { name: 'foo' },
+            { id: 2 },
+            { primaryKeyField: 'id' },
+            { returning: true }
+          ],
+          expectation: 'CREATE OR REPLACE FUNCTION pg_temp.sequelize_upsert(OUT created boolean, OUT primary_key text)  AS $func$ BEGIN INSERT INTO "myTable" ("name") VALUES (\'foo\') RETURNING "id" INTO primary_key; created := true; EXCEPTION WHEN unique_violation THEN UPDATE "myTable" SET "name"=\'foo\' WHERE "id" = 2 RETURNING "id" INTO primary_key; created := false; END; $func$ LANGUAGE plpgsql; SELECT * FROM pg_temp.sequelize_upsert();'
+        },
+        {
+          arguments: [
+            'myTable',
+            { name: 'RETURNING *', json: '{"foo":"RETURNING *"}' },
+            { name: 'RETURNING *', json: '{"foo":"RETURNING *"}' },
+            { id: 2 },
+            { primaryKeyField: 'id' },
+            { returning: true }
+          ],
+          expectation: 'CREATE OR REPLACE FUNCTION pg_temp.sequelize_upsert(OUT created boolean, OUT primary_key text)  AS $func$ BEGIN INSERT INTO "myTable" ("name","json") VALUES (\'RETURNING *\',\'{"foo":"RETURNING *"}\') RETURNING "id" INTO primary_key; created := true; EXCEPTION WHEN unique_violation THEN UPDATE "myTable" SET "name"=\'RETURNING *\',"json"=\'{"foo":"RETURNING *"}\' WHERE "id" = 2 RETURNING "id" INTO primary_key; created := false; END; $func$ LANGUAGE plpgsql; SELECT * FROM pg_temp.sequelize_upsert();'
         }
       ],
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes #11523

Postgres' upsert query generator replaces the first `RETURNING *` it finds on the insert and update query, so if the data being added has that string, it replaces it (so it replaces the wrong `RETURNING *`) changing the input data and messing with the the final query.

This PR updates the replace method to use a regex with a negative lookahead so it only chooses the last `RETURNING *` in the query.