### PR TITLE
fix(query-generator): add column casting in nested select (#11749)

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -2542,6 +2542,16 @@ class QueryGenerator {
     if (options.model && options.model.fieldRawAttributesMap && options.model.fieldRawAttributesMap[key]) {
       return options.model.fieldRawAttributesMap[key];
     }
+
+    if (typeof key === 'string' && key.startsWith('$') && key.endsWith('$') && options.includeMap) {
+      const trimmed = key.slice(1, -1);
+      const fieldsArray = trimmed.split('.');
+      const modelName = fieldsArray[Math.max(fieldsArray.length - 2, 0)];
+      const keyName = fieldsArray[Math.max(fieldsArray.length - 1, 0)];
+      const { model } = options.includeMap[modelName];
+
+      if (model) return this._findField(keyName, { model });
+    }
   }
 
   // OR/AND/NOT grouping logic
@@ -2883,7 +2893,8 @@ class QueryGenerator {
       return this.whereItemsQuery(smth, {
         model: factory,
         prefix: prepend && tableName,
-        type: options.type
+        type: options.type,
+        includeMap: options.includeMap
       });
     }
     if (typeof smth === 'number') {
@@ -2900,13 +2911,15 @@ class QueryGenerator {
 
       return this.whereItemsQuery(where, {
         model: factory,
-        prefix: prepend && tableName
+        prefix: prepend && tableName,
+        includeMap: options.includeMap
       });
     }
     if (typeof smth === 'string') {
       return this.whereItemsQuery(smth, {
         model: factory,
-        prefix: prepend && tableName
+        prefix: prepend && tableName,
+        includeMap: options.includeMap
       });
     }
     if (Buffer.isBuffer(smth)) {
@@ -2923,7 +2936,8 @@ class QueryGenerator {
     if (smth === null) {
       return this.whereItemsQuery(smth, {
         model: factory,
-        prefix: prepend && tableName
+        prefix: prepend && tableName,
+        includeMap: options.includeMap
       });
     }
 


### PR DESCRIPTION
Pass includeMap to whereItemsQuery in order to get model properties from nested fields.

Closes #11749

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Pass along includeMap in order to get field properties for nested fields.

See issue: (https://github.com/sequelize/sequelize/issues/11749) where for the nested array column it didnt add the varchar property due to it could'nt find out anything about the actual field in the _findField function.