### PR TITLE
refactor: use node native functions

### DIFF
--- a/docs/manual-utils.js
+++ b/docs/manual-utils.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 
 function getDeclaredManuals() {
   const declaredManualGroups = require('./manual-groups.json');
-  return _.flatten(_.values(declaredManualGroups)).map(file => {
+  return _.flatten(Object.values(declaredManualGroups)).map(file => {
     return normalize(`./docs/manual/${file}`);
   });
 }

--- a/lib/associations/mixin.js
+++ b/lib/associations/mixin.js
@@ -75,7 +75,7 @@ const Mixin = {
   },
 
   getAssociations(target) {
-    return _.values(this.associations).filter(association => association.target.name === target.name);
+    return Object.values(this.associations).filter(association => association.target.name === target.name);
   },
 
   getAssociationForAlias(target, alias) {

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -1041,7 +1041,7 @@ dialectMap.mariadb = require('./dialects/mariadb/data-types')(DataTypes);
 dialectMap.sqlite = require('./dialects/sqlite/data-types')(DataTypes);
 dialectMap.mssql = require('./dialects/mssql/data-types')(DataTypes);
 
-const dialectList = _.values(dialectMap);
+const dialectList = Object.values(dialectMap);
 
 for (const dataTypes of dialectList) {
   _.each(dataTypes, (DataType, key) => {

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -206,7 +206,7 @@ class AbstractQuery {
   }
 
   handleShowTablesQuery(results) {
-    return _.flatten(results.map(resultSet => _.values(resultSet)));
+    return _.flatten(results.map(resultSet => Object.values(resultSet)));
   }
 
   isShowIndexesQuery() {
@@ -334,7 +334,7 @@ class AbstractQuery {
     const logQueryParameters = this.sequelize.options.logQueryParameters || options.logQueryParameters;
     const startTime = Date.now();
     let logParameter = '';
-    
+
     if (logQueryParameters && parameters) {
       const delimiter = sql.endsWith(';') ? '' : ';';
       let paramStr;

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -384,7 +384,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
         throw new Error('Cannot LIMIT delete without a model.');
       }
 
-      const pks = _.values(model.primaryKeys).map(pk => this.quoteIdentifier(pk.field)).join(',');
+      const pks = Object.values(model.primaryKeys).map(pk => this.quoteIdentifier(pk.field)).join(',');
 
       primaryKeys = model.primaryKeyAttributes.length > 1 ? `(${pks})` : pks;
       primaryKeysSelection = pks;
@@ -838,10 +838,6 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     matches = matches.map(m => m.replace(/",$/, '').replace(/,$/, '').replace(/(^"|"$)/, ''));
 
     return matches.slice(0, -1);
-  }
-
-  padInt(i) {
-    return i < 10 ? `0${i.toString()}` : i.toString();
   }
 
   dataTypeMapping(tableName, attr, dataType) {

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -121,7 +121,7 @@ class Query extends AbstractQuery {
       }));
     }
     if (isTableNameQuery) {
-      return rows.map(row => _.values(row));
+      return rows.map(row => Object.values(row));
     }
 
     if (rows[0] && rows[0].sequelize_caught_exception !== undefined) {

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -23,7 +23,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     options = options || {};
 
     const primaryKeys = [];
-    const needsMultiplePrimaryKeys = _.values(attributes).filter(definition => definition.includes('PRIMARY KEY')).length > 1;
+    const needsMultiplePrimaryKeys = Object.values(attributes).filter(definition => definition.includes('PRIMARY KEY')).length > 1;
     const attrArray = [];
 
     for (const attr in attributes) {

--- a/lib/errors/association-error.js
+++ b/lib/errors/association-error.js
@@ -9,7 +9,6 @@ class AssociationError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeAssociationError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/base-error.js
+++ b/lib/errors/base-error.js
@@ -11,7 +11,6 @@ class BaseError extends Error {
   constructor(message) {
     super(message);
     this.name = 'SequelizeBaseError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/bulk-record-error.js
+++ b/lib/errors/bulk-record-error.js
@@ -15,7 +15,6 @@ class BulkRecordError extends BaseError {
     this.name = 'SequelizeBulkRecordError';
     this.errors = error;
     this.record = record;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection-error.js
+++ b/lib/errors/connection-error.js
@@ -16,7 +16,6 @@ class ConnectionError extends BaseError {
      */
     this.parent = parent;
     this.original = parent;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection/access-denied-error.js
+++ b/lib/errors/connection/access-denied-error.js
@@ -9,7 +9,6 @@ class AccessDeniedError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeAccessDeniedError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection/connection-acquire-timeout-error.js
+++ b/lib/errors/connection/connection-acquire-timeout-error.js
@@ -9,7 +9,6 @@ class ConnectionAcquireTimeoutError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeConnectionAcquireTimeoutError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection/connection-refused-error.js
+++ b/lib/errors/connection/connection-refused-error.js
@@ -9,7 +9,6 @@ class ConnectionRefusedError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeConnectionRefusedError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection/connection-timed-out-error.js
+++ b/lib/errors/connection/connection-timed-out-error.js
@@ -9,7 +9,6 @@ class ConnectionTimedOutError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeConnectionTimedOutError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection/host-not-found-error.js
+++ b/lib/errors/connection/host-not-found-error.js
@@ -9,7 +9,6 @@ class HostNotFoundError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeHostNotFoundError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection/host-not-reachable-error.js
+++ b/lib/errors/connection/host-not-reachable-error.js
@@ -9,7 +9,6 @@ class HostNotReachableError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeHostNotReachableError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/connection/invalid-connection-error.js
+++ b/lib/errors/connection/invalid-connection-error.js
@@ -9,7 +9,6 @@ class InvalidConnectionError extends ConnectionError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeInvalidConnectionError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/database-error.js
+++ b/lib/errors/database-error.js
@@ -29,7 +29,6 @@ class DatabaseError extends BaseError {
      * @type {Array<any>}
      */
     this.parameters = parent.parameters;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/database/exclusion-constraint-error.js
+++ b/lib/errors/database/exclusion-constraint-error.js
@@ -17,7 +17,6 @@ class ExclusionConstraintError extends DatabaseError {
     this.constraint = options.constraint;
     this.fields = options.fields;
     this.table = options.table;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/database/foreign-key-constraint-error.js
+++ b/lib/errors/database/foreign-key-constraint-error.js
@@ -19,7 +19,6 @@ class ForeignKeyConstraintError extends DatabaseError {
     this.value = options.value;
     this.index = options.index;
     this.reltype = options.reltype;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/database/timeout-error.js
+++ b/lib/errors/database/timeout-error.js
@@ -9,7 +9,6 @@ class TimeoutError extends DatabaseError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeTimeoutError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/database/unknown-constraint-error.js
+++ b/lib/errors/database/unknown-constraint-error.js
@@ -17,7 +17,6 @@ class UnknownConstraintError extends DatabaseError {
     this.constraint = options.constraint;
     this.fields = options.fields;
     this.table = options.table;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/eager-loading-error.js
+++ b/lib/errors/eager-loading-error.js
@@ -9,7 +9,6 @@ class EagerLoadingError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeEagerLoadingError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/empty-result-error.js
+++ b/lib/errors/empty-result-error.js
@@ -9,7 +9,6 @@ class EmptyResultError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeEmptyResultError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/instance-error.js
+++ b/lib/errors/instance-error.js
@@ -9,7 +9,6 @@ class InstanceError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeInstanceError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/optimistic-lock-error.js
+++ b/lib/errors/optimistic-lock-error.js
@@ -28,7 +28,6 @@ class OptimisticLockError extends BaseError {
      * @type {object}
      */
     this.where = options.where;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/query-error.js
+++ b/lib/errors/query-error.js
@@ -9,7 +9,6 @@ class QueryError extends BaseError {
   constructor(message) {
     super(message);
     this.name = 'SequelizeQueryError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/sequelize-scope-error.js
+++ b/lib/errors/sequelize-scope-error.js
@@ -9,7 +9,6 @@ class SequelizeScopeError extends BaseError {
   constructor(parent) {
     super(parent);
     this.name = 'SequelizeScopeError';
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/errors/validation-error.js
+++ b/lib/errors/validation-error.js
@@ -30,7 +30,6 @@ class ValidationError extends BaseError {
     } else if (this.errors.length > 0 && this.errors[0].message) {
       this.message = this.errors.map(err => `${err.type || err.origin}: ${err.message}`).join(',\n');
     }
-    Error.captureStackTrace(this, this.constructor);
   }
 
   /**

--- a/lib/errors/validation/unique-constraint-error.js
+++ b/lib/errors/validation/unique-constraint-error.js
@@ -19,7 +19,6 @@ class UniqueConstraintError extends ValidationError {
     this.parent = options.parent;
     this.original = options.parent;
     this.sql = options.parent.sql;
-    Error.captureStackTrace(this, this.constructor);
   }
 }
 

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -344,7 +344,7 @@ class InstanceValidator {
    */
   _validateSchema(rawAttribute, field, value) {
     if (rawAttribute.allowNull === false && (value === null || value === undefined)) {
-      const association = _.values(this.modelInstance.constructor.associations).find(association => association instanceof BelongsTo && association.foreignKey === rawAttribute.fieldName);
+      const association = Object.values(this.modelInstance.constructor.associations).find(association => association instanceof BelongsTo && association.foreignKey === rawAttribute.fieldName);
       if (!association || !this.modelInstance.get(association.associationAccessor)) {
         const validators = this.modelInstance.validators[field];
         const errMsg = _.get(validators, 'notNull.msg', `${this.modelInstance.constructor.name}.${field} cannot be null`);

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -296,7 +296,7 @@ class QueryInterface {
         if (!skip.includes(tableName.tableName || tableName)) {
           await this.dropTable(tableName, Object.assign({}, options, { cascade: true }) );
         }
-      } 
+      }
     };
 
     const tableNames = await this.showAllTables(options);
@@ -556,7 +556,7 @@ class QueryInterface {
     const attributes = {};
     options = options || {};
 
-    if (_.values(DataTypes).includes(dataTypeOrOptions)) {
+    if (Object.values(DataTypes).includes(dataTypeOrOptions)) {
       attributes[attributeName] = { type: dataTypeOrOptions, allowNull: true };
     } else {
       attributes[attributeName] = dataTypeOrOptions;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,7 +7,7 @@ const uuidv1 = require('uuid/v1');
 const uuidv4 = require('uuid/v4');
 const Promise = require('./promise');
 const operators = require('./operators');
-const operatorsSet = new Set(_.values(operators));
+const operatorsSet = new Set(Object.values(operators));
 
 let inflection = require('inflection');
 

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -5,8 +5,7 @@ const chai = require('chai'),
   Support = require('../support'),
   DataTypes = require('../../../lib/data-types'),
   Sequelize = require('../../../index'),
-  Promise = Sequelize.Promise,
-  _ = require('lodash');
+  Promise = Sequelize.Promise;
 
 describe(Support.getTestDialectTeaser('Self'), () => {
   it('supports freezeTableName', function() {
@@ -52,7 +51,7 @@ describe(Support.getTestDialectTeaser('Self'), () => {
     Person.belongsToMany(Person, { as: 'Parents', through: 'Family', foreignKey: 'ChildId', otherKey: 'PersonId' });
     Person.belongsToMany(Person, { as: 'Childs', through: 'Family', foreignKey: 'PersonId', otherKey: 'ChildId' });
 
-    const foreignIdentifiers = _.values(Person.associations).map(v => v.foreignIdentifier);
+    const foreignIdentifiers = Object.values(Person.associations).map(v => v.foreignIdentifier);
     const rawAttributes = Object.keys(this.sequelize.models.Family.rawAttributes);
 
     expect(foreignIdentifiers.length).to.equal(2);
@@ -94,7 +93,7 @@ describe(Support.getTestDialectTeaser('Self'), () => {
     Person.belongsToMany(Person, { as: 'Parents', through: Family, foreignKey: 'preexisting_child', otherKey: 'preexisting_parent' });
     Person.belongsToMany(Person, { as: 'Children', through: Family, foreignKey: 'preexisting_parent', otherKey: 'preexisting_child' });
 
-    const foreignIdentifiers = _.values(Person.associations).map(v => v.foreignIdentifier);
+    const foreignIdentifiers = Object.values(Person.associations).map(v => v.foreignIdentifier);
     const rawAttributes = Object.keys(Family.rawAttributes);
 
     expect(foreignIdentifiers.length).to.equal(2);

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -925,13 +925,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         return userWithDefaults.sync({ force: true }).then(() => {
           return userWithDefaults.create({}).then(user => {
             return userWithDefaults.findByPk(user.id).then(user => {
-              const now = new Date(),
-                pad = function(number) {
-                  if (number > 9) {
-                    return number;
-                  }
-                  return `0${number}`;
-                };
+              const now = new Date();
+              const pad = number =>  number.toString().padStart(2, '0');
 
               expect(user.year).to.equal(`${now.getUTCFullYear()}-${pad(now.getUTCMonth() + 1)}-${pad(now.getUTCDate())}`);
             });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Some of the changes salvaged from my earlier dead branches.

- Replaces `_.values` with the native variant `Object.values` function.
- Removes a custom implementation of padding function with native (and removes some related dead code).
- Removes manual stack capturing (no longer needed since node v8)