### PR TITLE
V5: allow options to be a JSON object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ jobs:
       node_js: '6'
       env: DIALECT=sqlite
     - stage: test
-      node_js: '10'
+      node_js: '6'
       sudo: required
       env: MARIADB_VER=mariadb-103 SEQ_MARIADB_PORT=8960 DIALECT=mariadb
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
       node_js: '6'
       env: DIALECT=sqlite
     - stage: test
-      node_js: '6'
+      node_js: '10'
       sudo: required
       env: MARIADB_VER=mariadb-103 SEQ_MARIADB_PORT=8960 DIALECT=mariadb
     - stage: test

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -212,10 +212,20 @@ class Sequelize {
       }
 
       if (urlParts.query) {
-        if (options.dialectOptions)
+        if (options.dialectOptions) {
           Object.assign(options.dialectOptions, urlParts.query);
-        else
+        } else {
           options.dialectOptions = urlParts.query;
+          if (urlParts.query.options) {
+            try {
+              const o = JSON.parse(urlParts.query.options);
+              options.dialectOptions.options = o;
+            } catch (e) {
+              // Nothing to do, string is not a valid JSON
+              // an thus does not need any further processing
+            }
+          }
+        }
       }
     } else {
       // new Sequelize(database, username, password, { ... options })

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -179,5 +179,11 @@ describe('Sequelize', () => {
       expect(dialectOptions.application_name).to.equal('client');
       expect(dialectOptions.ssl).to.equal('true');
     });
+
+    it('should handle JSON options', () => {
+      const sequelizeWithOptions = new Sequelize('mysql://example.com:9821/dbname?options={"encrypt":true}&anotherOption=1');
+      expect(sequelizeWithOptions.options.dialectOptions.options.encrypt).to.be.true;
+      expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal('1');
+    });
   });
 });


### PR DESCRIPTION
Backported to V5. This commit allows complex object to be passed as option in the URI connection string. For example it's now possibile to do something like:

```
const sequelize = new Sequelize('mssql://user:password@server.database.windows.net/database?options={"encrypt":true}&anotherOption=1');
```

so that it will be possible to correctly connect to an Azure SQL database, as encryption is required