### PR TITLE
Contextable: eject context to model's _options

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1765,7 +1765,7 @@ class Model {
           if (result._options && result._options instanceof Object) {
             result._options.context = options.context;
           }
-        })
+        });
       }
       if (options.hooks) {
         return this.runHooks('afterFind', results, options);

--- a/lib/model.js
+++ b/lib/model.js
@@ -1675,6 +1675,7 @@ class Model {
    * @param  {string}                                                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Error}                                             [options.rejectOnEmpty=false] Throws an error when no records found
    *
+   * @param  {Object}                                                    [options.context] An any type value attaching to the model's _option.context
    * @see
    * {@link Sequelize#query}
    *
@@ -1758,6 +1759,14 @@ class Model {
       const selectOptions = Object.assign({}, options, { tableNames: Object.keys(tableNames) });
       return this.QueryInterface.select(this, this.getTableName(selectOptions), selectOptions);
     }).tap(results => {
+      if (results) {
+        const resultsArr = Array.isArray(results) ? results : [results];
+        resultsArr.forEach(result => {
+          if (result._options && result._options instanceof Object) {
+            result._options.context = options.context;
+          }
+        })
+      }
       if (options.hooks) {
         return this.runHooks('afterFind', results, options);
       }
@@ -2160,6 +2169,7 @@ class Model {
    * @param {boolean} [options.raw=false] If set to true, values will ignore field and virtual setters.
    * @param {boolean} [options.isNewRecord=true] Is this new record
    * @param {Array}   [options.include] an array of include options - Used to build prefetched/included model instances. See `set`
+   * @param {Object}  [options.context] An any type value attaching to the model's _option.context
    *
    * @returns {Model|Array<Model>}
    */
@@ -2214,6 +2224,7 @@ class Model {
    * @param {Transaction}   [options.transaction] Transaction to run query under
    * @param {string}        [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param {boolean}       [options.returning=true] Return the affected rows (only for postgres)
+   * @param {Object}        [options.context] An any type value attaching to the model's _option.context
    *
    * @returns {Promise<Model>}
    *
@@ -2226,7 +2237,8 @@ class Model {
       attributes: options.fields,
       include: options.include,
       raw: options.raw,
-      silent: options.silent
+      silent: options.silent,
+      context: options.context
     }).save(options);
   }
 
@@ -2238,6 +2250,7 @@ class Model {
    * @param {Object}   options.where A hash of search attributes. If `where` is a plain object it will be appended with defaults to build a new instance.
    * @param {Object}   [options.defaults] Default values to use if building a new instance
    * @param {Object}   [options.transaction] Transaction to run query under
+   * @param  {Object}  [options.context]     An any type value attaching to the model's _option.context
    *
    * @returns {Promise<Model,boolean>}
    */
@@ -2282,6 +2295,7 @@ class Model {
    * @param {Object}      options.where where A hash of search attributes. If `where` is a plain object it will be appended with defaults to build a new instance.
    * @param {Object}      [options.defaults] Default values to use if creating a new instance
    * @param {Transaction} [options.transaction] Transaction to run query under
+   * @param {Object}      [options.context] An any type value attaching to the model's _option.context
    *
    * @returns {Promise<Model,boolean>}
    */
@@ -2391,6 +2405,7 @@ class Model {
    * @param {Object} options find options
    * @param {Object} options.where A hash of search attributes. If `where` is a plain object it will be appended with defaults to build a new instance.
    * @param {Object} [options.defaults] Default values to use if creating a new instance
+   * @param {Object} [options.context] An any type value attaching to the model's _option.context
    *
    * @returns {Promise<Model,boolean>}
    */
@@ -2531,6 +2546,7 @@ class Model {
    * @param  {boolean}      [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {boolean|Array} [options.returning=false]       If true, append RETURNING * to get back all values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}       [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {Object}       [options.context]                An any type value attaching to the model's _option.context
    *
    * @returns {Promise<Array<Model>>}
    */
@@ -2552,7 +2568,7 @@ class Model {
       }
     }
 
-    const instances = records.map(values => this.build(values, { isNewRecord: true, include: options.include }));
+    const instances = records.map(values => this.build(values, { isNewRecord: true, include: options.include, context: options.context }));
 
     const recursiveBulkCreate = (instances, options) => {
       options = Object.assign({

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -94,6 +94,13 @@ export interface DropOptions extends Logging {
   cascade?: boolean;
 }
 
+export interface Contextable {
+  /**
+   * An any type value attaching to the model's _option.context from finding and creating
+   */
+  context?: any;
+}
+
 /**
  * Schema Options provided for applying a schema to a model
  */
@@ -511,7 +518,7 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
  *
  * A hash of options to describe the scope of the search
  */
-export interface FindOptions extends QueryOptions, Filterable, Projectable, Paranoid, IndexHintable {
+export interface FindOptions extends QueryOptions, Filterable, Projectable, Paranoid, IndexHintable, Contextable {
   /**
    * A list of associations to eagerly load using a left join. Supported is either
    * `{ include: [ Model1, Model2, ...]}`, `{ include: [{ model: Model1, as: 'Alias' }]}` or
@@ -625,7 +632,7 @@ export interface FindAndCountOptions extends CountOptions, FindOptions {}
 /**
  * Options for Model.build method
  */
-export interface BuildOptions {
+export interface BuildOptions extends Contextable {
   /**
    * If set to true, values will ignore field and virtual setters.
    */
@@ -678,7 +685,7 @@ export interface CreateOptions extends BuildOptions, Logging, Silent, Transactio
 /**
  * Options for Model.findOrCreate method
  */
-export interface FindOrCreateOptions extends Logging, Transactionable {
+export interface FindOrCreateOptions extends Logging, Transactionable, Contextable {
   /**
    * A hash of search attributes.
    */
@@ -718,7 +725,7 @@ export interface UpsertOptions extends Logging, Transactionable, SearchPathable 
 /**
  * Options for Model.bulkCreate method
  */
-export interface BulkCreateOptions extends Logging, Transactionable {
+export interface BulkCreateOptions extends Logging, Transactionable, Contextable {
   /**
    * Fields to insert (defaults to all fields)
    */


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

## Description

This PR adds the ability to eject a context value to model's _options when finding, creating and building models.
With ejecting context to models, implementing something like i18n will be much easier. So this PR can solve #4361.

### Usage
```js
const User = sequelize.define("user", {
  age: {
    type: DataTypes.INTEGER,
    validate: {
      isEven(value) {
        if (parseInt(value) % 2 !== 0) {
          throw new Error(this._options.context.i18n("isEvenError"));
        }
      }
    }
  },
});

const i18n = function() {
  return "localized message";
}
const b = await User.create({ age: 21 }, {
  context: { i18n }
});
```