### PR TITLE
feat(postgres): Add `upsertIndex` and `upsertKeys` options to `BulkCreateOptions`

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -288,9 +288,16 @@ class QueryGenerator {
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
       if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
-        const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+        if (Array.isArray(options.upsertKeys)) {
+          const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
+          onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+        } else {
+          // If upsertKeys is an object, generate an ON CONFLICT WHERE
+          const conflictKeys = options.upsertKeys.fields.map(attr => this.quoteIdentifier(attr));
+          const where = this.whereQuery(options.upsertKeys.where);
+          onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${where} DO UPDATE SET ${updateKeys.join(',')}`;
+        }
       } else { // mysql / maria
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate = `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;

--- a/lib/model.js
+++ b/lib/model.js
@@ -2668,10 +2668,22 @@ class Model {
         // Map updateOnDuplicate attributes to fields
         if (options.updateOnDuplicate) {
           options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
-          // Get primary keys for postgres to enable updateOnDuplicate
-          options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
-          if (Object.keys(model.uniqueKeys).length > 0) {
-            options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length >= 1).map(c => c.fields).reduce(c => c[0]).value();
+          if (options.upsertIndex !== undefined) {
+            const upsertIndex = model._indexes.find(index => index.name === options.upsertIndex);
+            if (upsertIndex === undefined) {
+              throw new Error(`upsertIndex '${options.upsertIndex}' not defined.`);
+            }
+            if (!upsertIndex.unique) {
+              throw new Error(`upsertIndex '${options.upsertIndex}' not a unique index.`);
+            }
+            options.upsertKeys = { fields: upsertIndex.fields, where: upsertIndex.where };
+          }
+          if (options.upsertKeys == null) {
+            // Get primary keys for postgres to enable updateOnDuplicate
+            options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
+            if (Object.keys(model.uniqueKeys).length > 0) {
+              options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length >= 1).map(c => c.fields).reduce(c => c[0]).value();
+            }
           }
         }
 

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -751,6 +751,20 @@ export interface BulkCreateOptions extends Logging, Transactionable, Hookable {
   updateOnDuplicate?: string[];
 
   /**
+   * The name of a unique index to be used for generation of an `ON CONFLICT`
+   * clause. (Only supported by SQLite >= 3.24.0 & Postgres >= 9.5)
+   */
+  upsertIndex?: string;
+
+  /**
+   * Either an array of database columns that are either primary keys or
+   * composite members of a unique key, or an object containing fields and a
+   * where clause that represents a partial index. Used for generating an `ON
+   * CONFLICT` clause. (Only supported by SQLite >= 3.24.0 & Postgres >= 9.5)
+   */
+  upsertKeys?: string[] | { fields: string[], where: WhereOptions };
+
+  /**
    * Include options. See `find` for details
    */
   include?: Includeable | Includeable[];


### PR DESCRIPTION
This allows the use of a unique index for a `bulkCreate` with
`updateOnDuplicate` set, in postgres. The unique index may be
a partial index.

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This change adds the ability to specify `upsertIndex` or `upsertKeys` in `BulkCreateOptions`, so that a `ON CONFLICT` clause can be generated using columns other than the table's primary key.

Note: I was not able to get the tests running on my machine, and would appreciate help writing a new test for this functionality.

Closes #11534, #11569