### PR TITLE
fix(types): allow override json function with custom return type

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -2888,6 +2888,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * values gotten from the DB, and apply all custom getters.
    */
   public toJSON<T extends TModelAttributes>(): T;
+  public toJSON(): object;
 
   /**
    * Helper method to determine if a instance is "soft deleted". This is

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -13,7 +13,7 @@ class MyModel extends Model {
   }
 }
 
-class OtherModel extends Model { }
+class OtherModel extends Model {}
 
 const Instance: MyModel = new MyModel({ int: 10 });
 
@@ -31,7 +31,7 @@ MyModel.findOne({
 });
 
 MyModel.findOne({
-  include: [{ through: { paranoid: true } }]
+  include: [ { through: { paranoid: true } } ]
 });
 
 MyModel.findOne({
@@ -64,7 +64,7 @@ MyModel.build({ int: 10 }, { include: OtherModel });
 
 MyModel.bulkCreate([{ int: 10 }], { include: OtherModel, searchPath: 'public' });
 
-MyModel.update({}, { where: { foo: 'bar' }, paranoid: false });
+MyModel.update({}, { where: { foo: 'bar' }, paranoid: false});
 
 const sequelize = new Sequelize('mysql://user:user@localhost:3306/mydb');
 
@@ -89,7 +89,7 @@ const model: typeof MyModel = MyModel.init({
   sequelize,
   tableName: 'my_model',
   getterMethods: {
-    multiply: function () {
+    multiply: function() {
       return this.num * 2;
     }
   }
@@ -98,7 +98,7 @@ const model: typeof MyModel = MyModel.init({
 /**
  * Tests for findCreateFind() type.
  */
-class UserModel extends Model { }
+class UserModel extends Model {}
 
 UserModel.init({
   username: { type: DataTypes.STRING, allowNull: false },
@@ -121,7 +121,7 @@ UserModel.findCreateFind({
  */
 
 UserModel.findOrCreate({
-  fields: ["jane.doe"],
+  fields: [ "jane.doe" ],
   where: {
     username: "jane.doe"
   },
@@ -133,7 +133,7 @@ UserModel.findOrCreate({
 /**
  * Test for primaryKeyAttributes.
  */
-class TestModel extends Model { };
+class TestModel extends Model {};
 TestModel.primaryKeyAttributes;
 
 /**
@@ -151,9 +151,9 @@ someInstance.getOthers({
 /**
  * Test for through options in creating a BelongsToMany association
  */
-class Film extends Model { }
+class Film extends Model {}
 
-class Actor extends Model { }
+class Actor extends Model {}
 
 Film.belongsToMany(Actor, {
   through: {
@@ -174,7 +174,7 @@ interface ModelAttributes {
   name: string;
 }
 
-interface CreationAttributes extends Optional<ModelAttributes, 'id'> { }
+interface CreationAttributes extends Optional<ModelAttributes, 'id'> {}
 
 const ModelWithAttributes: ModelDefined<
   ModelAttributes,
@@ -205,7 +205,6 @@ expectTypeOf(modelWithAttributes.previous()).toEqualTypeOf<Partial<CreationAttri
 /**
  * Tests for toJson() type
  */
-
 interface FilmToJson {
   id: number;
   name?: string;

--- a/types/test/model.ts
+++ b/types/test/model.ts
@@ -13,7 +13,7 @@ class MyModel extends Model {
   }
 }
 
-class OtherModel extends Model {}
+class OtherModel extends Model { }
 
 const Instance: MyModel = new MyModel({ int: 10 });
 
@@ -31,7 +31,7 @@ MyModel.findOne({
 });
 
 MyModel.findOne({
-  include: [ { through: { paranoid: true } } ]
+  include: [{ through: { paranoid: true } }]
 });
 
 MyModel.findOne({
@@ -64,7 +64,7 @@ MyModel.build({ int: 10 }, { include: OtherModel });
 
 MyModel.bulkCreate([{ int: 10 }], { include: OtherModel, searchPath: 'public' });
 
-MyModel.update({}, { where: { foo: 'bar' }, paranoid: false});
+MyModel.update({}, { where: { foo: 'bar' }, paranoid: false });
 
 const sequelize = new Sequelize('mysql://user:user@localhost:3306/mydb');
 
@@ -89,7 +89,7 @@ const model: typeof MyModel = MyModel.init({
   sequelize,
   tableName: 'my_model',
   getterMethods: {
-    multiply: function() {
+    multiply: function () {
       return this.num * 2;
     }
   }
@@ -98,7 +98,7 @@ const model: typeof MyModel = MyModel.init({
 /**
  * Tests for findCreateFind() type.
  */
-class UserModel extends Model {}
+class UserModel extends Model { }
 
 UserModel.init({
   username: { type: DataTypes.STRING, allowNull: false },
@@ -121,7 +121,7 @@ UserModel.findCreateFind({
  */
 
 UserModel.findOrCreate({
-  fields: [ "jane.doe" ],
+  fields: ["jane.doe"],
   where: {
     username: "jane.doe"
   },
@@ -133,7 +133,7 @@ UserModel.findOrCreate({
 /**
  * Test for primaryKeyAttributes.
  */
-class TestModel extends Model {};
+class TestModel extends Model { };
 TestModel.primaryKeyAttributes;
 
 /**
@@ -151,9 +151,9 @@ someInstance.getOthers({
 /**
  * Test for through options in creating a BelongsToMany association
  */
-class Film extends Model {}
+class Film extends Model { }
 
-class Actor extends Model {}
+class Actor extends Model { }
 
 Film.belongsToMany(Actor, {
   through: {
@@ -174,7 +174,7 @@ interface ModelAttributes {
   name: string;
 }
 
-interface CreationAttributes extends Optional<ModelAttributes, 'id'> {}
+interface CreationAttributes extends Optional<ModelAttributes, 'id'> { }
 
 const ModelWithAttributes: ModelDefined<
   ModelAttributes,
@@ -205,6 +205,7 @@ expectTypeOf(modelWithAttributes.previous()).toEqualTypeOf<Partial<CreationAttri
 /**
  * Tests for toJson() type
  */
+
 interface FilmToJson {
   id: number;
   name?: string;
@@ -215,9 +216,22 @@ class FilmModelToJson extends Model<FilmToJson> implements FilmToJson {
 }
 const film = FilmModelToJson.build();
 
+class FilmModelExtendToJson extends Model<FilmToJson> implements FilmToJson {
+  id!: number;
+  name?: string;
+
+  public toJSON() {
+    return { id: this.id }
+  }
+}
+const filmOverrideToJson = FilmModelExtendToJson.build();
+
 const result = film.toJSON();
 expectTypeOf(result).toEqualTypeOf<FilmToJson>()
 
 type FilmNoNameToJson = Omit<FilmToJson, 'name'>
 const resultDerived = film.toJSON<FilmNoNameToJson>();
 expectTypeOf(resultDerived).toEqualTypeOf<FilmNoNameToJson>()
+
+const resultOverrideToJson = filmOverrideToJson.toJSON();
+expectTypeOf(resultOverrideToJson).toEqualTypeOf<FilmNoNameToJson>();


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

_Closes #13683_

This PR makes sure we still allow for the old behavior where we allow any `object` type to be returned for the `.toJSON()` function, but also allows adding the custom type. This allows for backwards compatibility.