### PR TITLE
Fix(options.query.raw)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1706,10 +1706,10 @@ class Model {
       : this.options.rejectOnEmpty;
 
     // set query.raw option, defaults to model options
-    if(!Object.prototype.hasOwnProperty.call(options, 'raw')){
-      Object.prototype.hasOwnProperty.call(this.sequelize.options.query, 'raw')
-      ? options.raw = this.sequelize.options.query.raw
-      : options.raw = false    
+    if (!Object.prototype.hasOwnProperty.call(options, 'raw')) {
+        Object.prototype.hasOwnProperty.call(this.sequelize.options.query, 'raw')
+        ? options.raw = this.sequelize.options.query.raw
+        : options.raw = false;    
     } 
 
     return Promise.try(() => {

--- a/lib/model.js
+++ b/lib/model.js
@@ -1703,7 +1703,14 @@ class Model {
     // set rejectOnEmpty option, defaults to model options
     options.rejectOnEmpty = Object.prototype.hasOwnProperty.call(options, 'rejectOnEmpty')
       ? options.rejectOnEmpty
-      : this.options.rejectOnEmpty;
+      : this.options.rejectOnEmpty
+
+    // set query.raw option, defaults to model options
+    if(!Object.prototype.hasOwnProperty.call(options, 'raw')){
+      Object.prototype.hasOwnProperty.call(this.sequelize.options.query, 'raw')
+      ? options.raw = this.sequelize.options.query.raw
+      : options.raw = false    
+    } 
 
     return Promise.try(() => {
       this._injectScope(options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1703,7 +1703,7 @@ class Model {
     // set rejectOnEmpty option, defaults to model options
     options.rejectOnEmpty = Object.prototype.hasOwnProperty.call(options, 'rejectOnEmpty')
       ? options.rejectOnEmpty
-      : this.options.rejectOnEmpty
+      : this.options.rejectOnEmpty;
 
     // set query.raw option, defaults to model options
     if(!Object.prototype.hasOwnProperty.call(options, 'raw')){


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This PR refers to 6408 issue.
Now we can define global raw option, or define at each query.
Param: query: {raw:true}

https://github.com/sequelize/sequelize/issues/6408
