### PR TITLE
fix(types): add paranoid to UpdateOptions interface

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -835,7 +835,7 @@ export interface RestoreOptions extends Logging, Transactionable, Filterable {
 /**
  * Options used for Model.update
  */
-export interface UpdateOptions extends Logging, Transactionable {
+export interface UpdateOptions extends Logging, Transactionable, Paranoid {
   /**
    * Options to describe the scope of the search.
    */

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -46,6 +46,8 @@ MyModel.build({ int: 10 }, { include: OtherModel });
 
 MyModel.bulkCreate([{ int: 10 }], { include: OtherModel });
 
+MyModel.update({}, { where: { foo: 'bar' }, paranoid: false});
+
 const sequelize = new Sequelize('mysql://user:user@localhost:3306/mydb');
 
 MyModel.init({}, {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This will add `paranoid` to the `UpdateOptions` interface. Closes #11200
