### PR TITLE
ci(node): drop support for node 10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 16]
+        node-version: [12, 16]
     name: SQLite (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     env:
@@ -66,7 +66,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 16]
+        node-version: [12, 16]
         postgres-version: [9.5, 10] # Does not work with 12
         minify-aliases: [true, false]
         native: [true, false]
@@ -108,7 +108,7 @@ jobs:
           - name: MySQL 5.7
             image: mysql:5.7
             dialect: mysql
-            node-version: 10
+            node-version: 12
           - name: MySQL 5.7
             image: mysql:5.7
             dialect: mysql
@@ -116,7 +116,7 @@ jobs:
           - name: MySQL 8.0
             image: mysql:8.0
             dialect: mysql
-            node-version: 10
+            node-version: 12
           - name: MySQL 8.0
             image: mysql:8.0
             dialect: mysql
@@ -124,7 +124,7 @@ jobs:
           - name: MariaDB 10.3
             image: mariadb:10.3
             dialect: mariadb
-            node-version: 10
+            node-version: 12
           - name: MariaDB 10.3
             image: mariadb:10.3
             dialect: mariadb
@@ -132,7 +132,7 @@ jobs:
           - name: MariaDB 10.5
             image: mariadb:10.5
             dialect: mariadb
-            node-version: 10
+            node-version: 12
           - name: MariaDB 10.5
             image: mariadb:10.5
             dialect: mariadb
@@ -168,7 +168,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 16]
+        node-version: [12, 16]
         mssql-version: [2017, 2019]
     name: MSSQL ${{ matrix.mssql-version }} (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
@@ -206,7 +206,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10, 16]
+        node-version: [12, 16]
     name: SNOWFLAKE (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     env:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Sequelize is a promise-based [Node.js](https://nodejs.org/en/about/) [ORM tool](https://en.wikipedia.org/wiki/Object-relational_mapping) for [Postgres](https://en.wikipedia.org/wiki/PostgreSQL), [MySQL](https://en.wikipedia.org/wiki/MySQL), [MariaDB](https://en.wikipedia.org/wiki/MariaDB), [SQLite](https://en.wikipedia.org/wiki/SQLite) and [Microsoft SQL Server](https://en.wikipedia.org/wiki/Microsoft_SQL_Server). It features solid transaction support, relations, eager and lazy loading, read replication and more.
 
-Sequelize follows [Semantic Versioning](http://semver.org) and supports Node v10 and above.
+Sequelize follows [Semantic Versioning](http://semver.org) and supports Node v12 and above.
 
 New to Sequelize? Take a look at the [Tutorials and Guides](https://sequelize.org/master). You might also be interested in the [API Reference](https://sequelize.org/master/identifiers).
 

--- a/build.js
+++ b/build.js
@@ -58,7 +58,7 @@ async function main() {
       // Adds source mapping
       sourcemap: true,
       // The compiled code should be usable in node v12.22
-      target: 'node12',
+      target: 'node12.22',
       // The source code's format is commonjs.
       format: 'cjs',
 

--- a/build.js
+++ b/build.js
@@ -58,7 +58,7 @@ async function main() {
       // Adds source mapping
       sourcemap: true,
       // The compiled code should be usable in node v10
-      target: 'node10',
+      target: 'node12',
       // The source code's format is commonjs.
       format: 'cjs',
 

--- a/build.js
+++ b/build.js
@@ -57,7 +57,7 @@ async function main() {
     build({
       // Adds source mapping
       sourcemap: true,
-      // The compiled code should be usable in node v10
+      // The compiled code should be usable in node v12.22
       target: 'node12',
       // The source code's format is commonjs.
       format: 'cjs',

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@
 
 Sequelize is a promise-based [Node.js](https://nodejs.org/en/about/) [ORM tool](https://en.wikipedia.org/wiki/Object-relational_mapping) for [Postgres](https://en.wikipedia.org/wiki/PostgreSQL), [MySQL](https://en.wikipedia.org/wiki/MySQL), [MariaDB](https://en.wikipedia.org/wiki/MariaDB), [SQLite](https://en.wikipedia.org/wiki/SQLite), [Microsoft SQL Server](https://en.wikipedia.org/wiki/Microsoft_SQL_Server), [Amazon Redshift](https://docs.aws.amazon.com/redshift/index.html) and [Snowflake’s Data Cloud](https://docs.snowflake.com/en/user-guide/intro-key-concepts.html). It features solid transaction support, relations, eager and lazy loading, read replication and more.
 
-Sequelize follows [Semantic Versioning](http://semver.org) and supports Node v10 and above.
+Sequelize follows [Semantic Versioning](http://semver.org) and supports Node v12 and above.
 
 You are currently looking at the **Tutorials and Guides** for Sequelize. You might also be interested in the [API Reference](identifiers.html).
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "./dist/index.js",
   "types": "./dist",
   "engines": {
-    "node": ">=12.0.0"
+    "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
   },
   "files": [
     "dist",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "main": "./dist/index.js",
   "types": "./dist",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This PR is dropping support for Node 10. Should we go straight to the latest LTS version of Node 12 or is any version >= 12 fine?