### PR TITLE
fix(upsert): do not overwrite an explcit created_at during upsert

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2460,7 +2460,7 @@ class Model {
     const now = Utils.now(this.sequelize.options.dialect);
 
     // Attach createdAt
-    if (createdAtAttr && !updateValues[createdAtAttr]) {
+    if (createdAtAttr && !insertValues[createdAtAttr]) {
       const field = this.rawAttributes[createdAtAttr].field || createdAtAttr;
       insertValues[field] = this._getDefaultTimestamp(createdAtAttr) || now;
     }

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -302,6 +302,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         clock.restore();
       });
 
+      it('does not overwrite createdAt when supplied as an explicit insert value when using fields', async function() {
+        const clock = sinon.useFakeTimers();
+        const originalCreatedAt = new Date('2010-01-01T12:00:00.000Z');
+        await this.User.upsert({ id: 42, username: 'john', createdAt: originalCreatedAt }, { fields: ['id', 'username'] });
+        const user = await this.User.findByPk(42);
+        expect(user.createdAt).to.deep.equal(originalCreatedAt);
+        clock.restore();
+      });
+
       it('does not update using default values', async function() {
         await this.User.create({ id: 42, username: 'john', baz: 'new baz value' });
         const user0 = await this.User.findByPk(42);
@@ -578,16 +587,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         });
 
-        it('should return default value set by the database (upsert)', async function() {      
+        it('should return default value set by the database (upsert)', async function() {
           const User = this.sequelize.define('User', {
             name: { type: DataTypes.STRING, primaryKey: true },
             code: { type: Sequelize.INTEGER, defaultValue: Sequelize.literal(2020) }
           });
-    
+
           await User.sync({ force: true });
-    
+
           const [user, created] = await User.upsert({ name: 'Test default value' }, { returning: true });
-      
+
           expect(user.name).to.be.equal('Test default value');
           expect(user.code).to.be.equal(2020);
 


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
We found that when doing an upsert with model data that already included a `createdAt` timestampe, our explcit `createdAt` was being overwritten with the current time any time we also utilized the `fields` option.

e.g.

```
const instance = await MyModel.upsert({ id: 1, myfield: 'blah', createdAt: new Date('2010-01-01T12:00:00.000Z') },  { fields: [ 'myfield' ], returning: true });
console.log(instance.createdAt); // expected 2010-01-01T12:00:00.000Z, but got a now()-ish timestamp.
```

Issue appears to be that the check for a provided `createdAt` was being checked against the `updateValues` instead of the `insertValues`.  Most of the time, this is inconsequential because the `insertValues` and `updateValues` both contain the same fields.  But, when using the `fields` feature, the `createdAt` field is stripped away from the `updateValues`, so sequelize happily overwrites the `insertValues.createAt` value.