### PR TITLE
fix(mssql): insert and upsert operations do not return all fields

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -380,6 +380,19 @@ class Query extends AbstractQuery {
       id = id || autoIncrementAttributeAlias && results && results[0][autoIncrementAttributeAlias];
 
       this.instance[autoIncrementAttribute] = id;
+
+      if (this.instance.dataValues) {
+        for (const key in results[0]) {
+          if (Object.prototype.hasOwnProperty.call(results[0], key)) {
+            const record = results[0][key];
+  
+            const attr = _.find(this.model.rawAttributes, attribute => attribute.fieldName === key || attribute.field === key);
+  
+            this.instance.dataValues[attr && attr.fieldName || key] = record;
+          }
+        }
+      }
+      
     }
   }
 }

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1420,4 +1420,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     expect(spy.called).to.be.ok;
   });
+
+  if (current.dialect.supports.returnValues) {
+    it('should return default value set by the database (create)', async function() {
+  
+      const User = this.sequelize.define('User', {
+        name: DataTypes.STRING,
+        code: { type: Sequelize.INTEGER, defaultValue: Sequelize.literal(2020) }
+      });
+
+      await User.sync({ force: true });
+
+      const user = await User.create({ name: 'FooBar' });
+  
+      expect(user.name).to.be.equal('FooBar');
+      expect(user.code).to.be.equal(2020);
+    });
+  }  
 });

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -577,6 +577,26 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             }
           });
         });
+
+        it('should return default value set by the database (upsert)', async function() {      
+          const User = this.sequelize.define('User', {
+            name: { type: DataTypes.STRING, primaryKey: true },
+            code: { type: Sequelize.INTEGER, defaultValue: Sequelize.literal(2020) }
+          });
+    
+          await User.sync({ force: true });
+    
+          const [user, created] = await User.upsert({ name: 'Test default value' }, { returning: true });
+      
+          expect(user.name).to.be.equal('Test default value');
+          expect(user.code).to.be.equal(2020);
+
+          if (dialect === 'sqlite' || dialect === 'postgres') {
+            expect(created).to.be.null;
+          } else {
+            expect(created).to.be.true;
+          }
+        });
       }
     });
   }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X]  Does the description below contain a link to an existing issue (Closes #12432 ) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

When using the MSSQL dialect, running Insert or Upsert operations, the mssql dialect is ignoring the values returned by OUTPUT INSERTED.* which can also include defaults values populated by the database or fields being updated by various triggers.
