### PR TITLE
fix: QueryGenerator has been renamed

### DIFF
--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -284,7 +284,7 @@ export class QueryInterface {
    *
    * We don't have a definition for the QueryGenerator, because I doubt it is commonly in use separately.
    */
-  public QueryGenerator: unknown;
+  public queryGenerator: unknown;
 
   /**
    * Returns the current sequelize instance.


### PR DESCRIPTION
### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Did you update the typescript typings accordingly (if applicable)?

### Description of change

This `QueryGenerator` property is now called `queryGenerator`, as mentioned in the "upgrading to v6" changelog: https://sequelize.org/master/manual/upgrade-to-v6.html