### PR TITLE
fix: typing on creation within an association

### DIFF
--- a/types/lib/associations/belongs-to-many.d.ts
+++ b/types/lib/associations/belongs-to-many.d.ts
@@ -303,8 +303,8 @@ export interface BelongsToManyCreateAssociationMixinOptions extends CreateOption
  * @see https://sequelize.org/master/class/lib/associations/belongs-to-many.js~BelongsToMany.html
  * @see Instance
  */
-export type BelongsToManyCreateAssociationMixin<TModel> = (
-  values?: { [attribute: string]: unknown },
+export type BelongsToManyCreateAssociationMixin<TModel extends Model> = (
+  values?: Model['_creationAttributes'],
   options?: BelongsToManyCreateAssociationMixinOptions
 ) => Promise<TModel>;
 

--- a/types/lib/associations/belongs-to.d.ts
+++ b/types/lib/associations/belongs-to.d.ts
@@ -116,8 +116,8 @@ export interface BelongsToCreateAssociationMixinOptions
  * @see https://sequelize.org/master/class/lib/associations/belongs-to.js~BelongsTo.html
  * @see Instance
  */
-export type BelongsToCreateAssociationMixin<TModel> = (
-  values?: { [attribute: string]: unknown },
+export type BelongsToCreateAssociationMixin<TModel extends Model> = (
+  values?: TModel['_creationAttributes'],
   options?: BelongsToCreateAssociationMixinOptions
 ) => Promise<TModel>;
 

--- a/types/lib/associations/has-many.d.ts
+++ b/types/lib/associations/has-many.d.ts
@@ -209,8 +209,8 @@ export interface HasManyCreateAssociationMixinOptions extends CreateOptions<any>
  * @see https://sequelize.org/master/class/lib/associations/has-many.js~HasMany.html
  * @see Instance
  */
-export type HasManyCreateAssociationMixin<TModel> = (
-  values?: { [attribute: string]: unknown },
+export type HasManyCreateAssociationMixin<TModel extends Model> = (
+  values?: Model['_creationAttributes'],
   options?: HasManyCreateAssociationMixinOptions
 ) => Promise<TModel>;
 

--- a/types/lib/associations/has-one.d.ts
+++ b/types/lib/associations/has-one.d.ts
@@ -113,7 +113,7 @@ export interface HasOneCreateAssociationMixinOptions extends HasOneSetAssociatio
  * @see https://sequelize.org/master/class/lib/associations/has-one.js~HasOne.html
  * @see Instance
  */
-export type HasOneCreateAssociationMixin<TModel> = (
-  values?: { [attribute: string]: unknown },
+export type HasOneCreateAssociationMixin<TModel extends Model> = (
+  values?: TModel['_creationAttributes'],
   options?: HasOneCreateAssociationMixinOptions
 ) => Promise<TModel>;

--- a/types/test/models/UserGroup.ts
+++ b/types/test/models/UserGroup.ts
@@ -10,9 +10,12 @@ import {
     HasManyRemoveAssociationMixin,
     HasManyRemoveAssociationsMixin,
     HasManySetAssociationsMixin,
-    Model,
+    Model
 } from 'sequelize';
 import { sequelize } from '../connection';
+// associate
+// it is important to import _after_ the model above is already exported so the circular reference works.
+import { User } from './User';
 
 // This class doesn't extend the generic Model<TAttributes>, but should still
 // function just fine, with a bit less safe type-checking
@@ -30,7 +33,7 @@ export class UserGroup extends Model {
     public setUsers!: HasManySetAssociationsMixin<User, number>;
     public addUser!: HasManyAddAssociationMixin<User, number>;
     public addUsers!: HasManyAddAssociationsMixin<User, number>;
-    public createUser!: HasManyCreateAssociationMixin<number>;
+    public createUser!: HasManyCreateAssociationMixin<User>;
     public countUsers!: HasManyCountAssociationsMixin;
     public hasUser!: HasManyHasAssociationMixin<User, number>;
     public removeUser!: HasManyRemoveAssociationMixin<User, number>;
@@ -41,7 +44,4 @@ export class UserGroup extends Model {
 // instead of this, you could also use decorators
 UserGroup.init({ name: DataTypes.STRING }, { sequelize });
 
-// associate
-// it is important to import _after_ the model above is already exported so the circular reference works.
-import { User } from './User';
 export const Users = UserGroup.hasMany(User, { as: 'users', foreignKey: 'groupId' });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change
Fixes https://github.com/sequelize/sequelize/issues/13000
This change restricts the typing on creating via association to the attributes of said model. 

<!-- Please provide a description of the change here. -->

### Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
