### PR TITLE
fix(describe-table-query): add condition to prevent subquery error

### DIFF
--- a/src/dialects/postgres/query-generator.js
+++ b/src/dialects/postgres/query-generator.js
@@ -133,7 +133,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       'c.is_nullable as "Null", ' +
       "(CASE WHEN c.udt_name = 'hstore' THEN c.udt_name ELSE c.data_type END) || (CASE WHEN c.character_maximum_length IS NOT NULL THEN '(' || c.character_maximum_length || ')' ELSE '' END) as \"Type\", " +
       '(SELECT array_agg(e.enumlabel) FROM pg_catalog.pg_type t JOIN pg_catalog.pg_enum e ON t.oid=e.enumtypid WHERE t.typname=c.udt_name) AS "special", ' +
-      '(SELECT pgd.description FROM pg_catalog.pg_statio_all_tables AS st INNER JOIN pg_catalog.pg_description pgd on (pgd.objoid=st.relid) WHERE c.ordinal_position=pgd.objsubid AND c.table_name=st.relname) AS "Comment" ' +
+      '(SELECT pgd.description FROM pg_catalog.pg_statio_all_tables AS st INNER JOIN pg_catalog.pg_description pgd on (pgd.objoid=st.relid) WHERE c.ordinal_position=pgd.objsubid AND c.table_name=st.relname AND c.table_schema = st.schemaname) AS "Comment" ' +
       'FROM information_schema.columns c ' +
       'LEFT JOIN (SELECT tc.table_schema, tc.table_name, ' +
       'cu.column_name, tc.constraint_type ' +


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

If there is more than one schema with the same table names (e. g.: `public` and `backup`), the `pgd.description `subquery in `describeTableQuery` will return more than one row and will result in the error `SequelizeDatabaseError: more than one row returned by a subquery used as an expression`. 

The added condition prevents this from happening.
