### PR TITLE
fix(associations): allow binary key for belongs-to-many

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -532,7 +532,8 @@ class BelongsToMany extends Association {
     };
 
     return this.get(sourceInstance, options).then(associatedObjects =>
-      _.differenceBy(instancePrimaryKeys, associatedObjects, this.targetKey).length === 0
+      _.differenceWith(instancePrimaryKeys, associatedObjects,
+        (a, b) => _.isEqual(a[this.targetKey], b[this.targetKey])).length === 0
     );
   }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
fix #11545