### PR TITLE
fix(types): adds missing function signature to Model.prototype.previous() types

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2706,10 +2706,13 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   public changed(): false | string[];
 
   /**
-   * Returns the previous value for key from `_previousDataValues`.
+   * If previous is called with a string it will return the previous value for that key from `_previousDataValues`.
+   *
+   * If previous is called without an argument it will return an object where the keys are the changed property names
+   *  and the values are the previous values for that key from `_previousDataValues`.
    */
-  public previous(): Record<string, unknown>;
   public previous<K extends keyof this>(key: K): this[K];
+  public previous(): Record<string, unknown>;
 
   /**
    * Validates this instance, and if the validation passes, persists it to the database.

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2708,6 +2708,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   /**
    * Returns the previous value for key from `_previousDataValues`.
    */
+  public previous(): Record<string, unknown>;
   public previous<K extends keyof this>(key: K): this[K];
 
   /**


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [N/A] Have you added new tests to prevent regressions?
- [N/A] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

In the type definition for `previous()` on a model instance, the only specified signature is for when you pass in an argument to get a specific properties previous value. However, Sequelize will let you call `previous()` with no arguments and get an object back that maps all changed properties to their previous values. This PR adds that additional function signature to the type definitions so you can use `previous()` that way as well. 
