### PR TITLE
fix(model): bulkCreate should not alter options

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2521,6 +2521,7 @@ class Model {
       return [];
     }
 
+    options = Utils.cloneDeep(options);
     const dialect = this.sequelize.options.dialect;
     const now = Utils.now(this.sequelize.options.dialect);
 

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -2638,13 +2638,5 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const users1 = await user.findAll();
       expect(users1[0].username).to.equal('jon');
     });
-
-    it('should not alter options', async function() {
-      const user = this.sequelize.define('User');
-      await this.sequelize.sync({ force: true });
-      const options = { toto: 1 };
-      await user.bulkCreate([{  }], options);
-      expect(options).to.eql({ toto: 1 });
-    });
   });
 });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -2638,5 +2638,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       const users1 = await user.findAll();
       expect(users1[0].username).to.equal('jon');
     });
+
+    it('should not alter options', async function() {
+      const user = this.sequelize.define('User');
+      await this.sequelize.sync({ force: true });
+      const options = { toto: 1 };
+      await user.bulkCreate([{  }], options);
+      expect(options).to.eql({ toto: 1 });
+    });
   });
 });

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -65,6 +65,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     }
 
+    it('should not alter options', async function() {
+      const User = this.sequelize.define('User');
+      await User.sync({ force: true });
+      const options = { anOption: 1 };
+      await User.bulkCreate([{  }], options);
+      expect(options).to.eql({ anOption: 1 });
+    });
+
     it('should be able to set createdAt and updatedAt if using silent: true', async function() {
       const User = this.sequelize.define('user', {
         name: DataTypes.STRING


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Hello, this PR solves #12406 (labeled as "good first issue"). 
This PR hopefully succeeds where the previous one (#12526) failed to be merged.
The change consists of cloning the options at the beginning of the method.

If this PR gets merged, we're ready to tackle more of the grunt work 😉 