### PR TITLE
feat: option for attributes having dotnotation

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1452,7 +1452,7 @@ class QueryGenerator {
           ? this.quoteAttribute(attr, options.model)
           : this.escape(attr);
       }
-      if (!_.isEmpty(options.include) && !attr.includes('.') && addTable) {
+      if (!_.isEmpty(options.include) && (!attr.includes('.') || options.dotnotation) && addTable) {
         attr = `${mainTableAs}.${attr}`;
       }
 

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1452,7 +1452,7 @@ class QueryGenerator {
           ? this.quoteAttribute(attr, options.model)
           : this.escape(attr);
       }
-      if (!_.isEmpty(options.include) && (!attr.includes('.') || options.dotnotation) && addTable) {
+      if (!_.isEmpty(options.include) && (!attr.includes('.') || options.dotNotation) && addTable) {
         attr = `${mainTableAs}.${attr}`;
       }
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -1672,6 +1672,7 @@ class Model {
    * @param  {object}                                                    [options.having] Having options
    * @param  {string}                                                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Error}                                             [options.rejectOnEmpty=false] Throws an error when no records found
+   * @param  {boolean}                                                   [options.dotnotation] Allows including tables having the same attribute/column names - which have a dot in them. 
    *
    * @see
    * {@link Sequelize#query}

--- a/lib/model.js
+++ b/lib/model.js
@@ -1672,7 +1672,7 @@ class Model {
    * @param  {object}                                                    [options.having] Having options
    * @param  {string}                                                    [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param  {boolean|Error}                                             [options.rejectOnEmpty=false] Throws an error when no records found
-   * @param  {boolean}                                                   [options.dotnotation] Allows including tables having the same attribute/column names - which have a dot in them. 
+   * @param  {boolean}                                                   [options.dotNotation] Allows including tables having the same attribute/column names - which have a dot in them. 
    *
    * @see
    * {@link Sequelize#query}

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -855,7 +855,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           model: User
         }).include,
         model: User,
-        dotnotation: true
+        dotNotation: true
       }, User), {
         default: 'SELECT [User].[name], [User].[age], [User].[status.label], [Posts].[id] AS [Posts.id], [Posts].[title] AS [Posts.title], [Posts].[status.label] AS [Posts.status.label] FROM [User] AS [User] LEFT OUTER JOIN [Post] AS [Posts] ON [User].[id] = [Posts].[user_id];',
         postgres: 'SELECT "User".name, "User".age, "User"."status.label", Posts.id AS "Posts.id", Posts.title AS "Posts.title", Posts."status.label" AS "Posts.status.label" FROM "User" AS "User" LEFT OUTER JOIN Post AS Posts ON "User".id = Posts.user_id;'

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -857,8 +857,8 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         model: User,
         dotnotation: true
       }, User), {
-        default: 'SELECT [User].[name], [User].[age], [User].[status.label], [Posts].[id] AS [Posts.id], [Posts].[title] AS [Posts.title], [Posts].[status.label] AS `Posts.status.label` FROM [User] AS [User] LEFT OUTER JOIN [Post] AS [Posts] ON [User].[id] = [Posts].[user_id];',
-        postgres: 'SELECT "User".name, "User".age, "User".[status.label], Posts.id AS "Posts.id", Posts.title AS "Posts.title", Posts.[status.label] AS `Posts.status.label` FROM "User" AS "User" LEFT OUTER JOIN Post AS Posts ON "User".id = Posts.user_id;'
+        default: 'SELECT [User].[name], [User].[age], [User].[status.label], [Posts].[id] AS [Posts.id], [Posts].[title] AS [Posts.title], [Posts].[status.label] AS [Posts.status.label] FROM [User] AS [User] LEFT OUTER JOIN [Post] AS [Posts] ON [User].[id] = [Posts].[user_id];',
+        postgres: 'SELECT "User".name, "User".age, "User"."status.label", Posts.id AS "Posts.id", Posts.title AS "Posts.title", Posts."status.label" AS "Posts.status.label" FROM "User" AS "User" LEFT OUTER JOIN Post AS Posts ON "User".id = Posts.user_id;'
       });
     });
 


### PR DESCRIPTION

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

The select query raises ambiguity errors when I join two tables that have the same attribute/column names which contain a dot(".") in them.

This PR fixes it by provides a new option; 
`options.dotnotation = true` 

