### PR TITLE
Handle affectedRows being null after an update

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3225,7 +3225,7 @@ class Model {
       return this.QueryInterface.bulkUpdate(this.getTableName(options), valuesUse, options.where, options, this.tableAttributes).then(affectedRows => {
         if (options.returning) {
           instances = affectedRows;
-          return [affectedRows.length, affectedRows];
+          return [(affectedRows || []).length, affectedRows];
         }
 
         return [affectedRows];


### PR DESCRIPTION
`affectedRows` is null for some reason after an update with zero affected rows.

This prevents Sequelize from throwing an error, but you may want to patch bulkUpdate not to return null and returns a empty [].

This happened while using the postgres driver.