### PR TITLE
fix(select): do not force set `subQuery` to `false`

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -528,7 +528,7 @@ class Model {
 
       if (include.subQuery !== false && options.hasDuplicating && options.topLimit) {
         if (include.duplicating) {
-          include.subQuery = false;
+          include.subQuery = include.subQuery || false;
           include.subQueryFilter = include.hasRequired;
         } else {
           include.subQuery = include.hasRequired;
@@ -538,7 +538,6 @@ class Model {
         include.subQuery = include.subQuery || false;
         if (include.duplicating) {
           include.subQueryFilter = include.subQuery;
-          include.subQuery = false;
         } else {
           include.subQueryFilter = false;
           include.subQuery = include.subQuery || include.hasParentRequired && include.hasRequired && !include.separate;

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -449,7 +449,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
-    it('include (subQuery alias)', () => {
+    describe('include (subQuery alias)', () => {
       const User = Support.sequelize.define('User', {
         name: DataTypes.STRING,
         age: DataTypes.INTEGER
@@ -466,29 +466,115 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
       User.Posts = User.hasMany(Post, { foreignKey: 'user_id', as: 'postaliasname' });
 
-      expectsql(sql.selectQuery('User', {
-        table: User.getTableName(),
-        model: User,
-        attributes: ['name', 'age'],
+      it('w/o filters', () => {
+        expectsql(sql.selectQuery('User', {
+          table: User.getTableName(),
+          model: User,
+          attributes: ['name', 'age'],
+          include: Model._validateIncludedElements({
+            include: [{
+              attributes: ['title'],
+              association: User.Posts,
+              subQuery: true,
+              required: true
+            }],
+            as: 'User'
+          }).include,
+          subQuery: true
+        }, User), {
+          default: 'SELECT [User].* FROM ' +
+            '(SELECT [User].[name], [User].[age], [User].[id] AS [id], [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM [User] AS [User] ' +
+            'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id] ' +
+            'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) LIMIT 1 ) IS NOT NULL) AS [User];',
+          mssql: 'SELECT [User].* FROM ' +
+            '(SELECT [User].[name], [User].[age], [User].[id] AS [id], [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM [User] AS [User] ' +
+            'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id] ' +
+            'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) ORDER BY [postaliasname].[id] OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY ) IS NOT NULL) AS [User];'
+        });
+      });
+
+      it('w/ nested column filter', () => {
+        expectsql(sql.selectQuery('User', {
+          table: User.getTableName(),
+          model: User,
+          attributes: ['name', 'age'],
+          where: { '$postaliasname.title$': 'test' },
+          include: Model._validateIncludedElements({
+            include: [{
+              attributes: ['title'],
+              association: User.Posts,
+              subQuery: true,
+              required: true
+            }],
+            as: 'User'
+          }).include,
+          subQuery: true
+        }, User), {
+          default: 'SELECT [User].* FROM ' +
+            '(SELECT [User].[name], [User].[age], [User].[id] AS [id], [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM [User] AS [User] ' +
+            'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id] ' +
+            'WHERE [postaliasname].[title] = \'test\' AND ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) LIMIT 1 ) IS NOT NULL) AS [User];',
+          mssql: 'SELECT [User].* FROM ' +
+            '(SELECT [User].[name], [User].[age], [User].[id] AS [id], [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM [User] AS [User] ' +
+            'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id] ' +
+            'WHERE [postaliasname].[title] = N\'test\' AND ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) ORDER BY [postaliasname].[id] OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY ) IS NOT NULL) AS [User];'
+        });
+      });
+    });
+
+    it('include w/ subQuery + nested filter + paging', () => {
+      const User = Support.sequelize.define('User', {
+        scopeId: DataTypes.INTEGER
+      });
+
+      const Company = Support.sequelize.define('Company', {
+        name: DataTypes.STRING,
+        public: DataTypes.BOOLEAN,
+        scopeId: DataTypes.INTEGER
+      });
+
+      const Profession = Support.sequelize.define('Profession', {
+        name: DataTypes.STRING,
+        scopeId: DataTypes.INTEGER
+      });
+
+      User.Company = User.belongsTo(Company, { foreignKey: 'companyId' });
+      User.Profession = User.belongsTo(Profession, { foreignKey: 'professionId' });
+      Company.Users = Company.hasMany(User, { as: 'Users', foreignKey: 'companyId' });
+      Profession.Users = Profession.hasMany(User, { as: 'Users', foreignKey: 'professionId' });
+
+      expectsql(sql.selectQuery('Company', {
+        table: Company.getTableName(),
+        model: Company,
+        attributes: ['name', 'public'],
+        where: { '$Users.Profession.name$': 'test', [Op.and]: { scopeId: [42] } },
         include: Model._validateIncludedElements({
           include: [{
-            attributes: ['title'],
-            association: User.Posts,
+            association: Company.Users,
+            attributes: [],
+            include: [{
+              association: User.Profession,
+              attributes: [],
+              required: true
+            }],
             subQuery: true,
             required: true
           }],
-          as: 'User'
+          model: Company
         }).include,
+        limit: 5,
+        offset: 0,
         subQuery: true
-      }, User), {
-        default: 'SELECT [User].*, [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM ' +
-          '(SELECT [User].[name], [User].[age], [User].[id] AS [id] FROM [User] AS [User] ' +
-          'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) LIMIT 1 ) IS NOT NULL) AS [User] ' +
-          'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id];',
-        mssql: 'SELECT [User].*, [postaliasname].[id] AS [postaliasname.id], [postaliasname].[title] AS [postaliasname.title] FROM ' +
-          '(SELECT [User].[name], [User].[age], [User].[id] AS [id] FROM [User] AS [User] ' +
-          'WHERE ( SELECT [user_id] FROM [Post] AS [postaliasname] WHERE ([postaliasname].[user_id] = [User].[id]) ORDER BY [postaliasname].[id] OFFSET 0 ROWS FETCH NEXT 1 ROWS ONLY ) IS NOT NULL) AS [User] ' +
-          'INNER JOIN [Post] AS [postaliasname] ON [User].[id] = [postaliasname].[user_id];'
+      }, Company), {
+        default: 'SELECT [Company].* FROM (' +
+        'SELECT [Company].[name], [Company].[public], [Company].[id] AS [id] FROM [Company] AS [Company] ' +
+        'INNER JOIN [Users] AS [Users] ON [Company].[id] = [Users].[companyId] ' +
+        'INNER JOIN [Professions] AS [Users->Profession] ON [Users].[professionId] = [Users->Profession].[id] ' +
+        `WHERE ([Company].[scopeId] IN (42)) AND [Users->Profession].[name] = ${sql.escape('test')} AND ( ` +
+        'SELECT [Users].[companyId] FROM [Users] AS [Users] ' +
+        'INNER JOIN [Professions] AS [Profession] ON [Users].[professionId] = [Profession].[id] ' +
+        `WHERE ([Users].[companyId] = [Company].[id])${sql.addLimitAndOffset({ limit: 1, tableAs: 'Users' }, User)} ` +
+        `) IS NOT NULL${sql.addLimitAndOffset({ limit: 5, offset: 0, tableAs: 'Company' }, Company)}) AS [Company];`
       });
     });
 


### PR DESCRIPTION
This occurs on validating included elements function in spite of a user sets it to `true` in `include` options

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Here it is the SSCCE:
```javascript
const { createSequelizeInstance } = require('./dev/sscce-helpers');
const { Model, DataTypes } = require('.');

const sequelize = createSequelizeInstance({ benchmark: true });

class User extends Model {}
User.init({
  scopeId: DataTypes.INTEGER
}, { sequelize, modelName: 'User' });

class Company extends Model {}
Company.init({
  name: DataTypes.STRING,
  public: DataTypes.BOOLEAN,
  scopeId: DataTypes.INTEGER
}, { sequelize, modelName: 'Company' });

class Profession extends Model {}
Profession.init({
  name: DataTypes.STRING,
  scopeId: DataTypes.INTEGER
}, { sequelize, modelName: 'Profession' });

User.belongsTo(Company, { foreignKey: 'companyId' });
User.belongsTo(Profession, { foreignKey: 'professionId' });
Company.hasMany(User, { foreignKey: 'companyId' });
Profession.hasMany(User, { foreignKey: 'professionId' });

(async () => {
  await sequelize.sync({ force: true });

  const companies = await Company.findAll({
    where: { '$Users.Profession.name$': 'test' },
    include: [
      {
        model: User,
        attributes: [],
        include: [
          {
            model: Profession,
            attributes: [],
            required: true
          }
        ],
        required: true,
        subQuery: true
      }
    ],
    limit: 5,
    offset: 0,
    subQuery: true
  });

  await sequelize.close();
})();

which generate an invalid SQL query

```
### What do you expect to happen?

I expect that query would not use not existing alias

### What is actually happening?

But it generated query like this:
```sql
SELECT `Company`.* FROM (
    SELECT `Company`.`id`, `Company`.`name`, `Company`.`public`, `Company`.`scopeId`, `Company`.`createdAt`, `Company`.`updatedAt` FROM `Companies` AS `Company` 
    INNER JOIN `Professions` AS `Users->Profession` ON `Users`.`professionId` = `Users->Profession`.`id` 
    WHERE `Users->Profession`.`name` = 'test' AND ( 
        SELECT `Users`.`companyId` FROM `Users` AS `Users` 
        INNER JOIN `Professions` AS `Profession` ON `Users`.`professionId` = `Profession`.`id` 
        WHERE (`Users`.`companyId` = `Company`.`id`) LIMIT 1 
    ) IS NOT NULL LIMIT 0, 5
) AS `Company` 
INNER JOIN `Users` AS `Users` ON `Company`.`id` = `Users`.`companyId`;
```
as you can see in line 3 it joins to the `Users` table but the `Users` alias is not exist in current sub select scope, it has been concatenated at the end of query. So DB returns error: `Unknown column 'Users.professionId' in 'on clause'`.

The following PR fixes the issue, for me at least. And now generates the following SQL:
```sql
SELECT `Company`.* FROM (
    SELECT `Company`.`id`, `Company`.`name`, `Company`.`public`, `Company`.`scopeId`, `Company`.`createdAt`, `Company`.`updatedAt` FROM `Companies` AS `Company` 
    INNER JOIN `Users` AS `Users` ON `Company`.`id` = `Users`.`companyId`
    INNER JOIN `Professions` AS `Users->Profession` ON `Users`.`professionId` = `Users->Profession`.`id` 
    WHERE `Users->Profession`.`name` = 'test' AND ( 
        SELECT `Users`.`companyId` FROM `Users` AS `Users` 
        INNER JOIN `Professions` AS `Profession` ON `Users`.`professionId` = `Profession`.`id` 
        WHERE (`Users`.`companyId` = `Company`.`id`) LIMIT 1 
    ) IS NOT NULL LIMIT 0, 5
) AS `Company`;
```
All tests look fine. 

Please have a look on it.