### PR TITLE
fix(mssql/async-queue): fix unable to start mysql due to circular ref

### DIFF
--- a/lib/dialects/mssql/async-queue.ts
+++ b/lib/dialects/mssql/async-queue.ts
@@ -1,4 +1,5 @@
-import { BaseError, ConnectionError } from '../../errors';
+import BaseError from '../../errors/base-error';
+import ConnectionError from '../../errors/connection-error';
 
 /**
  * Thrown when a connection to a database is closed while an operation is in progress


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->
Fix unable to start mysql docker in test due to circular reference

Why this happen? Because on this line, it attempts to export an Error that's outside `errors` dir and this outside AsyncQueueError has circular reference to `errors/index.ts`

https://github.com/sequelize/sequelize/blob/8cdce6aeb32b09e4bc1359250efcfacc6742501f/lib/errors/index.ts#L36

It's a bit weird to me that `errors/index.ts` attempts to expose an Error that's outside this dir, maybe it shouldn't do it in the first place but removing it will be a breaking change so I'll not change it in this PR. Taking it out requires a different discussion.

#### Steps to reproduce

Node: v14.18.1

run the follow command
```
npm run start-mysql 
```

and received the following error
```
class AsyncQueueError extends import_errors.BaseError {
                                            ^

TypeError: Class extends value undefined is not a constructor or null
```
