### PR TITLE
Change static this to class reference

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1121,7 +1121,7 @@ class Sequelize {
     if (!ns || typeof ns !== 'object' || typeof ns.bind !== 'function' || typeof ns.run !== 'function') throw new Error('Must provide CLS namespace');
 
     // save namespace as `Sequelize._cls`
-    this._cls = ns;
+    Sequelize._cls = ns;
 
     // return Sequelize for chaining
     return this;


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

This is just a one liner to change a static `this` to the actuall class `Sequelize`. The reason behind this is somewhat out of the scope of the Sequelize project, but [when working with sequelize-typescript, `this` is interpretted as the sequelize-typescript class and trying to make cls work is impossible without a workaround](https://github.com/RobinBuschmann/sequelize-typescript/issues/1083). 

I understand if you consider the responsability for fixing this lies on the sequelize-typescript repo, but being such a simple change that it's pretty much the same, I think it's worth it. Besides, I think it's less ambiguous that way, and actually fits better with the comment above.

This is my frist contribution, so any feedback is appreciated.
