### PR TITLE
fix(postgres): make transitive gets default to parent schema

### DIFF
--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -141,6 +141,8 @@ class BelongsTo extends Association {
 
     if (Object.prototype.hasOwnProperty.call(options, 'schema')) {
       Target = Target.schema(options.schema, options.schemaDelimiter);
+    } else if (instances._options && instances._options._schema) {
+      Target = Target.schema(instances._options._schema);
     }
 
     if (!Array.isArray(instances)) {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -561,6 +561,13 @@ class QueryGenerator {
       options.where = this.whereQuery(options.where);
     }
 
+    if (options.schema && !_.isObject(tableName)) {
+      tableName = {
+        tableName,
+        schema: options.schema
+      };
+    }
+
     if (typeof tableName === 'string') {
       tableName = this.quoteIdentifiers(tableName);
     } else {
@@ -1797,7 +1804,13 @@ class QueryGenerator {
 
   generateThroughJoin(include, includeAs, parentTableName, topLevelInfo) {
     const through = include.through;
-    const throughTable = through.model.getTableName();
+    let throughTable = through.model.getTableName();
+    if (include.model._schema && include.through.model._schema === null) {
+      throughTable = {
+        schema: include.model._schema,
+        tableName: through.model.getTableName()
+      };
+    }
     const throughAs = `${includeAs.internalAs}->${through.as}`;
     const externalThroughAs = `${includeAs.externalAs}.${through.as}`;
     const throughAttributes = through.attributes.map(attr => {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -369,9 +369,15 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     return `DELETE FROM ${table}${whereClause}`;
   }
 
-  showIndexesQuery(tableName) {
+  showIndexesQuery(tableName, options) {
     let schemaJoin = '';
     let schemaWhere = '';
+    if (typeof tableName === 'string' && options && options.schema) {
+      tableName = {
+        tableName,
+        schema: options.schema
+      };
+    }
     if (typeof tableName !== 'string') {
       schemaJoin = ', pg_namespace s';
       schemaWhere = ` AND s.oid = t.relnamespace AND s.nspname = '${tableName.schema}'`;

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -518,6 +518,51 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(task).to.be.ok;
         });
 
+        describe('regressions', () => {
+          it('should be able to sync model with schema set at sync time', async function() {
+            this.sequelize.models = [];
+            this.sequelize.define(
+              'User3',
+              {
+                name: DataTypes.STRING,
+                value: DataTypes.INTEGER
+              },
+              {
+                indexes: [
+                  {
+                    name: 'test_user3_idx',
+                    fields: ['name']
+                  }
+                ]
+              }
+            );
+
+            this.sequelize.define(
+              'Task3',
+              {
+                name: DataTypes.STRING,
+                value: DataTypes.INTEGER
+              },
+              {
+                indexes: [
+                  {
+                    name: 'test_task3_idx',
+                    fields: ['name']
+                  }
+                ]
+              }
+            );
+
+            return Promise.all([
+              this.sequelize.sync({ schema: SCHEMA_ONE, force: true }),
+              this.sequelize.sync({ schema: SCHEMA_TWO, force: true })
+            ]).then(([res1, res2]) => {
+              expect(res1).to.be.ok;
+              expect(res2).to.be.ok;
+            });
+          });
+        });
+
         // TODO: this should work with MSSQL / MariaDB too
         // Need to fix addSchema return type
         if (dialect.match(/^postgres/)) {
@@ -540,7 +585,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             const user0 = await User.schema(SCHEMA_ONE).create({});
             const task = await Task.schema(SCHEMA_ONE).create({});
             await task.setUserXYZ(user0);
-            const user = await task.getUserXYZ({ schema: SCHEMA_ONE });
+            let user = await task.getUserXYZ({ schema: SCHEMA_ONE });
+            expect(user).to.be.ok;
+            user = await task.getUserXYZ(); // Default to schema of task entity
             expect(user).to.be.ok;
           });
         }


### PR DESCRIPTION
Make index-creation work also if the schema is provided at sync time.

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/master/CONTRIBUTING.md)?

### Description of change

Fixes #11638, #11634