### PR TITLE
fix(model.d): accept `[Op.is]` in where (broken in TypeScript 4.4)

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -161,6 +161,9 @@ export interface WhereOperators {
   /** Example: `[Op.not]: true,` becomes `IS NOT TRUE` */
   [Op.not]?: null | boolean | string | number | Literal | WhereOperators;
 
+  /** Example: `[Op.is]: null,` becomes `IS NULL` */
+  [Op.is]?: null;
+
   /** Example: `[Op.between]: [6, 10],` becomes `BETWEEN 6 AND 10` */
   [Op.between]?: Rangable;
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

<!-- Please provide a description of the change here. -->
