### PR TITLE
fix(sqlite): fix wrongly overwriting storage if empty string

### DIFF
--- a/lib/dialects/sqlite/connection-manager.js
+++ b/lib/dialects/sqlite/connection-manager.js
@@ -45,7 +45,7 @@ class ConnectionManager extends AbstractConnectionManager {
   async getConnection(options) {
     options = options || {};
     options.uuid = options.uuid || 'default';
-    options.storage = this.sequelize.options.storage || this.sequelize.options.host || ':memory:';
+    options.storage = this.sequelize.options.storage ?? (this.sequelize.options.host || ':memory:');
     options.inMemory = options.storage === ':memory:' ? 1 : 0;
 
     const dialectOptions = this.sequelize.options.dialectOptions;

--- a/test/support.js
+++ b/test/support.js
@@ -113,7 +113,7 @@ const Support = {
       sequelizeOptions.native = true;
     }
 
-    if (config.storage) {
+    if (config.storage || config.storage === '') {
       sequelizeOptions.storage = config.storage;
     }
 

--- a/test/unit/dialects/sqlite/connection-manager.test.js
+++ b/test/unit/dialects/sqlite/connection-manager.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const chai = require('chai'),
+  expect = chai.expect,
+  Support = require('../../support'),
+  Sequelize = Support.Sequelize,
+  dialect = Support.getTestDialect(),
+  sinon = require('sinon');
+
+if (dialect === 'sqlite') {
+  describe('connectionManager', () => {
+    describe('getConnection', () => {
+      it('Should respect storage=\'\'', () => {
+        // storage='' means anonymous disk-based database
+        const sequelize = new Sequelize('', '', '', { dialect: 'sqlite', storage: '' });
+        sinon.stub(sequelize.connectionManager, 'lib').value({
+          Database: function FakeDatabase(_s, _m, cb) {
+            cb();
+            return {};
+          }
+        });
+        sinon.stub(sequelize.connectionManager, 'connections').value({ default: { run: () => {} } });
+        const options = {};
+        sequelize.dialect.connectionManager.getConnection(options);
+        expect(options.storage).to.be.equal('');
+      });
+    });
+  });
+}


### PR DESCRIPTION
Empty string in SQLite3 means anonymous disk-based db, but sequelize overwrited it with :memory:

Closes #13375

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
Closes https://github.com/sequelize/sequelize/issues/13375