### PR TITLE
fix(snowflake): fix to prevent disconnect attempt on already disconne…

### DIFF
--- a/lib/dialects/snowflake/connection-manager.js
+++ b/lib/dialects/snowflake/connection-manager.js
@@ -123,7 +123,7 @@ class ConnectionManager extends AbstractConnectionManager {
 
   async disconnect(connection) {
     // Don't disconnect connections with CLOSED state
-    if (connection._closing) {
+    if (!connection.isUp()) {
       debug('connection tried to disconnect but was already at CLOSED state');
       return;
     }


### PR DESCRIPTION
…cted connection

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [X] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

_closing is not a valid property on a snowflake connection. For the snowflake sdk, isUp() is the proper method to use to verify the connection status.
