### PR TITLE
ci(docs): add doc generation to checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,16 @@ jobs:
       - run: yarn install --frozen-lockfile --ignore-engines
       - run: yarn lint
       - run: yarn lint-docs
+  docs:
+    name: Generate docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - run: yarn install --frozen-lockfile --ignore-engines
+      - run: yarn docs
   test-typings:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
     needs:
       [
         lint,
+        docs,
         test-typings,
         test-sqlite,
         test-postgres,


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Have you added new tests to prevent regressions? _Not needed_
- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? _Not needed_
- [X] Did you update the typescript typings accordingly (if applicable)? _Not needed_
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This PR adds a check to generate the docs. Locally I ran `yarn docs` on https://github.com/sequelize/sequelize/pull/12642 and it failed. So this should prevent us from merging it in the future.

Fixes https://github.com/sequelize/meetings/issues/10

<!-- Please provide a description of the change here. -->
