### PR TITLE
chore(model.d.ts): explain the order of ModelCtor

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2846,7 +2846,8 @@ export type ModelType = typeof Model;
 
 // Do not switch the order of `typeof Model` and `{ new(): M }`. For
 // instances created by `sequelize.define` to typecheck well, `typeof Model`
-// must come first for unknown reasons.
+// must come first since constructor's intersection type is not commutative.
+// e.g https://gist.github.com/HerringtonDarkholme/293fc9fcc868aab2aa8a39e46eb8b6e5
 export type ModelCtor<M extends Model> = typeof Model & { new(): M };
 
 export type ModelDefined<S, T> = ModelCtor<Model<S, T>>;


### PR DESCRIPTION
Intersecting constructor signature is not commutative in TS. 
That is, swapping order will produce different types in constructor's return type. 
Add a public gist for example

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Skipped template checking since the pull request only changes comment.
<!-- Please provide a description of the change here. -->
