### PR TITLE
build(ci): only run on pushes to main/v6/v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - v6
+      - v7
+  pull_request:
 
 env:
   SEQ_DB: sequelize_test


### PR DESCRIPTION
Currently we run checks twice if the branch for the PR is in the sequelize repo. This would reduce the checks to be done on all Pull Requests and the pushes to the main/v6/v7 branches.

When a Pull Request has a new commit it will still run the checks.