### PR TITLE
test: fix mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "----------------------------------------- documentation -------------------------------------------": "",
     "docs": "rimraf esdoc && esdoc -c docs/esdoc-config.js && cp docs/favicon.ico esdoc/favicon.ico && cp docs/ROUTER.txt esdoc/ROUTER && node docs/run-docs-transforms.js && node docs/redirects/create-redirects.js && rimraf esdoc/file esdoc/source.html",
     "----------------------------------------- tests ---------------------------------------------------": "",
-    "mocha": "mocha -r ./test/requireHook",
+    "mocha": "mocha -r ./test/registerEsbuild",
     "test-unit": "yarn mocha \"test/unit/**/*.test.[tj]s\"",
     "test-integration": "yarn mocha \"test/integration/**/*.test.[tj]s\"",
     "teaser": "node test/teaser.js",


### PR DESCRIPTION
The file is not called requireHook anymore, but registerEsbuild. Thanks to @AllAwesome497 for figuring it out