### PR TITLE
fix(mssql): support nullable composite unique indexes

### DIFF
--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -465,7 +465,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
        * Exclude NULL Composite PK/UK. Partial Composite clauses should also be excluded as it doesn't guarantee a single row
        */
       for (const key in clause) {
-        if (typeof clause[key] === 'undefined' || clause[key] == null) {
+        if (primaryKeysAttrs.includes(key) && (typeof clause[key] === 'undefined' || clause[key] === null)) {
           valid = false;
           break;
         }
@@ -480,7 +480,7 @@ class MSSQLQueryGenerator extends AbstractQueryGenerator {
     const getJoinSnippet = array => {
       return array.map(key => {
         key = this.quoteIdentifier(key);
-        return `${targetTableAlias}.${key} = ${sourceTableAlias}.${key}`;
+        return `ISNULL(${targetTableAlias}.${key}, '') = ISNULL(${sourceTableAlias}.${key}, '')`;
       });
     };
 

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -69,7 +69,7 @@ if (current.dialect.name === 'mssql') {
       // the main purpose of this test is to validate this does not throw
       expectsql(this.queryGenerator.upsertQuery('test_table', updateValues, insertValues, where, testTable), {
         mssql:
-          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(24)) AS [test_table_source]([Age]) ON [test_table_target].[Name] = [test_table_source].[Name] AND [test_table_target].[IsOnline] = [test_table_source].[IsOnline] WHEN MATCHED THEN UPDATE SET [test_table_target].[Name] = N'Charlie', [test_table_target].[Age] = 24, [test_table_target].[IsOnline] = 0 WHEN NOT MATCHED THEN INSERT ([Age]) VALUES(24) OUTPUT $action, INSERTED.*;"
+          "MERGE INTO [test_table] WITH(HOLDLOCK) AS [test_table_target] USING (VALUES(24)) AS [test_table_source]([Age]) ON ISNULL([test_table_target].[Name], '') = ISNULL([test_table_source].[Name], '') AND ISNULL([test_table_target].[IsOnline], '') = ISNULL([test_table_source].[IsOnline], '') WHEN MATCHED THEN UPDATE SET [test_table_target].[Name] = N'Charlie', [test_table_target].[Age] = 24, [test_table_target].[IsOnline] = 0 WHEN NOT MATCHED THEN INSERT ([Age]) VALUES(24) OUTPUT $action, INSERTED.*;"
       });
     });
 


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Adds support for nullable composite unique indexes in MSSQL.
Fixes issue #13069 
