### PR TITLE
feat(postgres, sqlite): add support for where clauses with ON CONFLICT queries

### DIFF
--- a/docs/manual/other-topics/upgrade-to-v6.md
+++ b/docs/manual/other-topics/upgrade-to-v6.md
@@ -74,7 +74,7 @@ Signature for this method has been changed to `Promise<Model,boolean | null>`. F
 - SQLite - Implemented with ON CONFLICT DO UPDATE
 - MSSQL - Implemented with MERGE statement
 
-_<ins>Note for Postgres users:</ins>_ If upsert payload contains PK field, then PK will be used as the conflict target. Otherwise first unique constraint will be selected as the conflict key.
+_<ins>Note for Postgres users:</ins>_ If upsert payload contains PK field, then PK will be used as the conflict target. Otherwise first unique constraint will be selected as the conflict key.  The conflict fields may be specified via `conflictFields` and a where condition can be specified via `where`.
 
 ### QueryInterface
 

--- a/docs/manual/other-topics/upgrade-to-v6.md
+++ b/docs/manual/other-topics/upgrade-to-v6.md
@@ -74,7 +74,7 @@ Signature for this method has been changed to `Promise<Model,boolean | null>`. F
 - SQLite - Implemented with ON CONFLICT DO UPDATE
 - MSSQL - Implemented with MERGE statement
 
-_<ins>Note for Postgres users:</ins>_ If upsert payload contains PK field, then PK will be used as the conflict target. Otherwise first unique constraint will be selected as the conflict key.  The conflict fields may be specified via `conflictFields` and a where condition can be specified via `where`.
+_<ins>Note for Postgres users:</ins>_ If upsert payload contains PK field, then PK will be used as the conflict target. Otherwise first unique constraint will be selected as the conflict key.  The conflict fields may be specified via `conflictFields` and a where condition can be specified via `conflictWhere`.
 
 ### QueryInterface
 

