### PR TITLE
fix(connection-manager): support read option type

### DIFF
--- a/src/dialects/abstract/connection-manager.js
+++ b/src/dialects/abstract/connection-manager.js
@@ -159,7 +159,7 @@ class ConnectionManager {
     let reads = 0;
     this.pool = {
       release: client => {
-        if (client.queryType === 'read') {
+        if (client.queryType === 'read' || client.queryType === 'SELECT') {
           this.pool.read.release(client);
         } else {
           this.pool.write.release(client);
@@ -167,7 +167,7 @@ class ConnectionManager {
       },
       acquire: (queryType, useMaster) => {
         useMaster = useMaster === undefined ? false : useMaster;
-        if (queryType === 'SELECT' && !useMaster) {
+        if ((queryType === 'SELECT' || queryType === 'read') && !useMaster) {
           return this.pool.read.acquire();
         }
         return this.pool.write.acquire();


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ✔️  ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ✔️  ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ✔️  ] Have you added new tests to prevent regressions?
- [ N/A ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ N/A ] Did you update the typescript typings accordingly (if applicable)?
- [ ✔️ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This PR adds `read` as an option for `type` to get the read connection pool.  I believe this was the original intent since the documentation says that `read` should be an option:

https://github.com/sequelize/sequelize/blob/master/src/dialects/abstract/connection-manager.js#L229

However the code is only using the string `SELECT` in `options.type` to get the read pool.  This is confusing and problematic because if we don't specify the right string the default pool returned is the _write_ pool. 

It also checks the `SELECT` and `read` option when closing the connection for consistency.