### PR TITLE
fix(typings): returning can specify column names

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -719,7 +719,7 @@ export interface UpsertOptions<TAttributes = any> extends Logging, Transactionab
   /**
    * Return the affected rows (only for postgres)
    */
-  returning?: boolean;
+  returning?: boolean | (keyof TAttributes)[];
 
   /**
    * Run validations before the row is inserted

--- a/types/test/upsert.ts
+++ b/types/test/upsert.ts
@@ -1,15 +1,18 @@
 import {Model} from "sequelize"
 import {sequelize} from './connection';
 
-class TestModel extends Model {
+class TestModel extends Model<{ foo: string; bar: string }, {}> {
 }
 
-TestModel.init({}, {sequelize})
+TestModel.init({
+    foo: '<foo>',
+    bar: '<bar>',
+}, {sequelize})
 
 sequelize.transaction(async trx => {
   const res1: [TestModel, boolean | null] = await TestModel.upsert<TestModel>({}, {
     benchmark: true,
-    fields: ['testField'],
+    fields: ['foo'],
     hooks: true,
     logging: true,
     returning: true,
@@ -20,7 +23,7 @@ sequelize.transaction(async trx => {
 
   const res2: [TestModel, boolean | null] = await TestModel.upsert<TestModel>({}, {
     benchmark: true,
-    fields: ['testField'],
+    fields: ['foo'],
     hooks: true,
     logging: true,
     returning: false,
@@ -31,9 +34,10 @@ sequelize.transaction(async trx => {
 
   const res3: [TestModel, boolean | null] = await TestModel.upsert<TestModel>({}, {
     benchmark: true,
-    fields: ['testField'],
+    fields: ['foo'],
     hooks: true,
     logging: true,
+    returning: ['foo'],
     searchPath: 'DEFAULT',
     transaction: trx,
     validate: true,


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Update returning to match other methods like bulkCreate: https://github.com/sequelize/sequelize/blob/main/types/lib/model.d.ts#L772

Test was updated with attributes to enforce valid values, rather than `any`