### PR TITLE
fix: typo in JSDoc for PG array operators

### DIFF
--- a/docs/manual/core-concepts/model-querying-basics.md
+++ b/docs/manual/core-concepts/model-querying-basics.md
@@ -427,14 +427,14 @@ Keep in mind, the provided range value can [define the bound inclusion/exclusion
 
 ```js
 [Op.contains]: 2,            // @> '2'::integer  (PG range contains element operator)
-[Op.contains]: [1, 2],       // @> [1, 2)        (PG range contains range operator)
-[Op.contained]: [1, 2],      // <@ [1, 2)        (PG range is contained by operator)
-[Op.overlap]: [1, 2],        // && [1, 2)        (PG range overlap (have points in common) operator)
-[Op.adjacent]: [1, 2],       // -|- [1, 2)       (PG range is adjacent to operator)
-[Op.strictLeft]: [1, 2],     // << [1, 2)        (PG range strictly left of operator)
-[Op.strictRight]: [1, 2],    // >> [1, 2)        (PG range strictly right of operator)
-[Op.noExtendRight]: [1, 2],  // &< [1, 2)        (PG range does not extend to the right of operator)
-[Op.noExtendLeft]: [1, 2],   // &> [1, 2)        (PG range does not extend to the left of operator)
+[Op.contains]: [1, 2],       // @> [1, 2]        (PG range contains range operator)
+[Op.contained]: [1, 2],      // <@ [1, 2]        (PG range is contained by operator)
+[Op.overlap]: [1, 2],        // && [1, 2]        (PG range overlap (have points in common) operator)
+[Op.adjacent]: [1, 2],       // -|- [1, 2]       (PG range is adjacent to operator)
+[Op.strictLeft]: [1, 2],     // << [1, 2]        (PG range strictly left of operator)
+[Op.strictRight]: [1, 2],    // >> [1, 2]        (PG range strictly right of operator)
+[Op.noExtendRight]: [1, 2],  // &< [1, 2]        (PG range does not extend to the right of operator)
+[Op.noExtendLeft]: [1, 2],   // &> [1, 2]        (PG range does not extend to the left of operator)
 ```
 
 ### Deprecated: Operator Aliases

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -290,14 +290,14 @@ export interface WhereOperators {
   /**
    * PG only
    *
-   * Forces the operator to not extend the left eg. `&> [1, 2)`
+   * Forces the operator to not extend the left eg. `&> [1, 2]`
    */
   [Op.noExtendLeft]?: Rangable;
 
   /**
    * PG only
    *
-   * Forces the operator to not extend the left eg. `&< [1, 2)`
+   * Forces the operator to not extend the left eg. `&< [1, 2]`
    */
   [Op.noExtendRight]?: Rangable;
 
@@ -1778,12 +1778,12 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
    * always be called with a single instance.
    */
   public static findByPk<M extends Model>(
-    this: { new (): M } & typeof Model,
+    this: { new(): M } & typeof Model,
     identifier: Identifier,
     options: Omit<NonNullFindOptions, 'where'>
   ): Promise<M>;
   public static findByPk<M extends Model>(
-    this: { new (): M } & typeof Model,
+    this: { new(): M } & typeof Model,
     identifier?: Identifier,
     options?: Omit<FindOptions, 'where'>
   ): Promise<M | null>;
@@ -1791,7 +1791,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   /**
    * Search for a single instance. Returns the first instance found, or null if none can be found.
    */
-  public static findOne<M extends Model>(this: { new (): M } & typeof Model, options: NonNullFindOptions): Promise<M>;
+  public static findOne<M extends Model>(this: { new(): M } & typeof Model, options: NonNullFindOptions): Promise<M>;
   public static findOne<M extends Model>(
     this: { new(): M } & typeof Model,
     options?: FindOptions

--- a/types/lib/operators.d.ts
+++ b/types/lib/operators.d.ts
@@ -10,7 +10,7 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * -|- [1, 2)
+   * -|- [1, 2]
    * ```
    */
   readonly adjacent: unique symbol;
@@ -94,7 +94,7 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * <@ [1, 2)
+   * <@ [1, 2]
    * ```
    */
   readonly contained: unique symbol;
@@ -106,7 +106,7 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * @> [1, 2)
+   * @> [1, 2]
    * ```
    */
   readonly contains: unique symbol;
@@ -263,7 +263,7 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * &> [1, 2)
+   * &> [1, 2]
    * ```
    */
   readonly noExtendLeft: unique symbol;
@@ -275,7 +275,7 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * &< [1, 2)
+   * &< [1, 2]
    * ```
    */
   readonly noExtendRight: unique symbol;
@@ -383,12 +383,12 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * && [1, 2)
+   * && [1, 2]
    * ```
    */
   readonly overlap: unique symbol;
   /**
-   * Internal placeholder 
+   * Internal placeholder
    *
    * ```js
    * [Op.placeholder]: true
@@ -427,7 +427,7 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * << [1, 2)
+   * << [1, 2]
    * ```
    */
   readonly strictLeft: unique symbol;
@@ -439,7 +439,7 @@ declare const Op: {
    * ```
    * In SQL
    * ```sql
-   * >> [1, 2)
+   * >> [1, 2]
    * ```
    */
   readonly strictRight: unique symbol;
@@ -457,7 +457,7 @@ declare const Op: {
   readonly substring: unique symbol;
   /**
    * Operator VALUES
-   * 
+   *
    * ```js
    * [Op.values]: [4, 5, 6]
    * ```


### PR DESCRIPTION
In JSDoc are PG array operators with bad closing bracket