### PR TITLE
SRID support under MySQL 8.0 & compatible with 5.7

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -792,7 +792,7 @@ class ARRAY extends ABSTRACT {
  * GeoJSON is accepted as input and returned as output.
  *
  * In PostGIS, the GeoJSON is parsed using the PostGIS function `ST_GeomFromGeoJSON`.
- * In MySQL it is parsed using the function `GeomFromText`.
+ * In MySQL it is parsed using the function `ST_GeomFromText`.
  *
  * Therefore, one can just follow the [GeoJSON spec](https://tools.ietf.org/html/rfc7946) for handling geometry objects.  See the following examples:
  *
@@ -844,10 +844,16 @@ class GEOMETRY extends ABSTRACT {
     this.srid = options.srid;
   }
   _stringify(value, options) {
-    return `GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    if (this.srid) {
+      return `ST_GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())}, ${this.srid})`;
+    }
+    return `ST_GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
   _bindParam(value, options) {
-    return `GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    if (this.srid) {
+      return `ST_GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())}, ${this.srid})`;
+    }
+    return `ST_GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
 }
 
@@ -887,10 +893,16 @@ class GEOGRAPHY extends ABSTRACT {
     this.srid = options.srid;
   }
   _stringify(value, options) {
-    return `GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    if (this.srid) {
+      return `ST_GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())}, ${this.srid})`;
+    }
+    return `ST_GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
   _bindParam(value, options) {
-    return `GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    if (this.srid) {
+      return `ST_GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())}, ${this.srid})`;
+    }
+    return `ST_GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
 }
 

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -113,6 +113,12 @@ module.exports = BaseTypes => {
       return wkx.Geometry.parse(value).toGeoJSON({ shortCrs: true });
     }
     toSql() {
+      if (typeof this.srid !== 'undefined') {
+        // According to the documentation examples the format is: POINT NOT NULL SRID 4326
+        // however in practise the order of NOT NULL and the SRID specification doesn't seem to matter.
+        // Using the /*!80003 ... */ syntax is for backwards compat with MySQL versions before 8.0: MySQL 5.7 doesn't support SRIDs on table columns.
+        return `${this.sqlType} /*!80003 SRID ${this.srid} */`;
+      }
       return this.sqlType;
     }
   }

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -1460,7 +1460,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         testsql('GEOMETRY(\'POINT\',4326)', DataTypes.GEOMETRY('POINT', 4326), {
           postgres: 'GEOMETRY(POINT,4326)',
           mariadb: 'POINT',
-          mysql: 'POINT'
+          mysql: 'POINT /*!80003 SRID 4326 */'
         });
       });
     }


### PR DESCRIPTION
### Pull Request check-list

- [yep] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [yep] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [yep] Have you added new tests to prevent regressions?
- [minor, but yep] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [can't] Did you update the typescript typings accordingly (if applicable)?
- [yep] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Closes #9786.

While it's true that MySQL 8.0 still isn't fully supported, several tests are failing under 8.0, this at least makes the SRID functionality work better.

The goal here was to be able to define and use columns that have SRIDs. All tests still pass under MySQL 5.7, and a few more pass under MySQL 8.0.

These changes, especially the ST_GeomFromText change, have been hacks the community has been doing for some time, as can be seen at https://github.com/sequelize/sequelize/issues/9786#issuecomment-474122602 - I've simply made them core and kept backwards compat.