### PR TITLE
fix(mssql): insert and upsert operations do not return all fields (v5)

### DIFF
--- a/lib/dialects/mssql/query.js
+++ b/lib/dialects/mssql/query.js
@@ -204,7 +204,8 @@ class Query extends AbstractQuery {
       return this.handleShowIndexesQuery(data);
     }
     if (this.isUpsertQuery()) {
-      return data[0];
+      this.handleInsertQuery(data);
+      return this.instance || data[0];
     }
     if (this.isCallQuery()) {
       return data[0];
@@ -391,6 +392,18 @@ class Query extends AbstractQuery {
       id = id || autoIncrementAttributeAlias && results && results[0][autoIncrementAttributeAlias];
 
       this.instance[autoIncrementAttribute] = id;
+
+      if (this.instance.dataValues) {
+        for (const key in results[0]) {
+          if (Object.prototype.hasOwnProperty.call(results[0], key)) {
+            const record = results[0][key];
+
+            const attr = _.find(this.model.rawAttributes, attribute => attribute.fieldName === key || attribute.field === key);
+
+            this.instance.dataValues[attr && attr.fieldName || key] = record;
+          }
+        }
+      }
     }
   }
 }

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1454,6 +1454,23 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
   });
 
+  if (current.dialect.supports.returnValues) {
+    it('should return default value set by the database (create)', function() {
+  
+      const User = this.sequelize.define('User', {
+        name: DataTypes.STRING,
+        code: { type: Sequelize.INTEGER, defaultValue: Sequelize.literal(2020) }
+      });
+
+      return User.sync({ force: true })
+        .then(() => User.create({ name: 'FooBar' }))
+        .then(user => {
+          expect(user.name).to.be.equal('FooBar');
+          expect(user.code).to.be.equal(2020);    
+        });
+    });
+  }  
+
   it('should support logging', function() {
     const spy = sinon.spy();
 

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -620,6 +620,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             });
           });
         });
+
+        it('should return default value set by the database (upsert)', function() {      
+          const User = this.sequelize.define('User', {
+            name: { type: DataTypes.STRING, primaryKey: true },
+            code: { type: Sequelize.INTEGER, defaultValue: Sequelize.literal(2020) }
+          });
+    
+          return User.sync({ force: true })
+            .then(() => User.upsert({ name: 'Test default value' }, { returning: true }))
+            .then(([user, created]) => {
+              expect(user.name).to.be.equal('Test default value');
+              expect(user.code).to.be.equal(2020);
+              expect(created).to.be.true;
+            });
+        });
       }
     });
   }


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X]  Does the description below contain a link to an existing issue (Closes #12432 ) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

When using the MSSQL dialect, running Insert or Upsert operations, the mssql dialect is ignoring the values returned by OUTPUT INSERTED.* which can also include defaults values populated by the database or fields being updated by various triggers.

This is the sister to PR #21433 and solves the issue for Sequelize v5 as well