### PR TITLE
fix(upsert): set isNewRecord to false when upserting (#12447)

### DIFF
--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -96,7 +96,7 @@ class Query extends AbstractQuery {
       return data.affectedRows;
     }
     if (this.isUpsertQuery()) {
-      return [null, data.affectedRows === 1];
+      return [result, data.affectedRows === 1];
     }
     if (this.isInsertQuery(data)) {
       this.handleInsertQuery(data);

--- a/lib/model.js
+++ b/lib/model.js
@@ -2469,6 +2469,9 @@ class Model {
     }
     const result = await this.queryInterface.upsert(this.getTableName(options), insertValues, updateValues, instance.where(), options);
 
+    const [record] = result;
+    record.isNewRecord = false;
+
     if (options.hooks) {
       await this.runHooks('afterUpsert', result, options);
       return result;

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -85,6 +85,12 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       expect(user.isNewRecord).to.not.be.ok;
     });
 
+    it('returns false for upserted objects', async function() {
+      // adding id here so MSSQL doesn't fail. It needs a primary key to upsert
+      const [user] = await this.User.upsert({ id: 2, username: 'user' });
+      expect(user.isNewRecord).to.not.be.ok;
+    });
+
     it('returns false for objects found by find method', async function() {
       await this.User.create({ username: 'user' });
       const user = await this.User.create({ username: 'user' });

--- a/test/unit/model/upsert.test.js
+++ b/test/unit/model/upsert.test.js
@@ -43,7 +43,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       beforeEach(function() {
         this.query = sinon.stub(current, 'query').resolves();
-        this.stub = sinon.stub(current.getQueryInterface(), 'upsert').resolves([true, undefined]);
+        this.stub = sinon.stub(current.getQueryInterface(), 'upsert').resolves([this.User.build(), true]);
       });
 
       afterEach(function() {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Cherry picked #12447 into v6