### PR TITLE
ci(release): require snowflake and db2 runs before release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,8 @@ jobs:
         test-postgres,
         test-mysql-mariadb,
         test-mssql,
+        test-snowflake,
+        test-db2
       ]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/v6' || github.ref == 'refs/heads/v6-beta')
     env:


### PR DESCRIPTION
Require snowflake and db2 runs to be successful before releases