### PR TITLE
Feature: Observation of requests

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -23,6 +23,12 @@ class AbstractQuery {
       ...options
     };
     this.checkLoggingOption();
+    this.statistics = {
+      duration: undefined,
+      sql: undefined,
+      parameters: undefined,
+      labels: this.options.labels || {}
+    };
   }
 
   /**
@@ -333,7 +339,12 @@ class AbstractQuery {
     const { connection, options } = this;
     const benchmark = this.sequelize.options.benchmark || options.benchmark;
     const logQueryParameters = this.sequelize.options.logQueryParameters || options.logQueryParameters;
-    const startTime = Date.now();
+    this.statistics.duration = undefined;
+    this.statistics.sql = sql;
+    this.statistics.labels = {
+      ...this.sequelize.options.labels || {},
+      ...options.labels || {}
+    };
     let logParameter = '';
 
     if (logQueryParameters && parameters) {
@@ -345,18 +356,22 @@ class AbstractQuery {
         paramStr = JSON.stringify(parameters);
       }
       logParameter = `${delimiter} ${paramStr}`;
+      this.statistics.parameters = paramStr;
     }
+    
     const fmt = `(${connection.uuid || 'default'}): ${sql}${logParameter}`;
     const msg = `Executing ${fmt}`;
     debugContext(msg);
     if (!benchmark) {
       this.sequelize.log(`Executing ${fmt}`, options);
     }
+    const startTime = Date.now();
     return () => {
+      this.statistics.duration = Date.now() - startTime;
       const afterMsg = `Executed ${fmt}`;
       debugContext(afterMsg);
       if (benchmark) {
-        this.sequelize.log(afterMsg, Date.now() - startTime, options);
+        this.sequelize.log(afterMsg, this.statistics.duration, options);
       }
     };
   }

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -48,7 +48,9 @@ const hookTypes = {
   beforeBulkSync: { params: 1 },
   afterBulkSync: { params: 1 },
   beforeQuery: { params: 2 },
-  afterQuery: { params: 2 }
+  afterQuery: { params: 2 },
+  afterQuerySuccess: { params: 2 },
+  afterQueryError: { params: 3 }
 };
 exports.hooks = hookTypes;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1368,6 +1368,7 @@ class Model {
    * @param {boolean}  [options.cascade=false]   Also drop all objects depending on this table, such as views. Only works in postgres
    * @param {Function} [options.logging=false]   A function that gets executed while running the query to log the sql.
    * @param {boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param {object}   [options.labels]          Key / values to include in query statistics
    *
    * @returns {Promise}
    */
