### PR TITLE
Revert "fix: semantic-release should not push beta or alpha to default channel"

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,12 +198,10 @@
       "v6",
       {
         "name": "v6-beta",
-        "channel": "beta",
         "prerelease": "beta"
       },
       {
         "name": "v7",
-        "channel": "alpha",
         "prerelease": "alpha"
       }
     ]


### PR DESCRIPTION
Reverts sequelize/sequelize#13863