### PR TITLE
fix(types): init method should use all attributes

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1633,7 +1633,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   public static init<M extends Model>(
     this: ModelStatic<M>,
-    attributes: ModelAttributes<M, M['_creationAttributes']>, options: InitOptions<M>
+    attributes: ModelAttributes<M, M['_attributes']>, options: InitOptions<M>
   ): Model;
 
   /**


### PR DESCRIPTION
When you try to compile the example from https://github.com/sequelize/sequelize/blob/master/docs/manual/other-topics/typescript.md

You get an error:
```
error TS2345: Argument of type '{ id: { type: DataTypes.IntegerDataTypeConstructor; autoIncrement: boolean; primaryKey: boolean; }; name: { type: DataTypes.StringDataType; allowNull: false; }; preferredName: { ...; }; }' is not assignable to parameter of type 'ModelAttributes<User, UserCreationAttributes>'.
```

This fixes that error.

cc @hsource from https://github.com/sequelize/sequelize/pull/12405