### PR TITLE
refactor(abstract-query): improve _groupJoinData perf and readability

### DIFF
--- a/src/dialects/abstract/query.js
+++ b/src/dialects/abstract/query.js
@@ -5,6 +5,46 @@ const Dot = require('dottie');
 const deprecations = require('../../utils/deprecations');
 const uuid = require('uuid').v4;
 
+const stringify = obj => (obj instanceof Buffer ? obj.toString('hex') : obj);
+
+// Calculates the array prefix of a key (['User', 'Results'] for 'User.Results.id')
+const makeDoublePrefixMemoizer = () => {
+  const keyPrefixMemo = {};
+  return str => {
+    // We use a double memo and keyPrefixString so that different keys with the same prefix will receive the same array instead of differnet arrays with equal values
+    if (!Object.prototype.hasOwnProperty.call(keyPrefixMemo, str)) {
+      const prefixString = str.substr(0, str.lastIndexOf('.'));
+      if (!Object.prototype.hasOwnProperty.call(keyPrefixMemo, prefixString)) {
+        keyPrefixMemo[prefixString] = prefixString ? prefixString.split('.') : [];
+      }
+      keyPrefixMemo[str] = keyPrefixMemo[prefixString];
+    }
+    return keyPrefixMemo[str];
+  };
+};
+
+/**
+ * Calculate the last item in the array prefix ('Results' for 'User.Results.id')
+ *
+ * @param {string} str
+ */
+const secondSuffix = str => {
+  const lastDelim = str.lastIndexOf('.');
+  if (lastDelim === -1) {
+    return '';
+  }
+  const secondLastDelim = str.lastIndexOf('.', lastDelim - 1);
+  if (secondLastDelim === -1) {
+    return str.substr(0, lastDelim);
+  }
+  return str.substring(secondLastDelim + 1, lastDelim);
+};
+
+const getSuffix = str => {
+  const index = str.lastIndexOf('.');
+  return str.substr(index === -1 ? 0 : index + 1);
+};
+
 class AbstractQuery {
   constructor(connection, sequelize, options) {
     this.uuid = uuid();
@@ -425,220 +465,162 @@ class AbstractQuery {
       return [];
     }
 
-    // Generic looping
-    let i;
-    let length;
-    let $i;
-    let $length;
-    // Row specific looping
-    let rowsI;
-    let row;
-    const rowsLength = rows.length;
-    // Key specific looping
-    let keys;
-    let key;
-    let keyI;
-    let keyLength;
-    let prevKey;
-    let values;
-    let topValues;
-    let topExists;
-    const checkExisting = options.checkExisting;
-    // If we don't have to deduplicate we can pre-allocate the resulting array
-    let itemHash;
-    let parentHash;
-    let topHash;
-    const results = checkExisting ? [] : new Array(rowsLength);
-    const resultMap = {};
     const includeMap = {};
-    // Result variables for the respective functions
-    let $keyPrefix;
-    let $keyPrefixString;
-    let $prevKeyPrefixString; // eslint-disable-line
-    let $prevKeyPrefix;
-    let $lastKeyPrefix;
-    let $current;
-    let $parent;
-    // Map each key to an include option
-    let previousPiece;
-    const buildIncludeMap = piece => {
-      if (Object.prototype.hasOwnProperty.call($current.includeMap, piece)) {
-        includeMap[key] = $current = $current.includeMap[piece];
-        if (previousPiece) {
-          previousPiece = `${previousPiece}.${piece}`;
-        } else {
-          previousPiece = piece;
+
+    const memoKeyPrefix = makeDoublePrefixMemoizer();
+
+    /**
+     * @type {string}
+     */
+    let prevKey;
+    /**
+     * @type {object}
+     */
+    let values;
+    /**
+     * @type {boolean}
+     */
+    let topExists = false;
+
+    /**
+     * @type {boolean}
+     */
+    const checkExisting = options.checkExisting;
+
+    const resultMap = {};
+
+    const computeHashKeyForInstance = (row, prevKeyPrefix, topHash) => {
+      const length = prevKeyPrefix.length;
+      /**
+       * @type {string}
+       */
+      let parent = null;
+      /**
+       * @type {string}
+       */
+      let parentHash = null;
+      /**
+       * @type {string}
+       */
+      let itemHash = topHash;
+
+      for (let i = 0; i < length; i++) {
+        /**
+         * @type {string}
+         */
+        const prefix = parent ? `${parent}.${prevKeyPrefix[i]}` : prevKeyPrefix[i];
+        itemHash = prefix;
+        for (const primKeyAttr of includeMap[prefix].model.primaryKeyAttributes) {
+          itemHash += stringify(row[`${prefix}.${primKeyAttr}`]);
         }
-        includeMap[previousPiece] = $current;
-      }
-    };
-    // Calculate the string prefix of a key ('User.Results' for 'User.Results.id')
-    const keyPrefixStringMemo = {};
-    const keyPrefixString = (key, memo) => {
-      if (!Object.prototype.hasOwnProperty.call(memo, key)) {
-        memo[key] = key.substr(0, key.lastIndexOf('.'));
-      }
-      return memo[key];
-    };
-    // Removes the prefix from a key ('id' for 'User.Results.id')
-    const removeKeyPrefixMemo = {};
-    const removeKeyPrefix = key => {
-      if (!Object.prototype.hasOwnProperty.call(removeKeyPrefixMemo, key)) {
-        const index = key.lastIndexOf('.');
-        removeKeyPrefixMemo[key] = key.substr(index === -1 ? 0 : index + 1);
-      }
-      return removeKeyPrefixMemo[key];
-    };
-    // Calculates the array prefix of a key (['User', 'Results'] for 'User.Results.id')
-    const keyPrefixMemo = {};
-    const keyPrefix = key => {
-      // We use a double memo and keyPrefixString so that different keys with the same prefix will receive the same array instead of differnet arrays with equal values
-      if (!Object.prototype.hasOwnProperty.call(keyPrefixMemo, key)) {
-        const prefixString = keyPrefixString(key, keyPrefixStringMemo);
-        if (!Object.prototype.hasOwnProperty.call(keyPrefixMemo, prefixString)) {
-          keyPrefixMemo[prefixString] = prefixString ? prefixString.split('.') : [];
+        if (!parentHash) {
+          parentHash = topHash;
         }
-        keyPrefixMemo[key] = keyPrefixMemo[prefixString];
+
+        itemHash = parentHash + itemHash;
+        parent = prefix;
+        if (i < length - 1) {
+          parentHash = itemHash;
+        }
       }
-      return keyPrefixMemo[key];
-    };
-    // Calcuate the last item in the array prefix ('Results' for 'User.Results.id')
-    const lastKeyPrefixMemo = {};
-    const lastKeyPrefix = key => {
-      if (!Object.prototype.hasOwnProperty.call(lastKeyPrefixMemo, key)) {
-        const prefix = keyPrefix(key);
-        const length = prefix.length;
 
-        lastKeyPrefixMemo[key] = !length ? '' : prefix[length - 1];
+      if (itemHash === topHash) {
+        if (!resultMap[itemHash]) {
+          resultMap[itemHash] = values;
+          return;
+        }
+        topExists = true;
+        return;
       }
-      return lastKeyPrefixMemo[key];
-    };
-    const getUniqueKeyAttributes = model => {
-      let uniqueKeyAttributes = _.chain(model.uniqueKeys);
-      uniqueKeyAttributes = uniqueKeyAttributes
-        .result(`${uniqueKeyAttributes.findKey()}.fields`)
-        .map(field => _.findKey(model.attributes, chr => chr.field === field))
-        .value();
 
-      return uniqueKeyAttributes;
-    };
-    const stringify = obj => (obj instanceof Buffer ? obj.toString('hex') : obj);
-    let primaryKeyAttributes;
-    let uniqueKeyAttributes;
-    let prefix;
-
-    for (rowsI = 0; rowsI < rowsLength; rowsI++) {
-      row = rows[rowsI];
-
-      // Keys are the same for all rows, so only need to compute them on the first row
-      if (rowsI === 0) {
-        keys = Object.keys(row);
-        keyLength = keys.length;
+      if (resultMap[itemHash]) {
+        return;
       }
+
+      parent = resultMap[parentHash];
+      const lastKeyPrefix = secondSuffix(prevKey);
+
+      if (includeMap[prevKey].association.isSingleAssociation) {
+        if (parent) {
+          parent[lastKeyPrefix] = resultMap[itemHash] = values;
+        }
+        return;
+      }
+      if (!parent[lastKeyPrefix]) {
+        parent[lastKeyPrefix] = [];
+      }
+      parent[lastKeyPrefix].push((resultMap[itemHash] = values));
+    };
+
+    const rowsLength = rows.length;
+    const results = checkExisting ? [] : new Array(rowsLength);
+    // Keys are the same for all rows, so only need to compute them on the first row
+
+    const keys = rowsLength > 0 ? Object.keys(rows[0]) : undefined;
+    const keyPrefixes = keys ? new Array(keys.length) : undefined;
+    // precompute prefixes and include maps
+    if (keys) {
+      for (let i = 0; i < keys.length; ++i) {
+        const key = keys[i];
+        const keyPrefix = memoKeyPrefix(key);
+        keyPrefixes[i] = keyPrefix;
+        if (Object.prototype.hasOwnProperty.call(includeMap, key)) {
+          continue;
+        }
+        if (keyPrefix.length === 0) {
+          includeMap[key] = includeOptions;
+          continue;
+        }
+        /**
+         * @type {object}
+         */
+        let current = includeOptions;
+        /**
+         * @type {string}
+         */
+        let previousPiece = undefined;
+        for (const prefix of keyPrefix) {
+          if (!Object.prototype.hasOwnProperty.call(current.includeMap, prefix)) {
+            continue;
+          }
+          includeMap[key] = current = current.includeMap[prefix];
+          if (previousPiece) {
+            previousPiece = `${previousPiece}.${prefix}`;
+          } else {
+            previousPiece = prefix;
+          }
+          includeMap[previousPiece] = current;
+        }
+      }
+    }
+    /**
+     * @type {string}
+     */
+    let topHash;
+    for (let rowsI = 0; rowsI < rowsLength; rowsI++) {
+      const row = rows[rowsI];
 
       if (checkExisting) {
         topExists = false;
 
         // Compute top level hash key (this is usually just the primary key values)
-        $length = includeOptions.model.primaryKeyAttributes.length;
         topHash = '';
-        if ($length === 1) {
-          topHash = stringify(row[includeOptions.model.primaryKeyAttributes[0]]);
-        } else if ($length > 1) {
-          for ($i = 0; $i < $length; $i++) {
-            topHash += stringify(row[includeOptions.model.primaryKeyAttributes[$i]]);
-          }
-        } else if (!_.isEmpty(includeOptions.model.uniqueKeys)) {
-          uniqueKeyAttributes = getUniqueKeyAttributes(includeOptions.model);
-          for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
-            topHash += row[uniqueKeyAttributes[$i]];
-          }
+
+        for (const primKeyAttr of includeOptions.model.primaryKeyAttributes) {
+          topHash += stringify(row[primKeyAttr]);
         }
       }
 
-      topValues = values = {};
-      $prevKeyPrefix = undefined;
-      for (keyI = 0; keyI < keyLength; keyI++) {
-        key = keys[keyI];
+      const topValues = (values = {});
+      let prevKeyPrefix = undefined;
+      for (let j = 0; j < keys.length; ++j) {
+        const key = keys[j];
+        const keyPrefix = keyPrefixes[j];
 
-        // The string prefix isn't actualy needed
-        // We use it so keyPrefix for different keys will resolve to the same array if they have the same prefix
-        // TODO: Find a better way?
-        $keyPrefixString = keyPrefixString(key, keyPrefixStringMemo);
-        $keyPrefix = keyPrefix(key);
-
-        // On the first row we compute the includeMap
-        if (rowsI === 0 && !Object.prototype.hasOwnProperty.call(includeMap, key)) {
-          if (!$keyPrefix.length) {
-            includeMap[key] = includeMap[''] = includeOptions;
-          } else {
-            $current = includeOptions;
-            previousPiece = undefined;
-            $keyPrefix.forEach(buildIncludeMap);
-          }
-        }
         // End of key set
-        if ($prevKeyPrefix !== undefined && $prevKeyPrefix !== $keyPrefix) {
+        if (prevKeyPrefix !== undefined && prevKeyPrefix !== keyPrefix) {
           if (checkExisting) {
-            // Compute hash key for this set instance
-            // TODO: Optimize
-            length = $prevKeyPrefix.length;
-            $parent = null;
-            parentHash = null;
-
-            if (length) {
-              for (i = 0; i < length; i++) {
-                prefix = $parent ? `${$parent}.${$prevKeyPrefix[i]}` : $prevKeyPrefix[i];
-                primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
-                $length = primaryKeyAttributes.length;
-                itemHash = prefix;
-                if ($length === 1) {
-                  itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[0]}`]);
-                } else if ($length > 1) {
-                  for ($i = 0; $i < $length; $i++) {
-                    itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
-                  }
-                } else if (!_.isEmpty(includeMap[prefix].model.uniqueKeys)) {
-                  uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
-                  for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
-                    itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];
-                  }
-                }
-                if (!parentHash) {
-                  parentHash = topHash;
-                }
-
-                itemHash = parentHash + itemHash;
-                $parent = prefix;
-                if (i < length - 1) {
-                  parentHash = itemHash;
-                }
-              }
-            } else {
-              itemHash = topHash;
-            }
-
-            if (itemHash === topHash) {
-              if (!resultMap[itemHash]) {
-                resultMap[itemHash] = values;
-              } else {
-                topExists = true;
-              }
-            } else if (!resultMap[itemHash]) {
-              $parent = resultMap[parentHash];
-              $lastKeyPrefix = lastKeyPrefix(prevKey);
-
-              if (includeMap[prevKey].association.isSingleAssociation) {
-                if ($parent) {
-                  $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
-                }
-              } else {
-                if (!$parent[$lastKeyPrefix]) {
-                  $parent[$lastKeyPrefix] = [];
-                }
-                $parent[$lastKeyPrefix].push((resultMap[itemHash] = values));
-              }
-            }
+            computeHashKeyForInstance(row, prevKeyPrefix, topHash);
 
             // Reset values
             values = {};
@@ -646,84 +628,25 @@ class AbstractQuery {
             // If checkExisting is false it's because there's only 1:1 associations in this query
             // However we still need to map onto the appropriate parent
             // For 1:1 we map forward, initializing the value object on the parent to be filled in the next iterations of the loop
-            $current = topValues;
-            length = $keyPrefix.length;
-            if (length) {
-              for (i = 0; i < length; i++) {
-                if (i === length - 1) {
-                  values = $current[$keyPrefix[i]] = {};
-                }
-                $current = $current[$keyPrefix[i]] || {};
+            let current = topValues;
+            const length = keyPrefix.length;
+            for (let i = 0; i < length; i++) {
+              if (i === length - 1) {
+                values = current[keyPrefix[i]] = {};
               }
+              current = current[keyPrefix[i]] || {};
             }
           }
         }
 
         // End of iteration, set value and set prev values (for next iteration)
-        values[removeKeyPrefix(key)] = row[key];
+        values[getSuffix(key)] = row[key];
         prevKey = key;
-        $prevKeyPrefix = $keyPrefix;
-        $prevKeyPrefixString = $keyPrefixString;
+        prevKeyPrefix = keyPrefix;
       }
 
       if (checkExisting) {
-        length = $prevKeyPrefix.length;
-        $parent = null;
-        parentHash = null;
-
-        if (length) {
-          for (i = 0; i < length; i++) {
-            prefix = $parent ? `${$parent}.${$prevKeyPrefix[i]}` : $prevKeyPrefix[i];
-            primaryKeyAttributes = includeMap[prefix].model.primaryKeyAttributes;
-            $length = primaryKeyAttributes.length;
-            itemHash = prefix;
-            if ($length === 1) {
-              itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[0]}`]);
-            } else if ($length > 0) {
-              for ($i = 0; $i < $length; $i++) {
-                itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
-              }
-            } else if (!_.isEmpty(includeMap[prefix].model.uniqueKeys)) {
-              uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
-              for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
-                itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];
-              }
-            }
-            if (!parentHash) {
-              parentHash = topHash;
-            }
-
-            itemHash = parentHash + itemHash;
-            $parent = prefix;
-            if (i < length - 1) {
-              parentHash = itemHash;
-            }
-          }
-        } else {
-          itemHash = topHash;
-        }
-
-        if (itemHash === topHash) {
-          if (!resultMap[itemHash]) {
-            resultMap[itemHash] = values;
-          } else {
-            topExists = true;
-          }
-        } else if (!resultMap[itemHash]) {
-          $parent = resultMap[parentHash];
-          $lastKeyPrefix = lastKeyPrefix(prevKey);
-
-          if (includeMap[prevKey].association.isSingleAssociation) {
-            if ($parent) {
-              $parent[$lastKeyPrefix] = resultMap[itemHash] = values;
-            }
-          } else {
-            if (!$parent[$lastKeyPrefix]) {
-              $parent[$lastKeyPrefix] = [];
-            }
-            $parent[$lastKeyPrefix].push((resultMap[itemHash] = values));
-          }
-        }
+        computeHashKeyForInstance(row, prevKeyPrefix, topHash);
         if (!topExists) {
           results.push(topValues);
         }

--- a/src/model.js
+++ b/src/model.js
@@ -1985,11 +1985,9 @@ class Model {
     options = Utils.cloneDeep(options);
 
     if (options.limit === undefined) {
-      const uniqueSingleColumns = _.chain(this.uniqueKeys)
-        .values()
+      const uniqueSingleColumns = Object.values(this.uniqueKeys)
         .filter(c => c.fields.length === 1)
-        .map('column')
-        .value();
+        .map(c => c.column);
 
       // Don't add limit if querying directly on the pk or a unique column
       if (
@@ -2807,14 +2805,13 @@ class Model {
         if (options.updateOnDuplicate) {
           options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
           // Get primary keys for postgres to enable updateOnDuplicate
-          options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
           if (Object.keys(model.uniqueKeys).length > 0) {
-            options.upsertKeys = _.chain(model.uniqueKeys)
-              .values()
+            options.upsertKeys = Object.values(model.uniqueKeys)
               .filter(c => c.fields.length >= 1)
               .map(c => c.fields)
-              .reduce(c => c[0])
-              .value();
+              .reduce((next, prev) => next.concat(prev), []);
+          } else {
+            options.upsertKeys = Object.values(model.primaryKeys).map(k => k.field);
           }
         }
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This cleans up the probably worst function in the entire code base and manages to also make it slightly faster in the process.

Worth mentioning:
 - All code related to `getUniqueKeyAttributes` was removed as it was effectively broken (the does something that makes absolutely no sense and won't ever have an effect), I want to fix this but I don't understand what it was suppose to a achieve at all.
 - Function is about 10% faster.
 - 