### PR TITLE
fix(data-types): unnecessary warning when getting data with DATE dataTypes

### DIFF
--- a/lib/dialects/mariadb/data-types.js
+++ b/lib/dialects/mariadb/data-types.js
@@ -54,8 +54,12 @@ module.exports = BaseTypes => {
       return this._length ? `DATETIME(${this._length})` : 'DATETIME';
     }
     _stringify(date, options) {
-      date = this._applyTimezone(date, options);
-      return date.format('YYYY-MM-DD HH:mm:ss.SSS');
+      if(_.isDate(date)){
+        date = this._applyTimezone(date, options);
+        return date.format('YYYY-MM-DD HH:mm:ss.SSS');
+      }
+
+      return date;
     }
     static parse(value, options) {
       value = value.string();

--- a/lib/dialects/mysql/data-types.js
+++ b/lib/dialects/mysql/data-types.js
@@ -53,12 +53,16 @@ module.exports = BaseTypes => {
       return this._length ? `DATETIME(${this._length})` : 'DATETIME';
     }
     _stringify(date, options) {
-      date = this._applyTimezone(date, options);
-      // Fractional DATETIMEs only supported on MySQL 5.6.4+
-      if (this._length) {
-        return date.format('YYYY-MM-DD HH:mm:ss.SSS');
+      if(_.isDate(date)){
+        date = this._applyTimezone(date, options);
+        // Fractional DATETIMEs only supported on MySQL 5.6.4+
+        if (this._length) {
+          return date.format('YYYY-MM-DD HH:mm:ss.SSS');
+        }
+        return date.format('YYYY-MM-DD HH:mm:ss');
       }
-      return date.format('YYYY-MM-DD HH:mm:ss');
+
+      return date;
     }
     static parse(value, options) {
       value = value.string();


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

unnecessary warning when getting data with DATE dataTypes attributes.

<img width="732" alt="Capture" src="https://user-images.githubusercontent.com/50759463/143377384-63b53b98-f874-482f-bbb2-a30112cbca05.PNG">


### Todos

- [x] check if value is date
