### PR TITLE
Update query.js: Change assignment of "result" in "isInsertQuery" function.

### DIFF
--- a/src/dialects/abstract/query.js
+++ b/src/dialects/abstract/query.js
@@ -167,14 +167,12 @@ class AbstractQuery {
   }
 
   isInsertQuery(results, metaData) {
-    let result = true;
-
     if (this.options.type === QueryTypes.INSERT) {
       return true;
     }
 
     // is insert query if sql contains insert into
-    result = result && this.sql.toLowerCase().startsWith('insert into');
+    let result = this.sql.toLowerCase().startsWith('insert into');
 
     // is insert query if no results are passed or if the result has the inserted id
     result = result && (!results || Object.prototype.hasOwnProperty.call(results, this.getInsertIdField()));


### PR DESCRIPTION
Hello,


### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions? _Not applicable_
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? _Not applicable_
- [ ] Did you update the typescript typings accordingly (if applicable)? _Not applicable_
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

In the `isInsertQuery` function, variable `result` was declared and reassigned in the following way:

`let result = true;`
`result = result && this.sql.toLowerCase().startsWith('insert into');`

Setting `result` to `true` first and then reassigning it with a logical AND-operation will always result in the variable being assigned to the second operand of the AND-operation. Therefore, these 2 lines can be combined into a single variable declaration:

`let result = this.sql.toLowerCase().startsWith('insert into');`

I hope this is clear enough and look forward to your comments.

Kind regards,
Florian




