### PR TITLE
added support for queries made for columns with dot(.) in names

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1541,7 +1541,7 @@ class QueryGenerator {
               ? this.quoteAttribute(attr, options.model)
               : this.escape(attr);
         }
-        if (!_.isEmpty(options.include) && !attr.includes('.') && addTable) {
+        if (!_.isEmpty(options.include) && (!attr.includes('.') || options.dotnotation) && addTable) {
           attr = `${mainTableAs}.${attr}`;
         }
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

If Table has columns with dot(.) in names and doing a join with include, table name is not added to the column in select queries which raises potential issues in many scenarios. 
I am using Postgres with columns having dot(.) in name and two tables have that same column. When I am using include the query is giving error of ambiguous column as the table name is not prefixed in the query due to the dot(.).
