### PR TITLE
fix(typings): allow schema for queryInterface methods

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -4,7 +4,7 @@ import { DataType } from './data-types';
 import { Deferrable } from './deferrable';
 import { HookReturn, Hooks, ModelHooks } from './hooks';
 import { ValidationOptions } from './instance-validator';
-import { QueryOptions, IndexesOptions } from './query-interface';
+import { QueryOptions, IndexesOptions, TableName } from './query-interface';
 import { Sequelize, SyncOptions } from './sequelize';
 import { Transaction, LOCK } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
@@ -1232,7 +1232,7 @@ export interface ModelAttributeColumnReferencesOptions {
   /**
    * If this column references another table, provide it here as a Model, or a string
    */
-  model?: string | ModelType;
+  model?: TableName | ModelType;
 
   /**
    * The column of the foreign table that this column references

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -238,7 +238,7 @@ export interface AddPrimaryKeyConstraintOptions extends BaseConstraintOptions {
 export interface AddForeignKeyConstraintOptions extends BaseConstraintOptions {
   type: 'foreign key';
   references?: {
-    table: string;
+    table: TableName;
     field: string;
   };
   onDelete: string;
@@ -336,7 +336,7 @@ export class QueryInterface {
    * @param options       Table options.
    */
   public createTable<M extends Model>(
-    tableName: string | { schema?: string; tableName?: string },
+    tableName: TableName,
     attributes: ModelAttributes<M, M['_creationAttributes']>,
     options?: QueryInterfaceCreateTableOptions
   ): Promise<void>;
@@ -347,7 +347,7 @@ export class QueryInterface {
    * @param tableName Table name.
    * @param options   Query options, particularly "force".
    */
-  public dropTable(tableName: string, options?: QueryInterfaceDropTableOptions): Promise<void>;
+  public dropTable(tableName: TableName, options?: QueryInterfaceDropTableOptions): Promise<void>;
 
   /**
    * Drops all tables.
@@ -366,7 +366,7 @@ export class QueryInterface {
   /**
    * Renames a table
    */
-  public renameTable(before: string, after: string, options?: QueryInterfaceOptions): Promise<void>;
+  public renameTable(before: TableName, after: TableName, options?: QueryInterfaceOptions): Promise<void>;
 
   /**
    * Returns all tables
@@ -377,7 +377,7 @@ export class QueryInterface {
    * Describe a table
    */
   public describeTable(
-    tableName: string | { schema?: string; tableName?: string },
+    tableName: TableName,
     options?: string | { schema?: string; schemaDelimiter?: string } & Logging
   ): Promise<ColumnsDescription>;
 
@@ -385,7 +385,7 @@ export class QueryInterface {
    * Adds a new column to a table
    */
   public addColumn(
-    table: string | { schema?: string; tableName?: string },
+    table: TableName,
     key: string,
     attribute: ModelAttributeColumnOptions | DataType,
     options?: QueryInterfaceOptions
@@ -395,7 +395,7 @@ export class QueryInterface {
    * Removes a column from a table
    */
   public removeColumn(
-    table: string | { schema?: string; tableName?: string },
+    table: TableName,
     attribute: string,
     options?: QueryInterfaceOptions
   ): Promise<void>;
@@ -404,7 +404,7 @@ export class QueryInterface {
    * Changes a column
    */
   public changeColumn(
-    tableName: string | { schema?: string; tableName?: string },
+    tableName: TableName,
     attributeName: string,
     dataTypeOrOptions?: DataType | ModelAttributeColumnOptions,
     options?: QueryInterfaceOptions
@@ -414,7 +414,7 @@ export class QueryInterface {
    * Renames a column
    */
   public renameColumn(
-    tableName: string | { schema?: string; tableName?: string },
+    tableName: TableName,
     attrNameBefore: string,
     attrNameAfter: string,
     options?: QueryInterfaceOptions
@@ -424,13 +424,13 @@ export class QueryInterface {
    * Adds a new index to a table
    */
   public addIndex(
-    tableName: string,
+    tableName: TableName,
     attributes: string[],
     options?: QueryInterfaceIndexOptions,
     rawTablename?: string
   ): Promise<void>;
   public addIndex(
-    tableName: string,
+    tableName: TableName,
     options: SetRequired<QueryInterfaceIndexOptions, 'fields'>,
     rawTablename?: string
   ): Promise<void>;
@@ -438,21 +438,21 @@ export class QueryInterface {
   /**
    * Removes an index of a table
    */
-  public removeIndex(tableName: string, indexName: string, options?: QueryInterfaceIndexOptions): Promise<void>;
-  public removeIndex(tableName: string, attributes: string[], options?: QueryInterfaceIndexOptions): Promise<void>;
+  public removeIndex(tableName: TableName, indexName: string, options?: QueryInterfaceIndexOptions): Promise<void>;
+  public removeIndex(tableName: TableName, attributes: string[], options?: QueryInterfaceIndexOptions): Promise<void>;
 
   /**
    * Adds constraints to a table
    */
   public addConstraint(
-    tableName: string,
+    tableName: TableName,
     options?: AddConstraintOptions & QueryInterfaceOptions
   ): Promise<void>;
 
   /**
    * Removes constraints from a table
    */
-  public removeConstraint(tableName: string, constraintName: string, options?: QueryInterfaceOptions): Promise<void>;
+  public removeConstraint(tableName: TableName, constraintName: string, options?: QueryInterfaceOptions): Promise<void>;
 
   /**
    * Shows the index of a table
@@ -472,7 +472,7 @@ export class QueryInterface {
   /**
    * Get foreign key references details for the table
    */
-  public getForeignKeyReferencesForTable(tableName: string, options?: QueryInterfaceOptions): Promise<object>;
+  public getForeignKeyReferencesForTable(tableName: TableName, options?: QueryInterfaceOptions): Promise<object>;
 
   /**
    * Inserts a new record

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -25,6 +25,15 @@ async function test() {
         },
         type: DataTypes.INTEGER,
       },
+      attr5: {
+        onDelete: 'cascade',
+        onUpdate: 'cascade',
+        references: {
+          key: 'id',
+          model: { schema: '<schema>', tableName: 'another_table_name' },
+        },
+        type: DataTypes.INTEGER,
+      },
       createdAt: {
         type: DataTypes.DATE,
       },
@@ -49,8 +58,10 @@ async function test() {
       }
     }
   );
+  await queryInterface.createTable({ tableName: '<table-name>' }, {});
 
   await queryInterface.dropTable('nameOfTheExistingTable');
+  await queryInterface.dropTable({ schema: '<schema>', tableName: 'nameOfTheExistingTable' });
 
   await queryInterface.bulkDelete({ tableName: 'foo', schema: 'bar' }, {}, {});
 
@@ -65,6 +76,10 @@ async function test() {
   await queryInterface.dropAllTables();
 
   await queryInterface.renameTable('Person', 'User');
+  await queryInterface.renameTable(
+      { schema: '<schema>', tableName: 'Person' },
+      { schema: '<schema>', tableName: 'User' },
+    );
 
   const tableNames: string[] = await queryInterface.showAllTables();
 
@@ -128,9 +143,11 @@ async function test() {
   );
 
   await queryInterface.renameColumn('Person', 'signature', 'sig');
+  await queryInterface.renameColumn({ schema: '<schema>', tableName: 'Person' }, 'signature', 'sig');
 
   // This example will create the index person_firstname_lastname
   await queryInterface.addIndex('Person', ['firstname', 'lastname']);
+  await queryInterface.addIndex({ schema: '<schema>', tableName: 'Person' }, ['firstname', 'lastname']);
 
   // This example will create a unique index with the name SuperDuperIndex using the optional 'options' field.
   // Possible options:
@@ -167,6 +184,7 @@ async function test() {
   })
 
   await queryInterface.removeIndex('Person', 'SuperDuperIndex');
+  await queryInterface.removeIndex({ schema: '<schema>', tableName: 'Person' }, 'SuperDuperIndex');
 
   // or
 
@@ -180,8 +198,14 @@ async function test() {
   }))
 
   await queryInterface.removeConstraint('Person', 'firstnamexlastname');
+  await queryInterface.removeConstraint({ schema: '<schema>', tableName: 'Person' }, 'firstnamexlastname');
 
   await queryInterface.select(null, 'Person', {
+    where: {
+      a: 1,
+    },
+  });
+  await queryInterface.select(null, { schema: '<schema>', tableName: 'Person' }, {
     where: {
       a: 1,
     },


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Allow `schema` option with table name for queryInterface

Support already exists for all methods except [removeIndex](https://github.com/sequelize/sequelize/pull/13222)

Admittedly "support" to my knowledge is primarily postgres