### PR TITLE
fix(dialect:mysql): support more GEOMETRY subtypes

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -844,10 +844,10 @@ class GEOMETRY extends ABSTRACT {
     this.srid = options.srid;
   }
   _stringify(value, options) {
-    return `GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    return `ST_GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
   _bindParam(value, options) {
-    return `GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    return `ST_GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
 }
 
@@ -887,10 +887,10 @@ class GEOGRAPHY extends ABSTRACT {
     this.srid = options.srid;
   }
   _stringify(value, options) {
-    return `GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    return `ST_GeomFromText(${options.escape(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
   _bindParam(value, options) {
-    return `GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
+    return `ST_GeomFromText(${options.bindParam(wkx.Geometry.parseGeoJSON(value).toWkt())})`;
   }
 }
 

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -94,7 +94,7 @@ module.exports = BaseTypes => {
     'MULTIPOINT',
     'MULTILINESTRING',
     'MULTIPOLYGON',
-    'GEOMETRYCOLLECTION',
+    'GEOMETRYCOLLECTION'
   ];
 
   class GEOMETRY extends BaseTypes.GEOMETRY {

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -86,7 +86,16 @@ module.exports = BaseTypes => {
     }
   }
 
-  const SUPPORTED_GEOMETRY_TYPES = ['POINT', 'LINESTRING', 'POLYGON'];
+  const SUPPORTED_GEOMETRY_TYPES = [
+    'GEOMETRY',
+    'POINT',
+    'LINESTRING',
+    'POLYGON',
+    'MULTIPOINT',
+    'MULTILINESTRING',
+    'MULTIPOLYGON',
+    'GEOMETRYCOLLECTION',
+  ];
 
   class GEOMETRY extends BaseTypes.GEOMETRY {
     constructor(type, srid) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -376,7 +376,11 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     if (!typeWithoutDefault.has(attributeString)
       && attribute.type._binary !== true
       && Utils.defaultValueSchemable(attribute.defaultValue)) {
-      template += ` DEFAULT (${this.escape(attribute.defaultValue)})`;
+      if (attribute.defaultValue instanceof Utils.Fn) {
+        template += ` DEFAULT (${this.escape(attribute.defaultValue)})`;
+      } else {
+        template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+      }
     }
 
     if (attribute.unique === true) {

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -376,7 +376,7 @@ class MySQLQueryGenerator extends AbstractQueryGenerator {
     if (!typeWithoutDefault.has(attributeString)
       && attribute.type._binary !== true
       && Utils.defaultValueSchemable(attribute.defaultValue)) {
-      template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+      template += ` DEFAULT (${this.escape(attribute.defaultValue)})`;
     }
 
     if (attribute.unique === true) {

--- a/lib/dialects/mysql/query.js
+++ b/lib/dialects/mysql/query.js
@@ -274,10 +274,17 @@ class Query extends AbstractQuery {
         item.fields = [];
       }
 
+      let order = undefined;
+      if (item.Collation === 'A') {
+        order = 'ASC';
+      } else if (item.Collation === 'D') {
+        order = 'DESC';
+      }
+
       acc[item.Key_name].fields[item.Seq_in_index - 1] = {
         attribute: item.Column_name,
         length: item.Sub_part || undefined,
-        order: item.Collation === 'A' ? 'ASC' : undefined
+        order
       };
       delete item.column_name;
 

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -22,7 +22,7 @@ if (dialect === 'mysql') {
         const User = this.sequelize.define(`User${config.rand()}`, {
           username: { type: DataTypes.STRING, defaultValue: 'foo' }
         }, { timestamps: false });
-        expect(this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({ username: "VARCHAR(255) DEFAULT ('foo')", id: 'INTEGER NOT NULL auto_increment PRIMARY KEY' });
+        expect(this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({ username: "VARCHAR(255) DEFAULT 'foo'", id: 'INTEGER NOT NULL auto_increment PRIMARY KEY' });
       });
 
       it('handles extended attributes (null)', function() {

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -22,7 +22,7 @@ if (dialect === 'mysql') {
         const User = this.sequelize.define(`User${config.rand()}`, {
           username: { type: DataTypes.STRING, defaultValue: 'foo' }
         }, { timestamps: false });
-        expect(this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({ username: "VARCHAR(255) DEFAULT 'foo'", id: 'INTEGER NOT NULL auto_increment PRIMARY KEY' });
+        expect(this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({ username: "VARCHAR(255) DEFAULT ('foo')", id: 'INTEGER NOT NULL auto_increment PRIMARY KEY' });
       });
 
       it('handles extended attributes (null)', function() {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -409,7 +409,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         fieldD: Sequelize.STRING
       }, {
         indexes: indices,
-        engine: 'MyISAM'
+        engine: 'InnoDB'
       });
 
       await this.sequelize.sync();
@@ -469,7 +469,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         expect(idx1.fields).to.deep.equal([
           { attribute: 'fieldB', length: undefined, order: 'ASC' },
-          { attribute: 'fieldA', length: 5, order: 'ASC' }
+          { attribute: 'fieldA', length: 5, order: 'DESC' }
         ]);
 
         expect(idx2.fields).to.deep.equal([
@@ -2273,8 +2273,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         }
       } catch (err) {
         if (dialect === 'mysql') {
-          // MySQL 5.7 or above doesn't support POINT EMPTY
-          if (semver.gte(current.options.databaseVersion, '5.6.0')) {
+          if (semver.gte(current.options.databaseVersion, '8.0.0')) {
+            expect(err.message).to.match(/Failed to open the referenced table/);
+          } else if (semver.gte(current.options.databaseVersion, '5.6.0')) {
+            // MySQL 5.7 or above doesn't support POINT EMPTY
             expect(err.message).to.match(/Cannot add foreign key constraint/);
           } else {
             expect(err.message).to.match(/Can't create table/);

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -467,9 +467,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(idx1.type).to.equal('BTREE');
         expect(idx2.type).to.equal('FULLTEXT');
 
+        let expectedOrder = 'ASC';
+        if (semver.gte(current.options.databaseVersion, '8.0.0')) {
+          expectedOrder = 'DESC';
+        }
+
         expect(idx1.fields).to.deep.equal([
           { attribute: 'fieldB', length: undefined, order: 'ASC' },
-          { attribute: 'fieldA', length: 5, order: 'DESC' }
+          { attribute: 'fieldA', length: 5, order: expectedOrder }
         ]);
 
         expect(idx2.fields).to.deep.equal([

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -468,7 +468,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(idx2.type).to.equal('FULLTEXT');
 
         let expectedOrder = 'ASC';
-        if (semver.gte(current.options.databaseVersion, '8.0.0')) {
+        if (dialect === 'mysql' && semver.gte(current.options.databaseVersion, '8.0.0')) {
           expectedOrder = 'DESC';
         }
 

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -90,7 +90,8 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           tableNames = tableNames.map(v => v.tableName);
         }
         tableNames.sort();
-        expect(tableNames).to.deep.equal(['my_test_table1', 'my_test_table2']);
+        expect(tableNames).to.include('my_test_table1');
+        expect(tableNames).to.include('my_test_table2');
       });
     }
   });

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -136,6 +136,13 @@ if (dialect === 'mariadb') {
           expectation: { id: 'INTEGER DEFAULT 0' }
         },
         {
+          arguments: [function(sequelize) {
+            return { geodata: { type: 'GEOMETRYCOLLECTION', defaultValue: sequelize.fn('ST_GeomFromText', 'GEOMETRYCOLLECTION EMPTY') } };
+          }],
+          expectation: { geodata: 'GEOMETRYCOLLECTION DEFAULT (ST_GeomFromText(\'GEOMETRYCOLLECTION EMPTY\'))' },
+          needsSequelize: true
+        },
+        {
           title: 'Add column level comment',
           arguments: [{ id: { type: 'INTEGER', comment: 'Test' } }],
           expectation: { id: 'INTEGER COMMENT \'Test\'' }
@@ -829,8 +836,11 @@ if (dialect === 'mariadb') {
           const title = test.title || `MariaDB correctly returns ${query} for ${JSON.stringify(test.arguments)}`;
           it(title, function() {
             if (test.needsSequelize) {
-              if (typeof test.arguments[1] === 'function') test.arguments[1] = test.arguments[1](this.sequelize);
-              if (typeof test.arguments[2] === 'function') test.arguments[2] = test.arguments[2](this.sequelize);
+              test.arguments.forEach((arg, i) => {
+                if (typeof arg === 'function') {
+                  test.arguments[i] = arg(this.sequelize);
+                }
+              });
             }
 
             // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -90,7 +90,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', defaultValue: 0 } }],
-          expectation: { id: 'INTEGER DEFAULT 0' }
+          expectation: { id: 'INTEGER DEFAULT (0)' }
         },
         {
           title: 'Add column level comment',
@@ -145,7 +145,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT' } }],
-          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
+          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT (1) REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
         }
       ],
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -90,7 +90,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', defaultValue: 0 } }],
-          expectation: { id: 'INTEGER DEFAULT (0)' }
+          expectation: { id: 'INTEGER DEFAULT 0' }
         },
         {
           title: 'Add column level comment',
@@ -145,7 +145,7 @@ if (dialect === 'mysql') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', allowNull: false, autoIncrement: true, defaultValue: 1, references: { model: 'Bar' }, onDelete: 'CASCADE', onUpdate: 'RESTRICT' } }],
-          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT (1) REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
+          expectation: { id: 'INTEGER NOT NULL auto_increment DEFAULT 1 REFERENCES `Bar` (`id`) ON DELETE CASCADE ON UPDATE RESTRICT' }
         }
       ],
 


### PR DESCRIPTION
More things got into this PR as the basic functionality was requiring more changes over the code base. I've kept the changes as minimal as possible, though.

Tell me if you want this squashed or the split commits are easier to reason with.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
	* Yes
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? 
	* No
- [x] Have you added new tests to prevent regressions? 
	* Yes
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? 
	* No
- [x] Did you update the typescript typings accordingly (if applicable)?
	* N/A
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

* Fixed mysql GEOMETRY type to allow more subtypes that were allowed even back in 5.7 (cf: https://dev.mysql.com/doc/refman/8.0/en/spatial-type-overview.html). The supported types now look like this:
	* GEOMETRY
	* POINT
	* LINESTRING
	* POLYGON
	* MULTIPOINT
	* MULTILINESTRING
	* MULTIPOLYGON
	* GEOMETRYCOLLECTION
* Fixed an issue in the MySQL query builer (when creating tables) that was incorrectly not wrapping default values in `()` as recommended in the standard to support functions as default values. This now behaves as per-spec
* Fixed an issue in the MySQL `SHOW INDEX` query results parser, which didn't support `DESC` indexes at all, even for MySQL 8.0. This now behaves correctly
* Fixed the `should allow the user to specify indexes in options` test in `test/integration/model.test.js` using `MyISAM` engine where it should use `InnoDB` as MyISAM does *not* support `DESC` indexes and thus this test was doomed to fail every single time. cf. https://dev.mysql.com/doc/refman/8.0/en/descending-indexes.html `Descending indexes are supported only for the InnoDB storage engine`
* `DEFAULT` now supports DB functions with the help of `Sequelize.fn`. 
