### PR TITLE
feat(model): Adding Option to Toggle Automatic Id Column Creation

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -228,6 +228,12 @@ class Model {
         throw new Error(`A column called 'id' was added to the attributes of '${this.tableName}' but not marked with 'primaryKey: true'`);
       }
 
+      if (!this.options.generatePrimaryKey) {
+        // don't do anything further or it will
+        // implement an id column that we don't want
+        return;
+      }
+
       head = {
         id: {
           type: new DataTypes.INTEGER(),
@@ -910,6 +916,7 @@ class Model {
    * @param {string}                  [options.charset] Specify charset for model's table
    * @param {string}                  [options.comment] Specify comment for model's table
    * @param {string}                  [options.collate] Specify collation for model's table
+   * @param {boolean}                 [options.generatePrimaryKey] It will generate a primary key with column name id, if no other primary key was found and this boolean is set to true.
    * @param {string}                  [options.initialAutoIncrement] Set the initial AUTO_INCREMENT value for the table in MySQL.
    * @param {object}                  [options.hooks] An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, validationFailed, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, beforeSave, afterDestroy, afterUpdate, afterBulkCreate, afterSave, afterBulkDestroy and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions.
    * @param {object}                  [options.validate] An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error.
@@ -961,6 +968,7 @@ class Model {
       defaultScope: {},
       scopes: {},
       indexes: [],
+      generatePrimaryKey: true,
       ...options
     };
 

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -73,14 +73,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('should not create primary key with generatePrimaryKey false', () => {
-      const baz = current.define('bar', {
-        name: {
-          type: DataTypes.INTEGER.UNSIGNED
+      const baz = current.define('bar', 
+        {
+          name: {
+            type: DataTypes.INTEGER.UNSIGNED
+          },
         },
         {
           generatePrimaryKey: false,
         }
-      });
+      );
 
       expect(baz.rawAttributes.id).to.equal(undefined);
     });

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -72,6 +72,19 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       }).to.throw('Unrecognized datatype for attribute "bar.name"');
     });
 
+    it('should not create primary key with generatePrimaryKey false', () => {
+      const baz = current.define('bar', {
+        name: {
+          type: DataTypes.INTEGER.UNSIGNED
+        },
+        {
+          generatePrimaryKey: false,
+        }
+      });
+
+      expect(baz.rawAttributes.id).to.equal(undefined);
+    });
+
     it('should throw for notNull validator without allowNull', () => {
       expect(() => {
         current.define('user', {

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -77,10 +77,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         {
           name: {
             type: DataTypes.INTEGER.UNSIGNED
-          },
+          }
         },
         {
-          generatePrimaryKey: false,
+          generatePrimaryKey: false
         }
       );
 

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1372,13 +1372,13 @@ export interface ModelOptions<M extends Model = Model> {
    * Define the default search scope to use for this model. Scopes have the same form as the options passed to
    * find / findAll.
    */
-  defaultScope?: FindOptions<M['_attributes']>;
+  defaultScope?: FindOptions<M["_attributes"]>;
 
   /**
    * More scopes, defined in the same way as defaultScope above. See `Model.scope` for more information about
    * how scopes are defined, and what you can do with them
    */
-  scopes?: ModelScopeOptions<M['_attributes']>;
+  scopes?: ModelScopeOptions<M["_attributes"]>;
 
   /**
    * Don't persits null values. This means that all columns with null values will not be saved.
@@ -1469,6 +1469,12 @@ export interface ModelOptions<M extends Model = Model> {
   collate?: string;
 
   /**
+   * It will generate a primary key with column name id,
+   * if no other primary key was found and this boolean is set to true.
+   */
+  generatePrimaryKey?: boolean;
+
+  /**
    * Set the initial AUTO_INCREMENT value for the table in MySQL.
    */
   initialAutoIncrement?: string;
@@ -1478,7 +1484,7 @@ export interface ModelOptions<M extends Model = Model> {
    * See Hooks for more information about hook
    * functions and their signatures. Each property can either be a function, or an array of functions.
    */
-  hooks?: Partial<ModelHooks<M, M['_attributes']>>;
+  hooks?: Partial<ModelHooks<M, M["_attributes"]>>;
 
   /**
    * An object of model wide validations. Validations have access to all model values via `this`. If the


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Resolves #11830 

This adds the option to disable the automatic creation of an id column which is the primary key, if no primary key was set in the model initialization. 

Related Issues: #7800 #12096 #12092 #12242 #12288