### PR TITLE
fix(types): include 'paranoid' in IncludeThroughOptions definition

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -1655,6 +1655,7 @@ class Model {
    * @param  {boolean}                                                   [options.include[].separate] If true, runs a separate query to fetch the associated instances, only supported for hasMany associations
    * @param  {number}                                                    [options.include[].limit] Limit the joined rows, only supported with include.separate=true
    * @param  {string}                                                    [options.include[].through.as] The alias for the join model, in case you want to give it a different name than the default one.
+   * @param  {boolean}                                                   [options.include[].through.paranoid] If true, only non-deleted records will be returned from the join table. If false, both deleted and non-deleted records will be returned. Only applies if through model is paranoid.
    * @param  {object}                                                    [options.include[].through.where] Filter on the join model for belongsToMany relations
    * @param  {Array}                                                     [options.include[].through.attributes] A list of attributes to select from the join model for belongsToMany relations
    * @param  {Array<object|Model|string>}                                [options.include[].include] Load further nested related models

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -381,6 +381,13 @@ export interface IncludeThroughOptions extends Filterable<any>, Projectable {
    * `belongsTo`, this should be the singular name, and for `hasMany`, it should be the plural
    */
   as?: string;
+
+  /** 
+   * If true, only non-deleted records will be returned from the join table. 
+   * If false, both deleted and non-deleted records will be returned.
+   * Only applies if through model is paranoid.
+   */
+  paranoid?: boolean;
 }
 
 /**

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -31,6 +31,10 @@ MyModel.findOne({
 });
 
 MyModel.findOne({
+  include: [ { through: { paranoid: true } } ]
+});
+
+MyModel.findOne({
   include: [
     { model: OtherModel, paranoid: true }
   ]


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This will add `paranoid` property to the `IncludeThroughOptions` definition.
Closes #12848 
<!-- Please provide a description of the change here. -->

