### PR TITLE
fix(bulk-create): `ON CONFLICT` with unique index

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2687,7 +2687,7 @@ class Model {
           const upsertKeys = [];
 
           for (const i of model._indexes) {
-            if (i.unique) {
+            if (i.unique && !i.where) { // Don't infer partial indexes
               upsertKeys.push(...i.fields);
             }
           }

--- a/lib/model.js
+++ b/lib/model.js
@@ -2683,11 +2683,22 @@ class Model {
         // Map updateOnDuplicate attributes to fields
         if (options.updateOnDuplicate) {
           options.updateOnDuplicate = options.updateOnDuplicate.map(attr => model.rawAttributes[attr].field || attr);
-          // Get primary keys for postgres to enable updateOnDuplicate
-          options.upsertKeys = _.chain(model.primaryKeys).values().map('field').value();
-          if (Object.keys(model.uniqueKeys).length > 0) {
-            options.upsertKeys = _.chain(model.uniqueKeys).values().filter(c => c.fields.length >= 1).map(c => c.fields).reduce(c => c[0]).value();
+
+          const upsertKeys = [];
+
+          for (const i of model._indexes) {
+            if (i.unique) {
+              upsertKeys.push(...i.fields);
+            }
           }
+
+          const firstUniqueKey = Object.values(model.uniqueKeys).find(c => c.fields.length >= 1);
+
+          if (firstUniqueKey && firstUniqueKey.fields) {
+            upsertKeys.push(...firstUniqueKey.fields);
+          }
+
+          options.upsertKeys = upsertKeys.length > 0 ? upsertKeys : Object.values(model.primaryKeys).map(x => x.field);
         }
 
         // Map returning attributes to fields

--- a/lib/model.js
+++ b/lib/model.js
@@ -2698,7 +2698,9 @@ class Model {
             upsertKeys.push(...firstUniqueKey.fields);
           }
 
-          options.upsertKeys = upsertKeys.length > 0 ? upsertKeys : Object.values(model.primaryKeys).map(x => x.field);
+          options.upsertKeys = upsertKeys.length > 0
+            ? upsertKeys
+            : Object.values(model.primaryKeys).map(x => x.field);
         }
 
         // Map returning attributes to fields


### PR DESCRIPTION
Supersedes #12516

Also addresses https://github.com/sequelize/sequelize/pull/11984/files#r414863957 via refactor
