### PR TITLE
feat(pool): Expose the recently added maxUses pool config option

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -138,7 +138,8 @@ class ConnectionManager {
         min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        reapIntervalMillis: config.pool.evict
+        reapIntervalMillis: config.pool.evict,
+        maxUses: config.pool.maxUses
       });
 
       debug(`pool created with max/min: ${config.pool.max}/${config.pool.min}, no replication`);
@@ -207,7 +208,8 @@ class ConnectionManager {
         min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        reapIntervalMillis: config.pool.evict
+        reapIntervalMillis: config.pool.evict,
+        maxUses: config.pool.maxUses
       }),
       write: new Pool({
         name: 'sequelize:write',
@@ -223,7 +225,8 @@ class ConnectionManager {
         min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        reapIntervalMillis: config.pool.evict
+        reapIntervalMillis: config.pool.evict,
+        maxUses: config.pool.maxUses
       })
     };
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -158,6 +158,7 @@ class Sequelize {
    * @param {number}   [options.pool.acquire=60000] The maximum time, in milliseconds, that pool will try to get connection before throwing error
    * @param {number}   [options.pool.evict=1000] The time interval, in milliseconds, after which sequelize-pool will remove idle connections.
    * @param {Function} [options.pool.validate] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
+   * @param {number}   [options.pool.maxUses=Infinity] The number of times a connection can be used before discarding it for a replacement, [`used for eventual cluster rebalancing`](https://github.com/sequelize/sequelize-pool).
    * @param {boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.  WARNING: Setting this to false may expose vulnerabilities and is not recommended!
    * @param {string}   [options.transactionType='DEFERRED'] Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
    * @param {string}   [options.isolationLevel] Set the default transaction isolation level. See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options.

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -109,6 +109,11 @@ export interface PoolOptions {
   evict?: number;
 
   /**
+   * The number of times to use a connection before closing and replacing it.  Default is Infinity
+   */
+  maxUses?: number;
+
+  /**
    * A function that validates a connection. Called with client. The default function checks that client is an
    * object, and that its state is not disconnected
    */


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Expose the recently added `maxUses` pool config option (https://github.com/sequelize/sequelize-pool/pull/18).

I followed the instructions given in #12057, with the additional step of updating the `PoolOptions` type definition.

Thank you for all your help!