### PR TITLE
feat(postgresql): easier SSL config and options param support

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -118,7 +118,10 @@ class ConnectionManager extends AbstractConnectionManager {
           // Times out queries after a set time in milliseconds in client end, query would be still running in database end.
           'query_timeout',
           // Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds. Added in pg v7.17.0 only supported in postgres >= 10
-          'idle_in_transaction_session_timeout'
+          'idle_in_transaction_session_timeout',
+          // Postgres allows additional session variables to be configured in the connection string in the `options` param.
+          // see [https://www.postgresql.org/docs/14/libpq-connect.html#LIBPQ-CONNECT-OPTIONS]
+          'options'
         ]));
     }
 

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -2,6 +2,7 @@
 
 const url = require('url');
 const path = require('path');
+const pgConnectionString = require('pg-connection-string');
 const retry = require('retry-as-promised');
 const _ = require('lodash');
 
@@ -231,6 +232,12 @@ class Sequelize {
             }
           }
         }
+      }
+
+      // For postgres, we can use this helper to load certs directly from the
+      // connection string.
+      if (options.dialect === 'postgres' || options.dialect === 'postgresql') {
+        Object.assign(options.dialectOptions, pgConnectionString.parse(arguments[0]));
       }
     } else {
       // new Sequelize(database, username, password, { ... options })

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash": "^4.17.20",
     "moment": "^2.26.0",
     "moment-timezone": "^0.5.31",
+    "pg-connection-string": "^2.5.0",
     "retry-as-promised": "^3.2.0",
     "semver": "^7.3.2",
     "sequelize-pool": "^6.0.0",

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -47,6 +47,13 @@ if (dialect.match(/^postgres/)) {
       const error = await sequelize.query('select pg_sleep(2)').catch(e => e);
       expect(error.message).to.equal('Query read timeout');
     });
+
+    it('should allow overriding session variables through the `options` param', async () => {
+      const sequelize = Support.createSequelizeInstance({ dialectOptions: { options: '-csearch_path=abc' } });
+      const result = await sequelize.query('SHOW search_path');
+      expect(result[0].search_path).to.equal('abc');
+    });
+
   });
 
   describe('Dynamic OIDs', () => {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -59,7 +59,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     }
 
     if (dialect === 'postgres') {
-      const getConnectionUri = o => `${o.protocol}://${o.username}:${o.password}@${o.host}${o.port ? `:${o.port}` : ''}/${o.database}`;
+      const getConnectionUri = o => `${o.protocol}://${o.username}:${o.password}@${o.host}${o.port ? `:${o.port}` : ''}/${o.database}${o.options ? `?options=${o.options}` : ''}`;
       it('should work with connection strings (postgres protocol)', () => {
         const connectionUri = getConnectionUri({ ...config[dialect], protocol: 'postgres' });
         // postgres://...
@@ -70,6 +70,13 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         // postgresql://...
         new Sequelize(connectionUri);
       });
+      it('should work with options in the connection string (postgresql protocol)', async () => {
+        const connectionUri = getConnectionUri({ ...config[dialect], protocol: 'postgresql', options: '-c%20search_path%3dtest_schema' });
+        const sequelize = new Sequelize(connectionUri);
+        const result = await sequelize.query('SHOW search_path');
+        expect(result[0].search_path).to.equal('test_schema');
+      });
+
     }
   });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
I don't think docs are needed
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This commit uses the pg_connection_string package to parse the
connection string if the dialect is postgresql. This is helpful because
it automatically handles reading SSL certs that are specified in the
connection string.

As part of this, support was added for the `options` URL parameter,
which allows arbitrary session variables to be configured in the
connection string.

fixes https://github.com/sequelize/sequelize/issues/13672

### Todos

None