### PR TITLE
docs(upgrade-to-v6): remove confusing fat arrow in snippet

### DIFF
--- a/docs/manual/upgrade-to-v6.md
+++ b/docs/manual/upgrade-to-v6.md
@@ -36,12 +36,12 @@ This method now tests for equality with `_.isEqual` and is now deep aware. Modif
   const instance = await MyModel.findOne();
 
   instance.myJsonField.a = 1;
-  console.log(instance.changed()) => false
+  console.log(instance.changed()); // logs `false`
 
   await instance.save(); // this will not save anything
 
   instance.changed('myJsonField', true);
-  console.log(instance.changed()) => ['myJsonField']
+  console.log(instance.changed()); // logs `["myJsonField"]`
 
   await instance.save(); // will save
 ```


### PR DESCRIPTION
Fat arrow could mean arrow function and thus could be confusing. Changing it to comment. The exact formatting is copied from upgrade-to-v5.md.