### PR TITLE
feat(observation): implement observation at query level

### DIFF
--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -731,7 +731,6 @@ class QueryInterface {
 
     options.type = QueryTypes.INSERT;
     options.instance = instance;
-
     const results = await this.sequelize.query(sql, options);
     if (instance) results[0].isNewRecord = false;
 

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -333,8 +333,8 @@ class AbstractQuery {
     const { connection, options } = this;
     const benchmark = this.sequelize.options.benchmark || options.benchmark;
     const enableObserver = this.sequelize.options.observe || options.observe ? true : false;
-    const globalObserverDimensions = this.sequelize.options.observe === true ? {} : this.sequelize.options.observe;
-    const queryObserverDimensions = options.observe === true ? {} : options.observe;
+    const globalObserverDimensions = this.sequelize.options.observe === true ? {} : this.sequelize.options.observe || {};
+    const queryObserverDimensions = options.observe === true ? {} : options.observe || {};
     const logQueryParameters = this.sequelize.options.logQueryParameters || options.logQueryParameters;
     const startTime = Date.now();
     let logParameter = '';

--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -332,6 +332,9 @@ class AbstractQuery {
   _logQuery(sql, debugContext, parameters) {
     const { connection, options } = this;
     const benchmark = this.sequelize.options.benchmark || options.benchmark;
+    const enableObserver = this.sequelize.options.observe || options.observe ? true : false;
+    const globalObserverDimensions = this.sequelize.options.observe === true ? {} : this.sequelize.options.observe;
+    const queryObserverDimensions = options.observe === true ? {} : options.observe;
     const logQueryParameters = this.sequelize.options.logQueryParameters || options.logQueryParameters;
     const startTime = Date.now();
     let logParameter = '';
@@ -352,11 +355,38 @@ class AbstractQuery {
     if (!benchmark) {
       this.sequelize.log(`Executing ${fmt}`, options);
     }
-    return () => {
-      const afterMsg = `Executed ${fmt}`;
-      debugContext(afterMsg);
-      if (benchmark) {
-        this.sequelize.log(afterMsg, Date.now() - startTime, options);
+    let metricsDimensions = {};
+    if (enableObserver) {
+      metricsDimensions = {
+        type: options.type,
+        ...globalObserverDimensions,
+        ...queryObserverDimensions,
+        connection: connection.uuid || 'default',
+        sql,
+        parameters: logQueryParameters && logParameter || undefined
+      };
+      this.sequelize.observer.emit('beforeQuery', metricsDimensions);
+    }
+    return error => {
+      const queryDuration = Date.now() - startTime;
+      if (!error) {  
+        const afterMsg = `Executed ${fmt}`;
+        debugContext(afterMsg);
+        if (benchmark) {
+          this.sequelize.log(afterMsg, queryDuration, options);
+        }
+        if (enableObserver) {
+          this.sequelize.observer.emit('querySuccess', {
+            ...metricsDimensions,
+            queryDuration
+          });
+        }
+      } else if (enableObserver) {
+        this.sequelize.observer.emit('queryError', {
+          ...metricsDimensions,
+          queryDuration,
+          error
+        });
       }
     };
   }

--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -54,6 +54,7 @@ class Query extends AbstractQuery {
         await this.logWarnings(results);
       }
     } catch (err) {
+      complete(err);
       // MariaDB automatically rolls-back transactions in the event of a deadlock
       if (options.transaction && err.errno === 1213) {
         options.transaction.finished = 'rollback';

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -74,13 +74,13 @@ class Query extends AbstractQuery {
       const results = [];
       const request = new connection.lib.Request(sql, (err, rowCount) => {
 
-        complete();
-
         if (err) {
+          complete(err);
           err.sql = sql;
           err.parameters = parameters;
           reject(this.formatError(err));
         } else {
+          complete();
           resolve(this.formatResults(results, rowCount));
         }
       });

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -37,9 +37,8 @@ class Query extends AbstractQuery {
 
     const results = await new Promise((resolve, reject) => {
       const handler = (err, results) => {
-        complete();
-
         if (err) {
+          complete(err);
           // MySQL automatically rolls-back transactions in the event of a deadlock
           if (options.transaction && err.errno === 1213) {
             options.transaction.finished = 'rollback';
@@ -49,6 +48,7 @@ class Query extends AbstractQuery {
 
           reject(this.formatError(err));
         } else {
+          complete();
           resolve(results);
         }
       };

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -84,6 +84,7 @@ class Query extends AbstractQuery {
 
       err.sql = sql;
       err.parameters = parameters;
+      complete(err);
       throw this.formatError(err);
     }
 

--- a/lib/dialects/sqlite/query.js
+++ b/lib/dialects/sqlite/query.js
@@ -241,12 +241,13 @@ class Query extends AbstractQuery {
         // cannot use arrow function here because the function is bound to the statement
         function afterExecute(executionError, results) {
           try {
-            complete();
             // `this` is passed from sqlite, we have no control over this.
             // eslint-disable-next-line no-invalid-this
             resolve(query._handleQueryResponse(this, columnTypes, executionError, results));
+            complete();
             return;
           } catch (error) {
+            complete(error);
             reject(error);
           }
         }

--- a/lib/model.js
+++ b/lib/model.js
@@ -1659,6 +1659,7 @@ class Model {
    * @param  {object}                                                    [options.having] Having options
    * @param  {string}                                                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Error}                                             [options.rejectOnEmpty=false] Throws an error when no records found
+   * @param  {boolean|object}                                            [options.observe] Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @see
    * {@link Sequelize#query}
@@ -1919,6 +1920,7 @@ class Model {
    * @param {boolean}         [options.distinct] Applies DISTINCT to the field being aggregated over
    * @param {Transaction}     [options.transaction] Transaction to run query under
    * @param {boolean}         [options.plain] When `true`, the first returned value of `aggregateFunction` is cast to `dataType` and returned. If additional attributes are specified, along with `group` clauses, set `plain` to `false` to return all values of all returned rows.  Defaults to `true`
+   * @param {boolean|object}  [options.observe] Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise<DataTypes|object>} Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in which case the complete data result is returned.
    */
@@ -2186,6 +2188,7 @@ class Model {
    * @param  {Transaction}    [options.transaction]        Transaction to run query under
    * @param  {string}         [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Array}  [options.returning=true]     Appends RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
+   * @param  {boolean|object} [options.observe]            Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise<Model>}
    *
@@ -2404,16 +2407,17 @@ class Model {
    * * MSSQL - Implemented as a single query using `MERGE` and `WHEN (NOT) MATCHED THEN`
    * **Note** that SQLite returns undefined for created, no matter if the row was created or updated. This is because SQLite always runs INSERT OR IGNORE + UPDATE, in a single query, so there is no way to know whether the row was inserted or not.
    *
-   * @param  {object}       values                                        hash of values to upsert
-   * @param  {object}       [options]                                     upsert options
-   * @param  {boolean}      [options.validate=true]                       Run validations before the row is inserted
-   * @param  {Array}        [options.fields=Object.keys(this.attributes)] The fields to insert / update. Defaults to all changed fields
-   * @param  {boolean}      [options.hooks=true]                          Run before / after upsert hooks?
-   * @param  {boolean}      [options.returning=false]                     If true, fetches back auto generated values (Postgres only)
-   * @param  {Transaction}  [options.transaction]                         Transaction to run query under
-   * @param  {Function}     [options.logging=false]                       A function that gets executed while running the query to log the sql.
-   * @param  {boolean}      [options.benchmark=false]                     Pass query execution time in milliseconds as second argument to logging function (options.logging).
-   * @param  {string}       [options.searchPath=DEFAULT]                  An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {object}         values                                        hash of values to upsert
+   * @param  {object}         [options]                                     upsert options
+   * @param  {boolean}        [options.validate=true]                       Run validations before the row is inserted
+   * @param  {Array}          [options.fields=Object.keys(this.attributes)] The fields to insert / update. Defaults to all changed fields
+   * @param  {boolean}        [options.hooks=true]                          Run before / after upsert hooks?
+   * @param  {boolean}        [options.returning=false]                     If true, fetches back auto generated values (Postgres only)
+   * @param  {Transaction}    [options.transaction]                         Transaction to run query under
+   * @param  {Function}       [options.logging=false]                       A function that gets executed while running the query to log the sql.
+   * @param  {boolean}        [options.benchmark=false]                     Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param  {string}         [options.searchPath=DEFAULT]                  An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {boolean|object} [options.observe]                             Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise<boolean>} Returns a boolean indicating whether the row was created or updated. For MySQL/MariaDB, it returns `true` when inserted and `false` when updated. For Postgres/MSSQL with `options.returning` true, it returns record and created boolean with signature `<Model, created>`.
    */
@@ -2504,6 +2508,7 @@ class Model {
    * @param  {boolean}        [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {boolean|Array}  [options.returning=false]        If true, append RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}         [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {boolean|object} [options.observe]                Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise<Array<Model>>}
    */
@@ -2825,6 +2830,7 @@ class Model {
    * @param {boolean|Function} [options.logging] A function that logs sql queries, or false for no logging
    * @param {boolean}          [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param {string}           [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {boolean|objeect}  [options.observe] Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise}
    *
@@ -2840,18 +2846,19 @@ class Model {
   /**
    * Delete multiple instances, or set their deletedAt timestamp to the current time if `paranoid` is enabled.
    *
-   * @param  {object}       options                         destroy options
-   * @param  {object}       [options.where]                 Filter the destroy
-   * @param  {boolean}      [options.hooks=true]            Run before / after bulk destroy hooks?
-   * @param  {boolean}      [options.individualHooks=false] If set to true, destroy will SELECT all records matching the where parameter and will execute before / after destroy hooks on each row
-   * @param  {number}       [options.limit]                 How many rows to delete
-   * @param  {boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
-   * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored
-   * @param  {boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
-   * @param  {boolean}      [options.restartIdentity=false] Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table.
-   * @param  {Transaction}  [options.transaction] Transaction to run query under
-   * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
-   * @param  {boolean}      [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param  {object}         options                         destroy options
+   * @param  {object}         [options.where]                 Filter the destroy
+   * @param  {boolean}        [options.hooks=true]            Run before / after bulk destroy hooks?
+   * @param  {boolean}        [options.individualHooks=false] If set to true, destroy will SELECT all records matching the where parameter and will execute before / after destroy hooks on each row
+   * @param  {number}         [options.limit]                 How many rows to delete
+   * @param  {boolean}        [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
+   * @param  {boolean}        [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored
+   * @param  {boolean}        [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
+   * @param  {boolean}        [options.restartIdentity=false] Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table.
+   * @param  {Transaction}    [options.transaction] Transaction to run query under
+   * @param  {Function}       [options.logging=false]         A function that gets executed while running the query to log the sql.
+   * @param  {boolean}        [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param  {boolean|object} [options.observe]               Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise<number>} The number of destroyed rows
    */
@@ -2928,14 +2935,15 @@ class Model {
   /**
    * Restore multiple instances if `paranoid` is enabled.
    *
-   * @param  {object}       options                         restore options
-   * @param  {object}       [options.where]                 Filter the restore
-   * @param  {boolean}      [options.hooks=true]            Run before / after bulk restore hooks?
-   * @param  {boolean}      [options.individualHooks=false] If set to true, restore will find all records within the where parameter and will execute before / after bulkRestore hooks on each row
-   * @param  {number}       [options.limit]                 How many rows to undelete (only for mysql)
-   * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
-   * @param  {boolean}      [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
-   * @param  {Transaction}  [options.transaction]           Transaction to run query under
+   * @param  {object}         options                         restore options
+   * @param  {object}         [options.where]                 Filter the restore
+   * @param  {boolean}        [options.hooks=true]            Run before / after bulk restore hooks?
+   * @param  {boolean}        [options.individualHooks=false] If set to true, restore will find all records within the where parameter and will execute before / after bulkRestore hooks on each row
+   * @param  {number}         [options.limit]                 How many rows to undelete (only for mysql)
+   * @param  {Function}       [options.logging=false]         A function that gets executed while running the query to log the sql.
+   * @param  {boolean}        [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param  {Transaction}    [options.transaction]           Transaction to run query under
+   * @param  {boolean|object} [options.observe]               Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise}
    */
@@ -3005,6 +3013,7 @@ class Model {
    * @param  {boolean}        [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {Transaction}    [options.transaction]           Transaction to run query under
    * @param  {boolean}        [options.silent=false]          If true, the updatedAt timestamp will not be updated.
+   * @param  {boolean|object} [options.observe]               Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise<Array<number,number>>}  The promise returns an array with one or two elements. The first element is always the number
    * of affected rows, while the second element is the actual affected rows (only supported in postgres with `options.returning` true).
@@ -3780,15 +3789,16 @@ class Model {
    *
    * This method is not aware of eager loaded associations. In other words, if some other model instance (child) was eager loaded with this instance (parent), and you change something in the child, calling `save()` will simply ignore the change that happened on the child.
    *
-   * @param {object}      [options] save options
-   * @param {string[]}    [options.fields] An optional array of strings, representing database columns. If fields is provided, only those columns will be validated and saved.
-   * @param {boolean}     [options.silent=false] If true, the updatedAt timestamp will not be updated.
-   * @param {boolean}     [options.validate=true] If false, validations won't be run.
-   * @param {boolean}     [options.hooks=true] Run before and after create / update + validate hooks
-   * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
-   * @param {Transaction} [options.transaction] Transaction to run query under
-   * @param {string}      [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
-   * @param {boolean}     [options.returning] Append RETURNING * to get back auto generated values (Postgres only)
+   * @param {object}         [options] save options
+   * @param {string[]}       [options.fields] An optional array of strings, representing database columns. If fields is provided, only those columns will be validated and saved.
+   * @param {boolean}        [options.silent=false] If true, the updatedAt timestamp will not be updated.
+   * @param {boolean}        [options.validate=true] If false, validations won't be run.
+   * @param {boolean}        [options.hooks=true] Run before and after create / update + validate hooks
+   * @param {Function}       [options.logging=false] A function that gets executed while running the query to log the sql.
+   * @param {Transaction}    [options.transaction] Transaction to run query under
+   * @param {string}         [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {boolean}        [options.returning] Append RETURNING * to get back auto generated values (Postgres only)
+   * @param {boolean|object} [options.observe] Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise<Model>}
    */
@@ -3916,12 +3926,13 @@ class Model {
           .defaults({
             transaction: options.transaction,
             logging: options.logging,
-            parentRecord: this
+            parentRecord: this,
+            observe: options.observe
           }).value();
 
         await instance.save(includeOptions);
 
-        await this[include.association.accessors.set](instance, { save: false, logging: options.logging });
+        await this[include.association.accessors.set](instance, { save: false, logging: options.logging, observe: options.observe });
       }));
     }
     const realFields = options.fields.filter(field => !this.constructor._virtualAttributes.has(field));
@@ -3987,7 +3998,8 @@ class Model {
             .defaults({
               transaction: options.transaction,
               logging: options.logging,
-              parentRecord: this
+              parentRecord: this,
+              observe: options.observe
             }).value();
 
           // Instances will be updated in place so we can safely treat HasOne like a HasMany
@@ -4132,11 +4144,12 @@ class Model {
   /**
    * Destroy the row corresponding to this instance. Depending on your setting for paranoid, the row will either be completely deleted, or have its deletedAt timestamp set to the current time.
    *
-   * @param {object}      [options={}] destroy options
-   * @param {boolean}     [options.force=false] If set to true, paranoid models will actually be deleted
-   * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
-   * @param {Transaction} [options.transaction] Transaction to run query under
-   * @param {string}      [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {object}         [options={}] destroy options
+   * @param {boolean}        [options.force=false] If set to true, paranoid models will actually be deleted
+   * @param {Function}       [options.logging=false] A function that gets executed while running the query to log the sql.
+   * @param {Transaction}    [options.transaction] Transaction to run query under
+   * @param {string}         [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {boolean|object} [options.observe] Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise}
    */
@@ -4201,9 +4214,10 @@ class Model {
   /**
    * Restore the row corresponding to this instance. Only available for paranoid models.
    *
-   * @param {object}      [options={}] restore options
-   * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
-   * @param {Transaction} [options.transaction] Transaction to run query under
+   * @param {object}         [options={}] restore options
+   * @param {Function}       [options.logging=false] A function that gets executed while running the query to log the sql.
+   * @param {Transaction}    [options.transaction] Transaction to run query under
+   * @param {boolean|object} [options.observe] Activate observation for this query. Set the dimensions / labels you want to observe (key, value) in object.
    *
    * @returns {Promise}
    */

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -4,6 +4,7 @@ const url = require('url');
 const path = require('path');
 const retry = require('retry-as-promised');
 const _ = require('lodash');
+const EventEmitter = require('events');
 
 const Utils = require('./utils');
 const Model = require('./model');
@@ -168,6 +169,7 @@ class Sequelize {
    * @param {object}   [options.hooks] An object of global hook functions that are called before and after certain lifecycle events. Global hooks will run after any model-specific hooks defined for the same event (See `Sequelize.Model.init()` for a list).  Additionally, `beforeConnect()`, `afterConnect()`, `beforeDisconnect()`, and `afterDisconnect()` hooks may be defined here.
    * @param {boolean}  [options.minifyAliases=false] A flag that defines if aliases should be minified (mostly useful to avoid Postgres alias character limit of 64)
    * @param {boolean}  [options.logQueryParameters=false] A flag that defines if show bind patameters in log.
+   * @param {object|boolean}  [options.observe=false] Activate observation. Set the dimensions / labels (key, value) you want to observe in observation object.
    */
   constructor(database, username, password, options) {
     let config;
@@ -264,6 +266,7 @@ class Sequelize {
       benchmark: false,
       minifyAliases: false,
       logQueryParameters: false,
+      observe: false,
       ...options
     };
 
@@ -345,6 +348,7 @@ class Sequelize {
     this.models = {};
     this.modelManager = new ModelManager(this);
     this.connectionManager = this.dialect.connectionManager;
+    this.observer = new EventEmitter();
 
     Sequelize.runHooks('afterInit', this);
   }

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -1018,7 +1018,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       beforeEach(function() {
         this.sequelize.observer.on('beforeQuery', spy1);
         this.sequelize.observer.on('querySuccess', spy2);
-        this.sequelize.observer.on('queryError', spy2);
+        this.sequelize.observer.on('queryError', spy3);
       });
       afterEach(function() {
         this.sequelize.observer.off('beforeQuery', spy1);

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -1082,7 +1082,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(afterObservationObject).to.have.property('parameters', undefined);
           expect(afterObservationObject).to.have.property('queryDuration');
           expect(afterObservationObject.queryDuration).to.be.a('number');
-          expect(afterObservationObject.queryDuration).to.be.greaterThan(0);
+          expect(afterObservationObject.queryDuration).to.be.gte(0);
         });
       });
     });

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const chai = require('chai'),
+  sinon = require('sinon'),
   Sequelize = require('../../../index'),
   AggregateError = require('../../../lib/errors/aggregate-error'),
   Op = Sequelize.Op,
@@ -1004,6 +1005,85 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           .then(users => {
             expect(users.length).to.equal(1);
           });
+      });
+    });
+
+    describe('observation', () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      const spy3 = sinon.spy();
+      const values = [...Array(10).keys()].map(key => ({
+        uniqueName: `${key}`
+      }));
+      beforeEach(function() {
+        this.sequelize.observer.on('beforeQuery', spy1);
+        this.sequelize.observer.on('querySuccess', spy2);
+        this.sequelize.observer.on('queryError', spy2);
+      });
+      afterEach(function() {
+        this.sequelize.observer.off('beforeQuery', spy1);
+        this.sequelize.observer.off('querySuccess', spy2);
+        this.sequelize.observer.off('queryError', spy2);
+        this.sequelize.options.observe = undefined;
+        this.sequelize.options.logQueryParameters = false;
+        spy1.resetHistory();
+        spy2.resetHistory();
+        spy3.resetHistory();
+      });
+      it('should support observation', function() {
+        return this.User.bulkCreate(values, {
+          observe: {}
+        }).then(() => {
+          expect(spy3.called).not.to.be.ok;
+          expect(spy1.callCount).to.equal(1);
+          expect(spy2.callCount).to.equal(1);
+        });
+      });
+  
+      it('should not trigger observation if options.observe set to false', function() {
+        return this.User.bulkCreate(values, {
+          observe: false
+        }).then(() => {
+          expect(spy1.called).not.to.be.ok;
+          expect(spy2.called).not.to.be.ok;
+          expect(spy3.called).not.to.be.ok;
+        });
+      });
+  
+      it('should return the correct data in observation', function() {
+        this.sequelize.options.observe = {
+          globalLabel: 'global_value',
+          name: 'global_name'
+        };
+        return this.User.bulkCreate(values, {
+          observe: {
+            name: 'my_pretty_query'
+          },
+          logQueryParameters: true
+        }).then(() => {
+          const beforeObservationObject = spy1.getCall(0).args[0];
+          expect(beforeObservationObject).to.have.property('name', 'my_pretty_query');
+          expect(beforeObservationObject).to.have.property('globalLabel', 'global_value');
+          expect(beforeObservationObject).to.have.property('type', Support.Sequelize.QueryTypes.INSERT);
+          expect(beforeObservationObject).to.have.property('connection', 'default');
+          expect(beforeObservationObject).to.have.property('sql');
+          expect(beforeObservationObject.sql).to.be.a('string');
+          expect(beforeObservationObject.sql.indexOf('INSERT')).to.equal(0);
+          expect(beforeObservationObject).to.have.property('parameters', undefined);
+          expect(beforeObservationObject).not.to.have.property('queryDuration');
+  
+          const afterObservationObject = spy2.getCall(0).args[0];
+          expect(afterObservationObject).to.have.property('name', 'my_pretty_query');
+          expect(afterObservationObject).to.have.property('globalLabel', 'global_value');
+          expect(afterObservationObject).to.have.property('type', Support.Sequelize.QueryTypes.INSERT);
+          expect(afterObservationObject).to.have.property('connection', 'default');
+          expect(afterObservationObject).to.have.property('sql');
+          expect(afterObservationObject.sql).to.be.a('string');
+          expect(afterObservationObject).to.have.property('parameters', undefined);
+          expect(afterObservationObject).to.have.property('queryDuration');
+          expect(afterObservationObject.queryDuration).to.be.a('number');
+          expect(afterObservationObject.queryDuration).to.be.greaterThan(0);
+        });
       });
     });
   });

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -585,8 +585,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           returning: false,
           observe: {}
         }).then(() => {
-          expect(spy1.callCount).to.equal(4);
-          expect(spy2.callCount).to.equal(4);
+          
+          expect(spy1.called).to.be.ok;
+          expect(spy2.called).to.be.ok;
+          
           expect(spy3.called).not.to.be.ok;
         });
       });
@@ -617,82 +619,29 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             name: 'my_pretty_query'
           }
         }).then(() => {
-          const beforeObservationObjectCalls = spy1.getCalls().map(call => call.args[0]);
-          const afterObservationObjectCalls = spy2.getCalls().map(call => call.args[0]);
+          const beforeQueryArgs = spy1.getCalls().map(call => call.args[0]);
+          const afterQueryArgs = spy2.getCalls().map(call => call.args[0]);
+         
+          beforeQueryArgs.forEach(call => {
+            expect(call).to.have.property('name', 'my_pretty_query');
+            expect(call).to.have.property('globalLabel', 'global_value');
+            expect(call).to.have.property('type');
+            expect(call).to.have.property('connection');
+            expect(call).to.have.property('sql');
+            expect(call).to.have.property('parameters', undefined);
+            expect(call).not.to.have.property('queryDuration');
+          });
 
-          const beforeCall1Args = beforeObservationObjectCalls[0];
-          const afterCall1Args = afterObservationObjectCalls[0];
-          expect(beforeCall1Args).to.have.property('name', 'my_pretty_query');
-          expect(beforeCall1Args).to.have.property('globalLabel', 'global_value');
-          expect(beforeCall1Args).to.have.property('type');
-          expect(beforeCall1Args).to.have.property('connection');
-          expect(beforeCall1Args.connection).not.to.equal('default');
-          expect(beforeCall1Args).to.have.property('sql', 'START TRANSACTION;');
-          expect(beforeCall1Args).to.have.property('parameters', undefined);
-          expect(beforeCall1Args).not.to.have.property('queryDuration');
-
-          for (const entry of Object.entries(beforeCall1Args)) {
-            expect(afterCall1Args).to.have.property(entry[0], entry[1]);
-          }
-          expect(afterCall1Args).to.have.property('queryDuration');
-          expect(afterCall1Args.queryDuration).to.be.a('number');
-          expect(afterCall1Args.queryDuration).to.be.greaterThan(0);
-
-          const beforeCall2Args = beforeObservationObjectCalls[1];
-          const afterCall2Args = afterObservationObjectCalls[1];
-          expect(beforeCall2Args).to.have.property('name', 'my_pretty_query');
-          expect(beforeCall2Args).to.have.property('globalLabel', 'global_value');
-          expect(beforeCall2Args).to.have.property('type', Support.Sequelize.QueryTypes.SELECT);
-          expect(beforeCall2Args).to.have.property('connection');
-          expect(beforeCall2Args.connection).to.equal(beforeCall1Args.connection);
-          expect(beforeCall2Args).to.have.property('sql');
-          expect(beforeCall2Args.sql.indexOf('SELECT')).to.equal(0);
-          expect(beforeCall2Args).to.have.property('parameters', undefined);
-          expect(beforeCall2Args).not.to.have.property('queryDuration');
-
-          for (const entry of Object.entries(beforeCall2Args)) {
-            expect(afterCall2Args).to.have.property(entry[0], entry[1]);
-          }
-          expect(afterCall2Args).to.have.property('queryDuration');
-          expect(afterCall2Args.queryDuration).to.be.a('number');
-          expect(afterCall2Args.queryDuration).to.be.greaterThan(0);
-
-          const beforeCall3Args = beforeObservationObjectCalls[2];
-          const afterCall3Args = afterObservationObjectCalls[2];
-          expect(beforeCall3Args).to.have.property('name', 'my_pretty_query');
-          expect(beforeCall3Args).to.have.property('globalLabel', 'global_value');
-          expect(beforeCall3Args).to.have.property('type', Support.Sequelize.QueryTypes.INSERT);
-          expect(beforeCall3Args).to.have.property('connection');
-          expect(beforeCall3Args.connection).to.equal(beforeCall1Args.connection);
-          expect(beforeCall3Args).to.have.property('sql');
-          expect(beforeCall3Args.sql.indexOf('INSERT')).not.to.equal(-1);
-          expect(beforeCall3Args).to.have.property('parameters', undefined);
-          expect(beforeCall3Args).not.to.have.property('queryDuration');
-
-          for (const entry of Object.entries(beforeCall3Args)) {
-            expect(afterCall3Args).to.have.property(entry[0], entry[1]);
-          }
-          expect(afterCall3Args).to.have.property('queryDuration');
-          expect(afterCall3Args.queryDuration).to.be.a('number');
-          expect(afterCall3Args.queryDuration).to.be.greaterThan(0);
-
-          const beforeCall4Args = beforeObservationObjectCalls[3];
-          const afterCall4Args = afterObservationObjectCalls[3];
-          expect(beforeCall4Args).to.have.property('name', 'my_pretty_query');
-          expect(beforeCall4Args).to.have.property('globalLabel', 'global_value');
-          expect(beforeCall4Args).to.have.property('type');
-          expect(beforeCall4Args).to.have.property('connection');
-          expect(beforeCall4Args.connection).to.equal(beforeCall1Args.connection);
-          expect(beforeCall4Args).to.have.property('sql', 'COMMIT;');
-          expect(beforeCall4Args).to.have.property('parameters', undefined);
-          expect(beforeCall4Args).not.to.have.property('queryDuration');
-
-          for (const entry of Object.entries(beforeCall4Args)) {
-            expect(afterCall4Args).to.have.property(entry[0], entry[1]);
-          }
-          expect(afterCall4Args).to.have.property('queryDuration');
-          expect(afterCall4Args.queryDuration).to.be.a('number');
-          expect(afterCall4Args.queryDuration).to.be.greaterThan(0);
+          afterQueryArgs.forEach(call => {
+            expect(call).to.have.property('name', 'my_pretty_query');
+            expect(call).to.have.property('globalLabel', 'global_value');
+            expect(call).to.have.property('type');
+            expect(call).to.have.property('connection');
+            expect(call).to.have.property('sql');
+            expect(call).to.have.property('parameters', undefined);
+            expect(call).to.have.property('queryDuration');
+            expect(call.queryDuration).to.be.gte(0);
+          });
         });
       });
     });
@@ -1687,7 +1636,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(afterObservationObject).to.have.property('parameters', undefined);
         expect(afterObservationObject).to.have.property('queryDuration');
         expect(afterObservationObject.queryDuration).to.be.a('number');
-        expect(afterObservationObject.queryDuration).to.be.greaterThan(0);
+        expect(afterObservationObject.queryDuration).to.be.gte(0);
       });
     });
 
