### PR TITLE
feat/add tsvector datatype

### DIFF
--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -606,5 +606,7 @@ export const MACADDR: AbstractDataTypeConstructor;
  */
 export const CITEXT: AbstractDataTypeConstructor;
 
+export const TSVECTOR: AbstractDataTypeConstructor;
+
 // umzug compatibility
 export type DataTypeAbstract = AbstractDataTypeConstructor;


### PR DESCRIPTION
tsvector postgres type was added in pull request https://github.com/sequelize/sequelize/pull/12955/files but type is missing
