### PR TITLE
MSSQL: fix sanity checks of the 'limit' option

### DIFF
--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -410,7 +410,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
   updateQuery(tableName, attrValueHash, where, options, attributes) {
     const sql = super.updateQuery(tableName, attrValueHash, where, options, attributes);
-    if (options.limit) {
+    if (options.limit != null) {
       const updateArgs = `UPDATE TOP(${this.escape(options.limit)})`;
       sql.query = sql.query.replace('UPDATE', updateArgs);
     }
@@ -540,7 +540,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     return Utils.joinSQLFragments([
       'DELETE',
-      options.limit && `TOP(${this.escape(options.limit)})`,
+      options.limit != null && `TOP(${this.escape(options.limit)})`,
       'FROM',
       table,
       whereClause && `WHERE ${whereClause}`,
@@ -884,7 +884,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
         'FROM (',
         [
           'SELECT',
-          options.limit && `TOP ${options.limit}`,
+          options.limit != null && `TOP ${options.limit}`,
           '* FROM (',
           [
             'SELECT ROW_NUMBER() OVER (',
@@ -900,7 +900,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
 
     return Utils.joinSQLFragments([
       'SELECT',
-      isSQLServer2008 && options.limit && `TOP ${options.limit}`,
+      isSQLServer2008 && options.limit != null && `TOP ${options.limit}`,
       attributes.join(', '),
       `FROM ${tables}`,
       mainTableAs && `AS ${mainTableAs}`,
@@ -930,7 +930,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
       orders = this.getQueryOrders(options, model, isSubQuery);
     }
 
-    if (options.limit || options.offset) {
+    if (options.limit != null || options.offset != null) {
       if (!options.order || !options.order.length || (options.include && !orders.subQueryOrder.length)) {
         const tablePkFragment = `${this.quoteTable(options.tableAs || model.name)}.${this.quoteIdentifier(
           model.primaryKeyField
@@ -948,11 +948,11 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
         }
       }
 
-      if (options.offset || options.limit) {
+      if (options.offset != null || options.limit != null) {
         fragment += ` OFFSET ${this.escape(offset)} ROWS`;
       }
 
-      if (options.limit) {
+      if (options.limit != null) {
         fragment += ` FETCH NEXT ${this.escape(options.limit)} ROWS ONLY`;
       }
     }

--- a/test/unit/sql/offset-limit.test.js
+++ b/test/unit/sql/offset-limit.test.js
@@ -31,6 +31,19 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
     testsql(
       {
+        limit: 0,
+        order: [
+          ['email', 'DESC'] // for MSSQL
+        ]
+      },
+      {
+        default: ' LIMIT 0',
+        mssql: ' OFFSET 0 ROWS FETCH NEXT 0 ROWS ONLY'
+      }
+    );
+
+    testsql(
+      {
         limit: 10,
         order: [
           ['email', 'DESC'] // for MSSQL


### PR DESCRIPTION
This commit fixes a case where Sequelize ignores the `limit` option
when the underlying dialect is switched to MSSQL. This caused Sequelize
to generate an SQL query that incorrectly retrieves the *entire* records
of the table.

This commit introduces sanity checks similar to the ones found in
https://github.com/sequelize/sequelize/blob/e1446837196c07b8ff0c23359b958d68af40fd6d/src/dialects/abstract/query-generator.js#L2273

<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
