### PR TITLE
Use npm script to run commands with docker env vars

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,9 +123,6 @@
     "nodejs",
     "object relational mapper"
   ],
-  "options": {
-    "env_cmd": "-f ./test/config/.docker.env"
-  },
   "commitlint": {
     "extends": [
       "@commitlint/config-angular"
@@ -177,7 +174,7 @@
     "test": "npm run teaser && npm run test-unit && npm run test-integration",
     "test-docker": "npm run test-docker-unit && npm run test-docker-integration",
     "test-docker-unit": "npm run test-unit",
-    "test-docker-integration": "env-cmd $npm_package_options_env_cmd npm run test-integration",
+    "test-docker-integration": "npm run env-docker -- npm run test-integration",
     "docs": "rimraf esdoc && esdoc -c docs/esdoc-config.js && cp docs/favicon.ico esdoc/favicon.ico && cp docs/ROUTER.txt esdoc/ROUTER && node docs/run-docs-transforms.js && node docs/redirects/create-redirects.js && rimraf esdoc/file esdoc/source.html",
     "teaser": "node scripts/teaser",
     "test-unit": "mocha --globals setImmediate,clearImmediate --exit --check-leaks --colors -t 30000 --reporter spec \"test/unit/**/*.js\"",
@@ -210,13 +207,14 @@
     "cover-integration": "cross-env COVERAGE=true nyc --reporter=lcovonly mocha -t 30000 --exit \"test/integration/**/*.test.js\" && node -e \"require('fs').renameSync('coverage/lcov.info', 'coverage/integration.info')\"",
     "cover-unit": "cross-env COVERAGE=true nyc --reporter=lcovonly mocha -t 30000 --exit \"test/unit/**/*.test.js\" && node -e \"require('fs').renameSync('coverage/lcov.info', 'coverage/unit.info')\"",
     "merge-coverage": "lcov-result-merger \"coverage/*.info\" \"coverage/lcov.info\"",
-    "sscce": "env-cmd $npm_package_options_env_cmd node sscce.js",
+    "sscce": "npm run env-docker -- node sscce.js",
     "sscce-mariadb": "cross-env DIALECT=mariadb npm run sscce",
     "sscce-mysql": "cross-env DIALECT=mysql npm run sscce",
     "sscce-postgres": "cross-env DIALECT=postgres npm run sscce",
     "sscce-sqlite": "cross-env DIALECT=sqlite npm run sscce",
     "sscce-mssql": "cross-env DIALECT=mssql npm run sscce",
-    "setup-mssql": "env-cmd $npm_package_options_env_cmd ./scripts/setup-mssql",
-    "semantic-release": "semantic-release"
+    "setup-mssql": "npm run env-docker -- ./scripts/setup-mssql",
+    "semantic-release": "semantic-release",
+    "env-docker": "env-cmd -f ./test/config/.docker.env"
   }
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

NPM package.json options are not widely known and may be confusing. Moreover, in NPM v7 the `options` dictionary is renamed to `config` and breaks the current functionality https://docs.npmjs.com/cli/v7/configuring-npm/package-json#config.
By re-using an npm script to run commands with docker-specific environment variables we make the configuration more understandable and compatible with the current and the upcoming node versions