### PR TITLE
fix: allow deep imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
+    "./lib/*": "./dist/lib/*.js",
+    "./lib/errors": "./dist/lib/errors/index.js",
     "./*": "./*"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
   "types": "./dist",
   "type": "commonjs",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    ".": {
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./*": "./*"
   },
   "engines": {
     "node": ">=10.0.0"

--- a/test/registerEsbuild.js
+++ b/test/registerEsbuild.js
@@ -5,9 +5,17 @@ const esbuild = require('esbuild');
 const moduleAlias = require('module-alias');
 const sourceMapSupport = require('source-map-support');
 
-const distDir = path.join(__dirname, '../dist');
-// make imports from `sequelize/` go to `../dist/`
-moduleAlias.addAlias('sequelize', distDir);
+const nodeMajorVersion = Number(process.version.match(/(?<=^v)\d+/));
+
+// for node >= 12, we use the package.json "export" property to
+//  map imports to dist
+//  so "sequelize/lib/errors" is actually mapped to "sequelize/dist/errors/index.js"
+//  (see package.json).
+if (nodeMajorVersion < 12) {
+  const distDir = path.join(__dirname, '../dist');
+  // make imports from `sequelize/` go to `../dist/`
+  moduleAlias.addAlias('sequelize', distDir);
+}
 
 const maps = {};
 

--- a/test/registerEsbuild.js
+++ b/test/registerEsbuild.js
@@ -8,10 +8,13 @@ const sourceMapSupport = require('source-map-support');
 const nodeMajorVersion = Number(process.version.match(/(?<=^v)\d+/));
 
 // for node >= 12, we use the package.json "export" property to
-//  map imports to dist
+//  map imports to dist (except package.json)
 //  so "sequelize/lib/errors" is actually mapped to "sequelize/dist/errors/index.js"
 //  (see package.json).
 if (nodeMajorVersion < 12) {
+  const jsonFile = path.join(__dirname, '..', 'package.json');
+  moduleAlias.addAlias('sequelize/package.json', jsonFile);
+
   const distDir = path.join(__dirname, '../dist');
   // make imports from `sequelize/` go to `../dist/`
   moduleAlias.addAlias('sequelize', distDir);

--- a/test/unit/deep-exports.test.js
+++ b/test/unit/deep-exports.test.js
@@ -6,6 +6,8 @@ const chai = require('chai'),
  * Context: https://github.com/sequelize/sequelize/issues/13787
  */
 
+const nodeMajorVersion = Number(process.version.match(/(?<=^v)\d+/));
+
 describe('exports', () => {
   it('exposes /package.json', async () => {
     // await import('sequelize/package.json');
@@ -13,7 +15,7 @@ describe('exports', () => {
   });
 
   it('exposes lib files', async () => {
-    await import('sequelize/dist/lib/model.js');
-    require('sequelize/dist/lib/model.js');
+    await import('sequelize/lib/model');
+    require('sequelize/lib/model');
   });
 });

--- a/test/unit/deep-exports.test.js
+++ b/test/unit/deep-exports.test.js
@@ -1,0 +1,19 @@
+const chai = require('chai'),
+  expect = chai.expect;
+
+/**
+ * Tests whether users can import files deeper than "sequelize" (eg. "sequelize/package.json").
+ * Context: https://github.com/sequelize/sequelize/issues/13787
+ */
+
+describe('exports', () => {
+  it('exposes /package.json', async () => {
+    // await import('sequelize/package.json');
+    require('sequelize/package.json');
+  });
+
+  it('exposes lib files', async () => {
+    await import('sequelize/dist/lib/model.js');
+    require('sequelize/dist/lib/model.js');
+  });
+});

--- a/test/unit/deep-exports.test.js
+++ b/test/unit/deep-exports.test.js
@@ -10,12 +10,21 @@ const nodeMajorVersion = Number(process.version.match(/(?<=^v)\d+/));
 
 describe('exports', () => {
   it('exposes /package.json', async () => {
-    // await import('sequelize/package.json');
+    // TODO: uncomment test once https://nodejs.org/api/esm.html#json-modules are stable
+    // if (nodeMajorVersion >= 16) {
+    //   await import('sequelize/package.json', {
+    //     assert: { type: 'json' }
+    //   });
+    // }
+
     require('sequelize/package.json');
   });
 
   it('exposes lib files', async () => {
-    await import('sequelize/lib/model');
+    if (nodeMajorVersion >= 12) {
+      await import('sequelize/lib/model');
+    }
+
     require('sequelize/lib/model');
   });
 });

--- a/test/unit/dialects/abstract/query.test.js
+++ b/test/unit/dialects/abstract/query.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const Query = require('sequelize/lib/dialects/abstract/query.js');
+const Query = require('sequelize/lib/dialects/abstract/query');
 const Support = require(path.join(__dirname, './../../support'));
 const chai = require('chai');
 const { stub, match } = require('sinon');

--- a/test/unit/dialects/mssql/query.test.js
+++ b/test/unit/dialects/mssql/query.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const Query = require('sequelize/lib/dialects/mssql/query.js');
+const Query = require('sequelize/lib/dialects/mssql/query');
 const Support = require('../../support');
 const dialect = Support.getTestDialect();
 const sequelize = Support.sequelize;

--- a/test/unit/dialects/mysql/query.test.js
+++ b/test/unit/dialects/mysql/query.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const Query = require('sequelize/lib/dialects/mysql/query.js');
+const Query = require('sequelize/lib/dialects/mysql/query');
 const Support = require(path.join(__dirname, './../../support'));
 const chai = require('chai');
 const sinon = require('sinon');

--- a/test/unit/dialects/snowflake/query.test.js
+++ b/test/unit/dialects/snowflake/query.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const Query = require('sequelize/lib/dialects/snowflake/query.js');
+const Query = require('sequelize/lib/dialects/snowflake/query');
 const Support = require(path.join(__dirname, './../../support'));
 const chai = require('chai');
 const sinon = require('sinon');


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [N/A] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [N/A] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Fixes https://github.com/sequelize/sequelize/issues/13787

The issue was that once `exports` is defined in package.json, node uses it as the source of truth for all valid exports of a package.

I've configured `exports` to replicate how the imports worked in v6.  
I also had to remove the alias in `registerEsbuild.js` as it was redundant with `exports`.  
It also matches reality better as the tests use the same export definition as the published build. :)

I recommend changing the export declaration for V7, see below

---

## Breaking changes recommendations for V7

In v7, we could change the export definition to

```json
{
  "exports": {
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.js"
    },
    "./package.json": "./package.json",
    "./*": "./dist/lib/*.js"
  },
}
```

This way, instead of importing `sequelize/lib/model.js`, users could import `sequelize/model`.

If we still want users to specify `/lib` in v7, we can use this one instead

```json
{
  "exports": {
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.js"
    },
    "./lib/*": "./dist/lib/*.js",
    "./package.json": "./package.json",
  },
}
```

**[recommended]** If we want to prevent users from importing `/lib` which could result in unexpected breaking changes, we could instead use this one which only allows importing `sequelize` & `sequelize/package.json`

```json
{
  "exports": {
    ".": {
      "import": "./dist/index.mjs",
      "require": "./dist/index.js"
    },
    "./package.json": "./package.json",
  },
}
```