### PR TITLE
add dataTypes configuration when new sequelize. it can conver default data parser function. (#12564)

### DIFF
--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -65,11 +65,18 @@ class ConnectionManager extends AbstractConnectionManager {
 
     // Set parsers for normal data types
     dataType.types.postgres.forEach(name => {
-      if (!this.nameOidMap[name]) return;
-      this.oidParserMap.set(this.nameOidMap[name].oid, parser);
-
-      if (!this.nameOidMap[name].arrayOid) return;
-      this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParser);
+      if(this.sequelize.options.dataTypes && this.sequelize.options.dataTypes[name] && typeof this.sequelize.options.dataTypes[name].parser ==='function'){
+        const optionsParser = this.sequelize.options.dataTypes[name].parser
+        if (! this.nameOidMap[name]) return;
+        this.oidParserMap.set(this.nameOidMap[name].oid, optionsParser);
+        if (! this.nameOidMap[name].arrayOid) return;
+        this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParserBuilder(optionsParser));
+      }else{
+        if (! this.nameOidMap[name]) return;
+        this.oidParserMap.set(this.nameOidMap[name].oid, parser);
+        if (! this.nameOidMap[name].arrayOid) return;
+        this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParser);
+      }
     });
   }
 

--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -65,16 +65,20 @@ class ConnectionManager extends AbstractConnectionManager {
 
     // Set parsers for normal data types
     dataType.types.postgres.forEach(name => {
-      if(this.sequelize.options.dataTypes && this.sequelize.options.dataTypes[name] && typeof this.sequelize.options.dataTypes[name].parser ==='function'){
-        const optionsParser = this.sequelize.options.dataTypes[name].parser
-        if (! this.nameOidMap[name]) return;
+      if (
+        this.sequelize.options.dataTypes &&
+        this.sequelize.options.dataTypes[name] &&
+        typeof this.sequelize.options.dataTypes[name].parser === 'function'
+      ) {
+        const optionsParser = this.sequelize.options.dataTypes[name].parser;
+        if (!this.nameOidMap[name]) return;
         this.oidParserMap.set(this.nameOidMap[name].oid, optionsParser);
-        if (! this.nameOidMap[name].arrayOid) return;
+        if (!this.nameOidMap[name].arrayOid) return;
         this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParserBuilder(optionsParser));
-      }else{
-        if (! this.nameOidMap[name]) return;
+      } else {
+        if (!this.nameOidMap[name]) return;
         this.oidParserMap.set(this.nameOidMap[name].oid, parser);
-        if (! this.nameOidMap[name].arrayOid) return;
+        if (!this.nameOidMap[name].arrayOid) return;
         this.oidParserMap.set(this.nameOidMap[name].arrayOid, arrayParser);
       }
     });

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -113,6 +113,7 @@ class Sequelize {
    *     idle: 30000,
    *     acquire: 60000,
    *   },
+   *   // dataTypes configuration: you can conver datatpye parser function   
    *   dataTypes: {
    *     geometry: {
    *      parser: function(value) {

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -113,7 +113,13 @@ class Sequelize {
    *     idle: 30000,
    *     acquire: 60000,
    *   },
-   *
+   *   dataTypes: {
+   *     geometry: {
+   *      parser: function(value) {
+   *        return value
+   *      } 
+   *    }
+   *   }
    *   // isolation level of each transaction
    *   // defaults to dialect default
    *   isolationLevel: Transaction.ISOLATION_LEVELS.REPEATABLE_READ

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -113,12 +113,12 @@ class Sequelize {
    *     idle: 30000,
    *     acquire: 60000,
    *   },
-   *   // dataTypes configuration: you can conver datatpye parser function   
+   *   // dataTypes configuration: you can conver datatpye parser function
    *   dataTypes: {
    *     geometry: {
    *      parser: function(value) {
    *        return value
-   *      } 
+   *      }
    *    }
    *   }
    *   // isolation level of each transaction


### PR DESCRIPTION
I get geometry as geojson when I execute 'select * from testtable' on postgresql. But I want to get WKB geometry and i don't know the geom column. the geometry default parser function is convet data to geojson type. so I think of way to add datatypes configuration on sequelize constructor. and fix #12564 

default result:
![image](https://user-images.githubusercontent.com/26038018/88789849-d6c3a880-d1c9-11ea-94b3-125089f2df22.png)
the dataTypes config:
![image](https://user-images.githubusercontent.com/26038018/88789892-e2af6a80-d1c9-11ea-990e-f2a48e805d10.png)
use dataTypes result:
![image](https://user-images.githubusercontent.com/26038018/88789909-e9d67880-d1c9-11ea-8a29-4ba8b228bc0d.png)
