### PR TITLE
refactor(conn-mgr): remove overwrite of this.getConnection() in close()

### DIFF
--- a/lib/dialects/abstract/connection-manager.js
+++ b/lib/dialects/abstract/connection-manager.js
@@ -25,6 +25,7 @@ class ConnectionManager {
     this.dialect = dialect;
     this.versionPromise = null;
     this.dialectName = this.sequelize.options.dialect;
+    this.pool = null;
 
     if (config.pool === false) {
       throw new Error('Support for pool:false was removed in v4.0');
@@ -108,12 +109,8 @@ class ConnectionManager {
    * @returns {Promise}
    */
   async close() {
-    // Mark close of pool
-    this.getConnection = async function getConnection() {
-      throw new Error('ConnectionManager.getConnection was called after the connection manager was closed!');
-    };
-
-    return await this._onProcessExit();
+    await this._onProcessExit();
+    this.pool = null;
   }
 
   /**
@@ -242,6 +239,12 @@ class ConnectionManager {
    */
   async getConnection(options) {
     options = options || {};
+
+    if (!this.pool) {
+      throw new Error(`
+        ConnectionManager.getConnection was called either after the pool was closed or before the pool was initialized`
+      );
+    }
 
     if (this.sequelize.options.databaseVersion === 0) {
       if (!this.versionPromise) {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This PR modifies the `connectionManager` such that:
- the `close()` method does not overwrite the `getConnection()` method; instead, it sets `this.pool = null;`
- the `getConnection()` method checks `this.pool` and throws an error if it does not exist (either because `initPools()` has not been called, or `close()` has been called).

Closes https://github.com/sequelize/sequelize/issues/13198