### PR TITLE
fix(typings): fix missing file in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   "files": [
     "lib",
     "types/index.d.ts",
-    "types/lib"
+    "types/lib",
+    "types/type-helpers"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
I made a mistake on PR #11844 which was not noticed due to how our current TS tests are performed. In short it broke TS usage for v6.0.0-beta.5.

This is a quick fix to that. In the future we shall improve our TS tests (there is even a PR for this right now) and catch these things.

Please merge ASAP so users can update to latest beta and use TS.

Closes #11973