### PR TITLE
Added MSSQL domain auth example.

### DIFF
--- a/docs/manual/other-topics/dialect-specific-things.md
+++ b/docs/manual/other-topics/dialect-specific-things.md
@@ -95,6 +95,29 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 });
 ```
 
+#### MSSQL Domain Account
+
+In order to connect with a domain account, use the following format.
+
+```js
+const sequelize = new Sequelize('database', null, null, {
+  dialect: 'mssql',
+  dialectOptions: {
+    authentication: {
+      type: 'ntlm',
+      options: {
+        domain: 'yourDomain',
+        userName: 'username',
+        password: 'password'
+      }
+    },
+    options: {
+      instanceName: 'SQLEXPRESS'
+    }
+  }
+})
+```
+
 ## Data type: TIMESTAMP WITHOUT TIME ZONE - PostgreSQL only
 
 If you are working with the PostgreSQL `TIMESTAMP WITHOUT TIME ZONE` and you need to parse it to a different timezone, please use the pg library's own parser:


### PR DESCRIPTION
Creating this pull request to add an example to the MSSQL section for domain authentication. It took me a while to figure out how to do so in Sequelize when it was working in pure Tedious. The line in the docs, shown below, is what caused the confusion. Due to the statement, I had thought that ***all*** MSSQL specific configuration settings had to be in `options` under `dialectOptions`. Maybe the text can be changed, but I've added an example nonetheless.

> Please note: `tedious@^6.0.0` requires you to nest MSSQL specific options inside an additional `options`-object inside the `dialectOptions`-object.

