### PR TITLE
[WIP] Add 'query_timeout' to pg dialectOptions

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -113,8 +113,10 @@ class ConnectionManager extends AbstractConnectionManager {
           // This should help with backends incorrectly considering idle clients to be dead and prematurely disconnecting them.
           // this feature has been added in pg module v6.0.0, check pg/CHANGELOG.md
           'keepAlive',
-          // Times out queries after a set time in milliseconds. Added in pg v7.3
+          // DB statement timeout in milliseconds. Added in pg v7.3
           'statement_timeout',
+          // Client side request timeout in milliseconds. Added in pg v7.7
+          'query_timeout'
           // Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds. Added in pg v7.17.0 only supported in postgres >= 10
           'idle_in_transaction_session_timeout'
         ]));


### PR DESCRIPTION
### Pull Request check-list

- [X] (except for pre-existing 'Alias' FIXME Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [] N/A Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description of change

The `query_timeout` option has existed in pg since v7.7 - see discussion at https://github.com/brianc/node-postgres/pull/1760

This change adds it to properties to be passed to new connection config so it can be used with sequelize

