### PR TITLE
fix(docs): using incorrect esdocs syntax

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2447,7 +2447,7 @@ class Model {
    * @param  {boolean}      [options.benchmark=false]                     Pass query execution time in milliseconds as second argument to logging function (options.logging).
    * @param  {string}       [options.searchPath=DEFAULT]                  An optional parameter to specify the schema search_path (Postgres only)
    *
-   * @returns {Promise<[Model, boolean | null]>} returns an array with two elements, the first being the new record and the second being `true` if it was just created or `false` if it already existed (except on Postgres and SQLite, which can't detect this and will always return `null` instead of a boolean).
+   * @returns {Promise<Array<Model, boolean | null>>} returns an array with two elements, the first being the new record and the second being `true` if it was just created or `false` if it already existed (except on Postgres and SQLite, which can't detect this and will always return `null` instead of a boolean).
    */
   static async upsert(values, options) {
     options = {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request check-list

_Please make sure to review and check all of these items:_

- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Have you added new tests to prevent regressions?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description of change

Resolves the problem we've had with the documentation not being built. Replaces the incorrect esdocs syntax. Fixes #13612