### PR TITLE
typo in eager-loading.md docs (many-to-many w/o junction table)

### DIFF
--- a/docs/manual/advanced-association-concepts/eager-loading.md
+++ b/docs/manual/advanced-association-concepts/eager-loading.md
@@ -422,7 +422,9 @@ If you don't want anything from the junction table, you can explicitly provide a
 Foo.findOne({
   include: {
     model: Bar,
-    attributes: []
+    through: {
+      attributes: []
+    }
   }
 });
 ```


### PR DESCRIPTION
### Description of change

i was reading the docs and  found a typo if you want to omit the junction table in the result

```js
Foo.findOne({
  include: {
    model: Bar,
    through: { // <-was missing
      attributes: []
    }
  }
});
```
