### PR TITLE
fix(underscored): fix underscored for model and association attributes

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -229,12 +229,14 @@ class BelongsToMany extends Association {
       this.foreignKey = this.foreignKeyAttribute.name || this.foreignKeyAttribute.fieldName;
     } else {
       this.foreignKeyAttribute = {};
-      this.foreignKey = this.options.foreignKey || Utils.camelize(
+      const foreignKey = this.options.foreignKey || Utils.camelize(
         [
           this.source.options.name.singular,
           this.sourceKey
         ].join('_')
       );
+
+      this.foreignKey = Utils.underscoredIf(foreignKey, this.source.underscored);
     }
 
     if (_.isObject(this.options.otherKey)) {
@@ -246,12 +248,14 @@ class BelongsToMany extends Association {
       }
 
       this.otherKeyAttribute = {};
-      this.otherKey = this.options.otherKey || Utils.camelize(
+      const otherKey = this.options.otherKey || Utils.camelize(
         [
           this.isSelfAssociation ? Utils.singularize(this.as) : this.target.options.name.singular,
           this.targetKey
         ].join('_')
       );
+
+      this.otherKey = Utils.underscoredIf(otherKey, this.target.underscored);
     }
   }
 

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -39,12 +39,14 @@ class BelongsTo extends Association {
     }
 
     if (!this.foreignKey) {
-      this.foreignKey = Utils.camelize(
+      const foreignKey = Utils.camelize(
         [
           this.as,
           this.target.primaryKeyAttribute
         ].join('_')
       );
+
+      this.foreignKey = Utils.underscoredIf(foreignKey, this.target.underscored);
     }
 
     this.identifier = this.foreignKey;
@@ -59,7 +61,7 @@ class BelongsTo extends Association {
       throw new Error(`Unknown attribute "${this.options.targetKey}" passed as targetKey, define this attribute on model "${this.target.name}" first`);
     }
 
-    this.targetKey = this.options.targetKey || this.target.primaryKeyAttribute;
+    this.targetKey = this.options.targetKey || Utils.underscoredIf(this.target.primaryKeyAttribute, this.target.underscored);
     this.targetKeyField = this.target.rawAttributes[this.targetKey].field || this.targetKey;
     this.targetKeyIsPrimary = this.targetKey === this.target.primaryKeyAttribute;
     this.targetIdentifier = this.targetKey;

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -63,12 +63,14 @@ class HasMany extends Association {
     }
 
     if (!this.foreignKey) {
-      this.foreignKey = Utils.camelize(
+      const foreignKey = Utils.camelize(
         [
           this.source.options.name.singular,
           this.source.primaryKeyAttribute
         ].join('_')
       );
+
+      this.foreignKey = Utils.underscoredIf(foreignKey, this.target.underscored);
     }
 
     if (this.target.rawAttributes[this.foreignKey]) {
@@ -79,7 +81,7 @@ class HasMany extends Association {
     /*
      * Source key setup
      */
-    this.sourceKey = this.options.sourceKey || this.source.primaryKeyAttribute;
+    this.sourceKey = this.options.sourceKey || Utils.underscoredIf(this.source.primaryKeyAttribute, this.source.underscored);
 
     if (this.source.rawAttributes[this.sourceKey]) {
       this.sourceKeyAttribute = this.sourceKey;

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -40,12 +40,14 @@ class HasOne extends Association {
     }
 
     if (!this.foreignKey) {
-      this.foreignKey = Utils.camelize(
+      const foreignKey = Utils.camelize(
         [
           Utils.singularize(this.options.as || this.source.name),
           this.source.primaryKeyAttribute
         ].join('_')
       );
+
+      this.foreignKey = Utils.underscoredIf(foreignKey, this.source.underscored);
     }
 
     if (
@@ -55,7 +57,7 @@ class HasOne extends Association {
       throw new Error(`Unknown attribute "${this.options.sourceKey}" passed as sourceKey, define this attribute on model "${this.source.name}" first`);
     }
 
-    this.sourceKey = this.sourceKeyAttribute = this.options.sourceKey || this.source.primaryKeyAttribute;
+    this.sourceKey = this.sourceKeyAttribute = this.options.sourceKey || Utils.underscoredIf(this.source.primaryKeyAttribute, this.source.underscored);
     this.sourceKeyField = this.source.rawAttributes[this.sourceKey].field || this.sourceKey;
     this.sourceKeyIsPrimary = this.sourceKey === this.source.primaryKeyAttribute;
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1033,17 +1033,17 @@ class Model {
 
       if (this.options.createdAt !== false) {
         this._timestampAttributes.createdAt =
-          typeof this.options.createdAt === 'string' ? this.options.createdAt : 'createdAt';
+          typeof this.options.createdAt === 'string' ? this.options.createdAt : Utils.underscoredIf('createdAt', this.underscored);
         this._readOnlyAttributes.add(this._timestampAttributes.createdAt);
       }
       if (this.options.updatedAt !== false) {
         this._timestampAttributes.updatedAt =
-          typeof this.options.updatedAt === 'string' ? this.options.updatedAt : 'updatedAt';
+          typeof this.options.updatedAt === 'string' ? this.options.updatedAt : Utils.underscoredIf('updatedAt', this.underscored);
         this._readOnlyAttributes.add(this._timestampAttributes.updatedAt);
       }
       if (this.options.paranoid && this.options.deletedAt !== false) {
         this._timestampAttributes.deletedAt =
-          typeof this.options.deletedAt === 'string' ? this.options.deletedAt : 'deletedAt';
+          typeof this.options.deletedAt === 'string' ? this.options.deletedAt : Utils.underscoredIf('deletedAt', this.underscored);
         this._readOnlyAttributes.add(this._timestampAttributes.deletedAt);
       }
     }

--- a/test/unit/model/underscored.test.js
+++ b/test/unit/model/underscored.test.js
@@ -109,4 +109,26 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(this.NM.rawAttributes['m_id'].field).to.equal('mama_id');
     });
   });
+
+  describe('options.underscored timestamps', () => {
+    beforeEach(function() {
+      this.N = this.sequelize.define('N', {
+        id: {
+          type: DataTypes.CHAR(10),
+          primaryKey: true,
+          field: 'n_id'
+        }
+      }, {
+        underscored: true,
+        timestamps: true,
+        paranoid: true
+      });
+    });
+
+    it('underscores timestamp attributes', function() {
+      expect(this.N.rawAttributes['created_at'].field).to.equal('created_at');
+      expect(this.N.rawAttributes['updated_at'].field).to.equal('updated_at');
+      expect(this.N.rawAttributes['deleted_at'].field).to.equal('deleted_at');
+    });
+  });
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

This fixes the problems associated with the underscored/underscoredAll change described here: https://github.com/sequelize/sequelize/issues/11225

When someone provides `underscored: true`, this makes all generated fields, timestamp columns, and association keys underscored instead of camelcase.
