### PR TITLE
fix(instance-validator): run custom validators on null if no allowNull

### DIFF
--- a/lib/instance-validator.js
+++ b/lib/instance-validator.js
@@ -188,7 +188,7 @@ class InstanceValidator {
    */
   async _singleAttrValidate(value, field, allowNull) {
     // If value is null and allowNull is false, no validators should run (see #9143)
-    if ((value === null || value === undefined) && !allowNull) {
+    if ((value === null || value === undefined) && allowNull === false) {
       // The schema validator (_validateSchema) has already generated the validation error. Nothing to do here.
       return;
     }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

In the `allowNull interaction with other validators ` section of https://sequelize.org/master/manual/validations-and-constraints.html mentions that "if (a field) it is set to allow null (with allowNull: true) and that value has been set to null, only the built-in validators will be skipped, while the custom validators will still run". 

But IMO there was an unexpected behavior when `allowNull` was not specified. If i understand correctly, the behavior was as if `allowNull` was false, ie: if the value was set to null and allowNull wasn't specified, it wasn't running custom validators. But i think the default for `allowNull` is true (ie: if not specified, null is allowed), so i would expect custom validators to be run in that scenario.
