### PR TITLE
fix: sync duplicates existing foreign keys when schema is used

### DIFF
--- a/src/dialects/postgres/query-interface.js
+++ b/src/dialects/postgres/query-interface.js
@@ -153,15 +153,22 @@ class PostgresQueryInterface extends QueryInterface {
   /**
    * @override
    */
-  async getForeignKeyReferencesForTable(tableName, options) {
+  async getForeignKeyReferencesForTable(table, options) {
     const queryOptions = {
       ...options,
       type: QueryTypes.FOREIGNKEYS
     };
 
+    const tableName = typeof table === 'object' ? table.tableName : table;
+
     // postgres needs some special treatment as those field names returned are all lowercase
     // in order to keep same result with other dialects.
-    const query = this.queryGenerator.getForeignKeyReferencesQuery(tableName, this.sequelize.config.database);
+    const query = this.queryGenerator.getForeignKeyReferencesQuery(
+      tableName,
+      this.sequelize.config.database,
+      table.schema
+    );
+
     const result = await this.sequelize.query(query, queryOptions);
     return result.map(Utils.camelizeObjectKeys);
   }

--- a/src/model.js
+++ b/src/model.js
@@ -1420,7 +1420,10 @@ class Model {
           const references = currentAttribute.references;
           if (currentAttribute.references) {
             const database = this.sequelize.config.database;
-            const schema = this.sequelize.config.schema;
+            const schema = tableName.schema;
+            const foreignReferenceSchema = currentAttribute.references.model.schema;
+            const foreignReferenceTableName =
+              typeof references.model === 'object' ? references.model.tableName : references.model;
             // Find existed foreign keys
             for (const foreignKeyReference of foreignKeyReferences) {
               const constraintName = foreignKeyReference.constraintName;
@@ -1428,9 +1431,11 @@ class Model {
                 !!constraintName &&
                 foreignKeyReference.tableCatalog === database &&
                 (schema ? foreignKeyReference.tableSchema === schema : true) &&
-                foreignKeyReference.referencedTableName === references.model &&
+                foreignKeyReference.referencedTableName === foreignReferenceTableName &&
                 foreignKeyReference.referencedColumnName === references.key &&
-                (schema ? foreignKeyReference.referencedTableSchema === schema : true) &&
+                (foreignReferenceSchema
+                  ? foreignKeyReference.referencedTableSchema === foreignReferenceSchema
+                  : true) &&
                 !removedConstraints[constraintName]
               ) {
                 // Remove constraint on foreign keys.


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
`Sync` functionality duplicates existing foreign key associations for per sync executions when schema is used.
Expected behaviour: It shouldn't create foreign key association if exists.

This issue produced with the followings:
Postgres: 9.6.20, also 12.2
Node: 14.5
Dependencies:
pg: 8.5
pg-hstore: 2.3.3
sequelize: 6.3.5