### PR TITLE
feat(on-conflict-where): add on confluct do update where fixes #11656

### DIFF
--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -39,7 +39,8 @@ AbstractDialect.prototype.supports = {
   inserts: {
     ignoreDuplicates: '', /* dialect specific words for INSERT IGNORE or DO NOTHING */
     updateOnDuplicate: false, /* whether dialect supports ON DUPLICATE KEY UPDATE */
-    onConflictDoNothing: '' /* dialect specific words for ON CONFLICT DO NOTHING */
+    onConflictDoNothing: '', /* dialect specific words for ON CONFLICT DO NOTHING */
+    onConflictDoUpdateWhere: false /* where dialect supports ON CONFLICT UPDATE with WHERE clause */
   },
   constraints: {
     restrict: true,

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -186,7 +186,7 @@ class QueryGenerator {
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
-        if (this._dialect.supports.inserts.onConflictDoUpdateWhere) {
+        if (this._dialect.supports.inserts.onConflictDoUpdateWhere && options.onConflictDoUpdateWhere) {
           onDuplicateKeyUpdate += ` WHERE ${this.getWhereConditions(options.onConflictDoUpdateWhere, table, options.model, options)}`;
         }
       } else {
@@ -295,7 +295,7 @@ class QueryGenerator {
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
 
-        if (this._dialect.supports.inserts.onConflictDoUpdateWhere) {
+        if (this._dialect.supports.inserts.onConflictDoUpdateWhere && options.onConflictDoUpdateWhere) {
           onDuplicateKeyUpdate += ` WHERE ${this.getWhereConditions(options.onConflictDoUpdateWhere, tableName, options.model, options)}`;
         }
       } else { // mysql / maria

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -186,6 +186,9 @@ class QueryGenerator {
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+        if (this._dialect.supports.inserts.onConflictDoUpdateWhere) {
+          onDuplicateKeyUpdate += ` WHERE ${this.getWhereConditions(options.onConflictDoUpdateWhere, table, options.model, options)}`;
+        }
       } else {
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate += `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;
@@ -291,6 +294,10 @@ class QueryGenerator {
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+
+        if (this._dialect.supports.inserts.onConflictDoUpdateWhere) {
+          onDuplicateKeyUpdate += ` WHERE ${this.getWhereConditions(options.onConflictDoUpdateWhere, tableName, options.model, options)}`;
+        }
       } else { // mysql / maria
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate = `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -46,6 +46,7 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
   },
   inserts: {
     onConflictDoNothing: ' ON CONFLICT DO NOTHING',
+    onConflictDoUpdateWhere: true,
     updateOnDuplicate: ' ON CONFLICT DO UPDATE SET'
   },
   NUMERIC: true,

--- a/lib/dialects/sqlite/index.js
+++ b/lib/dialects/sqlite/index.js
@@ -29,7 +29,8 @@ SqliteDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   'RIGHT JOIN': false,
   inserts: {
     ignoreDuplicates: ' OR IGNORE',
-    updateOnDuplicate: ' ON CONFLICT DO UPDATE SET'
+    updateOnDuplicate: ' ON CONFLICT DO UPDATE SET',
+    onConflictDoUpdateWhere: true
   },
   index: {
     using: false,

--- a/lib/model.js
+++ b/lib/model.js
@@ -2559,6 +2559,9 @@ class Model {
       if (options.updateOnDuplicate && (dialect !== 'mysql' && dialect !== 'mariadb' && dialect !== 'sqlite' && dialect !== 'postgres')) {
         throw new Error(`${dialect} does not support the updateOnDuplicate option.`);
       }
+      if (options.updateOnDuplicate && options.where && dialect !== 'postgres') {
+        throw new Error(`${dialect} does not support the where clause option for bulkCreate.`);
+      }
 
       const model = options.model;
 

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -665,6 +665,50 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     }
 
+    if (current.dialect.supports.inserts.onConflictDoUpdateWhere) {
+      describe('onConflictDoUpdateWhere', () => {
+        it('should support the onConflictDoUpdateWhere option', async function() {
+          const data = [
+            { uniqueName: 'Peter', secretValue: '12', intVal: 12 },
+            { uniqueName: 'Paul', secretValue: '23', intVal: 23 }
+          ];
+
+          await this.User.bulkCreate(data, {
+            fields: ['uniqueName', 'secretValue', 'intVal'],
+            updateOnDuplicate: ['secretValue', 'intVal']
+          });
+          const new_data = [
+            { uniqueName: 'Peter', secretValue: '43', intVal: 43 },
+            { uniqueName: 'Paul', secretValue: '24', intVal: 24 },
+            { uniqueName: 'Michael', secretValue: '26', intVal: 26 }
+          ];
+          await this.User.bulkCreate(new_data, {
+            fields: ['uniqueName', 'secretValue', 'intVal'],
+            updateOnDuplicate: ['secretValue', 'intVal'],
+            onConflictDoUpdateWhere: {
+              intVal: 23
+            }
+          });
+          const users = await this.User.findAll({ order: ['id'] });
+          expect(users.length).to.equal(3);
+          // Peter is unchanged because the record already existed and was excluded from the UPDATE WHERE int_val=23
+          expect(users[0].uniqueName).to.equal('Peter');
+          expect(users[0].secretValue).to.equal('12');
+          expect(users[0].intVal).to.equal(12);
+
+          // Paul is updated because int_val=23 at time of update
+          expect(users[1].uniqueName).to.equal('Paul');
+          expect(users[1].secretValue).to.equal('24');
+          expect(users[1].intVal).to.equal(24);
+
+          // Michael is inserted (where doesn't apply since because Michael was inserted not updated)
+          expect(users[2].uniqueName).to.equal('Michael');
+          expect(users[2].secretValue).to.equal('26');
+          expect(users[2].intVal).to.equal(26);
+        });
+      });
+    }
+
     if (current.dialect.supports.returnValues) {
       describe('return values', () => {
         it('should make the auto incremented values available on the returned instances', async function() {

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const Support   = require('../support'),
+const Support = require('../support'),
   DataTypes = require('../../../lib/data-types'),
   expectsql = Support.expectsql,
-  current   = Support.sequelize,
-  sql       = current.dialect.queryGenerator;
+  current = Support.sequelize,
+  sql = current.dialect.queryGenerator;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
@@ -151,15 +151,69 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       // mapping primary keys to their "field" override values
       const primaryKeys = User.primaryKeyAttributes.map(attr => User.rawAttributes[attr].field || attr);
 
-      expectsql(sql.bulkInsertQuery(User.tableName, [{ user_name: 'testuser', pass_word: '12345' }], { updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'], upsertKeys: primaryKeys }, User.fieldRawAttributesMap),
-        {
-          default: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
-          postgres: 'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\') ON CONFLICT ("user_name") DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
-          mssql: 'INSERT INTO [users] ([user_name],[pass_word]) VALUES (N\'testuser\',N\'12345\');',
-          mariadb: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
-          mysql: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
-          sqlite: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON CONFLICT (`user_name`) DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
-        });
+      expectsql(sql.bulkInsertQuery(User.tableName, [{
+        user_name: 'testuser',
+        pass_word: '12345'
+      }], {
+        updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'],
+        upsertKeys: primaryKeys
+      }, User.fieldRawAttributesMap),
+      {
+        default: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
+        postgres: 'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\') ON CONFLICT ("user_name") DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at";',
+        mssql: 'INSERT INTO [users] ([user_name],[pass_word]) VALUES (N\'testuser\',N\'12345\');',
+        mariadb: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
+        mysql: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
+        sqlite: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON CONFLICT (`user_name`) DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at`;'
+      });
     });
+
+    it('bulk create with onConflictDoUpdateWhere', () => {
+      const User = Support.sequelize.define('user', {
+        username: {
+          type: DataTypes.STRING,
+          field: 'user_name',
+          primaryKey: true
+        },
+        password: {
+          type: DataTypes.STRING,
+          field: 'pass_word'
+        },
+        createdAt: {
+          type: DataTypes.DATE,
+          field: 'created_at'
+        },
+        updatedAt: {
+          type: DataTypes.DATE,
+          field: 'updated_at'
+        }
+      }, {
+        timestamps: true
+      });
+
+      const upsertKeys = User.primaryKeyAttributes.map(attr => User.rawAttributes[attr].field || attr);
+
+      expectsql(sql.bulkInsertQuery(
+        User.tableName,
+        [{ user_name: 'testuser', pass_word: '12345' }],
+        {
+          updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'],
+          onConflictDoUpdateWhere: {
+            user_name: 'test where value'
+          },
+          upsertKeys
+        },
+        User.fieldRawAttributesMap
+      ),
+      {
+        default: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
+        postgres: 'INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\') ON CONFLICT ("user_name") DO UPDATE SET "user_name"=EXCLUDED."user_name","pass_word"=EXCLUDED."pass_word","updated_at"=EXCLUDED."updated_at" WHERE "users"."user_name" = \'test where value\';',
+        mssql: 'INSERT INTO [users] ([user_name],[pass_word]) VALUES (N\'testuser\',N\'12345\');',
+        mariadb: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
+        mysql: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON DUPLICATE KEY UPDATE `user_name`=VALUES(`user_name`),`pass_word`=VALUES(`pass_word`),`updated_at`=VALUES(`updated_at`);',
+        sqlite: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\') ON CONFLICT (`user_name`) DO UPDATE SET `user_name`=EXCLUDED.`user_name`,`pass_word`=EXCLUDED.`pass_word`,`updated_at`=EXCLUDED.`updated_at` WHERE `users`.`user_name` = \'test where value\';'
+      });
+    });
+
   });
 });


### PR DESCRIPTION
Closed #11656

**Wanting some feedback on the API and can adjust.** Mysql doesn't support a where clause for updates.

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
I'd like to be able to include a where clause in the a postgres upsert `INSERT ON CONFLICT DO UPDATE` statement.  This is not currently possibly with sequelize. Something like:
```sql
INSERT INTO 
  person (name, last_action_tsp) 
  values ('steve', '2019-11-06T15:41:47.249Z') 
ON CONFLICT DO UPDATE 
  SET name=EXCLUDED.name, last_action_tsp=EXCLUDED.last_action_tsp 
WHERE 
   EXCLUDED.last_action_tsp > last_action_tsp
```
