### PR TITLE
fix(typings): added 'includeIgnoreAttributes' to FindOptions typing

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1654,6 +1654,7 @@ class Model {
    * @param  {Transaction}                                               [options.transaction] Transaction to run query under
    * @param  {string|object}                                             [options.lock] Lock the selected rows. Possible options are transaction.LOCK.UPDATE and transaction.LOCK.SHARE. Postgres also supports transaction.LOCK.KEY_SHARE, transaction.LOCK.NO_KEY_UPDATE and specific model locks with joins.
    * @param  {boolean}                                                   [options.skipLocked] Skip locked rows. Only supported in Postgres.
+   * @param  {boolean}                                                   [options.includeIgnoreAttributes] Exclude all attributes from included tables
    * @param  {boolean}                                                   [options.raw] Return raw result. See sequelize.query for more information.
    * @param  {Function}                                                  [options.logging=false] A function that gets executed while running the query to log the sql.
    * @param  {boolean}                                                   [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -561,6 +561,11 @@ export interface FindOptions<TAttributes = any>
   skipLocked?: boolean;
 
   /**
+   * Exclude all attributes from included tables
+   */
+  includeIgnoreAttributes?: boolean;
+
+  /**
    * Return raw result. See sequelize.query for more information.
    */
   raw?: boolean;


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Added the 'includeIgnoreAttributes' option to the Model.findAll documentation and to the FindOptions typing as it was missing from both.