### PR TITLE
fix(types): Updated Types to match JavaScript implementation

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1279,9 +1279,9 @@ export interface ModelAttributeColumnOptions<M extends Model = Model> extends Co
   comment?: string;
 
   /**
-   * An object with reference configurations
+   * An object with reference configurations or the column name as string
    */
-  references?: ModelAttributeColumnReferencesOptions;
+  references?: string | ModelAttributeColumnReferencesOptions;
 
   /**
    * What should happen when the referenced key is updated. One of CASCADE, RESTRICT, SET DEFAULT, SET NULL or


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Telling the `ModelAttributeColumnOptions` interface property `references` to accept strings as well.
This feature is actually implemented into sequelize, as can be seen in the [documentation](https://sequelize.org/master/class/lib/model.js~Model.html) you need to search for `attributes.column.references`.