### PR TITLE
fix(model): count() code generation for distinct rows

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2031,7 +2031,9 @@ class Model {
       if (options.include) {
         col = `${this.name}.${options.col || this.primaryKeyField}`;
       }
-
+      if (options.distinct && col === '*') {
+        col = this.primaryKeyField;
+      }
       options.plain = !options.group;
       options.dataType = new DataTypes.INTEGER();
       options.includeIgnoreAttributes = false;

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -109,6 +109,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
     });
 
+    it('should be able to specify NO column for COUNT() with DISTINCT', function() {
+      return this.User.bulkCreate([
+        { username: 'ember', age: 10 },
+        { username: 'angular', age: 20 },
+        { username: 'mithril', age: 10 }
+      ]).then(() => {
+        return this.User.count({
+          distinct: true
+        });
+      })
+        .then(count => {
+          expect(count).to.be.eql(3);
+        });
+    });
+
     it('should be able to use where clause on included models', function() {
       const countOptions = {
         col: 'username',


### PR DESCRIPTION
### Pull Request check-list

- [X] (see below) Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions? 
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (n/a)
- [X] Did you update the typescript typings accordingly (if applicable)? (n/a)
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Add code to `count()` to cause it to create valid SQL when `distinct=true` and `col` is unspecified or `"*"`. Otherwise the SQL generated is `COUNT(DISTINCT(*))`, which is invalid. Issues referenced below were already closed, but the issue hadn't actually been fixed, and it _keeps coming up_.

Made this change against v5, because I need it ASAP, but the identical change should work against v6. I can submit another PR against `master`

#### Notes:

Tested against Postgres 11 only. Three time-based tests failed; it seems like there's a time zone issue? Some other Model/create test failed, also likely due to database version mismatch (permission denied to create extension "uuid-ossp"). Sorry, I _don't_ have time to install the custom Docker Postgres; the related tests passed.

Related tickets: #2713, #6404, #6418, #7344 -- all were "closed", but none were previously _actually fixed_. Workarounds were listed, but those workarounds don't work _at all_ if you're using Sequelize with Feathers-Sequelize and Sequelize-TypeScript. Besides, Sequelize shouldn't generate bad code when the options aren't perfect.