### PR TITLE
fix(bulk-create): field field name mapping for postgres for upsertKeys

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2703,7 +2703,7 @@ class Model {
             // Get primary keys for postgres to enable updateOnDuplicate
             options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
             if (Object.keys(model.uniqueKeys).length > 0) {
-              options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length === 1).map('column').value();
+              options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length === 1).map('column').map(attr => model.rawAttributes[attr].field || attr).value();
             }
           }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ x ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ x ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change


bulkCreate on field/attributes that are defined in postgres that have a "pretty name" is not parametrizing query with the field attribute.


Similar issue in MSQL  https://github.com/sequelize/sequelize/issues/9016 and realized it was an quick fix. Didn't see any tests in this area, so let me know if that is required.

From defined model
```
externalId: {
        type: DataTypes.TEXT,
        allowNull: true,
        comment: "null",
        unique: true,
        field: "external_id"
      },
```

Query contains 
```
CONFLICT ("externalId") DO UPDATE SET "name"=EXCLUDED."name" RETURNING *;
```

Code executed

```
db.Location.bulkCreate(payload, {
      updateOnDuplicate: ["name"]
    });
```

Dialect: postgres
Database version: 10.7
Sequelize version: 5.2.21
