### PR TITLE
fix(types): add missing transaction typescript types (v6-beta)

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -18,7 +18,7 @@ import Op = require('./operators');
 import { Promise } from './promise';
 import { QueryOptions, IndexesOptions } from './query-interface';
 import { Config, Options, Sequelize, SyncOptions } from './sequelize';
-import { Transaction } from './transaction';
+import { Transaction, LOCK } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
 import { IndexHints } from '..';
 
@@ -549,8 +549,10 @@ export interface FindOptions extends QueryOptions, Filterable, Projectable, Para
    * Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model
    * locks with joins. See [transaction.LOCK for an example](transaction#lock)
    */
-  lock?: Transaction.LOCK | { level: Transaction.LOCK; of: typeof Model };
-
+  lock?:
+    | LOCK
+    | { level: LOCK; of: typeof Model }
+    | boolean;
   /**
    * Skip locked rows. Only supported in Postgres.
    */

--- a/types/lib/transaction.d.ts
+++ b/types/lib/transaction.d.ts
@@ -26,6 +26,18 @@ export class Transaction {
    * Adds hook that is run after a transaction is committed
    */
   public afterCommit(fn: (transaction: this) => void | Promise<void>): void;
+
+  /**
+   * Returns possible options for row locking
+   */
+  static get LOCK(): LOCK;
+
+  /**
+   * Same as its static version, but can also be called on instances of
+   * transactions to get possible options for row locking directly from the
+   * instance.
+   */
+  get LOCK(): LOCK;
 }
 
 // tslint:disable-next-line no-namespace
@@ -71,54 +83,61 @@ export namespace Transaction {
     IMMEDIATE = 'IMMEDIATE',
     EXCLUSIVE = 'EXCLUSIVE',
   }
+}
 
+/**
+ * Possible options for row locking. Used in conjunction with `find` calls:
+ *
+ * ```js
+ * t1 // is a transaction
+ * t1.LOCK.UPDATE,
+ * t1.LOCK.SHARE,
+ * t1.LOCK.KEY_SHARE, // Postgres 9.3+ only
+ * t1.LOCK.NO_KEY_UPDATE // Postgres 9.3+ only
+ * ```
+ *
+ * Usage:
+ * ```js
+ * t1 // is a transaction
+ * Model.findAll({
+ *   where: ...,
+ *   transaction: t1,
+ *   lock: t1.LOCK...
+ * });
+ * ```
+ *
+ * Postgres also supports specific locks while eager loading by using OF:
+ * ```js
+ * UserModel.findAll({
+ *   where: ...,
+ *   include: [TaskModel, ...],
+ *   transaction: t1,
+ *   lock: {
+ *   level: t1.LOCK...,
+ *   of: UserModel
+ *   }
+ * });
+ * ```
+ * UserModel will be locked but TaskModel won't!
+ */
+export enum LOCK {
+  UPDATE = 'UPDATE',
+  SHARE = 'SHARE',
   /**
-   * Possible options for row locking. Used in conjunction with `find` calls:
-   *
-   * ```js
-   * t1 // is a transaction
-   * t1.LOCK.UPDATE,
-   * t1.LOCK.SHARE,
-   * t1.LOCK.KEY_SHARE, // Postgres 9.3+ only
-   * t1.LOCK.NO_KEY_UPDATE // Postgres 9.3+ only
-   * ```
-   *
-   * Usage:
-   * ```js
-   * t1 // is a transaction
-   * Model.findAll({
-   *   where: ...,
-   *   transaction: t1,
-   *   lock: t1.LOCK...
-   * });
-   * ```
-   *
-   * Postgres also supports specific locks while eager loading by using OF:
-   * ```js
-   * UserModel.findAll({
-   *   where: ...,
-   *   include: [TaskModel, ...],
-   *   transaction: t1,
-   *   lock: {
-   *   level: t1.LOCK...,
-   *   of: UserModel
-   *   }
-   * });
-   * ```
-   * UserModel will be locked but TaskModel won't!
+   * Postgres 9.3+ only
    */
-  enum LOCK {
-    UPDATE = 'UPDATE',
-    SHARE = 'SHARE',
-    /**
-     * Postgres 9.3+ only
-     */
-    KEY_SHARE = 'KEY SHARE',
-    /**
-     * Postgres 9.3+ only
-     */
-    NO_KEY_UPDATE = 'NO KEY UPDATE',
-  }
+  KEY_SHARE = 'KEY SHARE',
+  /**
+   * Postgres 9.3+ only
+   */
+  NO_KEY_UPDATE = 'NO KEY UPDATE',
+}
+
+interface LOCK {
+  UPDATE: LOCK.UPDATE;
+  SHARE: LOCK.SHARE;
+  KEY_SHARE: LOCK.KEY_SHARE;
+  NO_KEY_UPDATE: LOCK.NO_KEY_UPDATE;
 }
 
 /**

--- a/types/test/transaction.ts
+++ b/types/test/transaction.ts
@@ -18,6 +18,48 @@ async function trans() {
     });
 }
 
+async function trans2() {
+    return await sequelize.transaction(async transaction => {
+        transaction.afterCommit(() => console.log('transaction complete'));
+        User.findAll(
+            {
+                transaction,
+                lock: transaction.LOCK.UPDATE,
+            }
+        );
+        return 1;
+    });
+}
+
+async function trans3() {
+    return await sequelize.transaction(async transaction => {
+        transaction.afterCommit(() => console.log('transaction complete'));
+        User.findAll(
+            {
+                transaction,
+                lock: true,
+            }
+        );
+        return 1;
+    });
+}
+
+async function trans4() {
+    return await sequelize.transaction(async transaction => {
+        transaction.afterCommit(() => console.log('transaction complete'));
+        User.findAll(
+            {
+                transaction,
+                lock: {
+                    level: transaction.LOCK.UPDATE,
+                    of: User,
+                },
+            }
+        );
+        return 1;
+    });
+}
+
 async function transact() {
     const t = await sequelize.transaction({
         deferrable: Deferrable.SET_DEFERRED(['test']),


### PR DESCRIPTION
### Pull Request check-list

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

As stated in the sequelize docs (https://sequelize.org/master/class/lib/transaction.js~Transaction.html#static-get-LOCK), when performing find operations, a lock property can be passed, and that can be either `true` or `false` or also a lock level obtained from the actual instance, i.e. `t1.LOCK.UPDATE`, which ends up being a string.

The TypeScript types were failing when trying to pass a boolean value to `lock` or when trying to access `t1.LOCK...` on a transaction instance.

This PR adds those missing types.

Link to existing issue: https://github.com/sequelize/sequelize/issues/11178#issuecomment-547014408
