### PR TITLE
fix(mysql): Add parentheses to default value

### DIFF
--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -388,7 +388,12 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     if (!typeWithoutDefault.has(attributeString)
       && attribute.type._binary !== true
       && Utils.defaultValueSchemable(attribute.defaultValue)) {
-      template += ` DEFAULT (${this.escape(attribute.defaultValue)})`;
+
+      if (attribute.defaultValue instanceof Utils.Fn) {
+        template += ` DEFAULT (${this.escape(attribute.defaultValue)})`;
+      } else {
+        template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+      }
     }
 
     if (attribute.unique === true) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -388,7 +388,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     if (!typeWithoutDefault.has(attributeString)
       && attribute.type._binary !== true
       && Utils.defaultValueSchemable(attribute.defaultValue)) {
-      template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+      template += ` DEFAULT (${this.escape(attribute.defaultValue)})`;
     }
 
     if (attribute.unique === true) {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -378,11 +378,30 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
 
     it('should parse an empty GEOMETRY field', () => {
       const Type = new Sequelize.GEOMETRY();
-
       // MySQL 5.7 or above doesn't support POINT EMPTY
       if (dialect === 'mysql' && semver.gte(current.options.databaseVersion, '5.7.0')) {
         return;
       }
+
+      it('should return parenteses when default values is a function', function() {
+        const Model = this.sequelize.define('model', {
+          uuid: {
+            type: 'BINARY(16)',
+            defaultValue: Sequelize.fn('UUID_TO_BIN', Sequelize.fn('UUID')),
+            primaryKey: true
+          }
+        });
+
+        return Model.sync({ force: true }).then(() => {
+          return Model.create({
+            id: 1
+          });
+        }).then(() => {
+          return Model.findOne({ where: { id: 1 } });
+        }).then(user => {
+          expect(user.get('double')).to.eq(Infinity);
+        });
+      });
 
       return new Promise((resolve, reject) => {
         if (/^postgres/.test(dialect)) {

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -90,11 +90,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', defaultValue: 0 } }],
-          expectation: { id: 'INTEGER DEFAULT (0)' }
-        },
-        {
-          arguments: [{ id: { type: 'INTEGER', defaultValue: (0) } }],
-          expectation: { id: 'INTEGER DEFAULT (0)' }
+          expectation: { id: 'INTEGER DEFAULT 0' }
         },
         {
           title: 'Add column level comment',
@@ -149,7 +145,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT' } }],
-          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT (1) REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
+          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
         }
       ],
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -90,7 +90,11 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', defaultValue: 0 } }],
-          expectation: { id: 'INTEGER DEFAULT 0' }
+          expectation: { id: 'INTEGER DEFAULT (0)' }
+        },
+        {
+          arguments: [{ id: { type: 'INTEGER', defaultValue: (0) } }],
+          expectation: { id: 'INTEGER DEFAULT (0)' }
         },
         {
           title: 'Add column level comment',
@@ -145,7 +149,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT' } }],
-          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
+          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT (1) REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
         }
       ],
 


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

- This close issue #12102. However, I did tests on MySQL version 5.7 and 8. 

####  On 5.7 Do not accept default with parentheses.

```
CREATE TABLE IF NOT EXISTS `foo2` (`uuid` CHAR(16) DEFAULT (0) );
```
We have this error 
```
ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '(0) )' at line 1
```

#### - On Version 8 accept 
This same query creates the table, so it works as well.

I don't know how the project works with old versions. It up to you guys. 