### PR TITLE
Better typing support for Model.init()

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1338,12 +1338,9 @@ export interface ModelAttributeColumnOptions<M extends Model = Model> extends Co
 /**
  * Interface for Attributes provided for a column
  */
-export interface ModelAttributes<M extends Model = Model> {
-  /**
-   * The description of a database column
-   */
-  [name: string]: DataType | ModelAttributeColumnOptions<M>;
-}
+export type ModelAttributes<M extends Model = Model> = {
+  [P in keyof M]?: DataType | ModelAttributeColumnOptions<M>;
+};
 
 /**
  * Possible types for primary keys


### PR DESCRIPTION
By converting the `ModelAttribute` interface into an advanced type, you are able to add an autocompletion on the fields while using `Model.init()`.

![](https://i.imgur.com/BW5jllJ.png)
