### PR TITLE
fix: allows insert primary key with zero

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -156,7 +156,7 @@ class QueryGenerator {
         fields.push(this.quoteIdentifier(key));
 
         // SERIALS' can't be NULL in postgresql, use DEFAULT where supported
-        if (modelAttributeMap && modelAttributeMap[key] && modelAttributeMap[key].autoIncrement === true && !value) {
+        if (modelAttributeMap && modelAttributeMap[key] && modelAttributeMap[key].autoIncrement === true && value == null) {
           if (!this._dialect.supports.autoIncrement.defaultValue) {
             fields.splice(-1, 1);
           } else if (this._dialect.supports.DEFAULT) {
@@ -276,7 +276,8 @@ class QueryGenerator {
           this._dialect.supports.bulkDefault
           && serials[key] === true
         ) {
-          return fieldValueHash[key] || 'DEFAULT';
+          // fieldValueHashes[key] ?? 'DEFAULT'
+          return fieldValueHash[key] != null ? fieldValueHash[key] : 'DEFAULT';
         }
 
         return this.escape(fieldValueHash[key], fieldMappedAttributes[key], { context: 'INSERT' });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

Before now, I create a row, the primary key pass `0`, the sql generator will ignore the `0`, use `DEFAULT` instead, this pr will fixes the problem.
