### PR TITLE
fix(types): missing upsert hooks

### DIFF
--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -31,10 +31,10 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   afterDestroy(instance: M, options: InstanceDestroyOptions): HookReturn;
   beforeRestore(instance: M, options: InstanceRestoreOptions): HookReturn;
   afterRestore(instance: M, options: InstanceRestoreOptions): HookReturn;
-  beforeUpdate(instance: M, options: UpsertOptions<TAttributes>): HookReturn;
-  afterUpdate(instance: M, options: UpsertOptions<TAttributes>): HookReturn;
-  beforeUpsert(instance: M, options: InstanceUpsertOptions<TAttributes>): HookReturn;
-  afterUpsert(instance: M, options: InstanceUpsertOptions<TAttributes>): HookReturn;
+  beforeUpdate(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
+  afterUpdate(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
+  beforeUpsert(attributes: M, options: UpsertOptions<TAttributes>): HookReturn;
+  afterUpsert(attributes: M, options: UpsertOptions<TAttributes>): HookReturn;
   beforeSave(
     instance: M,
     options: InstanceUpdateOptions<TAttributes> | CreateOptions<TAttributes>

--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -32,6 +32,8 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   afterRestore(instance: M, options: InstanceRestoreOptions): HookReturn;
   beforeUpdate(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
   afterUpdate(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
+  beforeUpsert(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
+  afterUpsert(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
   beforeSave(
     instance: M,
     options: InstanceUpdateOptions<TAttributes> | CreateOptions<TAttributes>

--- a/types/lib/hooks.d.ts
+++ b/types/lib/hooks.d.ts
@@ -5,6 +5,7 @@ import Model, {
   CreateOptions,
   DestroyOptions,
   RestoreOptions,
+  UpsertOptions,
   FindOptions,
   InstanceDestroyOptions,
   InstanceRestoreOptions,
@@ -30,10 +31,10 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   afterDestroy(instance: M, options: InstanceDestroyOptions): HookReturn;
   beforeRestore(instance: M, options: InstanceRestoreOptions): HookReturn;
   afterRestore(instance: M, options: InstanceRestoreOptions): HookReturn;
-  beforeUpdate(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
-  afterUpdate(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
-  beforeUpsert(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
-  afterUpsert(instance: M, options: InstanceUpdateOptions<TAttributes>): HookReturn;
+  beforeUpdate(instance: M, options: UpsertOptions<TAttributes>): HookReturn;
+  afterUpdate(instance: M, options: UpsertOptions<TAttributes>): HookReturn;
+  beforeUpsert(instance: M, options: InstanceUpsertOptions<TAttributes>): HookReturn;
+  afterUpsert(instance: M, options: InstanceUpsertOptions<TAttributes>): HookReturn;
   beforeSave(
     instance: M,
     options: InstanceUpdateOptions<TAttributes> | CreateOptions<TAttributes>


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Upsert hooks are missing in types. I've made this PR directly from Github UI editor.