### PR TITLE
feat (postgres): Added dialectOption to omit range-types other than the internal ones

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -257,16 +257,23 @@ class ConnectionManager extends AbstractConnectionManager {
 
     // Refresh dynamic OIDs for some types
     // These include Geometry / Geography / HStore / Enum / Citext / Range
+
+    // use new dialect-specific option "onlyInternalTypes" in order to check if we don't
+    // want to pull all range types. This comes in handy for huge databases with thousands of
+    // tables.
+    const onlyInternalRanges = String(_.get(this.sequelize.options,
+      'dialectOptions.onlyInternalTypes', false)) === 'true' || false;
     return (connection || this.sequelize).query(
-      'WITH ranges AS (' +
-      '  SELECT pg_range.rngtypid, pg_type.typname AS rngtypname,' +
-      '         pg_type.typarray AS rngtyparray, pg_range.rngsubtype' +
-      '    FROM pg_range LEFT OUTER JOIN pg_type ON pg_type.oid = pg_range.rngtypid' +
-      ')' +
-      'SELECT pg_type.typname, pg_type.typtype, pg_type.oid, pg_type.typarray,' +
-      '       ranges.rngtypname, ranges.rngtypid, ranges.rngtyparray' +
-      '  FROM pg_type LEFT OUTER JOIN ranges ON pg_type.oid = ranges.rngsubtype' +
-      ' WHERE (pg_type.typtype IN(\'b\', \'e\'));'
+      `WITH ranges AS (
+        SELECT pg_range.rngtypid, pg_type.typname AS rngtypname,
+               pg_type.typarray AS rngtyparray, pg_range.rngsubtype
+          FROM pg_range LEFT OUTER JOIN pg_type ON pg_type.oid = pg_range.rngtypid
+      )
+      SELECT pg_type.typname, pg_type.typtype, pg_type.oid, pg_type.typarray,
+             ranges.rngtypname, ranges.rngtypid, ranges.rngtyparray
+        FROM pg_type LEFT OUTER JOIN ranges ON pg_type.oid = ranges.rngsubtype
+       WHERE (pg_type.typtype IN('b', 'e'))
+       ${onlyInternalRanges ? 'and typnamespace = (select oid from pg_namespace where nspname = \'pg_catalog\')' : ''};`
     ).then(results => {
       let result = Array.isArray(results) ? results.pop() : results;
 

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -262,7 +262,7 @@ class ConnectionManager extends AbstractConnectionManager {
     // want to pull all range types. This comes in handy for huge databases with thousands of
     // tables.
     const onlyInternalRanges = String(_.get(this.sequelize.options,
-      'dialectOptions.onlyInternalTypes', false)) === 'true' || false;
+      'dialectOptions.onlyInternalRanges', false)) === 'true' || false;
     return (connection || this.sequelize).query(
       `WITH ranges AS (
         SELECT pg_range.rngtypid, pg_type.typname AS rngtypname,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "sequelize",
+  "name": "@perengo/sequelize-patched",
   "description": "Multi dialect ORM for Node.JS",
-  "version": "0.0.0-development",
+  "version": "5.22.4-development",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     "Sascha Depold <sascha@depold.com>",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@perengo/sequelize-patched",
+  "name": "sequelize",
   "description": "Multi dialect ORM for Node.JS",
-  "version": "5.22.4-development",
+  "version": "0.0.0-development",
   "author": "Sascha Depold <sascha@depold.com>",
   "contributors": [
     "Sascha Depold <sascha@depold.com>",


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
The postgres connection-manager always reads in the whole type ranges. 
This is contra-productive for huge databases with thousands of tables since it bloats memory-usage. 
To avoid that, we introduced a switch which would just grab the internal ranges thus lowering the memory-footprint.