### PR TITLE
fix(postgres): make transitive gets default to parent schema

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -140,6 +140,8 @@ class BelongsTo extends Association {
 
     if (Object.prototype.hasOwnProperty.call(options, 'schema')) {
       Target = Target.schema(options.schema, options.schemaDelimiter);
+    } else if (instances._options && instances._options._schema) {
+      Target = Target.schema(instances._options._schema);
     }
 
     if (!Array.isArray(instances)) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -563,6 +563,13 @@ class QueryGenerator {
       options.where = this.whereQuery(options.where);
     }
 
+    if (options.schema && !_.isObject(tableName)) {
+      tableName = {
+        tableName,
+        schema: options.schema
+      };
+    }
+
     if (typeof tableName === 'string') {
       tableName = this.quoteIdentifiers(tableName);
     } else {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -394,9 +394,15 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     return `DELETE FROM ${table}${whereClause}`;
   }
 
-  showIndexesQuery(tableName) {
+  showIndexesQuery(tableName, options) {
     let schemaJoin = '';
     let schemaWhere = '';
+    if (typeof tableName === 'string' && options && options.schema) {
+      tableName = {
+        tableName,
+        schema: options.schema
+      };
+    }
     if (typeof tableName !== 'string') {
       schemaJoin = ', pg_namespace s';
       schemaWhere = ` AND s.oid = t.relnamespace AND s.nspname = '${tableName.schema}'`;

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -577,11 +577,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }).then(user => {
               return Task.schema(SCHEMA_ONE).create({}).then(task => {
                 return task.setUserXYZ(user).then(() => {
-                  return task.getUserXYZ({ schema: SCHEMA_ONE });
+                  const promises = [];
+                  promises.push(task.getUserXYZ()); // Default to schema of tasks
+                  promises.push(task.getUserXYZ({ schema: SCHEMA_ONE }));
+                  return Promise.all(promises);
                 });
               });
-            }).then(user => {
-              expect(user).to.be.ok;
+            }).then(users => {
+              expect(users[0]).to.be.ok;
+              expect(users[1]).to.be.ok;
             });
           });
         }

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -553,6 +553,43 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         });
 
+        describe('regressions', () => {
+          it('should be able to sync model with schema provided at sync time', function() {
+            this.sequelize.models = [];
+            this.sequelize.define('User3', {
+              name: DataTypes.STRING,
+              value: DataTypes.INTEGER
+            }, {
+              indexes: [
+                {
+                  name: 'test_user3_idx',
+                  fields: ['name']
+                }
+              ]
+            });
+
+            this.sequelize.define('Task3', {
+              name: DataTypes.STRING,
+              value: DataTypes.INTEGER
+            }, {
+              indexes: [
+                {
+                  name: 'test_task3_idx',
+                  fields: ['name']
+                }
+              ]
+            });
+
+            return Promise.all([
+              this.sequelize.sync({ schema: SCHEMA_ONE, force: true }),
+              this.sequelize.sync({ schema: SCHEMA_TWO, force: true })
+            ]).then(([res1, res2]) => {
+              expect(res1).to.be.ok;
+              expect(res2).to.be.ok;
+            });
+          });
+        });
+
         // TODO: this should work with MSSQL / MariaDB too
         // Need to fix addSchema return type
         if (dialect.match(/^postgres/)) {


### PR DESCRIPTION
Make index-creation work also if the schema is provided at sync time.

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes #11638
