### PR TITLE
fix: fix invalid ts import style of lib/operators

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import DataTypes = require("./lib/data-types");
 import Deferrable = require("./lib/deferrable");
-import Op = require('../lib/operators');
+import Op = require("../lib/operators");
 import QueryTypes = require("./lib/query-types");
 import TableHints = require("./lib/table-hints");
 import IndexHints = require("./lib/index-hints");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import DataTypes = require("./lib/data-types");
 import Deferrable = require("./lib/deferrable");
-import * as Op from "../lib/operators";
+import Op = require('../lib/operators');
 import QueryTypes = require("./lib/query-types");
 import TableHints = require("./lib/table-hints");
 import IndexHints = require("./lib/index-hints");

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -9,7 +9,7 @@ import { Sequelize, SyncOptions } from './sequelize';
 import { LOCK, Transaction } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
 import { SetRequired } from '../type-helpers/set-required'
-import * as Op from '../../lib/operators';
+import Op = require('../../lib/operators');
 
 export interface Logging {
   /**


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [n/a] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [n/a] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Replacement PR of https://github.com/sequelize/sequelize/pull/13796

Attempt to fix https://github.com/sequelize/sequelize/issues/13791

There was an issue in PR https://github.com/sequelize/sequelize/pull/13731 where `Op` was exported using `export =` but was imported using `import Op from './operator'` which is not compatible (source https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require).

This is a simple fix that changes the imports back to `import Op = require('./lib/operators')` syntax.

This one does not include any lint correction either as types/* is not linted and will be removed anyway (https://github.com/sequelize/sequelize/pull/13796#issuecomment-998023312)

---

## Concerns

Things I noticed while working on this PR. Putting them here to decide between fixing them here or opening an issue.

### Avoiding breaking changes

As talked about in https://github.com/sequelize/sequelize/pull/13796, we should stick to [this import/export syntax](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require) in v6 to avoid breaking changes.

We can revisit this in v7.

### Two operators.ts definitions

`index.d.ts` imports `'../lib/operators'` which points to `sequelize/lib/operators.ts` instead of `sequelize/dist/lib/operators.d.ts`. 

This could be a problem.

A potential solution to import /lib from /types would be to change the import from `../lib/operators` to `sequelize/lib/operators`.