@@ -1721,8 +1670,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(beforeObservationObject).to.have.property('parameters', undefined);
         expect(beforeObservationObject).not.to.have.property('queryDuration');
         
-        expect(spy2.callCount).to.equal(1);
-        expect(spy3.callCount).to.equal(1);
+        expect(spy2.called).to.be.ok;
+        expect(spy3.called).to.be.ok;
 
         const afterObservationObject = spy3.getCall(0).args[0];
         expect(afterObservationObject).to.have.property('name', 'my_pretty_query');
@@ -1734,7 +1683,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(afterObservationObject).to.have.property('parameters', undefined);
         expect(afterObservationObject).to.have.property('queryDuration');
         expect(afterObservationObject.queryDuration).to.be.a('number');
-        expect(afterObservationObject.queryDuration).to.be.greaterThan(0);
+        expect(afterObservationObject.queryDuration).to.be.gte(0);
         expect(afterObservationObject).to.have.property('error');
         if (afterObservationObject.error instanceof Sequelize.UniqueConstraintError) {
           expect(afterObservationObject).to.have.property('error', error);

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -567,7 +567,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       beforeEach(function() {
         this.sequelize.observer.on('beforeQuery', spy1);
         this.sequelize.observer.on('querySuccess', spy2);
-        this.sequelize.observer.on('queryError', spy2);
+        this.sequelize.observer.on('queryError', spy3);
       });
       afterEach(function() {
         this.sequelize.observer.off('beforeQuery', spy1);
@@ -1618,12 +1618,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     beforeEach(function() {
       this.sequelize.observer.on('beforeQuery', spy1);
       this.sequelize.observer.on('querySuccess', spy2);
-      this.sequelize.observer.on('queryError', spy2);
+      this.sequelize.observer.on('queryError', spy3);
     });
     afterEach(function() {
       this.sequelize.observer.off('beforeQuery', spy1);
       this.sequelize.observer.off('querySuccess', spy2);
-      this.sequelize.observer.off('queryError', spy2);
+      this.sequelize.observer.off('queryError', spy3);
       this.sequelize.options.observe = undefined;
       spy1.resetHistory();
       spy2.resetHistory();
@@ -1720,8 +1720,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(beforeObservationObject.sql.indexOf('INSERT')).to.equal(0);
         expect(beforeObservationObject).to.have.property('parameters', undefined);
         expect(beforeObservationObject).not.to.have.property('queryDuration');
+        
+        expect(spy2.callCount).to.equal(1);
+        expect(spy3.callCount).to.equal(1);
 
-        const afterObservationObject = spy2.getCall(0).args[0];
+        const afterObservationObject = spy3.getCall(0).args[0];
         expect(afterObservationObject).to.have.property('name', 'my_pretty_query');
         expect(afterObservationObject).to.have.property('globalLabel', 'global_value');
         expect(afterObservationObject).to.have.property('type', Support.Sequelize.QueryTypes.INSERT);

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -474,7 +474,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         beforeEach(function() {
           this.sequelize.observer.on('beforeQuery', spy1);
           this.sequelize.observer.on('querySuccess', spy2);
-          this.sequelize.observer.on('queryError', spy2);
+          this.sequelize.observer.on('queryError', spy3);
         });
         afterEach(function() {
           this.sequelize.observer.off('beforeQuery', spy1);

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1609,7 +1609,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(afterObservationObject).to.have.property('parameters', undefined);
           expect(afterObservationObject).to.have.property('queryDuration');
           expect(afterObservationObject.queryDuration).to.be.a('number');
-          expect(afterObservationObject.queryDuration).to.be.greaterThan(0);
+          expect(afterObservationObject.queryDuration).to.be.gte(0);
         });
       });
     });

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1535,6 +1535,84 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
       });
     });
