### PR TITLE
fix(mssql): no default returning in update

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -362,7 +362,7 @@ class QueryGenerator {
       }
     }
 
-    if (this._dialect.supports.returnValues && (this._dialect.supports.returnValues.output || options.returning)) {
+    if (this._dialect.supports.returnValues && options.returning) {
       const returnValues = this.generateReturnValues(attributes, options);
 
       suffix += returnValues.returningFragment;

--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -847,7 +847,7 @@ class QueryInterface {
 
   async update(instance, tableName, values, identifier, options) {
     options = { ...options };
-    options.hasTrigger = !!(instance && instance._modelOptions && instance._modelOptions.hasTrigger);
+    options.hasTrigger = instance && instance.constructor.options.hasTrigger;
 
     const sql = this.queryGenerator.updateQuery(tableName, values, identifier, options, instance.constructor.rawAttributes);
 

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -211,7 +211,7 @@ class Query extends AbstractQuery {
       return data[0];
     }
     if (this.isBulkUpdateQuery()) {
-      return data.length;
+      return rowCount;
     }
     if (this.isBulkDeleteQuery()) {
       return data[0] && data[0].AFFECTEDROWS;

--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -160,7 +160,7 @@ class InstanceValidator {
    */
   async _customValidators() {
     const validators = [];
-    _.each(this.modelInstance._modelOptions.validate, (validator, validatorType) => {
+    _.each(this.modelInstance.constructor.options.validate, (validator, validatorType) => {
       if (this.options.skip.includes(validatorType)) {
         return;
       }

--- a/lib/model.js
+++ b/lib/model.js
@@ -105,7 +105,6 @@ class Model {
     this.dataValues = {};
     this._previousDataValues = {};
     this._changed = new Set();
-    this._modelOptions = this.constructor.options;
     this._options = options || {};
 
     /**
@@ -3394,7 +3393,7 @@ class Model {
     }, {});
 
     if (_.size(where) === 0) {
-      return this._modelOptions.whereCollection;
+      return this.constructor.options.whereCollection;
     }
     const versionAttr = this.constructor._versionAttribute;
     if (checkVersion && versionAttr) {

--- a/test/unit/sql/update.test.js
+++ b/test/unit/sql/update.test.js
@@ -10,6 +10,30 @@ const Support   = require('../support'),
 
 describe(Support.getTestDialectTeaser('SQL'), () => {
   describe('update', () => {
+    it('supports returning false', () => {
+      const User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name'
+        }
+      }, {
+        timestamps: false
+      });
+
+      const options = {
+        returning: false
+      };
+      expectsql(sql.updateQuery(User.tableName, { user_name: 'triggertest' }, { id: 2 }, options, User.rawAttributes),
+        {
+          query: {
+            default: 'UPDATE [users] SET [user_name]=$1 WHERE [id] = $2'
+          },
+          bind: {
+            default: ['triggertest', 2]
+          }
+        });
+    });
+
     it('with temp table for trigger', () => {
       const User = Support.sequelize.define('user', {
         username: {
@@ -38,8 +62,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         });
     });
 
-
-    it('Works with limit', () => {
+    it('works with limit', () => {
       const User = Support.sequelize.define('User', {
         username: {
           type: DataTypes.STRING
@@ -53,7 +76,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
       expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }), {
         query: {
-          mssql: 'UPDATE TOP(1) [Users] SET [username]=$1 OUTPUT INSERTED.* WHERE [username] = $2',
+          mssql: 'UPDATE TOP(1) [Users] SET [username]=$1 WHERE [username] = $2',
           mariadb: 'UPDATE `Users` SET `username`=$1 WHERE `username` = $2 LIMIT 1',
           mysql: 'UPDATE `Users` SET `username`=$1 WHERE `username` = $2 LIMIT 1',
           sqlite: 'UPDATE `Users` SET `username`=$1 WHERE rowid IN (SELECT rowid FROM `Users` WHERE `username` = $2 LIMIT 1)',


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

~This is a breaking change for MSSQL. MSSQL lacks ability to return `affectedRows` for update operation without `OUTPUT INSERTED.*` statement. As this PR fixes that behavior, we are not automatically injecting that statement.~

~So MSSQL users if need `affectedRows` count from `update`, will need to call it with `returning: true`~

Supports disabling `OUTPUT INSERTED.*` with `returning: false`

Closes #11203
Fixes #11304
Fixes #11201
