### PR TITLE
Expose beforeUpsert/afterUpsert hooks

### DIFF
--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -57,6 +57,11 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   afterSync(options: SyncOptions): HookReturn;
   beforeBulkSync(options: SyncOptions): HookReturn;
   afterBulkSync(options: SyncOptions): HookReturn;
+  beforeUpsert(attributes: ModelAttributes<M, TAttributes>, options: UpsertOptions<TAttributes>): HookReturn;
+  /**
+   * result is an array of 2 elements [instance, a boolean indicating whether row was created:true or updated:false]
+   */
+  afterUpsert(result: [M, boolean], options: UpsertOptions<TAttributes>): HookReturn;
 }
 
 export interface SequelizeHooks<

--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -12,6 +12,7 @@ import Model, {
   ModelAttributes,
   ModelOptions,
   UpdateOptions,
+  UpsertOptions,
 } from './model';
 import { Config, Options, Sequelize, SyncOptions } from './sequelize';
 

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1231,12 +1231,12 @@ export class Sequelize extends Hooks {
   public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
   public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SHOWTABLES>): Promise<string[]>;
   public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.DESCRIBE>): Promise<ColumnsDescription>;
-  public query<M extends Model>(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithModel<M> & { plain: true; }): Promise<M>;
+  public query<M extends Model>(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithModel<M> & { plain: true; }): Promise<M | null>;
   public query<M extends Model>(
     sql: string | { query: string; values: unknown[] },
     options: QueryOptionsWithModel<M>
   ): Promise<M[]>;
-  public query<T extends object>(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SELECT> & { plain: true }): Promise<T>;
+  public query<T extends object>(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SELECT> & { plain: true }): Promise<T | null>;
   public query<T extends object>(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SELECT>): Promise<T[]>;
   public query(sql: string | { query: string; values: unknown[] }, options: (QueryOptions | QueryOptionsWithType<QueryTypes.RAW>) & { plain: true }): Promise<{ [key: string]: unknown }>;
   public query(sql: string | { query: string; values: unknown[] }, options?: QueryOptions | QueryOptionsWithType<QueryTypes.RAW>): Promise<[unknown[], unknown]>;

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1231,6 +1231,7 @@ export class Sequelize extends Hooks {
   public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.BULKDELETE>): Promise<number>;
   public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.SHOWTABLES>): Promise<string[]>;
   public query(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithType<QueryTypes.DESCRIBE>): Promise<ColumnsDescription>;
+  public query<M extends Model>(sql: string | { query: string; values: unknown[] }, options: QueryOptionsWithModel<M> & { plain: true; }): Promise<M>;
   public query<M extends Model>(
     sql: string | { query: string; values: unknown[] },
     options: QueryOptionsWithModel<M>


### PR DESCRIPTION
### Description of change

Allow Typescript users to use beforeUpsert and afterUpsert in their model hooks !