### PR TITLE
fix(dialect): sequelize pool doesn't take effect in dialect "mssql" with new tedious version v13.1.0

### DIFF
--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -163,7 +163,7 @@ class ConnectionManager extends AbstractConnectionManager {
   }
 
   validate(connection) {
-    return connection && connection.loggedIn;
+    return connection && (connection.loggedIn || (connection.state.name === "LoggedIn"));
   }
 }
 


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [√] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [√] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [√] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change
fix sequelize pool doesn't take effect in dialect "mssql"
please refer issue https://github.com/sequelize/sequelize/issues/13865 for detail info