### PR TITLE
fix: make operator.ts export style match import style

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -9,7 +9,7 @@ const HasMany = require('./has-many');
 const HasOne = require('./has-one');
 const AssociationError = require('../errors').AssociationError;
 const EmptyResultError = require('../errors').EmptyResultError;
-const Op = require('../operators');
+const Op = require('../operators').default;
 
 /**
  * Many-to-many association with a join table.

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -4,7 +4,7 @@ const Utils = require('./../utils');
 const Helpers = require('./helpers');
 const _ = require('lodash');
 const Association = require('./base');
-const Op = require('../operators');
+const Op = require('../operators').default;
 
 /**
  * One-to-one association

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -4,7 +4,7 @@ const Utils = require('./../utils');
 const Helpers = require('./helpers');
 const _ = require('lodash');
 const Association = require('./base');
-const Op = require('../operators');
+const Op = require('../operators').default;
 
 /**
  * One-to-many association

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -4,7 +4,7 @@ const Utils = require('./../utils');
 const Helpers = require('./helpers');
 const _ = require('lodash');
 const Association = require('./base');
-const Op = require('../operators');
+const Op = require('../operators').default;
 
 /**
  * One-to-one association

--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -13,7 +13,7 @@ const Association = require('../../associations/base');
 const BelongsTo = require('../../associations/belongs-to');
 const BelongsToMany = require('../../associations/belongs-to-many');
 const HasMany = require('../../associations/has-many');
-const Op = require('../../operators');
+const Op = require('../../operators').default;
 const sequelizeError = require('../../errors');
 const IndexHints = require('../../index-hints');
 

--- a/lib/dialects/abstract/query-generator/operators.js
+++ b/lib/dialects/abstract/query-generator/operators.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
-const Op = require('../../../operators');
+const Op = require('../../../operators').default;
 const Utils = require('../../../utils');
 
 const OperatorHelpers = {

--- a/lib/dialects/db2/query-generator.js
+++ b/lib/dialects/db2/query-generator.js
@@ -5,7 +5,7 @@ const Utils = require('../../utils');
 const DataTypes = require('../../data-types');
 const AbstractQueryGenerator = require('../abstract/query-generator');
 const randomBytes = require('crypto').randomBytes;
-const Op = require('../../operators');
+const Op = require('../../operators').default;
 
 /* istanbul ignore next */
 const throwMethodUndefined = function(methodName) {
@@ -325,7 +325,7 @@ class Db2QueryGenerator extends AbstractQueryGenerator {
     if (valuesForEmptyQuery.length > 0) {
       allQueries.push(`${emptyQuery } VALUES ${ valuesForEmptyQuery.join(',')}`);
     }
-	
+
     if (allAttributes.length > 0) {
       _.forEach(attrValueHashes, attrValueHash => {
         tuples.push(`(${
@@ -485,9 +485,9 @@ class Db2QueryGenerator extends AbstractQueryGenerator {
         return `${targetTableAlias}.${key} = ${value}`;
       }).join(', ');
     const updateSnippet = filteredUpdateClauses.length > 0 ? `WHEN MATCHED THEN UPDATE SET ${filteredUpdateClauses}` : '';
-	
+
     const insertSnippet = `(${insertKeysQuoted}) VALUES(${insertValuesEscaped})`;
-	
+
     let query = `MERGE INTO ${tableNameQuoted} AS ${targetTableAlias} USING (${sourceTableQuery}) AS ${sourceTableAlias}(${insertKeysQuoted}) ON ${joinCondition}`;
     query += ` ${updateSnippet} WHEN NOT MATCHED THEN INSERT ${insertSnippet};`;
     return query;
@@ -741,7 +741,7 @@ class Db2QueryGenerator extends AbstractQueryGenerator {
    * Generates an SQL query that returns all foreign keys of a table.
    *
    * @param {Stirng|object} table The name of the table.
-   * @param {string} schemaName   The name of the schema. 
+   * @param {string} schemaName   The name of the schema.
    * @returns {string}            The generated sql query.
    */
   getForeignKeysQuery(table, schemaName) {

--- a/lib/dialects/db2/query-interface.js
+++ b/lib/dialects/db2/query-interface.js
@@ -2,7 +2,7 @@
 
 const _ = require('lodash');
 const Utils = require('../../utils');
-const Op = require('../../operators');
+const Op = require('../../operators').default;
 const { QueryInterface } = require('../abstract/query-interface');
 const QueryTypes = require('../../query-types');
 
@@ -91,12 +91,12 @@ class Db2QueryInterface extends QueryInterface {
     attributes = _.mapValues(
       attributes,
       attribute => this.sequelize.normalizeAttribute(attribute)
-    );  
+    );
     if (options.indexes) {
       options.indexes.forEach(fields=>{
         const fieldArr = fields.fields;
         if (fieldArr.length === 1) {
-          fieldArr.forEach(field=>{       
+          fieldArr.forEach(field=>{
             for (const property in attributes) {
               if (field === attributes[property].field) {
                 attributes[property].unique = true;
@@ -111,7 +111,7 @@ class Db2QueryInterface extends QueryInterface {
         options.indexes.forEach(fields=>{
           const fieldArr = fields.fields;
           if (fieldArr.length === 1) {
-            fieldArr.forEach(field=>{       
+            fieldArr.forEach(field=>{
               for (const property in attributes) {
                 if (field === attributes[property].field && attributes[property].unique) {
                   attributes[property].unique = false;

--- a/lib/dialects/mssql/query-generator.js
+++ b/lib/dialects/mssql/query-generator.js
@@ -7,7 +7,7 @@ const TableHints = require('../../table-hints');
 const AbstractQueryGenerator = require('../abstract/query-generator');
 const randomBytes = require('crypto').randomBytes;
 const semver = require('semver');
-const Op = require('../../operators');
+const Op = require('../../operators').default;
 
 /* istanbul ignore next */
 const throwMethodUndefined = function(methodName) {

--- a/lib/dialects/mssql/query-interface.js
+++ b/lib/dialects/mssql/query-interface.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 
 const Utils = require('../../utils');
 const QueryTypes = require('../../query-types');
-const Op = require('../../operators');
+const Op = require('../../operators').default;
 const { QueryInterface } = require('../abstract/query-interface');
 
 /**

--- a/lib/dialects/mysql/query-generator.js
+++ b/lib/dialects/mysql/query-generator.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const Utils = require('../../utils');
 const AbstractQueryGenerator = require('../abstract/query-generator');
 const util = require('util');
-const Op = require('../../operators');
+const Op = require('../../operators').default;
 
 
 const JSON_FUNCTION_REGEX = /^\s*((?:[a-z]+_){0,2}jsonb?(?:_[a-z]+){0,2})\([^)]*\)/i;

--- a/lib/dialects/snowflake/query-generator.js
+++ b/lib/dialects/snowflake/query-generator.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const Utils = require('../../utils');
 const AbstractQueryGenerator = require('../abstract/query-generator');
 const util = require('util');
-const Op = require('../../operators');
+const Op = require('../../operators').default;
 
 
 const JSON_FUNCTION_REGEX = /^\s*((?:[a-z]+_){0,2}jsonb?(?:_[a-z]+){0,2})\([^)]*\)/i;
@@ -32,7 +32,7 @@ const FOREIGN_KEY_FIELDS = [
  * @private
  */
 const SNOWFLAKE_RESERVED_WORDS = 'account,all,alter,and,any,as,between,by,case,cast,check,column,connect,connections,constraint,create,cross,current,current_date,current_time,current_timestamp,current_user,database,delete,distinct,drop,else,exists,false,following,for,from,full,grant,group,gscluster,having,ilike,in,increment,inner,insert,intersect,into,is,issue,join,lateral,left,like,localtime,localtimestamp,minus,natural,not,null,of,on,or,order,organization,qualify,regexp,revoke,right,rlike,row,rows,sample,schema,select,set,some,start,table,tablesample,then,to,trigger,true,try_cast,union,unique,update,using,values,view,when,whenever,where,with'.split(',');
-  
+
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 class SnowflakeQueryGenerator extends AbstractQueryGenerator {

--- a/lib/model.js
+++ b/lib/model.js
@@ -16,7 +16,7 @@ const HasMany = require('./associations/has-many');
 const DataTypes = require('./data-types');
 const Hooks = require('./hooks');
 const associationsMixin = require('./associations/mixin');
-const Op = require('./operators');
+const Op = require('./operators').default;
 const { noDoubleNestedGroup } = require('./utils/deprecations');
 
 
@@ -291,7 +291,7 @@ class Model {
 
   /**
    * Returns the attributes of the model.
-   * 
+   *
    * @returns {object|any}
   */
   static getAttributes() {
@@ -2544,7 +2544,7 @@ class Model {
    * @param  {boolean}        [options.hooks=true]             Run before / after bulk create hooks?
    * @param  {boolean}        [options.individualHooks=false]  Run before / after create hooks for each individual Instance? BulkCreate hooks will still be run if options.hooks is true.
    * @param  {boolean}        [options.ignoreDuplicates=false] Ignore duplicate values for primary keys? (not supported by MSSQL or Postgres < 9.5)
-   * @param  {Array}          [options.updateOnDuplicate]      Fields to update if row key already exists (on duplicate key update)? (only supported by MySQL, MariaDB, SQLite >= 3.24.0 & Postgres >= 9.5). 
+   * @param  {Array}          [options.updateOnDuplicate]      Fields to update if row key already exists (on duplicate key update)? (only supported by MySQL, MariaDB, SQLite >= 3.24.0 & Postgres >= 9.5).
    * @param  {Transaction}    [options.transaction]            Transaction to run query under
    * @param  {Function}       [options.logging=false]          A function that gets executed while running the query to log the sql.
    * @param  {boolean}        [options.benchmark=false]        Pass query execution time in milliseconds as second argument to logging function (options.logging).

--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -521,4 +521,4 @@ const Op: OpTypes = {
   match: Symbol.for('match')
 } as OpTypes;
 
-export = Op;
+export default Op;

--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -19,7 +19,7 @@ const sequelizeErrors = require('./errors');
 const Hooks = require('./hooks');
 const Association = require('./associations/index');
 const Validator = require('./utils/validator-extras').validator;
-const Op = require('./operators');
+const Op = require('./operators').default;
 const deprecations = require('./utils/deprecations');
 const { QueryInterface } = require('./dialects/abstract/query-interface');
 const { BelongsTo } = require('./associations/belongs-to');
@@ -628,7 +628,7 @@ class Sequelize {
       checkTransaction();
 
       const connection = await (options.transaction ? options.transaction.connection : this.connectionManager.getConnection(options));
-      
+
       if (this.options.dialect === 'db2' && options.alter) {
         if (options.alter.drop === false) {
           connection.dropTable = false;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,7 +6,7 @@ const _ = require('lodash');
 const baseIsNative = require('lodash/_baseIsNative');
 const uuidv1 = require('uuid').v1;
 const uuidv4 = require('uuid').v4;
-const operators = require('./operators');
+const operators = require('./operators').default;
 const operatorsSet = new Set(Object.values(operators));
 
 let inflection = require('inflection');

--- a/test/unit/associations/has-many.test.js
+++ b/test/unit/associations/has-many.test.js
@@ -8,7 +8,7 @@ const chai = require('chai'),
   Support = require('../support'),
   DataTypes = require('sequelize/lib/data-types'),
   HasMany = require('sequelize/lib/associations/has-many'),
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('hasMany'), () => {

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai'),
   expect = chai.expect,
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   getAbstractQueryGenerator = require('../../support').getAbstractQueryGenerator;
 const AbstractQueryGenerator = require('sequelize/lib/dialects/abstract/query-generator');
 

--- a/test/unit/dialects/db2/query-generator.test.js
+++ b/test/unit/dialects/db2/query-generator.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support = require('../../support'),
   dialect = Support.getTestDialect(),
   _ = require('lodash'),
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   IndexHints = require('sequelize/lib/index-hints'),
   QueryGenerator = require('sequelize/lib/dialects/db2/query-generator');
 

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support = require('../../support'),
   dialect = Support.getTestDialect(),
   _ = require('lodash'),
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   IndexHints = require('sequelize/lib/index-hints'),
   QueryGenerator = require('sequelize/lib/dialects/mariadb/query-generator');
 

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -4,7 +4,7 @@ const Support = require('../../support');
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
 const DataTypes = require('sequelize/lib/data-types');
-const Op = require('sequelize/lib/operators');
+const Op = require('sequelize/lib/operators').default;
 const TableHints = require('sequelize/lib/table-hints');
 const QueryGenerator = require('sequelize/lib/dialects/mssql/query-generator');
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support = require('../../support'),
   dialect = Support.getTestDialect(),
   _ = require('lodash'),
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   IndexHints = require('sequelize/lib/index-hints'),
   QueryGenerator = require('sequelize/lib/dialects/mysql/query-generator');
 

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -2,7 +2,7 @@
 
 const chai = require('chai'),
   expect = chai.expect,
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   QueryGenerator = require('sequelize/lib/dialects/postgres/query-generator'),
   Support = require('../../support'),
   dialect = Support.getTestDialect(),

--- a/test/unit/dialects/snowflake/query-generator.test.js
+++ b/test/unit/dialects/snowflake/query-generator.test.js
@@ -5,7 +5,7 @@ const chai = require('chai'),
   Support = require('../../support'),
   dialect = Support.getTestDialect(),
   _ = require('lodash'),
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   IndexHints = require('sequelize/lib/index-hints'),
   QueryGenerator = require('sequelize/lib/dialects/snowflake/query-generator');
 
@@ -345,7 +345,7 @@ if (dialect === 'snowflake') {
           arguments: ['myTable'],
           expectation: 'DROP TABLE IF EXISTS "myTable";'
         },
-        
+
         // Variants when quoteIdentifiers is false
         {
           arguments: ['myTable'],

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -7,7 +7,7 @@ const chai = require('chai'),
   dialect = Support.getTestDialect(),
   _ = require('lodash'),
   moment = require('moment'),
-  Op = require('sequelize/lib/operators'),
+  Op = require('sequelize/lib/operators').default,
   QueryGenerator = require('sequelize/lib/dialects/sqlite/query-generator');
 
 if (dialect === 'sqlite') {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,21 +1,21 @@
-import DataTypes = require("./lib/data-types");
-import Deferrable = require("./lib/deferrable");
-import * as Op from "../lib/operators";
-import QueryTypes = require("./lib/query-types");
-import TableHints = require("./lib/table-hints");
-import IndexHints = require("./lib/index-hints");
-import Utils = require("./lib/utils");
+import DataTypes = require('./lib/data-types');
+import Deferrable = require('./lib/deferrable');
+import Op from '../lib/operators';
+import QueryTypes = require('./lib/query-types');
+import TableHints = require('./lib/table-hints');
+import IndexHints = require('./lib/index-hints');
+import Utils = require('./lib/utils');
 
-export * from "./lib/associations/index";
-export * from "./lib/data-types";
-export * from "./lib/errors";
-export { BaseError as Error } from "./lib/errors";
-export * from "./lib/model";
-export * from "./lib/query-interface";
-export * from "./lib/sequelize";
-export * from "./lib/transaction";
-export { useInflection } from "./lib/utils";
-export { Validator } from "./lib/utils/validator-extras";
+export * from './lib/associations/index';
+export * from './lib/data-types';
+export * from './lib/errors';
+export { BaseError as Error } from './lib/errors';
+export * from './lib/model';
+export * from './lib/query-interface';
+export * from './lib/sequelize';
+export * from './lib/transaction';
+export { useInflection } from './lib/utils';
+export { Validator } from './lib/utils/validator-extras';
 export { Utils, QueryTypes, Op, TableHints, IndexHints, DataTypes, Deferrable };
 
 /**

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -9,7 +9,7 @@ import { Sequelize, SyncOptions } from './sequelize';
 import { LOCK, Transaction } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
 import { SetRequired } from '../type-helpers/set-required'
-import * as Op from '../../lib/operators';
+import Op from '../../lib/operators';
 
 export interface Logging {
   /**
@@ -1612,7 +1612,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   /**
    * Returns the attributes of the model
    */
-  public static  getAttributes(): { [attribute: string]: ModelAttributeColumnOptions }; 
+  public static  getAttributes(): { [attribute: string]: ModelAttributeColumnOptions };
 
   /**
    * Reference to the sequelize instance the model was initialized with


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [?] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [n/a] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Attempt to fix https://github.com/sequelize/sequelize/issues/13791

There was an issue in PR https://github.com/sequelize/sequelize/pull/13731 where `Op` was exported using `export =` but was imported using `import Op from './operator'` which is not compatible (source https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require).

This is a simple fix that changes the export to be `export default Op` instead.

---

## Concerns

### Potential Breaking change

The change of export style from `export = ` to `export default` can be considered a breaking change as users that did `const Op = require('sequelize/lib/operators')` are going to have to change to `const Op = require('sequelize/lib/operators').default` (or better: `const { Op } = require('sequelize')`). 

I don't know if anyone does this, but if we want to be sure to avoid a breaking change here (also the case for the rest of the TypeScript migration), we should avoid changing the export style from `export =` to `export default`.

This also means sticking with `import Op = require('./lib/operators')` too, for now.

We can revisit this in v7.

### eslint not linting

I have also reverted a change in `index.d.ts` where the quotes were changed from single to double quotes which goes against the eslint config of the project. 

That's because eslint is not configured to run on .d.ts. We should fix that by changing `lint` from `"lint": "eslint lib test --quiet --fix",` to `"lint": "eslint lib test --quiet --fix --ext .js,.mjs,.cjs,.ts,.mts,.cts,.d.ts",` (yes file extensions for JS are getting wild).

### Two operators.ts definitions

- `index.d.ts` imports `'../lib/operators'` which points to `sequelize/lib/operators.ts` instead of `sequelize/dist/lib/operators.d.ts`. This could be a problem. I don't have a solution other than "finish the typescript migration"