### PR TITLE
fix(types): fixed getForeignKeysForTables argument definition

### DIFF
--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -677,7 +677,7 @@ class QueryInterface {
 
 
   /**
-   * Returns all foreign key constraints of a table
+   * Returns all foreign key constraints of requested tables
    *
    * @param {string[]} tableNames table names
    * @param {object} [options] Query options

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -439,9 +439,9 @@ export class QueryInterface {
   public nameIndexes(indexes: string[], rawTablename: string): Promise<void>;
 
   /**
-   * Returns all foreign key constraints of a table
+   * Returns all foreign key constraints of requested tables
    */
-  public getForeignKeysForTables(tableNames: string, options?: QueryInterfaceOptions): Promise<object>;
+  public getForeignKeysForTables(tableNames: string[], options?: QueryInterfaceOptions): Promise<object>;
 
   /**
    * Get foreign key references details for the table


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Fixes the definition of `getForeignKeysForTables` in TS.

This change can also apply to v5. Is it ok to merge to master?

PS: I don't think any of the above is needed, right? I couldn't even run `DIALECT=sqlite npm run test` successfully.