### PR TITLE
feat(types): defining models, offers stricter type safety by default

### DIFF
--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -21,7 +21,6 @@ Example of a minimal TypeScript project with strict type-checking for attributes
 import {
   Sequelize,
   Model,
-  ModelDefined,
   DataTypes,
   HasManyGetAssociationsMixin,
   HasManyAddAssociationMixin,
@@ -176,10 +175,10 @@ Address.init(
 );
 
 // And with a functional approach defining a module looks like this
-const Note: ModelDefined<
-  NoteAttributes,
-  NoteCreationAttributes
-> = sequelize.define(
+const Note = sequelize.define<
+    NoteAttributes,
+    NoteCreationAttributes
+  >(
   'Note',
   {
     id: {

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1,4 +1,3 @@
-import * as DataTypes from './data-types';
 import { HookReturn, Hooks, SequelizeHooks } from './hooks';
 import { ValidationOptions } from './instance-validator';
 import {
@@ -27,6 +26,7 @@ import QueryTypes = require('./query-types');
 import { Transaction, TransactionOptions } from './transaction';
 import { Cast, Col, Fn, Json, Literal, Where } from './utils';
 import { ConnectionManager } from './connection-manager';
+import { ModelDefined } from './model';
 
 /**
  * Additional options for table altering during sync
@@ -1164,11 +1164,18 @@ export class Sequelize extends Hooks {
    * @param options  These options are merged with the default define options provided to the Sequelize
    *           constructor
    */
-  public define<M extends Model, TCreationAttributes = M['_attributes']>(
+  public define<
+    TModelAttributes extends Model | Model["_attributes"],
+    TCreationAttributes = Model["_attributes"]
+  >(
     modelName: string,
-    attributes: ModelAttributes<M, TCreationAttributes>,
+    attributes: ModelAttributes<Model, Partial<TCreationAttributes>>,
     options?: ModelOptions
-  ): ModelCtor<M>;
+  ): ModelDefined<
+    | (TCreationAttributes & Record<string, unknown>)
+    | (TModelAttributes & Record<string, unknown>),
+    TCreationAttributes & Record<string, unknown>
+  >;
 
   /**
    * Fetch a Model which is already defined

--- a/types/test/sequelize.ts
+++ b/types/test/sequelize.ts
@@ -1,4 +1,6 @@
-import { Config, Sequelize, Model, QueryTypes, ModelCtor } from 'sequelize';
+import { expectTypeOf } from 'expect-type';
+import { Config, Sequelize, Model, QueryTypes, ModelCtor, DataTypes, Optional } from 'sequelize';
+import { ModelDefined } from '../lib/model';
 import { Fn } from '../lib/utils';
 
 Sequelize.useCLS({
@@ -59,6 +61,47 @@ class Model2 extends Model{}
 const myModel: ModelCtor<Model1> = sequelize.models.asd;
 myModel.hasOne(Model2)
 myModel.findAll();
+
+// expect type tests
+/// implicitly specifying attributes
+const myModel2 = sequelize.define("myModel2", {
+  column: DataTypes.STRING,
+});
+
+expectTypeOf(myModel2).toEqualTypeOf<
+  ModelDefined<
+    | Record<string, unknown>
+    | ({
+        column: unknown;
+      } & Record<string, unknown>),
+    {
+      column: unknown;
+    }
+  >
+>();
+
+/// explicitly specifying attributes
+interface ModelAttributes {
+  id: number;
+  column: string;
+}
+
+interface CreationAttributes extends Optional<ModelAttributes, "id"> {}
+
+const myModel3 = sequelize.define<ModelAttributes, CreationAttributes>(
+  "myModel3",
+  {
+    column: DataTypes.STRING,
+  }
+);
+
+expectTypeOf(myModel3).toEqualTypeOf<
+  ModelDefined<
+    | (CreationAttributes & Record<string, unknown>)
+    | (ModelAttributes & Record<string, unknown>),
+    CreationAttributes & Record<string, unknown>
+  >
+>();
 
 async function test() {
   const [results, meta]: [unknown[], unknown] = await sequelize.query('SELECT * FROM `user`', { type: QueryTypes.RAW });

--- a/types/test/sequelize.ts
+++ b/types/test/sequelize.ts
@@ -76,7 +76,7 @@ expectTypeOf(myModel2).toEqualTypeOf<
       } & Record<string, unknown>),
     {
       column: unknown;
-    }
+    } & Record<string, unknown>
   >
 >();
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

***This PR currently introduces a breaking change***

#### Better API design for strictly defining models

The best way to offer type safety for a Sequelize model that is defined with the `define` method is to create a `ModelAttributes` and a `CreationAttributes` interface like the following:

```ts
interface InstrumentAttributes {
	id: number;
	type: string;
	purchaseDate: Date;
}

interface InstrumentCreationAttributes
	extends Optional<InstrumentAttributes, "id"> {}

const Instrument: ModelDefined<
  InstrumentAttributes, 
  InstrumentCreationAttributes
> = sequelize.define("instrument", {
	type: DataTypes.STRING,
	purchaseDate: DataTypes.DATE,
});
```

This generally works, but it has one flaw. We must always import the `ModelDefined` type. A better solution for this is to instead write:

```ts
const Instrument = sequelize.define<InstrumentAttributes, InstrumentCreationAttributes>("instrument", {
	type: DataTypes.STRING,
	purchaseDate: DataTypes.DATE,
});
```

This PR introduces this new API design.

#### Stricter type safety if not strictly passing `ModelAttributes` & `CreationAttributes`

Currently, when defining a model, without passing the `ModelAttributes` and `CreationAttributes`, we run into the following Problem; The return type is: `ModelCtor<Model>`, which does not offer type safety for attributes at all, meaning if we write this: `Instrument.create({ type: 'foo' })`, it won't give any type suggestions for the attribute `type`.

With this PR and out above example, but with the generics `InstrumentAttributes` and `InstrumentCreationAttributes` removed, `sequelize.define` would return the following type: 

```ts
ModelDefined<
    | Record<string, unknown>
    | ({
        type: unknown; 
        purchaseDate: unknown;
      } & Record<string, unknown>),
    {
      type: unknown; 
      purchaseDate: unknown;
    } & Record<string, unknown>
  >
```

With this addition, it is known that the attributes `type` and `purchaseDate` exist, but are of type `unknown`. It is also possible to add `attributes`, that were not explicitly specified during the model definition, such as `id`.

#### Summing up

This PR offers a more accessible API design, at the cost of introducing a breaking change. The breaking change is, that you can't strictly define the `ModelAttributes` and `CreationAttributes`, as you could before. I'm currently investigating this, to see if there's any way we can offer this backwards compatibility, and I'm open to ideas.