### PR TITLE
Fix function definition for await keyword usage

### DIFF
--- a/docs/manual/other-topics/transactions.md
+++ b/docs/manual/other-topics/transactions.md
@@ -98,7 +98,7 @@ Note that `t.commit()` and `t.rollback()` were not called directly (which is cor
 When using the managed transaction you should *never* commit or rollback the transaction manually. If all queries are successful (in the sense of not throwing any error), but you still want to rollback the transaction, you should throw an error yourself:
 
 ```js
-await sequelize.transaction(t => {
+await sequelize.transaction((async (t) => {
   const user = await User.create({
     firstName: 'Abraham',
     lastName: 'Lincoln'

--- a/docs/manual/other-topics/transactions.md
+++ b/docs/manual/other-topics/transactions.md
@@ -98,7 +98,7 @@ Note that `t.commit()` and `t.rollback()` were not called directly (which is cor
 When using the managed transaction you should *never* commit or rollback the transaction manually. If all queries are successful (in the sense of not throwing any error), but you still want to rollback the transaction, you should throw an error yourself:
 
 ```js
-await sequelize.transaction((async (t) => {
+await sequelize.transaction(async t => {
   const user = await User.create({
     firstName: 'Abraham',
     lastName: 'Lincoln'


### PR DESCRIPTION
**await** keyword doesn't work inside a function if the function is not defined using **async** keyword

### Description of change

Added **async** keyword to the anonymous function