### PR TITLE
fix(data-types): add support for srid geometry without a type

### DIFF
--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -301,6 +301,8 @@ module.exports = BaseTypes => {
           result += `,${this.srid}`;
         }
         result += ')';
+      } else if (this.srid) {
+        result += `(GEOMETRY, ${this.srid})`;
       }
       return result;
     }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [n/a Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- n/a Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

[GISType](https://geoalchemy-2.readthedocs.io/en/latest/types.html#geoalchemy2.types._GISType) supports several types including "none". This PR adds support for a SRID without a type set.
