### PR TITLE
fix(example): fix coordinates format as per GeoJson

### DIFF
--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -822,7 +822,7 @@ class ARRAY extends ABSTRACT {
  * @example <caption>Create a new point with a custom SRID</caption>
  * const point = {
  *   type: 'Point',
- *   coordinates: [39.807222,-76.984722],
+ *   coordinates: [-76.984722, 39.807222], // GeoJson format: [lng, lat]
  *   crs: { type: 'name', properties: { name: 'EPSG:4326'} }
  * };
  *

--- a/lib/data-types.js
+++ b/lib/data-types.js
@@ -802,7 +802,7 @@ class ARRAY extends ABSTRACT {
  * DataTypes.GEOMETRY('POINT', 4326)
  *
  * @example <caption>Create a new point</caption>
- * const point = { type: 'Point', coordinates: [39.807222,-76.984722]};
+ * const point = { type: 'Point', coordinates: [-76.984722, 39.807222]}; // GeoJson format: [lng, lat]
  *
  * User.create({username: 'username', geometry: point });
  *


### PR DESCRIPTION
### Description Of Change

A minor fix in the examples for GeoJson format

closes: #13671