### PR TITLE
docs(typescript): add plugin to parse TS files

### DIFF
--- a/docs/esdoc-config.js
+++ b/docs/esdoc-config.js
@@ -7,7 +7,7 @@ checkManuals();
 module.exports = {
   source: './lib',
   destination: './esdoc',
-  includes: ['\\.js$'],
+  includes: ['\\.[tj]s$'],
   plugins: [
     {
       name: 'esdoc-ecmascript-proposal-plugin',
@@ -51,6 +51,9 @@ module.exports = {
           files: getDeclaredManuals()
         }
       }
+    },
+    {
+      name: './esdoc-ts'
     }
   ]
 };

--- a/esdoc-ts.js
+++ b/esdoc-ts.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const { transformSync } = require('esbuild');
+
+module.exports = {
+  onHandleCode({ data }) {
+    if (path.extname(data.filePath) === '.ts') {
+      // @preserve tells esbuild not to omit the comment.  This is intended for legal comments,
+      // but works here too as a hack.
+      data.code = transformSync(data.code.replace(/\/\*\*/g, '/**@preserve'), {
+        target: 'node10',
+        format: 'cjs',
+        loader: 'ts'
+      }).code.replace(/\/\*\*@preserve/g, '/**');
+    }
+  }
+};


### PR DESCRIPTION
Adds partial support for TS files in generated docs.  This isn't the ideal solution but it unhides TS files from docs for now.

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

In #13569 I forgot to add support for generated docs, so TS files were being omitted from documentation.

### Todos

Properly support TS docs (eg function overloading, inferring types from type annotations), possibly switch to an alternate tool for generated tooling.  

Unsure how the current theme will be translated or if it even will at all; its missing support for some TS features like function overloading which is better shown by tools and themes built around TS.