### PR TITLE
fix: escape dollarsign in sequelize.fn related to issue 11533

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -943,7 +943,6 @@ class QueryGenerator {
         }
       }
     }
-
     return SqlString.escape(value, this.options.timezone, this.dialect);
   }
 
@@ -2134,7 +2133,7 @@ class QueryGenerator {
         if (_.isPlainObject(arg)) {
           return this.whereItemsQuery(arg);
         }
-        return this.escape(arg);
+        return this.escape(arg.replace('$', '$$$'));
       }).join(', ')})`;
     }
     if (smth instanceof Utils.Col) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2133,7 +2133,7 @@ class QueryGenerator {
         if (_.isPlainObject(arg)) {
           return this.whereItemsQuery(arg);
         }
-        return this.escape(arg.replace('$', '$$$'));
+        return this.escape(typeof arg === 'string' ? arg.replace('$', '$$$') : arg);
       }).join(', ')})`;
     }
     if (smth instanceof Utils.Col) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0-beta.3",
   "maintainers": [
     "Sascha Depold <sascha@depold.com>",
     "Jan Aagaard Meier <janzeh@gmail.com>",

--- a/test/integration/instance/save.test.js
+++ b/test/integration/instance/save.test.js
@@ -428,6 +428,17 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
     });
 
+    it('updates with function that contains escaped dollar symbol', function() {
+      return this.User.create({}).then(user => {
+        user.username = this.sequelize.fn('upper', '$sequelize');
+        return user.save().then(() => {
+          return this.User.findByPk(user.id).then(userAfterUpdate => {
+            expect(userAfterUpdate.username).to.equal('$SEQUELIZE');
+          });
+        });
+      });
+    });
+
     describe('without timestamps option', () => {
       it("doesn't update the updatedAt column", function() {
         const User2 = this.sequelize.define('User2', {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -330,6 +330,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    it('returns instance if username is a sequelize fn with $ in value', function() {
+      const data = {
+        username: Sequelize.fn('upper', '$username')
+      };
+
+      return this.User.create(data).then(user => {
+        expect(user.username).to.equal('$USERNAME');
+      });
+    });
+
     it('Returns instance if already existent. Multiple find fields.', function() {
       const data = {
         username: 'Username',

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -102,7 +102,7 @@ describe('QueryGenerator', () => {
     it('should correctly escape $ in sequelize.fn arguments', function() {
       const QG = getAbstractQueryGenerator(this.sequelize);
       QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user'))
-        .should.be.equal('upper(\'$$user\')');
+        .should.include('$$user');
     });
   });
 

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -98,6 +98,12 @@ describe('QueryGenerator', () => {
       QG.handleSequelizeMethod(this.sequelize.where(this.sequelize.col('foo'), Op.not, null))
         .should.be.equal('foo IS NOT NULL');
     });
+
+    it('should correctly escape $ in sequelize.fn arguments', function() {
+      const QG = getAbstractQueryGenerator(this.sequelize);
+      QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user'))
+        .should.be.equal('upper(\'$$user\')');
+    });
   });
 
   describe('format', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
https://github.com/sequelize/sequelize/issues/11533
- changed the abstract query generator handleSequelizeMethod to escape dollar ($) in argument
