### PR TITLE
fix(typings): `comparator` arg of `Sequelize.where`

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1473,7 +1473,7 @@ export type LogicType = Fn | Col | Literal | OrOperator | AndOperator | WhereOpe
  * @param logic The condition. Can be both a simply type, or a further condition (`.or`, `.and`, `.literal`
  *   etc.)
  */
-export function where(attr: AttributeType, comparator: string, logic: LogicType): Where;
+export function where(attr: AttributeType, comparator: string | symbol, logic: LogicType): Where;
 export function where(attr: AttributeType, logic: LogicType): Where;
 
 export default Sequelize;

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1453,7 +1453,7 @@ export function or(...args: (WhereOperators | WhereAttributeHash | Where)[]): Or
 export function json(conditionsOrPath: string | object, value?: string | number | boolean): Json;
 
 export type AttributeType = Fn | Col | Literal | ModelAttributeColumnOptions | string;
-export type LogicType = Fn | Col | Literal | OrOperator | AndOperator | WhereOperators | string;
+export type LogicType = Fn | Col | Literal | OrOperator | AndOperator | WhereOperators | string | symbol | null;
 
 /**
  * A way of specifying attr = condition.

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -325,3 +325,13 @@ Sequelize.where(
         [Op.notILike]: Sequelize.literal('LIT')
     }
 )
+
+Sequelize.where(Sequelize.col("ABS"), Op.is, null);
+
+Sequelize.where(
+  Sequelize.fn("ABS", Sequelize.col("age")),
+  Op.like,
+  Sequelize.fn("ABS", Sequelize.col("age"))
+);
+
+Sequelize.where(Sequelize.col("ABS"), null);


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
In the types of the where function, in the comparator parameter a symbol is added as type, this solves problems when using the constant Op the function where

Example of the problem i had:
```typescript 
import { Op } from 'sequelize';

Sequelize.where(
 Sequelize.fn('LOWER', Sequelize.col('email')),
 Op.like, // error Argument of type 'unique symbol' is not assignable to parameter of type 'string'.ts
 Sequelize.fn('LOWER', email + '%'),
)
```

Closes #11241