### PR TITLE
refactor: replace bluebird .get

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -277,7 +277,7 @@ class QueryInterface {
         }
       }
 
-      return Promise.all(promises).get(0);
+      return Promise.all(promises).then(obj => obj[0]);
     });
   }
 

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -47,7 +47,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
         dateField: moment('2011 10 31', 'YYYY MM DD')
       });
     }).then(() => {
-      return User.findAll().get(0);
+      return User.findAll().then(obj => obj[0]);
     }).then(user => {
       expect(parse).to.have.been.called;
       expect(stringify).to.have.been.called;
@@ -87,7 +87,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
         field: value
       });
     }).then(() => {
-      return User.findAll().get(0);
+      return User.findAll().then(obj => obj[0]);
     }).then(() => {
       expect(parse).to.have.been.called;
       if (options && options.useBindParam) {

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -71,7 +71,7 @@ if (dialect.match(/^postgres/)) {
             name: 'John Smythe'
           }]
         });
-      }).get('friends')
+      }).then(obj => obj['friends'])
         .then(friends => {
           expect(friends).to.have.length(1);
           expect(friends[0].name).to.equal('John Smythe');

--- a/test/integration/dialects/sqlite/dao.test.js
+++ b/test/integration/dialects/sqlite/dao.test.js
@@ -52,7 +52,7 @@ if (dialect === 'sqlite') {
         return this.User.create({
           dateField: new Date(2010, 10, 10)
         }).then(() => {
-          return this.User.findAll().get(0);
+          return this.User.findAll().then(obj => obj[0]);
         }).then(user => {
           expect(user.get('dateField')).to.be.an.instanceof(Date);
           expect(user.get('dateField')).to.equalTime(new Date(2010, 10, 10));
@@ -67,7 +67,7 @@ if (dialect === 'sqlite') {
         }, { include: [this.Project] }).then(() => {
           return this.User.findAll({
             include: [this.Project]
-          }).get(0);
+          }).then(obj => obj[0]);
         }).then(user => {
           expect(user.projects[0].get('dateField')).to.be.an.instanceof(Date);
           expect(user.projects[0].get('dateField')).to.equalTime(new Date(1990, 5, 5));

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -123,7 +123,7 @@ describe(Support.getTestDialectTeaser('Paranoid'), () => {
 
       return X.findAll({
         include: [Y]
-      }).get(0);
+      }).then(obj => obj[0]);
     }).then(x => {
       expect(x.ys).to.have.length(0);
     });

--- a/test/integration/model/scope/associations.test.js
+++ b/test/integration/model/scope/associations.test.js
@@ -127,7 +127,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should apply default scope when including an associations', function() {
           return this.Company.findAll({
             include: [this.UserAssociation]
-          }).get(0).then(company => {
+          }).then(obj => obj[0]).then(company => {
             expect(company.users).to.have.length(2);
           });
         });
@@ -135,7 +135,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should apply default scope when including a model', function() {
           return this.Company.findAll({
             include: [{ model: this.ScopeMe, as: 'users' }]
-          }).get(0).then(company => {
+          }).then(obj => obj[0]).then(company => {
             expect(company.users).to.have.length(2);
           });
         });
@@ -143,7 +143,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should be able to include a scoped model', function() {
           return this.Company.findAll({
             include: [{ model: this.ScopeMe.scope('isTony'), as: 'users' }]
-          }).get(0).then(company => {
+          }).then(obj => obj[0]).then(company => {
             expect(company.users).to.have.length(1);
             expect(company.users[0].get('username')).to.equal('tony');
           });
