### PR TITLE
fix(types): allow rangable to take a string tuple

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -131,7 +131,7 @@ export interface AllOperator {
   [Op.all]: readonly (string | number | Date | Literal)[];
 }
 
-export type Rangable = readonly [number, number] | readonly [Date, Date] | Literal;
+export type Rangable = readonly [number, number] | readonly [Date, Date] | readonly [string, string] | Literal;
 
 /**
  * Operators that can be used in WhereOptions

--- a/types/test/where.ts
+++ b/types/test/where.ts
@@ -227,7 +227,7 @@ MyModel.findAll({
       [Op.lt]: 10, // id < 10
       [Op.lte]: 10, // id <= 10
       [Op.ne]: 20, // id != 20
-      [Op.between]: [6, 10] || [new Date(), new Date()], // BETWEEN 6 AND 10
+      [Op.between]: [6, 10] || [new Date(), new Date()] || ["2020-01-01", "2020-12-31"], // BETWEEN 6 AND 10
       [Op.notBetween]: [11, 15], // NOT BETWEEN 11 AND 15
       [Op.in]: [1, 2], // IN [1, 2]
       [Op.notIn]: [1, 2], // NOT IN [1, 2]


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Currently the type definitions for a Rangable does not accept strings. In the example below Sequelize has no problem working with a string version of a date and make a valid query. I found this when upgrading typescript for my project from 4.0.5 to 4.4.2.

```ts
const startRange = "2021-01-01";
const endRange = "2021-12-31";
const entities = await SomeEntity.findAll({
    where: {
        dueDate: {
            [Op.between]: [startRange, endRange]
        }
    },
});
```
