### PR TITLE
fix(logger): use promise.then for processing query results(mysql)

### DIFF
--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Utils = require('../../utils');
 const AbstractQuery = require('../abstract/query');
+const Promise = require('../../promise');
 const sequelizeErrors = require('../../errors');
 const _ = require('lodash');
 const { logger } = require('../../utils/logger');
@@ -34,34 +34,26 @@ class Query extends AbstractQuery {
     //do we need benchmark for this query execution
     const showWarnings = this.sequelize.options.showWarnings || options.showWarnings;
 
+    const query = parameters && parameters.length
+      ? new Promise((resolve, reject) => connection.execute(sql, parameters, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100))
+      : new Promise((resolve, reject) => connection.query({ sql }, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100));
+
     const complete = this._logQuery(sql, debug, parameters);
 
-    return new Utils.Promise((resolve, reject) => {
-      const handler = (err, results) => {
-        complete();
-
-        if (err) {
-          // MySQL automatically rolls-back transactions in the event of a deadlock
-          if (options.transaction && err.errno === 1213) {
-            options.transaction.finished = 'rollback';
-          }
-          err.sql = sql;
-          err.parameters = parameters;
-
-          reject(this.formatError(err));
-        } else {
-          resolve(results);
-        }
-      };
-      if (parameters) {
-        debug('parameters(%j)', parameters);
-        connection.execute(sql, parameters, handler).setMaxListeners(100);
-      } else {
-        connection.query({ sql }, handler).setMaxListeners(100);
+    return query.catch(err => {
+      // MySQL automatically rolls-back transactions in the event of a deadlock
+      if (options.transaction && err.errno === 1213) {
+        options.transaction.finished = 'rollback';
       }
+      err.sql = sql;
+      err.parameters = parameters;
+
+      throw this.formatError(err);
     })
     // Log warnings if we've got them.
       .then(results => {
+        complete();
+
         if (showWarnings && results && results.warningStatus > 0) {
           return this.logWarnings(results);
         }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Using `promise.then` instead of custom handler function for processing run query results for mysql dialect.
It change fix losing CLS context for mysql logging custom function in case of `benchmark: true` #12317 
