### PR TITLE
passed sourceKey and targetKey to belongsTo through belongsToMany

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -346,9 +346,12 @@ class BelongsToMany extends Association {
       this.paired.foreignIdentifierField = this.through.model.rawAttributes[this.paired.otherKey].field || this.paired.otherKey;
     }
 
-    this.toSource = new BelongsTo(this.through.model, this.source, {
-      foreignKey: this.foreignKey
-    });
+    let toSourceOptions = { foreignKey: this.foreignKey };
+    if(this.sourceKey){
+      toSourceOptions = Object.assign({ targetKey: this.sourceKey }, toSourceOptions);
+    }
+    this.toSource = new BelongsTo(this.through.model, this.source, toSourceOptions);
+    
     this.manyFromSource = new HasMany(this.source, this.through.model, {
       foreignKey: this.foreignKey
     });
@@ -358,9 +361,12 @@ class BelongsToMany extends Association {
       as: this.through.model.name
     });
 
-    this.toTarget = new BelongsTo(this.through.model, this.target, {
-      foreignKey: this.otherKey
-    });
+    let toTargetOptions = { foreignKey: this.otherKey };
+    if(this.targetKey){
+      toTargetOptions = Object.assign({ targetKey: this.targetKey }, toTargetOptions);
+    }
+    this.toTarget = new BelongsTo(this.through.model, this.target, toTargetOptions);
+
     this.manyFromTarget = new HasMany(this.target, this.through.model, {
       foreignKey: this.otherKey
     });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
There seems to be an issue when 
1- i define explicitly the ID property of a model and in migration file (to set to UUID)
2- belongsTo relationship starts REQUIRING targetKey to work properly (understandable, given point 4)
3- belongsToMany calls belongsTo without passing targetKey if available (which should follow point 2)
4- for some reason when the ID field is set explicitly and even with "primaryKey" flag on that field is set to true in both the model and the migration file, the this.target.primaryKeyAttribute in belongsTo is always undefined (which creates this whole issue)