### PR TITLE
fix: mark database drivers as optional peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,26 @@
     "tedious": "8.3.0",
     "typescript": "^3.9.3"
   },
+  "peerDependenciesMeta": {
+    "pg": {
+      "optional": true
+    },
+    "pg-hstore": {
+      "optional": true
+    },
+    "mysql2": {
+      "optional": true
+    },
+    "mariadb": {
+      "optional": true
+    },
+    "sqlite3": {
+      "optional": true
+    },
+    "tedious": {
+      "optional": true
+    }
+  },
   "keywords": [
     "mysql",
     "mariadb",


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
When using yarn 2 and PnP, it will throw an error because sequelize is trying to access the database drivers without listing them as direct dependencies/peerDependencies in package.json

```sh
(node:13140) [MODULE_NOT_FOUND] Error: sequelize tried to access mysql2, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```

Since we don't want to list them as direct dependencies, we can fix this error by listing all the database drivers as optional peer dependencies using the new `peerDependenciesMeta` field.