### PR TITLE
fix(types): DataType.TEXT overloading definition

### DIFF
--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -112,6 +112,8 @@ export const TEXT: TextDataTypeConstructor;
 
 interface TextDataTypeConstructor extends AbstractDataTypeConstructor {
   new (length?: TextLength): TextDataType;
+  new (options?: TextDataTypeOptions): TextDataType;
+  (length?: TextLength): TextDataType;
   (options?: TextDataTypeOptions): TextDataType;
 }
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

https://github.com/sequelize/sequelize/blob/7e43212f6f12db8afa3e5ceb9ef5502919effbcc/lib/data-types.js#L1073
`TEXT` class could be invoked as a static function, which has two types of params. This PR is trying to keep the definition and behavior consistent.

### Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
