### PR TITLE
fix(datatypes): stringify dates as iso8601 strings

### DIFF
--- a/src/data-types.js
+++ b/src/data-types.js
@@ -464,7 +464,7 @@ class DATE extends ABSTRACT {
   _stringify(date, options) {
     date = this._applyTimezone(date, options);
     // Z here means current timezone, _not_ UTC
-    return date.format('YYYY-MM-DD HH:mm:ss.SSS Z');
+    return date.format('YYYY-MM-DD HH:mm:ss.SSSZ');
   }
 }
 


### PR DESCRIPTION
### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

DATE's stringify function emits a date formatted with a space between
its time and timezone components, which does not conform to ISO8601[1],
so this commit removes the space.

1 - https://en.wikipedia.org/wiki/ISO_8601#Time_zone_designators
