### PR TITLE
fix(types): add Association into OrderItem type

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -451,7 +451,7 @@ export interface IncludeOptions extends Filterable, Projectable, Paranoid {
   subQuery?: boolean;
 }
 
-type OrderItemModel = typeof Model | { model: typeof Model; as: string } | string
+type OrderItemAssociation = Association | typeof Model | { model: typeof Model; as: string } | string
 type OrderItemColumn = string | Col | Fn | Literal
 export type OrderItem =
   | string
@@ -459,14 +459,14 @@ export type OrderItem =
   | Col
   | Literal
   | [OrderItemColumn, string]
-  | [OrderItemModel, OrderItemColumn]
-  | [OrderItemModel, OrderItemColumn, string]
-  | [OrderItemModel, OrderItemModel, OrderItemColumn]
-  | [OrderItemModel, OrderItemModel, OrderItemColumn, string]
-  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn]
-  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn, string]
-  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn]
-  | [OrderItemModel, OrderItemModel, OrderItemModel, OrderItemModel, OrderItemColumn, string]
+  | [OrderItemAssociation, OrderItemColumn]
+  | [OrderItemAssociation, OrderItemColumn, string]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemColumn]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemColumn, string]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn, string]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn, string]
 export type Order = string | Fn | Col | Literal | OrderItem[];
 
 /**


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Association ordering is preferred in docs, but not allowed from typescript.