### PR TITLE
add dataTypes configuration when new sequelize. it can conver default data parser function

### DIFF
--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -65,11 +65,18 @@ class ConnectionManager extends AbstractConnectionManager {
 
     // Set parsers for normal data types
     dataType.types.postgres.forEach(name => {
-      if (!this.nameOidMap[name]) return;
-      this.oidParserMap.set(this.nameOidMap[name].oid, parser);
-
-      if (!this.nameOidMap[name].arrayOid) return;
-      this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParser);
+      if(this.sequelize.options.dataTypes && this.sequelize.options.dataTypes[name] && typeof this.sequelize.options.dataTypes[name].parser ==='function'){
+        const optionsParser = this.sequelize.options.dataTypes[name].parser
+        if (! this.nameOidMap[name]) return;
+        this.oidParserMap.set(this.nameOidMap[name].oid, optionsParser);
+        if (! this.nameOidMap[name].arrayOid) return;
+        this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParserBuilder(optionsParser));
+      }else{
+        if (! this.nameOidMap[name]) return;
+        this.oidParserMap.set(this.nameOidMap[name].oid, parser);
+        if (! this.nameOidMap[name].arrayOid) return;
+        this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParser);
+      }
     });
   }
 

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -113,6 +113,7 @@ class Sequelize {
    *     idle: 30000,
    *     acquire: 60000,
    *   },
+   *   // dataTypes configuration: you can conver datatpye parser function   
    *   dataTypes: {
    *     geometry: {
    *      parser: function(value) {

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -113,7 +113,13 @@ class Sequelize {
    *     idle: 30000,
    *     acquire: 60000,
    *   },
-   *
+   *   dataTypes: {
+   *     geometry: {
+   *      parser: function(value) {
+   *        return value
+   *      } 
+   *    }
+   *   }
    *   // isolation level of each transaction
    *   // defaults to dialect default
    *   isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ


### PR DESCRIPTION
I get geometry as geojson when I execute 'select * from testtable' on postgresql. But I want to get WKB geometry and i don't know the geom column. the geometry default parser function is  convet data to geojson type. so I  think of way to add datatypes configuration on sequelize constructor.

default result:
![image](https://user-images.githubusercontent.com/26038018/88776208-44ff6f80-d1b8-11ea-9b14-5355b6ac0108.png)
the dataTypes config:
![image](https://user-images.githubusercontent.com/26038018/88776310-606a7a80-d1b8-11ea-8bb0-dfe997cffd4f.png)

use dataTypes result: 
![image](https://user-images.githubusercontent.com/26038018/88776087-197c8500-d1b8-11ea-9395-41819e39912c.png)

