### PR TITLE
Added unit test as an example and to cover dollarsign in sequelize.fn

### DIFF
--- a/test/integration/instance/save.test.js
+++ b/test/integration/instance/save.test.js
@@ -428,6 +428,17 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
     });
 
+    it('updates with function that contains escaped dollar symbol', function() {
+      return this.User.create({}).then(user => {
+        user.username = this.sequelize.fn('upper', '$$sequelize');
+        return user.save().then(() => {
+          return this.User.findByPk(user.id).then(userAfterUpdate => {
+            expect(userAfterUpdate.username).to.equal('$SEQUELIZE');
+          });
+        });
+      });
+    });
+
     describe('without timestamps option', () => {
       it("doesn't update the updatedAt column", function() {
         const User2 = this.sequelize.define('User2', {


### PR DESCRIPTION
### Description of change

Added unit test that covers dollar sign in `sequelize.fn`. This serves mainly as an example for now, but might also be merged depending on conversation in the related issue. 

Related to #11533.