@@ -191,7 +191,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
 
           it('belongsToMany', function() {
-            return this.Project.findAll().get(0).then(p => {
+            return this.Project.findAll().then(obj => obj[0]).then(p => {
               return p.getCompanies({ scope: false });
             }).then(companies => {
               expect(companies).to.have.length(2);
@@ -230,7 +230,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
 
           it('belongsToMany', function() {
-            return this.Project.findAll().get(0).then(p => {
+            return this.Project.findAll().then(obj => obj[0]).then(p => {
               return p.getCompanies();
             }).then(companies => {
               expect(companies).to.have.length(1);
@@ -271,7 +271,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
 
           it('belongsToMany', function() {
-            return this.Project.findAll().get(0).then(p => {
+            return this.Project.findAll().then(obj => obj[0]).then(p => {
               return p.getCompanies({ scope: 'reversed' });
             }).then(companies => {
               expect(companies).to.have.length(2);

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -590,7 +590,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       const tickChar = dialect === 'postgres' || dialect === 'mssql' ? '"' : '`',
         sql = `select 1 as ${Sequelize.Utils.addTicks('foo.bar.baz', tickChar)}`;
 
-      return expect(this.sequelize.query(sql, { raw: true, nest: false }).get(0)).to.eventually.deep.equal([{ 'foo.bar.baz': 1 }]);
+      return expect(this.sequelize.query(sql, { raw: true, nest: false }).then(obj => obj[0])).to.eventually.deep.equal([{ 'foo.bar.baz': 1 }]);
     });
 
     it('destructs dot separated attributes when doing a raw query using nest', function() {
@@ -609,22 +609,22 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     });
 
     it('replaces named parameters with the passed object', function() {
-      return expect(this.sequelize.query('select :one as foo, :two as bar', { raw: true, replacements: { one: 1, two: 2 } }).get(0))
+      return expect(this.sequelize.query('select :one as foo, :two as bar', { raw: true, replacements: { one: 1, two: 2 } }).then(obj => obj[0]))
         .to.eventually.deep.equal([{ foo: 1, bar: 2 }]);
     });
 
     it('replaces named parameters with the passed object and ignore those which does not qualify', function() {
-      return expect(this.sequelize.query('select :one as foo, :two as bar, \'00:00\' as baz', { raw: true, replacements: { one: 1, two: 2 } }).get(0))
+      return expect(this.sequelize.query('select :one as foo, :two as bar, \'00:00\' as baz', { raw: true, replacements: { one: 1, two: 2 } }).then(obj => obj[0]))
         .to.eventually.deep.equal([{ foo: 1, bar: 2, baz: '00:00' }]);
     });
 
     it('replaces named parameters with the passed object using the same key twice', function() {
-      return expect(this.sequelize.query('select :one as foo, :two as bar, :one as baz', { raw: true, replacements: { one: 1, two: 2 } }).get(0))
+      return expect(this.sequelize.query('select :one as foo, :two as bar, :one as baz', { raw: true, replacements: { one: 1, two: 2 } }).then(obj => obj[0]))
         .to.eventually.deep.equal([{ foo: 1, bar: 2, baz: 1 }]);
     });
 
     it('replaces named parameters with the passed object having a null property', function() {
-      return expect(this.sequelize.query('select :one as foo, :two as bar', { raw: true, replacements: { one: 1, two: null } }).get(0))
+      return expect(this.sequelize.query('select :one as foo, :two as bar', { raw: true, replacements: { one: 1, two: null } }).then(obj => obj[0]))
         .to.eventually.deep.equal([{ foo: 1, bar: null }]);
     });
 
@@ -789,12 +789,12 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
     if (Support.getTestDialect() === 'postgres') {
       it('replaces named parameters with the passed object and ignores casts', function() {
-        return expect(this.sequelize.query('select :one as foo, :two as bar, \'1000\'::integer as baz', { raw: true, replacements: { one: 1, two: 2 } }).get(0))
+        return expect(this.sequelize.query('select :one as foo, :two as bar, \'1000\'::integer as baz', { raw: true, replacements: { one: 1, two: 2 } }).then(obj => obj[0]))
           .to.eventually.deep.equal([{ foo: 1, bar: 2, baz: 1000 }]);
       });
 
       it('supports WITH queries', function() {
-        return expect(this.sequelize.query('WITH RECURSIVE t(n) AS ( VALUES (1) UNION ALL SELECT n+1 FROM t WHERE n < 100) SELECT sum(n) FROM t').get(0))
+        return expect(this.sequelize.query('WITH RECURSIVE t(n) AS ( VALUES (1) UNION ALL SELECT n+1 FROM t WHERE n < 100) SELECT sum(n) FROM t').then(obj => obj[0]))
           .to.eventually.deep.equal([{ 'sum': '5050' }]);
       });
     }


### PR DESCRIPTION
I may have missed one or two cases of `.get('stringLiteral')`.  ~~I haven't checked for `.get(identifier)`...~~ Okay, I didn't find any instances of `.get(identifier)` being in a bluebird promise chain


<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->


_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->


<!-- Please provide a description of the change here. -->