### PR TITLE
fix(model): Change charset by model options (#12534, #12273)

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -436,6 +436,7 @@ class Sequelize {
   define(modelName, attributes, options = {}) {
     options.modelName = modelName;
     options.sequelize = this;
+    options.sequelize.options.charset = options.charset;
 
     const model = class extends Model {};
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -33,6 +33,15 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       expect(DAO.options.underscored).to.be.ok;
     });
 
+    it('should change charset when came from model options', () => {
+      const sequelize = Support.createSequelizeInstance({
+          define: { charset: 'utf8' }
+        }),
+        DAO = sequelize.define('dao', { name: DataTypes.STRING }, { charset: 'utf8mb4' });
+
+      expect(DAO.options.charset).to.equal('utf8mb4');
+    });
+
     it('should correctly set the host and the port', () => {
       const sequelize = Support.createSequelizeInstance({
         host: '127.0.0.1',

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -29,6 +29,12 @@ if (dialect === 'mysql') {
           arguments: ['myDatabase', { charset: 'utf8mb4', collate: 'utf8mb4_unicode_ci' }],
           expectation:
             "CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT CHARACTER SET 'utf8mb4' DEFAULT COLLATE 'utf8mb4_unicode_ci';"
+        },
+        {
+          context: { options: { charset: 'utf8' } },
+          arguments: ['myDatabase', { charset: 'utf8mb4', collate: 'utf8mb4_general_ci' }],
+          expectation:
+            "CREATE DATABASE IF NOT EXISTS `myDatabase` DEFAULT CHARACTER SET 'utf8mb4' DEFAULT COLLATE 'utf8mb4_general_ci';"
         }
       ],
       dropDatabaseQuery: [


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Setting sequelize charset if is set on model options.

Close those issues  #12534 #12273 
