### PR TITLE
fix(types): add getForeignKeyReferencesForTable type

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -673,6 +673,15 @@ class QueryInterface {
     return this.sequelize.query(sql, Object.assign({}, options, { type: QueryTypes.SHOWINDEXES }));
   }
 
+
+  /**
+   * Returns all foreign key constraints of a table
+   *
+   * @param {string[]} tableNames table names
+   * @param {Object} [options] Query options
+   * 
+   * @returns {Promise}
+   */
   getForeignKeysForTables(tableNames, options) {
     if (tableNames.length === 0) {
       return Promise.resolve({});

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -437,6 +437,11 @@ export class QueryInterface {
   public getForeignKeysForTables(tableNames: string, options?: QueryInterfaceOptions): Promise<object>;
 
   /**
+   * Get foreign key references details for the table
+   */
+  public getForeignKeyReferencesForTable(tableName: string, options?: QueryInterfaceOptions): Promise<object>;
+
+  /**
    * Inserts a new record
    */
   public insert(instance: Model, tableName: string, values: object, options?: QueryOptions): Promise<object>;


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change 


- Add missing getForeignKeyReferencesForTable type
- Add comments for getForeignKeysForTables method. There are no comments in the code so that there are no documentations in the QueryInterface API Reference:  https://sequelize.org/v5/class/lib/query-interface.js~QueryInterface.html#instance-method-getForeignKeysForTables

<!-- Please provide a description of the change here. -->
