### PR TITLE
On conflict where support (v6)

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -182,10 +182,13 @@ class QueryGenerator {
 
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
       if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
+        const upsertKeys = options.upsertKeys;
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
-        const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
+        const conflictKeys = upsertKeys.fields.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+        let whereClause = this.whereQuery(upsertKeys.where);
+        if (whereClause) whereClause = ` ${whereClause}`;
+        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')})${whereClause} DO UPDATE SET ${updateKeys.join(',')}`;
       } else {
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate += `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;

--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -753,23 +753,23 @@ class QueryInterface {
 
     const model = options.model;
     const primaryKeys = Object.values(model.primaryKeys).map(item => item.field);
-    const uniqueKeys = Object.values(model.uniqueKeys).filter(c => c.fields.length >= 1).map(c => c.fields);
-    const indexKeys = Object.values(model._indexes).filter(c => c.unique && c.fields.length >= 1).map(c => c.fields);
+    const uniqueKeys = Object.values(model.uniqueKeys).filter(c => c.fields.length >= 1);
+    const indexKeys = Object.values(model._indexes).filter(c => c.unique && c.fields.length >= 1);
 
     options.type = QueryTypes.UPSERT;
     options.updateOnDuplicate = Object.keys(updateValues);
-    options.upsertKeys = [];
+    options.upsertKeys = { fields: [] };
 
     // For fields in updateValues, try to find a constraint or unique index
     // that includes given field. Only first matching upsert key is used.
     for (const field of options.updateOnDuplicate) {
-      const uniqueKey = uniqueKeys.find(fields => fields.includes(field));
+      const uniqueKey = uniqueKeys.find(({ fields }) => fields.includes(field));
       if (uniqueKey) {
         options.upsertKeys = uniqueKey;
         break;
       }
 
-      const indexKey = indexKeys.find(fields => fields.includes(field));
+      const indexKey = indexKeys.find(({ fields }) => fields.includes(field));
       if (indexKey) {
         options.upsertKeys = indexKey;
         break;
@@ -778,13 +778,13 @@ class QueryInterface {
 
     // Always use PK, if no constraint available OR update data contains PK
     if (
-      options.upsertKeys.length === 0
-      || _.intersection(options.updateOnDuplicate, primaryKeys).length
+      options.upsertKeys.fields.length === 0
+      || _.intersection(options.updateOnDuplicate, primaryKeys).length > 0
     ) {
-      options.upsertKeys = primaryKeys;
+      options.upsertKeys = {
+        fields: primaryKeys
+      };
     }
-
-    options.upsertKeys = _.uniq(options.upsertKeys);
 
     const sql = this.queryGenerator.insertQuery(tableName, insertValues, model.rawAttributes, options);
     return await this.sequelize.query(sql, options);


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? DIALECT=postgres
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? n/a
- [ ] Did you update the typescript typings accordingly (if applicable)? n/a
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change
This changes in this PR arrange for a reference to the relevant index, rather than just its fields, to be passed down as `upsertKeys` into the insertQuery() generation function. With that available, the query generation code is able to check whether the index has a `.where` property on it and generate the correct ON CONCLICT WHERE clause allowing the upset in the case described in the issue to succeed.

Some technical notes, the changes maintain the behaviour of locating the first matching index so this should not alter any user-facing behaviour.

Closes #12595