### PR TITLE
fix _logQuery crashing when logging bigints

### DIFF
--- a/lib/dialects/abstract/query.js
+++ b/lib/dialects/abstract/query.js
@@ -6,6 +6,7 @@ const QueryTypes = require('../../query-types');
 const Dot = require('dottie');
 const deprecations = require('../../utils/deprecations');
 const uuid = require('uuid').v4;
+const { safeStringifyJson } = require('../../utils.js');
 
 class AbstractQuery {
 
@@ -339,9 +340,9 @@ class AbstractQuery {
       const delimiter = sql.endsWith(';') ? '' : ';';
       let paramStr;
       if (Array.isArray(parameters)) {
-        paramStr = parameters.map(p=>JSON.stringify(p)).join(', ');
+        paramStr = parameters.map(p=>safeStringifyJson(p)).join(', ');
       } else {
-        paramStr = JSON.stringify(parameters);
+        paramStr = safeStringifyJson(parameters);
       }
       logParameter = `${delimiter} ${paramStr}`;
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -633,3 +633,23 @@ function intersects(arr1, arr2) {
   return arr1.some(v => arr2.includes(v));
 }
 exports.intersects = intersects;
+
+/**
+ * Stringify a value as JSON with some differences:
+ * - bigints are stringified as a json string. (`safeStringifyJson({ val: 1n })` outputs `'{ "val": "1" }'`).
+ *   This is because of a decision by TC39 to not support bigint in JSON.stringify https://github.com/tc39/proposal-bigint/issues/24
+ *
+ * @param {any} value the value to stringify.
+ * @returns {string} the resulting json.
+ */
+function safeStringifyJson(value /* : any */) /* : string */ {
+  return JSON.stringify(value, (key, value) => {
+    if (typeof value === 'bigint') {
+      return String(value);
+    }
+
+    return value;
+  });
+}
+
+exports.safeStringifyJson = safeStringifyJson;

--- a/package.json
+++ b/package.json
@@ -198,13 +198,12 @@
       "v6",
       {
         "name": "v7",
-        "channel": "alpha",
-        "prerelease": "alpha2"
+        "prerelease": "alpha"
       }
     ]
   },
   "publishConfig": {
-    "tag": "latest"
+    "tag": "alpha"
   },
   "scripts": {
     "----------------------------------------- static analysis -----------------------------------------": "",

--- a/test/integration/sequelize/query.test.js
+++ b/test/integration/sequelize/query.test.js
@@ -193,43 +193,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           expect(updateSql).to.match(/; ("li", 1|{"(\$1|0)":"li","(\$2|1)":1})/);
         });
 
-        it('supports bigint', async function() {
-          // this test was added because while most of the time `bigint`s are stringified,
-          // they're not always. For instance, if the PK is a bigint, calling .save()
-          // will pass the PK as a bigint instead of a string as a parameter.
-          // This is fine, as bigints should be supported natively,
-          // but AbstractQuery#_logQuery used JSON.stringify on parameters,
-          // which does not support serializing bigints (https://github.com/tc39/proposal-bigint/issues/24)
-          // This test was added to ensure bigints don't cause a crash
-          // when `logQueryParameters` is true.
-
-          expect(this.sequelize.options.logQueryParameters).to.equal(true, '"logQueryParameters" must be true for this test');
-
-          let createSql, updateSql;
-
-          const user = await this.User.create({
-            // this is beyond Number.MAX_SAFE_INTEGER
-            id: 9007199254740999n
-          }, {
-            logging: s => {
-              createSql = s;
-            }
-          });
-
-          user.username = 'Test';
-
-          expect(typeof user.id).to.equal('bigint');
-
-          await user.save({
-            logging: s => {
-              updateSql = s;
-            }
-          });
-
-          expect(createSql).to.match(/; ("9007199254740999"|{"(\$1|0)":"9007199254740999"})/);
-          expect(updateSql).to.match(/; ("Test", "9007199254740999"|{"(\$1|0)":"Test","(\$2|1)":"9007199254740999"})/);
-        });
-
         it('add parameters in log sql when use bind value', async function() {
           let logSql;
           let typeCast = dialect === 'postgres' ? '::text' : '';

--- a/test/integration/sequelize/query.test.js
+++ b/test/integration/sequelize/query.test.js
@@ -152,7 +152,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
           });
           this.User = this.sequelize.define('User', {
             id: {
-              type: DataTypes.BIGINT,
+              type: DataTypes.INTEGER,
               primaryKey: true,
               autoIncrement: true
             },

--- a/test/unit/dialects/abstract/query.test.js
+++ b/test/unit/dialects/abstract/query.test.js
@@ -508,5 +508,33 @@ describe('[ABSTRACT]', () => {
       expect(debugStub).to.have.been.calledWith('Executing (test): SELECT 1');
       expect(debugStub).to.have.been.calledWith('Executed (test): SELECT 1');
     });
+
+    it('supports logging bigints', function() {
+      // this test was added because while most of the time `bigint`s are stringified,
+      // they're not always. For instance, if the PK is a bigint, calling .save()
+      // will pass the PK as a bigint instead of a string as a parameter.
+      // This is fine, as bigints should be supported natively,
+      // but AbstractQuery#_logQuery used JSON.stringify on parameters,
+      // which does not support serializing bigints (https://github.com/tc39/proposal-bigint/issues/24)
+      // This test was added to ensure bigints don't cause a crash
+      // when `logQueryParameters` is true.
+
+      const sequelizeStub = {
+        ...this.sequelizeStub,
+        options: {
+          ...this.sequelizeStub.options,
+          logQueryParameters: true
+        }
+      };
+
+      const debugStub = stub();
+      const qry = new this.cls(this.connectionStub, sequelizeStub, {});
+      const complete = qry._logQuery('SELECT 1', debugStub, [1n]);
+
+      complete();
+
+      expect(debugStub).to.have.been.calledWith('Executing (test): SELECT 1; "1"');
+      expect(debugStub).to.have.been.calledWith('Executed (test): SELECT 1; "1"');
+    });
   });
 });


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [n/a] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [n/a] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Closes https://github.com/sequelize/sequelize/issues/13724

There is an issue where `AbstractQuery#_logQuery` crashes when it receives a `bigint` and `logQueryParameters` is true due to `JSON.stringify` being unable to stringify bigints (related to https://github.com/tc39/proposal-bigint/issues/24).