### PR TITLE
chore(stale): exempt issues with type label

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,5 +17,6 @@ jobs:
           days-before-close: 14
           operations-per-run: 1000
           days-before-pr-close: -1
+          exempt-issue-labels: 'type: bug, type: docs, type: feature, type: other, type: performance, type: refactor, type: typescript' # All 'type: ' labels
       - name: Print outputs
         run: echo ${{ join(steps.stale.outputs.*, ',') }}


### PR DESCRIPTION
@fncolon @sdepold just a suggestion for the labels to be exempt as mentioned in #13648 

This does require maintainers/issue reviewers to add type labels to all still occurring issues and regularly update them.
