### PR TITLE
docs(manuals): fix missing models-definition page

### DIFF
--- a/docs/manual-groups.json
+++ b/docs/manual-groups.json
@@ -44,6 +44,7 @@
   "__hidden__": [
     "moved/associations.md",
     "moved/data-types.md",
+    "moved/models-definition.md",
     "moved/models-usage.md",
     "moved/querying.md"
   ]


### PR DESCRIPTION
The [models-definition](https://sequelize.org/master/manual/models-definition.html) page of the manuals is currently a 404, this was an oversight by me, the fix is this one-liner...