### PR TITLE
fix(types): add Includeable to IncludeOptions.include type

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -513,13 +513,13 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
  */
 export interface FindOptions extends QueryOptions, Filterable, Projectable, Paranoid, IndexHintable {
   /**
-   * A list of associations to eagerly load using a left join. Supported is either
-   * `{ include: [ Model1, Model2, ...]}`, `{ include: [{ model: Model1, as: 'Alias' }]}` or
+   * A list of associations to eagerly load using a left join (a single association is also supported). Supported is either
+   * `{ include: Model1 }`, `{ include: [ Model1, Model2, ...]}`, `{ include: [{ model: Model1, as: 'Alias' }]}` or
    * `{ include: [{ all: true }]}`.
    * If your association are set up with an `as` (eg. `X.hasMany(Y, { as: 'Z }`, you need to specify Z in
    * the as attribute when eager loading Y).
    */
-  include?: Includeable[];
+  include?: Includeable | Includeable[];
 
   /**
    * Specifies an ordering. If a string is provided, it will be escaped. Using an array, you can provide
@@ -588,7 +588,7 @@ export interface CountOptions extends Logging, Transactionable, Filterable, Proj
   /**
    * Include options. See `find` for details
    */
-  include?: Includeable[];
+  include?: Includeable | Includeable[];
 
   /**
    * Apply COUNT(DISTINCT(col))
@@ -637,11 +637,11 @@ export interface BuildOptions {
   isNewRecord?: boolean;
 
   /**
-   * an array of include options - Used to build prefetched/included model instances. See `set`
+   * An array of include options. A single option is also supported - Used to build prefetched/included model instances. See `set`
    *
    * TODO: See set
    */
-  include?: Includeable[];
+  include?: Includeable | Includeable[];
 }
 
 export interface Silent {
@@ -757,7 +757,7 @@ export interface BulkCreateOptions extends Logging, Transactionable {
   /**
    * Include options. See `find` for details
    */
-  include?: Includeable[];
+  include?: Includeable | Includeable[];
 
   /**
    * Return all columns or only the specified columns for the affected rows (only for postgres)

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -1,4 +1,4 @@
-import { Association, HasOne, Model, Sequelize, DataTypes } from 'sequelize';
+import { Association, DataTypes, HasOne, Model, Sequelize } from 'sequelize';
 
 class MyModel extends Model {
   public num!: number;
@@ -26,6 +26,14 @@ MyModel.findOne({
 MyModel.hasOne(OtherModel, { as: 'OtherModelAlias' });
 
 MyModel.findOne({ include: ['OtherModelAlias'] });
+
+MyModel.findOne({ include: OtherModel });
+
+MyModel.count({ include: OtherModel });
+
+MyModel.build({ int: 10 }, { include: OtherModel });
+
+MyModel.bulkCreate([{ int: 10 }], { include: OtherModel });
 
 const sequelize = new Sequelize('mysql://user:user@localhost:3306/mydb');
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This will update the field `IncludeOptions.include` type so that it now supports `Includeable | Includeable[]`. This change also affects other interfaces which were updated accordingly.

Closes #11376
