### PR TITLE
fix(scopes): overwrite order correctly when merging scopes

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -865,7 +865,11 @@ class Model {
 
   static _mergeFunction(objValue, srcValue, key) {
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
-      return _.union(objValue, srcValue);
+      if (['where', 'include'].indexOf(key) >= 0) {
+        return _.union(objValue, srcValue);
+      }
+
+      return srcValue;
     }
     if (key === 'where' || key === 'having') {
       if (srcValue instanceof Utils.SequelizeMethod) {

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -379,6 +379,51 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ]
       });
     });
+
+    it('should join subsequent scopes when where or include', () => {
+      Company.addScope('scope', {
+        include: [{ model: Project, where: { something: false, somethingElse: 99 } }],
+        where: { something: false }
+      });
+      Company.addScope('otherScope', {
+        include: [{ model: Project, limit: 1 }],
+        where: { somethingElse: true }
+      });
+      expect(Company.scope(['scope', 'otherScope'])._scope).to.deep.equal({
+        include: [
+          {
+            model: Project,
+            where: { something: false, somethingElse: 99 },
+            limit: 1
+          }
+        ],
+        where: {
+          something: false,
+          somethingElse: true
+        }
+      });
+    });
+
+    it('should not join subsequent scopes when not where or include', () => {
+      Company.addScope('orderScope', {
+        order: [
+          ['field1', 'ASC'],
+          ['field2', 'ASC']
+        ]
+      });
+      Company.addScope('otherOrderScope', {
+        order: [
+          ['field1', 'DESC'],
+          ['field2', 'DESC']
+        ]
+      });
+      expect(Company.scope(['orderScope', 'otherOrderScope'])._scope).to.deep.equal({
+        order: [
+          ['field1', 'DESC'],
+          ['field2', 'DESC']
+        ]
+      });
+    });
   });
 
   describe('_injectScope', () => {


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This PR closes #11415. I changed the `mergeFunction` to do the union only when "where" or "include". Otherwise, it will just return the `srcValue`
