### PR TITLE
fix(types): add array of Buffers to WhereValue type

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -350,7 +350,7 @@ export type WhereValue =
   | OrOperator
   | AndOperator
   | WhereGeometryOptions
-  | (string | number | WhereAttributeHash)[]; // implicit [Op.or]
+  | (string | number | Buffer | WhereAttributeHash)[]; // implicit [Op.or]
 
 /**
  * A hash of attributes to describe your search.

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -15,9 +15,12 @@ let where: WhereOptions;
  */
 where = {
   string: 'foo',
+  strings: ['foo'],
   number: 1,
+  numbers: [1],
   boolean: true,
   buffer: Buffer.alloc(0),
+  buffers: [Buffer.alloc(0)],
   null: null,
 };
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

`where` clauses that contain arrays of Buffers (querying binary fields) fail Typescript validation due to a missing type declaration. Example:

```js
Foo.findOne({
  where: { bar: [Buffer.alloc(0)] },
});
```

Buffer support was just added in https://github.com/sequelize/sequelize/pull/11499. This PR adds support for arrays of Buffers to the `WhereValue` type definition.

I ran `npm run test-typings`