### PR TITLE
fix(truncate): fix missing await in truncate all model with cascade

### DIFF
--- a/src/dialects/abstract/index.js
+++ b/src/dialects/abstract/index.js
@@ -63,7 +63,8 @@ AbstractDialect.prototype.supports = {
   groupedLimit: true,
   indexViaAlter: false,
   JSON: false,
-  deferrableConstraints: false
+  deferrableConstraints: false,
+  truncateCascade: false
 };
 
 module.exports = AbstractDialect;

--- a/src/dialects/abstract/query-interface.js
+++ b/src/dialects/abstract/query-interface.js
@@ -965,6 +965,9 @@ class QueryInterface {
     options = _.defaults(options, { limit: null });
 
     if (options.truncate === true) {
+      if (options.cascade && !this.sequelize.dialect.supports.truncateCascade) {
+        throw new Error('truncate with cascade is not supported for the current dialect');
+      }
       return this.sequelize.query(this.queryGenerator.truncateTableQuery(tableName, options), options);
     }
 

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -56,7 +56,8 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
   JSONB: true,
   HSTORE: true,
   deferrableConstraints: true,
-  searchPath: true
+  searchPath: true,
+  truncateCascade: true
 });
 
 PostgresDialect.prototype.defaultVersion = '9.5.0';

--- a/src/dialects/sqlite/index.js
+++ b/src/dialects/sqlite/index.js
@@ -43,7 +43,8 @@ SqliteDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   },
   joinTableDependent: false,
   groupedLimit: false,
-  JSON: true
+  JSON: true,
+  truncateCascade: true
 });
 
 SqliteDialect.prototype.defaultVersion = '3.8.0';

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -817,17 +817,13 @@ class Sequelize {
    */
   async truncate(options) {
     const models = [];
-    this.modelManager.forEachModel(
-      model => {
-        if (model) {
-          models.push(model);
-        }
-      },
-      { reverse: false }
-    );
+
+    this.modelManager.forEachModel(model => models.push(model), { reverse: false });
 
     if (options && options.cascade) {
-      for (const model of models) await model.truncate(options);
+      for (const model of models) {
+        await model.truncate(options);
+      }
     } else {
       await Promise.all(models.map(model => model.truncate(options)));
     }


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?


### Description of change

Fix a missing `await` in `sequelize.truncate` with `cascade` option. Without it, all models try to truncate in parallel which triggers a deadlock when 2 models truncate the same child model.
