### PR TITLE
feat(query-interface): add support for defining composite foreign keys

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -697,11 +697,15 @@ class QueryGenerator {
         break;
       case 'FOREIGN KEY':
         const references = options.references;
-        if (!references || !references.table || !references.field) {
+        if (!references || !references.table || !(references.field || references.fields)) {
           throw new Error('references object with table and field must be specified');
         }
         constraintName = this.quoteIdentifier(options.name || `${tableName}_${fieldsSqlString}_${references.table}_fk`);
-        const referencesSnippet = `${this.quoteTable(references.table)} (${this.quoteIdentifier(references.field)})`;
+        const quotedReferences =
+          typeof references.field !== 'undefined'
+            ? this.quoteIdentifier(references.field)
+            : references.fields.map(f => this.quoteIdentifier(f)).join(', ');
+        const referencesSnippet = `${this.quoteTable(references.table)} (${quotedReferences})`;
         constraintSnippet = `CONSTRAINT ${constraintName} `;
         constraintSnippet += `FOREIGN KEY (${fieldsSqlQuotedString}) REFERENCES ${referencesSnippet}`;
         if (options.onUpdate) {

--- a/src/dialects/abstract/query-interface.js
+++ b/src/dialects/abstract/query-interface.js
@@ -692,16 +692,30 @@ class QueryInterface {
    *   onUpdate: 'cascade'
    * });
    *
-   * @param {string} tableName                  Table name where you want to add a constraint
-   * @param {object} options                    An object to define the constraint name, type etc
-   * @param {string} options.type               Type of constraint. One of the values in available constraints(case insensitive)
-   * @param {Array}  options.fields             Array of column names to apply the constraint over
-   * @param {string} [options.name]             Name of the constraint. If not specified, sequelize automatically creates a named constraint based on constraint type, table & column names
-   * @param {string} [options.defaultValue]     The value for the default constraint
-   * @param {object} [options.where]            Where clause/expression for the CHECK constraint
-   * @param {object} [options.references]       Object specifying target table, column name to create foreign key constraint
-   * @param {string} [options.references.table] Target table name
-   * @param {string} [options.references.field] Target column name
+   * @example <caption>Composite Foreign Key</caption>
+   * queryInterface.addConstraint('TableName', {
+   *   fields: ['source_column_name', 'other_source_column_name'],
+   *   type: 'foreign key',
+   *   name: 'custom_fkey_constraint_name',
+   *   references: { //Required field
+   *     table: 'target_table_name',
+   *     fields: ['target_column_name', 'other_target_column_name']
+   *   },
+   *   onDelete: 'cascade',
+   *   onUpdate: 'cascade'
+   * });
+   *
+   * @param {string} tableName                   Table name where you want to add a constraint
+   * @param {object} options                     An object to define the constraint name, type etc
+   * @param {string} options.type                Type of constraint. One of the values in available constraints(case insensitive)
+   * @param {Array}  options.fields              Array of column names to apply the constraint over
+   * @param {string} [options.name]              Name of the constraint. If not specified, sequelize automatically creates a named constraint based on constraint type, table & column names
+   * @param {string} [options.defaultValue]      The value for the default constraint
+   * @param {object} [options.where]             Where clause/expression for the CHECK constraint
+   * @param {object} [options.references]        Object specifying target table, column name to create foreign key constraint
+   * @param {string} [options.references.table]  Target table name
+   * @param {string} [options.references.field]  Target column name
+   * @param {string} [options.references.fields] Target column names for a composite primary key. Must match the order of fields in options.fields.
    *
    * @returns {Promise}
    */

--- a/test/unit/sql/add-constraint.test.js
+++ b/test/unit/sql/add-constraint.test.js
@@ -203,6 +203,25 @@ if (current.dialect.supports.constraints.addConstraint) {
           );
         });
 
+        it('supports composite keys', () => {
+          expectsql(
+            sql.addConstraintQuery('myTable', {
+              type: 'foreign key',
+              fields: ['myColumn', 'anotherColumn'],
+              references: {
+                table: 'myOtherTable',
+                fields: ['id1', 'id2']
+              },
+              onUpdate: 'cascade',
+              onDelete: 'cascade'
+            }),
+            {
+              default:
+                'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_anotherColumn_myOtherTable_fk] FOREIGN KEY ([myColumn], [anotherColumn]) REFERENCES [myOtherTable] ([id1], [id2]) ON UPDATE CASCADE ON DELETE CASCADE;'
+            }
+          );
+        });
+
         it('uses onDelete, onUpdate', () => {
           expectsql(
             sql.addConstraintQuery('myTable', {


### PR DESCRIPTION
Only in the query interface.  Extensive support for composite keys is the subject of #311; this is merely one step in the right direction.

### Pull Request check-list

- [yep] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [yep] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [yep] Have you added new tests to prevent regressions?
- [yep] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [can't] Did you update the typescript typings accordingly (if applicable)?
- [yep] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Added support for defining composite foreign keys using `queryInterface.addConstraint`. To accomplish this the `references` object was extended to support either the existing `field:string` pair or the new key `fields: string[]` pair - but not both.

Test was added, documentation updated.

I've attached a patch for the typescript definitions, but the entire typescript typings seem to have been deleted from master in commit 042cd693635ffba83ff7a2079974692af6f710a7.

[sequelize_composite-foreign-keys_type-change.patch.txt](https://github.com/sequelize/sequelize/files/4867004/sequelize_composite-foreign-keys_type-change.patch.txt)

