### PR TITLE
allow options to be a JSON object

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -222,10 +222,9 @@ class Sequelize {
         else 
         {
           options.dialectOptions = urlParts.query;
-          if (urlParts.query['options']) {
-            try 
-            {
-              const o = JSON.parse(urlParts.query['options']);
+          if (urlParts.query.options) {
+            try {
+              const o = JSON.parse(urlParts.query.options);
               options.dialectOptions.options = o;
             } catch (e) {
               // Nothing to do, string is not a valid JSON

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -221,6 +221,16 @@ class Sequelize {
           Object.assign(options.dialectOptions, urlParts.query);
         else
           options.dialectOptions = urlParts.query;
+          if(urlParts.query["options"]) {
+            try 
+            {
+              const o = JSON.parse(urlParts.query["options"]);
+              options.dialectOptions.options = o;
+            } catch (e) {
+              // Nothing to do, string is not a valid JSON
+              // an thus does not need any further processing
+            }
+          }
       }
     } else {
       // new Sequelize(database, username, password, { ... options })

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -217,10 +217,9 @@ class Sequelize {
           options.host = urlParts.query.host;
         }
 
-        if (options.dialectOptions)
+        if (options.dialectOptions) {
           Object.assign(options.dialectOptions, urlParts.query);
-        else 
-        {
+        } else {
           options.dialectOptions = urlParts.query;
           if (urlParts.query.options) {
             try {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -219,18 +219,20 @@ class Sequelize {
 
         if (options.dialectOptions)
           Object.assign(options.dialectOptions, urlParts.query);
-        else
+        else 
+        {
           options.dialectOptions = urlParts.query;
-          if(urlParts.query["options"]) {
+          if (urlParts.query['options']) {
             try 
             {
-              const o = JSON.parse(urlParts.query["options"]);
+              const o = JSON.parse(urlParts.query['options']);
               options.dialectOptions.options = o;
             } catch (e) {
               // Nothing to do, string is not a valid JSON
               // an thus does not need any further processing
             }
           }
+        }
       }
     } else {
       // new Sequelize(database, username, password, { ... options })

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -69,6 +69,14 @@ describe(Support.getTestDialectTeaser('Configuration'), () => {
     });
   });
 
+  describe('Instantiation with a URL string', () => { 
+    it('should handle options in URL', async () => {
+      const sequelizeWithOptions = new Sequelize('mssql://user:password!@server.database.windows.net/database?options={"encrypt":true}&anotherOption=1');
+      expect(sequelizeWithOptions.options.dialectOptions.options.encrypt).to.equal(true);
+      expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal(1);
+    });
+  });
+
   describe('Instantiation with arguments', () => {
     if (dialect === 'sqlite') {
       it('should respect READONLY / READWRITE connection modes', async () => {

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -73,7 +73,7 @@ describe(Support.getTestDialectTeaser('Configuration'), () => {
     it('should handle options in URL', async () => {
       const sequelizeWithOptions = new Sequelize('mssql://user:password!@server.database.windows.net/database?options={"encrypt":true}&anotherOption=1');
       expect(sequelizeWithOptions.options.dialectOptions.options.encrypt).to.equal(true);
-      expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal(1);
+      expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal('1');
     });
   });
 

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -70,7 +70,7 @@ describe(Support.getTestDialectTeaser('Configuration'), () => {
   });
 
   describe('Instantiation with a URL string', () => { 
-    it('should handle options in URL', async () => {
+    it('should handle options in URL', () => {
       const sequelizeWithOptions = new Sequelize('mssql://user:password!@server.database.windows.net/database?options={"encrypt":true}&anotherOption=1');
       expect(sequelizeWithOptions.options.dialectOptions.options.encrypt).to.equal(true);
       expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal('1');

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -69,14 +69,6 @@ describe(Support.getTestDialectTeaser('Configuration'), () => {
     });
   });
 
-  describe('Instantiation with a URL string', () => { 
-    it('should handle options in URL', () => {
-      const sequelizeWithOptions = new Sequelize('mssql://user:password!@server.database.windows.net/database?options={"encrypt":true}&anotherOption=1');
-      expect(sequelizeWithOptions.options.dialectOptions.options.encrypt).to.equal(true);
-      expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal('1');
-    });
-  });
-
   describe('Instantiation with arguments', () => {
     if (dialect === 'sqlite') {
       it('should respect READONLY / READWRITE connection modes', async () => {

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -180,6 +180,12 @@ describe('Sequelize', () => {
       expect(dialectOptions.ssl).to.equal('true');
     });
 
+    it('should handle JSON options', () => {
+      const sequelizeWithOptions = new Sequelize('mysql://example.com:9821/dbname?options={"encrypt":true}&anotherOption=1');
+      expect(sequelizeWithOptions.options.dialectOptions.options.encrypt).to.be.true;
+      expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal('1');
+    });
+    
     it('should use query string host if specified', () => {
       const sequelize = new Sequelize('mysql://localhost:9821/dbname?host=example.com');
 


### PR DESCRIPTION
This commit allows complex object to be passed as option in the URI connection string. For example it's now possibile to do something like:

```
const sequelize = new Sequelize('mssql://user:password@server.database.windows.net/database?options={"encrypt":true}&anotherOption=1');
```

so that it will be possible to correctly connect to an Azure SQL database, as encryption is required