### PR TITLE
refactor: replace lodash clone with object spread

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -423,7 +423,7 @@ class BelongsToMany extends Association {
     let throughWhere;
 
     if (this.scope) {
-      scopeWhere = _.clone(this.scope);
+      scopeWhere = { ...this.scope };
     }
 
     options.where = {
@@ -667,7 +667,7 @@ class BelongsToMany extends Association {
     // If newInstances is null or undefined, no-op
     if (!newInstances) return Promise.resolve();
 
-    options = _.clone(options) || {};
+    options = { ...options };
 
     const association = this;
     const sourceKey = association.sourceKey;

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -114,7 +114,7 @@ class HasMany extends Association {
   _injectAttributes() {
     const newAttributes = {};
     // Create a new options object for use with addForeignKeyConstraints, to avoid polluting this.options in case it is later used for a n:m
-    const constraintOptions = _.clone(this.options);
+    const constraintOptions = { ...this.options };
 
     newAttributes[this.foreignKey] = _.defaults({}, this.foreignKeyAttribute, {
       type: this.options.keyType || this.source.rawAttributes[this.sourceKeyAttribute].type,

--- a/lib/dialects/postgres/query-interface.js
+++ b/lib/dialects/postgres/query-interface.js
@@ -2,8 +2,6 @@
 
 const DataTypes = require('../../data-types');
 const QueryTypes = require('../../query-types');
-const _ = require('lodash');
-
 
 /**
  Returns an object that handles Postgres special needs to do certain queries.
@@ -55,9 +53,11 @@ async function ensureEnums(qi, tableName, attributes, options, model) {
 
   // This little function allows us to re-use the same code that prepends or appends new value to enum array
   const addEnumValue = (field, value, relativeValue, position = 'before', spliceStart = promises.length) => {
-    const valueOptions = _.clone(options);
-    valueOptions.before = null;
-    valueOptions.after = null;
+    const valueOptions = {
+      ...options,
+      before: null,
+      after: null
+    };
 
     switch (position) {
       case 'after':

--- a/lib/dialects/sqlite/query-interface.js
+++ b/lib/dialects/sqlite/query-interface.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const sequelizeErrors = require('../../errors');
 const QueryTypes = require('../../query-types');
 
@@ -86,7 +85,7 @@ async function renameColumn(qi, tableName, attrNameBefore, attrNameAfter, option
   options = options || {};
 
   const fields = await qi.describeTable(tableName, options);
-  fields[attrNameAfter] = _.clone(fields[attrNameBefore]);
+  fields[attrNameAfter] = { ...fields[attrNameBefore] };
   delete fields[attrNameBefore];
 
   const sql = qi.QueryGenerator.renameColumnQuery(tableName, attrNameBefore, attrNameAfter, fields);

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -18,7 +18,7 @@ const { promisify } = require('util');
  */
 class InstanceValidator {
   constructor(modelInstance, options) {
-    options = _.clone(options) || {};
+    options = { ...options };
 
     if (options.fields && !options.skip) {
       options.skip = _.difference(Object.keys(modelInstance.constructor.rawAttributes), options.fields);
@@ -405,7 +405,7 @@ class InstanceValidator {
 }
 /**
  * The error key for arguments as passed by custom validators
- * 
+ *
  * @type {string}
  * @private
  */

--- a/lib/model.js
+++ b/lib/model.js
@@ -122,7 +122,7 @@ class Model {
     let defaults;
     let key;
 
-    values = values && _.clone(values) || {};
+    values = { ...values };
 
     if (options.isNewRecord) {
       defaults = {};
@@ -271,22 +271,17 @@ class Model {
       };
     }
 
-    const existingAttributes = _.clone(this.rawAttributes);
-    this.rawAttributes = {};
-
-    _.each(head, (value, attr) => {
-      this.rawAttributes[attr] = value;
-    });
-
-    _.each(existingAttributes, (value, attr) => {
-      this.rawAttributes[attr] = value;
-    });
-
+    const newRawAttributes = {
+      ...head,
+      ...this.rawAttributes
+    };
     _.each(tail, (value, attr) => {
-      if (this.rawAttributes[attr] === undefined) {
-        this.rawAttributes[attr] = value;
+      if (newRawAttributes[attr] === undefined) {
+        newRawAttributes[attr] = value;
       }
     });
+
+    this.rawAttributes = newRawAttributes;
 
     if (!Object.keys(this.primaryKeys).length) {
       this.primaryKeys.id = this.rawAttributes.id;
@@ -1068,7 +1063,7 @@ class Model {
 
     ['get', 'set'].forEach(type => {
       const opt = `${type}terMethods`;
-      const funcs = _.clone(_.isObject(this.options[opt]) ? this.options[opt] : {});
+      const funcs = { ...this.options[opt] };
       const _custom = type === 'get' ? this.prototype._customGetters : this.prototype._customSetters;
 
       _.each(funcs, (method, attribute) => {
@@ -2232,7 +2227,7 @@ class Model {
 
     let instance = await this.findOne(options);
     if (instance === null) {
-      values = _.clone(options.defaults) || {};
+      values = { ...options.defaults };
       if (_.isPlainObject(options.where)) {
         values = Utils.defaults(values, options.where);
       }
@@ -2303,7 +2298,7 @@ class Model {
         return [found, false];
       }
 
-      values = _.clone(options.defaults) || {};
+      values = { ...options.defaults };
       if (_.isPlainObject(options.where)) {
         values = Utils.defaults(values, options.where);
       }
@@ -2381,7 +2376,7 @@ class Model {
       );
     }
 
-    let values = _.clone(options.defaults) || {};
+    let values = { ...options.defaults };
     if (_.isPlainObject(options.where)) {
       values = Utils.defaults(values, options.where);
     }
@@ -2580,7 +2575,7 @@ class Model {
       // Validate
       if (options.validate) {
         const errors = [];
-        const validateOptions = _.clone(options);
+        const validateOptions = { ...options };
         validateOptions.hooks = options.individualHooks;
 
         await Promise.all(instances.map(async instance => {
@@ -2598,12 +2593,14 @@ class Model {
       }
       if (options.individualHooks) {
         await Promise.all(instances.map(async instance => {
-          const individualOptions = _.clone(options);
+          const individualOptions = {
+            ...options,
+            validate: false,
+            hooks: true
+          };
           delete individualOptions.fields;
           delete individualOptions.individualHooks;
           delete individualOptions.ignoreDuplicates;
-          individualOptions.validate = false;
-          individualOptions.hooks = true;
 
           await instance.save(individualOptions);
         }));
@@ -3140,10 +3137,12 @@ class Model {
           }
         } else {
           instances = await Promise.all(instances.map(async instance => {
-            const individualOptions = _.clone(options);
+            const individualOptions = {
+              ...options,
+              hooks: false,
+              validate: false
+            };
             delete individualOptions.individualHooks;
-            individualOptions.hooks = false;
-            individualOptions.validate = false;
 
             return instance.save(individualOptions);
           }));
@@ -3561,7 +3560,7 @@ class Model {
           this.dataValues = values;
         }
         // If raw, .changed() shouldn't be true
-        this._previousDataValues = _.clone(this.dataValues);
+        this._previousDataValues = { ...this.dataValues };
       } else {
         // Loop and call set
         if (options.attributes) {
@@ -3588,7 +3587,7 @@ class Model {
 
         if (options.raw) {
           // If raw, .changed() shouldn't be true
-          this._previousDataValues = _.clone(this.dataValues);
+          this._previousDataValues = { ...this.dataValues };
         }
       }
       return this;

--- a/lib/query-interface.js
+++ b/lib/query-interface.js
@@ -193,7 +193,7 @@ class QueryInterface {
   async createTable(tableName, attributes, options, model) {
     let sql = '';
 
-    options = _.clone(options) || {};
+    options = { ...options };
 
     if (options && options.uniqueKeys) {
       _.forOwn(options.uniqueKeys, uniqueKey => {
@@ -243,7 +243,7 @@ class QueryInterface {
    */
   async dropTable(tableName, options) {
     // if we're forcing we should be cascading unless explicitly stated otherwise
-    options = _.clone(options) || {};
+    options = { ...options };
     options.cascade = options.cascade || options.force || false;
 
     let sql = this.QueryGenerator.dropTableQuery(tableName, options);
@@ -913,7 +913,7 @@ class QueryInterface {
     let indexes = [];
     let indexFields;
 
-    options = _.clone(options);
+    options = { ...options };
 
     if (!Utils.isWhereEmpty(where)) {
       wheres.push(where);
@@ -994,7 +994,7 @@ class QueryInterface {
    * @returns {Promise}
    */
   async bulkInsert(tableName, records, options, attributes) {
-    options = _.clone(options) || {};
+    options = { ...options };
     options.type = QueryTypes.INSERT;
 
     const results = await this.sequelize.query(
@@ -1006,7 +1006,7 @@ class QueryInterface {
   }
 
   async update(instance, tableName, values, identifier, options) {
-    options = _.clone(options || {});
+    options = { ...options };
     options.hasTrigger = !!(instance && instance._modelOptions && instance._modelOptions.hasTrigger);
 
     const sql = this.QueryGenerator.updateQuery(tableName, values, identifier, options, instance.constructor.rawAttributes);
@@ -1053,7 +1053,7 @@ class QueryInterface {
     const cascades = [];
     const sql = this.QueryGenerator.deleteQuery(tableName, identifier, {}, instance.constructor);
 
-    options = _.clone(options) || {};
+    options = { ...options };
 
     // Check for a restrict field
     if (!!instance.constructor && !!instance.constructor.associations) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -750,7 +750,7 @@ class Sequelize {
    * @returns {Promise}
    */
   async sync(options) {
-    options = _.clone(options) || {};
+    options = { ...options };
     options.hooks = options.hooks === undefined ? true : !!options.hooks;
     options = _.defaults(options, this.options.sync, this.options);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -263,8 +263,11 @@ function toDefaultValue(value, dialect) {
   if (value instanceof DataTypes.NOW) {
     return now(dialect);
   }
-  if (_.isPlainObject(value) || Array.isArray(value)) {
-    return _.clone(value);
+  if (Array.isArray(value)) {
+    return value.slice();
+  }
+  if (_.isPlainObject(value)) {
+    return { ...value };
   }
   return value;
 }

--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -6,8 +6,7 @@ const chai = require('chai'),
   sinon = require('sinon'),
   Config = require('../../../config/config'),
   ConnectionManager = require('../../../../lib/dialects/abstract/connection-manager'),
-  Pool = require('sequelize-pool').Pool,
-  _ = require('lodash');
+  Pool = require('sequelize-pool').Pool;
 
 const baseConf = Config[Support.getTestDialect()];
 const poolEntry = {
@@ -43,8 +42,8 @@ describe('Connection Manager', () => {
   it('should initialize a multiple pools with replication', () => {
     const options = {
       replication: {
-        write: _.clone(poolEntry),
-        read: [_.clone(poolEntry), _.clone(poolEntry)]
+        write: { ...poolEntry },
+        read: [{ ...poolEntry }, { ...poolEntry }]
       }
     };
     const sequelize = Support.createSequelizeInstance(options);
@@ -60,14 +59,14 @@ describe('Connection Manager', () => {
       return;
     }
 
-    const slave1 = _.clone(poolEntry);
-    const slave2 = _.clone(poolEntry);
+    const slave1 = { ...poolEntry };
+    const slave2 = { ...poolEntry };
     slave1.host = 'slave1';
     slave2.host = 'slave2';
 
     const options = {
       replication: {
-        write: _.clone(poolEntry),
+        write: { ...poolEntry },
         read: [slave1, slave2]
       }
     };
@@ -106,13 +105,13 @@ describe('Connection Manager', () => {
   });
 
   it('should allow forced reads from the write pool', () => {
-    const master = _.clone(poolEntry);
+    const master = { ...poolEntry };
     master.host = 'the-boss';
 
     const options = {
       replication: {
         write: master,
-        read: [_.clone(poolEntry)]
+        read: [{ ...poolEntry }]
       }
     };
     const sequelize = Support.createSequelizeInstance(options);

--- a/test/unit/model/destroy.test.js
+++ b/test/unit/model/destroy.test.js
@@ -5,8 +5,7 @@ const chai = require('chai'),
   Support = require('../support'),
   current = Support.sequelize,
   sinon = require('sinon'),
-  DataTypes = require('../../../lib/data-types'),
-  _ = require('lodash');
+  DataTypes = require('../../../lib/data-types');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
 
@@ -22,7 +21,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     beforeEach(function() {
       this.deloptions = { where: { secretValue: '1' } };
-      this.cloneOptions = _.clone(this.deloptions);
+      this.cloneOptions = { ...this.deloptions };
       this.stubDelete.resetHistory();
     });
 

--- a/test/unit/model/update.test.js
+++ b/test/unit/model/update.test.js
@@ -5,8 +5,7 @@ const chai = require('chai'),
   Support = require('../support'),
   current = Support.sequelize,
   sinon = require('sinon'),
-  DataTypes = require('../../../lib/data-types'),
-  _ = require('lodash');
+  DataTypes = require('../../../lib/data-types');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method update', () => {
@@ -20,7 +19,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     beforeEach(function() {
       this.stubUpdate = sinon.stub(current.getQueryInterface(), 'bulkUpdate').resolves([]);
       this.updates = { name: 'Batman', secretValue: '7' };
-      this.cloneUpdates = _.clone(this.updates);
+      this.cloneUpdates = { ...this.updates };
     });
 
     afterEach(function() {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This replaces (almost) all `_.clone` calls with object spreading (there was 1 array clone).

Turns out `_.clone` is around least an order of magnitude slower compared to native object spreading!

Consider this (rather naive) performance test:

```js
'use strict';

const { clone } = require('lodash');

const data = {
  a: 1,
  b: 2,
  c: 3,
  d: 4,
  e: 5
};


let out;
console.time('clone');
for (let i = 0; i < 0xffffff; i++) {
  data[Math.floor(Math.random() * 10)] = Math.random(); //avoid opt
  out = clone(data);
}
console.timeEnd('clone');

console.time('spread');
for (let i = 0; i < 0xffffff; i++) {
  data[Math.floor(Math.random() * 10)] = Math.random(); //avoid opt
  out = { ...data };
}
console.timeEnd('spread');
console.log(out); // avoid opt
```

The results (on my machine):
```
$ node speed.js
clone: 23.944s
spread: 840.681ms
```

See also https://www.measurethat.net/Benchmarks/Show/4542/0/object-cloning-with-lodash-clone-vs-clonedeep-vs-merge