### PR TITLE
fix: use lodash _baseIsNative directly instead of _.isNative (#12358)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 const DataTypes = require('./data-types');
 const SqlString = require('./sql-string');
 const _ = require('lodash');
+const baseIsNative = require('lodash/_baseIsNative');
 const uuidv1 = require('uuid').v1;
 const uuidv4 = require('uuid').v4;
 const operators = require('./operators');
@@ -51,7 +52,9 @@ function mergeDefaults(a, b) {
   return _.mergeWith(a, b, (objectValue, sourceValue) => {
     // If it's an object, let _ handle it this time, we will be called again for each property
     if (!_.isPlainObject(objectValue) && objectValue !== undefined) {
-      if (_.isFunction(objectValue) && _.isNative(objectValue)) {
+      // _.isNative includes a check for core-js and throws an error if present.
+      // Depending on _baseIsNative bypasses the core-js check.
+      if (_.isFunction(objectValue) && baseIsNative(objectValue)) {
         return sourceValue || objectValue;
       }
       return objectValue;


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change
Cherry-pick of #12475 for v6 release.
Closes #12358 

Lodash throws an error when calling _.isNative if core-js has been loaded because some of its shims can interfere with lodash's ability to accurate determine if a particular function is a native function or not. Using the _baseIsNative module directly bypasses the core-js check in lodash without requiring a custom implementation if the native function detection.

I didn't add any new unit test to validate that an error isn't thrown when core-js shims are loaded because I wasn't sure if you wanted an extra dev dependency for that. I also wasn't sure since Mocha doesn't isolate each test file to a separate process if you wanted the core-js loaded for all tests since that could in theory mask some other problem when core-js is not present.