### PR TITLE
test: fix failing stack trace test

### DIFF
--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -47,7 +47,7 @@ describe('errors', () => {
       expect(err).to.exist;
       const stackParts = err.stack.split('\n');
 
-      const fullErrorName = `Sequelize${errorName}`;
+      const fullErrorName = `Sequelize${errorName}: `;
       expect(stackParts[0]).to.equal(fullErrorName);
       expect(stackParts[1]).to.match(/^ {4}at throwError \(.*errors.test.js:\d+:\d+\)$/);
     });


### PR DESCRIPTION
The remaining checks that fail for postgres and sqlite are due to https://github.com/sequelize/sequelize/pull/13594 
The one test that failed on MySQL 8 can be ignored, that one happens quite often and we are not yet sure why

@slickmb we had an issue that the tests in the checks were not actually running. This is fixed now and we noticed some failing tests for your PR on postgres and sqlite. Any idea on how to solve them?