### PR TITLE
docs(optimistic-locking): fix missing manual

### DIFF
--- a/docs/manual/other-topics/optimistic-locking.md
+++ b/docs/manual/other-topics/optimistic-locking.md
@@ -1,4 +1,4 @@
-## Optimistic Locking
+# Optimistic Locking
 
 Sequelize has built-in support for optimistic locking through a model instance version count.
 


### PR DESCRIPTION
The manual on optimistic locking was missing from the left menu because apparently ESDoc only renders those for manuals with a single `#` at the top level