### PR TITLE
chore(development) make docker-compose file compatible with recent co…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       MYSQL_USER: sequelize_test
       MYSQL_PASSWORD: sequelize_test
     volumes:
-    - $MARIADB_ENTRYPOINT:/docker-entrypoint-initdb.d
+    - $MARIADB_ENTRYPOINT/:/docker-entrypoint-initdb.d
     ports:
     - "8960:3306"
     container_name: mariadb-103
@@ -67,7 +67,7 @@ services:
       MYSQL_USER: sequelize_test
       MYSQL_PASSWORD: sequelize_test
     volumes:
-    - $MYSQLDB_ENTRYPOINT:/docker-entrypoint-initdb.d
+    - $MYSQLDB_ENTRYPOINT/:/docker-entrypoint-initdb.d
     ports:
       - "8980:3306"
     container_name: mysql-57


### PR DESCRIPTION
…mpose versions

Recent versions don't like how the volume is specified, see the discussion and fix here:

https://stackoverflow.com/questions/59904878/docker-compose-volume-name-is-too-short-names-should-be-at-least-two-alphanume