### PR TITLE
fix(model destroy): Return 0 when options is truncate. 

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -214,7 +214,7 @@ class Query extends AbstractQuery {
       return data.length;
     }
     if (this.isBulkDeleteQuery()) {
-      return data[0] && data[0].AFFECTEDROWS;
+      return data[0] && data[0].AFFECTEDROWS || 0;
     }
     if (this.isVersionQuery()) {
       return data[0].version;

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -214,7 +214,7 @@ class Query extends AbstractQuery {
       return data.length;
     }
     if (this.isBulkDeleteQuery()) {
-      return data[0] && data[0].AFFECTEDROWS || 0;
+      return data[0] ? data[0].AFFECTEDROWS : 0;
     }
     if (this.isVersionQuery()) {
       return data[0].version;

--- a/lib/dialects/postgres/query.js
+++ b/lib/dialects/postgres/query.js
@@ -97,7 +97,7 @@ class Query extends AbstractQuery {
         (count, r) => Number.isFinite(r.rowCount) ? count + r.rowCount : count,
         0
       )
-      : queryResult.rowCount;
+      : queryResult.rowCount || 0;
 
     if (this.sequelize.options.minifyAliases && this.options.aliasesMapping) {
       rows = rows
@@ -389,7 +389,6 @@ class Query extends AbstractQuery {
     return 'id';
   }
 }
-
 
 module.exports = Query;
 module.exports.Query = Query;

--- a/lib/model.js
+++ b/lib/model.js
@@ -2846,7 +2846,7 @@ class Model {
    * @param  {boolean}      [options.individualHooks=false] If set to true, destroy will SELECT all records matching the where parameter and will execute before / after destroy hooks on each row
    * @param  {number}       [options.limit]                 How many rows to delete
    * @param  {boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
-   * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored, and do not return the number of destroyed rows, because truncate doesn't show affected rows.
+   * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored, and do not return the number of destroyed rows, because truncate doesn't show affected rows only on SQLITE.
    * @param  {boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
    * @param  {boolean}      [options.restartIdentity=false] Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table.
    * @param  {Transaction}  [options.transaction] Transaction to run query under

--- a/lib/model.js
+++ b/lib/model.js
@@ -2846,7 +2846,7 @@ class Model {
    * @param  {boolean}      [options.individualHooks=false] If set to true, destroy will SELECT all records matching the where parameter and will execute before / after destroy hooks on each row
    * @param  {number}       [options.limit]                 How many rows to delete
    * @param  {boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
-   * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored, and do not return the number of destroyed rows, because truncate doesn't show affected rows only on SQLITE.
+   * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored
    * @param  {boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
    * @param  {boolean}      [options.restartIdentity=false] Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table.
    * @param  {Transaction}  [options.transaction] Transaction to run query under

--- a/lib/model.js
+++ b/lib/model.js
@@ -2846,7 +2846,7 @@ class Model {
    * @param  {boolean}      [options.individualHooks=false] If set to true, destroy will SELECT all records matching the where parameter and will execute before / after destroy hooks on each row
    * @param  {number}       [options.limit]                 How many rows to delete
    * @param  {boolean}      [options.force=false]           Delete instead of setting deletedAt to current timestamp (only applicable if `paranoid` is enabled)
-   * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored
+   * @param  {boolean}      [options.truncate=false]        If set to true, dialects that support it will use TRUNCATE instead of DELETE FROM. If a table is truncated the where and limit options are ignored, and do not return the number of destroyed rows, because truncate doesn't show affected rows.
    * @param  {boolean}      [options.cascade=false]         Only used in conjunction with TRUNCATE. Truncates  all tables that have foreign-key references to the named table, or to any tables added to the group due to CASCADE.
    * @param  {boolean}      [options.restartIdentity=false] Only used in conjunction with TRUNCATE. Automatically restart sequences owned by columns of the truncated table.
    * @param  {Transaction}  [options.transaction] Transaction to run query under

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1239,7 +1239,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       await User.bulkCreate([{ username: 'user1' }, { username: 'user2' }]);
       const affectedRows = await User.destroy({ truncate: true });
       expect(await User.findAll()).to.have.lengthOf(0);
-      expect(affectedRows).to.be.a('number')
+      expect(affectedRows).to.be.a('number');
     });
 
     it('throws an error if no where clause is given', async function() {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1233,6 +1233,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(await User.findAll()).to.have.lengthOf(0);
     });
 
+    it('`truncate` option returns 0 afftectedRows', async function() {
+      const User = this.sequelize.define('User', { username: DataTypes.STRING });
+      await this.sequelize.sync({ force: true });
+      await User.bulkCreate([{ username: 'user1' }, { username: 'user2' }]);
+      const affectedRows = await User.destroy({ truncate: true });
+      expect(await User.findAll()).to.have.lengthOf(0);
+      expect(affectedRows).to.equal(0);
+    });
+
     it('throws an error if no where clause is given', async function() {
       const User = this.sequelize.define('User', { username: DataTypes.STRING });
       await this.sequelize.sync({ force: true });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1233,13 +1233,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(await User.findAll()).to.have.lengthOf(0);
     });
 
-    it('`truncate` option returns 0 afftectedRows', async function() {
+    it('`truncate` option returns a number', async function() {
       const User = this.sequelize.define('User', { username: DataTypes.STRING });
       await this.sequelize.sync({ force: true });
       await User.bulkCreate([{ username: 'user1' }, { username: 'user2' }]);
       const affectedRows = await User.destroy({ truncate: true });
       expect(await User.findAll()).to.have.lengthOf(0);
-      expect(affectedRows).to.equal(0);
+      expect(affectedRows).to.be.a('number')
     });
 
     it('throws an error if no where clause is given', async function() {


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This close #12164.
 
I was debugging and realize, the [SSCE](https://github.com/papb/sequelize-sscce/pull/72) examples is passing truncate as an option. Therefore truncate on the database does not show affected rows so we can't return the value, thus I found the Postgres NaN in these cases.
 
- I changed the doc adding info about it when use truncate will no show rows affected only on Sqlite do this.
- Fixed Postgres rowCount when queryResult.rowCount isn't returning 
- Fixed MSsql  when data is empty return 0 on isBulkDeleteQuery