### PR TITLE
feat(model): whereCollection must be stored per instance, not per class

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -109,6 +109,8 @@ class Model {
       isNewRecord: true,
       _schema: this.constructor._schema,
       _schemaDelimiter: this.constructor._schemaDelimiter,
+      // whereCollection is used per instance for non-primary key updates
+      whereCollection: null,
       ...options,
     };
 
@@ -1027,7 +1029,6 @@ class Model {
       underscored: false,
       paranoid: false,
       rejectOnEmpty: false,
-      whereCollection: null,
       schema: null,
       schemaDelimiter: '',
       defaultScope: {},
@@ -1839,9 +1840,6 @@ class Model {
       options.originalAttributes = this._injectDependentVirtualAttributes(options.attributes);
     }
 
-    // whereCollection is used for non-primary key updates
-    this.options.whereCollection = options.where || null;
-
     Utils.mapFinderOptions(options, this);
 
     options = this._paranoidClause(this, options);
@@ -1854,6 +1852,11 @@ class Model {
     const results = await this.queryInterface.select(this, this.getTableName(selectOptions), selectOptions);
     if (options.hooks) {
       await this.runHooks('afterFind', results, options);
+    }
+    for (const result of Array.isArray(results) ? results : [results]) {
+      if (result && result._options) {
+        result._options.whereCollection = options.where;
+      }
     }
 
     // rejectOnEmpty mode
@@ -1958,6 +1961,7 @@ class Model {
       });
 
       for (const result of results) {
+        result._options.whereCollection = options.where;
         result.set(
           include.association.as,
           map[result.get(include.association.sourceKey)],
@@ -3622,7 +3626,7 @@ class Model {
     }, {});
 
     if (_.size(where) === 0) {
-      return this.constructor.options.whereCollection;
+      return this._options.whereCollection;
     }
 
     const versionAttr = this.constructor._versionAttribute;


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Have you added new tests to prevent regressions? - NO
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)? - ` DIALECT=sqlite yarn test` passes.
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? - Not applicable
- [ ] Did you update the typescript typings accordingly (if applicable)? - Not applicable
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving? - Description is included here.
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)? - No

### Description Of Change

I have a model without primary key, and as proposed at https://sequelize.org/master/manual/legacy.html, I call `Model.removeAttribute('id');`.

I want to load many models simultaneously.  Whenever I get a model with .findOne({where}), in `static findAll()` is called `this.options.whereCollection = options.where || null;`.  Since findAll() is static, options.where is assigned to the class, and not to the fetched instance.  So all instances share the same value of whereCollection.

Once any of these models is updated, I want to call instance.save().  In lib/model.js the method save() calls
```javascript
if (this.isNewRecord) {
  query = 'insert';
  args = [this, this.constructor.getTableName(options), values, options];
} else {
  where = this.where(true);
  if (versionAttr) {
    values[versionFieldName] = parseInt(values[versionFieldName], 10) + 1;
  }
  query = 'update';
  args = [this, this.constructor.getTableName(options), values, where, options];
}
```
and this.where(true) calls
```javascript
where(checkVersion) {
  const where = this.constructor.primaryKeyAttributes.reduce((result, attribute) => {
    result[attribute] = this.get(attribute, { raw: true });
    return result;
   }, {});

   if (_.size(where) === 0) {
    return this.constructor.options.whereCollection;
   }
```
The point is, that all instances share the same whereCollection value and whichever model I try to persist, only the last loaded model is updated.  Which model is persisted, is determined by `this.which(true)`.

The provided patch does help, by storing `whereCollection` per instance, but I do not understand all the conseqences, and whether all the changes are necessary.