### PR TITLE
fix(typings): allow where in order + specify order options

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@ import IndexHints = require('./lib/index-hints');
 import Utils = require('./lib/utils');
 
 export * from './lib/sequelize';
+export { default } from './lib/sequelize';
 export * from './lib/query-interface';
 export * from './lib/data-types';
 export * from './lib/model';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,6 @@ import IndexHints = require('./lib/index-hints');
 import Utils = require('./lib/utils');
 
 export * from './lib/sequelize';
-export { default } from './lib/sequelize';
 export * from './lib/query-interface';
 export * from './lib/data-types';
 export * from './lib/model';

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1818,7 +1818,10 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   public static findAll<M extends Model>(
     this: ModelStatic<M>,
-    options?: FindOptions<M['_attributes']>): Promise<M[]>;
+    options?: FindOptions<M['_attributes']> & { raw?: false }): Promise<M[]>;
+  public static findAll<M extends Model, R extends any = M['_attributes']>(
+    this: ModelStatic<M>,
+    options?: FindOptions<M['_attributes']> & { raw: true }): Promise<R[]>;
 
   /**
    * Search for a single instance by its primary key. This applies LIMIT 1, so the listener will
@@ -1827,25 +1830,43 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   public static findByPk<M extends Model>(
     this: ModelStatic<M>,
     identifier: Identifier,
-    options: Omit<NonNullFindOptions<M['_attributes']>, 'where'>
+    options: Omit<NonNullFindOptions<M['_attributes']>, 'where'> & { raw?: false }
   ): Promise<M>;
+  public static findByPk<M extends Model, R extends any = M['_attributes']>(
+    this: ModelStatic<M>,
+    identifier: Identifier,
+    options: Omit<NonNullFindOptions<M['_attributes']>, 'where'> & { raw: true }
+  ): Promise<R>;
   public static findByPk<M extends Model>(
     this: ModelStatic<M>,
     identifier?: Identifier,
-    options?: Omit<FindOptions<M['_attributes']>, 'where'>
+    options?: Omit<FindOptions<M['_attributes']>, 'where'> & { raw?: false }
   ): Promise<M | null>;
+  public static findByPk<M extends Model, R extends any = M['_attributes']>(
+    this: ModelStatic<M>,
+    identifier?: Identifier,
+    options?: Omit<FindOptions<M['_attributes']>, 'where'> & { raw: true }
+  ): Promise<R | null>;
 
   /**
    * Search for a single instance. Returns the first instance found, or null if none can be found.
    */
   public static findOne<M extends Model>(
     this: ModelStatic<M>,
-    options: NonNullFindOptions<M['_attributes']>
+    options: NonNullFindOptions<M['_attributes']> & { raw?: false }
   ): Promise<M>;
+  public static findOne<M extends Model, R extends any = M['_attributes']>(
+    this: ModelStatic<M>,
+    options: NonNullFindOptions<M['_attributes']> & { raw: true }
+  ): Promise<R>;
   public static findOne<M extends Model>(
     this: ModelStatic<M>,
-    options?: FindOptions<M['_attributes']>
+    options?: FindOptions<M['_attributes']> & { raw?: false }
   ): Promise<M | null>;
