### PR TITLE
docs(transaction): fix typo

### DIFF
--- a/docs/manual/transactions.md
+++ b/docs/manual/transactions.md
@@ -98,7 +98,7 @@ You can have concurrent transactions within a sequence of queries or have some o
 
 **Warning:** _SQLite does not support more than one transaction at the same time._
 
-### Without CLS enabled
+### With CLS enabled
 
 ```js
 sequelize.transaction((t1) => {


### PR DESCRIPTION
Subsections of "Concurrent/Partial transactions" in transactions.md 
should be "WITH CLS enabled" instead of "WITHOUT CLS enabled".
See comment in the code below section header

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
