### PR TITLE
chore(build): never close PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,5 +16,6 @@ jobs:
           days-before-stale: 14
           days-before-close: 14
           operations-per-run: 1000
+          days-before-pr-close: -1
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Look like some important PRs is staled and closed, so I'm adding `days-before-pr-close: -1` to avoid PRs being closed without assignees or contributors permission.

### Todos

- [x] Add `days-before-pr-close: -1`
