### PR TITLE
fix(postgres, sqlite): composite unique key skipped when using update…

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2702,7 +2702,7 @@ class Model {
             // Get primary keys for postgres to enable updateOnDuplicate
             options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
             if (Object.keys(model.uniqueKeys).length > 0) {
-              options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length === 1).map('column').value();
+              options.upsertKeys = _.chain(model.uniqueKeys).values().flatMap('fields').value();
             }
           }
 


### PR DESCRIPTION
…OnDuplicate

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? I am unable to get tests to run with the docker solution. Seems travis succeeded though.
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Fixes https://github.com/sequelize/sequelize/issues/11534
It seemed that the `fields` contains all fields related to an unique composite index. So instead of skipping composite unique indexes we use `fields` to populate the ON CONFLICT statement.