### PR TITLE
fix(query-generator): support utils in index upsert

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -183,7 +183,12 @@ class QueryGenerator {
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
       if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
-        const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
+        const conflictKeys = options.upsertKeys.map(attr => {
+          if (attr instanceof Utils.SequelizeMethod) {
+            return this.escape(attr);
+          }
+          return this.quoteIdentifier(attr);
+        });
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
       } else {
@@ -288,7 +293,12 @@ class QueryGenerator {
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
       if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
-        const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
+        const conflictKeys = options.upsertKeys.map(attr => {
+          if (attr instanceof Utils.SequelizeMethod) {
+            return this.escape(attr);
+          }
+          return this.quoteIdentifier(attr);
+        });
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
       } else { // mysql / maria


### PR DESCRIPTION
Fixes part 2 in https://github.com/sequelize/sequelize/issues/13240

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

When index attribute is a Sequelize.Util, stringify as appropriate