### PR TITLE
docs(*): corrects async/await example that uses transactions

### DIFF
--- a/docs/manual/migrations.md
+++ b/docs/manual/migrations.md
@@ -258,7 +258,7 @@ module.exports = {
 };
 ```
 
-The next is an example of a migration that has a foreign key. You can use references to specify a foreign key:
+The next example is of a migration that has a foreign key. You can use references to specify a foreign key:
 
 ```js
 module.exports = {
@@ -291,7 +291,7 @@ module.exports = {
 
 ```
 
-The next is an example of a migration that has uses async/await where you create an unique index on a new column:
+The next example is of a migration that uses async/await where you create an unique index on a new column:
 
 ```js
 module.exports = {

--- a/docs/manual/migrations.md
+++ b/docs/manual/migrations.md
@@ -312,8 +312,8 @@ module.exports = {
         {
           fields: 'petName',
           unique: true,
-        },
-        { transaction }
+          transaction,
+        }
       );
       await transaction.commit();
     } catch (err) {


### PR DESCRIPTION
Fixes #11758

### Pull Request check-list

- [x] Documentation update

### Description of change

This PR fixes a code example in the documentation under:

**Advance Topics** -> **Migration Skeleton** -> "The next is an example of a migration that has uses async/await where you create an unique index on a new column:"

![image](https://user-images.githubusercontent.com/2119264/71127468-2a443180-21b9-11ea-88cf-8c23a4f70d00.png)

https://sequelize.org/master/manual/migrations.html#migration-skeleton
