### PR TITLE
test(dropEnum): minor refactor

### DIFF
--- a/test/integration/query-interface/dropEnum.test.js
+++ b/test/integration/query-interface/dropEnum.test.js
@@ -19,18 +19,9 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   describe('dropEnum', () => {
     beforeEach(async function() {
       await this.queryInterface.createTable('menus',  {
-        structuretype: {
-          type: DataTypes.ENUM('menus', 'submenu', 'routine'),
-          allowNull: true
-        },
-        sequence: {
-          type: DataTypes.INTEGER,
-          allowNull: true
-        },
-        name: {
-          type: DataTypes.STRING,
-          allowNull: true
-        }
+        structuretype: DataTypes.ENUM('menus', 'submenu', 'routine'),
+        sequence: DataTypes.INTEGER,
+        name: DataTypes.STRING
       });
     });
 


### PR DESCRIPTION
Minor refactor since `allowNull` is already true by default and since only `{ type: X }` would be left we can use the shorthand syntax passing `X` directly.