### PR TITLE
build(docs): save space

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "test-docker": "npm run test-docker-unit && npm run test-docker-integration",
     "test-docker-unit": "npm run test-unit",
     "test-docker-integration": "env-cmd $npm_package_options_env_cmd npm run test-integration",
-    "docs": "rimraf esdoc && esdoc -c docs/esdoc-config.js && cp docs/favicon.ico esdoc/favicon.ico && cp docs/ROUTER.txt esdoc/ROUTER && node docs/run-docs-transforms.js && node docs/redirects/create-redirects.js",
+    "docs": "rimraf esdoc && esdoc -c docs/esdoc-config.js && cp docs/favicon.ico esdoc/favicon.ico && cp docs/ROUTER.txt esdoc/ROUTER && node docs/run-docs-transforms.js && node docs/redirects/create-redirects.js && rimraf esdoc/file esdoc/source.html",
     "teaser": "node scripts/teaser",
     "test-unit": "mocha --require scripts/mocha-bootload --globals setImmediate,clearImmediate --exit --check-leaks --colors -t 30000 --reporter spec \"test/unit/**/*.js\"",
     "test-unit-mariadb": "cross-env DIALECT=mariadb npm run test-unit",


### PR DESCRIPTION
We already hide the links to source from our docs:

https://github.com/sequelize/sequelize/blob/9d3be832838b3db2326cdbac60d670118b4112ec/docs/css/style.css#L58-L61

However we still generate them and deploy them. For example:

https://sequelize.org/master/file/lib/query-interface.js.html

There is no way to navigate to the above link using the interface in the docs, but if you press F12 you will figure out that link.

We should save deployment space and not deploy those at all, since they're hidden anyway...