+
+    describe('observation', () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      const spy3 = sinon.spy();
+      beforeEach(function() {
+        this.sequelize.observer.on('beforeQuery', spy1);
+        this.sequelize.observer.on('querySuccess', spy2);
+        this.sequelize.observer.on('queryError', spy2);
+      });
+      afterEach(function() {
+        this.sequelize.observer.off('beforeQuery', spy1);
+        this.sequelize.observer.off('querySuccess', spy2);
+        this.sequelize.observer.off('queryError', spy2);
+        spy1.resetHistory();
+        spy2.resetHistory();
+        spy3.resetHistory();
+      });
+      it('should support observation', function() {
+        return this.User.findAll({
+          where: {},
+          observe: true
+        }).then(() => {
+          expect(spy1.called).to.be.ok;
+          expect(spy2.called).to.be.ok;
+          expect(spy3.called).not.to.be.ok;
+        });
+      });
+  
+      it('should not trigger observation if options.observe set to false', function() {
+    
+        return this.User.findAll({
+          where: {},
+          observe: false
+        }).then(() => {
+          expect(spy1.called).not.to.be.ok;
+          expect(spy2.called).not.to.be.ok;
+          expect(spy3.called).not.to.be.ok;
+        });
+      });
+  
+      it('should return the correct data in observation', function() {
+        this.sequelize.options.observe = {
+          globalLabel: 'global_value',
+          name: 'global_name'
+        };
+    
+        return this.User.findAll({
+          where: {},
+          observe: {
+            name: 'my_pretty_query'
+          }
+        }).then(() => {
+          const beforeObservationObject = spy1.getCall(0).args[0];
+          expect(beforeObservationObject).to.have.property('name', 'my_pretty_query');
+          expect(beforeObservationObject).to.have.property('globalLabel', 'global_value');
+          expect(beforeObservationObject).to.have.property('type', Support.Sequelize.QueryTypes.SELECT);
+          expect(beforeObservationObject).to.have.property('connection', 'default');
+          expect(beforeObservationObject).to.have.property('sql');
+          expect(beforeObservationObject.sql).to.be.a('string');
+          expect(beforeObservationObject.sql.indexOf('SELECT')).to.equal(0);
+          expect(beforeObservationObject).to.have.property('parameters', undefined);
+          expect(beforeObservationObject).not.to.have.property('queryDuration');
+  
+          const afterObservationObject = spy2.getCall(0).args[0];
+          expect(afterObservationObject).to.have.property('name', 'my_pretty_query');
+          expect(afterObservationObject).to.have.property('globalLabel', 'global_value');
+          expect(afterObservationObject).to.have.property('type', Support.Sequelize.QueryTypes.SELECT);
+          expect(afterObservationObject).to.have.property('connection', 'default');
+          expect(afterObservationObject).to.have.property('sql');
+          expect(afterObservationObject.sql).to.be.a('string');
+          expect(afterObservationObject).to.have.property('parameters', undefined);
+          expect(afterObservationObject).to.have.property('queryDuration');
+          expect(afterObservationObject.queryDuration).to.be.a('number');
+          expect(afterObservationObject.queryDuration).to.be.greaterThan(0);
+        });
+      });
+    });
   });
 
   describe('findAndCountAll', () => {
@@ -1667,6 +1745,33 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(info.rows[1].dataValues).to.not.have.property('username');
       });
     });
