### PR TITLE
fix: fix type of methods in query-interface

### DIFF
--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -120,14 +120,14 @@ export interface QueryInterfaceDropAllTablesOptions extends QueryInterfaceOption
   skip?: string[];
 }
 
-export interface TablenameWithSchema {
+export interface TableNameWithSchema {
   tableName: string;
   schema?: string;
   delimiter?: string;
   as?: string;
   name?: string;
 }
-export type Tablename = string | TablenameWithSchema;
+export type TableName = string | TableNameWithSchema;
 
 export type IndexType = 'UNIQUE' | 'FULLTEXT' | 'SPATIAL';
 export type IndexMethod = 'BTREE' | 'HASH' | 'GIST' | 'SPGIST' | 'GIN' | 'BRIN' | string;
@@ -445,7 +445,7 @@ export class QueryInterface {
    * Inserts or Updates a record in the database
    */
   public upsert(
-    tableName: Tablename,
+    tableName: TableName,
     values: object,
     updateValues: object,
     model: typeof Model,
@@ -456,7 +456,7 @@ export class QueryInterface {
    * Inserts multiple records at once
    */
   public bulkInsert(
-    tableName: Tablename,
+    tableName: TableName,
     records: object[],
     options?: QueryOptions,
     attributes?: string[] | string
@@ -467,7 +467,7 @@ export class QueryInterface {
    */
   public update(
     instance: Model,
-    tableName: Tablename,
+    tableName: TableName,
     values: object,
     identifier: WhereOptions,
     options?: QueryOptions
@@ -477,7 +477,7 @@ export class QueryInterface {
    * Updates multiple rows at once
    */
   public bulkUpdate(
-    tableName: Tablename,
+    tableName: TableName,
     values: object,
     identifier: WhereOptions,
     options?: QueryOptions,
@@ -487,13 +487,13 @@ export class QueryInterface {
   /**
    * Deletes a row
    */
-  public delete(instance: Model | null, tableName: Tablename, identifier: WhereOptions, options?: QueryOptions): Promise<object>;
+  public delete(instance: Model | null, tableName: TableName, identifier: WhereOptions, options?: QueryOptions): Promise<object>;
 
   /**
    * Deletes multiple rows at once
    */
   public bulkDelete(
-    tableName: Tablename,
+    tableName: TableName,
     identifier: WhereOptions,
     options?: QueryOptions,
     model?: typeof Model
@@ -502,14 +502,14 @@ export class QueryInterface {
   /**
    * Returns selected rows
    */
-  public select(model: typeof Model | null, tableName: Tablename, options?: QueryOptionsWithWhere): Promise<object[]>;
+  public select(model: typeof Model | null, tableName: TableName, options?: QueryOptionsWithWhere): Promise<object[]>;
 
   /**
    * Increments a row value
    */
   public increment(
     instance: Model,
-    tableName: Tablename,
+    tableName: TableName,
     values: object,
     identifier: WhereOptions,
     options?: QueryOptions
@@ -519,7 +519,7 @@ export class QueryInterface {
    * Selects raw without parsing the string into an object
    */
   public rawSelect(
-    tableName: Tablename,
+    tableName: TableName,
     options: QueryOptionsWithWhere,
     attributeSelector: string | string[],
     model?: typeof Model
@@ -530,7 +530,7 @@ export class QueryInterface {
    * parameters.
    */
   public createTrigger(
-    tableName: Tablename,
+    tableName: TableName,
     triggerName: string,
     timingType: string,
     fireOnArray: {
@@ -545,13 +545,13 @@ export class QueryInterface {
   /**
    * Postgres only. Drops the specified trigger.
    */
-  public dropTrigger(tableName: Tablename, triggerName: string, options?: QueryInterfaceOptions): Promise<void>;
+  public dropTrigger(tableName: TableName, triggerName: string, options?: QueryInterfaceOptions): Promise<void>;
 
   /**
    * Postgres only. Renames a trigger
    */
   public renameTrigger(
-    tableName: Tablename,
+    tableName: TableName,
     oldTriggerName: string,
     newTriggerName: string,
     options?: QueryInterfaceOptions
@@ -594,7 +594,7 @@ export class QueryInterface {
   /**
    * Escape a table name
    */
-  public quoteTable(identifier: Tablename): string;
+  public quoteTable(identifier: TableName): string;
 
   /**
    * Split an identifier into .-separated tokens and quote each part. If force is true, the identifier will be

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -120,6 +120,15 @@ export interface QueryInterfaceDropAllTablesOptions extends QueryInterfaceOption
   skip?: string[];
 }
 
+export interface TablenameWithSchema {
+  tableName: string;
+  schema?: string;
+  delimiter?: string;
+  as?: string;
+  name?: string;
+}
+export type Tablename = string | TablenameWithSchema;
+
 export type IndexType = 'UNIQUE' | 'FULLTEXT' | 'SPATIAL';
 export type IndexMethod = 'BTREE' | 'HASH' | 'GIST' | 'SPGIST' | 'GIN' | 'BRIN' | string;
 
@@ -436,7 +445,7 @@ export class QueryInterface {
    * Inserts or Updates a record in the database
    */
   public upsert(
-    tableName: string,
+    tableName: Tablename,
     values: object,
     updateValues: object,
     model: typeof Model,
@@ -447,7 +456,7 @@ export class QueryInterface {
    * Inserts multiple records at once
    */
   public bulkInsert(
-    tableName: string,
+    tableName: Tablename,
     records: object[],
     options?: QueryOptions,
     attributes?: string[] | string
@@ -458,7 +467,7 @@ export class QueryInterface {
    */
   public update(
     instance: Model,
-    tableName: string,
+    tableName: Tablename,
     values: object,
     identifier: WhereOptions,
     options?: QueryOptions
@@ -468,7 +477,7 @@ export class QueryInterface {
    * Updates multiple rows at once
    */
   public bulkUpdate(
-    tableName: string,
+    tableName: Tablename,
     values: object,
     identifier: WhereOptions,
     options?: QueryOptions,
@@ -478,13 +487,13 @@ export class QueryInterface {
   /**
    * Deletes a row
    */
-  public delete(instance: Model | null, tableName: string, identifier: WhereOptions, options?: QueryOptions): Promise<object>;
+  public delete(instance: Model | null, tableName: Tablename, identifier: WhereOptions, options?: QueryOptions): Promise<object>;
 
   /**
    * Deletes multiple rows at once
    */
   public bulkDelete(
-    tableName: string,
+    tableName: Tablename,
     identifier: WhereOptions,
     options?: QueryOptions,
     model?: typeof Model
@@ -493,14 +502,14 @@ export class QueryInterface {
   /**
    * Returns selected rows
    */
-  public select(model: typeof Model | null, tableName: string, options?: QueryOptionsWithWhere): Promise<object[]>;
+  public select(model: typeof Model | null, tableName: Tablename, options?: QueryOptionsWithWhere): Promise<object[]>;
 
   /**
    * Increments a row value
    */
   public increment(
     instance: Model,
-    tableName: string,
+    tableName: Tablename,
     values: object,
     identifier: WhereOptions,
     options?: QueryOptions
@@ -510,7 +519,7 @@ export class QueryInterface {
    * Selects raw without parsing the string into an object
    */
   public rawSelect(
-    tableName: string,
+    tableName: Tablename,
     options: QueryOptionsWithWhere,
     attributeSelector: string | string[],
     model?: typeof Model
@@ -521,7 +530,7 @@ export class QueryInterface {
    * parameters.
    */
   public createTrigger(
-    tableName: string,
+    tableName: Tablename,
     triggerName: string,
     timingType: string,
     fireOnArray: {
@@ -536,13 +545,13 @@ export class QueryInterface {
   /**
    * Postgres only. Drops the specified trigger.
    */
-  public dropTrigger(tableName: string, triggerName: string, options?: QueryInterfaceOptions): Promise<void>;
+  public dropTrigger(tableName: Tablename, triggerName: string, options?: QueryInterfaceOptions): Promise<void>;
 
   /**
    * Postgres only. Renames a trigger
    */
   public renameTrigger(
-    tableName: string,
+    tableName: Tablename,
     oldTriggerName: string,
     newTriggerName: string,
     options?: QueryInterfaceOptions
@@ -585,7 +594,7 @@ export class QueryInterface {
   /**
    * Escape a table name
    */
-  public quoteTable(identifier: string): string;
+  public quoteTable(identifier: Tablename): string;
 
   /**
    * Split an identifier into .-separated tokens and quote each part. If force is true, the identifier will be

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -53,6 +53,14 @@ queryInterface.dropTable('nameOfTheExistingTable');
 
 queryInterface.bulkDelete({ tableName: 'foo', schema: 'bar' }, {}, {});
 
+queryInterface.bulkInsert({ tableName: 'foo', as: 'bar', name: 'as' }, [{}], {});
+
+queryInterface.bulkUpdate({ tableName: 'foo', delimiter: 'bar', as: 'baz', name: 'quz' }, {}, {});
+
+queryInterface.dropTrigger({ tableName: 'foo', as: 'bar', name: 'baz' }, 'foo', {});
+
+queryInterface.quoteTable({ tableName: 'foo', delimiter: 'bar' });
+
 queryInterface.dropAllTables();
 
 queryInterface.renameTable('Person', 'User');

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -51,6 +51,8 @@ queryInterface.createTable(
 
 queryInterface.dropTable('nameOfTheExistingTable');
 
+queryInterface.bulkDelete({ tableName: 'foo', schema: 'bar' }, {}, {});
+
 queryInterface.dropAllTables();
 
 queryInterface.renameTable('Person', 'User');


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
(npm run test-typings, actaully)
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
as described in #11027, many of the QueryInterface methods accept something like `string | { tableName: string, schema: string }` as the first argument. however, they are accepting tableName with string type only. So I added interface and type so that they could get arguments other than string.   
<!-- Please provide a description of the change here. -->



