### PR TITLE
Type expected for model.d.ts file

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -104,7 +104,7 @@ export interface ScopeOptions {
    * any arguments, or an array, where the first element is the name of the method, and consecutive elements
    * are arguments to that method. Pass null to remove all scopes, including the default.
    */
-  method: string | [string, ...unknown[]];
+  method;
 }
 
 /**


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Node 12.13.0 
TS Version 3.7.2 
Sequelize 5.21.2

When compiling sequelize packages this errors occures:

> node_modules/sequelize/types/lib/model.d.ts:118:29 - error TS1110: Type expected.
> 
> 118 method: string | [string, ...unknown[]];

So i removed the typing of the `method` property
https://github.com/sequelize/sequelize/issues/10810