--- a/lib/dialects/abstract/index.js
+++ b/lib/dialects/abstract/index.js
@@ -37,6 +37,8 @@ AbstractDialect.prototype.supports = {
   migrations: true,
   upserts: true,
   inserts: {
+    // Is there support for ON CONFLICT ... WHERE syntax
+    onConflictWhere: false,
     ignoreDuplicates: '', /* dialect specific words for INSERT IGNORE or DO NOTHING */
     updateOnDuplicate: false, /* whether dialect supports ON DUPLICATE KEY UPDATE */
     onConflictDoNothing: '' /* dialect specific words for ON CONFLICT DO NOTHING */

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -187,7 +187,7 @@ class QueryGenerator {
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         const maybeWhere = this.whereQuery(conflictWhere);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere || `${maybeWhere} `}DO UPDATE SET ${updateKeys.join(',')}`;
+        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere ? `${maybeWhere} ` : ''}DO UPDATE SET ${updateKeys.join(',')}`;
       } else {
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate += `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;
@@ -295,7 +295,7 @@ class QueryGenerator {
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         const maybeWhere = this.whereQuery(conflictWhere);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere || `${maybeWhere} `}DO UPDATE SET ${updateKeys.join(',')}`;
+        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere ? `${maybeWhere} ` : ''}DO UPDATE SET ${updateKeys.join(',')}`;
       } else { // mysql / maria
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate = `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -187,7 +187,7 @@ class QueryGenerator {
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         const maybeWhere = this.whereQuery(conflictWhere);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere ? `${maybeWhere} ` : ''}DO UPDATE SET ${updateKeys.join(',')}`;
+        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere || `${maybeWhere} `}DO UPDATE SET ${updateKeys.join(',')}`;
       } else {
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate += `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;
@@ -295,7 +295,7 @@ class QueryGenerator {
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
         const maybeWhere = this.whereQuery(conflictWhere);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere ? `${maybeWhere} ` : ''}DO UPDATE SET ${updateKeys.join(',')}`;
+        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere || `${maybeWhere} `}DO UPDATE SET ${updateKeys.join(',')}`;
       } else { // mysql / maria
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate = `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -100,6 +100,7 @@ class QueryGenerator {
     options = options || {};
     _.defaults(options, this.options);
 
+    const conflictWhere = options.upsertWhere || {};
     const modelAttributeMap = {};
     const bind = [];
     const fields = [];
@@ -181,11 +182,12 @@ class QueryGenerator {
     let onDuplicateKeyUpdate = '';
 
     if (this._dialect.supports.inserts.updateOnDuplicate && options.updateOnDuplicate) {
-      if (this._dialect.supports.inserts.updateOnDuplicate == ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
+      if (this._dialect.supports.inserts.updateOnDuplicate === ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+        const maybeWhere = this.whereQuery(conflictWhere);
+        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere ? `${maybeWhere} ` : ''}DO UPDATE SET ${updateKeys.join(',')}`;
       } else {
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate += `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;
@@ -256,6 +258,8 @@ class QueryGenerator {
     const allAttributes = [];
     let onDuplicateKeyUpdate = '';
 
+    const conflictWhere = options.upsertWhere || {};
+
     for (const fieldValueHash of fieldValueHashes) {
       _.forOwn(fieldValueHash, (value, key) => {
         if (!allAttributes.includes(key)) {
@@ -290,7 +294,8 @@ class QueryGenerator {
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) DO UPDATE SET ${updateKeys.join(',')}`;
+        const maybeWhere = this.whereQuery(conflictWhere);
+        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')}) ${maybeWhere ? `${maybeWhere} ` : ''}DO UPDATE SET ${updateKeys.join(',')}`;
       } else { // mysql / maria
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         onDuplicateKeyUpdate = `${this._dialect.supports.inserts.updateOnDuplicate} ${valueKeys.join(',')}`;

--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -770,24 +770,27 @@ class QueryInterface {
     const primaryKeys = Object.values(model.primaryKeys).map(item => item.field);
     const uniqueKeys = Object.values(model.uniqueKeys).filter(c => c.fields.length >= 1).map(c => c.fields);
     const indexKeys = Object.values(model._indexes).filter(c => c.unique && c.fields.length >= 1).map(c => c.fields);
+    const hasUpsertKeys = Object.prototype.hasOwnProperty.call(options, 'upsertKeys') && Array.isArray(options.upsertKeys);
 
     options.type = QueryTypes.UPSERT;
     options.updateOnDuplicate = Object.keys(updateValues);
-    options.upsertKeys = [];
+    options.upsertKeys = hasUpsertKeys ? options.upsertKeys : [];
 
-    // For fields in updateValues, try to find a constraint or unique index
-    // that includes given field. Only first matching upsert key is used.
-    for (const field of options.updateOnDuplicate) {
-      const uniqueKey = uniqueKeys.find(fields => fields.includes(field));
-      if (uniqueKey) {
-        options.upsertKeys = uniqueKey;
-        break;
-      }
+    if (!hasUpsertKeys) {
+      // For fields in updateValues, try to find a constraint or unique index
+      // that includes given field. Only first matching upsert key is used.
+      for (const field of options.updateOnDuplicate) {
+        const uniqueKey = uniqueKeys.find(fields => fields.includes(field));
+        if (uniqueKey) {
+          options.upsertKeys = uniqueKey;
+          break;
+        }
 
-      const indexKey = indexKeys.find(fields => fields.includes(field));
-      if (indexKey) {
-        options.upsertKeys = indexKey;
-        break;
+        const indexKey = indexKeys.find(fields => fields.includes(field));
+        if (indexKey) {
+          options.upsertKeys = indexKey;
+          break;
+        }
       }
     }
 

--- a/lib/dialects/mariadb/index.js
+++ b/lib/dialects/mariadb/index.js
@@ -30,6 +30,7 @@ MariadbDialect.prototype.supports = _.merge(
     settingIsolationLevelDuringTransaction: false,
     schemas: true,
     inserts: {
+      onConflictWhere: false,
       ignoreDuplicates: ' IGNORE',
       updateOnDuplicate: ' ON DUPLICATE KEY UPDATE'
     },

--- a/lib/dialects/mssql/index.js
+++ b/lib/dialects/mssql/index.js
@@ -43,6 +43,7 @@ MssqlDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype.
     default: true
   },
   index: {
+    onConflictWhere: false,
     collate: false,
     length: false,
     parser: false,

--- a/lib/dialects/mysql/index.js
+++ b/lib/dialects/mysql/index.js
@@ -28,6 +28,7 @@ MysqlDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype.
   forShare: 'LOCK IN SHARE MODE',
   settingIsolationLevelDuringTransaction: false,
   inserts: {
+    onConflictWhere: false,
     ignoreDuplicates: ' IGNORE',
     updateOnDuplicate: ' ON DUPLICATE KEY UPDATE'
   },

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -45,6 +45,7 @@ PostgresDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototy
     operator: true
   },
   inserts: {
+    onConflictWhere: true,
     onConflictDoNothing: ' ON CONFLICT DO NOTHING',
     updateOnDuplicate: ' ON CONFLICT DO UPDATE SET'
   },

--- a/lib/dialects/sqlite/index.js
+++ b/lib/dialects/sqlite/index.js
@@ -28,6 +28,7 @@ SqliteDialect.prototype.supports = _.merge(_.cloneDeep(AbstractDialect.prototype
   'UNION ALL': false,
   'RIGHT JOIN': false,
   inserts: {
+    onConflictWhere: true,
     ignoreDuplicates: ' OR IGNORE',
     updateOnDuplicate: ' ON CONFLICT DO UPDATE SET'
   },

--- a/lib/model.js
+++ b/lib/model.js
@@ -826,6 +826,71 @@ class Model {
   }
 
   /**
+   * A helper function for upserts that is used to generate a where clause
+   * for the ON CONFLICT part of the query. This also picks up partial unique indexes
+   * where the only condition is that the deletedAt field is null and the conflict keys are
+   * the ones in the index.
+   *
+   * @param {*} options The options for the query.
+   * @param {object} where The where clause for the query.
+   * @returns {object} The where clause for ON CONFLICT in the generated query.
+   */
+  static _getUpsertWhere(options, where) {
+    const model = options.model;
+
+    const upsertWhere = where || {};
+
+    const deletedAtAttr = model._timestampAttributes.deletedAt;
+
+    if (deletedAtAttr) {
+      // For paranoid tables that have unique indexes partial on items that aren't soft deleted,
+      // try to pick that up automatically.
+      for (const index of model._indexes) {
+
+        // Make sure that:
+        if (!(
+          // 1. The index is a unique index.
+          index.unique &&
+          // 2. index.fields is an array (might be unnecessary)
+          Array.isArray(index.fields) &&
+          // 3. All of the index fields are listed in the conflict keys
+          index.fields.every(
+            key => options.upsertKeys.includes(key)
+          )
+        )) {
+          continue;
+        }
+
+        if (
+          // Ensure the table has a deletedAt column
+          deletedAtAttr &&
+          // Check that the index is partial
+          Object.prototype.hasOwnProperty.call(index, 'where') &&
+          // Ensure that the index's where condition is an object (again: maybe unnecessary)
+          typeof index.where === 'object'
+        ) {
+          // Get the names of the columns which the index is partial on.
+          const indexWhereKeys = Object.keys(index.where);
+
+          // Add `where ${deletedAtAttr}=NULL` if:
+          if (
+            // 1. The index where clause only has 1 key.
+            indexWhereKeys.length === 1 &&
+            // 2. The key in the where clause is deletedAtAttr.
+            indexWhereKeys[0] === deletedAtAttr &&
+            // 3. The  conditon of the index is that `${deletedAt}=NULL`.
+            index.where[deletedAtAttr] === null
+          ) {
+            upsertWhere[deletedAtAttr] = null;
+          }
+        }
+      }
+    }
+
+    return upsertWhere;
+  }
+
+  /**
    * Initialize a model, representing a table in the DB, with attributes and options.
    *
    * The table columns are defined by the hash that is given as the first argument.
@@ -2426,6 +2491,8 @@ class Model {
    * @param  {Function}     [options.logging=false]                       A function that gets executed while running the query to log the sql.
    * @param  {boolean}      [options.benchmark=false]                     Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {string}       [options.searchPath=DEFAULT]                  An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {Array}        [options.conflictFields]                      Optional specification for the conflict fields in the ON CONFLICT part of the query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   * @param  {object}       [options.conflictWhere]                       Optional where clause for the ON CONFLICT part of the generated query. Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
    *
    * @returns {Promise<[Model, boolean | null]>} returns an array with two elements, the first being the new record and the second being `true` if it was just created or `false` if it already existed (except on Postgres and SQLite, which can't detect this and will always return `null` instead of a boolean).
    */
@@ -2476,6 +2543,12 @@ class Model {
       delete updateValues[this.primaryKeyField];
     }
 
+    if (Object.prototype.hasOwnProperty.call(options, 'conflictFields') && Array.isArray(options.conflictFields)) {
+      // Rename options.conflictFields to upsertKeys for the query generator + _getupsertFields.
+      options.upsertKeys = options.conflictFields;
+      options.upsertWhere = this._getUpsertWhere(options, options.conflictWhere);
+    }
+
     if (options.hooks) {
       await this.runHooks('beforeUpsert', values, options);
     }
@@ -2513,6 +2586,8 @@ class Model {
    * @param  {boolean}        [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {boolean|Array}  [options.returning=false]        If true, append RETURNING <model columns> to get back all defined values; if an array of column names, append RETURNING <columns> to get back specific columns (Postgres only)
    * @param  {string}         [options.searchPath=DEFAULT]     An optional parameter to specify the schema search_path (Postgres only)
+   * @param  {Array}          [options.upsertFields]           An optional parameter that specifies which keys should be used in the `ON CONFLICT` part of the query. (note: updateOnDuplicate must be present for this to be used.)
+   * @param  {object}         [options.upsertWhere]            An optional parameter that specifies a where clause for the `ON CONFLICT` part of the query. (note: updateOnDuplicate must be present for this to be used.)
    *
    * @returns {Promise<Array<Model>>}
    */
@@ -2680,15 +2755,24 @@ class Model {
           fieldMappedAttributes[model.rawAttributes[attr].field || attr] = model.rawAttributes[attr];
         }
 
+
         // Map updateOnDuplicate attributes to fields
         if (options.updateOnDuplicate) {
-          options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
+
+
+          if (Object.prototype.hasOwnProperty.call(options, 'upsertFields') && Array.isArray(options.upsertFields)) {
+            options.upsertKeys = options.upsertFields;
+            options.upsertWhere = this._getUpsertWhere(options, options.upsertWhere);
+          } else {
           // Get primary keys for postgres to enable updateOnDuplicate
-          options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
-          if (Object.keys(model.uniqueKeys).length > 0) {
-            options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length >= 1).map(c => c.fields).reduce(c => c[0]).value();
+            options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
+            if (Object.keys(model.uniqueKeys).length > 0) {
+              options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length >= 1).map(c => c.fields).reduce(c => c[0]).value();
+            }
           }
+          options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
         }
+
 
         // Map returning attributes to fields
         if (options.returning && Array.isArray(options.returning)) {

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -724,11 +724,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
               const dbValues = await Model.findAll({
                 order: ['columnA'],
-                attributes: ['columnA', 'columnB'],
-                raw: true
+                attributes: ['columnA', 'columnB']
               });
 
-              expect(dbValues).to.deep.equal(expectedValues);
+              expect(
+                dbValues.map(v => v.get({ plain: true }))
+              ).to.deep.equal(expectedValues);
             });
 
             it('picks up partial index on deletedAt = NULL if multiple index fields are specified', async function() {
@@ -789,11 +790,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
               const dbValues = await Model.findAll({
                 order: ['columnA'],
-                attributes: ['columnA', 'columnB', 'columnC'],
-                raw: true
+                attributes: ['columnA', 'columnB', 'columnC']
               });
 
-              expect(dbValues).to.deep.equal(expectedValues);
+              expect(
+                dbValues.map(v => v.get({ plain: true }))
+              ).to.deep.equal(expectedValues);
             });
 
             it('Uses the where clause of the query with on conflict w/ an index that has only 1 field.', async function() {
@@ -847,11 +849,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               );
 
               const dbValues = await Model.findAll({
-                attributes: ['columnA', 'columnB', 'isUnique'],
-                raw: true
+                attributes: ['columnA', 'columnB', 'isUnique']
               });
 
-              expect(dbValues).to.deep.contain.members(
+              expect(
+                dbValues.map(v => v.get({ plain: true }))
+              ).to.deep.contain.members(
                 initialValues
                   .map(v => ({
                     columnA: v.columnA,

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -598,6 +598,193 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         });
       }
+
+      if (current.dialect.supports.inserts.onConflictWhere) {
+        it('Automatically picks up deletedAt null when name is specified as a conflictKey', async function() {
+          const Model = this.sequelize.define('deleted_at_null_test', {
+            name: { type: DataTypes.STRING },
+            data: { type: DataTypes.STRING },
+            deletedAt: { type: DataTypes.DATE }
+          }, {
+            paranoid: true,
+            deletedAt: 'deletedAt',
+            indexes: [{
+              fields: ['name'],
+              unique: true,
+              where: { deletedAt: null }
+            }]
+          });
+
+          await Model.sync({ force: true });
+
+          const userInfo = {
+            name: 'some name idk',
+            data: 'old data'
+          };
+          const deletedUserInfo = { ...userInfo, data: 'deleted data' };
+
+          await Model.create(deletedUserInfo).then(user => user.destroy());
+
+          await Model.upsert(userInfo, { conflictFields: ['name'] });
+
+          const updatedUserInfo = { ...userInfo, data: 'new data' };
+
+          await Model.upsert(updatedUserInfo, { conflictFields: ['name'] });
+
+          const userDBValues = await Model.findOne({
+            where: { name: userInfo.name }
+          });
+
+          expect(userDBValues.data).to.be.equal(userDBValues.data);
+
+          const deletedUserDBValues = await Model.findOne({
+            where: {
+              name: userInfo.name
+            },
+            paranoid: false
+          });
+
+          expect(deletedUserDBValues.data).to.be.equal(deletedUserInfo.data);
+        });
+
+        it("doesn't add a where clause for deletedAt in a partial unique index on multiple fields if not all index fields are specified", async function() {
+          const Model = this.sequelize.define('deleted_at_null_test_2', {
+            name: { type: DataTypes.STRING },
+            identifier: { type: DataTypes.INTEGER },
+            data: { type: DataTypes.STRING },
+            deletedAt: { type: DataTypes.DATE }
+          }, {
+            paranoid: true,
+            deletedAt: 'deletedAt',
+            indexes: [{
+              fields: ['name', 'identifier'],
+              unique: true,
+              where: { deletedAt: null }
+            }]
+          });
+
+          await Model.sync({ force: true });
+
+          const userInfo = {
+            name: 'abcdef',
+            data: 'old blob',
+            identifier: 1234
+          };
+
+          const deletedUserInfo = { ...userInfo, data: 'deleted data' };
+
+          await Model.create(deletedUserInfo).then(user => user.destroy());
+
+          expect(
+            Model.upsert(userInfo, { conflictFields: ['name'] })
+          ).to.eventually.be.rejectedWith(Sequelize.SequelizeDatabaseError);
+        });
+
+        it('Automatically picks up deletedAt null w/ multiple fields in a unique index', async function() {
+          const Model = this.sequelize.define('deleted_at_null_test_2', {
+            name: { type: DataTypes.STRING },
+            identifier: { type: DataTypes.INTEGER },
+            data: { type: DataTypes.STRING },
+            deletedAt: { type: DataTypes.DATE }
+          }, {
+            paranoid: true,
+            deletedAt: 'deletedAt',
+            indexes: [{
+              fields: ['name', 'identifier'],
+              unique: true,
+              where: { deletedAt: null }
+            }]
+          });
+
+          await Model.sync({ force: true });
+
+          const userInfo = {
+            name: 'abcdef',
+            data: 'old blob',
+            identifier: 1234
+          };
+
+          const deletedUserInfo = { ...userInfo, data: 'deleted data' };
+
+          await Model.create(deletedUserInfo).then(user => user.destroy());
+
+          await Model.upsert(userInfo, { conflictFields: ['name', 'identifier'] });
+
+          const updatedUserInfo = { ...userInfo, data: 'new data' };
+
+          await Model.upsert(updatedUserInfo, { conflictFields: ['name', 'identifier'] });
+
+          const userDBValues = await Model.findOne({
+            where: { name: userInfo.name }
+          });
+
+          expect(userDBValues.data).to.be.equal(userDBValues.data);
+
+          const deletedUserDBValues = await Model.findOne({
+            where: {
+              name: userInfo.name
+            },
+            paranoid: false
+          });
+
+          expect(deletedUserDBValues).to.be.ok;
+          expect(deletedUserDBValues.data).to.be.equal(deletedUserInfo.data);
+        });
+
+        it('Automatically picks up deletedAt null when username is specified as a conflictKey', async function() {
+          const Model = this.sequelize.define('is_unique_index_test', {
+            name: { type: DataTypes.STRING },
+            data: { type: DataTypes.STRING },
+            isUnique: { type: DataTypes.BOOLEAN }
+          }, {
+            indexes: [{
+              fields: ['name'],
+              unique: true,
+              where: { isUnique: true }
+            }]
+          });
+
+          await Model.sync({ force: true });
+
+          const userInfo = {
+            name: 'notDeleted',
+            data: 'old data',
+            isUnique: true
+          };
+          const nonUniqueUserInfo = {
+            ...userInfo,
+            data: 'non-unique data',
+            isUnique: false
+          };
+
+          await Model.create(nonUniqueUserInfo);
+
+          await Model.upsert(userInfo, { conflictFields: ['name'], conflictWhere: { isUnique: true } });
+
+          const updatedUserInfo = { ...userInfo, data: 'new data' };
+
+          await Model.upsert(updatedUserInfo, {
+            conflictFields: ['name'],
+            conflictWhere: { isUnique: true }
+          });
+
+          const userDBValues = await Model.findOne({
+            where: { name: userInfo.name, isUnique: true }
+          });
+
+          expect(!!userDBValues).to.be.true;
+          expect(userDBValues.data).to.be.equal(userDBValues.data);
+
+          const nonUniqueUserDBValues = await Model.findOne({
+            where: { name: userInfo.name, isUnique: false }
+          });
+          expect(!!nonUniqueUserDBValues).to.be.true;
+
+          expect(nonUniqueUserDBValues.data).to.be.equal(
+            nonUniqueUserInfo.data
+          );
+        });
+      }
     });
   }
 });

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -715,7 +715,16 @@ export interface UpsertOptions<TAttributes = any> extends Logging, Transactionab
    * The fields to insert / update. Defaults to all fields
    */
   fields?: (keyof TAttributes)[];
-
+  /**
+   * Optional specification for the conflict fields in the ON CONFLICT part of the query.
+   * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   */
+  conflictFields?: (keyof TAttributes)[];
+  /**
+   * Optional where clause for the `ON CONFLICT` part of the generated query.
+   * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   */
+   conflictWhere?: WhereOptions<TAttributes>;
   /**
    * Return the affected rows (only for postgres)
    */
@@ -770,6 +779,20 @@ export interface BulkCreateOptions<TAttributes = any> extends Logging, Transacti
    * Return all columns or only the specified columns for the affected rows (only for postgres)
    */
   returning?: boolean | (keyof TAttributes)[];
+
+  /**
+   * An optional parameter that specifies which keys should be used in the `ON CONFLICT` part of the query.
+   * (note: updateOnDuplicate must be present for this to be used.)
+   * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   */
+  upsertFields?: (keyof TAttributes)[];
+
+  /**
+   * An optional parameter that specifies a where clause for the `ON CONFLICT` part of the query.
+   * (note: updateOnDuplicate must be present for this to be used.)
+   * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   */
+  upsertWhere?: WhereOptions<TAttributes>;
 }
 
 /**
@@ -2033,7 +2056,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   public static upsert<M extends Model>(
     this: ModelStatic<M>,
-    values: M['_creationAttributes'],
+    values: Partial<M['_creationAttributes']>,
     options?: UpsertOptions<M['_attributes']>
   ): Promise<[M, boolean | null]>;
 

--- a/types/test/upsert.ts
+++ b/types/test/upsert.ts
@@ -66,7 +66,7 @@ sequelize.transaction(async (trx) => {
   const res4: [TestModel, boolean | null] = await TestModel.upsert(
     {},
     {
-      where: {
+      conflictWhere: {
         testEnum: null,
       },
       conflictFields: ['testId'],

--- a/types/test/upsert.ts
+++ b/types/test/upsert.ts
@@ -1,41 +1,75 @@
-import {Model} from "sequelize"
-import {sequelize} from './connection';
+import { DataTypes, Model, Optional } from 'sequelize';
+import { sequelize } from './connection';
 
-class TestModel extends Model {
+interface ITestModel {
+  testId: number;
+  testString: string | null;
+  testEnum: 'd' | 'e' | 'f' | null;
 }
 
-TestModel.init({}, {sequelize})
+class TestModel extends Model<
+  ITestModel,
+  Optional<ITestModel, 'testString' | 'testEnum'>
+> {}
 
-sequelize.transaction(async trx => {
-  const res1: [TestModel, boolean | null] = await TestModel.upsert<TestModel>({}, {
-    benchmark: true,
-    fields: ['testField'],
-    hooks: true,
-    logging: true,
-    returning: true,
-    searchPath: 'DEFAULT',
-    transaction: trx,
-    validate: true,
-  });
+TestModel.init(
+  {
+    testId: { type: DataTypes.NUMBER },
+    testString: { type: DataTypes.STRING },
+    testEnum: { type: DataTypes.STRING },
+  },
+  { sequelize }
+);
 
-  const res2: [TestModel, boolean | null] = await TestModel.upsert<TestModel>({}, {
-    benchmark: true,
-    fields: ['testField'],
-    hooks: true,
-    logging: true,
-    returning: false,
-    searchPath: 'DEFAULT',
-    transaction: trx,
-    validate: true,
-  });
+sequelize.transaction(async (trx) => {
+  const res1: [TestModel, boolean | null] = await TestModel.upsert(
+    {},
+    {
+      benchmark: true,
+      fields: ['testEnum'],
+      hooks: true,
+      logging: true,
+      returning: true,
+      searchPath: 'DEFAULT',
+      transaction: trx,
+      validate: true,
+    }
+  );
 
-  const res3: [TestModel, boolean | null] = await TestModel.upsert<TestModel>({}, {
-    benchmark: true,
-    fields: ['testField'],
-    hooks: true,
-    logging: true,
-    searchPath: 'DEFAULT',
-    transaction: trx,
-    validate: true,
-  });
-})
+  const res2: [TestModel, boolean | null] = await TestModel.upsert(
+    {},
+    {
+      benchmark: true,
+      fields: ['testId'],
+      hooks: true,
+      logging: true,
+      returning: false,
+      searchPath: 'DEFAULT',
+      transaction: trx,
+      validate: true,
+    }
+  );
+
+  const res3: [TestModel, boolean | null] = await TestModel.upsert(
+    {},
+    {
+      benchmark: true,
+      fields: ['testString'],
+      hooks: true,
+      logging: true,
+      searchPath: 'DEFAULT',
+      transaction: trx,
+      validate: true,
+    }
+  );
+
+  const res4: [TestModel, boolean | null] = await TestModel.upsert(
+    {},
+    {
+      where: {
+        testEnum: null,
+      },
+      conflictFields: ['testId'],
+    }
+  );
+});


### PR DESCRIPTION
Add support for where clauses used in the ON CONFLICT part of the queries generated by model.bulkCreate and model.upsert for usage >



<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This is similar to #11611 but a bit different.  Unique indexes partial on the records not being soft deleted (eg, `CREATE UNIQUE INDEX 'abc' ON 'table1' ("col1") WHERE time_deleted IS NULL`) are picked up automatically so long as:
1. All of the fields in the index are being specified in `conflictFields` (for upsert, `upsertFields` for bulkCreate, happy to change naming if needed) 
2. The index is in the model's definition.

`Model.upsert` has 2 more options:
- `conflictFields` - This is for specifying the keys which are added in `ON CONFLICT()`. (eg, `ON CONFLICT(${conflictFields})`).
- `conflictWhere` - This is used to specify a where clause for the `ON CONFLICT` part of the query. 

`Model.bulkCreate` has the same options but with different names (might be worth changing them to match):
- `upsertFields` - Same thing as `conflictFields`.
- `upsertWhere` - Same as `conflictWhere`. 
Note: bulkCreate will ignore these options if `updateOnDuplicate` isn't specified.

An example case of where this is handy:
```js
// Create a table for Users
// Users need unique usernames, but only if they haven't been deleted.
const Users = sequelize.define('users', {
    username: { type: DataTypes.CITEXT },
    email: { type: DataTypes.CITEXT },
    time_deleted: { type: DataTypes.DATE }, 
}, {
    paranoid: true,
    deletedAt: 'time_deleted',
    indexes: [{
        fields: ['username'],
        unique: true,
        where: { time_deleted: null },
    }],
});

await Users.upsert({
    username: 'User123',
    email: 'newEmail@abc.com' 
}, {
    conflictFields: ['username'],
});
```

<!-- Please provide a description of the change here. -->


Closes #13240, #13066, #13031, #12774, #12742, #12595, #11656