### PR TITLE
feat(postgres): add mustExist option to removeColumn

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -259,10 +259,10 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     return query;
   }
 
-  removeColumnQuery(tableName, attributeName) {
+  removeColumnQuery(tableName, attributeName, options) {
     const quotedTableName = this.quoteTable(this.extractTableDetails(tableName));
     const quotedAttributeName = this.quoteIdentifier(attributeName);
-    return `ALTER TABLE ${quotedTableName} DROP COLUMN ${quotedAttributeName};`;
+    return `ALTER TABLE ${quotedTableName} DROP COLUMN${options && !options.mustExist ? ' IF EXISTS' : ''} ${quotedAttributeName};`;
   }
 
   changeColumnQuery(tableName, attributes) {

--- a/lib/dialects/postgres/query-interface.js
+++ b/lib/dialects/postgres/query-interface.js
@@ -154,4 +154,21 @@ function ensureEnums(qi, tableName, attributes, options, model) {
 }
 
 
+/**
+ A wrapper that fixes MySQL's inability to cleanly remove columns from existing tables if they have a foreign key constraint.
+
+ @param  {QueryInterface} qi
+ @param  {string} tableName     The name of the table.
+ @param  {string} columnName    The name of the attribute that we want to remove.
+ @param  {object} options
+
+ @private
+ */
+function removeColumn(qi, tableName, columnName, options) {
+  options = options || {};
+  return qi.sequelize.query(qi.QueryGenerator.removeColumnQuery(tableName, columnName, options), options);
+}
+
+
 exports.ensureEnums = ensureEnums;
+exports.removeColumn = removeColumn;

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -536,6 +536,8 @@ class QueryInterface {
       case 'mariadb':
         // mysql/mariadb need special treatment as it cannot drop a column with a foreign key constraint
         return MySQLQueryInterface.removeColumn(this, tableName, attributeName, options);
+      case 'postgres':
+        return PostgresQueryInterface.removeColumn(this, tableName, attributeName, options);
       default:
         return this.sequelize.query(this.QueryGenerator.removeColumnQuery(tableName, attributeName), options);
     }

--- a/test/integration/query-interface/removeColumn.test.js
+++ b/test/integration/query-interface/removeColumn.test.js
@@ -96,6 +96,15 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           });
         });
       }
+      
+      if (dialect === 'postgres') {
+        describe('with mustExist option', () => {
+          it('should not throw error if column doesn\'t exists', function() {
+            expect(() => this.queryInterface.removeColumn('users', 'random', { mustExist: false }))
+              .to.not.throw();
+          });
+        });
+      }
     });
 
     describe('(with a schema)', () => {

--- a/test/unit/sql/remove-column.test.js
+++ b/test/unit/sql/remove-column.test.js
@@ -21,6 +21,20 @@ if (current.dialect.name !== 'sqlite') {
           postgres: 'ALTER TABLE "archive"."user" DROP COLUMN "email";'
         });
       });
+
+      describe('with if exists option', () => {
+        it('schema', () => {
+          expectsql(sql.removeColumnQuery({
+            schema: 'archive',
+            tableName: 'user'
+          }, 'email', { mustExist: false }), {
+            mssql: 'ALTER TABLE [archive].[user] DROP COLUMN [email];',
+            mariadb: 'ALTER TABLE `archive`.`user` DROP `email`;',
+            mysql: 'ALTER TABLE `archive.user` DROP `email`;',
+            postgres: 'ALTER TABLE "archive"."user" DROP COLUMN IF EXISTS "email";'
+          });
+        });
+      });
     });
   });
 }

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -118,6 +118,13 @@ export interface QueryInterfaceCreateTableOptions extends QueryInterfaceOptions,
   };
 }
 
+export interface QueryInterfaceRemoveColumnOptions extends QueryInterfaceOptions {
+  /**
+   * Used to check if column exists before removing it (only postgres dialect)
+   */
+  mustExist?: boolean;
+}
+
 export interface QueryInterfaceDropTableOptions extends QueryInterfaceOptions {
   cascade?: boolean;
   force?: boolean;
@@ -370,7 +377,7 @@ export class QueryInterface {
   public removeColumn(
     table: string | { schema?: string; tableName?: string },
     attribute: string,
-    options?: QueryInterfaceOptions
+    options?: QueryInterfaceRemoveColumnOptions
   ): Promise<void>;
 
   /**


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
added "mustExist" option to queryInterface.dropColumn, the option must be boolean and if marked as false, then the database checks if column exist before trying to drop, and doesn't throw an error when trying to remove non-existing column in postgresql.

Closes #11774 