### PR TITLE
docs(model-querying-basics.md): Fix a typo in the docs

### DIFF
--- a/docs/manual/core-concepts/model-querying-basics.md
+++ b/docs/manual/core-concepts/model-querying-basics.md
@@ -355,7 +355,7 @@ The above will generate:
 SELECT *
 FROM `Projects`
 WHERE (
-  `Projects`.`name` = 'a project'
+  `Projects`.`name` = 'Some Project'
   AND NOT (
     `Projects`.`id` IN (1,2,3)
     OR


### PR DESCRIPTION
### Description of change

just found a typo in model-querying-basics at the "Examples with Op.not" section.