### PR TITLE
variable 'jane' instead of 'user'

### DIFF
--- a/docs/manual/core-concepts/model-instances.md
+++ b/docs/manual/core-concepts/model-instances.md
@@ -147,7 +147,7 @@ In order to increment/decrement values of an instance without running into concu
 
 ```js
 const jane = await User.create({ name: "Jane", age: 100 });
-const incrementResult = await user.increment('age', { by: 2 });
+const incrementResult = await jane.increment('age', { by: 2 });
 // Note: to increment by 1 you can omit the `by` option and just do `user.increment('age')`
 
 // In PostgreSQL, `incrementResult` will be the updated user, unless the option


### PR DESCRIPTION
## Description of change
_PR only contains changes to documentation_
Shouldn't this be 'jane' instead of 'user' when calling the increment method to increment the age of the 'jane' instance by 2 ?
