### PR TITLE
Bring back quoteIdentifier(s) to queryInterface to ease migration to v6

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -925,7 +925,7 @@ class QueryGenerator {
   }
 
   /**
-   * Split a list of identifiers by "." and quote each part
+   * Adds quotes to identifier
    *
    * @param {string} identifier
    * @param {boolean} force
@@ -936,6 +936,13 @@ class QueryGenerator {
     throw new Error(`quoteIdentifier for Dialect "${this.dialect}" is not implemented`);
   }
 
+  /**
+   * Split a list of identifiers by "." and quote each part.
+   *
+   * @param {string} identifiers 
+   * 
+   * @returns {string}
+   */
   quoteIdentifiers(identifiers) {
     if (identifiers.includes('.')) {
       identifiers = identifiers.split('.');

--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -431,6 +431,29 @@ class QueryInterface {
   }
 
   /**
+   * Split a list of identifiers by "." and quote each part
+   *
+   * @param {string} identifier
+   * @param {boolean} force
+   *
+   * @returns {string}
+   */
+  quoteIdentifier(identifier, force) {
+    return this.queryGenerator.quoteIdentifier(identifier, force);
+  }
+
+  /**
+   * Split a list of identifiers by "." and quote each part.
+   *
+   * @param {string} identifiers 
+   * 
+   * @returns {string}
+   */
+  quoteIdentifiers(identifiers) {
+    return this.queryGenerator.quoteIdentifiers(identifiers);
+  }
+
+  /**
    * Change a column definition
    *
    * @param {string} tableName          Table name to change from

--- a/lib/utils/class-to-invokable.ts
+++ b/lib/utils/class-to-invokable.ts
@@ -15,7 +15,7 @@ interface Invokeable<Args extends Array<any>, Instance> {
  * @private
  */
 export function classToInvokable<Args extends Array<any>, Instance extends object>(
-  Class: new (...args: Args) => Instance,
+  Class: new (...args: Args) => Instance
 ): Invokeable<Args, Instance> {
   return new Proxy<Invokeable<Args, Instance>>(Class as any, {
     apply(_target, _thisArg, args: Args) {
@@ -23,6 +23,6 @@ export function classToInvokable<Args extends Array<any>, Instance extends objec
     },
     construct(_target, args: Args) {
       return new Class(...args);
-    },
+    }
   });
 }

--- a/test/unit/dialects/abstract/query-interface.test.ts
+++ b/test/unit/dialects/abstract/query-interface.test.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import Support from '../../support';
+
+const { sequelize } = Support as any;
+
+describe('QueryInterface', () => {
+  describe('quoteIdentifier', () => {
+    // regression test which covers https://github.com/sequelize/sequelize/issues/12627
+    it('should quote the identifier', () => {
+      const identifier = 'identifier';
+      const quotedIdentifier = sequelize
+        .getQueryInterface()
+        .quoteIdentifier(identifier);
+      const expectedQuotedIdentifier = sequelize
+        .getQueryInterface()
+        .queryGenerator.quoteIdentifier(identifier);
+
+      expect(quotedIdentifier).not.to.be.undefined;
+      expect(expectedQuotedIdentifier).not.to.be.undefined;
+      expect(quotedIdentifier).to.equal(expectedQuotedIdentifier);
+    });
+  });
+
+  describe('quoteIdentifiers', () => {
+    // regression test which covers https://github.com/sequelize/sequelize/issues/12627
+    it('should quote the identifiers', () => {
+      const identifier = 'table.identifier';
+      const quotedIdentifiers = sequelize
+        .getQueryInterface()
+        .quoteIdentifiers(identifier);
+      const expectedQuotedIdentifiers = sequelize
+        .getQueryInterface()
+        .queryGenerator.quoteIdentifiers(identifier);
+
+      expect(quotedIdentifiers).not.to.be.undefined;
+      expect(expectedQuotedIdentifiers).not.to.be.undefined;
+      expect(quotedIdentifiers).to.equal(expectedQuotedIdentifiers);
+    });
+  });
+});

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -630,21 +630,20 @@ export class QueryInterface {
   ): Promise<void>;
 
   /**
-   * Escape an identifier (e.g. a table or attribute name). If force is true, the identifier will be quoted
-   * even if the `quoteIdentifiers` option is false.
-   */
-  public quoteIdentifier(identifier: string, force: boolean): string;
-
-  /**
    * Escape a table name
    */
   public quoteTable(identifier: TableName): string;
 
   /**
-   * Split an identifier into .-separated tokens and quote each part. If force is true, the identifier will be
-   * quoted even if the `quoteIdentifiers` option is false.
+   * Escape an identifier (e.g. a table or attribute name). If force is true, the identifier will be quoted
+   * even if the `quoteIdentifiers` option is false.
    */
-  public quoteIdentifiers(identifiers: string, force: boolean): string;
+  public quoteIdentifier(identifier: string, force?: boolean): string;
+
+  /**
+   * Split an identifier into .-separated tokens and quote each part.
+   */
+  public quoteIdentifiers(identifiers: string): string;
 
   /**
    * Escape a value (e.g. a string, number or date)

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -73,6 +73,10 @@ async function test() {
 
   await queryInterface.quoteTable({ tableName: 'foo', delimiter: 'bar' });
 
+  queryInterface.quoteIdentifier("foo");
+  queryInterface.quoteIdentifier("foo", true);
+  queryInterface.quoteIdentifiers("table.foo");
+
   await queryInterface.dropAllTables();
 
   await queryInterface.renameTable('Person', 'User');


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

In some version of v6, the queryInterface apparently lost `quoteIdentifier` and `quoteIdentifiers` which is hindering people to update to v6 (https://github.com/sequelize/sequelize/issues/12627). Interestingly, the types haven't been updated accordingly. So there is a certain discrepancy. This PR is recovering the methods.
