### PR TITLE
fix(model.reload): ignore options.where and always use this.where()

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -4049,8 +4049,9 @@ class Model {
    * @returns {Promise<Model>}
    */
   async reload(options) {
-    options = Utils.defaults({}, options, {
-      where: this.where(),
+    options = Utils.defaults({
+      where: this.where()
+    }, options, {
       include: this._options.include || null
     });
 

--- a/test/integration/instance/reload.test.js
+++ b/test/integration/instance/reload.test.js
@@ -91,6 +91,20 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
     });
 
+    it('should use default internal where', async function() {
+      const user = await this.User.create({ username: 'Balak Bukhara' });
+      const anotherUser = await this.User.create({ username: 'John Smith' });
+
+      const primaryKey = user.get('id');
+
+      await user.reload();
+      expect(user.get('id')).to.equal(primaryKey);
+
+      // options.where should be ignored
+      await user.reload({ where: { id: anotherUser.get('id') } });
+      expect(user.get('id')).to.equal(primaryKey).and.not.equal(anotherUser.get('id'));
+    });
+
     it('should update the values on all references to the DAO', function() {
       return this.User.create({ username: 'John Doe' }).then(originalUser => {
         return this.User.findByPk(originalUser.id).then(updater => {


### PR DESCRIPTION
# Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes https://github.com/sequelize/sequelize/issues/12046

Now `reload` ignores `options.where`
