### PR TITLE
Escape trailing parenthesis at eager loading doc page

### DIFF
--- a/docs/manual/advanced-association-concepts/eager-loading.md
+++ b/docs/manual/advanced-association-concepts/eager-loading.md
@@ -1,6 +1,6 @@
 # Eager Loading
 
-As briefly mentioned in [the associations guide](assocs.html), eager Loading is the act of querying data of several models at once (one 'main' model and one or more associated models). At the SQL level, this is a query with one or more [joins](https://en.wikipedia.org/wiki/Join_(SQL)).
+As briefly mentioned in [the associations guide](assocs.html), eager Loading is the act of querying data of several models at once (one 'main' model and one or more associated models). At the SQL level, this is a query with one or more [joins](https://en.wikipedia.org/wiki/Join_\(SQL\)).
 
 When this is done, the associated models will be added by Sequelize in appropriately named, automatically created field(s) in the returned objects.
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

I'm not sure if most of the items above are applicable for this change.

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
There's a currently an extra parenthesis in the `eager loading` page:
![image](https://user-images.githubusercontent.com/13336905/113052988-2e158080-917e-11eb-812e-c82b6f2d2dd6.png)

This is caused due to the link having its own parenthesis: `https://en.wikipedia.org/wiki/Join_(SQL)` that breaks the markdown parsing.

Escaping those parenthesis (`https://en.wikipedia.org/wiki/Join_\(SQL\)`) should already fix it.

<!-- Please provide a description of the change here. -->
