### PR TITLE
refactor: replace lodash defaults with object spread

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -284,8 +284,8 @@ class BelongsToMany extends Association {
     const targetKey = this.target.rawAttributes[this.targetKey];
     const targetKeyType = targetKey.type;
     const targetKeyField = this.targetKeyField;
-    const sourceAttribute = _.defaults({}, this.foreignKeyAttribute, { type: sourceKeyType });
-    const targetAttribute = _.defaults({}, this.otherKeyAttribute, { type: targetKeyType });
+    const sourceAttribute = { type: sourceKeyType, ...this.foreignKeyAttribute };
+    const targetAttribute = { type: targetKeyType, ...this.otherKeyAttribute };
 
     if (this.primaryKeyDeleted === true) {
       targetAttribute.primaryKey = sourceAttribute.primaryKey = true;
@@ -594,7 +594,7 @@ class BelongsToMany extends Association {
             throughAttributes = {};
           }
 
-          const attributes = _.defaults({}, throughAttributes, defaultAttributes);
+          const attributes = { ...defaultAttributes, ...throughAttributes };
 
           if (Object.keys(attributes).length) {
             promises.push(
@@ -612,28 +612,26 @@ class BelongsToMany extends Association {
 
       if (obsoleteAssociations.length > 0) {
         promises.push(
-          this.through.model.destroy(_.defaults({
+          this.through.model.destroy({
+            ...options,
             where: {
               [identifier]: sourceInstance.get(sourceKey),
               [foreignIdentifier]: obsoleteAssociations.map(obsoleteAssociation => obsoleteAssociation[foreignIdentifier]),
               ...this.through.scope
             }
-          }, options))
+          })
         );
       }
 
       if (unassociatedObjects.length > 0) {
         const bulk = unassociatedObjects.map(unassociatedObject => {
-          let attributes = {};
-
-          attributes[identifier] = sourceInstance.get(sourceKey);
-          attributes[foreignIdentifier] = unassociatedObject.get(targetKey);
-
-          attributes = _.defaults(attributes, unassociatedObject[this.through.model.name], defaultAttributes);
-
-          Object.assign(attributes, this.through.scope);
-
-          return attributes;
+          return {
+            ...defaultAttributes,
+            ...unassociatedObject[this.through.model.name],
+            [identifier]: sourceInstance.get(sourceKey),
+            [foreignIdentifier]: unassociatedObject.get(targetKey),
+            ...this.through.scope
+          };
         });
 
         promises.push(this.through.model.bulkCreate(bulk, { validate: true, ...options }));
@@ -643,7 +641,7 @@ class BelongsToMany extends Association {
     };
 
     try {
-      const currentRows = await this.through.model.findAll(_.defaults({ where, raw: true }, options));
+      const currentRows = await this.through.model.findAll({ ...options, where, raw: true });
       return await updateAssociations(currentRows);
     } catch (error) {
       if (error instanceof EmptyResultError) return updateAssociations([]);
@@ -695,7 +693,7 @@ class BelongsToMany extends Association {
           unassociatedObjects.push(obj);
         } else {
           const throughAttributes = obj[association.through.model.name];
-          const attributes = _.defaults({}, throughAttributes, defaultAttributes);
+          const attributes = { ...defaultAttributes, ...throughAttributes };
 
           if (Object.keys(attributes).some(attribute => attributes[attribute] !== existingAssociation[attribute])) {
             changedAssociations.push(obj);
@@ -706,7 +704,7 @@ class BelongsToMany extends Association {
       if (unassociatedObjects.length > 0) {
         const bulk = unassociatedObjects.map(unassociatedObject => {
           const throughAttributes = unassociatedObject[association.through.model.name];
-          const attributes = _.defaults({}, throughAttributes, defaultAttributes);
+          const attributes = { ...defaultAttributes, ...throughAttributes };
 
           attributes[identifier] = sourceInstance.get(sourceKey);
           attributes[foreignIdentifier] = unassociatedObject.get(targetKey);
@@ -721,7 +719,7 @@ class BelongsToMany extends Association {
 
       for (const assoc of changedAssociations) {
         let throughAttributes = assoc[association.through.model.name];
-        const attributes = _.defaults({}, throughAttributes, defaultAttributes);
+        const attributes = { ...defaultAttributes, ...throughAttributes };
         // Quick-fix for subtle bug when using existing objects that might have the through model attached (not as an attribute object)
         if (throughAttributes instanceof association.through.model) {
           throughAttributes = {};
@@ -737,7 +735,7 @@ class BelongsToMany extends Association {
     };
 
     try {
-      const currentRows = await association.through.model.findAll(_.defaults({ where, raw: true }, options));
+      const currentRows = await association.through.model.findAll({ ...options, where, raw: true });
       const [associations] = await updateAssociations(currentRows);
       return associations;
     } catch (error) {
@@ -767,7 +765,7 @@ class BelongsToMany extends Association {
       [association.foreignIdentifier]: oldAssociatedObjects.map(newInstance => newInstance.get(association.targetKey))
     };
 
-    return association.through.model.destroy(_.defaults({ where }, options));
+    return association.through.model.destroy({ ...options, where });
   }
 
   /**

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -79,12 +79,13 @@ class BelongsTo extends Association {
 
   // the id is in the source table
   _injectAttributes() {
-    const newAttributes = {};
-
-    newAttributes[this.foreignKey] = _.defaults({}, this.foreignKeyAttribute, {
-      type: this.options.keyType || this.target.rawAttributes[this.targetKey].type,
-      allowNull: true
-    });
+    const newAttributes = {
+      [this.foreignKey]: {
+        type: this.options.keyType || this.target.rawAttributes[this.targetKey].type,
+        allowNull: true,
+        ...this.foreignKeyAttribute
+      }
+    };
 
     if (this.options.constraints !== false) {
       const source = this.source.rawAttributes[this.foreignKey] || newAttributes[this.foreignKey];

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -112,14 +112,16 @@ class HasMany extends Association {
   // the id is in the target table
   // or in an extra table which connects two tables
   _injectAttributes() {
-    const newAttributes = {};
+    const newAttributes = {
+      [this.foreignKey]: {
+        type: this.options.keyType || this.source.rawAttributes[this.sourceKeyAttribute].type,
+        allowNull: true,
+        ...this.foreignKeyAttribute
+      }
+    };
+
     // Create a new options object for use with addForeignKeyConstraints, to avoid polluting this.options in case it is later used for a n:m
     const constraintOptions = { ...this.options };
-
-    newAttributes[this.foreignKey] = _.defaults({}, this.foreignKeyAttribute, {
-      type: this.options.keyType || this.source.rawAttributes[this.sourceKeyAttribute].type,
-      allowNull: true
-    });
 
     if (this.options.constraints !== false) {
       const target = this.target.rawAttributes[this.foreignKey] || newAttributes[this.foreignKey];
@@ -329,7 +331,7 @@ class HasMany extends Association {
       targetInstances = this.toInstanceArray(targetInstances);
     }
 
-    const oldAssociations = await this.get(sourceInstance, _.defaults({ scope: false, raw: true }, options));
+    const oldAssociations = await this.get(sourceInstance, { ...options, scope: false, raw: true });
     const promises = [];
     const obsoleteAssociations = oldAssociations.filter(old =>
       !targetInstances.find(obj =>
@@ -357,9 +359,10 @@ class HasMany extends Association {
 
       promises.push(this.target.unscoped().update(
         update,
-        _.defaults({
+        {
+          ...options,
           where: updateWhere
-        }, options)
+        }
       ));
     }
 
@@ -376,9 +379,10 @@ class HasMany extends Association {
 
       promises.push(this.target.unscoped().update(
         update,
-        _.defaults({
+        {
+          ...options,
           where: updateWhere
-        }, options)
+        }
       ));
     }
 
@@ -414,7 +418,7 @@ class HasMany extends Association {
       )
     };
 
-    await this.target.unscoped().update(update, _.defaults({ where }, options));
+    await this.target.unscoped().update(update, { ...options, where });
 
     return sourceInstance;
   }
@@ -442,7 +446,7 @@ class HasMany extends Association {
       )
     };
 
-    await this.target.unscoped().update(update, _.defaults({ where }, options));
+    await this.target.unscoped().update(update, { ...options, where });
 
     return this;
   }

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -78,12 +78,13 @@ class HasOne extends Association {
 
   // the id is in the target table
   _injectAttributes() {
-    const newAttributes = {};
-
-    newAttributes[this.foreignKey] = _.defaults({}, this.foreignKeyAttribute, {
-      type: this.options.keyType || this.source.rawAttributes[this.sourceKey].type,
-      allowNull: true
-    });
+    const newAttributes = {
+      [this.foreignKey]: {
+        type: this.options.keyType || this.source.rawAttributes[this.sourceKey].type,
+        allowNull: true,
+        ...this.foreignKeyAttribute
+      }
+    };
 
     if (this.options.constraints !== false) {
       const target = this.target.rawAttributes[this.foreignKey] || newAttributes[this.foreignKey];

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -401,7 +401,7 @@ class QueryGenerator {
       }
     }
 
-    const whereOptions = _.defaults({ bindParam }, options);
+    const whereOptions = { ...options, bindParam };
 
     if (values.length === 0) {
       return '';

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -344,7 +344,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
   upsertQuery(tableName, insertValues, updateValues, where, model, options) {
     const primaryField = this.quoteIdentifier(model.primaryKeyField);
 
-    const upsertOptions = _.defaults({ bindParam: false, returning: ['*'] }, options);
+    const upsertOptions = { ...options, bindParam: false, returning: ['*'] };
     const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, upsertOptions);
     const update = this.updateQuery(tableName, updateValues, where, upsertOptions, model.rawAttributes);
     const returningRegex = /RETURNING \*(?![\s\S]*RETURNING \*)/;

--- a/lib/dialects/sqlite/query-generator.js
+++ b/lib/dialects/sqlite/query-generator.js
@@ -181,7 +181,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     const bind = [];
     const bindParam = this.bindParam(bind);
 
-    const upsertOptions = _.defaults({ bindParam }, options);
+    const upsertOptions = { ...options, bindParam };
     const insert = this.insertQuery(tableName, insertValues, model.rawAttributes, upsertOptions);
     const update = this.updateQuery(tableName, updateValues, where, upsertOptions, model.rawAttributes);
 
@@ -221,7 +221,7 @@ class SQLiteQueryGenerator extends MySqlQueryGenerator {
     }
 
     let query;
-    const whereOptions = _.defaults({ bindParam }, options);
+    const whereOptions = { ...options, bindParam };
 
     if (options.limit) {
       query = `UPDATE ${this.quoteTable(tableName)} SET ${values.join(',')} WHERE rowid IN (SELECT rowid FROM ${this.quoteTable(tableName)} ${this.whereQuery(where, whereOptions)} LIMIT ${this.escape(options.limit)})`;

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -18,17 +18,19 @@ const { promisify } = require('util');
  */
 class InstanceValidator {
   constructor(modelInstance, options) {
-    options = { ...options };
+    options = {
+      // assign defined and default options
+      hooks: true,
+      ...options
+    };
 
     if (options.fields && !options.skip) {
       options.skip = _.difference(Object.keys(modelInstance.constructor.rawAttributes), options.fields);
+    } else {
+      options.skip = options.skip || [];
     }
 
-    // assign defined and default options
-    this.options = _.defaults(options, {
-      skip: [],
-      hooks: true
-    });
+    this.options = options;
 
     this.modelInstance = modelInstance;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -3367,11 +3367,11 @@ class Model {
    * @returns {Promise<Model[],?number>} returns an array of affected rows and affected count with `options.returning` true, whenever supported by dialect
    */
   static async decrement(fields, options) {
-    options = _.defaults({ increment: false }, options, {
-      by: 1
+    return this.increment(fields, {
+      by: 1,
+      ...options,
+      increment: false
     });
-
-    return await this.increment(fields, options);
   }
 
   static _optionsMustContainWhere(options) {
@@ -4086,7 +4086,7 @@ class Model {
   * @returns {Promise}
   */
   async validate(options) {
-    return await new InstanceValidator(this, options).validate();
+    return new InstanceValidator(this, options).validate();
   }
 
   /**
@@ -4167,7 +4167,7 @@ class Model {
         this.setDataValue(attributeName, new Date());
       }
 
-      result = await this.save(_.defaults({ hooks: false }, options));
+      result = await this.save({ ...options, hooks: false });
     } else {
       result = await this.constructor.QueryInterface.delete(this, this.constructor.getTableName(options), where, { type: QueryTypes.DELETE, limit: null, ...options });
     }
@@ -4307,11 +4307,11 @@ class Model {
    * @returns {Promise}
    */
   async decrement(fields, options) {
-    options = _.defaults({ increment: false }, options, {
-      by: 1
+    return this.increment(fields, {
+      by: 1,
+      ...options,
+      increment: false
     });
-
-    return await this.increment(fields, options);
   }
 
   /**

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -751,9 +751,12 @@ class Sequelize {
    * @returns {Promise}
    */
   async sync(options) {
-    options = { ...options };
-    options.hooks = options.hooks === undefined ? true : !!options.hooks;
-    options = _.defaults(options, this.options.sync, this.options);
+    options = {
+      ...this.options,
+      ...this.options.sync,
+      ...options,
+      hooks: options ? options.hooks !== false : true
+    };
 
     if (options.match) {
       if (!options.match.test(this.config.database)) {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Replaces most instances of `_.defaults` with object spreading.

- _.defaults has somewhat of a high mental overhead as you have to go from last to first argument to understand the object assignment, especially complicated when used with nested spreading and/or Object.assign.
- object spread is a bit faster (~10% in my tests).
- less memory/gc pressure due to less intermediate object creation.