### PR TITLE
fix(logger): use promise.then for processing query results(mysql)

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -50,40 +50,23 @@ class Query extends AbstractQuery {
 
     const complete = this._logQuery(sql, debug, parameters);
 
-    const result = await new Promise((resolve, reject) => {
-      const handleTransaction = err => {
-        if (err) {
-          err.sql = sql;
-          err.parameters = parameters;
-          reject(this.formatError(err));
-          return;
-        }
-        resolve(this.formatResults());
-      };
+    const query = new Promise((resolve, reject) => {
       // TRANSACTION SUPPORT
       if (sql.startsWith('BEGIN TRANSACTION')) {
-        return connection.beginTransaction(handleTransaction, options.transaction.name, connection.lib.ISOLATION_LEVEL[options.isolationLevel]);
+        return connection.beginTransaction(error => error ? reject(error) : resolve([]), options.transaction.name, connection.lib.ISOLATION_LEVEL[options.isolationLevel]);
       }
       if (sql.startsWith('COMMIT TRANSACTION')) {
-        return connection.commitTransaction(handleTransaction);
+        return connection.commitTransaction(error => error ? reject(error) : resolve([]));
       }
       if (sql.startsWith('ROLLBACK TRANSACTION')) {
-        return connection.rollbackTransaction(handleTransaction, options.transaction.name);
+        return connection.rollbackTransaction(error => error ? reject(error) : resolve([]), options.transaction.name);
       }
       if (sql.startsWith('SAVE TRANSACTION')) {
-        return connection.saveTransaction(handleTransaction, options.transaction.name);
+        return connection.saveTransaction(error => error ? reject(error) : resolve([]), options.transaction.name);
       }
-      const results = [];
-      const request = new connection.lib.Request(sql, (err, rowCount) => {
 
-        if (err) {
-          err.sql = sql;
-          err.parameters = parameters;
-          reject(this.formatError(err));
-        } else {
-          resolve(this.formatResults(results, rowCount));
-        }
-      });
+      const rows = [];
+      const request = new connection.lib.Request(sql, (err, rowCount) => err ? reject(err) : resolve([rows, rowCount]));
 
       if (parameters) {
         _.forOwn(parameters, (value, key) => {
@@ -93,6 +76,27 @@ class Query extends AbstractQuery {
       }
 
       request.on('row', columns => {
+        rows.push(columns);
+      });
+
+      connection.execSql(request);
+    });
+
+    let rows, rowCount;
+
+    try {
+      [rows, rowCount] = await query;
+    } catch (err) {
+      err.sql = sql;
+      err.parameters = parameters;
+
+      throw this.formatError(err);
+    }
+
+    complete();
+
+    if (Array.isArray(rows)) {
+      rows = rows.map(columns => {
         const row = {};
         for (const column of columns) {
           const typeid = column.metadata.type.id;
@@ -104,16 +108,11 @@ class Query extends AbstractQuery {
           }
           row[column.metadata.colName] = value;
         }
-
-        results.push(row);
+        return row;
       });
+    }
 
-      connection.execSql(request);
-    });
-
-    complete();
-
-    return result;
+    return this.formatResults(rows, rowCount);
   }
 
   run(sql, parameters) {

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -44,13 +44,13 @@ class Query extends AbstractQuery {
     return paramType;
   }
 
-  _run(connection, sql, parameters) {
+  async _run(connection, sql, parameters) {
     this.sql = sql;
     const { options } = this;
 
     const complete = this._logQuery(sql, debug, parameters);
 
-    return new Promise((resolve, reject) => {
+    const result = await new Promise((resolve, reject) => {
       const handleTransaction = err => {
         if (err) {
           err.sql = sql;
@@ -75,8 +75,6 @@ class Query extends AbstractQuery {
       }
       const results = [];
       const request = new connection.lib.Request(sql, (err, rowCount) => {
-
-        complete();
 
         if (err) {
           err.sql = sql;
@@ -112,6 +110,10 @@ class Query extends AbstractQuery {
 
       connection.execSql(request);
     });
+
+    complete();
+
+    return result;
   }
 
   run(sql, parameters) {

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -33,11 +33,11 @@ class Query extends AbstractQuery {
     //do we need benchmark for this query execution
     const showWarnings = this.sequelize.options.showWarnings || options.showWarnings;
 
+    const complete = this._logQuery(sql, debug, parameters);
+
     const query = parameters && parameters.length
       ? new Promise((resolve, reject) => connection.execute(sql, parameters, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100))
       : new Promise((resolve, reject) => connection.query({ sql }, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100));
-
-    const complete = this._logQuery(sql, debug, parameters);
 
     const results = await query.catch(err => {
       // MySQL automatically rolls-back transactions in the event of a deadlock

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -33,32 +33,25 @@ class Query extends AbstractQuery {
     //do we need benchmark for this query execution
     const showWarnings = this.sequelize.options.showWarnings || options.showWarnings;
 
+    const query = parameters && parameters.length
+      ? new Promise((resolve, reject) => connection.execute(sql, parameters, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100))
+      : new Promise((resolve, reject) => connection.query({ sql }, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100));
+
     const complete = this._logQuery(sql, debug, parameters);
 
-    const results = await new Promise((resolve, reject) => {
-      const handler = (err, results) => {
-        complete();
-
-        if (err) {
-          // MySQL automatically rolls-back transactions in the event of a deadlock
-          if (options.transaction && err.errno === 1213) {
-            options.transaction.finished = 'rollback';
-          }
-          err.sql = sql;
-          err.parameters = parameters;
-
-          reject(this.formatError(err));
-        } else {
-          resolve(results);
-        }
-      };
-      if (parameters) {
-        debug('parameters(%j)', parameters);
-        connection.execute(sql, parameters, handler).setMaxListeners(100);
-      } else {
-        connection.query({ sql }, handler).setMaxListeners(100);
+    const results = await query.catch(err => {
+      // MySQL automatically rolls-back transactions in the event of a deadlock
+      if (options.transaction && err.errno === 1213) {
+        options.transaction.finished = 'rollback';
       }
+      err.sql = sql;
+      err.parameters = parameters;
+
+      throw this.formatError(err);
     });
+
+    complete();
+
     // Log warnings if we've got them.
     if (showWarnings && results && results.warningStatus > 0) {
       await this.logWarnings(results);

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -39,7 +39,11 @@ class Query extends AbstractQuery {
       ? new Promise((resolve, reject) => connection.execute(sql, parameters, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100))
       : new Promise((resolve, reject) => connection.query({ sql }, (error, result) => error ? reject(error) : resolve(result)).setMaxListeners(100));
 
-    const results = await query.catch(err => {
+    let results;
+
+    try {
+      results = await query;
+    } catch (err) {
       // MySQL automatically rolls-back transactions in the event of a deadlock
       if (options.transaction && err.errno === 1213) {
         options.transaction.finished = 'rollback';
@@ -48,7 +52,7 @@ class Query extends AbstractQuery {
       err.parameters = parameters;
 
       throw this.formatError(err);
-    });
+    }
 
     complete();
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Using promise.then instead of custom handler function for processing run query results for mysql dialect.
It change fix losing CLS context for mysql logging custom function in case of `benchmark: true` #12317
MR for v5: #12318