### PR TITLE
refactor(postgres): move `clientMinMessages` from general to pg options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ test/binary/tmp/*
 .vscode/
 esdoc
 node_modules
-dist/*
+dist

--- a/docs/manual/other-topics/dialect-specific-things.md
+++ b/docs/manual/other-topics/dialect-specific-things.md
@@ -75,6 +75,24 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 });
 ```
 
+The default `client_min_messages` config in sequelize is `WARNING`.
+
+### Redshift
+Most configuration is same as PostgreSQL above.
+
+Redshift doesn't support `client_min_messages`, 'ignore' is needed to skip the configuration:
+
+```js
+const sequelize = new Sequelize('database', 'username', 'password', {
+  dialect: 'postgres',
+  dialectOptions: {
+    // Your pg options here
+    // ...
+    clientMinMessages: 'ignore' // case insensitive
+  }
+});
+```
+
 ### MSSQL
 
 The underlying connector library used by Sequelize for MSSQL is the [tedious](https://www.npmjs.com/package/tedious) npm package (version 6.0.0 or above).

--- a/docs/manual/other-topics/dialect-specific-things.md
+++ b/docs/manual/other-topics/dialect-specific-things.md
@@ -78,6 +78,7 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 The default `client_min_messages` config in sequelize is `WARNING`.
 
 ### Redshift
+
 Most configuration is same as PostgreSQL above.
 
 Redshift doesn't support `client_min_messages`, 'ignore' is needed to skip the configuration:

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -211,8 +211,11 @@ class ConnectionManager extends AbstractConnectionManager {
 
     // Redshift dosen't support client_min_messages, use 'ignore' to skip this settings.
     // If no option, the default value in sequelize is 'warning'
-    if (!config.dialectOptions.clientMinMessages || config.dialectOptions.clientMinMessages.toLowerCase() !== 'ignore' ) {
-      query += `SET client_min_messages TO ${config.dialectOptions.clientMinMessages || 'warning'};`;
+    if ( !( config.dialectOptions && config.dialectOptions.clientMinMessages && config.dialectOptions.clientMinMessages.toLowerCase() === 'ignore' ||
+            this.sequelize.options.clientMinMessages === false ) ) {
+      const clientMinMessages = config.dialectOptions && config.dialectOptions.clientMinMessages || config.clientMinMessages || 'warning';
+      query += `SET client_min_messages TO ${clientMinMessages};`;
+
     }
 
     if (!this.sequelize.config.keepDefaultTimezone) {

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -209,7 +209,7 @@ class ConnectionManager extends AbstractConnectionManager {
       query += 'SET standard_conforming_strings=on;';
     }
 
-    // Readshift dosen't support client_min_messages, use 'ignore' to skip this settings.
+    // Redshift dosen't support client_min_messages, use 'ignore' to skip this settings.
     // If no option, the default value in sequelize is 'warning'
     if (!config.dialectOptions.clientMinMessages || config.dialectOptions.clientMinMessages.toLowerCase() !== 'ignore' ) {
       query += `SET client_min_messages TO ${config.dialectOptions.clientMinMessages || 'warning'};`;

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -213,7 +213,7 @@ class ConnectionManager extends AbstractConnectionManager {
     // If no option, the default value in sequelize is 'warning'
     if ( !( config.dialectOptions && config.dialectOptions.clientMinMessages && config.dialectOptions.clientMinMessages.toLowerCase() === 'ignore' ||
             this.sequelize.options.clientMinMessages === false ) ) {
-      const clientMinMessages = config.dialectOptions && config.dialectOptions.clientMinMessages || config.clientMinMessages || 'warning';
+      const clientMinMessages = config.dialectOptions && config.dialectOptions.clientMinMessages || this.sequelize.options.clientMinMessages || 'warning';
       query += `SET client_min_messages TO ${clientMinMessages};`;
 
     }

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -209,8 +209,10 @@ class ConnectionManager extends AbstractConnectionManager {
       query += 'SET standard_conforming_strings=on;';
     }
 
-    if (this.sequelize.options.clientMinMessages !== false) {
-      query += `SET client_min_messages TO ${this.sequelize.options.clientMinMessages};`;
+    // Readshift dosen't support client_min_messages, use 'ignore' to skip this settings.
+    // If no option, the default value in sequelize is 'warning'
+    if (!config.dialectOptions.clientMinMessages || config.dialectOptions.clientMinMessages.toLowerCase() !== 'ignore' ) {
+      query += `SET client_min_messages TO ${config.dialectOptions.clientMinMessages || 'warning'};`;
     }
 
     if (!this.sequelize.config.keepDefaultTimezone) {

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -143,6 +143,7 @@ class Sequelize {
    * @param {object}   [options.set={}] Default options for sequelize.set
    * @param {object}   [options.sync={}] Default options for sequelize.sync
    * @param {string}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.
+   * @param {string|boolean} [options.clientMinMessages='warning'] (Deprecated) The PostgreSQL `client_min_messages` session parameter. Set to `false` to not override the database's default.
    * @param {boolean}  [options.standardConformingStrings=true] The PostgreSQL `standard_conforming_strings` session parameter. Set to `false` to not set the option. WARNING: Setting this to false may expose vulnerabilities and is not recommended!
    * @param {Function} [options.logging=console.log] A function that gets executed every time Sequelize would log something. Function may receive multiple parameters but only first one is printed by `console.log`. To print all values use `(...msg) => console.log(msg)`
    * @param {boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -143,7 +143,6 @@ class Sequelize {
    * @param {object}   [options.set={}] Default options for sequelize.set
    * @param {object}   [options.sync={}] Default options for sequelize.sync
    * @param {string}   [options.timezone='+00:00'] The timezone used when converting a date from the database into a JavaScript date. The timezone is also used to SET TIMEZONE when connecting to the server, to ensure that the result of NOW, CURRENT_TIMESTAMP and other time related functions have in the right timezone. For best cross platform performance use the format +/-HH:MM. Will also accept string versions of timezones used by moment.js (e.g. 'America/Los_Angeles'); this is useful to capture daylight savings time changes.
-   * @param {string|boolean} [options.clientMinMessages='warning'] The PostgreSQL `client_min_messages` session parameter. Set to `false` to not override the database's default.
    * @param {boolean}  [options.standardConformingStrings=true] The PostgreSQL `standard_conforming_strings` session parameter. Set to `false` to not set the option. WARNING: Setting this to false may expose vulnerabilities and is not recommended!
    * @param {Function} [options.logging=console.log] A function that gets executed every time Sequelize would log something. Function may receive multiple parameters but only first one is printed by `console.log`. To print all values use `(...msg) => console.log(msg)`
    * @param {boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
@@ -257,7 +256,6 @@ class Sequelize {
       query: {},
       sync: {},
       timezone: '+00:00',
-      clientMinMessages: 'warning',
       standardConformingStrings: true,
       // eslint-disable-next-line no-console
       logging: console.log,
@@ -1226,7 +1224,7 @@ class Sequelize {
     attribute.type = this.normalizeDataType(attribute.type);
 
     if (Object.prototype.hasOwnProperty.call(attribute, 'defaultValue')) {
-      if (typeof attribute.defaultValue === 'function' && 
+      if (typeof attribute.defaultValue === 'function' &&
         [DataTypes.NOW, DataTypes.UUIDV1, DataTypes.UUIDV4].includes(attribute.defaultValue)
       ) {
         attribute.defaultValue = new attribute.defaultValue();

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -322,7 +322,6 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           });
 
           it('should create, find and include associations with scope values', async function() {
-            await this.sequelize.sync({ force: true });
             await Promise.all([this.Post.sync({ force: true }), this.Tag.sync({ force: true })]);
             await this.PostTag.sync({ force: true });
 

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -322,6 +322,7 @@ describe(Support.getTestDialectTeaser('associations'), () => {
           });
 
           it('should create, find and include associations with scope values', async function() {
+            await this.sequelize.sync({ force: true });
             await Promise.all([this.Post.sync({ force: true }), this.Tag.sync({ force: true })]);
             await this.PostTag.sync({ force: true });
 

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -28,13 +28,13 @@ if (dialect.match(/^postgres/)) {
     });
 
     it('should allow overriding client_min_messages', async () => {
-      const sequelize = Support.createSequelizeInstance({ clientMinMessages: 'ERROR' });
+      const sequelize = Support.createSequelizeInstance({ dialectOptions: { clientMinMessages: 'ERROR' } });
       const result = await sequelize.query('SHOW client_min_messages');
       expect(result[0].client_min_messages).to.equal('error');
     });
 
-    it('should not set client_min_messages if clientMinMessages is false', async () => {
-      const sequelize = Support.createSequelizeInstance({ clientMinMessages: false });
+    it('should not set client_min_messages if clientMinMessages is ignore', async () => {
+      const sequelize = Support.createSequelizeInstance({ dialectOptions: { clientMinMessages: 'IGNORE' } });
       const result = await sequelize.query('SHOW client_min_messages');
       // `notice` is Postgres's default
       expect(result[0].client_min_messages).to.equal('notice');

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -27,6 +27,19 @@ if (dialect.match(/^postgres/)) {
       expect(result[0].client_min_messages).to.equal('warning');
     });
 
+    it('should allow overriding client_min_messages (deprecated in v7)', async () => {
+      const sequelize = Support.createSequelizeInstance({ clientMinMessages: 'ERROR' });
+      const result = await sequelize.query('SHOW client_min_messages');
+      expect(result[0].client_min_messages).to.equal('error');
+    });
+
+    it('should not set client_min_messages if clientMinMessages is false (deprecated in v7)', async () => {
+      const sequelize = Support.createSequelizeInstance({ clientMinMessages: false });
+      const result = await sequelize.query('SHOW client_min_messages');
+      // `notice` is Postgres's default
+      expect(result[0].client_min_messages).to.equal('notice');
+    });
+
     it('should allow overriding client_min_messages', async () => {
       const sequelize = Support.createSequelizeInstance({ dialectOptions: { clientMinMessages: 'ERROR' } });
       const result = await sequelize.query('SHOW client_min_messages');

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -362,6 +362,17 @@ export interface Options extends Logging {
   standardConformingStrings?: boolean;
 
   /**
+   * The PostgreSQL `client_min_messages` session parameter.
+   * Set to `false` to not override the database's default.
+   *
+   * Deprecated in v7, please use option.dialectOption.clientMinMessages instead
+   *
+   * @deprecated
+   * @default 'warning'
+   */
+  clientMinMessages?: string | boolean;
+
+  /**
    * Sets global permanent hooks.
    */
   hooks?: Partial<SequelizeHooks<Model, any, any>>;

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -362,14 +362,6 @@ export interface Options extends Logging {
   standardConformingStrings?: boolean;
 
   /**
-   * The PostgreSQL `client_min_messages` session parameter.
-   * Set to `false` to not override the database's default.
-   *
-   * @default 'warning'
-   */
-  clientMinMessages?: string | boolean;
-
-  /**
    * Sets global permanent hooks.
    */
   hooks?: Partial<SequelizeHooks<Model, any, any>>;
@@ -390,7 +382,7 @@ export interface Options extends Logging {
   logQueryParameters?: boolean;
 
   retry?: RetryOptions;
-  
+
   /**
    * If defined the connection will use the provided schema instead of the default ("public").
    */


### PR DESCRIPTION
### Pull Request Checklist

Please make sure to review and check all of these items:

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change
Move `clientMinMessages` out of general option for decouple dialect purpose.
