### PR TITLE
fix(model): count() code generation for distinct rows

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2033,7 +2033,9 @@ class Model {
       if (options.include) {
         col = `${this.name}.${options.col || this.primaryKeyField}`;
       }
-
+      if (options.distinct && col === '*') {
+        col = this.primaryKeyField;
+      }
       options.plain = !options.group;
       options.dataType = new DataTypes.INTEGER();
       options.includeIgnoreAttributes = false;

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -109,6 +109,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
     });
 
+    it('should be able to specify NO column for COUNT() with DISTINCT', function() {
+      return this.User.bulkCreate([
+        { username: 'ember', age: 10 },
+        { username: 'angular', age: 20 },
+        { username: 'mithril', age: 10 }
+      ]).then(() => {
+        return this.User.count({
+          distinct: true
+        });
+      })
+        .then(count => {
+          expect(count).to.be.eql(3);
+        });
+    });
+
     it('should be able to use where clause on included models', function() {
       const countOptions = {
         col: 'username',


### PR DESCRIPTION
Add code to count() to cause it to create valid SQL when distinct=true and col is unspecified or `"*"`. Otherwise the SQL generated is `COUNT(DISTINCT(*))`, which is invalid. Issues referenced below were already closed, but the issue hadn't actually been fixed, and it _keeps coming up_.

Closes: #11894, #2713, #6404, #6418, #7344

### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? **See Below**
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **N/A**
- [ ] Did you update the typescript typings accordingly (if applicable)? **N/A**
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Add code to count() to cause it to create valid SQL when distinct=true and col is unspecified or "*". Otherwise the SQL generated is COUNT(DISTINCT(*)), which is invalid. Issues referenced below were already closed, but the issue hadn't actually been fixed, and it keeps coming up.

#11893 was this PR against v5. This PR is against master.

Notes:
**Tests:** Tested against Postgres 11 only. There are failures, but they seem to be failures in `master`, not in anything that I changed. The only change I made is in the `count()` function, and none of the failures hits that function. Sorry, I don't have time to install the custom Docker Postgres; the related tests passed.

Related tickets: #2713, #6404, #6418, #7344 -- all were "closed", but none were previously actually fixed. Workarounds were listed, but those workarounds don't work at all if you're using Sequelize with Feathers-Sequelize and Sequelize-TypeScript. Besides, Sequelize shouldn't generate bad code when the options aren't perfect.