### PR TITLE
fix(types): allow `(keyof TAttributes)[]` in `UpdateOptions.returning`

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -875,7 +875,7 @@ export interface UpdateOptions<TAttributes = any> extends Logging, Transactionab
   /**
    * Return the affected rows (only for postgres)
    */
-  returning?: boolean;
+  returning?: boolean | (keyof TAttributes)[];
 
   /**
    * How many rows to update (only for mysql and mariadb)

--- a/types/test/update.ts
+++ b/types/test/update.ts
@@ -1,0 +1,18 @@
+import { Model } from 'sequelize';
+import { User } from './models/User';
+
+class TestModel extends Model {
+}
+
+TestModel.update({}, { where: {} });
+TestModel.update({}, { where: {}, returning: false });
+TestModel.update({}, { where: {}, returning: true });
+TestModel.update({}, { where: {}, returning: ['foo'] });
+
+
+User.update({}, { where: {} });
+User.update({}, { where: {}, returning: true });
+User.update({}, { where: {}, returning: false });
+User.update({}, { where: {}, returning: ['username'] });
+// @ts-expect-error
+User.update({}, { where: {}, returning: ['foo'] });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Allow to use an array of columns for the `returning` option
Closes https://github.com/sequelize/sequelize/issues/13070
