### PR TITLE
fix(types): set and update function corrections

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2601,7 +2601,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * @param options.reset Clear all previously set data values
    */
   public set<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
-  public set(keys: Partial<this>, options?: SetOptions): this;
+  public set(keys: Partial<Omit<this, keyof Model>>, options?: SetOptions): this;
   public setAttributes<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
   public setAttributes(keys: object, options?: SetOptions): this;
 
@@ -2654,8 +2654,15 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   /**
    * This is the same as calling `set` and then calling `save`.
    */
-  public update<K extends keyof this>(key: K, value: this[K], options?: InstanceUpdateOptions): Promise<this>;
-  public update(keys: object, options?: InstanceUpdateOptions): Promise<this>;
+  public update<K extends keyof this>(
+    key: K, 
+    value: this[K], 
+    options?: InstanceUpdateOptions
+  ): Promise<this>;
+  public update(
+    keys: Partial<Omit<this, keyof Model>>, 
+    options?: InstanceUpdateOptions
+  ): Promise<this>;
 
   /**
    * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2601,7 +2601,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * @param options.reset Clear all previously set data values
    */
   public set<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
-  public set(keys: Partial<Omit<this, keyof Model>>, options?: SetOptions): this;
+  public set(keys: Partial<this>, options?: SetOptions): this;
   public setAttributes<K extends keyof this>(key: K, value: this[K], options?: SetOptions): this;
   public setAttributes(keys: object, options?: SetOptions): this;
 
@@ -2660,7 +2660,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
     options?: InstanceUpdateOptions
   ): Promise<this>;
   public update(
-    keys: Partial<Omit<this, keyof Model>>, 
+    keys: Partial<this>, 
     options?: InstanceUpdateOptions
   ): Promise<this>;
 


### PR DESCRIPTION
### Pull Request check-list
 
_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

I'm updating the types for two functions on `Model`: `set` and `update`. When the user calls those functions by passing in an object first (which is supposed to be the new data), the keys of those objects should be restricted to the model attributes and not include the public properties of the actual `Model` class. This is done by using `Partial<Omit<this, keyof Model>>` which just says: the keys of the object can be anything from `this` which is the specific model defined by the user, minus the properties defined on the actual `Model` class. All this simply translates to the model attributes.

- Also added some line breaks for readability (better for people that prefer 80 chars per line)
