### PR TITLE
Merge AND conditions into one when chaining scopes

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -801,6 +801,11 @@ class Model {
         srcValue = { [Op.and]: srcValue };
       }
       if (_.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
+        if (objValue[Op.and] && srcValue[Op.and]) {
+          objValue[Op.and] = [].concat(objValue[Op.and]).concat(srcValue[Op.and]);
+          delete srcValue[Op.and];
+        }
+
         return Object.assign(objValue, srcValue);
       }
     } else if (key === 'attributes' && _.isPlainObject(objValue) && _.isPlainObject(srcValue)) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -824,11 +824,43 @@ class Model {
                 const baseCondition = handlePrimitive(objValue[ownKey]);
                 const srcCondition = handlePrimitive(srcValue[ownKey]);
 
-                objValue[ownKey] = {
-                  [Op.and]: [].concat(baseCondition).concat(srcCondition)
+                const destructureCondition = condition => {
+                  // Using custom approach here instead of object destructuring until Object Rest Spread proposal is accepted
+                  // https://github.com/tc39/proposal-object-rest-spread
+
+                  let andPart, restPart;
+
+                  const isEmpty = object => {
+                    object = object || {};
+                    return Object.getOwnPropertyNames(object).concat(Object.getOwnPropertySymbols(object)).length === 0;
+                  };
+
+                  // The condition below prevents getting empty objects in the merged condition
+                  if (isEmpty(andPart = condition[Op.and])) {
+                    andPart = undefined;
+                  }
+
+                  // The condition below prevents getting empty objects in the merged condition
+                  if (isEmpty(restPart = _.omit(condition, [Op.and]))) {
+                    restPart = undefined;
+                  }
+
+                  return [andPart, restPart];
                 };
 
-              // TODO: Maybe it also worth cleaning duplicates if there are such
+                const [baseConditionAndPart, baseConditionOtherPart] = destructureCondition(baseCondition);
+                const [srcConditionAndPart, srcConditionOtherPart] = destructureCondition(srcCondition);
+
+                // TODO: Remember about possible ORs
+                // TODO: More test cases on this
+                objValue[ownKey] = {
+                  [Op.and]: [].concat(baseConditionAndPart || [])
+                    .concat(baseConditionOtherPart || [])
+                    .concat(srcConditionAndPart || [])
+                    .concat(srcConditionOtherPart || [])
+                };
+
+              // TODO: Maybe it also worth cleaning duplicates if there are such but this is probably more up to the user
               }
 
               delete srcValue[ownKey];

--- a/lib/model.js
+++ b/lib/model.js
@@ -792,7 +792,7 @@ class Model {
     return args[0];
   }
 
-  static _mergeFunction(objValue, srcValue, key) {
+  static _mergeFunction(objValue, srcValue, key, object, source, enableExtendedScopeWhereMerges) {
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
       return _.union(objValue, srcValue);
     }
@@ -801,7 +801,8 @@ class Model {
         srcValue = { [Op.and]: srcValue };
       }
       if (_.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
-        if (objValue[Op.and] && srcValue[Op.and]) {
+
+        if (enableExtendedScopeWhereMerges && objValue[Op.and] && srcValue[Op.and]) {
           objValue[Op.and] = [].concat(objValue[Op.and]).concat(srcValue[Op.and]);
           delete srcValue[Op.and];
         }
@@ -825,7 +826,17 @@ class Model {
   }
 
   static _assignOptions(...args) {
-    return this._baseMerge(...args, this._mergeFunction);
+    let enableExtendedScopeWhereMerges = false;
+
+    if (this.options) {
+      enableExtendedScopeWhereMerges = this.options.enableExtendedScopeWhereMerges;
+    }
+
+    return this._baseMerge(...args,
+      (...args) => {
+        return this._mergeFunction(...args, enableExtendedScopeWhereMerges);
+      }
+    );
   }
 
   static _defaultsOptions(target, opts) {
@@ -863,7 +874,7 @@ class Model {
    *
    * @see
    * <a href="/master/manual/model-basics.html">Model Basics</a> guide
-   * 
+   *
    * @see
    * <a href="/master/manual/model-basics.html">Hooks</a> guide
    *
@@ -969,7 +980,8 @@ class Model {
       schemaDelimiter: '',
       defaultScope: {},
       scopes: {},
-      indexes: []
+      indexes: [],
+      enableExtendedScopeWhereMerges: false
     }, options);
 
     // if you call "define" multiple times for the same modelName, do not clutter the factory
@@ -3847,13 +3859,13 @@ class Model {
 
   /**
    * Validates this instance, and if the validation passes, persists it to the database.
-   * 
+   *
    * Returns a Promise that resolves to the saved instance (or rejects with a `Sequelize.ValidationError`, which will have a property for each of the fields for which the validation failed, with the error message for that field).
-   * 
+   *
    * This method is optimized to perform an UPDATE only into the fields that changed. If nothing has changed, no SQL query will be performed.
-   * 
+   *
    * This method is not aware of eager loaded associations. In other words, if some other model instance (child) was eager loaded with this instance (parent), and you change something in the child, calling `save()` will simply ignore the change that happened on the child.
-   * 
+   *
    * @param {object}      [options] save options
    * @param {string[]}    [options.fields] An optional array of strings, representing database columns. If fields is provided, only those columns will be validated and saved.
    * @param {boolean}     [options.silent=false] If true, the updatedAt timestamp will not be updated.

--- a/lib/model.js
+++ b/lib/model.js
@@ -802,9 +802,19 @@ class Model {
       }
       if (_.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
 
-        if (enableExtendedScopeWhereMerges && objValue[Op.and] && srcValue[Op.and]) {
-          objValue[Op.and] = [].concat(objValue[Op.and]).concat(srcValue[Op.and]);
-          delete srcValue[Op.and];
+        if (enableExtendedScopeWhereMerges) {
+          // TODO: Still need to refactor this a bit to make the code more obvious
+          Object.getOwnPropertyNames(objValue).concat(Object.getOwnPropertySymbols(objValue)).forEach( ownKey => {
+
+            // Maybe it also worth making it enough smart to merge single value with object
+            if (_.isPlainObject(srcValue[ownKey]) && _.isPlainObject(objValue[ownKey])) {
+              // It still probably overrides the lower level keys
+              objValue[ownKey] = [].concat(objValue[ownKey]).concat(srcValue[ownKey]);
+              delete srcValue[ownKey];
+            } else {
+              //  TODO: Raise exception here
+            }
+          });
         }
 
         return Object.assign(objValue, srcValue);

--- a/lib/model.js
+++ b/lib/model.js
@@ -803,16 +803,35 @@ class Model {
       if (_.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
 
         if (enableExtendedScopeWhereMerges) {
-          // TODO: Still need to refactor this a bit to make the code more obvious
+          // TODO: Still need to refactor this a bit to make the code more obvious by for example extracting this code into separate function
           Object.getOwnPropertyNames(objValue).concat(Object.getOwnPropertySymbols(objValue)).forEach( ownKey => {
 
-            // TODO: Maybe it also worth making it enough smart to merge single value with object
-            if (_.isPlainObject(srcValue[ownKey]) && _.isPlainObject(objValue[ownKey])) {
-              // It still probably overrides the lower level keys
-              objValue[ownKey] = [].concat(objValue[ownKey]).concat(srcValue[ownKey]);
+            if (srcValue[ownKey]) {
+              // TODO: Also handle Op.or operator here
+              if (ownKey === Op.and) {
+                objValue[ownKey] = [].concat(objValue[ownKey]).concat(srcValue[ownKey]);
+              } else {
+                const handlePrimitive = condition => {
+                  if (_.isPlainObject(condition)) {
+                    return condition;
+                  }
+
+                  return {
+                    [Op.eq]: condition
+                  };
+                };
+
+                const baseCondition = handlePrimitive(objValue[ownKey]);
+                const srcCondition = handlePrimitive(srcValue[ownKey]);
+
+                objValue[ownKey] = {
+                  [Op.and]: [].concat(baseCondition).concat(srcCondition)
+                };
+
+              // TODO: Maybe it also worth cleaning duplicates if there are such
+              }
+
               delete srcValue[ownKey];
-            } else {
-              //  TODO: Raise exception here
             }
           });
         }

--- a/lib/model.js
+++ b/lib/model.js
@@ -792,6 +792,67 @@ class Model {
     return args[0];
   }
 
+  static _mergeOverlappingAttributeConditions(accumulatedCondition, nextCondition) {
+    const convertToFlatCondition = condition => {
+      // Using custom approach here instead of object destructuring until Object Rest Spread proposal is accepted
+      // https://github.com/tc39/proposal-object-rest-spread
+
+      let andPart, restPart;
+
+      const isEmpty = object => {
+        object = object || {};
+        return Object.getOwnPropertyNames(object).concat(Object.getOwnPropertySymbols(object)).length === 0;
+      };
+
+      // The condition below prevents getting empty objects in the merged condition
+      if (isEmpty(andPart = condition[Op.and])) {
+        andPart = undefined;
+      }
+
+      // The condition below prevents getting empty objects in the merged condition
+      if (isEmpty(restPart = _.omit(condition, [Op.and]))) {
+        restPart = undefined;
+      }
+
+      return (andPart || []).concat(restPart || []);
+    };
+    const convertPrimitiveToEquation = condition => {
+      if (_.isPlainObject(condition)) {
+        return condition;
+      }
+
+      return {
+        [Op.eq]: condition
+      };
+    };
+
+    const allAccumulatedConditionKeys = Object.getOwnPropertyNames(accumulatedCondition).concat(Object.getOwnPropertySymbols(accumulatedCondition));
+
+    allAccumulatedConditionKeys.forEach( currentKey => {
+
+      if (!nextCondition[currentKey]) {
+        return;
+      }
+
+      if (currentKey === Op.and || currentKey === Op.or) {
+        accumulatedCondition[currentKey] = [].concat(accumulatedCondition[currentKey]).concat(nextCondition[currentKey]);
+      } else {
+
+        let baseCondition = convertPrimitiveToEquation(accumulatedCondition[currentKey]);
+        let srcCondition = convertPrimitiveToEquation(nextCondition[currentKey]);
+
+        baseCondition = convertToFlatCondition(baseCondition);
+        srcCondition = convertToFlatCondition(srcCondition);
+
+        accumulatedCondition[currentKey] = {
+          [Op.and]: [].concat(baseCondition || []).concat(srcCondition || [])
+        };
+      }
+
+      delete nextCondition[currentKey];
+    });
+  }
+
   static _mergeFunction(objValue, srcValue, key, object, source, enableExtendedScopeWhereMerges) {
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
       return _.union(objValue, srcValue);
@@ -803,69 +864,7 @@ class Model {
       if (_.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
 
         if (enableExtendedScopeWhereMerges) {
-          // TODO: Still need to refactor this a bit to make the code more obvious by for example extracting this code into separate function
-          Object.getOwnPropertyNames(objValue).concat(Object.getOwnPropertySymbols(objValue)).forEach( ownKey => {
-
-            if (srcValue[ownKey]) {
-              // TODO: Also handle Op.or operator here
-              if (ownKey === Op.and) {
-                objValue[ownKey] = [].concat(objValue[ownKey]).concat(srcValue[ownKey]);
-              } else {
-                const handlePrimitive = condition => {
-                  if (_.isPlainObject(condition)) {
-                    return condition;
-                  }
-
-                  return {
-                    [Op.eq]: condition
-                  };
-                };
-
-                const baseCondition = handlePrimitive(objValue[ownKey]);
-                const srcCondition = handlePrimitive(srcValue[ownKey]);
-
-                const destructureCondition = condition => {
-                  // Using custom approach here instead of object destructuring until Object Rest Spread proposal is accepted
-                  // https://github.com/tc39/proposal-object-rest-spread
-
-                  let andPart, restPart;
-
-                  const isEmpty = object => {
-                    object = object || {};
-                    return Object.getOwnPropertyNames(object).concat(Object.getOwnPropertySymbols(object)).length === 0;
-                  };
-
-                  // The condition below prevents getting empty objects in the merged condition
-                  if (isEmpty(andPart = condition[Op.and])) {
-                    andPart = undefined;
-                  }
-
-                  // The condition below prevents getting empty objects in the merged condition
-                  if (isEmpty(restPart = _.omit(condition, [Op.and]))) {
-                    restPart = undefined;
-                  }
-
-                  return [andPart, restPart];
-                };
-
-                const [baseConditionAndPart, baseConditionOtherPart] = destructureCondition(baseCondition);
-                const [srcConditionAndPart, srcConditionOtherPart] = destructureCondition(srcCondition);
-
-                // TODO: Remember about possible ORs
-                // TODO: More test cases on this
-                objValue[ownKey] = {
-                  [Op.and]: [].concat(baseConditionAndPart || [])
-                    .concat(baseConditionOtherPart || [])
-                    .concat(srcConditionAndPart || [])
-                    .concat(srcConditionOtherPart || [])
-                };
-
-              // TODO: Maybe it also worth cleaning duplicates if there are such but this is probably more up to the user
-              }
-
-              delete srcValue[ownKey];
-            }
-          });
+          this._mergeOverlappingAttributeConditions(objValue, srcValue);
         }
 
         return Object.assign(objValue, srcValue);

--- a/lib/model.js
+++ b/lib/model.js
@@ -806,7 +806,7 @@ class Model {
           // TODO: Still need to refactor this a bit to make the code more obvious
           Object.getOwnPropertyNames(objValue).concat(Object.getOwnPropertySymbols(objValue)).forEach( ownKey => {
 
-            // Maybe it also worth making it enough smart to merge single value with object
+            // TODO: Maybe it also worth making it enough smart to merge single value with object
             if (_.isPlainObject(srcValue[ownKey]) && _.isPlainObject(objValue[ownKey])) {
               // It still probably overrides the lower level keys
               objValue[ownKey] = [].concat(objValue[ownKey]).concat(srcValue[ownKey]);

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -43,7 +43,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         { model: User, where: { something: 42 } }
       ]
     },
-    chainableSomething() {
+    chainableSomethingAnding() {
       return {
         where: {
           [Op.and]: {
@@ -54,7 +54,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         }
       };
     },
-    chainableSomethingElse() {
+    chainableSomethingElseAnding() {
       return {
         where: {
           [Op.and]: {
@@ -62,6 +62,28 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               [Op.lte]: 15
             }
           }
+        }
+      };
+    },
+    chainableSomething() {
+      return {
+        where: {
+
+          something: {
+            [Op.gte]: 4
+          }
+
+        }
+      };
+    },
+    chainableSomethingElse() {
+      return {
+        where: {
+
+          something: {
+            [Op.lte]: 15
+          }
+
         }
       };
     },
@@ -143,18 +165,29 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     describe('chaining scopes', () => {
-      expect(Company.scope([{ method: ['chainableSomething'] }, { method: ['chainableSomethingElse'] }])._scope.where[Op.and]).to.deep.equal([
-        {
-          something: {
-            [Op.gte]: 4
+
+      it('chains scopes defined on AND', () => {
+        expect(Company.scope([{ method: ['chainableSomethingAnding'] }, { method: ['chainableSomethingElseAnding'] }])._scope.where[Op.and]).to.deep.equal([
+          {
+            something: {
+              [Op.gte]: 4
+            }
+          },
+          {
+            something: {
+              [Op.lte]: 15
+            }
           }
-        },
-        {
-          something: {
-            [Op.lte]: 15
-          }
-        }
-      ]);
+        ]);
+      });
+
+      it('chains scopes defined on field name', () => {
+        expect(Company.scope([{ method: ['chainableSomething'] }, { method: ['chainableSomethingElse'] }])._scope.where.something).to.deep.equal([
+          { [Op.gte]: 4 },
+          { [Op.lte]: 15 }
+        ]);
+      });
+
     });
 
     it('defaultScope should be an empty object if not overridden', () => {

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -126,6 +126,20 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
             }
           };
+        },
+        somethingNoOperator() {
+          return {
+            where: {
+              something: 4
+            }
+          };
+        },
+        somethingElseNoOperator() {
+          return {
+            where: {
+              something: 5
+            }
+          };
         }
       };
 
@@ -139,10 +153,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('should not merge scopes and apply only the last scope', () => {
-          expect(User.scope([{ method: ['andSomething'] }, { method: ['andSomethingElse'] }])._scope.where[Op.and]).to.deep.equal(
+          expect(User.scope([{ method: ['andSomething'] }, { method: ['andSomethingElse'] }])._scope).to.deep.equal(
             {
-              something: {
-                [Op.lte]: 15
+              where: {
+                [Op.and]: {
+                  something: {
+                    [Op.lte]: 15
+                  }
+                }
               }
             }
           );
@@ -160,25 +178,48 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('should merge scopes defined on AND', () => {
-          expect(User.scope([{ method: ['andSomething'] }, { method: ['andSomethingElse'] }])._scope.where[Op.and]).to.deep.equal([
-            {
-              something: {
-                [Op.gte]: 4
-              }
-            },
-            {
-              something: {
-                [Op.lte]: 15
-              }
+          expect(User.scope([{ method: ['andSomething'] }, { method: ['andSomethingElse'] }])._scope).to.deep.equal({
+            where: {
+              [Op.and]: [
+                {
+                  something: {
+                    [Op.gte]: 4
+                  }
+                },
+                {
+                  something: {
+                    [Op.lte]: 15
+                  }
+                }
+              ]
             }
-          ]);
+          });
         });
 
         it('should merge scopes defined on field name', () => {
-          expect(User.scope([{ method: ['something'] }, { method: ['somethingElse'] }])._scope.where.something).to.deep.equal([
-            { [Op.gte]: 4 },
-            { [Op.lte]: 15 }
-          ]);
+          expect(User.scope([{ method: ['something'] }, { method: ['somethingElse'] }])._scope).to.deep.equal({
+            where: {
+              something: {
+                [Op.and]: [
+                  { [Op.gte]: 4 },
+                  { [Op.lte]: 15 }
+                ]
+              }
+            }
+          });
+        });
+
+        it('should merge scopes defined on field name without operators', () => {
+          expect(User.scope([{ method: ['somethingNoOperator'] }, { method: ['somethingElseNoOperator'] }])._scope).to.deep.equal({
+            where: {
+              something: {
+                [Op.and]: [
+                  { [Op.eq]: 4 },
+                  { [Op.eq]: 15 }
+                ]
+              }
+            }
+          });
         });
       });
 

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -8,6 +8,8 @@ const chai = require('chai'),
   DataTypes = require('../../../lib/data-types'),
   current   = Support.sequelize;
 
+const { inspect } = require('util');
+
 describe(Support.getTestDialectTeaser('Model'), () => {
   const Project = current.define('project'),
     User = current.define('user');
@@ -137,11 +139,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         somethingElseNoOperator() {
           return {
             where: {
-              something: 5
+              something: 15
             }
           };
         }
       };
+
+      inspect.defaultOptions.showHidden = true;
+      inspect.defaultOptions.depth = null;
 
       describe('when enableExtendedScopeWhereMerges option is false or not set explicitly', () => {
         const User = current.define('user', {
@@ -153,16 +158,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('should not merge scopes and apply only the last scope', () => {
-          expect(User.scope([{ method: ['andSomething'] }, { method: ['andSomethingElse'] }])._scope).to.deep.equal(
-            {
-              where: {
-                [Op.and]: {
-                  something: {
-                    [Op.lte]: 15
+          expect(
+            inspect(
+              User.scope([
+                { method: ['andSomething'] },
+                { method: ['andSomethingElse'] }
+              ])._scope
+            )
+          ).to.equal(
+            inspect(
+              {
+                where: {
+                  [Op.and]: {
+                    something: {
+                      [Op.lte]: 15
+                    }
                   }
                 }
               }
-            }
+            )
           );
         });
       });
@@ -178,7 +192,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('should merge scopes defined on AND', () => {
-          expect(User.scope([{ method: ['andSomething'] }, { method: ['andSomethingElse'] }])._scope).to.deep.equal({
+
+          expect(
+            inspect(
+              User.scope([
+                { method: ['andSomething'] },
+                { method: ['andSomethingElse'] }
+              ])._scope
+            )
+          ).to.equal(inspect({
             where: {
               [Op.and]: [
                 {
@@ -193,38 +215,57 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 }
               ]
             }
-          });
+          }));
         });
 
         it('should merge scopes defined on field name', () => {
-          expect(User.scope([{ method: ['something'] }, { method: ['somethingElse'] }])._scope).to.deep.equal({
-            where: {
-              something: {
-                [Op.and]: [
-                  { [Op.gte]: 4 },
-                  { [Op.lte]: 15 }
-                ]
+
+          expect(
+            inspect(
+              User.scope([
+                { method: ['something'] },
+                { method: ['somethingElse'] }
+              ])._scope
+            )
+          ).to.equal(
+            inspect(
+              {
+                where: {
+                  something: {
+                    [Op.and]: [
+                      { [Op.gte]: 4 },
+                      { [Op.lte]: 15 }
+                    ]
+                  }
+                }
               }
-            }
-          });
+            ));
         });
 
         it('should merge scopes defined on field name without operators', () => {
-          expect(User.scope([{ method: ['somethingNoOperator'] }, { method: ['somethingElseNoOperator'] }])._scope).to.deep.equal({
-            where: {
-              something: {
-                [Op.and]: [
-                  { [Op.eq]: 4 },
-                  { [Op.eq]: 15 }
-                ]
+          expect(
+            inspect(
+              User.scope([
+                { method: ['somethingNoOperator'] },
+                { method: ['somethingElseNoOperator'] }
+              ])._scope
+            )
+          ).to.equal(
+            inspect(
+              {
+                where: {
+                  something: {
+                    [Op.and]: [
+                      { [Op.eq]: 4 },
+                      { [Op.eq]: 15 }
+                    ]
+                  }
+                }
               }
-            }
-          });
+            )
+          );
         });
       });
-
-
-
     });
 
     describe('attribute exclude / include', () => {

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -43,6 +43,29 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         { model: User, where: { something: 42 } }
       ]
     },
+    chainableSomething() {
+      return {
+        where: {
+          [Op.and]: {
+            something: {
+              [Op.gte]: 4
+            }
+          }
+        }
+      };
+    },
+    chainableSomethingElse() {
+      return {
+        where: {
+          [Op.and]: {
+            something: {
+              [Op.lte]: 15
+            }
+          }
+        }
+      };
+    },
+
     projects: {
       include: [Project]
     },
@@ -116,6 +139,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should not modify the original scopes when merging them', () => {
         expect(User.scope('defaultScope', 'aScope').options.defaultScope.attributes).to.deep.equal({ exclude: ['password'] });
       });
+    });
+
+    describe('chaining scopes', () => {
+      expect(Company.scope([{ method: ['chainableSomething'] }, { method: ['chainableSomethingElse'] }])._scope.where[Op.and]).to.deep.equal([
+        {
+          something: {
+            [Op.gte]: 4
+          }
+        },
+        {
+          something: {
+            [Op.lte]: 15
+          }
+        }
+      ]);
     });
 
     it('defaultScope should be an empty object if not overridden', () => {

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -100,6 +100,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       include: [Project],
       where: { active: true }
     },
+    enableExtendedScopeWhereMerges: true,
     scopes
   });
 

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -148,6 +148,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       inspect.defaultOptions.showHidden = true;
       inspect.defaultOptions.depth = null;
 
+      // TODO: Add more tests covering different cases
+
       describe('when enableExtendedScopeWhereMerges option is false or not set explicitly', () => {
         const User = current.define('user', {
           password: DataTypes.STRING,


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Closes #11588

<!-- Please provide a description of the change here. -->

Making it possible to chain scopes without overriding. 

For example without this change only the last scope is applied while chaining if they both map condition to `Op.and` operator. 