### PR TITLE
fix: handle bulkCreate when @@auto_increment_increment is not 1

### DIFF
--- a/src/dialects/mariadb/connection-manager.js
+++ b/src/dialects/mariadb/connection-manager.js
@@ -93,6 +93,12 @@ class ConnectionManager extends AbstractConnectionManager {
             this.pool.destroy(connection);
         }
       });
+
+      const [{ autoIncrementIncrement }] = await connection.query(
+        'SELECT @@auto_increment_increment AS autoIncrementIncrement'
+      );
+      this.sequelize.options.autoIncrementIncrement = autoIncrementIncrement;
+
       return connection;
     } catch (err) {
       switch (err.code) {

--- a/src/dialects/mariadb/query.js
+++ b/src/dialects/mariadb/query.js
@@ -105,13 +105,13 @@ class Query extends AbstractQuery {
           this.model.autoIncrementAttribute === this.model.primaryKeyAttribute &&
           this.model.rawAttributes[this.model.primaryKeyAttribute]
         ) {
-          //ONLY TRUE IF @auto_increment_increment is set to 1 !!
-          //Doesn't work with GALERA => each node will reserve increment (x for first server, x+1 for next node ...
+          const autoIncrementIncrement = this.sequelize.options.autoIncrementIncrement || 1;
+
           const startId = data[this.getInsertIdField()];
           result = new Array(data.affectedRows);
           const pkField = this.model.rawAttributes[this.model.primaryKeyAttribute].field;
           for (let i = 0; i < data.affectedRows; i++) {
-            result[i] = { [pkField]: startId + i };
+            result[i] = { [pkField]: startId + i * autoIncrementIncrement };
           }
           return [result, data.affectedRows];
         }


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

The `formatResults` function is responsible of populating the instance `id` when performing `bulkCreate` operation as you can see below. This function assumes that the `@@auto_increment_increment` variable is set to `1`.

https://github.com/sequelize/sequelize/blob/933b3f62640e218587d34ec141029b2416ff7845/lib/dialects/mariadb/query.js#L104-L124

On clustered setups this variable is often set to a value different than `1`. This merge request ensures that the value of `@@auto_increment_increment` is fetched when a connection is established. This value is then used to properly calculate the instance `id`.

This pull request is perhaps a bit naive and feedback is welcome.

One potential optimization would be to add this behind a flag so that a `SELECT @@auto_increment_increment` is not executed for each new connection for users where this is not necessary.

I have not added tests for this, some guidance would be helpful in order to create some sort of integration test for this use case.

Another option to solve this issue would be to allow to user to specify the value `@@auto_increment_increment` value when initializing the sequelize instance.


