### PR TITLE
refactor: replace util.defaults with native spread

### DIFF
--- a/src/dialects/abstract/query-generator/helpers/quote.js
+++ b/src/dialects/abstract/query-generator/helpers/quote.js
@@ -32,13 +32,14 @@ const postgresReservedWords = 'all,analyse,analyze,and,any,array,as,asc,asymmetr
  * @returns {string}
  * @private
  */
-function quoteIdentifier(dialect, identifier, options) {
+function quoteIdentifier(dialect, identifier, options = {}) {
   if (identifier === '*') return identifier;
 
-  options = Utils.defaults(options || {}, {
+  options = {
+    ...options,
     force: false,
     quoteIdentifiers: true
-  });
+  };
 
   switch (dialect) {
     case 'sqlite':

--- a/src/model.js
+++ b/src/model.js
@@ -2331,7 +2331,7 @@ class Model {
     if (instance === null) {
       values = { ...options.defaults };
       if (_.isPlainObject(options.where)) {
-        values = Utils.defaults(values, options.where);
+        values = { ...options.where, ...values };
       }
 
       instance = this.build(values, options);
@@ -2395,14 +2395,14 @@ class Model {
       transaction = t;
       options.transaction = t;
 
-      const found = await this.findOne(Utils.defaults({ transaction }, options));
+      const found = await this.findOne({ ...options, transaction });
       if (found !== null) {
         return [found, false];
       }
 
       values = { ...options.defaults };
       if (_.isPlainObject(options.where)) {
-        values = Utils.defaults(values, options.where);
+        values = { ...options.where, ...values };
       }
 
       options.exception = true;
@@ -2445,14 +2445,10 @@ class Model {
         }
 
         // Someone must have created a matching instance inside the same transaction since we last did a find. Let's find it!
-        const otherCreated = await this.findOne(
-          Utils.defaults(
-            {
-              transaction: internalTransaction ? null : transaction
-            },
-            options
-          )
-        );
+        const otherCreated = await this.findOne({
+          ...options,
+          transaction: internalTransaction ? null : transaction
+        });
 
         // Sanity check, ideally we caught this at the defaultFeilds/err.fields check
         // But if we didn't and instance is null, we will throw
@@ -2487,7 +2483,7 @@ class Model {
 
     let values = { ...options.defaults };
     if (_.isPlainObject(options.where)) {
-      values = Utils.defaults(values, options.where);
+      values = { ...options.where, ...values };
     }
 
     const found = await this.findOne(options);
@@ -3498,11 +3494,13 @@ class Model {
     this._injectScope(options);
     this._optionsMustContainWhere(options);
 
-    options = Utils.defaults({}, options, {
+    options = {
       by: 1,
       where: {},
-      increment: true
-    });
+      increment: true,
+      ...options
+    };
+
     const isSubtraction = !options.increment;
 
     Utils.mapOptionFieldNames(options, this);
@@ -4310,15 +4308,11 @@ class Model {
    * @returns {Promise<Model>}
    */
   async reload(options) {
-    options = Utils.defaults(
-      {
-        where: this.where()
-      },
-      options,
-      {
-        include: this._options.include || undefined
-      }
-    );
+    options = {
+      include: this._options.include || undefined,
+      ...options,
+      where: this.where()
+    };
 
     const reloaded = await this.constructor.findOne(options);
     if (!reloaded) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -570,42 +570,6 @@ function camelizeObjectKeys(obj) {
 exports.camelizeObjectKeys = camelizeObjectKeys;
 
 /**
- * Assigns own and inherited enumerable string and symbol keyed properties of source
- * objects to the destination object.
- *
- * https://lodash.com/docs/4.17.4#defaults
- *
- * **Note:** This method mutates `object`.
- *
- * @param {object} object The destination object.
- * @param {...object} [sources] The source objects.
- * @returns {object} Returns `object`.
- * @private
- */
-function defaults(object, ...sources) {
-  object = Object(object);
-
-  sources.forEach(source => {
-    if (source) {
-      source = Object(source);
-
-      getComplexKeys(source).forEach(key => {
-        const value = object[key];
-        if (
-          value === undefined ||
-          (_.eq(value, Object.prototype[key]) && !Object.prototype.hasOwnProperty.call(object, key))
-        ) {
-          object[key] = source[key];
-        }
-      });
-    }
-  });
-
-  return object;
-}
-exports.defaults = defaults;
-
-/**
  *
  * @param {object} index
  * @param {Array}  index.fields

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -55,28 +55,6 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
     });
   });
 
-  describe('defaults', () => {
-    it('defaults normal object', () => {
-      expect(Utils.defaults({ a: 1, c: 3 }, { b: 2 }, { c: 4, d: 4 })).to.eql({
-        a: 1,
-        b: 2,
-        c: 3,
-        d: 4
-      });
-    });
-
-    it('defaults symbol keys', () => {
-      expect(
-        Utils.defaults({ a: 1, [Symbol.for('c')]: 3 }, { b: 2 }, { [Symbol.for('c')]: 4, [Symbol.for('d')]: 4 })
-      ).to.eql({
-        a: 1,
-        b: 2,
-        [Symbol.for('c')]: 3,
-        [Symbol.for('d')]: 4
-      });
-    });
-  });
-
   describe('mapFinderOptions', () => {
     it('virtual attribute dependencies', () => {
       expect(


### PR DESCRIPTION
#4525 # Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ]  Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change

Replaces Utils.defaults with native spread, this should be none breaking and much faster than the custom implementation.
Minor caveat is that this will *also* copy non sequelize symbols, this should have no effects however.