### PR TITLE
fix(postgres): sync with alter method fails with dataType enum (#7649)

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -800,7 +800,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       values = dataType.toString().match(/^ENUM\(.+\)/)[0];
     }
 
-    let sql = `CREATE TYPE ${enumName} AS ${values};`;
+    let sql = `DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'enum_${ tableName }_${ attr }') THEN CREATE TYPE ${ enumName } AS ${ values }; END IF; END$$;`;
     if (!!options && options.force === true) {
       sql = this.pgEnumDrop(tableName, attr) + sql;
     }

--- a/test/integration/dialects/postgres/sync-alter-enum.test.js
+++ b/test/integration/dialects/postgres/sync-alter-enum.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const chai = require('chai'),
+  assert = chai.assert,
+  Support = require('../../support'),
+  Sequelize = Support.Sequelize,
+  dialect = Support.getTestDialect();
+
+if (dialect.match(/^postgres/)) {
+  describe('[POSTGRES Specific] sync with alter method with dataType enum', () => {
+    it('properly sync, #7649', function() {
+      this.sequelize.define('User', {
+        role: Sequelize.ENUM('guest', 'customer', 'admin')
+      });
+
+      return this.sequelize
+        .sync({ alter: true })
+        .catch(err => {
+          assert.fail(err.message);
+        });
+    });
+  });
+}

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -302,7 +302,7 @@ if (dialect.startsWith('postgres')) {
             col_1: "ENUM('value 1', 'value 2') NOT NULL",
             col_2: "ENUM('value 3', 'value 4') NOT NULL"
           }],
-          expectation: 'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(\'value 1\', \'value 2\');ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(\'value 3\', \'value 4\');ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");'
+          expectation: 'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = \'enum_myTable_col_1\') THEN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(\'value 1\', \'value 2\'); END IF; END$$;ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = \'enum_myTable_col_2\') THEN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(\'value 3\', \'value 4\'); END IF; END$$;ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");'
         }
       ],
 

--- a/test/unit/sql/enum.test.js
+++ b/test/unit/sql/enum.test.js
@@ -43,13 +43,13 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       describe('pgEnum', () => {
         it('uses schema #3171', () => {
           expectsql(sql.pgEnum(FooUser.getTableName(), 'mood', FooUser.rawAttributes.mood.type), {
-            postgres: 'CREATE TYPE "foo"."enum_users_mood" AS ENUM(\'happy\', \'sad\');'
+            postgres: 'DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = \'enum_"foo"."users"_mood\') THEN CREATE TYPE "foo"."enum_users_mood" AS ENUM(\'happy\', \'sad\'); END IF; END$$;'
           });
         });
 
         it('does add schema when public', () => {
           expectsql(sql.pgEnum(PublicUser.getTableName(), 'theirMood', PublicUser.rawAttributes.mood.type), {
-            postgres: 'CREATE TYPE "public"."enum_users_theirMood" AS ENUM(\'happy\', \'sad\');'
+            postgres: 'DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = \'enum_users_theirMood\') THEN CREATE TYPE "public"."enum_users_theirMood" AS ENUM(\'happy\', \'sad\'); END IF; END$$;'
           });
         });
       });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Closes #7649 

This change fixes an error that occurs when calling `sync({ alter : true })` on a model with the ENUM data type.

The solution is taken from https://github.com/sequelize/sequelize/issues/7649#issuecomment-316942602 by @GrigoryGraborenko.