### PR TITLE
fix(mssql): returning data for bulkUpdate

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -197,6 +197,10 @@ class Query extends AbstractQuery {
       return data[0];
     }
     if (this.isBulkUpdateQuery()) {
+      if (this.options.returning) {
+        return this.handleSelectQuery(data);
+      }
+
       return rowCount;
     }
     if (this.isBulkDeleteQuery()) {

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -134,6 +134,25 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     }
 
+    if (_.get(current.dialect.supports, 'returnValues.output')) {
+      it('should output the updated record', async function() {
+        const account = await this.Account.create({ ownerId: 2 });
+
+        const [, accounts] = await this.Account.update({ name: 'FooBar' }, {
+          where: {
+            id: account.get('id')
+          },
+          returning: true
+        });
+
+        const firstAcc = accounts[0];
+        expect(firstAcc.name).to.be.equal('FooBar');
+
+        await firstAcc.reload();
+        expect(firstAcc.ownerId, 'Reloaded as output update only return primary key and changed fields').to.be.equal(2);
+      });
+    }
+
     if (current.dialect.supports['LIMIT ON UPDATE']) {
       it('should only update one row', async function() {
         await this.Account.create({

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2010,7 +2010,7 @@ export abstract class Model<T = any, T2 = any> extends Hooks {
   /**
    * Update multiple instances that match the where options. The promise returns an array with one or two
    * elements. The first element is always the number of affected rows, while the second element is the actual
-   * affected rows (only supported in postgres with `options.returning` true.)
+   * affected rows (only supported in postgres and mssql with `options.returning` true.)
    */
   public static update<M extends Model>(
     this: { new(): M } & typeof Model,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fix for the MSSQL dialect to return changed records when using bulkUpdate with `returning: true`

- bulkUpdate will now return the updates if options.returning is true.
- Fix documentation for model.update

This is in relation to #12410 as requested