### PR TITLE
fix(mysql, mariadb): release connection on deadlocks

### DIFF
--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -54,11 +54,18 @@ class Query extends AbstractQuery {
         await this.logWarnings(results);
       }
     } catch (err) {
-      // MariaDB automatically rolls-back transactions in the event of a deadlock
+      // MariaDB automatically rolls-back transactions in the event of a
+      // deadlock.
       //
-      // We explicitly initiate a (redundant) rollback - otherwise, the
-      // connection ends up in a limbo state where future transactions may
-      // not behave properly.
+      // Even though we shouldn't need to do this, we initiate a manual
+      // rollback. Without the rollback, the next transaction using the
+      // connection seems to retain properties of the previous transaction
+      // (e.g. isolation level) and not work as expected.
+      //
+      // For example (in our tests), a follow-up READ_COMMITTED transaction
+      // doesn't work as expected unless we explicitly rollback the
+      // transaction: it would fail to read a value inserted outside of that
+      // transaction.
       if (options.transaction && err.errno === 1213) {
         try {
           await options.transaction.rollback();

--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -55,7 +55,17 @@ class Query extends AbstractQuery {
       }
     } catch (err) {
       // MariaDB automatically rolls-back transactions in the event of a deadlock
+      //
+      // We explicitly initiate a (redundant) rollback - otherwise, the
+      // connection ends up in a limbo state where future transactions may
+      // not behave properly.
       if (options.transaction && err.errno === 1213) {
+        try {
+          await options.transaction.rollback();
+        } catch (err) {
+          // Ignore errors - since MariaDB automatically rolled back, we're
+          // not that worried about this redundant rollback failing.
+        }
         options.transaction.finished = 'rollback';
       }
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1091,12 +1091,15 @@ class Sequelize {
         await transaction.commit();
         return await result;
       } catch (err) {
-        if (!transaction.finished) {
-          try {
+        try {
+          if (!transaction.finished) {
             await transaction.rollback();
-          } catch (err0) {
-            // ignore
+          } else {
+            // release the connection, even if we don't need to rollback
+            await transaction.cleanup();
           }
+        } catch (err0) {
+          // ignore
         }
         throw err;
       }

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1107,7 +1107,10 @@ class Sequelize {
   }
 
   /**
-   * Use CLS with Sequelize.
+   * Use CLS (Continuation Local Storage) with Sequelize. With Continuation
+   * Local Storage, all queries within the transaction callback will
+   * automatically receive the transaction object.
+   *
    * CLS namespace provided is stored as `Sequelize._cls`
    *
    * @param {object} ns CLS namespace

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -91,6 +91,13 @@ class Transaction {
     }
   }
 
+  /**
+   * Called to acquire a connection to use and set the correct options on the connection.
+   * We should ensure all of the environment that's set up is cleaned up in `cleanup()` below.
+   *
+   * @param {boolean} useCLS Defaults to true: Use CLS (Continuation Local Storage) with Sequelize. With CLS, all queries within the transaction callback will automatically receive the transaction object.
+   * @returns {Promise}
+   */
   async prepareEnvironment(useCLS) {
     let connectionPromise;
 

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -56,15 +56,11 @@ class Transaction {
       throw new Error(`Transaction cannot be committed because it has been finished with state: ${this.finished}`);
     }
 
-    this._clearCls();
-
     try {
       return await this.sequelize.getQueryInterface().commitTransaction(this, this.options);
     } finally {
       this.finished = 'commit';
-      if (!this.parent) {
-        this.cleanup();
-      }
+      this.cleanup();
       for (const hook of this._afterCommitHooks) {
         await hook.apply(this, [this]);
       }
@@ -85,17 +81,13 @@ class Transaction {
       throw new Error('Transaction cannot be rolled back because it never started');
     }
 
-    this._clearCls();
-
     try {
       return await this
         .sequelize
         .getQueryInterface()
         .rollbackTransaction(this, this.options);
     } finally {
-      if (!this.parent) {
-        this.cleanup();
-      }
+      this.cleanup();
     }
   }
 
@@ -162,6 +154,11 @@ class Transaction {
   }
 
   cleanup() {
+    // Don't release the connection if there's a parent transaction or
+    // if we've already cleaned up
+    if (this.parent || this.connection.uuid === undefined) return;
+
+    this._clearCls();
     const res = this.sequelize.connectionManager.releaseConnection(this.connection);
     this.connection.uuid = undefined;
     return res;

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -611,13 +611,16 @@ if (current.dialect.supports.transactions) {
 
         await expect(
           this.sequelize.sync({ force: true }).then(() => {
-            return this.sequelize.transaction({ isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED }, async transaction => {
-              const users0 = await User.findAll({ transaction });
-              await expect( users0 ).to.have.lengthOf(0);
-              await User.create({ username: 'jan' }); // Create a User outside of the transaction
-              const users = await User.findAll({ transaction });
-              return expect( users ).to.have.lengthOf(1); // We SHOULD see the created user inside the transaction
-            });
+            return this.sequelize.transaction(
+              { isolationLevel: Transaction.ISOLATION_LEVELS.READ_COMMITTED },
+              async transaction => {
+                const users0 = await User.findAll({ transaction });
+                expect(users0).to.have.lengthOf(0);
+                await User.create({ username: 'jan' }); // Create a User outside of the transaction
+                const users = await User.findAll({ transaction });
+                expect(users).to.have.lengthOf(1); // We SHOULD see the created user inside the transaction
+              }
+            );
           })
         ).to.eventually.be.fulfilled;
       });


### PR DESCRIPTION
<!-- 
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Closes #11571

This change makes deadlocked queries release the MariaDB/MySQL connection and does a redundant rollback. These ensure that subsequent queries work properly.

#### Debugging

While running sequelize in production for a collaborative document editor, we found that deadlocks on MariaDB would sometimes cause other queries to stall. After debugging, we realized that this is because MySQL/MariaDB has custom deadlock handling in Sequelize.

1. Because InnoDB (MariaDB/MySQL engine) automatically rolls back one query in the case of deadlocks, sequelize marks the `transaction.finished = 'rollback'` in the `run` function of [query.js](https://github.com/sequelize/sequelize/blob/4097aaa/src/dialects/mariadb/query.js#L54)
2. In `transaction()` of [sequelize.js](https://github.com/sequelize/sequelize/blob/4097aaa/src/sequelize.js#L1105), `transaction.rollback()` isn't called if `transaction.finished` is set
3. As such, `transaction.cleanup()`, which releases the connection is never called for this connection, and can cause hangs in this case

#### Fix

The fix was to ensure we call `transaction.cleanup()`, even if we don't rollback the transaction. I added a test for this case too.

Interestingly, on MariaDB, we still need to do an explicit rollback query. Without it, a follow-up READ COMMITTED transaction wouldn't behave as expected. I added this to the testcase too.

<!-- Please provide a description of the change here. -->
