### PR TITLE
Update documentation - hooks.md - fixed URL

### DIFF
--- a/docs/manual/other-topics/hooks.md
+++ b/docs/manual/other-topics/hooks.md
@@ -6,7 +6,7 @@ Hooks (also known as lifecycle events), are functions which are called before an
 
 ## Available hooks
 
-Sequelize provides a lot of hooks. The full list can be found in directly in the [source code - lib/hooks.js](https://github.com/sequelize/sequelize/blob/master/lib/hooks.js#L7).
+Sequelize provides a lot of hooks. The full list can be found in directly in the [source code - lib/hooks.js](https://github.com/sequelize/sequelize/blob/v6/lib/hooks.js#L7).
 
 ## Hooks firing order
 


### PR DESCRIPTION
URL changed to "v6", this is a continuation of #12669 - which was branched of master instead of v6
