### PR TITLE
Added some commas

### DIFF
--- a/docs/manual/core-concepts/model-querying-basics.md
+++ b/docs/manual/core-concepts/model-querying-basics.md
@@ -18,7 +18,7 @@ console.log("Jane's auto-generated ID:", jane.id);
 
 The [`Model.create()`](../class/lib/model.js~Model.html#static-method-create) method is a shorthand for building an unsaved instance with [`Model.build()`](../class/lib/model.js~Model.html#static-method-build) and saving the instance with [`instance.save()`](../class/lib/model.js~Model.html#instance-method-save).
 
-It is also possible to define which attributes can be set in the `create` method. This can be especially useful if you create database entries based on a form which can be filled by a user. Using that would for example allow you to restrict the `User` model to set only an username and an address but not an admin flag:
+It is also possible to define which attributes can be set in the `create` method. This can be especially useful if you create database entries based on a form which can be filled by a user. Using that would, for example, allow you to restrict the `User` model to set only an username and an address but not an admin flag:
 
 ```js
 const user = await User.create({


### PR DESCRIPTION
Added two commas to a sentence to allow it to be clearer. Reference: https://data.grammarbook.com/blog/commas/commas-part-10/ (Rule #2)

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

#### Documentation only update. No form needed

### Description of change

Edited a sentence adding and thus surrounding with two commas a 'for example' expression
