### PR TITLE
fix(typings): correct options for 'bulkDelete()'

### DIFF
--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -209,6 +209,15 @@ export interface IndexesOptions {
 
 export interface QueryInterfaceIndexOptions extends IndexesOptions, QueryInterfaceOptions {}
 
+/**
+ * Interface for bulk delete options
+ */
+export interface QueryInterfaceBulkDeleteOptions {
+  truncate?: boolean
+  cascade?: boolean
+  restartIdentity?: boolean
+}
+
 export interface BaseConstraintOptions {
   name?: string;
   fields: string[];
@@ -535,7 +544,7 @@ export class QueryInterface {
   public bulkDelete(
     tableName: TableName,
     identifier: WhereOptions<any>,
-    options?: QueryOptions,
+    options?: QueryInterfaceBulkDeleteOptions,
     model?: typeof Model
   ): Promise<object>;
 

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -54,6 +54,8 @@ async function test() {
 
   await queryInterface.bulkDelete({ tableName: 'foo', schema: 'bar' }, {}, {});
 
+  await queryInterface.bulkDelete({ tableName: 'foo', schema: 'bar' }, {}, { truncate: true });
+
   const bulkInsertRes: Promise<number | object> = queryInterface.bulkInsert({ tableName: 'foo', as: 'bar', name: 'as' }, [{}], {});
 
   await queryInterface.bulkUpdate({ tableName: 'foo', delimiter: 'bar', as: 'baz', name: 'quz' }, {}, {});


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [yes] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [yes] Did you update the typescript typings accordingly (if applicable)?
- [yes] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Added interface 'QueryInterfaceBulkDeleteOptions' to match with the implementation of 'bulkDelete()' ('truncate' option support for TypeScript).
