### PR TITLE
docs: fix error in the name of interface

### DIFF
--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -63,7 +63,7 @@ class User extends Model<UserAttributes, UserCreationAttributes> implements User
 
 const sequelize = new Sequelize('mysql://root:asd123@localhost:3306/mydb');
 
-interface ProjectAttributes {
+interface ProjectCreationAttributes {
   ownerId: number;
   name: string;
 }


### PR DESCRIPTION
Fixes error when you try to compile the example:
```
TS2304: Cannot find name 'ProjectCreationAttributes'.
```