+  public static findOne<M extends Model, R extends any = M['_attributes']>(
+    this: ModelStatic<M>,
+    options?: FindOptions<M['_attributes']> & { raw: true }
+  ): Promise<R | null>;
 
   /**
    * Run an aggregation method on the specified field

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -460,7 +460,7 @@ export interface IncludeOptions extends Filterable<any>, Projectable, Paranoid {
 
 type OrderItemAssociation = Association | ModelStatic<Model> | { model: ModelStatic<Model>; as: string } | string
 type OrderItemColumn = string | Col | Fn | Literal | Where
-type OrderOptions = 'ASC' | 'DESC' | `${'ASC' | 'DESC'} NULLS ${'FIRST' | 'LAST'}` | `NULLS ${'FIRST' | 'LAST'}`
+type OrderOptions = 'ASC' | 'DESC' | 'ASC NULLS FIRST' | 'ASC NULLS LAST' | 'DESC NULLS FIRST' | 'DESC NULLS LAST' | 'NULLS FIRST' | 'NULLS LAST'
 export type OrderItem =
   | string
   | Fn

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -459,22 +459,24 @@ export interface IncludeOptions extends Filterable<any>, Projectable, Paranoid {
 }
 
 type OrderItemAssociation = Association | ModelStatic<Model> | { model: ModelStatic<Model>; as: string } | string
-type OrderItemColumn = string | Col | Fn | Literal
+type OrderItemColumn = string | Col | Fn | Literal | Where
+type OrderOptions = 'ASC' | 'DESC' | `${'ASC' | 'DESC'} NULLS ${'FIRST' | 'LAST'}` | `NULLS ${'FIRST' | 'LAST'}`
 export type OrderItem =
   | string
   | Fn
   | Col
   | Literal
-  | [OrderItemColumn, string]
+  | Where
+  | [OrderItemColumn, OrderOptions]
   | [OrderItemAssociation, OrderItemColumn]
-  | [OrderItemAssociation, OrderItemColumn, string]
+  | [OrderItemAssociation, OrderItemColumn, OrderOptions]
   | [OrderItemAssociation, OrderItemAssociation, OrderItemColumn]
-  | [OrderItemAssociation, OrderItemAssociation, OrderItemColumn, string]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemColumn, OrderOptions]
   | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn]
-  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn, string]
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn, OrderOptions]
   | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn]
-  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn, string]
-export type Order = Fn | Col | Literal | OrderItem[];
+  | [OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemAssociation, OrderItemColumn, OrderOptions]
+export type Order = Fn | Col | Literal | Where | OrderItem[];
 
 /**
  * Please note if this is used the aliased property will not be available on the model instance

--- a/types/test/findAll.ts
+++ b/types/test/findAll.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf } from 'expect-type'
-import Sequelize, { Op } from 'sequelize';
+import { Sequelize, Op } from 'sequelize';
 import { User } from './models/User';
 
 async () => {

--- a/types/test/findAll.ts
+++ b/types/test/findAll.ts
@@ -1,0 +1,24 @@
+import { expectTypeOf } from 'expect-type'
+import Sequelize from 'sequelize';
+import { User } from './models/User';
+
+async () => {
+    const users = await User.findAll({ raw: false });
+    expectTypeOf(users).toEqualTypeOf<User[]>()
+
+    interface RawUser {
+        foo: 'bar';
+    }
+    const rawUsers = await User.findAll<User, RawUser>({
+        attributes: [
+            ['bar', 'foo'],
+            'ignored',
+            [Sequelize.col('table.id'), 'xyz'],
+        ],
+        raw: true,
+    });
+    expectTypeOf(rawUsers).toEqualTypeOf<RawUser[]>();
+
+    // @ts-expect-error
+    rawUsers[0].id = 123; // not an instance
+};

--- a/types/test/findAll.ts
+++ b/types/test/findAll.ts
@@ -1,10 +1,28 @@
 import { expectTypeOf } from 'expect-type'
-import Sequelize from 'sequelize';
+import Sequelize, { Op } from 'sequelize';
 import { User } from './models/User';
 
 async () => {
     const users = await User.findAll({ raw: false });
     expectTypeOf(users).toEqualTypeOf<User[]>()
+
+    await User.findAll({
+      order: [
+        ['id', 'DESC'],
+        ['AssociatedModel', User, 'id', 'DESC'],
+        ['AssociatedModel', User, Sequelize.col('MyModel.id')],
+        [User, 'id'],
+        'id',
+        Sequelize.col('id'),
+        Sequelize.fn('FN'),
+        Sequelize.literal('<literal>'),
+        Sequelize.where(Sequelize.col('id'), Op.eq, '<id>'),
+        [Sequelize.col('id'), 'ASC'],
+        [Sequelize.fn('FN'), 'DESC NULLS LAST'],
+        [Sequelize.literal('<literal>'), 'NULLS FIRST'],
+        [Sequelize.where(Sequelize.col('id'), Op.eq, '<id>'), 'DESC'],
+      ],
+    });
 
     interface RawUser {
         foo: 'bar';

--- a/types/test/findByPk.ts
+++ b/types/test/findByPk.ts
@@ -1,3 +1,16 @@
+import { expectTypeOf } from 'expect-type'
 import { User } from './models/User';
 
-User.findByPk(Buffer.from('asdf'));
+async () => {
+    const user = await User.findByPk(Buffer.from('asdf'));
+    expectTypeOf(user).toEqualTypeOf<User | null>()
+
+    interface RawUser {
+        foo: 'bar';
+    }
+    const rawUser = await User.findByPk<User, RawUser>(123, {
+        attributes: [['bar', 'foo']],
+        raw: true,
+    });
+    expectTypeOf(rawUser).toEqualTypeOf<RawUser | null>();
+};

--- a/types/test/findOne.ts
+++ b/types/test/findOne.ts
@@ -1,6 +1,17 @@
+import { expectTypeOf } from 'expect-type'
 import { User } from "./models/User";
 
-User.findOne({ where: { firstName: 'John' } });
+async () => {
+    const user = await User.findOne({ where: { firstName: 'John' } });
+    expectTypeOf(user).toEqualTypeOf<User | null>()
 
-// @ts-expect-error
-User.findOne({ where: { blah: 'blah2' } });
+    // @ts-expect-error
+    User.findOne({ where: { blah: 'blah2' } });
+
+    const rawUser = await User.findOne({
+        where: { firstName: 'John' },
+        raw: true,
+        rejectOnEmpty: true,
+    });
+    expectTypeOf(rawUser).toEqualTypeOf<User['_attributes']>()
+};

--- a/types/test/include.ts
+++ b/types/test/include.ts
@@ -1,4 +1,4 @@
-import { Model, Sequelize, HasMany } from 'sequelize';
+import { Model, Sequelize, HasMany, Op, col, fn, literal, where } from 'sequelize';
 
 class MyModel extends Model {
   public static associations: {
@@ -17,7 +17,21 @@ MyModel.findAll({
       on: {
         a: 1,
       },
-      order: [['id', 'DESC'], [ 'AssociatedModel', MyModel, 'id', 'DESC' ], [ MyModel, 'id' ] ],
+      order: [
+        ['id', 'DESC'],
+        ['AssociatedModel', MyModel, 'id', 'DESC'],
+        ['AssociatedModel', MyModel, col('MyModel.id')],
+        [MyModel, 'id'],
+        'id',
+        col('id'),
+        fn('FN'),
+        literal('<literal>'),
+        where(col('id'), Op.eq, '<id>'),
+        [col('id'), 'ASC'],
+        [fn('FN'), 'DESC NULLS LAST'],
+        [literal('<literal>'), 'NULLS FIRST'],
+        [where(col('id'), Op.eq, '<id>'), 'DESC'],
+      ],
       separate: true,
       where: { state: Sequelize.col('project.state') },
       all: true,


### PR DESCRIPTION
Based on https://github.com/sequelize/sequelize/pull/12921/files to get `findAll` test, but that should probably still be merged/reviewed separately

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Allow `where()` functions in ORDER (useful for sorting by boolean).

Also explicitly declare order options for better type inference/autocomplete: https://github.com/sequelize/sequelize/blob/main/lib/dialects/abstract/query-generator.js#L735

Note the `OrderItemColumn` type still includes `string` so ending an array with any string is still valid
