### PR TITLE
fix(model): updateOnDuplicate handles composite keys (#11984)

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2707,7 +2707,7 @@ class Model {
             // Get primary keys for postgres to enable updateOnDuplicate
             options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
             if (Object.keys(model.uniqueKeys).length > 0) {
-              options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length === 1).map(c => c.fields[0]).value();
+              options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length >= 1).map(c => c.fields).reduce(c => c[0]).value();
             }
           }
 

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -586,6 +586,117 @@ describe(Support.getTestDialectTeaser('Model'), () => {
                 expect(people[1].name).to.equal('Bob');
               });
           });
+
+          it('when the composite primary key column names and model field names are different', function() {
+            const Person = this.sequelize.define('Person', {
+              systemId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                primaryKey: true,
+                field: 'system_id'
+              },
+              system: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                primaryKey: true,
+                field: 'system'
+              },
+              name: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                field: 'name'
+              }
+            }, {});
+
+            return Person.sync({ force: true })
+              .then(() => {
+                const inserts = [
+                  { systemId: 1, system: 'system1', name: 'Alice' }
+                ];
+                return Person.bulkCreate(inserts);
+              })
+              .then(people => {
+                expect(people.length).to.equal(1);
+                expect(people[0].systemId).to.equal(1);
+                expect(people[0].system).to.equal('system1');
+                expect(people[0].name).to.equal('Alice');
+
+                const updates = [
+                  { systemId: 1, system: 'system1', name: 'CHANGED NAME' },
+                  { systemId: 1, system: 'system2', name: 'Bob' }
+                ];
+
+                return Person.bulkCreate(updates, { updateOnDuplicate: ['systemId', 'system', 'name'] });
+              })
+              .then(people => {
+                expect(people.length).to.equal(2);
+                expect(people[0].systemId).to.equal(1);
+                expect(people[0].system).to.equal('system1');
+                expect(people[0].name).to.equal('CHANGED NAME');
+                expect(people[1].systemId).to.equal(1);
+                expect(people[1].system).to.equal('system2');
+                expect(people[1].name).to.equal('Bob');
+              });
+          });
+
+          it('when the primary key column names and model field names are different and have composite unique constraints', function() {
+            const Person = this.sequelize.define('Person', {
+              id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                primaryKey: true,
+                field: 'id'
+              },
+              systemId: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                unique: 'system_id_system_unique',
+                field: 'system_id'
+              },
+              system: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                unique: 'system_id_system_unique',
+                field: 'system'
+              },
+              name: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                field: 'name'
+              }
+            }, {});
+
+            return Person.sync({ force: true })
+              .then(() => {
+                const inserts = [
+                  { id: 1, systemId: 1, system: 'system1', name: 'Alice' }
+                ];
+                return Person.bulkCreate(inserts);
+              })
+              .then(people => {
+                expect(people.length).to.equal(1);
+                expect(people[0].systemId).to.equal(1);
+                expect(people[0].system).to.equal('system1');
+                expect(people[0].name).to.equal('Alice');
+
+                const updates = [
+                  { id: 1, systemId: 1, system: 'system1', name: 'CHANGED NAME' },
+                  { id: 2, systemId: 1, system: 'system2', name: 'Bob' }
+                ];
+
+                return Person.bulkCreate(updates, { updateOnDuplicate: ['systemId', 'system', 'name'] });
+              })
+              .then(people => {
+                expect(people.length).to.equal(2);
+                expect(people[0].systemId).to.equal(1);
+                expect(people[0].system).to.equal('system1');
+                expect(people[0].name).to.equal('CHANGED NAME');
+                expect(people[1].systemId).to.equal(1);
+                expect(people[1].system).to.equal('system2');
+                expect(people[1].name).to.equal('Bob');
+              });
+          });
+
         });
 
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

This is a cherry-pick of https://github.com/sequelize/sequelize/pull/11984 for the v5 branch.
