### PR TITLE
fix(query-generator): handle rawTablename correctly

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -468,6 +468,7 @@ class QueryGenerator {
     options = options || {};
 
     if (!Array.isArray(attributes)) {
+      rawTablename = options;
       options = attributes;
       attributes = undefined;
     } else {
@@ -531,7 +532,11 @@ class QueryGenerator {
     }
 
     if (typeof tableName === 'string') {
-      tableName = this.quoteIdentifiers(tableName);
+      if (tableName !== rawTablename) {
+        tableName = this.quoteIdentifiers(tableName);
+      } else {
+        tableName = this.quoteIdentifier(rawTablename);
+      }
     } else {
       tableName = this.quoteTable(tableName);
     }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
(it failed 1 test but the latest version of sequelize fails 1 test, too)
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
#10944
when `tableName` and `rawTablename` are same, tableName(or rawTablename, as they're same in this case) should be given to the method `this.quoteIdentifier` as an argument, not to the `this.quoteIndentifiers`.

By the way, `addIndexQuery` and `removeIndexQuery` don't handle a table name in the same way.
in `addIndexQuery`(sequelize\lib\dialects\abstract\query-generator.js), there's a block of code like below:
```javascript
    options.prefix = options.prefix || rawTablename || tableName;
    if (options.prefix && typeof options.prefix === 'string') {
      options.prefix = options.prefix.replace(/\./g, '_');
      options.prefix = options.prefix.replace(/("|')/g, '');
    }
```
but in `removeIndexQuery` (sequelize\lib\dialects\mysql\query-generator.js):
```javascript
    if (typeof indexName !== 'string') {
      indexName = Utils.underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
    }
``` 
plus, when I tried to reproduce the issue(#10944) like below,
```javascript
  up: (queryInterface, Sequelize) => {
    return queryInterface.addIndex("dev.user", ["id"], {
      logging: console.log,
      indexName: "dev.user_id",
    });
```
I found that acutally `addndexQuery` takes `options.name`(according to the [doc](https://sequelize.org/v5/class/lib/query-interface.js~QueryInterface.html#instance-method-addIndex)) and I got an index named `dev_user_id`, not `dev.user_id`.

then I tried to migrate down, and I got error messages.
```
Executing (default): DROP INDEX `dev.user_id` ON `dev.user`

ERROR: Can't DROP 'dev.user_id'; check that column/key exists
```
it tried to drop `dev.user_id`, not `dev_user_id`. it seems `addIndexQuery` doesn't take `options.indexName` but `removeIndexQuery` does. I think both of method should handle options in the same way. 

<!-- Please provide a description of the change here. -->
