### PR TITLE
fix(types): Update model.d.ts to give more correct return type for `.toJSON()`

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2820,7 +2820,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Convert the instance to a JSON representation. Proxies to calling `get` with no keys. This means get all
    * values gotten from the DB, and apply all custom getters.
    */
-  public toJSON(): object;
+  public toJSON(): TModelAttributes;
 
   /**
    * Helper method to determine if a instance is "soft deleted". This is

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -16,6 +16,8 @@ class OtherModel extends Model {}
 
 const Instance: MyModel = new MyModel({ int: 10 });
 
+const gotten = Instance.get();
+expectTypeOf(Instance.toJSON()).toEqualTypeOf<typeof gotten>();
 expectTypeOf(Instance.get('num')).toEqualTypeOf<number>();
 
 MyModel.findOne({


### PR DESCRIPTION
### Description of change

Change the return type of a model's `.toJSON()` method from generic `object` to the more specifc and helpful `TModelAttributes`. 
