### PR TITLE
Update documentation for TypeScript Model Definition & Class Fields

### DIFF
--- a/docs/manual/core-concepts/model-basics.md
+++ b/docs/manual/core-concepts/model-basics.md
@@ -101,6 +101,7 @@ User.init({
 const user = new User({ id: 1 });
 user.id; // undefined
 ```
+
 ```typescript
 // Valid
 class User extends Model {

--- a/docs/manual/core-concepts/model-basics.md
+++ b/docs/manual/core-concepts/model-basics.md
@@ -77,6 +77,68 @@ console.log(User === sequelize.models.User); // true
 
 Internally, `sequelize.define` calls `Model.init`, so both approaches are essentially equivalent.
 
+#### Caveat with Public Class Fields
+
+Adding a [Public Class Field](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Public_class_fields) with the same name as one of the model's attribute is going to cause issues.
+Sequelize adds a getter & a setter for each attribute defined through `Model.init`.
+Adding a Public Class Field will shadow those getter and setters, blocking access to the model's actual data.
+
+```typescript
+// Invalid
+class User extends Model {
+  id; // this field will shadow sequelize's getter & setter. It should be removed.
+  otherPublicField; // this field does not shadow anything. It is fine.
+}
+
+User.init({
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true
+  }
+}, { sequelize });
+
+const user = new User({ id: 1 });
+user.id; // undefined
+```
+```typescript
+// Valid
+class User extends Model {
+  otherPublicField;
+}
+
+User.init({
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true
+  }
+}, { sequelize });
+
+const user = new User({ id: 1 });
+user.id; // 1
+```
+
+In TypeScript, you can add typing information without adding an actual public class field by using the `declare` keyword:
+
+```typescript
+// Invalid
+class User extends Model {
+  declare id: number; // this is ok! The 'declare' keyword ensures this field will not be emitted by TypeScript.
+}
+
+User.init({
+  id: {
+    type: DataTypes.INTEGER,
+    autoIncrement: true,
+    primaryKey: true
+  }
+}, { sequelize });
+
+const user = new User({ id: 1 });
+user.id; // 1
+```
+
 ## Table name inference
 
 Observe that, in both methods above, the table name (`Users`) was never explicitly defined. However, the model name was given (`User`).

--- a/docs/manual/core-concepts/model-basics.md
+++ b/docs/manual/core-concepts/model-basics.md
@@ -123,7 +123,7 @@ user.id; // 1
 In TypeScript, you can add typing information without adding an actual public class field by using the `declare` keyword:
 
 ```typescript
-// Invalid
+// Valid
 class User extends Model {
   declare id: number; // this is ok! The 'declare' keyword ensures this field will not be emitted by TypeScript.
 }

--- a/lib/model.js
+++ b/lib/model.js
@@ -97,7 +97,7 @@ class Model {
       // TODO: v7 - throw error instead.
       logger.warn(`Model ${this.constructor.name} is declaring class properties for attributes: ${overwrittenAttributes.join(', ')}.` +
         '\nThese class properties are shadowing Sequelize\'s attribute getters & setters.' +
-        '\nSee https://sequelize.org/main/manual/class-properties.html');
+        '\nSee https://sequelize.org/main/manual/model-basics.html#caveat-with-public-class-fields');
     }
 
     options = {

--- a/lib/model.js
+++ b/lib/model.js
@@ -83,6 +83,23 @@ class Model {
    * @param {Array}   [options.include] an array of include options - Used to build prefetched/included model instances. See `set`
    */
   constructor(values = {}, options = {}) {
+    // note: this only detects *native* public class fields
+    //  as they are set before this constructor is called.
+    //  transpiled public class fields will not always be detected properly.
+    const overwrittenAttributes = [];
+    for (const key of Object.keys(this.constructor._attributeManipulation)) {
+      if (Object.prototype.hasOwnProperty.call(this, key)) {
+        overwrittenAttributes.push(key);
+      }
+    }
+
+    if (overwrittenAttributes.length > 0) {
+      // TODO: v7 - throw error instead.
+      logger.warn(`Model ${this.constructor.name} is declaring class properties for attributes: ${overwrittenAttributes.join(', ')}.` +
+        '\nThese class properties are shadowing Sequelize\'s attribute getters & setters.' +
+        '\nSee https://sequelize.org/main/manual/class-properties.html');
+    }
+
     options = {
       isNewRecord: true,
       _schema: this.constructor._schema,
@@ -1268,6 +1285,8 @@ class Model {
 
     this._hasPrimaryKeys = this.primaryKeyAttributes.length > 0;
     this._isPrimaryKey = key => this.primaryKeyAttributes.includes(key);
+
+    this._attributeManipulation = attributeManipulation;
   }
 
   /**

--- a/lib/model.js
+++ b/lib/model.js
@@ -83,21 +83,27 @@ class Model {
    * @param {Array}   [options.include] an array of include options - Used to build prefetched/included model instances. See `set`
    */
   constructor(values = {}, options = {}) {
-    // note: this only detects *native* public class fields
-    //  as they are set before this constructor is called.
-    //  transpiled public class fields will not always be detected properly.
-    const overwrittenAttributes = [];
-    for (const key of Object.keys(this.constructor._attributeManipulation)) {
-      if (Object.prototype.hasOwnProperty.call(this, key)) {
-        overwrittenAttributes.push(key);
-      }
-    }
+    if (!this.constructor._overwrittenAttributesChecked) {
+      this.constructor._overwrittenAttributesChecked = true;
 
-    if (overwrittenAttributes.length > 0) {
-      // TODO: v7 - throw error instead.
-      logger.warn(`Model ${this.constructor.name} is declaring class properties for attributes: ${overwrittenAttributes.join(', ')}.` +
-        '\nThese class properties are shadowing Sequelize\'s attribute getters & setters.' +
-        '\nSee https://sequelize.org/main/manual/model-basics.html#caveat-with-public-class-fields');
+      // setTimeout is hacky but necessary.
+      // Public Class Fields declared by descendants of this class
+      // will not be available until after their call to super, so after
+      // this constructor is done running.
+      setTimeout(() => {
+        const overwrittenAttributes = [];
+        for (const key of Object.keys(this.constructor._attributeManipulation)) {
+          if (Object.prototype.hasOwnProperty.call(this, key)) {
+            overwrittenAttributes.push(key);
+          }
+        }
+
+        if (overwrittenAttributes.length > 0) {
+          logger.warn(`Model ${JSON.stringify(this.constructor.name)} is declaring public class fields for attribute(s): ${overwrittenAttributes.map(attr => JSON.stringify(attr)).join(', ')}.` +
+            '\nThese class fields are shadowing Sequelize\'s attribute getters & setters.' +
+            '\nSee https://sequelize.org/main/manual/model-basics.html#caveat-with-public-class-fields');
+        }
+      }, 0);
     }
 
     options = {

--- a/types/test/typescriptDocs/ModelInit.ts
+++ b/types/test/typescriptDocs/ModelInit.ts
@@ -21,28 +21,28 @@ interface UserCreationAttributes extends Optional<UserAttributes, "id"> {}
 
 class User extends Model<UserAttributes, UserCreationAttributes>
   implements UserAttributes {
-  public id!: number; // Note that the `null assertion` `!` is required in strict mode.
-  public name!: string;
-  public preferredName!: string | null; // for nullable fields
+  declare id: number; // Note that the `null assertion` `!` is required in strict mode.
+  declare name: string;
+  declare preferredName: string | null; // for nullable fields
 
   // timestamps!
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 
   // Since TS cannot determine model association at compile time
   // we have to declare them here purely virtually
   // these will not exist until `Model.init` was called.
-  public getProjects!: HasManyGetAssociationsMixin<Project>; // Note the null assertions!
-  public addProject!: HasManyAddAssociationMixin<Project, number>;
-  public hasProject!: HasManyHasAssociationMixin<Project, number>;
-  public countProjects!: HasManyCountAssociationsMixin;
-  public createProject!: HasManyCreateAssociationMixin<Project>;
+  declare getProjects: HasManyGetAssociationsMixin<Project>; // Note the null assertions!
+  declare addProject: HasManyAddAssociationMixin<Project, number>;
+  declare hasProject: HasManyHasAssociationMixin<Project, number>;
+  declare countProjects: HasManyCountAssociationsMixin;
+  declare createProject: HasManyCreateAssociationMixin<Project>;
 
   // You can also pre-declare possible inclusions, these will only be populated if you
   // actively include a relation.
-  public readonly projects?: Project[]; // Note this is optional since it's only populated when explicitly requested in code
+  declare readonly projects?: Project[]; // Note this is optional since it's only populated when explicitly requested in code
 
-  public static associations: {
+  declare static associations: {
     projects: Association<User, Project>;
   };
 }
@@ -58,12 +58,12 @@ interface ProjectCreationAttributes extends Optional<ProjectAttributes, "id"> {}
 
 class Project extends Model<ProjectAttributes, ProjectCreationAttributes>
   implements ProjectAttributes {
-  public id!: number;
-  public ownerId!: number;
-  public name!: string;
+  declare id: number;
+  declare ownerId: number;
+  declare name: string;
 
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 }
 
 interface AddressAttributes {
@@ -74,11 +74,11 @@ interface AddressAttributes {
 // You can write `extends Model<AddressAttributes, AddressAttributes>` instead,
 // but that will do the exact same thing as below
 class Address extends Model<AddressAttributes> implements AddressAttributes {
-  public userId!: number;
-  public address!: string;
+  declare userId: number;
+  declare address: string;
 
-  public readonly createdAt!: Date;
-  public readonly updatedAt!: Date;
+  declare readonly createdAt: Date;
+  declare readonly updatedAt: Date;
 }
 
 // You can also define modules in a functional way
@@ -213,3 +213,8 @@ async function doStuffWithUser() {
   // the model or not
   console.log(ourUser.projects![0].name);
 }
+
+(async () => {
+  await sequelize.sync();
+  await doStuffWithUser();
+})();


### PR DESCRIPTION
### Pull Request Checklist

- [n/a] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [n/a] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

There is an incompatibility between Sequelize & adding public class fields for attributes.

This PR documents how this incompatibility & explains how to add typing without introducing actual class fields that will cause bugs.

It also detects uses of public class fields that shadow a model's attributes, and warns the user. Doing this:

<img width="309" alt="image" src="https://user-images.githubusercontent.com/1280915/147741811-e59effb3-f81b-466a-b2e2-5bf19b2b79d4.png">

Will log the following to the console:

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/1280915/147741843-9334fcd2-9705-4547-9a40-359a811a6641.png">

Closes https://github.com/sequelize/sequelize/issues/10579
Closes https://github.com/sequelize/sequelize/issues/12603
Closes https://github.com/sequelize/sequelize/issues/11675
Closes https://github.com/sequelize/sequelize/issues/11032
Closes https://github.com/sequelize/sequelize/issues/11494

---

Note: this documentation update is a temporary fix as things are going to break again once decorators are stage 4. I'll open an rfc with possible solutions that resolve this caveat for good for V7.