### PR TITLE
fix(types): make between operator accept date ranges

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -157,7 +157,7 @@ export interface WhereOperators {
   [Op.not]?: null | boolean | string | number | Literal | WhereOperators;
 
   /** Example: `[Op.between]: [6, 10],` becomes `BETWEEN 6 AND 10` */
-  [Op.between]?: [number, number];
+  [Op.between]?: Rangable;
 
   /** Example: `[Op.in]: [1, 2],` becomes `IN [1, 2]` */
   [Op.in]?: (string | number | Literal)[] | Literal;
@@ -222,7 +222,7 @@ export interface WhereOperators {
   [Op.notILike]?: string | Literal | AnyOperator | AllOperator;
 
   /** Example: `[Op.notBetween]: [11, 15],` becomes `NOT BETWEEN 11 AND 15` */
-  [Op.notBetween]?: [number, number];
+  [Op.notBetween]?: Rangable;
 
   /**
    * Strings starts with value.

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -201,7 +201,7 @@ MyModel.findAll({
             [Op.lt]: 10, // id < 10
             [Op.lte]: 10, // id <= 10
             [Op.ne]: 20, // id != 20
-            [Op.between]: [6, 10], // BETWEEN 6 AND 10
+            [Op.between]: [6, 10] || [new Date(), new Date()], // BETWEEN 6 AND 10
             [Op.notBetween]: [11, 15], // NOT BETWEEN 11 AND 15
             [Op.in]: [1, 2], // IN [1, 2]
             [Op.notIn]: [1, 2], // NOT IN [1, 2]
@@ -324,7 +324,7 @@ Sequelize.where(
         [Op.contains]: Sequelize.literal('LIT'),
         [Op.contained]: Sequelize.literal('LIT'),
         [Op.gt]: Sequelize.literal('LIT'),
-        [Op.notILike]: Sequelize.literal('LIT')
+        [Op.notILike]: Sequelize.literal('LIT'),
     }
 )
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Allows `Op.between` to process data ranges.