### PR TITLE
fix(model): columns with getter sort problem

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -3499,27 +3499,26 @@ class Model {
       const values = {};
       let _key;
 
-      if (this._hasCustomGetters) {
-        for (_key in this._customGetters) {
-          if (
-            this._options.attributes
-            && !this._options.attributes.includes(_key)
-          ) {
-            continue;
+      for (_key in this.dataValues) {
+        if (Object.prototype.hasOwnProperty.call(this.dataValues, _key)) {
+          if (this._hasCustomGetters && this._customGetters[_key]) {
+            if (
+              this._options.attributes
+              && !this._options.attributes.includes(_key)
+            ) {
+              values[_key] = this.get(_key, options);
+            }
+            else {
+              if (Object.prototype.hasOwnProperty.call(this._customGetters, _key)) {
+                values[_key] = this.get(_key, options);
+              } else {
+                values[_key] = this.get(_key, options);
+              }
+            }
           }
-
-          if (Object.prototype.hasOwnProperty.call(this._customGetters, _key)) {
+          else {
             values[_key] = this.get(_key, options);
           }
-        }
-      }
-
-      for (_key in this.dataValues) {
-        if (
-          !Object.prototype.hasOwnProperty.call(values, _key)
-          && Object.prototype.hasOwnProperty.call(this.dataValues, _key)
-        ) {
-          values[_key] = this.get(_key, options);
         }
       }
 

--- a/test/unit/model/findone-with-getters.test.js
+++ b/test/unit/model/findone-with-getters.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const chai = require('chai');
+const expect = chai.expect;
+const Support = require('../support');
+const current = Support.sequelize;
+const sinon = require('sinon');
+const DataTypes = require('../../../lib/data-types');
+const { Logger } = require('../../../lib/utils/logger');
+const sequelizeErrors = require('../../../lib/errors');
+
+describe(Support.getTestDialectTeaser('Model'), () => {
+  describe('method findAll with getters', () => {
+    const Model = current.define('model', {
+      name: DataTypes.STRING,
+      age: {
+        type: DataTypes.INTEGER,
+        get() {
+          const rawValue = this.getDataValue('age');
+          return rawValue + 1;
+        }
+      }
+    }, { timestamps: false });
+
+    before(function() {
+      this.stub = sinon.stub(current.getQueryInterface(), 'select').callsFake(() => Model.build({
+        name: 'test',
+        age: 33
+      }));
+      this.warnOnInvalidOptionsStub = sinon.stub(Model, 'warnOnInvalidOptions');
+    });
+
+    beforeEach(function() {
+      this.stub.resetHistory();
+      this.warnOnInvalidOptionsStub.resetHistory();
+    });
+
+    after(function() {
+      this.stub.restore();
+      this.warnOnInvalidOptionsStub.restore();
+    });
+
+    describe('attributes sort', () => {
+      it('show return the correct sort', async function() {
+        const data = await Model.findAll();
+
+        expect(Object.keys(JSON.parse(JSON.stringify(data)))).to.deep.equal([
+          'id',
+          'name',
+          'age'
+        ]);
+      });
+
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->

The column(s) with getter always show at the beginning of the column(s) without getter

Please check the example code bellow of the problem is
1. define a model with the getter for column `age`.
```javascript
const Model = db.define('model', {
      name: DataTypes.STRING,
      age: {
        type: DataTypes.INTEGER,
        get() {
          const rawValue = this.getDataValue('age');
          return rawValue + 1;
        }
      }
}, { timestamps: false });
```
use `findAll` and `findOne`, then return the result to JSON

we think we should get

```
{
  "id": 0,
  "name": "",
  "age": 1
}
```
but we got

```
{
  "age": 1,
  "id": 0,
  "name": ""
}
```