### PR TITLE
feat(model): add order by option to destroy

### DIFF
--- a/docs/manual/querying.md
+++ b/docs/manual/querying.md
@@ -481,6 +481,17 @@ Subtask.findAll({
 })
 ```
 
+`order` is also supported in the `destroy` method, but will only accept an an array of attributes and directions.
+
+```js
+Subtask.destroy({
+  order: [
+    // Will escape title and age and validate DESC and ASC respectively against a list of valid direction parameters
+    ['title', 'DESC'], ['age', 'ASC']
+  ]
+})
+```
+
 ## Table Hint
 
 `tableHint` can be used to optionally pass a table hint when using mssql. The hint must be a value from `Sequelize.TableHints` and should only be used when absolutely necessary. Only a single table hint is currently supported per query.

--- a/docs/manual/querying.md
+++ b/docs/manual/querying.md
@@ -481,12 +481,11 @@ Subtask.findAll({
 })
 ```
 
-`order` is also supported in the `destroy` method, but will only accept an an array of attributes and directions.
+`order` is also supported in the `destroy` method and will only accept an array of attributes and directions.
 
 ```js
 Subtask.destroy({
   order: [
-    // Will escape title and age and validate DESC and ASC respectively against a list of valid direction parameters
     ['title', 'DESC'], ['age', 'ASC']
   ]
 })

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -509,7 +509,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (options.order) { 
-      order = ` ORDER BY ${this.escape(options.order.map(o => o.join(' ')).join(', '))}`;
+      order = ` ORDER BY ${options.order.map(o => o.join(' ')).join(', ')}`;
     }
 
     if (whereClause) {

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -502,16 +502,21 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     let whereClause = this.getWhereConditions(where, null, model, options);
     let limit = '';
+    let order = '';
 
     if (options.limit) {
       limit = ` TOP(${this.escape(options.limit)})`;
+    }
+
+    if (options.order) { 
+      order = ` ORDER BY ${this.escape(options.order.map(o => o.join(' ')).join(', '))}`;
     }
 
     if (whereClause) {
       whereClause = ` WHERE ${whereClause}`;
     }
 
-    return `DELETE${limit} FROM ${table}${whereClause}; SELECT @@ROWCOUNT AS AFFECTEDROWS;`;
+    return `DELETE${limit} FROM ${table}${whereClause}${order}; SELECT @@ROWCOUNT AS AFFECTEDROWS;`;
   }
 
   showIndexesQuery(tableName) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -285,9 +285,14 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
   deleteQuery(tableName, where, options = {}, model) {
     let limit = '';
     let query = `DELETE FROM ${this.quoteTable(tableName)}`;
+    let order = '';
 
     if (options.limit) {
       limit = ` LIMIT ${this.escape(options.limit)}`;
+    }
+
+    if (options.order) {
+      order = ` ORDER BY ${options.order.map(o => o.join(' ')).join(', ')}`;
     }
 
     where = this.getWhereConditions(where, null, model, options);
@@ -296,7 +301,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
       query += ` WHERE ${where}`;
     }
 
-    return query + limit;
+    return query + order + limit;
   }
 
   showIndexesQuery(tableName, options) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -372,6 +372,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const table = this.quoteTable(tableName);
     let whereClause = this.getWhereConditions(where, null, model, options);
     const limit = options.limit ? ` LIMIT ${this.escape(options.limit)}` : '';
+    const order = options.order ? ` ORDER BY ${options.order.map(o => o.join(' ')).join(', ')}` : '';
     let primaryKeys = '';
     let primaryKeysSelection = '';
 
@@ -379,9 +380,9 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       whereClause = ` WHERE ${whereClause}`;
     }
 
-    if (options.limit) {
+    if (options.order || options.limit) {
       if (!model) {
-        throw new Error('Cannot LIMIT delete without a model.');
+        throw new Error('Cannot ORDER or LIMIT delete without a model.');
       }
 
       const pks = _.values(model.primaryKeys).map(pk => this.quoteIdentifier(pk.field)).join(',');
@@ -389,7 +390,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       primaryKeys = model.primaryKeyAttributes.length > 1 ? `(${pks})` : pks;
       primaryKeysSelection = pks;
 
-      return `DELETE FROM ${table} WHERE ${primaryKeys} IN (SELECT ${primaryKeysSelection} FROM ${table}${whereClause}${limit})`;
+      return `DELETE FROM ${table} WHERE ${primaryKeys} IN (SELECT ${primaryKeysSelection} FROM ${table}${whereClause}${order}${limit})`;
     }
     return `DELETE FROM ${table}${whereClause}`;
   }

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -248,8 +248,18 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
       whereClause = `WHERE ${whereClause}`;
     }
 
-    if (options.limit) {
-      whereClause = `WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${whereClause} LIMIT ${this.escape(options.limit)})`;
+    if (options.limit || options.order) {
+      whereClause = `WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${whereClause}`;
+
+      if (options.order) {
+        whereClause += ` ORDER BY ${options.order.map(x => x.join(' ')).join(', ')}`;
+      }
+
+      if (options.limit) {
+        whereClause += ` LIMIT ${this.escape(options.limit)})`;
+      } else {
+        whereClause += ')';
+      }
     }
 
     return `DELETE FROM ${this.quoteTable(tableName)} ${whereClause}`;

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -123,6 +123,89 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
+    describe('delete with order', () => {
+      const options = {
+        table: User.getTableName(),
+        where: { name: 'foo' },
+        order: [['id', 'DESC']],
+        type: QueryTypes.BULKDELETE
+      };
+
+      it(util.inspect(options, { depth: 2 }), () => {
+        return expectsql(
+          sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            User
+          ), {
+            postgres: 'DELETE FROM "public"."test_users" WHERE "id" IN (SELECT "id" FROM "public"."test_users" WHERE "name" = \'foo\' ORDER BY id DESC)',
+            sqlite: "DELETE FROM `public.test_users` WHERE rowid IN (SELECT rowid FROM `public.test_users` WHERE `name` = 'foo' ORDER BY id DESC)",
+            mssql: "DELETE FROM [public].[test_users] WHERE [name] = N'foo' ORDER BY id DESC; SELECT @@ROWCOUNT AS AFFECTEDROWS;",
+            default: "DELETE FROM [public.test_users] WHERE `name` = 'foo' ORDER BY id DESC"
+          }
+        );
+      });
+    });
+
+    describe('delete with order and limit', () => {
+      const options = {
+        table: User.getTableName(),
+        where: { name: 'foo' },
+        order: [['id', 'DESC']],
+        limit: 10,
+        type: QueryTypes.BULKDELETE
+      };
+
+      it(util.inspect(options, { depth: 2 }), () => {
+        return expectsql(
+          sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            User
+          ), {
+            postgres: 'DELETE FROM "public"."test_users" WHERE "id" IN (SELECT "id" FROM "public"."test_users" WHERE "name" = \'foo\' ORDER BY id DESC LIMIT 10)',
+            sqlite: "DELETE FROM `public.test_users` WHERE rowid IN (SELECT rowid FROM `public.test_users` WHERE `name` = 'foo' ORDER BY id DESC LIMIT 10)",
+            mssql: "DELETE TOP(10) FROM [public].[test_users] WHERE [name] = N'foo' ORDER BY id DESC; SELECT @@ROWCOUNT AS AFFECTEDROWS;",
+            default: "DELETE FROM [public.test_users] WHERE `name` = 'foo' ORDER BY id DESC LIMIT 10"
+          }
+        );
+      });
+    });
+
+    describe('delete with order and without model', () => {
+      const options = {
+        table: User.getTableName(),
+        where: { name: "foo';DROP TABLE mySchema.myTable;" },
+        order: [['id', 'DESC']],
+        type: QueryTypes.BULKDELETE
+      };
+
+      it(util.inspect(options, { depth: 2 }), () => {
+        let query;
+        try {
+          query = sql.deleteQuery(
+            options.table,
+            options.where,
+            options,
+            null
+          );
+        } catch (err) {
+          query = err;
+        }
+
+        return expectsql(
+          query, {
+            postgres: new Error('Cannot ORDER or LIMIT delete without a model.'),
+            sqlite: "DELETE FROM `public.test_users` WHERE rowid IN (SELECT rowid FROM `public.test_users` WHERE `name` = 'foo'';DROP TABLE mySchema.myTable;' ORDER BY id DESC)",
+            mssql: "DELETE FROM [public].[test_users] WHERE [name] = N'foo'';DROP TABLE mySchema.myTable;' ORDER BY id DESC; SELECT @@ROWCOUNT AS AFFECTEDROWS;",
+            default: "DELETE FROM [public.test_users] WHERE `name` = 'foo\\';DROP TABLE mySchema.myTable;' ORDER BY id DESC"
+          }
+        );
+      });
+    });
+
     describe('delete with limit and without model', () => {
       const options = {
         table: User.getTableName(),
@@ -146,7 +229,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
         return expectsql(
           query, {
-            postgres: new Error('Cannot LIMIT delete without a model.'),
+            postgres: new Error('Cannot ORDER or LIMIT delete without a model.'),
             mariadb: "DELETE FROM `public`.`test_users` WHERE `name` = 'foo\\';DROP TABLE mySchema.myTable;' LIMIT 10",
             sqlite: "DELETE FROM `public.test_users` WHERE rowid IN (SELECT rowid FROM `public.test_users` WHERE `name` = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)",
             mssql: "DELETE TOP(10) FROM [public].[test_users] WHERE [name] = N'foo'';DROP TABLE mySchema.myTable;'; SELECT @@ROWCOUNT AS AFFECTEDROWS;",


### PR DESCRIPTION
Add order by option to destroy, useful when deleting hierarchical data.
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Closes #9715

Add order by option to destroy method

This PRs it's a copy from this https://github.com/sequelize/sequelize/pull/10196 the credits of the code is from @jasonli12.