### PR TITLE
fix(mssql): upsert query with falsey values (#12453)

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -465,7 +465,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
        * Exclude NULL Composite PK/UK. Partial Composite clauses should also be excluded as it doesn't guarantee a single row
        */
       for (const key in clause) {
-        if (!clause[key]) {
+        if (typeof clause[key] === 'undefined' || clause[key] == null) {
           valid = false;
           break;
         }

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -3,6 +3,8 @@
 const Support = require('../../support');
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
+const DataTypes = require('../../../../lib/data-types');
+const Op = require('../../../../lib/operators');
 const TableHints = require('../../../../lib/table-hints');
 const QueryGenerator = require('../../../../lib/dialects/mssql/query-generator');
 
@@ -18,6 +20,56 @@ if (current.dialect.name === 'mssql') {
     it('createDatabaseQuery', function() {
       expectsql(this.queryGenerator.createDatabaseQuery('myDatabase'), {
         mssql: "IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = 'myDatabase' ) BEGIN CREATE DATABASE [myDatabase] ; END;"
+      });
+    });
+
+    it('upsertQuery with falsey values', function() {
+      const testTable = this.sequelize.define(
+        'test_table',
+        {
+          Name: {
+            type: DataTypes.STRING,
+            primaryKey: true
+          },
+          Age: {
+            type: DataTypes.INTEGER
+          },
+          IsOnline: {
+            type: DataTypes.BOOLEAN,
+            primaryKey: true
+          }
+        },
+        {
+          freezeTableName: true,
+          timestamps: false
+        }
+      );
+
+      const insertValues = {
+        Name: 'Charlie',
+        Age: 24,
+        IsOnline: false
+      };
+
+      const updateValues = {
+        Age: 24
+      };
+
+      const whereValues = [
+        {
+          Name: 'Charlie',
+          IsOnline: false
+        }
+      ];
+
+      const where = {
+        [Op.or]: whereValues
+      };
+
+      // the main purpose of this test is to validate this does not throw
+      expectsql(this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable), {
+        mssql:
+          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(24)) AS [test_table_source]([Age]) ON [test_table_target].[Name] = [test_table_source].[Name] AND [test_table_target].[IsOnline] = [test_table_source].[IsOnline] WHEN MATCHED THEN UPDATE SET [test_table_target].[Name] = N'Charlie', [test_table_target].[Age] = 24, [test_table_target].[IsOnline] = 0 WHEN NOT MATCHED THEN INSERT ([Age]) VALUES(24) OUTPUT $action, INSERTED.*;"
       });
     });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

cherry-pick of #12453 

properly determines if a value used in a filter clause for upsert is relevant. currently there is a bug where it treats "falsey" values as not being specified, making it impossible to use something like a default value of `0` in a unique key and then filter by that value. 

closes https://github.com/sequelize/sequelize/issues/11902
closes https://github.com/sequelize/sequelize/issues/11684