### PR TITLE
docs(eager-loading): add await to code example

### DIFF
--- a/docs/manual/advanced-association-concepts/eager-loading.md
+++ b/docs/manual/advanced-association-concepts/eager-loading.md
@@ -378,7 +378,7 @@ await sequelize.sync();
 const foo = await Foo.create({ name: 'foo' });
 const bar = await Bar.create({ name: 'bar' });
 await foo.addBar(bar);
-const fetchedFoo = Foo.findOne({ include: Bar });
+const fetchedFoo = await Foo.findOne({ include: Bar });
 console.log(JSON.stringify(fetchedFoo, null, 2));
 ```
 


### PR DESCRIPTION
### Description of change
This line is missing an await, so the console.log does not actually log the expected Foo object as it hasn't been retrieved yet.

**Without `await` (existing documentation)**
Code:
```js
const { Sequelize, DataTypes } = require('sequelize');
const sequelize = new Sequelize('sqlite::memory:');

const Foo = sequelize.define('Foo', { name: DataTypes.TEXT });
const Bar = sequelize.define('Bar', { name: DataTypes.TEXT });
Foo.belongsToMany(Bar, { through: 'Foo_Bar' });
Bar.belongsToMany(Foo, { through: 'Foo_Bar' });

(async () => {
    await sequelize.sync();
    const foo = await Foo.create({ name: 'foo' });
    const bar = await Bar.create({ name: 'bar' });
    await foo.addBar(bar);
    const fetchedFoo = Foo.findOne({ include: Bar });
    console.log(JSON.stringify(fetchedFoo, null, 2));
})();
```
Output:
![logs showing no result for fetchedFoo](https://user-images.githubusercontent.com/8452261/128230117-64c13e7d-69bb-4b6f-970d-e1bfbdde4f97.png)

**With `await` (the proposed change)**
```js
const { Sequelize, DataTypes } = require('sequelize');
const sequelize = new Sequelize('sqlite::memory:');

const Foo = sequelize.define('Foo', { name: DataTypes.TEXT });
const Bar = sequelize.define('Bar', { name: DataTypes.TEXT });
Foo.belongsToMany(Bar, { through: 'Foo_Bar' });
Bar.belongsToMany(Foo, { through: 'Foo_Bar' });

(async () => {
    await sequelize.sync();
    const foo = await Foo.create({ name: 'foo' });
    const bar = await Bar.create({ name: 'bar' });
    await foo.addBar(bar);
    const fetchedFoo = await Foo.findOne({ include: Bar });
    console.log(JSON.stringify(fetchedFoo, null, 2));
})();
```
Output:
![logs showing a result for fetchedFoo](https://user-images.githubusercontent.com/8452261/128230246-fa13185f-7e96-441c-8b7c-8a571ad6a493.png)


As for the change on line 664, that was added by GitHub (I used the Edit feature) so I imagine it fixed some spacing using the  editorconfig settings