### PR TITLE
feat(types): add type hint to AbstractDataTypeConstructor, closes #12893

### DIFF
--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -49,7 +49,7 @@ export type DataType = string | AbstractDataTypeConstructor | AbstractDataType;
 
 export const ABSTRACT: AbstractDataTypeConstructor;
 
-interface AbstractDataTypeConstructor {
+interface AbstractDataTypeConstructor<T = void> {
   key: string;
   warn(link: string, text: string): void;
 }
@@ -102,7 +102,7 @@ export interface CharDataType extends StringDataType {
 }
 
 export interface CharDataTypeOptions extends StringDataTypeOptions {}
-   
+
 export type TextLength = 'tiny' | 'medium' | 'long';
 
 /**
@@ -315,12 +315,12 @@ export interface DecimalDataTypeOptions {
 /**
  * A boolean / tinyint column, depending on dialect
  */
-export const BOOLEAN: AbstractDataTypeConstructor;
+export const BOOLEAN: AbstractDataTypeConstructor<"boolean">;
 
 /**
  * A time column
  */
-export const TIME: AbstractDataTypeConstructor;
+export const TIME: AbstractDataTypeConstructor<"time">;
 
 /**
  * A datetime column
@@ -359,22 +359,22 @@ export interface DateOnlyDataType extends AbstractDataType {
 /**
  * A key / value column. Only available in postgres.
  */
-export const HSTORE: AbstractDataTypeConstructor;
+export const HSTORE: AbstractDataTypeConstructor<"hstore">;
 
 /**
  * A JSON string column. Only available in postgres.
  */
-export const JSON: AbstractDataTypeConstructor;
+export const JSON: AbstractDataTypeConstructor<"json">;
 
 /**
  * A pre-processed JSON data column. Only available in postgres.
  */
-export const JSONB: AbstractDataTypeConstructor;
+export const JSONB: AbstractDataTypeConstructor<"jsonb">;
 
 /**
  * A default value of the current timestamp
  */
-export const NOW: AbstractDataTypeConstructor;
+export const NOW: AbstractDataTypeConstructor<"now">;
 
 /**
  * Binary storage. Available lengths: `tiny`, `medium`, `long`
@@ -438,17 +438,17 @@ export interface RangeDataTypeOptions<T extends RangeableDataType> {
 /**
  * A column storing a unique universal identifier. Use with `UUIDV1` or `UUIDV4` for default values.
  */
-export const UUID: AbstractDataTypeConstructor;
+export const UUID: AbstractDataTypeConstructor<"uuid">;
 
 /**
  * A default unique universal identifier generated following the UUID v1 standard
  */
-export const UUIDV1: AbstractDataTypeConstructor;
+export const UUIDV1: AbstractDataTypeConstructor<"uuidv1">;
 
 /**
  * A default unique universal identifier generated following the UUID v4 standard
  */
-export const UUIDV4: AbstractDataTypeConstructor;
+export const UUIDV4: AbstractDataTypeConstructor<"uuidv4">;
 
 /**
  * A virtual value that is not stored in the DB. This could for example be useful if you want to provide a default value in your model that is returned to the user but not stored in the DB.
@@ -595,16 +595,16 @@ export interface GeographyDataTypeOptions {
   srid?: number;
 }
 
-export const CIDR: AbstractDataTypeConstructor;
+export const CIDR: AbstractDataTypeConstructor<"cidr">;
 
-export const INET: AbstractDataTypeConstructor;
+export const INET: AbstractDataTypeConstructor<"inet">;
 
-export const MACADDR: AbstractDataTypeConstructor;
+export const MACADDR: AbstractDataTypeConstructor<"macaddr">;
 
 /**
  * Case incenstive text
  */
-export const CITEXT: AbstractDataTypeConstructor;
+export const CITEXT: AbstractDataTypeConstructor<"citext">;
 
 // umzug compatibility
 export type DataTypeAbstract = AbstractDataTypeConstructor;

--- a/types/test/data-types.ts
+++ b/types/test/data-types.ts
@@ -1,5 +1,5 @@
 import { INTEGER, IntegerDataType, TINYINT } from 'sequelize';
-import { SmallIntegerDataType, SMALLINT, MEDIUMINT, MediumIntegerDataType, BigIntDataType, BIGINT } from '../lib/data-types';
+import { AbstractDataTypeConstructor, BIGINT, CIDR, INET, MACADDR, CITEXT, BigIntDataType, BOOLEAN, HSTORE, JSON, JSONB, MEDIUMINT, MediumIntegerDataType, NOW, SMALLINT, SmallIntegerDataType, TIME, UUID, UUIDV1, UUIDV4 } from '../lib/data-types';
 
 let tinyint: IntegerDataType;
 tinyint = TINYINT();
@@ -30,3 +30,24 @@ bigint = BIGINT();
 bigint = new BIGINT();
 bigint = BIGINT.UNSIGNED.ZEROFILL();
 bigint = new BIGINT.UNSIGNED.ZEROFILL();
+
+const validateAbstractDataTypeConstructorLabel =
+  <T>(obj: T extends AbstractDataTypeConstructor<infer Label> ? Label : never) =>
+    undefined
+
+validateAbstractDataTypeConstructorLabel<typeof BOOLEAN>("boolean")
+validateAbstractDataTypeConstructorLabel<typeof TIME>("time")
+validateAbstractDataTypeConstructorLabel<typeof HSTORE>("hstore")
+
+validateAbstractDataTypeConstructorLabel<typeof JSON>("json")
+validateAbstractDataTypeConstructorLabel<typeof JSONB>("jsonb")
+validateAbstractDataTypeConstructorLabel<typeof NOW>("now")
+
+validateAbstractDataTypeConstructorLabel<typeof UUID>("uuid")
+validateAbstractDataTypeConstructorLabel<typeof UUIDV1>("uuidv1")
+validateAbstractDataTypeConstructorLabel<typeof UUIDV4>("uuidv4")
+
+validateAbstractDataTypeConstructorLabel<typeof CIDR>("cidr")
+validateAbstractDataTypeConstructorLabel<typeof INET>("inet")
+validateAbstractDataTypeConstructorLabel<typeof MACADDR>("macaddr")
+validateAbstractDataTypeConstructorLabel<typeof CITEXT>("citext")


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

- Adds an optional type parameter to `AbstractDataTypeConstructor`.
- Provides literal hint for types that directly use `AbstractDataTypeConstructor`.