### PR TITLE
Add async hooks flag to bluebird

### DIFF
--- a/lib/promise.js
+++ b/lib/promise.js
@@ -2,6 +2,7 @@
 
 const Promise = require('bluebird').getNewLibraryCopy();
 
+Promise.config({asyncHooks: true});
 module.exports = Promise;
 module.exports.Promise = Promise;
 module.exports.default = Promise;

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -2,7 +2,8 @@
 
 const Promise = require('bluebird').getNewLibraryCopy();
 
-Promise.config({asyncHooks: true});
+Promise.config({ asyncHooks: true });
+
 module.exports = Promise;
 module.exports.Promise = Promise;
 module.exports.default = Promise;

--- a/test/unit/promise.test.js
+++ b/test/unit/promise.test.js
@@ -5,12 +5,49 @@ const chai = require('chai'),
   Support = require('./support'),
   Sequelize = Support.Sequelize,
   Promise = Sequelize.Promise,
-  Bluebird = require('bluebird');
+  Bluebird = require('bluebird'),
+  AsyncHooks = require('async_hooks');
+
+
+const currentId = AsyncHooks.executionAsyncId;
+
+const tree = new Set();
+const hook = AsyncHooks.createHook({
+  init(asyncId, _, triggerId) {
+    if (tree.has(triggerId)) {
+      tree.add(asyncId);
+    }
+  }
+});
+
+
 
 describe('Promise', () => {
   it('should be an independent copy of bluebird library', () => {
     expect(Promise.prototype.then).to.be.a('function');
     expect(Promise).to.not.equal(Bluebird);
     expect(Promise.prototype).to.not.equal(Bluebird.prototype);
+  });
+
+  it('should keep async id across bluebird promises', () => {
+    // Based on the test from https://github.com/petkaantonov/bluebird/blob/808fdf8fce0cf4dbb1b95129607777a0cd53df36/test/mocha/async_hooks.js#L68
+    // Looks like there is no way to test if flag is on beside testing that it works
+    hook.enable();
+    tree.add(currentId());
+    const d1 = new Promise(resolve => {
+      setTimeout(() => {
+        setTimeout(resolve, 1);
+      }, 1);
+    });
+
+    return new Promise(resolve => {
+      resolve(Promise.map([d1, null, Promise.resolve(1), Promise.delay(1)], () => {
+        return currentId();
+      }).then(asyncIds => {
+        for (let i = 0; i < asyncIds.length; ++i) {
+          expect(asyncIds[i]).to.not.equal(true);
+        }
+      }));
+    });
   });
 });

--- a/test/unit/promise.test.js
+++ b/test/unit/promise.test.js
@@ -45,7 +45,7 @@ describe('Promise', () => {
         return currentId();
       }).then(asyncIds => {
         for (let i = 0; i < asyncIds.length; ++i) {
-          expect(asyncIds[i]).to.not.equal(true);
+          expect(tree.has(asyncIds[i])).to.equal(true);
         }
       }));
     });


### PR DESCRIPTION
### Pull Request check-list

_Please make sure to review and check all of these items:_

- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Looks like using Bluebird makes async hooks based features and libraries to lose context, this is a flag on Bluebird, I will be happy to get your feedback if you think it should be added with a dynamic flag.
Looks like this solved our problem.
