### PR TITLE
Fix TS support for operators.ts

### DIFF
--- a/lib/operators.ts
+++ b/lib/operators.ts
@@ -521,4 +521,9 @@ const Op: OpTypes = {
   match: Symbol.for('match')
 } as OpTypes;
 
-export = Op;
+export default Op;
+
+// https://github.com/sequelize/sequelize/issues/13791
+// remove me in v7: kept for backward compatibility as `export default Op` is
+// transpiled to `module.exports.default` instead of `module.exports`
+module.exports = Op;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 import DataTypes = require("./lib/data-types");
 import Deferrable = require("./lib/deferrable");
-import Op = require("../lib/operators");
+import Op from "../lib/operators";
 import QueryTypes = require("./lib/query-types");
 import TableHints = require("./lib/table-hints");
 import IndexHints = require("./lib/index-hints");

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -9,7 +9,7 @@ import { Sequelize, SyncOptions } from './sequelize';
 import { LOCK, Transaction } from './transaction';
 import { Col, Fn, Literal, Where } from './utils';
 import { SetRequired } from '../type-helpers/set-required'
-import Op = require('../../lib/operators');
+import Op from '../../lib/operators';
 
 export interface Logging {
   /**


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [n/a] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [n/a] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Closes #13791

Fix turned out more complicated than previously thought (https://github.com/sequelize/sequelize/pull/13797)

Current solution is definitely a hack to please both TypeScript and Node.

I think the TypeScript migration is going to keep breaking things due to how `esbuild` transpiles ESM. I've opened an issue regarding this as the decision will impact this PR https://github.com/sequelize/sequelize/issues/13806