### PR TITLE
fix(docs): fix scope name on association scope

### DIFF
--- a/docs/manual/advanced-association-concepts/association-scopes.md
+++ b/docs/manual/advanced-association-concepts/association-scopes.md
@@ -58,7 +58,7 @@ Bar.addScope('open', {
     }
 });
 Foo.hasMany(Bar);
-Foo.hasMany(Bar.scope('testTitleScope'), { as: 'openBars' });
+Foo.hasMany(Bar.scope('open'), { as: 'openBars' });
 ```
 
 With the above code, `myFoo.getOpenBars()` yields the same SQL shown above.


### PR DESCRIPTION
# Description of change
Simple documentation fix, wrong scope name.

Closes #12198

