### PR TITLE
fix(mssql): cast sql_variant in query generator

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -195,7 +195,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
       "COLUMN_DEFAULT AS 'Default',",
       "pk.CONSTRAINT_TYPE AS 'Constraint',",
       "COLUMNPROPERTY(OBJECT_ID(c.TABLE_SCHEMA+'.'+c.TABLE_NAME), c.COLUMN_NAME, 'IsIdentity') as 'IsIdentity',",
-      "prop.value AS 'Comment'",
+      "CAST(prop.value AS NVARCHAR) AS 'Comment'",
       'FROM',
       'INFORMATION_SCHEMA.TABLES t',
       'INNER JOIN',


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? **description see below**
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? **not applicable**
- [x] Did you update the typescript typings accordingly (if applicable)? **not applicable**
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md] **hope so** (https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change

sys.extended_properties.value is a column of type sql_variant. If used with msnodesqlv8, the driver will crash when executing this query without casting the sql_variant to nvarchar.

The issue is only relevant if a model is synced with `{alter: true}` option. In this case, the Application will just exit without any error. The "real" error is probably in the c++ driver of msnodesqlv8, since I was not able to debug it any further. However, I was able to isolate the query which is causing the bug. Running the same query without sequelize causes the same problem. I started modifying the query and found it that it is related to the extended_properties value column. Casting it to NVARCHAR solves the issue.

This is a really small fix. I tested it locally in my project. I don't want to install all the test environments. I think a new test would be overkill or impossible, since there is nothing to try/catch, since the application exits without any error! Please let me know what you think. I would be very happy if the change could be implemented.