### PR TITLE
fix(model): fix count with grouping typing

### DIFF
--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1907,7 +1907,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   public static count<M extends Model>(
     this: ModelStatic<M>,
     options: CountWithOptions<M['_attributes']>
-  ): Promise<{ [key: string]: number }>;
+  ): Promise<Array<{ [groupKey: string]: unknown, count: number }>>;
 
   /**
    * Count the number of records matching the provided where clause.

--- a/types/test/count.ts
+++ b/types/test/count.ts
@@ -4,7 +4,8 @@ import { Model, Op } from 'sequelize';
 class MyModel extends Model {}
 
 expectTypeOf(MyModel.count()).toEqualTypeOf<Promise<number>>();
-expectTypeOf(MyModel.count({ group: 'tag' })).toEqualTypeOf<Promise<{ [key: string]: number }>>();
+expectTypeOf(MyModel.count({ group: 'tag' }))
+  .toEqualTypeOf<Promise<Array<{ [groupKey: string]: unknown, count: number }>>>();
 expectTypeOf(MyModel.count({ col: 'tag', distinct: true })).toEqualTypeOf<Promise<number>>();
 expectTypeOf(MyModel.count({
   where: {


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [n/a] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Closes #13871

Current typings state that count with grouping returns an object `{ [columnName: count] }` when in reality something like this:

<img width="652" alt="image" src="https://user-images.githubusercontent.com/1280915/147890029-46d87003-dd3e-406a-ba1c-561156234cb3.png">

returns this:

<img width="617" alt="image" src="https://user-images.githubusercontent.com/1280915/147890046-98172250-27c1-46e7-9c4b-4b9817d0c27b.png">

An array where each entry is an object with column -> column value of the group, plus a `count` property.

`count.test.js` backs this, so it's only a typing issue.

---

I also noticed `Model.count({ group: ['count'] })` is going to return a broken result. I've added it to my [future improvements list](https://gist.github.com/ephys/50a6a05be7322c64645be716fea6186a).