### PR TITLE
feat(pool): expose maxUses pool config option, upgrade sequelize-pool

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -143,7 +143,8 @@ class ConnectionManager {
         min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        reapIntervalMillis: config.pool.evict
+        reapIntervalMillis: config.pool.evict,
+        maxUses: config.pool.maxUses
       });
 
       debug(`pool created with max/min: ${config.pool.max}/${config.pool.min}, no replication`);
@@ -211,7 +212,8 @@ class ConnectionManager {
         min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        reapIntervalMillis: config.pool.evict
+        reapIntervalMillis: config.pool.evict,
+        maxUses: config.pool.maxUses
       }),
       write: new Pool({
         name: 'sequelize:write',
@@ -226,7 +228,8 @@ class ConnectionManager {
         min: config.pool.min,
         acquireTimeoutMillis: config.pool.acquire,
         idleTimeoutMillis: config.pool.idle,
-        reapIntervalMillis: config.pool.evict
+        reapIntervalMillis: config.pool.evict,
+        maxUses: config.pool.maxUses
       })
     };
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -159,6 +159,7 @@ class Sequelize {
    * @param {number}   [options.pool.acquire=60000] The maximum time, in milliseconds, that pool will try to get connection before throwing error
    * @param {number}   [options.pool.evict=1000] The time interval, in milliseconds, after which sequelize-pool will remove idle connections.
    * @param {Function} [options.pool.validate] A function that validates a connection. Called with client. The default function checks that client is an object, and that its state is not disconnected
+   * @param {number}   [options.pool.maxUses=Infinity] The number of times a connection can be used before discarding it for a replacement, [`used for eventual cluster rebalancing`](https://github.com/sequelize/sequelize-pool).
    * @param {boolean}  [options.quoteIdentifiers=true] Set to `false` to make table names and attributes case-insensitive on Postgres and skip double quoting of them.  WARNING: Setting this to false may expose vulnerabilities and is not recommended!
    * @param {string}   [options.transactionType='DEFERRED'] Set the default transaction type. See `Sequelize.Transaction.TYPES` for possible options. Sqlite only.
    * @param {string}   [options.isolationLevel] Set the default transaction isolation level. See `Sequelize.Transaction.ISOLATION_LEVELS` for possible options.

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "moment-timezone": "^0.5.21",
     "retry-as-promised": "^3.2.0",
     "semver": "^6.3.0",
-    "sequelize-pool": "^2.3.0",
+    "sequelize-pool": "^6.1.0",
     "toposort-class": "^1.0.1",
     "uuid": "^3.3.3",
     "validator": "^10.11.0",

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -102,6 +102,11 @@ export interface PoolOptions {
   evict?: number;
 
   /**
+   * The number of times to use a connection before closing and replacing it. Default is Infinity
+   */
+  maxUses?: number;
+
+  /**
    * A function that validates a connection. Called with client. The default function checks that client is an
    * object, and that its state is not disconnected
    */


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?

I tried to get the tests running with Docker but I don't think the integration tests work properly on Windows. After some tweaking, I was able to get the tests to throw an error that the database user/pass is wrong. I figured the custom Docker image for Postgres would set that up. The other tests passed (non integration).
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?

I did not see any tests for this in the sequelize v6 codebase so I was not able to add any. I am not knowledgeable enough to test this properly.
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

I just upgraded sequelize-pool to 6.1 and added the maxUses config option. I copied this from the commit that sequelize v6 had:
https://github.com/sequelize/sequelize/commit/5d51e696734585f56e40e93273028328171a7113

I wanted to add the maxUses config option to sequelize v5 that v6 already has, since I think it's a very useful feature.

Since sequelize-pool doesn't seem to specify any breaking changes in it's versions, I don't know if upgrading from v2 to v6 will cause any issues. 
