### PR TITLE
fix(types): include 'as' in IncludeThroughOptions definition

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,22 @@ Now launch the docker mysql and postgres servers with this command (you can add 
 $ docker-compose up postgres-95 mysql-57 mssql
 ```
 
+> **_NOTE:_** If you get the following output:
+>```
+>...
+>Creating mysql-57 ... error
+>
+>ERROR: for mysql-57  Cannot create container for service mysql-57: b'create .: volume name is too short, names should be at least two alphanumeric characters'
+>
+>ERROR: for mysql-57  Cannot create container for service mysql-57: b'create .: volume name is too short, names should be at least two alphanumeric characters'
+>ERROR: Encountered errors while bringing up the project.
+>```
+>You need to set the variables `MARIADB_ENTRYPOINT` and `MYSQLDB_ENTRYPOINT` accordingly:
+>```sh
+>$ export MARIADB_ENTRYPOINT="$PATH_TO_PROJECT/test/config/mariadb"
+>$ export MYSQLDB_ENTRYPOINT="$PATH_TO_PROJECT/test/config/mysql"
+>```
+
 **MSSQL:** Please run `npm run setup-mssql` to create the test database.
 
 **POSTGRES:** Sequelize uses [special](https://github.com/sushantdhiman/sequelize-postgres) Docker image for PostgreSQL, which install all the extensions required by tests.

--- a/lib/model.js
+++ b/lib/model.js
@@ -1654,6 +1654,7 @@ class Model {
    * @param  {boolean}                                                   [options.include[].right] If true, converts to a right join if dialect support it. Ignored if `include.required` is true.
    * @param  {boolean}                                                   [options.include[].separate] If true, runs a separate query to fetch the associated instances, only supported for hasMany associations
    * @param  {number}                                                    [options.include[].limit] Limit the joined rows, only supported with include.separate=true
+   * @param  {string}                                                    [options.include[].through.as] The alias for the join model, in case you want to give it a different name than the default one.
    * @param  {Object}                                                    [options.include[].through.where] Filter on the join model for belongsToMany relations
    * @param  {Array}                                                     [options.include[].through.attributes] A list of attributes to select from the join model for belongsToMany relations
    * @param  {Array<Object|Model|string>}                                [options.include[].include] Load further nested related models

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -2569,6 +2569,32 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
         });
       });
 
+      it('should be able to alias the default name of the join table', function() {
+        return Promise.all([
+          this.User.create(),
+          this.Project.create()
+        ]).then(([user, project]) => {
+          return user.addProject(project, { through: { status: 'active', data: 42 } }).return(user);
+        }).then(() => {
+          return this.User.findAll({
+            include: [{
+              model: this.Project,
+              through: {
+                as: 'myProject'
+              }
+            }]
+          });
+        }).then(users => {
+          const project = users[0].Projects[0];
+          
+          expect(project.UserProjects).not.to.exist;
+          expect(project.status).not.to.exist;
+          expect(project.myProject).to.be.ok;
+          expect(project.myProject.status).to.equal('active');
+          expect(project.myProject.data).to.equal(42);
+        });
+      });
+
       it('should be able to limit the join table attributes returned', function() {
         return Promise.all([
           this.User.create(),

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1,26 +1,15 @@
-import {
-  Association,
-  BelongsTo,
-  BelongsToMany,
-  BelongsToManyOptions,
-  BelongsToOptions,
-  HasMany,
-  HasManyOptions,
-  HasOne,
-  HasOneOptions,
-} from './associations/index';
+import { IndexHints } from '..';
+import { Association, BelongsTo, BelongsToMany, BelongsToManyOptions, BelongsToOptions, HasMany, HasManyOptions, HasOne, HasOneOptions } from './associations/index';
 import { DataType } from './data-types';
 import { Deferrable } from './deferrable';
 import { HookReturn, Hooks, ModelHooks } from './hooks';
 import { ValidationOptions } from './instance-validator';
-import { ModelManager } from './model-manager';
-import Op = require('./operators');
 import { Promise } from './promise';
 import { QueryOptions, IndexesOptions } from './query-interface';
 import { Config, Options, Sequelize, SyncOptions } from './sequelize';
 import { Transaction, LOCK } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
-import { IndexHints } from '..';
+import Op = require('./operators');
 
 export interface Logging {
   /**
@@ -373,7 +362,13 @@ export interface WhereAttributeHash {
 /**
  * Through options for Include Options
  */
-export interface IncludeThroughOptions extends Filterable, Projectable {}
+export interface IncludeThroughOptions extends Filterable, Projectable {
+  /**
+   * The alias of the relation, in case the model you want to eagerly load is aliassed. For `hasOne` /
+   * `belongsTo`, this should be the singular name, and for `hasMany`, it should be the plural
+   */
+  as?: string;
+}
 
 /**
  * Options for eager-loading associated models, also allowing for all associations to be loaded at once

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -19,6 +19,17 @@ const num: number = Instance.get('num');
 
 MyModel.findOne({
   include: [
+    {
+      through: {
+        as: "OtherModel",
+        attributes: ['num']
+      }
+    }
+  ]
+});
+
+MyModel.findOne({
+  include: [
     { model: OtherModel, paranoid: true }
   ]
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This will add `as` property to the `IncludeThroughOptions` definition.
Closes #11185 
