### PR TITLE
Add missing 'through' option in documentation example

### DIFF
--- a/docs/manual/advanced-association-concepts/eager-loading.md
+++ b/docs/manual/advanced-association-concepts/eager-loading.md
@@ -422,7 +422,9 @@ If you don't want anything from the junction table, you can explicitly provide a
 Foo.findOne({
   include: {
     model: Bar,
-    attributes: []
+    through: {
+      attributes: []
+    }
   }
 });
 ```


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Description of change

Documentation change only. 

In order to get the described output, I needed to add the `through` option to the query.