### PR TITLE
fix(types): add specifc tojson type in model.d.ts

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -4,9 +4,9 @@ import { DataType } from './data-types';
 import { Deferrable } from './deferrable';
 import { HookReturn, Hooks, ModelHooks } from './hooks';
 import { ValidationOptions } from './instance-validator';
-import { QueryOptions, IndexesOptions, TableName } from './query-interface';
+import { IndexesOptions, QueryOptions, TableName } from './query-interface';
 import { Sequelize, SyncOptions } from './sequelize';
-import { Transaction, LOCK } from './transaction';
+import { LOCK, Transaction } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
 import Op = require('./operators');
 
@@ -2884,7 +2884,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Convert the instance to a JSON representation. Proxies to calling `get` with no keys. This means get all
    * values gotten from the DB, and apply all custom getters.
    */
-  public toJSON(): object;
+  public toJSON<T extends TModelAttributes>(): T;
 
   /**
    * Helper method to determine if a instance is "soft deleted". This is

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -201,3 +201,23 @@ expectTypeOf(modelWithAttributes.previous).parameter(0).not.toEqualTypeOf<'unref
 expectTypeOf(modelWithAttributes.previous).returns.toEqualTypeOf<string | number | undefined>();
 expectTypeOf(modelWithAttributes.previous('name')).toEqualTypeOf<string | undefined>();
 expectTypeOf(modelWithAttributes.previous()).toEqualTypeOf<Partial<CreationAttributes>>();
+
+/**
+ * Tests for toJson() type
+ */
+interface FilmToJson {
+  id: number;
+  name?: string;
+}
+class FilmModelToJson extends Model<FilmToJson> implements FilmToJson {
+  id!: number;
+  name?: string;
+}
+const film = FilmModelToJson.build();
+
+const result = film.toJSON();
+expectTypeOf(result).toEqualTypeOf<FilmToJson>()
+
+type FilmNoNameToJson = Omit<FilmToJson, 'name'>
+const resultDerived = film.toJSON<FilmNoNameToJson>();
+expectTypeOf(resultDerived).toEqualTypeOf<FilmNoNameToJson>()


### PR DESCRIPTION
_This is a continuation of the closed PR of https://github.com/sequelize/sequelize/pull/13044_
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Ran `npm run test-typings`
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This PR introduces a more precise type to the `.toJSON()` function. Default it returns the given interface of a Sequelize model and allows to also pass along derived models that can be used to force an expected state. For example, that can be used to simulate the type after a specific sequelize `.find()`. 
This acts as an alternative to the `.toJSON() as <x>` notation, where using this generic type parameter restricts the type to only derived model types.
