### PR TITLE
fix(abstract): patch jsonb operator for pg if value is json

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -1062,12 +1062,13 @@ class QueryGenerator {
   /**
    * Generates an SQL query that extract JSON property of given path.
    *
-   * @param   {string}               column  The JSON column
-   * @param   {string|Array<string>} [path]  The path to extract (optional)
-   * @returns {string}                       The generated sql query
+   * @param   {string}               column   The JSON column
+   * @param   {string|Array<string>} [path]   The path to extract (optional)
+   * @param   {boolean}              [isJson] The value is JSON use alt symbols (optional)
+   * @returns {string}                        The generated sql query
    * @private
    */
-  jsonPathExtractionQuery(column, path) {
+  jsonPathExtractionQuery(column, path, isJson) {
     let paths = _.toPath(path);
     let pathStr;
     const quotedColumn = this.isIdentifierQuoted(column)
@@ -1102,8 +1103,9 @@ class QueryGenerator {
         return `json_unquote(json_extract(${quotedColumn},${pathStr}))`;
 
       case 'postgres':
+        const join = isJson ? '#>' : '#>>';
         pathStr = this.escape(`{${paths.join(',')}}`);
-        return `(${quotedColumn}#>>${pathStr})`;
+        return `(${quotedColumn}${join}${pathStr})`;
 
       default:
         throw new Error(`Unsupported ${this.dialect} for JSON operations`);
@@ -2459,11 +2461,19 @@ class QueryGenerator {
       path[path.length - 1] = tmp[0];
     }
 
-    const pathKey = this.jsonPathExtractionQuery(baseKey, path);
+    let pathKey = this.jsonPathExtractionQuery(baseKey, path);
 
     if (_.isPlainObject(item)) {
       Utils.getOperators(item).forEach(op => {
         const value = this._toJSONValue(item[op]);
+        let isJson = false;
+        try {
+          JSON.stringify(value);
+          isJson = true;
+        } catch (e) {
+          // failed to parse, is not json so isJson remains false
+        }
+        pathKey = this.jsonPathExtractionQuery(baseKey, path, isJson);
         items.push(this.whereItemQuery(this._castKey(pathKey, value, cast), { [op]: value }));
       });
       _.forOwn(item, (value, itemProp) => {

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -2467,11 +2467,13 @@ class QueryGenerator {
       Utils.getOperators(item).forEach(op => {
         const value = this._toJSONValue(item[op]);
         let isJson = false;
-        try {
-          JSON.stringify(value);
-          isJson = true;
-        } catch (e) {
-          // failed to parse, is not json so isJson remains false
+        if (typeof value === 'string' && op === Op.contains) {
+          try {
+            JSON.stringify(value);
+            isJson = true;
+          } catch (e) {
+            // failed to parse, is not json so isJson remains false
+          }
         }
         pathKey = this.jsonPathExtractionQuery(baseKey, path, isJson);
         items.push(this.whereItemQuery(this._castKey(pathKey, value, cast), { [op]: value }));

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -1263,11 +1263,11 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       current.where(current.fn('lower', current.col('name')), null)], {
       default: '(SUM([hours]) > 0 AND lower([name]) IS NULL)'
     });
-    
+
     testsql(current.where(current.col('hours'), Op.between, [0, 5]), {
       default: '[hours] BETWEEN 0 AND 5'
     });
-    
+
     testsql(current.where(current.col('hours'), Op.notBetween, [0, 5]), {
       default: '[hours] NOT BETWEEN 0 AND 5'
     });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change
Issue: When querying a JSONB column in PG and the data stored in the column is an Object PG uses `#>>` when it should be `#>`

Updated abstract/query-generator to check the operator and value type while running _traverseJSON.  If the value is a string and the operator is Op.contains it attempts to parse the value as JSON.  If it doesn't fail it sends true to jsonPathExtractionQuery new third parameter isJson.  This is only used in postgres so it knows to use `#>` instead of `#>>` to join the query string.
