### PR TITLE
Add query_timeout option to postgres dialectOptions

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -113,8 +113,10 @@ class ConnectionManager extends AbstractConnectionManager {
           // This should help with backends incorrectly considering idle clients to be dead and prematurely disconnecting them.
           // this feature has been added in pg module v6.0.0, check pg/CHANGELOG.md
           'keepAlive',
-          // Times out queries after a set time in milliseconds. Added in pg v7.3
+          // Times out queries after a set time in milliseconds in the database end. Added in pg v7.3
           'statement_timeout',
+          // Times out queries after a set time in milliseconds in client end, query would be still running in database end.
+          'query_timeout',
           // Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds. Added in pg v7.17.0 only supported in postgres >= 10
           'idle_in_transaction_session_timeout'
         ]));

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -39,6 +39,14 @@ if (dialect.match(/^postgres/)) {
       // `notice` is Postgres's default
       expect(result[0].client_min_messages).to.equal('notice');
     });
+    
+    it("should time out the query request when the query runs beyond the configured query_timeout", async () => {
+      const sequelize = Support.createSequelizeInstance({
+        dialectOptions: { query_timeout: 100 },
+      });
+      const error = await sequelize.query("select pg_sleep(2)").catch((e) => e);
+      expect(error.message).to.equal("Query read timeout");
+    });
   });
 
   describe('Dynamic OIDs', () => {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
In this PR, I have added enabled the `dialectOptions` to override the postgres' `query_timeout` option. `pg` will close the query request when the query runs more than the configured time limit (in ms).

<!-- Please provide a description of the change here. -->
