### PR TITLE
mark instances as non-new after reloading 

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -4333,6 +4333,7 @@ class Model {
       raw: true,
       reset: true && !options.attributes
     });
+    this.isNewRecord = false;
 
     return this;
   }

--- a/test/unit/instance/reload.test.js
+++ b/test/unit/instance/reload.test.js
@@ -45,6 +45,12 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
           instance.reload();
         }).to.not.throw();
       });
+
+      it('should mark reloaded records as non-new / persisted', async () => {
+        instance = Model.build({ id: 1 }, { isNewRecord: true });
+        await instance.reload();
+        expect(instance.isNewRecord).to.be.false;
+      });
     });
   });
 });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? *does not modify APIs*
- [x] Did you update the typescript typings accordingly (if applicable)? *not applicable*
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
[Associated issue](#12539)

Sets isNewRecord to false in reload function. If an instance is reloaded it is not new, since it was just pulled from the database.

I wasn't sure if I should be modifying other properties (e.g. `is_new`), so I opted for the smaller change. If there need to be more changes here feel free to let me know or add them.