### PR TITLE
fix(associations): ensure correct schema on all generated attributes

### DIFF
--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -23,10 +23,11 @@ function addForeignKeyConstraints(newAttribute, source, target, options, key) {
     if (primaryKeys.length === 1 || !primaryKeys.includes(key)) {
       newAttribute.references = {
         model: source.getTableName(),
-        key: key || primaryKeys[0],
-        onDelete: options.onDelete,
-        onUpdate: options.onUpdate
+        key: key || primaryKeys[0]
       };
+
+      newAttribute.onDelete = options.onDelete;
+      newAttribute.onUpdate = options.onUpdate;
     }
   }
 }

--- a/lib/associations/helpers.js
+++ b/lib/associations/helpers.js
@@ -21,21 +21,12 @@ function addForeignKeyConstraints(newAttribute, source, target, options, key) {
       .map(primaryKeyAttribute => source.rawAttributes[primaryKeyAttribute].field || primaryKeyAttribute);
 
     if (primaryKeys.length === 1 || !primaryKeys.includes(key)) {
-      if (source._schema) {
-        newAttribute.references = {
-          model: source.sequelize.getQueryInterface().queryGenerator.addSchema({
-            tableName: source.tableName,
-            _schema: source._schema,
-            _schemaDelimiter: source._schemaDelimiter
-          })
-        };
-      } else {
-        newAttribute.references = { model: source.tableName };
-      }
-
-      newAttribute.references.key = key || primaryKeys[0];
-      newAttribute.onDelete = options.onDelete;
-      newAttribute.onUpdate = options.onUpdate;
+      newAttribute.references = {
+        model: source.getTableName(),
+        key: key || primaryKeys[0],
+        onDelete: options.onDelete,
+        onUpdate: options.onUpdate
+      };
     }
   }
 }

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -648,7 +648,6 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
       attribute = attributes[key];
 
       if (attribute.references) {
-
         if (existingConstraints.includes(attribute.references.model.toString())) {
           // no cascading constraints to a table more than once
           attribute.onDelete = '';

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -411,7 +411,6 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (attribute.references) {
-
       if (options && options.context === 'addColumn' && options.foreignKey) {
         const attrName = this.quoteIdentifier(options.foreignKey);
         const fkName = this.quoteIdentifier(`${options.tableName}_${attrName}_foreign_idx`);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,7 @@ function mergeDefaults(a, b) {
     // If it's an object, let _ handle it this time, we will be called again for each property
     if (!_.isPlainObject(objectValue) && objectValue !== undefined) {
       if (_.isFunction(objectValue) && _.isNative(objectValue)) {
-        return sourceValue;
+        return sourceValue || objectValue;
       }
       return objectValue;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -48,9 +48,12 @@ exports.isPrimitive = isPrimitive;
 
 // Same concept as _.merge, but don't overwrite properties that have already been assigned
 function mergeDefaults(a, b) {
-  return _.mergeWith(a, b, objectValue => {
+  return _.mergeWith(a, b, (objectValue, sourceValue) => {
     // If it's an object, let _ handle it this time, we will be called again for each property
     if (!_.isPlainObject(objectValue) && objectValue !== undefined) {
+      if (_.isFunction(objectValue) && _.isNative(objectValue)) {
+        return sourceValue;
+      }
       return objectValue;
     }
   });

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -136,7 +136,9 @@ if (dialect.match(/^mssql/)) {
         'Child',
         {},
         {
-          timestamps: false
+          timestamps: false,
+          freezeTableName: true,
+          schema: 'a'
         }
       );
       const Toys = this.sequelize.define(
@@ -159,15 +161,11 @@ if (dialect.match(/^mssql/)) {
       );
 
       Child.hasOne(Toys, {
-        foreignKey: {
-          onDelete: 'CASCADE'
-        }
+        onDelete: 'CASCADE'
       });
 
       Parent.hasOne(Toys, {
-        foreignKey: {
-          onDelete: 'CASCADE'
-        }
+        onDelete: 'CASCADE'
       });
 
       const spy = sinon.spy();


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes an general issue with association, improper merging of newly generated attributes was overriding schema based `toString` fn with `Object.isString`

Closes #10125