+    describe('observation', () => {
+      const spy1 = sinon.spy();
+      const spy2 = sinon.spy();
+      const spy3 = sinon.spy();
+      beforeEach(function() {
+        this.sequelize.observer.on('beforeQuery', spy1);
+        this.sequelize.observer.on('querySuccess', spy2);
+        this.sequelize.observer.on('queryError', spy2);
+      });
+      afterEach(function() {
+        this.sequelize.observer.off('beforeQuery', spy1);
+        this.sequelize.observer.off('querySuccess', spy2);
+        this.sequelize.observer.off('queryError', spy2);
+        spy1.resetHistory();
+        spy2.resetHistory();
+        spy3.resetHistory();
+      });
+      it('should observe find and count queries', function() {
+        return this.User.findAndCountAll({
+          observe: true
+        }).then(() => {
+          expect(spy1.callCount).to.equal(2);
+          expect(spy2.callCount).to.equal(2);
+          expect(spy3.callCount).to.equal(0);
+        });
+      });
+    });
   });
 
   describe('all', () => {
@@ -1717,6 +1822,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
   });
 
+  
+  
   describe('rejectOnEmpty mode', () => {
     it('works from model options', () => {
       const Model = current.define('Test', {

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1543,7 +1543,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       beforeEach(function() {
         this.sequelize.observer.on('beforeQuery', spy1);
         this.sequelize.observer.on('querySuccess', spy2);
-        this.sequelize.observer.on('queryError', spy2);
+        this.sequelize.observer.on('queryError', spy3);
       });
       afterEach(function() {
         this.sequelize.observer.off('beforeQuery', spy1);
@@ -1752,7 +1752,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       beforeEach(function() {
         this.sequelize.observer.on('beforeQuery', spy1);
         this.sequelize.observer.on('querySuccess', spy2);
-        this.sequelize.observer.on('queryError', spy2);
+        this.sequelize.observer.on('queryError', spy3);
       });
       afterEach(function() {
         this.sequelize.observer.off('beforeQuery', spy1);

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -919,7 +919,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       beforeEach(function() {
         this.sequelize.observer.on('beforeQuery', spy1);
         this.sequelize.observer.on('querySuccess', spy2);
-        this.sequelize.observer.on('queryError', spy2);
+        this.sequelize.observer.on('queryError', spy3);
       });
       afterEach(function() {
         this.sequelize.observer.off('beforeQuery', spy1);

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -984,7 +984,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(afterObservationObject).to.have.property('parameters', undefined);
           expect(afterObservationObject).to.have.property('queryDuration');
           expect(afterObservationObject.queryDuration).to.be.a('number');
-          expect(afterObservationObject.queryDuration).to.be.greaterThan(0);
+          expect(afterObservationObject.queryDuration).to.be.gte(0);
         });
       });
     });

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -27,6 +27,7 @@ import QueryTypes = require('./query-types');
 import { Transaction, TransactionOptions } from './transaction';
 import { Cast, Col, Fn, Json, Literal, Where } from './utils';
 import { ConnectionManager } from './connection-manager';
+import { EventEmitter } from 'events';
 
 /**
  * Additional options for table altering during sync
@@ -374,6 +375,13 @@ export interface Options extends Logging {
   logQueryParameters?: boolean;
 
   retry?: RetryOptions;
+
+  /**
+   * Set to `true` or an object conaining key / value labels to observe all queries
+   *
+   * @default false
+   */
+  observe?: boolean | object;
 }
 
 export interface QueryOptionsTransactionRequired { }
@@ -790,6 +798,8 @@ export class Sequelize extends Hooks {
   public readonly modelManager: ModelManager;
 
   public readonly connectionManager: ConnectionManager;
+
+  public readonly observer: EventEmitter
 
   /**
    * Dictionary of all models linked with this instance.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Adds a query observer to Sequelize. I would use it to instrument Prometheus metrics for instance.

Example:
```javascript
const { Summary, Gauge, Counter } = require('prom-client");

const currentRequests = new Gauge({
  labels: ['type']
});

const specificQueryCounter = new Counter({
  labels: ['type', 'name']
});

const queryErrorCounter = new Counter({
  labels: ['type', 'name', 'errorName']
});

const dbRequestTime = new Summary({
  labels: ['type', 'name']
});

sequelize.observer.on('beforeQuery', data => {
  currentRequests.inc({type: data.type})
  if (data.name) {
    specificQueryCounter.inc({type: data.type, name: data.name})
  }
});

sequelize.observer.on('querySuccess', data => {
  currentRequests.dec({type: data.type})
  dbRequestTime.observe({type: data.type, name: data.name}, data.queryDuration)
});

sequelize.observer.on('queryError', data => {
  currentRequests.dec({type: data.type})
  queryErrorCounter.inc({type: data.type, name: data.name, errorName: data.error.name })
});

...

User.findAll({
  observe: {
    name: 'my favorite request'
  }
});
```