### PR TITLE
fix (mssql): bulkUpdate returning values

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -393,7 +393,7 @@ class QueryGenerator {
 
           suffix += selectFromTmp;
         }
-      } else if (this._dialect.supports.returnValues && options.returning) {
+      } else if (options.returning) {
         // ensure that the return output is properly mapped to model fields.
         options.mapToModel = true;
         suffix += ' RETURNING *';

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -393,7 +393,7 @@ class QueryGenerator {
 
           suffix += selectFromTmp;
         }
-      } else if (options.returning) {
+      } else if (this._dialect.supports.returnValues && options.returning) {
         // ensure that the return output is properly mapped to model fields.
         options.mapToModel = true;
         suffix += ' RETURNING *';

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -210,7 +210,10 @@ class Query extends AbstractQuery {
       return data[0];
     }
     if (this.isBulkUpdateQuery()) {
-      return data.length;
+      if (this.options.returning)
+        return this.handleSelectQuery(data);
+      else
+        return data.length;
     }
     if (this.isBulkDeleteQuery()) {
       return data[0] && data[0].AFFECTEDROWS;

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -210,10 +210,11 @@ class Query extends AbstractQuery {
       return data[0];
     }
     if (this.isBulkUpdateQuery()) {
-      if (this.options.returning)
+      if (this.options.returning) {
         return this.handleSelectQuery(data);
+      }
 
-      return data.length;
+      return rowCount;
     }
     if (this.isBulkDeleteQuery()) {
       return data[0] && data[0].AFFECTEDROWS;

--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -212,8 +212,8 @@ class Query extends AbstractQuery {
     if (this.isBulkUpdateQuery()) {
       if (this.options.returning)
         return this.handleSelectQuery(data);
-      else
-        return data.length;
+
+      return data.length;
     }
     if (this.isBulkDeleteQuery()) {
       return data[0] && data[0].AFFECTEDROWS;

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -139,6 +139,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     }
 
+    if (_.get(current.dialect.supports, 'returnValues.output')) {
+      it('should output the updated record', function() {
+        return this.Account.create({ ownerId: 2 }).then(account => {
+          return this.Account.update({ name: 'FooBar' }, {
+            where: {
+              id: account.get('id')
+            },
+            returning: true
+          }).then(([, accounts]) => {
+            const firstAcc = accounts[0];
+            expect(firstAcc.name).to.be.equal('FooBar');
+            return firstAcc.reload();
+          }).then(accountReloaded => {
+            expect(accountReloaded.ownerId, 'Reloaded as output update only return primary key and changed fields').to.be.equal(2);
+          });
+        });
+      });
+    }
+
     if (current.dialect.supports['LIMIT ON UPDATE']) {
       it('should only update one row', function() {
         return this.Account.create({

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2043,7 +2043,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   /**
    * Update multiple instances that match the where options. The promise returns an array with one or two
    * elements. The first element is always the number of affected rows, while the second element is the actual
-   * affected rows (only supported in postgres with `options.returning` true.)
+   * affected rows (only supported in postgres and mssql with `options.returning` true.)
    */
   public static update<M extends Model>(
     this: { new (): M } & typeof Model,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fix MSSQL returning values for bulkUpdate

The issue creates a major performance hit for v5 - as bulkUpdates right now does not work correctly and requires to run another query to get the model data - which is returning already in the update itself.

- bulkUpdate will now return the updates if options.returning is true.
- updateQuery removed redundant setting check
- Fix documentation for model.update
