### PR TITLE
fix(query-interface): allow passing null for query interface insert

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -151,10 +151,10 @@ export interface WhereOperators {
   [Op.lte]?: number | string | Date | Literal;
 
   /** Example: `[Op.ne]: 20,` becomes `!= 20` */
-  [Op.ne]?: string | number | Literal | WhereOperators;
+  [Op.ne]?: null | string | number | Literal | WhereOperators;
 
   /** Example: `[Op.not]: true,` becomes `IS NOT TRUE` */
-  [Op.not]?: boolean | string | number | Literal | WhereOperators;
+  [Op.not]?: null | boolean | string | number | Literal | WhereOperators;
 
   /** Example: `[Op.between]: [6, 10],` becomes `BETWEEN 6 AND 10` */
   [Op.between]?: [number, number];
@@ -2605,11 +2605,11 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
 
   /**
    * Validates this instance, and if the validation passes, persists it to the database.
-   * 
+   *
    * Returns a Promise that resolves to the saved instance (or rejects with a `Sequelize.ValidationError`, which will have a property for each of the fields for which the validation failed, with the error message for that field).
-   * 
+   *
    * This method is optimized to perform an UPDATE only into the fields that changed. If nothing has changed, no SQL query will be performed.
-   * 
+   *
    * This method is not aware of eager loaded associations. In other words, if some other model instance (child) was eager loaded with this instance (parent), and you change something in the child, calling `save()` will simply ignore the change that happened on the child.
    */
   public save(options?: SaveOptions): Promise<this>;

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -451,7 +451,7 @@ export class QueryInterface {
   /**
    * Inserts a new record
    */
-  public insert(instance: Model, tableName: string, values: object, options?: QueryOptions): Promise<object>;
+  public insert(instance: Model | null, tableName: string, values: object, options?: QueryOptions): Promise<object>;
 
   /**
    * Inserts or Updates a record in the database
@@ -473,7 +473,7 @@ export class QueryInterface {
     records: object[],
     options?: QueryOptions,
     attributes?: string[] | string
-  ): Promise<object>;
+  ): Promise<object | number>;
 
   /**
    * Updates a row

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -53,7 +53,7 @@ queryInterface.dropTable('nameOfTheExistingTable');
 
 queryInterface.bulkDelete({ tableName: 'foo', schema: 'bar' }, {}, {});
 
-queryInterface.bulkInsert({ tableName: 'foo', as: 'bar', name: 'as' }, [{}], {});
+const bulkInsertRes: Promise<number | object> = queryInterface.bulkInsert({ tableName: 'foo', as: 'bar', name: 'as' }, [{}], {});
 
 queryInterface.bulkUpdate({ tableName: 'foo', delimiter: 'bar', as: 'baz', name: 'quz' }, {}, {});
 
@@ -181,3 +181,5 @@ queryInterface.delete(null, 'Person', {
 });
 
 queryInterface.upsert("test", {"a": 1}, {"b": 2}, {"c": 3}, Model, {});
+
+queryInterface.insert(null, 'test', {});


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Add `null` as allowed parameter to `insert` on `queryInterface` and adjust return type of `bulkInsert` to include `number` as it can be one.