### PR TITLE
fix(types): Allow transaction to be null in Transactionable interface (#13092).

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -35,7 +35,7 @@ export interface Transactionable {
   /**
    * Transaction to run query under
    */
-  transaction?: Transaction;
+  transaction?: Transaction | null;
 }
 
 export interface SearchPathable {

--- a/types/test/transaction.ts
+++ b/types/test/transaction.ts
@@ -81,6 +81,6 @@ async function nestedTransact() {
 
 async function excludeFromTransaction() {
   await sequelize.transaction(async t =>
-    sequelize.query('SELECT 1', { transaction: null })
+    await sequelize.query('SELECT 1', { transaction: null })
   );
 }

--- a/types/test/transaction.ts
+++ b/types/test/transaction.ts
@@ -78,3 +78,9 @@ async function nestedTransact() {
   });
   await tr.commit();
 }
+
+async function excludeFromTransaction() {
+  await sequelize.transaction(async t =>
+    sequelize.query('SELECT 1', { transaction: null })
+  );
+}


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions? (typing issue)
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

When using TypeScript with `strictNullChecks` enabled, we cannot pass `null` to `transaction`, but this is actually allowed and used to execute in a non-transaction context when in an auto-transaction block.

Closes #13092.

I wish for this change to also be backported to v5. How do I go about doing that? 