### PR TITLE
This PR is a rework of #12937

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -794,7 +794,7 @@ class ARRAY extends ABSTRACT {
  * In PostGIS, the GeoJSON is parsed using the PostGIS function `ST_GeomFromGeoJSON`.
  * In MySQL it is parsed using the function `GeomFromText`.
  *
- * Therefore, one can just follow the [GeoJSON spec](http://geojson.org/geojson-spec.html) for handling geometry objects.  See the following examples:
+ * Therefore, one can just follow the [GeoJSON spec](https://tools.ietf.org/html/rfc7946) for handling geometry objects.  See the following examples:
  *
  * @example <caption>Defining a Geometry type attribute</caption>
  * DataTypes.GEOMETRY


### PR DESCRIPTION
The following changes update the link of an obsolete resource that is the `GeoJSON` link in `data-types.js` file. The old resource is from 2008 and the new one is from 2016. @papb please leave a review.