@@ -1394,6 +1395,7 @@ class Model {
    * @param {string}   [options.schemaDelimiter='.'] The character(s) that separates the schema name from the table name
    * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param {object}   [options.labels]          Key / values to include in query statistics
    *
    * @see
    * {@link Sequelize#define} for more information about setting a default schema.
@@ -1659,6 +1661,7 @@ class Model {
    * @param  {object}                                                    [options.having] Having options
    * @param  {string}                                                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Error}                                             [options.rejectOnEmpty=false] Throws an error when no records found
+   * @param  {object}                                                    [options.labels]          Key / values to include in query statistics
    *
    * @see
    * {@link Sequelize#query}
@@ -1919,6 +1922,7 @@ class Model {
    * @param {boolean}         [options.distinct] Applies DISTINCT to the field being aggregated over
    * @param {Transaction}     [options.transaction] Transaction to run query under
    * @param {boolean}         [options.plain] When `true`, the first returned value of `aggregateFunction` is cast to `dataType` and returned. If additional attributes are specified, along with `group` clauses, set `plain` to `false` to return all values of all returned rows.  Defaults to `true`
+   * @param {object}          [options.labels] Key / values to include in query statistics
    *
    * @returns {Promise<DataTypes|object>} Returns the aggregate result cast to `options.dataType`, unless `options.plain` is false, in which case the complete data result is returned.
    */
@@ -1994,6 +1998,7 @@ class Model {
    * @param {Function}      [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {boolean}       [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param {string}        [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {object}        [options.labels] Key / values to include in query statistics
    *
    * @returns {Promise<number>}
    */
@@ -2186,6 +2191,7 @@ class Model {
    * @param  {Transaction}    [options.transaction]        Transaction to run query under
    * @param  {string}         [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Array}  [options.returning=true]     Appends RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
+   * @param  {object}         [options.labels]             Key / values to include in query statistics
    *
    * @returns {Promise<Model>}
    *
@@ -2210,6 +2216,7 @@ class Model {
    * @param {object}   options.where A hash of search attributes. If `where` is a plain object it will be appended with defaults to build a new instance.
    * @param {object}   [options.defaults] Default values to use if building a new instance
    * @param {object}   [options.transaction] Transaction to run query under
+   * @param {object}   [options.labels]      Key / values to include in query statistics
    *
    * @returns {Promise<Model,boolean>}
    */
@@ -2414,6 +2421,7 @@ class Model {
    * @param  {Function}     [options.logging=false]                       A function that gets executed while running the query to log the sql.
    * @param  {boolean}      [options.benchmark=false]                     Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {string}       [options.searchPath=DEFAULT]                  An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {object}       [options.labels]                              Key / values to include in query statistics
    *
    * @returns {Promise<boolean>} Returns a boolean indicating whether the row was created or updated. For MySQL/MariaDB, it returns `true` when inserted and `false` when updated. For Postgres/MSSQL with `options.returning` true, it returns record and created boolean with signature `<Model, created>`.
    */
@@ -2504,6 +2512,7 @@ class Model {
    * @param  {boolean}        [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {boolean|Array}  [options.returning=false]        If true, append RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}         [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {object}         [options.labels]                 Key / values to include in query statistics
    *
    * @returns {Promise<Array<Model>>}
    */
@@ -2825,6 +2834,7 @@ class Model {
    * @param {boolean|Function} [options.logging] A function that logs sql queries, or false for no logging
    * @param {boolean}          [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param {string}           [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {object}           [options.labels] Key / values to include in query statistics
    *
    * @returns {Promise}
    *
@@ -2852,6 +2862,7 @@ class Model {
    * @param  {Transaction}  [options.transaction] Transaction to run query under
    * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
    * @param  {boolean}      [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
+   * @param  {object}       [options.labels]                Key / values to include in query statistics
    *
    * @returns {Promise<number>} The number of destroyed rows
    */
@@ -2936,6 +2947,7 @@ class Model {
    * @param  {Function}     [options.logging=false]         A function that gets executed while running the query to log the sql.
    * @param  {boolean}      [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {Transaction}  [options.transaction]           Transaction to run query under
+   * @param  {object}       [options.labels]                Key / values to include in query statistics
    *
    * @returns {Promise}
    */
@@ -3005,6 +3017,7 @@ class Model {
    * @param  {boolean}        [options.benchmark=false]       Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {Transaction}    [options.transaction]           Transaction to run query under
    * @param  {boolean}        [options.silent=false]          If true, the updatedAt timestamp will not be updated.
+   * @param  {object}         [options.labels]                Key / values to include in query statistics
    *
    * @returns {Promise<Array<number,number>>}  The promise returns an array with one or two elements. The first element is always the number
    * of affected rows, while the second element is the actual affected rows (only supported in postgres with `options.returning` true).
@@ -3789,6 +3802,7 @@ class Model {
    * @param {Transaction} [options.transaction] Transaction to run query under
    * @param {string}      [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param {boolean}     [options.returning] Append RETURNING * to get back auto generated values (Postgres only)
+   * @param {object}      [options.labels] Key / values to include in query statistics
    *
    * @returns {Promise<Model>}
    */
@@ -3916,7 +3930,8 @@ class Model {
           .defaults({
             transaction: options.transaction,
             logging: options.logging,
-            parentRecord: this
+            parentRecord: this,
+            labels: options.labels
           }).value();
 
         await instance.save(includeOptions);
@@ -3987,7 +4002,8 @@ class Model {
             .defaults({
               transaction: options.transaction,
               logging: options.logging,
-              parentRecord: this
+              parentRecord: this,
+              labels: options.labels
             }).value();
 
           // Instances will be updated in place so we can safely treat HasOne like a HasMany
@@ -4137,6 +4153,7 @@ class Model {
    * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {Transaction} [options.transaction] Transaction to run query under
    * @param {string}      [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
+   * @param {object}      [options.labels] Key / values to include in query statistics
    *
    * @returns {Promise}
    */
@@ -4204,6 +4221,7 @@ class Model {
    * @param {object}      [options={}] restore options
    * @param {Function}    [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param {Transaction} [options.transaction] Transaction to run query under
+   * @param {object}      [options.labels] Key / values to include in query statistics
    *
    * @returns {Promise}
    */

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -595,6 +595,38 @@ class Sequelize {
       }
     };
 
+    const addModelHooks = queryId => {
+      const executeHookConditionnally = hookFn => (...args) => {
+        if (args && args[1] && args[1].uuid === queryId) {
+          return hookFn(...args);
+        }
+        return;
+      };
+      const modelHooks = options.instance && options.instance._modelOptions && options.instance._modelOptions.hooks;
+      if (options.hooks && modelHooks) {
+        for (const hook of ['beforeQuery', 'afterQuery', 'afterQuerySuccess', 'afterQueryError']) {
+          if (_.isArray(modelHooks[hook])) {
+            modelHooks[hook].forEach((hookFn, index) => {
+              this.addHook(hook, `model_${queryId}_${index}`, executeHookConditionnally(hookFn));
+            });
+          }
+        }
+      }
+    };
+
+    const removeModelHooks = queryId => {
+      const modelHooks = options.instance && options.instance._modelOptions && options.instance._modelOptions.hooks;
+      if (options.hooks && modelHooks) {
+        for (const hook of ['beforeQuery', 'afterQuery', 'afterQuerySuccess', 'afterQueryError']) {
+          if (_.isArray(modelHooks[hook])) {
+            for (let index = 0; index < modelHooks[hook].length; index++) {
+              this.removeHook(hook, `model_${queryId}_${index}`);
+            }
+          }
+        }
+      }
+    };
+
     const retryOptions = { ...this.options.retry, ...options.retry };
 
     return retry(async () => {
@@ -606,13 +638,27 @@ class Sequelize {
 
       const connection = await (options.transaction ? options.transaction.connection : this.connectionManager.getConnection(options));
       const query = new this.dialect.Query(connection, this, options);
-
+      addModelHooks(query.uuid);
       try {
-        await this.runHooks('beforeQuery', options, query);
+        if (options.hooks) {
+          await this.runHooks('beforeQuery', options, query);
+        }
         checkTransaction();
-        return await query.run(sql, bindParameters);
+        const result = await query.run(sql, bindParameters);
+        if (options.hooks) {
+          await Promise.all([
+            this.runHooks('afterQuery', options, query),
+            this.runHooks('afterQuerySuccess', options, query)
+          ]);
+        }
+        return result;
+      } catch (error) {
+        if (options.hooks) {
+          await this.runHooks('afterQueryError', options, query, error);
+        }
+        throw error;
       } finally {
-        await this.runHooks('afterQuery', options, query);
+        removeModelHooks(query.uuid);
         if (!options.transaction) {
           await this.connectionManager.releaseConnection(connection);
         }

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -1591,4 +1591,270 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
     });
   });
+
+  describe('Query hooks', () => {
+    describe('beforeQuery', () => {
+      const spy = sinon.spy();
+      afterEach(function() {
+        spy.resetHistory();
+        try {
+          this.sequelize.removeHook('beforeQuery', 'tempHook');
+        } catch (e) {
+          // Do nothing
+        }
+      });
+      it('Should execute beforeQuery hook once when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('beforeQuery', 'tempHook', spy);
+        await User.create({ username: 'user1' });
+        expect(spy.callCount).to.equal(1);
+      });
+      it('Should not execute beforeQuery hook once when defined globally if hooks are disable in request', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('beforeQuery', 'tempHook', spy);
+        await User.create({ username: 'user1' }, { hooks: false });
+        expect(spy.callCount).to.equal(0);
+      });
+      
+      it('Should execute beforeQuery hook with correct args when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('beforeQuery', 'tempHook', spy);
+        await User.create({ username: 'user1' }, { labels: { name: 'myQuery' } } );
+        expect(spy.getCall(0).args).to.have.lengthOf(2);
+        expect(spy.getCall(0).args[0]).to.have.nested.property('labels.name', 'myQuery');
+        expect(spy.getCall(0).args[1]).to.have.property('statistics');
+        const statistics = spy.getCall(0).args[1].statistics;
+        expect(statistics).to.have.property('sql');
+        expect(statistics).to.have.deep.property('labels', { name: 'myQuery' });
+      });
+
+      it('Should execute beforeQuery hook once when defined in model', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        }, {
+          hooks: { beforeQuery: spy } 
+        });
+        await this.sequelize.sync({ force: true });
+        await User.create({ username: 'user1' });
+        expect(spy.callCount).to.equal(1);
+      });
+    });
+    describe('afterQuery', () => {
+      const spy = sinon.spy();
+      afterEach(function() {
+        spy.resetHistory();
+        try {
+          this.sequelize.removeHook('afterQuery', 'tempHook');
+        } catch (e) {
+          // Do nothing
+        }
+      });
+      it('Should execute afterQuery hook once when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQuery', 'tempHook', spy);
+        await User.create({ username: 'user1' });
+        expect(spy.callCount).to.equal(1);
+      });
+      it('Should not execute afterQuery hook when defined globally if hooks are disable in request', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQuery', 'tempHook', spy);
+        await User.create({ username: 'user1' }, { hooks: false });
+        expect(spy.callCount).to.equal(0);
+      });
+      it('Should execute afterQuery hook once when defined in model', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        }, {
+          hooks: { afterQuery: spy } 
+        });
+        await this.sequelize.sync({ force: true });
+        await User.create({ username: 'user1' });
+        expect(spy.callCount).to.equal(1);
+      });
+      it('Should execute afterQuery hook with correct args when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQuery', 'tempHook', spy);
+        await User.create({ username: 'user1' }, { labels: { name: 'myQuery' } } );
+        expect(spy.getCall(0).args).to.have.lengthOf(2);
+        expect(spy.getCall(0).args[0]).to.have.nested.property('labels.name', 'myQuery');
+        expect(spy.getCall(0).args[1]).to.have.property('statistics');
+        const statistics = spy.getCall(0).args[1].statistics;
+        expect(statistics).to.have.property('sql');
+        expect(statistics).to.have.deep.property('labels', { name: 'myQuery' });
+        expect(statistics).to.have.property('duration');
+        expect(statistics.duration).to.be.a('number');
+        expect(statistics.duration).to.be.gte(0);
+      });
+    });
+    describe('afterQuerySuccess', () => {
+      const spy = sinon.spy();
+      afterEach(function() {
+        spy.resetHistory();
+        try {
+          this.sequelize.removeHook('afterQuerySuccess', 'tempHook');
+        } catch (e) {
+          // Do nothing
+        }
+      });
+      it('Should execute afterQuerySuccess hook once when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQuerySuccess', 'tempHook', spy);
+        await User.create({ username: 'user1' });
+        expect(spy.callCount).to.equal(1);
+      });
+      it('Should not execute afterQuerySuccess hook when defined globally if hooks are disabled in request', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQuerySuccess', 'tempHook', spy);
+        await User.create({ username: 'user1' }, { hooks: false });
+        expect(spy.callCount).to.equal(0);
+      });
+      it('Should execute afterQuerySuccess hook once when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        }, {
+          hooks: {
+            afterQuerySuccess: spy
+          }
+        });
+        await this.sequelize.sync({ force: true });
+        await User.create({ username: 'user1' });
+        expect(spy.callCount).to.equal(1);
+      });
+      it('Should execute afterQuerySuccess hook with correct args when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: DataTypes.STRING
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQuerySuccess', 'tempHook', spy);
+        await User.create({ username: 'user1' }, { labels: { name: 'myQuery' } } );
+        expect(spy.getCall(0).args).to.have.lengthOf(2);
+        expect(spy.getCall(0).args[0]).to.have.nested.property('labels.name', 'myQuery');
+        expect(spy.getCall(0).args[1]).to.have.property('statistics');
+        const statistics = spy.getCall(0).args[1].statistics;
+        expect(statistics).to.have.property('sql');
+        expect(statistics).to.have.deep.property('labels', { name: 'myQuery' });
+        expect(statistics).to.have.property('duration');
+        expect(statistics.duration).to.be.a('number');
+        expect(statistics.duration).to.be.gte(0);
+      });
+    });
+    describe('afterQueryError', () => {
+      const spy = sinon.spy();
+      afterEach(async function() {
+        spy.resetHistory();
+        try {
+          await this.sequelize.removeHook('afterQueryError', 'tempHook');
+        } catch (e) {
+          // Do nothing
+        }
+      });
+      
+      it('Should execute afterQueryError hook once when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: {
+            type: DataTypes.STRING,
+            unique: true
+          }
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQueryError', 'tempHook', spy);
+        await User.create({ username: 'user1' });
+        try {
+          await User.create({ username: 'user1' });
+          throw new Error('Shouldn\'t be here');
+        } catch (e) {
+          // do nothing
+        }
+        expect(spy.callCount).to.equal(1);
+      });
+      it('Should not execute afterQueryError hook when defined globally if hooks are disabled in request', async function() {
+        const User = this.sequelize.define('user', {
+          username: {
+            type: DataTypes.STRING,
+            unique: true
+          }
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQueryError', 'tempHook', spy);
+        await User.create({ username: 'user1' });
+        try {
+          await User.create({ username: 'user1' }, { hooks: false });
+          throw new Error('Shouldn\'t be here');
+        } catch (e) {
+          // do nothing
+        }
+        expect(spy.callCount).to.equal(0);
+      });
+      it('Should execute afterQueryError hook once when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: {
+            type: DataTypes.STRING,
+            unique: true
+          }
+        }, {
+          hooks: {
+            afterQueryError: spy
+          }
+        });
+        await this.sequelize.sync({ force: true });
+        await User.create({ username: 'user1' });
+        try {
+          await User.create({ username: 'user1' });
+          throw new Error('Shouldn\'t be here');
+        } catch (e) {
+          // do nothing
+        }
+        expect(spy.callCount).to.equal(1);
+      });
+      it('Should execute afterQueryError hook with correct args when defined globally', async function() {
+        const User = this.sequelize.define('user', {
+          username: {
+            type: DataTypes.STRING,
+            unique: true
+          }
+        });
+        await this.sequelize.sync({ force: true });
+        this.sequelize.addHook('afterQueryError', 'tempHook', spy);
+        await User.create({ username: 'user1' }, { labels: { name: 'myQuery' } });
+        try {
+          await User.create({ username: 'user1' }, { labels: { type: 'myError' } });
+          throw new Error('Shouldn\'t be here');
+        } catch (e) {
+          // do nothing
+        }
+        expect(spy.getCall(0).args).to.have.lengthOf(3);
+        expect(spy.getCall(0).args[0]).to.have.nested.property('labels.type', 'myError');
+        expect(spy.getCall(0).args[0]).not.to.have.nested.property('labels.name');
+        expect(spy.getCall(0).args[1]).to.have.property('statistics');
+        const statistics = spy.getCall(0).args[1].statistics;
+        expect(statistics).to.have.property('sql');
+        expect(statistics).to.have.deep.property('labels', { type: 'myError' });
+        expect(spy.getCall(0).args[2]).to.be.an.instanceOf(Sequelize.UniqueConstraintError);
+      });
+    });
+  });
 });

--- a/test/integration/support.js
+++ b/test/integration/support.js
@@ -11,6 +11,9 @@ before(function() {
   this.sequelize.addHook('afterQuery', (options, query) => {
     runningQueries.delete(query);
   });
+  this.sequelize.addHook('afterQueryError', (options, query) => {
+    runningQueries.delete(query);
+  });
 });
 
 beforeEach(function() {

--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -14,6 +14,7 @@ import Model, {
   UpdateOptions,
 } from './model';
 import { Config, Options, Sequelize, SyncOptions } from './sequelize';
+import { Query } from './query';
 
 export type HookReturn = Promise<void> | void;
 
@@ -51,6 +52,10 @@ export interface ModelHooks<M extends Model = Model> {
   afterSync(options: SyncOptions): HookReturn;
   beforeBulkSync(options: SyncOptions): HookReturn;
   afterBulkSync(options: SyncOptions): HookReturn;
+  beforeQuery(options: FindOptions|UpdateOptions|CountOptions|CreateOptions|RestoreOptions|DestroyOptions|BulkCreateOptions, query: Query): HookReturn;
+  afterQuery(options: FindOptions|UpdateOptions|CountOptions|CreateOptions|RestoreOptions|DestroyOptions|BulkCreateOptions, query: Query): HookReturn;
+  afterQuerySuccess(options: FindOptions|UpdateOptions|CountOptions|CreateOptions|RestoreOptions|DestroyOptions|BulkCreateOptions, query: Query): HookReturn;
+  afterQueryError(options: FindOptions|UpdateOptions|CountOptions|CreateOptions|RestoreOptions|DestroyOptions|BulkCreateOptions, query: Query, error: Error): HookReturn;
 }
 
 export interface SequelizeHooks extends ModelHooks {

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -566,6 +566,11 @@ export interface FindOptions extends QueryOptions, Filterable, Projectable, Para
    * Use sub queries (internal)
    */
   subQuery?: boolean;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 export interface NonNullFindOptions extends FindOptions {
@@ -600,6 +605,11 @@ export interface CountOptions extends Logging, Transactionable, Filterable, Proj
    * The column to aggregate on.
    */
   col?: string;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**
@@ -668,6 +678,10 @@ export interface CreateOptions extends BuildOptions, Logging, Silent, Transactio
    */
   validate?: boolean;
 
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 export interface Hookable {
@@ -693,6 +707,11 @@ export interface FindOrCreateOptions extends Logging, Transactionable {
    * Default values to use if building a new instance
    */
   defaults?: object;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**
@@ -713,6 +732,11 @@ export interface UpsertOptions extends Logging, Transactionable, SearchPathable,
    * Run validations before the row is inserted
    */
   validate?: boolean;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**
@@ -758,6 +782,11 @@ export interface BulkCreateOptions extends Logging, Transactionable, Hookable {
    * Return all columns or only the specified columns for the affected rows (only for postgres)
    */
   returning?: boolean | string[];
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**
@@ -793,6 +822,11 @@ export interface TruncateOptions extends Logging, Transactionable, Filterable, H
    * Automatically restart sequences owned by columns of the truncated table
    */
   restartIdentity?: boolean;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**
@@ -821,6 +855,11 @@ export interface RestoreOptions extends Logging, Transactionable, Filterable, Ho
    * How many rows to undelete
    */
   limit?: number;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**
@@ -874,6 +913,11 @@ export interface UpdateOptions extends Logging, Transactionable, Paranoid, Hooka
    * If true, the updatedAt timestamp will not be updated.
    */
   silent?: boolean;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**
@@ -890,6 +934,11 @@ export interface AggregateOptions<T extends DataType | unknown> extends QueryOpt
    * Applies DISTINCT to the field being aggregated over
    */
   distinct?: boolean;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 // instance
@@ -962,6 +1011,11 @@ export interface SaveOptions extends Logging, Transactionable, Silent {
    * @default true
    */
   validate?: boolean;
+
+  /**
+   * Add labels to query
+   */
+  labels?: {[key: string]: any};
 }
 
 /**

--- a/types/lib/query.d.ts
+++ b/types/lib/query.d.ts
@@ -1,0 +1,9 @@
+export interface Query {
+    uuid: string,
+    statistics: {
+        duration?: number,
+        sql: string,
+        parameters?: string,
+        labels: {[key: string]: any}
+    }
+}

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -374,6 +374,11 @@ export interface Options extends Logging {
   logQueryParameters?: boolean;
 
   retry?: RetryOptions;
+
+  /**
+   * Define Sequelize-wide key / value labels
+   */
+  labels?: {[key: string]: any}
 }
 
 export interface QueryOptionsTransactionRequired { }


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

- Make `beforeQuery` and `afterQuery` skippable if request `options.hooks = false`
- Add hooks `afterQuerySuccess` and `afterQueryError`
- Make possible to set `beforeQuery` `afterQuery` `afterQuerySuccess` and `afterQueryError` hooks at the model level
- Notion of query `labels`
- Add a `statistics` public member to `AbstractQuery` containing:
  - `sql` string executed
  - `duration` of the request in ms
  - `labels` object
  - `parameters` if applicable / `logQueryParameters` activated in options
