### PR TITLE
feat(sync): allow to bypass drop statements when sync with alter enabled

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1309,35 +1309,39 @@ class Model {
                 changes.push(() => this.QueryInterface.addColumn(this.getTableName(options), attributes[columnName].field || columnName, attributes[columnName]));
               }
             });
-            _.each(columns, (columnDesc, columnName) => {
-              const currentAttribute = rawAttributes[columnName];
-              if (!currentAttribute) {
-                changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
-              } else if (!currentAttribute.primaryKey) {
+
+            if (options.alter === true || typeof options.alter === 'object' && options.alter.drop !== false) {
+              _.each(columns, (columnDesc, columnName) => {
+                const currentAttribute = rawAttributes[columnName];
+                if (!currentAttribute) {
+                  changes.push(() => this.QueryInterface.removeColumn(this.getTableName(options), columnName, options));
+                } else if (!currentAttribute.primaryKey) {
                 // Check foreign keys. If it's a foreign key, it should remove constraint first.
-                const references = currentAttribute.references;
-                if (currentAttribute.references) {
-                  const database = this.sequelize.config.database;
-                  const schema = this.sequelize.config.schema;
-                  // Find existed foreign keys
-                  _.each(foreignKeyReferences, foreignKeyReference => {
-                    const constraintName = foreignKeyReference.constraintName;
-                    if (!!constraintName
-                      && foreignKeyReference.tableCatalog === database
-                      && (schema ? foreignKeyReference.tableSchema === schema : true)
-                      && foreignKeyReference.referencedTableName === references.model
-                      && foreignKeyReference.referencedColumnName === references.key
-                      && (schema ? foreignKeyReference.referencedTableSchema === schema : true)
-                      && !removedConstraints[constraintName]) {
-                      // Remove constraint on foreign keys.
-                      changes.push(() => this.QueryInterface.removeConstraint(this.getTableName(options), constraintName, options));
-                      removedConstraints[constraintName] = true;
-                    }
-                  });
+                  const references = currentAttribute.references;
+                  if (currentAttribute.references) {
+                    const database = this.sequelize.config.database;
+                    const schema = this.sequelize.config.schema;
+                    // Find existed foreign keys
+                    _.each(foreignKeyReferences, foreignKeyReference => {
+                      const constraintName = foreignKeyReference.constraintName;
+                      if (!!constraintName
+                        && foreignKeyReference.tableCatalog === database
+                        && (schema ? foreignKeyReference.tableSchema === schema : true)
+                        && foreignKeyReference.referencedTableName === references.model
+                        && foreignKeyReference.referencedColumnName === references.key
+                        && (schema ? foreignKeyReference.referencedTableSchema === schema : true)
+                        && !removedConstraints[constraintName]) {
+                        // Remove constraint on foreign keys.
+                        changes.push(() => this.QueryInterface.removeConstraint(this.getTableName(options), constraintName, options));
+                        removedConstraints[constraintName] = true;
+                      }
+                    });
+                  }
+                  changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnName, currentAttribute));
                 }
-                changes.push(() => this.QueryInterface.changeColumn(this.getTableName(options), columnName, currentAttribute));
-              }
-            });
+              });
+            }
+
             return Promise.each(changes, f => f());
           });
       })

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -775,7 +775,8 @@ class Sequelize {
    * @param {string} [options.schema='public'] The schema that the tables should be created in. This can be overridden for each table in sequelize.define
    * @param {string} [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param {boolean} [options.hooks=true] If hooks is true then beforeSync, afterSync, beforeBulkSync, afterBulkSync hooks will be called
-   * @param {boolean} [options.alter=false] Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
+   * @param {boolean|Object} [options.alter=false] Alters tables to fit models. Provide an object for additional configuration. Not recommended for production use. If not further configured deletes data in columns that were removed or had their type changed in the model.
+   * @param {boolean} [options.alter.drop=true] Prevents any drop statements while altering a table when set to `false`
    *
    * @returns {Promise}
    */

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -56,6 +56,40 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
     });
 
+    it('should not remove columns if drop is set to false in alter configuration', function() {
+      const testSync = this.sequelize.define('testSync', {
+        name: Sequelize.STRING,
+        age: Sequelize.INTEGER
+      });
+      return this.sequelize.sync()
+        .then(() => this.sequelize.define('testSync', {
+          name: Sequelize.STRING
+        }))
+        .then(() => this.sequelize.sync({ alter: { drop: false } }))
+        .then(() => testSync.describe())
+        .then(data => {
+          expect(data).to.have.ownProperty('name');
+          expect(data).to.have.ownProperty('age');
+        });
+    });
+
+    it('should remove columns if drop is set to true in alter configuration', function() {
+      const testSync = this.sequelize.define('testSync', {
+        name: Sequelize.STRING,
+        age: Sequelize.INTEGER
+      });
+      return this.sequelize.sync()
+        .then(() => this.sequelize.define('testSync', {
+          name: Sequelize.STRING
+        }))
+        .then(() => this.sequelize.sync({ alter: { drop: true } }))
+        .then(() => testSync.describe())
+        .then(data => {
+          expect(data).to.have.ownProperty('name');
+          expect(data).not.to.have.ownProperty('age');
+        });
+    });
+
     it('should alter a column using the correct column name (#9515)', function() {
       const testSync = this.sequelize.define('testSync', {
         name: Sequelize.STRING

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -34,6 +34,16 @@ import { validator } from './utils/validator-extras';
 import { ConnectionManager } from './connection-manager';
 
 /**
+ * Additional options for table altering during sync
+ */
+export interface SyncAlterOptions {
+  /**
+   * Prevents any drop statements while altering a table when set to `false`
+   */
+  drop?: boolean;
+}
+
+/**
  * Sync Options
  */
 export interface SyncOptions extends Logging {
@@ -44,9 +54,9 @@ export interface SyncOptions extends Logging {
 
   /**
    * If alter is true, each DAO will do ALTER TABLE ... CHANGE ...
-   * Alters tables to fit models. Not recommended for production use. Deletes data in columns that were removed or had their type changed in the model.
+   * Alters tables to fit models. Provide an object for additional configuration. Not recommended for production use. If not further configured deletes data in columns that were removed or had their type changed in the model.
    */
-  alter?: boolean;
+  alter?: boolean | SyncAlterOptions;
 
   /**
    * Match a regex against the database name before syncing, a safety check for cases where force: true is


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

This is a less impactful version of a PR from last year (#9732 #9731). This feature implements the ability for the `alter` option to take an object for further configuration of the alter process during `sequelize.sync()`. Inside of the object the developer then can decide whether to allow drop statements or not using the `drop` option.

To give a small example why this feature is useful: I'm currently developing an app that can be extended by plugins. These plugins should have the ability to extend existing database models. I found out about the `alter` option in sync but it is currently not suitable for me since the end-user would instantly lose data if a plugin would not load correctly or would get removed by the user. 

Usage of this feature would look like this:

```javascript
// Alter table but don't generate drop statements
sequelize.sync({ alter: { drop : false } });

// Normal alter behavior as expected
sequelize.sync({ alter: true });

// Same behavior as { alter: true } (for safety reasons)
sequelize.sync({ alter: {} });

// Normal behavior as expected
sequelize.sync();
```
