### PR TITLE
docs(postgres): warn about deprecated clientMinMessage option

### DIFF
--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -211,7 +211,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
     if (this.sequelize.options.clientMinMessages !== undefined) {
       console.warn('Usage of "options.clientMinMessages" is deprecated and will be removed in v7.');
-      console.warn('Please use "option.dialectOption.clientMinMessages" instead.');
+      console.warn('Please use "option.dialectOptions.clientMinMessages" instead.');
     }
     
     // Redshift dosen't support client_min_messages, use 'ignore' to skip this settings.

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -209,6 +209,11 @@ class ConnectionManager extends AbstractConnectionManager {
       query += 'SET standard_conforming_strings=on;';
     }
 
+    if (this.sequelize.options.clientMinMessages !== undefined) {
+      console.warn('Usage of "options.clientMinMessages" is deprecated and will be removed in v7.');
+      console.warn('Please use "option.dialectOption.clientMinMessages" instead.');
+    }
+    
     // Redshift dosen't support client_min_messages, use 'ignore' to skip this settings.
     // If no option, the default value in sequelize is 'warning'
     if ( !( config.dialectOptions && config.dialectOptions.clientMinMessages && config.dialectOptions.clientMinMessages.toLowerCase() === 'ignore' ||

--- a/lib/dialects/postgres/connection-manager.js
+++ b/lib/dialects/postgres/connection-manager.js
@@ -211,7 +211,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
     if (this.sequelize.options.clientMinMessages !== undefined) {
       console.warn('Usage of "options.clientMinMessages" is deprecated and will be removed in v7.');
-      console.warn('Please use "option.dialectOptions.clientMinMessages" instead.');
+      console.warn('Please use the sequelize option "dialectOptions.clientMinMessages" instead.');
     }
     
     // Redshift dosen't support client_min_messages, use 'ignore' to skip this settings.

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -365,7 +365,7 @@ export interface Options extends Logging {
    * The PostgreSQL `client_min_messages` session parameter.
    * Set to `false` to not override the database's default.
    *
-   * Deprecated in v7, please use option.dialectOptions.clientMinMessages instead
+   * Deprecated in v7, please use the sequelize option "dialectOptions.clientMinMessages" instead
    *
    * @deprecated
    * @default 'warning'

--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -365,7 +365,7 @@ export interface Options extends Logging {
    * The PostgreSQL `client_min_messages` session parameter.
    * Set to `false` to not override the database's default.
    *
-   * Deprecated in v7, please use option.dialectOption.clientMinMessages instead
+   * Deprecated in v7, please use option.dialectOptions.clientMinMessages instead
    *
    * @deprecated
    * @default 'warning'


### PR DESCRIPTION
Follow-up to #13720.

It will render warnings when the option is used and point out the deprecation.