### PR TITLE
v5: fix(postgres): parse enums correctly when describing a table

### DIFF
--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -838,7 +838,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       return [];
     }
 
-    matches = matches.map(m => m.replace(/",$/, '').replace(/,$/, '').replace(/(^"|"$)/, ''));
+    matches = matches.map(m => m.replace(/",$/, '').replace(/,$/, '').replace(/(^"|"$)/g, ''));
 
     return matches.slice(0, -1);
   }

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -1312,5 +1312,45 @@ if (dialect.startsWith('postgres')) {
         });
       });
     });
+
+    describe('fromArray()', () => {
+      beforeEach(function() {
+        this.queryGenerator = new QueryGenerator({
+          sequelize: this.sequelize,
+          _dialect: this.sequelize.dialect
+        });
+      });
+
+      const tests = [
+        {
+          title: 'should convert an enum with no quoted strings to an array',
+          arguments: '{foo,bar,foobar}',
+          expectation: ['foo', 'bar', 'foobar']
+        }, {
+          title: 'should convert an enum starting with a quoted string to an array',
+          arguments: '{"foo bar",foo,bar}',
+          expectation: ['foo bar', 'foo', 'bar']
+        }, {
+          title: 'should convert an enum ending with a quoted string to an array',
+          arguments: '{foo,bar,"foo bar"}',
+          expectation: ['foo', 'bar', 'foo bar']
+        }, {
+          title: 'should convert an enum with a quoted string in the middle to an array',
+          arguments: '{foo,"foo bar",bar}',
+          expectation: ['foo', 'foo bar', 'bar']
+        }, {
+          title: 'should convert an enum full of quoted strings to an array',
+          arguments: '{"foo bar","foo bar","foo bar"}',
+          expectation: ['foo bar', 'foo bar', 'foo bar']
+        }
+      ];
+
+      _.each(tests, test => {
+        it(test.title, function() {
+          const convertedText = this.queryGenerator.fromArray(test.arguments);
+          expect(convertedText).to.deep.equal(test.expectation);
+        });
+      });
+    });
   });
 }


### PR DESCRIPTION
This PR is a cherry-pick of #12409, as the bug exists in v5 and v6!
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

When you have a PostgreSQL table containing a user-defined enum, if the last value of this enum contains multiple words, using a `describeTable()` on it will generate an array with a trailing quote due to a bad parsing of the result data. It works well in other cases (as long as the enum doesn't end with a multi-word value).

Consider this schema:
```sql
CREATE TYPE my_enum AS ENUM ('foo', 'bar', 'foo bar');
CREATE TABLE my_table (
  foo my_enum
);
```

Sequelize uses `array_agg(pg_catalog.pg_enum.enumlabel)` to fetch the enum values, before passing it to `QueryGenerator.fromArray()` to parse it. In this case it will send the string `{foo,bar,"foo bar"}`, and the resulting array will be `['foo', 'bar', 'foo bar"']`, with the unwanted trailing quote.

---

Tests aren't passing but I'm not sure that it's related to my fix, tell me if I need to change something! Here's the stacktrace just in case:
```
> mocha --require scripts/mocha-bootload --globals setImmediate,clearImmediate --exit --check-leaks --colors -t 30000 --reporter spec "test/integration/**/*.test.js"

FIXME: I want to be supported in this dialect as well :-(


  [POSTGRES] Alias
    1) "before each" hook for "should uppercase the first letter in alias getter, but not in eager loading"


  0 passing (1m)
  1 failing

  1) "before each" hook for "should uppercase the first letter in alias getter, but not in eager loading":
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
      at listOnTimeout (internal/timers.js:549:17)
      at processTimers (internal/timers.js:492:7)
```