### PR TITLE
Typescript typings: Add TSVECTOR to data-types.d.ts and Op.match to operators.d.ts

### DIFF
--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -372,6 +372,11 @@ export const JSON: AbstractDataTypeConstructor;
 export const JSONB: AbstractDataTypeConstructor;
 
 /**
+ * A text search column. Only available in postgres.
+ */
+export const TSVECTOR: AbstractDataTypeConstructor;
+
+/**
  * A default value of the current timestamp
  */
 export const NOW: AbstractDataTypeConstructor;
@@ -602,7 +607,7 @@ export const INET: AbstractDataTypeConstructor;
 export const MACADDR: AbstractDataTypeConstructor;
 
 /**
- * Case incenstive text
+ * Case insensitive text
  */
 export const CITEXT: AbstractDataTypeConstructor;
 

--- a/types/lib/operators.d.ts
+++ b/types/lib/operators.d.ts
@@ -467,6 +467,18 @@ declare const Op: {
    * ```
    */
   readonly values: unique symbol;
+  /**
+   * Operator @@ (PG only)
+   * 
+   * ```js
+   * [Op.match]: Sequelize.fn('to_tsquery', 'fat & rat')
+   * ```
+   * In SQL
+   * ```sql
+   * @@ to_tsquery('fat & rat');
+   * ```
+   */
+  readonly match: unique symbol;
 };
 
 export = Op;


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change
Adds TSVECTOR typing
<!-- Please provide a description of the change here. -->

fixes #13316