### PR TITLE
fix(queryGenerator): use AND for not/between

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2162,7 +2162,9 @@ class QueryGenerator {
           model: factory
         });
       }
-      if (typeof value === 'boolean') {
+      if ([this.OperatorMap[Op.between], this.OperatorMap[Op.notBetween]].includes(smth.comparator)) {
+        value = `${this.escape(value[0])} AND ${this.escape(value[1])}`;
+      } else if (typeof value === 'boolean') {
         value = this.booleanValue(value);
       } else {
         value = this.escape(value);

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -1263,5 +1263,13 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       current.where(current.fn('lower', current.col('name')), null)], {
       default: '(SUM([hours]) > 0 AND lower([name]) IS NULL)'
     });
+    
+    testsql(current.where(current.col('hours'), Op.between, [0, 5]), {
+      default: '[hours] BETWEEN 0 AND 5'
+    });
+    
+    testsql(current.where(current.col('hours'), Op.notBetween, [0, 5]), {
+      default: '[hours] NOT BETWEEN 0 AND 5'
+    });
   });
 });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Fix handling of Op.between / Op.notBetween when using Sequelize.where
Closes #13040
