### PR TITLE
fix(query): JSON value already an object

### DIFF
--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -197,8 +197,9 @@ class Query extends AbstractQuery {
       if (modelField.type instanceof DataTypes.JSON) {
         // Value is returned as String, not JSON
         rows = rows.map(row => {
-          row[modelField.fieldName] = row[modelField.fieldName] ? JSON.parse(
-            row[modelField.fieldName]) : null;
+          row[modelField.fieldName] = row[modelField.fieldName] ?
+            typeof row[modelField.fieldName] === 'string' ? JSON.parse(
+              row[modelField.fieldName]) : row[modelField.fieldName] : null;
           if (DataTypes.JSON.parse) {
             return DataTypes.JSON.parse(modelField, this.sequelize.options,
               row[modelField.fieldName]);


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Adding a type check before parsing JSON value (ensure that value is a string).
Was crashing as already an object in my context.

Behavior do not change if value is a string.

