### PR TITLE
Add `clientMinMessages` to Options interface

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -354,6 +354,14 @@ export interface Options extends Logging {
   standardConformingStrings?: boolean;
 
   /**
+   * The PostgreSQL `client_min_messages` session parameter. 
+   Set to `false` to not override the database's default.
+   *
+   * @default true
+   */
+  clientMinMessages?: false;
+  
+  /**
    * Sets global permanent hooks.
    */
   hooks?: Partial<SequelizeHooks>;


### PR DESCRIPTION
This adds the clientMinMessages to the Options interface for postgres specific configuration

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ X ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ X ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ X ] Have you added new tests to prevent regressions?
- [ X ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ X] Did you update the typescript typings accordingly (if applicable)?
- [ X  ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Add additional `clientMinMessages` for postgres support seen in https://github.com/sequelize/sequelize/blob/7afd589938ca01996f40d12d8fff1a93360bff19/lib/sequelize.js#L145
