### PR TITLE
fix(types): allow any values in `isIn` validator

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1093,13 +1093,13 @@ export interface ModelValidateOptions {
   /**
    * check the value is not one of these
    */
-  notIn?: ReadonlyArray<readonly string[]> | { msg: string; args: ReadonlyArray<readonly string[]> };
+  notIn?: ReadonlyArray<readonly any[]> | { msg: string; args: ReadonlyArray<readonly any[]> };
 
   /**
    * check the value is one of these
    */
-  isIn?: ReadonlyArray<readonly string[]> | { msg: string; args: ReadonlyArray<readonly string[]> };
-
+  isIn?: ReadonlyArray<readonly any[]> | { msg: string; args: ReadonlyArray<readonly any[]> };
+  
   /**
    * don't allow specific substrings
    */


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Hi,

this is to update current types for `isIn` validator of validator.js lib. It should accept array of any values. It is then coerced to string regardless the content.
It updates both `isIn` and `notIn` signatures are both are using validator.js `isIn`.
This is e.g. useful when model's column is number and you're validating against list of numbers.

Reference:
- Validator.js src: https://github.com/validatorjs/validator.js/blob/master/src/lib/isIn.js#L4
- Validator.js types: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/validator/index.d.ts#L633
- very past fix in validator.js to allow array of any values: (though current code already modified, see first reference) https://github.com/validatorjs/validator.js/commit/5c4cbf7616e06f86a65266db1d88646e9c0e770d

