### PR TITLE
Deferrable typings

### DIFF
--- a/types/lib/transaction.d.ts
+++ b/types/lib/transaction.d.ts
@@ -145,7 +145,7 @@ export interface TransactionOptions extends Logging {
   autocommit?: boolean;
   isolationLevel?: Transaction.ISOLATION_LEVELS;
   type?: Transaction.TYPES;
-  deferrable?: string | Deferrable;
+  deferrable?: Deferrable;
   /**
    * Parent transaction.
    */


### PR DESCRIPTION
**This PR is based on #13096, and should be merged after.**

*******


### Description of change

As mentioned in #13096: disallow the use of `string` in deferrable properties, for TypeScript users.

All Deferrable options should be implemented in the `Deferrable` class already, and should be considered for addition if not.