### PR TITLE
Fix missing comma in example options object

### DIFF
--- a/docs/manual/core-concepts/model-querying-basics.md
+++ b/docs/manual/core-concepts/model-querying-basics.md
@@ -161,7 +161,7 @@ Multiple checks can be passed:
 ```js
 Post.findAll({
   where: {
-    authorId: 12
+    authorId: 12,
     status: 'active'
   }
 });


### PR DESCRIPTION
It's a simple documentation change so I'll skip any form of template. Just a broken object that may confuse new people.
