### PR TITLE
feat(types): Add ModelDefined type as syntactic sugar

### DIFF
--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -15,7 +15,9 @@ In order to avoid installation bloat for non TS users, you must install the foll
 
 Example of a minimal TypeScript project with strict type-checking for attributes.
 
-**NOTE:** Keep the following code in sync with `typescriptDocs/ModelInit.ts` to ensure it typechecks correctly.
+<!-- 
+**NOTE:** Keep the following code in sync with `/types/test/typescriptDocs/ModelInit.ts` to ensure it typechecks correctly.
+-->
 
 ```ts
 import {

--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -21,6 +21,7 @@ Example of a minimal TypeScript project with strict type-checking for attributes
 import {
   Sequelize,
   Model,
+  ModelDefined,
   DataTypes,
   HasManyGetAssociationsMixin,
   HasManyAddAssociationMixin,
@@ -104,6 +105,16 @@ class Address extends Model<AddressAttributes> implements AddressAttributes {
   public readonly updatedAt!: Date;
 }
 
+// You can also define modules in a functional way
+interface NoteAttributes {
+  id: number;
+  title: string;
+  content: string;
+}
+
+// You can also set multiple attributes optional at once
+interface NoteCreationAttributes extends Optional<NoteAttributes, 'id' | 'title'> {};
+
 Project.init(
   {
     id: {
@@ -161,6 +172,32 @@ Address.init(
   {
     tableName: "address",
     sequelize, // passing the `sequelize` instance is required
+  }
+);
+
+// And with a functional approach defining a module looks like this
+const Note: ModelDefined<
+  NoteAttributes, 
+  NoteCreationAttributes
+> = sequelize.define(
+  'Note',
+  {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    title: {
+      type: new DataTypes.STRING(64),
+      defaultValue: 'Unnamed Note',
+    },
+    content: {
+      type: new DataTypes.STRING(4096),
+      allowNull: false,
+    },
+  },
+  {
+    tableName: 'notes',
   }
 );
 

--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -177,7 +177,7 @@ Address.init(
 
 // And with a functional approach defining a module looks like this
 const Note: ModelDefined<
-  NoteAttributes, 
+  NoteAttributes,
   NoteCreationAttributes
 > = sequelize.define(
   'Note',

--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -15,9 +15,7 @@ In order to avoid installation bloat for non TS users, you must install the foll
 
 Example of a minimal TypeScript project with strict type-checking for attributes.
 
-<!-- 
 **NOTE:** Keep the following code in sync with `/types/test/typescriptDocs/ModelInit.ts` to ensure it typechecks correctly.
--->
 
 ```ts
 import {

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2849,6 +2849,8 @@ export type ModelType = typeof Model;
 // must come first for unknown reasons.
 export type ModelCtor<M extends Model> = typeof Model & { new(): M };
 
+export type ModelDefined<S, T> = ModelCtor<Model<S, T>>;
+
 export type ModelStatic<M extends Model> = { new(): M };
 
 export default Model;

--- a/types/test/typescriptDocs/ModelInit.ts
+++ b/types/test/typescriptDocs/ModelInit.ts
@@ -4,6 +4,7 @@
 import {
   Sequelize,
   Model,
+  ModelDefined,
   DataTypes,
   HasManyGetAssociationsMixin,
   HasManyAddAssociationMixin,
@@ -12,9 +13,9 @@ import {
   HasManyCountAssociationsMixin,
   HasManyCreateAssociationMixin,
   Optional,
-} from 'sequelize';
+} from "sequelize";
 
-const sequelize = new Sequelize('mysql://root:asd123@localhost:3306/mydb');
+const sequelize = new Sequelize("mysql://root:asd123@localhost:3306/mydb");
 
 // These are all the attributes in the User model
 interface UserAttributes {
@@ -24,7 +25,7 @@ interface UserAttributes {
 }
 
 // Some attributes are optional in `User.build` and `User.create` calls
-interface UserCreationAttributes extends Optional<UserAttributes, 'id'> {}
+interface UserCreationAttributes extends Optional<UserAttributes, "id"> {}
 
 class User extends Model<UserAttributes, UserCreationAttributes>
   implements UserAttributes {
@@ -60,7 +61,7 @@ interface ProjectAttributes {
   name: string;
 }
 
-interface ProjectCreationAttributes extends Optional<ProjectAttributes, 'id'> {}
+interface ProjectCreationAttributes extends Optional<ProjectAttributes, "id"> {}
 
 class Project extends Model<ProjectAttributes, ProjectCreationAttributes>
   implements ProjectAttributes {
@@ -87,6 +88,17 @@ class Address extends Model<AddressAttributes> implements AddressAttributes {
   public readonly updatedAt!: Date;
 }
 
+// You can also define modules in a functional way
+interface NoteAttributes {
+  id: number;
+  title: string;
+  content: string;
+}
+
+// You can also set multiple attributes optional at once
+interface NoteCreationAttributes
+  extends Optional<NoteAttributes, "id" | "title"> {}
+
 Project.init(
   {
     id: {
@@ -105,8 +117,8 @@ Project.init(
   },
   {
     sequelize,
-    tableName: 'projects',
-  },
+    tableName: "projects",
+  }
 );
 
 User.init(
@@ -126,9 +138,9 @@ User.init(
     },
   },
   {
-    tableName: 'users',
+    tableName: "users",
     sequelize, // passing the `sequelize` instance is required
-  },
+  }
 );
 
 Address.init(
@@ -142,30 +154,56 @@ Address.init(
     },
   },
   {
-    tableName: 'address',
+    tableName: "address",
     sequelize, // passing the `sequelize` instance is required
+  }
+);
+
+// And with a functional approach defining a module looks like this
+const Note: ModelDefined<
+  NoteAttributes,
+  NoteCreationAttributes
+> = sequelize.define(
+  "Note",
+  {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    title: {
+      type: new DataTypes.STRING(64),
+      defaultValue: "Unnamed Note",
+    },
+    content: {
+      type: new DataTypes.STRING(4096),
+      allowNull: false,
+    },
   },
+  {
+    tableName: "notes",
+  }
 );
 
 // Here we associate which actually populates out pre-declared `association` static and other methods.
 User.hasMany(Project, {
-  sourceKey: 'id',
-  foreignKey: 'ownerId',
-  as: 'projects', // this determines the name in `associations`!
+  sourceKey: "id",
+  foreignKey: "ownerId",
+  as: "projects", // this determines the name in `associations`!
 });
 
-Address.belongsTo(User, { targetKey: 'id' });
-User.hasOne(Address, { sourceKey: 'id' });
+Address.belongsTo(User, { targetKey: "id" });
+User.hasOne(Address, { sourceKey: "id" });
 
 async function doStuffWithUser() {
   const newUser = await User.create({
-    name: 'Johnny',
-    preferredName: 'John',
+    name: "Johnny",
+    preferredName: "John",
   });
   console.log(newUser.id, newUser.name, newUser.preferredName);
 
   const project = await newUser.createProject({
-    name: 'first!',
+    name: "first!",
   });
 
   const ourUser = await User.findByPk(1, {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

The current way to define a module in a functional way with Typescript works like this:

```ts
const Note: ModelCtor<
  Model<
    NoteAttributes, 
    NoteCreationAttributes
  >
> = sequelize.define(
  ...
);
```

However this approach is a bit much to write, and with the `ModelDefined` type it could be reduced to:

```ts
const Note: ModelDefined<
  NoteAttributes, 
  NoteCreationAttributes
> = sequelize.define(
  ...
);
```

It's just added syntactic sugar, that simplifies things.
Also there is no reference to `ModelCtor` nor a functional way with Typescript in the docs.

So another change is, I've added an example for defining models in a functional way in Typescript.