### PR TITLE
fix(mssql) insert record failure because of BOOLEAN column type

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -36,6 +36,8 @@ class Query extends AbstractQuery {
         //Default to a reasonable numeric precision/scale pending more sophisticated logic
         paramType.typeOptions = { precision: 30, scale: getScale(value) };
       }
+    } else if (typeof value === 'boolean') {
+      paramType.type = TYPES.Bit;
     }
     if (Buffer.isBuffer(value)) {
       paramType.type = TYPES.VarBinary;

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -132,4 +132,28 @@ if (dialect.match(/^mssql/)) {
         expect(Number(record.business_id)).to.equals(bigIntValue);
       });
   });
+
+  it('saves boolean is true, #12090', function() {
+    const BooleanTable =  this.sequelize.define('BooleanTable', {
+      status: {
+        type: Sequelize.BOOLEAN,
+        allowNull: false
+      }
+    }, {
+      freezeTableName: true
+    });
+
+    const status = true;
+
+    return BooleanTable.sync({ force: true })
+      .then(() => {
+        return BooleanTable.create({
+          status: status
+        });
+      })
+      .then(() => BooleanTable.findOne())
+      .then(record => {
+        expect(record.status).to.equals(status);
+      });
+  });
 }

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -143,17 +143,17 @@ if (dialect.match(/^mssql/)) {
       freezeTableName: true
     });
 
-    const status = true;
+    const value = true;
 
     return BooleanTable.sync({ force: true })
       .then(() => {
         return BooleanTable.create({
-          status: status
+          status: value
         });
       })
       .then(() => BooleanTable.findOne())
       .then(record => {
-        expect(record.status).to.equals(status);
+        expect(record.status).to.equals(value);
       });
   });
 }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->


Hi @sushantdhiman 

I reopen an PR to merge to master tree simply.
#12024 

This is issue is similar with #11121

> 
> sequelize@^5.21.5
> tedious@8.2.0

The sample code is following

```js
var Company= sequelize.define('tm_company', {
   "COMPANY_GUID": {
       "type": Sequelize.STRING(36)",  "allowNull": false, "primaryKey": true, "defaultValue": Sequelize.UUIDV1},
    "ENCRYPT_ALL": { "type": Sequelize.BOOLEAN, "allowNull": false, "defaultValue": false },
    "MORE_INFO": { "type": Sequelize.TEXT, "allowNull": true}
});

Company.sync().then(() => {
  Company.create({});
})
```

The db query exception: 

> SequelizeDatabaseError: Conversion failed when converting the nvarchar value 'false' to data type smallint.     at Query.formatError (/opt/o365/node/node_modules/sequelize/lib/dialects/mssql/query.js:314:12)     at Request.connection.lib.Request [as userCallback] (/opt/o365/node/node_modules/sequelize/lib/dialects/mssql/query.js:74:23)     at Request.callback 
> .......
>  sql: 'INSERT INTO [tm_company] ([COMPANY_GUID],[ENCRYPT_ALL],[CREATED_AT],[UPDATED_AT]) OUTPUT INSERTED.* VALUES (@0,@1,@2,@3);',   parameters:     { '0': 'aba8c810-6d83-11ea-a5bd-b122539542df',      '1': false,      '2': '2020-03-24 03:58:07.701 +00:00',      '3': '2020-03-24 03:58:07.701 +00:00' } }

According to the [`tedious` document](https://tediousjs.github.io/tedious/api-datatypes.html), we need to set the `boolean` type to `TYPES.Bit`

