### PR TITLE
fix(options): adds string as a type to the port option

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -236,7 +236,7 @@ export interface Options extends Logging {
   /**
    * The port of the relational database.
    */
-  port?: number;
+  port?: string | number;
 
   /**
    * A flag that defines if is used SSL.


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
  - `DIALECT=postgres` 
  - 2 failures 
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

The port option should accept both strings and numbers. The NodeJS URL
API defines port as a string, where this value ultimately ends up.

It should not be necessary to `parseInt(process.env.PORT)`, for example.

```
import { Sequelize } from 'sequelize';

const seq = new Sequelize({
  port: process.env.PORT || '5432'
});
```

