### PR TITLE
Fix failing pg native tests

### DIFF
--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -429,15 +429,9 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         const User2 = this.sequelizeWithInvalidCredentials.define('User', { name: DataTypes.STRING, bio: DataTypes.TEXT });
 
         try {
-          console.log('TRYYYYYYYYY');
           await User2.sync();
-          console.log('sync worked!');
           expect.fail();
         } catch (err) {
-          console.log(dialect);
-          console.log('!!!!!error case!!!!!');
-          console.log(err.message);
-
           if (dialect === 'postgres' || dialect === 'postgres-native') {
             assert([
               'fe_sendauth: no password supplied',


### PR DESCRIPTION
The issue was that during the native pg tests, the following error messages for thrown:

`connection to server at "127.0.0.1", port 5432 failed: fe_sendauth: no password supplied`

The former exact comparison was only checking for the latter part of the error message. It was now changed to do partial comparison

