### PR TITLE
add SequelizeGuard library into acl category in documentation/resources

### DIFF
--- a/docs/manual/other-topics/resources.md
+++ b/docs/manual/other-topics/resources.md
@@ -6,6 +6,7 @@
 
 * [ssacl](https://github.com/pumpupapp/ssacl)
 * [ssacl-attribute-roles](https://github.com/mickhansen/ssacl-attribute-roles)
+* [SequelizeGuard](https://github.com/lotivo/sequelize-acl) - Role, Permission based Authorization for Sequelize.
 
 ### Auto Code Generation & Scaffolding
 


### PR DESCRIPTION
I have written this library to solve the problem of having a very natural API.
It has very fast role permissions based Authorization resolution.
Role permission map is stored in cache which makes permission resolution fast.

please check if out and merge this if you guys like it. It would be big help in making it better.
 https://github.com/lotivo/sequelize-acl/

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
