### PR TITLE
fix(postgres): reuse `searchPath` in `extractTableDetails` 

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -41,8 +41,9 @@ class QueryGenerator {
   extractTableDetails(tableName, options) {
     options = options || {};
     tableName = tableName || {};
+    const schema = tableName.schema || options.schema || options.schema !== false && this.sequelize.options.searchPath || 'public';
     return {
-      schema: tableName.schema || options.schema || 'public',
+      schema,
       tableName: _.isPlainObject(tableName) ? tableName.tableName : tableName,
       delimiter: tableName.delimiter || options.delimiter || '.'
     };

--- a/test/unit/sql/enum.test.js
+++ b/test/unit/sql/enum.test.js
@@ -17,6 +17,11 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         schema: 'foo'
       });
 
+      const FooUser2 = current.define('user', {
+        mood: DataTypes.ENUM('happy', 'sad')
+      }, {
+      });
+
       const PublicUser = current.define('user', {
         mood: {
           type: DataTypes.ENUM('happy', 'sad'),
@@ -45,6 +50,14 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           expectsql(sql.pgEnum(FooUser.getTableName(), 'mood', FooUser.rawAttributes.mood.type), {
             postgres: 'CREATE TYPE "foo"."enum_users_mood" AS ENUM(\'happy\', \'sad\');'
           });
+        });
+
+        it('uses schema from Sequelize searchPath', () => {
+          current.options.searchPath = 'nonPublicSchema';
+          expectsql(sql.pgEnum(FooUser2.getTableName(), 'mood', FooUser.rawAttributes.mood.type), {
+            postgres: 'CREATE TYPE "nonPublicSchema"."enum_users_mood" AS ENUM(\'happy\', \'sad\');'
+          });
+          current.options.searchPath = null;
         });
 
         it('does add schema when public', () => {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Reuse `searchPath` in `extractTableDetails` to make enums + addColumn/updateColumn queries match the default schema
