### PR TITLE
fix(mariadb): Process JSON fields only if actually requested (#13027 & #12583

### DIFF
--- a/lib/dialects/mariadb/query.js
+++ b/lib/dialects/mariadb/query.js
@@ -183,11 +183,12 @@ class Query extends AbstractQuery {
       if (modelField.type instanceof DataTypes.JSON) {
         // Value is returned as String, not JSON
         rows = rows.map(row => {
-          row[modelField.fieldName] = row[modelField.fieldName] ? JSON.parse(
-            row[modelField.fieldName]) : null;
-          if (DataTypes.JSON.parse) {
-            return DataTypes.JSON.parse(modelField, this.sequelize.options,
-              row[modelField.fieldName]);
+          if(row[modelField.fieldName] !== undefined) {
+            row[modelField.fieldName] = JSON.parse(row[modelField.fieldName]);
+            if (DataTypes.JSON.parse) {
+              return DataTypes.JSON.parse(modelField, this.sequelize.options,
+                row[modelField.fieldName]);
+            }
           }
           return row;
         });


### PR DESCRIPTION
Adding JSON fields to rows regardless if requested or not breaks AbstractQuery::_groupJoinData() for example.

Fixes #13027 & #12583
