### PR TITLE
fix: Separate queries are not subQueries

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -548,7 +548,7 @@ class Model {
           include.subQuery = false;
         } else {
           include.subQueryFilter = false;
-          include.subQuery = include.subQuery || include.hasParentRequired && include.hasRequired;
+          include.subQuery = include.subQuery || include.hasParentRequired && include.hasRequired && !include.separate;
         }
       }
 

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -405,6 +405,26 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(options.include[0].subQueryFilter).to.equal(false);
       });
 
+      it('should not tag a separate hasMany association with subQuery true', function() {
+        const options = Sequelize.Model._validateIncludedElements({
+          model: this.Company,
+          include: [
+            {
+              association: this.Company.Employees,
+              separate: true,
+              include: [
+                { association: this.User.Tasks, required: true }
+              ]
+            }
+          ],
+          required: true
+        });
+
+        expect(options.subQuery).to.equal(false);
+        expect(options.include[0].subQuery).to.equal(false);
+        expect(options.include[0].subQueryFilter).to.equal(false);
+      });
+
       it('should tag a hasMany association with where', function() {
         const options = Sequelize.Model._validateIncludedElements({
           model: this.User,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? (N/A)
- [x] Did you update the typescript typings accordingly (if applicable)? (N/A)
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Port of master PR: https://github.com/sequelize/sequelize/pull/12144

Only significant change is integration test was altered to use promise.then() rather than async/await