### PR TITLE
Fix tedious connect deprecation

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -61,6 +61,9 @@ class ConnectionManager extends AbstractConnectionManager {
     try {
       return await new Promise((resolve, reject) => {
         const connection = new this.lib.Connection(connectionConfig);
+        if (connection.state === connection.STATE.INITIALIZED) {
+          connection.connect();
+        }
         connection.queue = new AsyncQueue();
         connection.lib = this.lib;
 

--- a/test/unit/dialects/mssql/connection-manager.test.js
+++ b/test/unit/dialects/mssql/connection-manager.test.js
@@ -79,5 +79,29 @@ if (dialect === 'mssql') {
           expect(err.parent.message).to.equal('Connection was closed by remote server');
         });
     });
+
+    it('connectionManager._connect() should call connect if state is initialized', function() {
+      const connectStub = sinon.stub();
+      const INITIALIZED = { name: 'INITIALIZED' };
+      this.connectionStub.returns({
+        STATE: { INITIALIZED },
+        state: INITIALIZED,
+        connect: connectStub,
+        once(event, cb) {
+          if (event === 'connect') {
+            setTimeout(() => {
+              cb();
+            }, 500);
+          }
+        },
+        removeListener: () => {},
+        on: () => {}
+      });
+
+      return this.instance.dialect.connectionManager._connect(this.config)
+        .then(() => {
+          expect(connectStub.called).to.equal(true);
+        });
+    });
   });
 }

--- a/test/unit/dialects/mssql/connection-manager.test.js
+++ b/test/unit/dialects/mssql/connection-manager.test.js
@@ -39,6 +39,8 @@ if (dialect === 'mssql') {
 
     it('connectionManager._connect() does not delete `domain` from config.dialectOptions', function() {
       this.connectionStub.returns({
+        STATE: {},
+        state: '',
         once(event, cb) {
           if (event === 'connect') {
             setTimeout(() => {
@@ -58,6 +60,8 @@ if (dialect === 'mssql') {
 
     it('connectionManager._connect() should reject if end was called and connect was not', function() {
       this.connectionStub.returns({
+        STATE: {},
+        state: '',
         once(event, cb) {
           if (event === 'end') {
             setTimeout(() => {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Call `connect` after creating `tedious` connection if required.

Fixes #12181 

<!-- Please provide a description of the change here. -->
