### PR TITLE
fix(mssql): solving issue 10472 for v5

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -869,9 +869,20 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     }
 
     if (options.limit || options.offset) {
-      if (!options.order || options.include && !orders.subQueryOrder.length) {
-        fragment += options.order && !isSubQuery ? ', ' : ' ORDER BY ';
-        fragment += `${this.quoteTable(options.tableAs || model.name)}.${this.quoteIdentifier(model.primaryKeyField)}`;
+      if (!options.order || !options.order.length || options.include && !orders.subQueryOrder.length) {
+        const tablePkFragment = `${this.quoteTable(options.tableAs || model.name)}.${this.quoteIdentifier(model.primaryKeyField)}`;
+
+        if (!options.order || !options.order.length) {
+          fragment += ` ORDER BY ${tablePkFragment}`;
+        } else {
+          const orderFieldNames = _.map(options.order, order => order[0]);
+          const primaryKeyFieldAlreadyPresent = _.includes(orderFieldNames, model.primaryKeyField);
+
+          if (!primaryKeyFieldAlreadyPresent) {
+            fragment += options.order && !isSubQuery ? ', ' : ' ORDER BY ';
+            fragment += tablePkFragment;
+          }
+        }
       }
 
       if (options.offset || options.limit) {

--- a/test/unit/sql/offset-limit.test.js
+++ b/test/unit/sql/offset-limit.test.js
@@ -79,5 +79,14 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       mysql: " LIMIT '\\';DELETE FROM user', 10",
       mssql: " OFFSET N''';DELETE FROM user' ROWS FETCH NEXT 10 ROWS ONLY"
     });
+
+    testsql({
+      limit: 10,
+      order: [], // When the order is an empty array, one is automagically prepended
+      model: { primaryKeyField: 'id', name: 'tableRef' }
+    }, {
+      default: ' LIMIT 10',
+      mssql: ' ORDER BY [tableRef].[id] OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY'
+    });
   });
 });


### PR DESCRIPTION
Closes https://github.com/sequelize/sequelize/pull/12261, https://github.com/sequelize/sequelize/issues/7447 for v5
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
I already made this [change](https://github.com/sequelize/sequelize/pull/12261/commits) for the master branch a few months ago and now I am doing it for the v5 branch.

It is a small fix for the mssql dialect when using the FETCH and OFFSET clauses since these must be used together with the ORDER BY clause and when sending an `options.order` like a empty array, the ORDER BY clause is not applyed and throw the error