### PR TITLE
fix: exclude parent required on separate query

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1312,7 +1312,7 @@ class Model {
           if (!currentAttribute) {
             await this.QueryInterface.removeColumn(this.getTableName(options), columnName, options);
             continue;
-          } 
+          }
           if (currentAttribute.primaryKey) continue;
           // Check foreign keys. If it's a foreign key, it should remove constraint first.
           const references = currentAttribute.references;
@@ -1832,7 +1832,7 @@ class Model {
       const map = await include.association.get(results, Object.assign(
         {},
         _.omit(options, nonCascadingOptions),
-        _.omit(include, ['parent', 'association', 'as', 'originalAttributes'])
+        _.omit(include, ['parent', 'association', 'as', 'originalAttributes', 'hasParentRequired'])
       ));
 
       for (const result of results) {
@@ -3086,7 +3086,7 @@ class Model {
     }
 
     valuesUse = values;
-    
+
     // Get instances and run beforeUpdate hook on each record individually
     let instances;
     let updateDoneRowByRow = false;

--- a/lib/model.js
+++ b/lib/model.js
@@ -547,7 +547,7 @@ class Model {
           include.subQuery = false;
         } else {
           include.subQueryFilter = false;
-          include.subQuery = include.subQuery || include.hasParentRequired && include.hasRequired;
+          include.subQuery = include.subQuery || include.hasParentRequired && include.hasRequired && !include.separate;
         }
       }
 
@@ -1832,7 +1832,7 @@ class Model {
       const map = await include.association.get(results, Object.assign(
         {},
         _.omit(options, nonCascadingOptions),
-        _.omit(include, ['parent', 'association', 'as', 'originalAttributes', 'hasParentRequired'])
+        _.omit(include, ['parent', 'association', 'as', 'originalAttributes'])
       ));
 
       for (const result of results) {

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -405,6 +405,26 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(options.include[0].subQueryFilter).to.equal(false);
       });
 
+      it('should not tag a separate hasMany association with subQuery true', function() {
+        const options = Sequelize.Model._validateIncludedElements({
+          model: this.Company,
+          include: [
+            {
+              association: this.Company.Employees,
+              separate: true,
+              include: [
+                { association: this.User.Tasks, required: true }
+              ]
+            }
+          ],
+          required: true
+        });
+
+        expect(options.subQuery).to.equal(false);
+        expect(options.include[0].subQuery).to.equal(false);
+        expect(options.include[0].subQueryFilter).to.equal(false);
+      });
+
       it('should tag a hasMany association with where', function() {
         const options = Sequelize.Model._validateIncludedElements({
           model: this.User,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Link to issue: https://github.com/sequelize/sequelize/issues/12141

As stated in issue, I believe "separate" queries are being negatively impacted if their "parent" is required, even if that parent is not part of the current query.

The generated SQL expects the parent to be generating a literal subquery (wrapped in parentheses) but due to the nature of "separate" queries, that isn't actually happening.

This change fixes things locally for me.

~I don't believe this portion of code is currently covered by unit-tests, and I'm not entirely sure where to start on a higher level integration test...~
Added unit test