### PR TITLE
fix(typings): makes Transactionable compatible with TransactionOptions

### DIFF
--- a/types/lib/transaction.d.ts
+++ b/types/lib/transaction.d.ts
@@ -149,7 +149,7 @@ export interface TransactionOptions extends Logging {
   /**
    * Parent transaction.
    */
-  transaction?: Transaction;
+  transaction?: Transaction | null;
 }
 
 export default Transaction;

--- a/types/test/models/User.ts
+++ b/types/test/models/User.ts
@@ -111,10 +111,8 @@ User.addHook('beforeFind', 'test', (options: FindOptions<UserAttributes>) => {
 });
 
 User.addHook('afterDestroy', async (instance, options) => {
-  await instance.sequelize.transaction(options, () => {
-    // allow for transactions without destructuring
-    return Promise.resolve();
-  });
+  // `options` from `afterDestroy` should be passable to `sequelize.transaction`
+  await instance.sequelize.transaction(options, async () => undefined);
 });
 
 // Model#addScope

--- a/types/test/models/User.ts
+++ b/types/test/models/User.ts
@@ -110,6 +110,13 @@ User.addHook('beforeFind', 'test', (options: FindOptions<UserAttributes>) => {
   return undefined;
 });
 
+User.addHook('afterDestroy', async (instance, options) => {
+  await instance.sequelize.transaction(options, () => {
+    // allow for transactions without destructuring
+    return Promise.resolve();
+  });
+});
+
 // Model#addScope
 User.addScope('withoutFirstName', {
   where: {


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This change makes `Transactionable` compatible with `TransactionOptions`. Having both compatible allows for much cleaner code like this:

```javascript
async afterDestroy(instance: Model, options: InstanceDestroyOptions) {
  return sequelize.transaction(options, async (transaction) => {
```

This piece of code was working before but broke on #13093. We can either merge this change or revert that PR to make these interfaces compatible but I think allowing `null` (merging this PR) is the way to go because it better represents the reality of this library.