### PR TITLE
docs: fix typo in the associations docs

### DIFF
--- a/docs/manual/core-concepts/assocs.md
+++ b/docs/manual/core-concepts/assocs.md
@@ -287,8 +287,8 @@ const ActorMovies = sequelize.define('ActorMovies', {
     }
   }
 });
-Movie.belongsToMany(Actor, { through: 'ActorMovies' });
-Actor.belongsToMany(Movie, { through: 'ActorMovies' });
+Movie.belongsToMany(Actor, { through: ActorMovies });
+Actor.belongsToMany(Movie, { through: ActorMovies });
 ```
 
 The above yields the following SQL in PostgreSQL, which is equivalent to the one shown above:


### PR DESCRIPTION
The documentation under the `Associations` says that instead of a string
we can use a model directly but in the example still a string was used.