### PR TITLE
perf(associations): improve perf for many-to-many/has-many setters

### DIFF
--- a/src/associations/belongs-to-many.js
+++ b/src/associations/belongs-to-many.js
@@ -593,13 +593,25 @@ class BelongsToMany extends Association {
       const obsoleteAssociations = [];
       const promises = [];
       const defaultAttributes = options.through || {};
+      const currentRowsFkMap = {};
+      for (const currentRow of currentRows) {
+        const fk = currentRow[foreignIdentifier];
+        currentRowsFkMap[fk] = true;
+      }
 
-      const unassociatedObjects = newAssociatedObjects.filter(
-        obj => !currentRows.some(currentRow => currentRow[foreignIdentifier] === obj.get(targetKey))
-      );
+      const newAssociatedObjectMap = {};
+      for (const newAssociatedObject of newAssociatedObjects) {
+        const targetValue = newAssociatedObject.get(targetKey);
+        newAssociatedObjectMap[targetValue] = newAssociatedObject;
+      }
+
+      const unassociatedObjects = newAssociatedObjects.filter(obj => {
+        const tk = obj.get(targetKey);
+        return !currentRowsFkMap[tk];
+      });
 
       for (const currentRow of currentRows) {
-        const newObj = newAssociatedObjects.find(obj => currentRow[foreignIdentifier] === obj.get(targetKey));
+        const newObj = newAssociatedObjectMap[currentRow[foreignIdentifier]];
 
         if (!newObj) {
           obsoleteAssociations.push(currentRow);

--- a/src/associations/has-many.js
+++ b/src/associations/has-many.js
@@ -336,12 +336,24 @@ class HasMany extends Association {
       raw: true
     });
     const promises = [];
-    const obsoleteAssociations = oldAssociations.filter(
-      old => !targetInstances.find(obj => obj[this.target.primaryKeyAttribute] === old[this.target.primaryKeyAttribute])
-    );
-    const unassociatedObjects = targetInstances.filter(
-      obj => !oldAssociations.find(old => obj[this.target.primaryKeyAttribute] === old[this.target.primaryKeyAttribute])
-    );
+    const targetInstancesPkMap = {};
+    for (const targetInstance of targetInstances) {
+      const pk = targetInstance[this.target.primaryKeyAttribute];
+      targetInstancesPkMap[pk] = true;
+    }
+    const obsoleteAssociations = oldAssociations.filter(old => {
+      const pk = old[this.target.primaryKeyAttribute];
+      return !targetInstancesPkMap[pk];
+    });
+    const oldAssociationsPkMap = {};
+    for (const oldAssociation of oldAssociations) {
+      const pk = oldAssociation[this.target.primaryKeyAttribute];
+      oldAssociationsPkMap[pk] = true;
+    }
+    const unassociatedObjects = targetInstances.filter(obj => {
+      const pk = obj[this.target.primaryKeyAttribute];
+      return !oldAssociationsPkMap[pk];
+    });
     let updateWhere;
     let update;
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Previously the status of old and new associations were done through a linear scan (within another linear scan), leading to suboptimal performance in O(n^2). By creating temporary lookup maps, this can be reduced to O(n).
