### PR TITLE
fix: semantic-release should not push beta or alpha to default channel

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,10 +199,12 @@
       "v6",
       {
         "name": "v6-beta",
+        "channel": "beta",
         "prerelease": "beta"
       },
       {
         "name": "v7",
+        "channel": "alpha",
         "prerelease": "alpha"
       }
     ]


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

v6 and v7 have been publishing updated versions to the default `latest` tag and this should correct that.
Documentation: https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#channel

Evidence:
```
$ npm dist-tag ls sequelize
latest: 6.12.4
v4: 4.44.4
v5: 5.22.5
```

This means that anyone installing with `npm i sequelize@latest` will get alpha and beta versions (e.g., `7.0.0-alpha.3`) when they just happen to be the latest published versions.

### Todos

- [ ] Get this fix into v6
- [x] Get this fix into v7 (consider https://github.com/sequelize/sequelize/pull/13862)