### PR TITLE
fix: add missing fields to 'FindOrCreateType'

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -685,12 +685,11 @@ export interface Hookable {
 /**
  * Options for Model.findOrCreate method
  */
-export interface FindOrCreateOptions extends Logging, Transactionable {
+export interface FindOrCreateOptions extends Filterable, Logging, Transactionable {
   /**
-   * A hash of search attributes.
+   * The fields to insert / update. Defaults to all fields
    */
-  where: WhereOptions;
-
+  fields?: string[];
   /**
    * Default values to use if building a new instance
    */

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -99,6 +99,20 @@ UserModel.findCreateFind({
 })
 
 /**
+ * Tests for findCreateFind() type.
+ */
+
+ UserModel.findOrCreate({
+  fields: [ "jane.doe" ],
+  where: {
+    username: "jane.doe"
+  },
+  defaults: {
+    username: "jane.doe"
+  }
+})
+
+/**
  * Test for primaryKeyAttributes.
  */
 class TestModel extends Model {};
@@ -116,12 +130,12 @@ someInstance.getOthers({
     joinTableAttributes: { include: [ 'id' ] }
 })
 
-/** 
+/**
  * Test for through options in creating a BelongsToMany association
  */
 class Film extends Model {}
 
-class Actor extends Model {} 
+class Actor extends Model {}
 
 Film.belongsToMany(Actor, {
   through: {

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -99,7 +99,7 @@ UserModel.findCreateFind({
 })
 
 /**
- * Tests for findCreateFind() type.
+ * Tests for findOrCreate() type.
  */
 
  UserModel.findOrCreate({


### PR DESCRIPTION

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This PR includes some typings needed to provide clarification in regards to the usage of `findOrCreate` functionality, thus the `FindOrCreateOptions` interface has been altered to include the `fields` string array to whitelist which fields should be persisted as explained in https://github.com/sequelize/sequelize/issues/12325 . Tests are not passing, as well as in master upstream.
