### PR TITLE
Add onDelete constraint to option example in doc for association One-To-Many

### DIFF
--- a/docs/manual/core-concepts/assocs.md
+++ b/docs/manual/core-concepts/assocs.md
@@ -226,7 +226,10 @@ The options to be applied in this case are the same from the One-To-One case. Fo
 Team.hasMany(Player, {
   foreignKey: 'clubId'
 });
-Player.belongsTo(Team);
+Player.belongsTo(Team, {
+  foreignKey: 'clubId',
+  onDelete: 'RESTRICT'
+});
 ```
 
 Like One-To-One relationships, `ON DELETE` defaults to `SET NULL` and `ON UPDATE` defaults to `CASCADE`.


### PR DESCRIPTION
### Description of change

<!-- Please provide a description of the change here. -->
In the **One-To-One** example the constraints were added in the options as parameter for `HasOne` association method, there is no example in the **One-To-Many** so I assumed the constraints worked the same and put them in `HasMany` side...
This never worked for me, I tried them in the `BelongsTo` side and they worked.

I did not found the issue so I assumed everyone figured out too but for newbies like me it would be great to have it explicit just like the One-To-One example.

Finally I decided to make a pull request with an example, I defined the key again in the BelongsTo side because I got the `parentModelNameID FK` created alongside with the `customName FK`. 

I hope this could help and thanks a lot for your work!

