### PR TITLE
fix(model): V6 unique composite index upsert

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2673,8 +2673,29 @@ class Model {
           options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
           // Get primary keys for postgres to enable updateOnDuplicate
           options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
+          const onConflictKeys = model._indexes.reduce((acc, modelIndex) => {
+            if (modelIndex.unique) {
+              modelIndex.fields.forEach(uniqueKey => {
+                acc.push(uniqueKey);
+              });
+            }
+
+            return acc;
+          }, []);
+
           if (Object.keys(model.uniqueKeys).length > 0) {
-            options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length >= 1).map(c => c.fields).reduce(c => c[0]).value();
+            const restOnConflictKeys = _.chain(model.uniqueKeys)
+              .values()
+              .filter(c => c.fields.length >= 1)
+              .map(c => c.fields)
+              .reduce(c => c[0])
+              .value();
+
+            onConflictKeys.push(...restOnConflictKeys);
+          }
+
+          if (onConflictKeys.length > 0) {
+            options.upsertKeys = onConflictKeys;
           }
         }
 

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -638,7 +638,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(people[1].name).to.equal('Bob');
           });
 
-          it('when the primary key column names and model field names are different and have composite unique index constraints', async function () {
+          it('when the primary key column names and model field names are different and have composite unique index constraints', async function() {
             const Person = this.sequelize.define(
               'Person',
               {

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -638,6 +638,66 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(people[1].name).to.equal('Bob');
           });
 
+          it('when the primary key column names and model field names are different and have composite unique index constraints', async function () {
+            const Person = this.sequelize.define(
+              'Person',
+              {
+                id: {
+                  type: DataTypes.INTEGER,
+                  allowNull: false,
+                  primaryKey: true,
+                  field: 'id'
+                },
+                systemId: {
+                  type: DataTypes.INTEGER,
+                  allowNull: false,
+                  field: 'system_id'
+                },
+                system: {
+                  type: DataTypes.STRING,
+                  allowNull: false,
+                  field: 'system'
+                },
+                name: {
+                  type: DataTypes.STRING,
+                  allowNull: false,
+                  field: 'name'
+                }
+              },
+              {
+                indexes: [
+                  {
+                    unique: true,
+                    fields: ['system_id', 'system']
+                  }
+                ]
+              }
+            );
+
+            await Person.sync({ force: true });
+            const inserts = [{ id: 1, systemId: 1, system: 'system1', name: 'Alice' }];
+            const people0 = await Person.bulkCreate(inserts);
+            expect(people0.length).to.equal(1);
+            expect(people0[0].systemId).to.equal(1);
+            expect(people0[0].system).to.equal('system1');
+            expect(people0[0].name).to.equal('Alice');
+
+            const updates = [
+              { id: 1, systemId: 1, system: 'system1', name: 'CHANGED NAME' },
+              { id: 2, systemId: 1, system: 'system2', name: 'Bob' }
+            ];
+
+            const people = await Person.bulkCreate(updates, {
+              updateOnDuplicate: ['systemId', 'system', 'name']
+            });
+            expect(people.length).to.equal(2);
+            expect(people[0].systemId).to.equal(1);
+            expect(people[0].system).to.equal('system1');
+            expect(people[0].name).to.equal('CHANGED NAME');
+            expect(people[1].systemId).to.equal(1);
+            expect(people[1].system).to.equal('system2');
+            expect(people[1].name).to.equal('Bob');
+          });
         });
 
 


### PR DESCRIPTION
Currently updateOnDuplicate for unique index and indexes do not work. This PR solves this issue.

This is following the conversation in this PR: #12516