### PR TITLE
feat(types): add types for nullable association mixins

### DIFF
--- a/types/lib/associations/belongs-to.d.ts
+++ b/types/lib/associations/belongs-to.d.ts
@@ -58,6 +58,26 @@ export interface BelongsToGetAssociationMixinOptions extends FindOptions<any> {
 export type BelongsToGetAssociationMixin<TModel> = (options?: BelongsToGetAssociationMixinOptions) => Promise<TModel>;
 
 /**
+ * The getAssociation mixin applied to models with nullable belongsTo.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.belongsTo(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttrib>, UserAttrib {
+ *  getRole: Sequelize.BelongsToGetAssociationMixin<RoleInstance>;
+ *  // setRole...
+ *  // createRole...
+ * }
+ * ```
+ *
+ * @see https://sequelize.org/master/class/lib/associations/belongs-to.js~BelongsTo.html
+ * @see Instance
+ */
+export type BelongsToGetNullableAssociationMixin<TModel> = (options?: BelongsToGetAssociationMixinOptions) => Promise<TModel | null>;
+
+/**
  * The options for the setAssociation mixin of the belongsTo association.
  * @see BelongsToSetAssociationMixin
  */

--- a/types/lib/associations/has-one.d.ts
+++ b/types/lib/associations/has-one.d.ts
@@ -56,6 +56,26 @@ export interface HasOneGetAssociationMixinOptions extends FindOptions<any> {
 export type HasOneGetAssociationMixin<TModel> = (options?: HasOneGetAssociationMixinOptions) => Promise<TModel>;
 
 /**
+ * The getAssociation mixin applied to models with nullable hasOne.
+ * An example of usage is as follows:
+ *
+ * ```js
+ *
+ * User.hasOne(Role);
+ *
+ * interface UserInstance extends Sequelize.Instance<UserInstance, UserAttrib>, UserAttrib {
+ *  getRole: Sequelize.HasOneGetAssociationMixin<RoleInstance>;
+ *  // setRole...
+ *  // createRole...
+ * }
+ * ```
+ *
+ * @see https://sequelize.org/master/class/lib/associations/has-one.js~HasOne.html
+ * @see Instance
+ */
+export type HasOneGetNullableAssociationMixin<TModel> = (options?: HasOneGetAssociationMixinOptions) => Promise<TModel | null>;
+
+/**
  * The options for the setAssociation mixin of the hasOne association.
  * @see HasOneSetAssociationMixin
  */


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
  *no change to source code*
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
  *no change to source code*
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
  *I am not sure where to add it*
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Currently the TypeScript definitions for the `BelongsTo` and `HasOne` associations define their `get` methods as `(options?: FooGetAssociationMixinOptions) => Promise<TModel>`, which is correct, when the corresponding foreign key is not nullable.

If, however, the foreign key can be `NULL`, then the result of `User.getRole()` can be `null` as well.

This PR adds a `BelongsToGetNullableAssociationMixin<TModel>` and `HasOneGetNullableAssociationMixin<TModel>` type, where both return a `Promise<TModel | null>`.