### PR TITLE
feat(typescript): add 'restore' hooks to types

### DIFF
--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -4,8 +4,10 @@ import Model, {
   CountOptions,
   CreateOptions,
   DestroyOptions,
+  RestoreOptions,
   FindOptions,
   InstanceDestroyOptions,
+  InstanceRestoreOptions,
   InstanceUpdateOptions,
   ModelAttributes,
   ModelOptions,
@@ -26,6 +28,8 @@ export interface ModelHooks<M extends Model = Model> {
   afterCreate(attributes: M, options: CreateOptions): HookReturn;
   beforeDestroy(instance: M, options: InstanceDestroyOptions): HookReturn;
   afterDestroy(instance: M, options: InstanceDestroyOptions): HookReturn;
+  beforeRestore(instance: M, options: InstanceRestoreOptions): HookReturn;
+  afterRestore(instance: M, options: InstanceRestoreOptions): HookReturn;
   beforeUpdate(instance: M, options: InstanceUpdateOptions): HookReturn;
   afterUpdate(instance: M, options: InstanceUpdateOptions): HookReturn;
   beforeSave(instance: M, options: InstanceUpdateOptions | CreateOptions): HookReturn;
@@ -34,6 +38,8 @@ export interface ModelHooks<M extends Model = Model> {
   afterBulkCreate(instances: M[], options: BulkCreateOptions): HookReturn;
   beforeBulkDestroy(options: DestroyOptions): HookReturn;
   afterBulkDestroy(options: DestroyOptions): HookReturn;
+  beforeBulkRestore(options: RestoreOptions): HookReturn;
+  afterBulkRestore(options: RestoreOptions): HookReturn;
   beforeBulkUpdate(options: UpdateOptions): HookReturn;
   afterBulkUpdate(options: UpdateOptions): HookReturn;
   beforeFind(options: FindOptions): HookReturn;


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
The `hooks.d.ts` file is missing the restore hooks (`beforeRestore`, `afterRestore` and so on). This PR adds missing restore hook definitions to the `hooks.d.ts` file.