### PR TITLE
fix(dialects): add dialects only when successfully required

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -1051,11 +1051,35 @@ _.each(DataTypes, (dataType, name) => {
 });
 
 const dialectMap = {};
-dialectMap.postgres = require('./dialects/postgres/data-types')(DataTypes);
-dialectMap.mysql = require('./dialects/mysql/data-types')(DataTypes);
-dialectMap.mariadb = require('./dialects/mariadb/data-types')(DataTypes);
-dialectMap.sqlite = require('./dialects/sqlite/data-types')(DataTypes);
-dialectMap.mssql = require('./dialects/mssql/data-types')(DataTypes);
+try {
+  dialectMap.postgres = require('./dialects/postgres/data-types')(DataTypes);
+} catch (err) {
+  /* continue regardless of error */
+}
+
+try {
+  dialectMap.mysql = require('./dialects/mysql/data-types')(DataTypes);
+} catch (err) {
+  /* continue regardless of error */
+}
+
+try {
+  dialectMap.mariadb = require('./dialects/mariadb/data-types')(DataTypes);
+} catch (err) {
+  /* continue regardless of error */
+}
+
+try {
+  dialectMap.sqlite = require('./dialects/sqlite/data-types')(DataTypes);
+} catch (err) {
+  /* continue regardless of error */
+}
+
+try {
+  dialectMap.mssql = require('./dialects/mssql/data-types')(DataTypes);
+} catch (err) {
+  /* continue regardless of error */ 
+}
 
 const dialectList = Object.values(dialectMap);
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?

Someone else may have to run this, I'm not familiar enough with this repo to even run this test, I'm getting strange errors (on Windows) trying to run this script or npm run test-all or any of the specific ones. This PR may or may not pass this test. I'm going to assume it does if someone knows what they're doing. The automated tests appear to pass if that's what's being referred to.
```
Error: Cannot find module 'C:\~...~\sequelize\scripts\teaser'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:880:15)
    at Function.Module._load (internal/modules/cjs/loader.js:725:27)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:72:12)    at internal/main/run_main_module.js:17:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! sequelize@0.0.0-development teaser: `node scripts/teaser`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the sequelize@0.0.0-development teaser script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
```
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?

No*, technically this change handles errors requiring modules which may not have been installed (intentionally or unintentionally by the user). This may shift where errors occur, but should not impact any existing tests.
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

No*, this pr doesn't modify any apis or add any new ones. Although as mentioned in #7509 it might be better to have an api for users to add drivers they plan to use.
- [x] Did you update the typescript typings accordingly (if applicable)?

Not applicable*
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

With the exception of passing the tests on my own system*
<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

Wraps require section in `/lib/data-types.js` with try catch. This should resolve #7509 and similar. Another approach as pointed out would be to refactor so these are optionally added by the user. This edit makes it such that it's sufficient to install only the database drivers the user needs, however it will silence errors about the drivers which failed to be required that the user may want to know about. This PR silently drops drivers which failed to be required*. You may want to log the disabled and enabled drivers in the catch blocks.