### PR TITLE
fix(mssql): upsert query with falsey values

### DIFF
--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -476,7 +476,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
        * Exclude NULL Composite PK/UK. Partial Composite clauses should also be excluded as it doesn't guarantee a single row
        */
       for (const key in clause) {
-        if (!clause[key]) {
+        if (typeof clause[key] === 'undefined' || clause[key] == null) {
           valid = false;
           break;
         }

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -70,7 +70,7 @@ if (current.dialect.name === 'mssql') {
       // the main purpose of this test is to validate this does not throw
       expectsql(this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable), {
         mssql:
-          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(N''Charlie'', 24, 0)) AS [test_table_source](Name, Age, IsOnline) ON [test_table_target].Name = [test_table_source].Name AND [test_table_target].IsOnline = [test_table_source].IsOnline WHEN MATCHED THEN UPDATE SET Age = 24 WHEN NOT MATCHED THEN INSERT (Name, Age, IsOnline) VALUES(N''Charlie'', 24, 0) OUTPUT $action, INSERTED.*;"
+          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(24)) AS [test_table_source]([Age]) ON [test_table_target].[Name] = [test_table_source].[Name] AND [test_table_target].[IsOnline] = [test_table_source].[IsOnline] WHEN MATCHED THEN UPDATE SET [test_table_target].[Name] = N'Charlie', [test_table_target].[Age] = 24, [test_table_target].[IsOnline] = 0 WHEN NOT MATCHED THEN INSERT ([Age]) VALUES(24) OUTPUT $action, INSERTED.*;"
       });
     });
 

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -4,6 +4,7 @@ const Support = require('../../support');
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
 const DataTypes = require('../../../../lib/data-types');
+const Op = require('../../../../lib/operators');
 const TableHints = require('../../../../lib/table-hints');
 const QueryGenerator = require('../../../../lib/dialects/mssql/query-generator');
 
@@ -60,8 +61,12 @@ if (current.dialect.name === 'mssql') {
         IsOnline: false
       };
 
+      const where = {
+        [Op.or]: whereValues
+      };
+
       // the main purpose of this test is to validate this does not throw
-      this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, whereValues, testTable);
+      this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable);
     });
 
     it('createDatabaseQuery with collate', function () {

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -23,7 +23,7 @@ if (current.dialect.name === 'mssql') {
       });
     });
 
-    it('upsertQuery with falsey values', async function () {
+    it('upsertQuery with falsey values', function () {
       let testTable = this.sequelize.define(
         'test_table',
         {
@@ -45,11 +45,23 @@ if (current.dialect.name === 'mssql') {
         }
       );
 
-      await testTable.upsert({
+      const insertValues = {
         Name: 'Charlie',
         Age: 24,
         IsOnline: false
-      });
+      };
+
+      const updateValues = {
+        Age: 24
+      };
+
+      const whereValues = {
+        Name: 'Charlie',
+        IsOnline: false
+      };
+
+      // the main purpose of this test is to validate this does not throw
+      this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, whereValues, testTable);
     });
 
     it('createDatabaseQuery with collate', function () {

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -3,6 +3,7 @@
 const Support = require('../../support');
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
+const DataTypes = require('../../../../lib/data-types');
 const TableHints = require('../../../../lib/table-hints');
 const QueryGenerator = require('../../../../lib/dialects/mssql/query-generator');
 
@@ -19,6 +20,35 @@ if (current.dialect.name === 'mssql') {
       expectsql(this.queryGenerator.createDatabaseQuery('myDatabase'), {
         mssql:
           "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'myDatabase' ) BEGIN CREATE DATABASE [myDatabase] ; END;"
+      });
+    });
+
+    it('upsertQuery with falsey values', async function () {
+      let testTable = this.sequelize.define(
+        'test_table',
+        {
+          Name: {
+            type: DataTypes.STRING,
+            primaryKey: true
+          },
+          Age: {
+            type: DataTypes.INTEGER
+          },
+          IsOnline: {
+            type: DataTypes.BOOLEAN,
+            primaryKey: true
+          }
+        },
+        {
+          freezeTableName: true,
+          timestamps: false
+        }
+      );
+
+      await testTable.upsert({
+        Name: 'Charlie',
+        Age: 24,
+        IsOnline: false
       });
     });
 

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -70,7 +70,7 @@ if (current.dialect.name === 'mssql') {
       // the main purpose of this test is to validate this does not throw
       expectsql(this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable), {
         mssql:
-          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(N''Charlie'', 24, 0)) AS [test_table_source](Name, Age, Online) ON [test_table_target].Name = [test_table_source].Name AND [test_table_target].Online = [test_table_source].Online WHEN MATCHED THEN UPDATE SET Age = 24 WHEN NOT MATCHED THEN INSERT (Name, Age, Online) VALUES(N''Charlie'', 24, 0) OUTPUT $action, INSERTED.*;"
+          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(N''Charlie'', 24, 0)) AS [test_table_source](Name, Age, IsOnline) ON [test_table_target].Name = [test_table_source].Name AND [test_table_target].IsOnline = [test_table_source].IsOnline WHEN MATCHED THEN UPDATE SET Age = 24 WHEN NOT MATCHED THEN INSERT (Name, Age, IsOnline) VALUES(N''Charlie'', 24, 0) OUTPUT $action, INSERTED.*;"
       });
     });
 

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -68,7 +68,9 @@ if (current.dialect.name === 'mssql') {
       };
 
       // the main purpose of this test is to validate this does not throw
-      this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable);
+      expectsql(this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable), {
+        mssql: ''
+      });
     });
 
     it('createDatabaseQuery with collate', function () {

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -56,10 +56,12 @@ if (current.dialect.name === 'mssql') {
         Age: 24
       };
 
-      const whereValues = {
-        Name: 'Charlie',
-        IsOnline: false
-      };
+      const whereValues = [
+        {
+          Name: 'Charlie',
+          IsOnline: false
+        }
+      ];
 
       const where = {
         [Op.or]: whereValues

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -69,7 +69,8 @@ if (current.dialect.name === 'mssql') {
 
       // the main purpose of this test is to validate this does not throw
       expectsql(this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable), {
-        mssql: ''
+        mssql:
+          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(N''Charlie'', 24, 0)) AS [test_table_source](Name, Age, Online) ON [test_table_target].Name = [test_table_source].Name AND [test_table_target].Online = [test_table_source].Online WHEN MATCHED THEN UPDATE SET Age = 24 WHEN NOT MATCHED THEN INSERT (Name, Age, Online) VALUES(N''Charlie'', 24, 0) OUTPUT $action, INSERTED.*;"
       });
     });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

properly determines if a value used in a filter clause for upsert is relevant. currently there is a bug where it treats "falsey" values as not being specified, making it impossible to use something like a default value of `0` in a unique key and then filter by that value. 

closes https://github.com/sequelize/sequelize/issues/11902
closes https://github.com/sequelize/sequelize/issues/11684