### PR TITLE
fix(typings): fn is assigning to where

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -110,7 +110,7 @@ export interface ScopeOptions {
 /**
  * The type accepted by every `where` option
  */
-export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | Literal | Where;
+export type WhereOptions = WhereAttributeHash | AndOperator | OrOperator | Literal | Fn | Where;
 
 /**
  * Example: `[Op.any]: [2,3]` becomes `ANY ARRAY[2, 3]::INTEGER`

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -291,6 +291,8 @@ where = whereFn('test', {
 // Literal as where
 where = literal('true')
 
+where = fn('LOWER', 'asd')
+
 MyModel.findAll({
     where: literal('true')
 })


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Added `Fn` to the type union to allow performing `model.findOne({ where: fn(...) })` which is currently supported by sequelize.