### PR TITLE
Index hints on join statement for mysql

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1581,9 +1581,17 @@ class QueryGenerator {
 
     if (include.subQuery && topLevelInfo.subQuery) {
       if (requiredMismatch && subChildIncludes.length > 0) {
-        joinQueries.subQuery.push(` ${joinQuery.join} ( ${joinQuery.body}${subChildIncludes.join('')} ) ON ${joinQuery.condition}`);
+        joinQueries.subQuery.push(
+          ` ${joinQuery.join} ( ${joinQuery.body}${subChildIncludes.join('')} )${ 
+            joinQuery.indexHints ? ` ${joinQuery.indexHints}` : '' 
+          } ON ${joinQuery.condition}`
+        );
       } else {
-        joinQueries.subQuery.push(` ${joinQuery.join} ${joinQuery.body} ON ${joinQuery.condition}`);
+        joinQueries.subQuery.push(
+          ` ${joinQuery.join} ${joinQuery.body}${ 
+            joinQuery.indexHints ? ` ${joinQuery.indexHints}` : '' 
+          } ON ${joinQuery.condition}`
+        );
         if (subChildIncludes.length > 0) {
           joinQueries.subQuery.push(subChildIncludes.join(''));
         }
@@ -1591,9 +1599,17 @@ class QueryGenerator {
       joinQueries.mainQuery.push(mainChildIncludes.join(''));
     } else {
       if (requiredMismatch && mainChildIncludes.length > 0) {
-        joinQueries.mainQuery.push(` ${joinQuery.join} ( ${joinQuery.body}${mainChildIncludes.join('')} ) ON ${joinQuery.condition}`);
+        joinQueries.mainQuery.push(
+          ` ${joinQuery.join} ( ${joinQuery.body}${mainChildIncludes.join('')} )${ 
+            joinQuery.indexHints ? ` ${joinQuery.indexHints}` : '' 
+          } ON ${joinQuery.condition}`
+        );
       } else {
-        joinQueries.mainQuery.push(` ${joinQuery.join} ${joinQuery.body} ON ${joinQuery.condition}`);
+        joinQueries.mainQuery.push(
+          ` ${joinQuery.join} ${joinQuery.body}${ 
+            joinQuery.indexHints ? ` ${joinQuery.indexHints}` : '' 
+          } ON ${joinQuery.condition}`
+        );
         if (mainChildIncludes.length > 0) {
           joinQueries.mainQuery.push(mainChildIncludes.join(''));
         }
@@ -1718,6 +1734,7 @@ class QueryGenerator {
     return {
       join: include.required ? 'INNER JOIN' : include.right && this._dialect.supports['RIGHT JOIN'] ? 'RIGHT OUTER JOIN' : 'LEFT OUTER JOIN',
       body: this.quoteTable(tableRight, asRight),
+      indexHints: include.indexHints && this._dialect.supports.indexHints ? this.indexHintsFragment(include.indexHints) : '',
       condition: joinOn,
       attributes: {
         main: [],
@@ -1749,6 +1766,7 @@ class QueryGenerator {
     const tableTarget = includeAs.internalAs;
     const identTarget = association.foreignIdentifierField;
     const attrTarget = association.targetKeyField;
+    const indexHints = through.indexHints && this._dialect.supports.indexHints ? this.indexHintsFragment(through.indexHints) : '';
 
     const joinType = include.required ? 'INNER JOIN' : include.right && this._dialect.supports['RIGHT JOIN'] ? 'RIGHT OUTER JOIN' : 'LEFT OUTER JOIN';
     let joinBody;
@@ -1805,7 +1823,11 @@ class QueryGenerator {
 
     if (this._dialect.supports.joinTableDependent) {
       // Generate a wrapped join so that the through table join can be dependent on the target join
-      joinBody = `( ${this.quoteTable(throughTable, throughAs)} INNER JOIN ${this.quoteTable(include.model.getTableName(), includeAs.internalAs)} ON ${targetJoinOn}`;
+      joinBody = `( ${this.quoteTable(throughTable, throughAs)} INNER JOIN ${this.quoteTable(include.model.getTableName(), includeAs.internalAs)}`;
+      if (indexHints) {
+        joinBody += ` ${indexHints}`;
+      }
+      joinBody += ` ON ${targetJoinOn}`;
       if (throughWhere) {
         joinBody += ` AND ${throughWhere}`;
       }
@@ -1813,7 +1835,11 @@ class QueryGenerator {
       joinCondition = sourceJoinOn;
     } else {
       // Generate join SQL for left side of through
-      joinBody = `${this.quoteTable(throughTable, throughAs)} ON ${sourceJoinOn} ${joinType} ${this.quoteTable(include.model.getTableName(), includeAs.internalAs)}`;
+      joinBody = `${this.quoteTable(throughTable, throughAs)}`;
+      if (indexHints) {
+        joinBody += ` ${indexHints}`;
+      }
+      joinBody += ` ON ${sourceJoinOn} ${joinType} ${this.quoteTable(include.model.getTableName(), includeAs.internalAs)}`; 
       joinCondition = targetJoinOn;
       if (throughWhere) {
         joinCondition += ` AND ${throughWhere}`;
@@ -1834,6 +1860,7 @@ class QueryGenerator {
     return {
       join: joinType,
       body: joinBody,
+      indexHints: include.indexHints && this._dialect.supports.indexHints ? this.indexHintsFragment(include.indexHints) : '',
       condition: joinCondition,
       attributes
     };
@@ -2015,14 +2042,31 @@ class QueryGenerator {
     }
 
     if (options.indexHints && this._dialect.supports.indexHints) {
-      for (const hint of options.indexHints) {
-        if (IndexHints[hint.type]) {
-          fragment += ` ${IndexHints[hint.type]} INDEX (${hint.values.map(indexName => this.quoteIdentifiers(indexName)).join(',')})`;
-        }
+      const indexHints = this.indexHintsFragment(options.indexHints);
+      if (indexHints) {
+        fragment += ` ${indexHints}`;
       }
     }
 
     return fragment;
+  }
+
+  /**
+   * Return an SQL fragment for index hints. 
+   * 
+   * @param {Object} indexHints An object of index hints 
+   * @returns {string}
+   */
+  indexHintsFragment(indexHints) {
+    const fragments = [];
+
+    for (const hint of indexHints) {
+      if (IndexHints[hint.type]) {
+        fragments.push(`${IndexHints[hint.type]} INDEX (${hint.values.map(indexName => this.quoteIdentifiers(indexName)).join(',')})`);
+      }
+    }
+
+    return fragments[0] ? fragments.join(' ') : '';
   }
 
   /**

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -763,6 +763,33 @@ if (dialect === 'mysql') {
           ],
           expectation: 'SELECT * FROM `Project`'
         }
+      ],
+
+      indexHintsFragment: [
+        {
+          arguments: [[{ type: IndexHints.USE, values: ['index_project_on_name'] }]],
+          expectation: 'USE INDEX (`index_project_on_name`)'
+        },
+        {
+          arguments: [[{ type: IndexHints.FORCE, values: ['index_project_on_name'] }]],
+          expectation: 'FORCE INDEX (`index_project_on_name`)'
+        },
+        {
+          arguments: [[{ type: IndexHints.IGNORE, values: ['index_project_on_name'] }]],
+          expectation: 'IGNORE INDEX (`index_project_on_name`)'
+        },
+        {
+          arguments: [[{ type: IndexHints.USE, values: ['index_project_on_name', 'index_project_on_name_and_foo'] }]], 
+          expectation: 'USE INDEX (`index_project_on_name`,`index_project_on_name_and_foo`)' 
+        },
+        {
+          arguments: [[{ indexHints: [{ type: 'FOO', values: ['index_project_on_name'] }] }]], 
+          expectation: '' 
+        },
+        {
+          arguments: [[{ indexHints: [{ type: 'FOO', values: ['index_project_on_name'] }] }, { indexHints: [{ type: 'BAR', values: ['index_project_on_name'] }] }]],
+          expectation: ''
+        }
       ]
     };
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Per #9421 this takes the proposed indexHints API and implements it for mysql includes/joins, so that something like this:


```
Project.findAll({
  where: {
    id: {
      [Op.gt]: 623
    },
    name: {
      [Op.like]: 'Foo %'
    }
  },
  include:[{
    association: Company,
    indexHints: [
      {
        type: IndexHints.USE, 
        values: ['index1', 'index2'] 
      }
    ]
  }]
})
```
Generates a mysql query statement like this:

```
SELECT * FROM Project
INNER JOIN `company` AS `Company` 
  USE INDEX (`index1`,`index2`) 
  ON `Project`.`company_id` = `Company`.`id`
WHERE name LIKE 'FOO %' AND id > 623;
```
