### PR TITLE
Update lodash version to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "debug": "^4.1.1",
     "dottie": "^2.0.0",
     "inflection": "1.12.0",
-    "lodash": "^4.17.20",
+    "lodash": "^4.17.21",
     "moment": "^2.26.0",
     "moment-timezone": "^0.5.31",
     "retry-as-promised": "^3.2.0",


### PR DESCRIPTION
In this version, a vulnerability is fixed.

Info: https://nvd.nist.gov/vuln/detail/CVE-2021-23337
