### PR TITLE
feat(sequelize): handle query string host value

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -211,6 +211,13 @@ class Sequelize {
       }
 
       if (urlParts.query) {
+        // Allow host query argument to override the url host.
+        // Enables specifying domain socket hosts which cannot be specified via the typical
+        // host part of a url.
+        if (urlParts.query.host) {
+          options.host = urlParts.query.host;
+        }
+
         if (options.dialectOptions)
           Object.assign(options.dialectOptions, urlParts.query);
         else

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -179,5 +179,12 @@ describe('Sequelize', () => {
       expect(dialectOptions.application_name).to.equal('client');
       expect(dialectOptions.ssl).to.equal('true');
     });
+
+    it('should use query string host if specified', () => {
+      const sequelize = new Sequelize('mysql://localhost:9821/dbname?host=example.com');
+
+      const options = sequelize.options;
+      expect(options.host).to.equal('example.com');
+    });
   });
 });


### PR DESCRIPTION

### Description of change

Allow the query string `host` value to override the host value from the
uri. The host query string is used to specify domain socket paths which
cannot be specified in host part of a uri.

I've found a few references online (including #695) which indicate that the `host` query string value should work for domain sockets. However, upon review of the code and tests, this functionality may have been lost.

Related: https://github.com/sequelize/cli/issues/695
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] ~~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~~
- [ ] ~~Did you update the typescript typings accordingly (if applicable)?~~
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

