### PR TITLE
chore(probot-stale): reenable auto-close issues bot. #13573

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,13 +1,14 @@
-
 # Configuration for probot-stale - https://github.com/probot/stale
 
-# Number of days of inactivity before an issue becomes stale
-# daysUntilStale: 90
-daysUntilStale: 900000 # Temporarily disable
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
 
-# Number of days of inactivity before a stale issue is closed
-# daysUntilClose: 7
-daysUntilClose: 70000 # Temporarily disable
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
 
 # Issues with these labels will never be considered stale
 exemptLabels:
@@ -21,10 +22,16 @@ exemptLabels:
   - good first issue
   - suggestion
 
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
 # Set to true to ignore issues in a milestone (defaults to false)
 exemptMilestones: true
 
-# Label to use when marking an issue as stale
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
 staleLabel: stale
 
 # Limit to only `issues` or `pulls`
@@ -36,5 +43,5 @@ markComment: >
   recent activity. It will be closed if no further activity occurs.
   If this is still an issue, just leave a comment 🙂
 
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: false
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30


### PR DESCRIPTION
Possibly close #13573 

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Have you added new tests to prevent regressions?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)? (need squashed)

### Description of change

Reenable probot stale bot and refactor the comments.
