### PR TITLE
fix(13804): use schema for ARRAY(ENUM) type name

### DIFF
--- a/lib/dialects/postgres/data-types.js
+++ b/lib/dialects/postgres/data-types.js
@@ -479,13 +479,19 @@ module.exports = BaseTypes => {
       let castKey = this.toSql();
 
       if (this.type instanceof BaseTypes.ENUM) {
+        const table = options.field.Model.getTableName();
+        const useSchema = table.schema !== undefined;
+        const schemaWithDelimiter = useSchema ? `${Utils.addTicks(table.schema, '"')}${table.delimiter}` : '';
+
         castKey = `${Utils.addTicks(
-          Utils.generateEnumName(options.field.Model.getTableName(), options.field.field),
+          Utils.generateEnumName(useSchema ? table.tableName : table, options.field.field),
           '"'
         ) }[]`;
-      }
 
-      str += `::${castKey}`;
+        str += `::${schemaWithDelimiter}${castKey}`;
+      } else {
+        str += `::${castKey}`;
+      }
     }
 
     return str;

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -466,8 +466,9 @@ if (dialect.match(/^postgres/)) {
         });
 
         it('should be able to insert a new record even with an array of enums in a schema', async function() {
+          const schema = 'special_schema';
+          this.sequelize.createSchema(schema);
           const User = this.sequelize.define('UserEnums', {
-            schema: 'specialSchema',
             name: DataTypes.STRING,
             type: DataTypes.ENUM('A', 'B', 'C'),
             owners: DataTypes.ARRAY(DataTypes.STRING),
@@ -480,6 +481,8 @@ if (dialect.match(/^postgres/)) {
               ])),
               field: 'special_permissions'
             }
+          }, {
+            schema
           });
 
           await User.sync({ force: true });

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -465,6 +465,35 @@ if (dialect.match(/^postgres/)) {
           expect(user.length).to.equal(1);
         });
 
+        it('should be able to insert a new record even with an array of enums in a schema', async function() {
+          const User = this.sequelize.define('UserEnums', {
+            schema: 'specialSchema',
+            name: DataTypes.STRING,
+            type: DataTypes.ENUM('A', 'B', 'C'),
+            owners: DataTypes.ARRAY(DataTypes.STRING),
+            specialPermissions: {
+              type: DataTypes.ARRAY(DataTypes.ENUM([
+                'access',
+                'write',
+                'check',
+                'delete'
+              ])),
+              field: 'special_permissions'
+            }
+          });
+
+          await User.sync({ force: true });
+
+          const user = await User.bulkCreate([{
+            name: 'file.exe',
+            type: 'C',
+            owners: ['userA', 'userB'],
+            specialPermissions: ['access', 'write']
+          }]);
+
+          expect(user.length).to.equal(1);
+        });
+
         it('should fail when trying to insert foreign element on ARRAY(ENUM)', async function() {
           const User = this.sequelize.define('UserEnums', {
             name: DataTypes.STRING,


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes  #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Closes #13804

This change is also realated with #13204 PR #13210. It not caused by it but the source of both bugs is the same, improper handling of ARRAY[ENUM] on postgres. In this scenario is only when we are using schemas.