### PR TITLE
feat(postgres): drop indices concurrently in Postgres

### DIFF
--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -640,12 +640,13 @@ class QueryInterface {
    * @param {string} tableName                    Table name to drop index from
    * @param {string|string[]} indexNameOrAttributes  Index name or list of attributes that in the index
    * @param {object} [options]                    Query options
+   * @param {boolean} [options.concurrently]      Pass CONCURRENTLY so other operations run while the index is created
    *
    * @returns {Promise}
    */
   async removeIndex(tableName, indexNameOrAttributes, options) {
     options = options || {};
-    const sql = this.queryGenerator.removeIndexQuery(tableName, indexNameOrAttributes);
+    const sql = this.queryGenerator.removeIndexQuery(tableName, indexNameOrAttributes, options);
     return await this.sequelize.query(sql, options);
   }
 

--- a/lib/dialects/mssql/connection-manager.js
+++ b/lib/dialects/mssql/connection-manager.js
@@ -163,7 +163,7 @@ class ConnectionManager extends AbstractConnectionManager {
   }
 
   validate(connection) {
-    return connection && (connection.loggedIn || (connection.state.name === "LoggedIn"));
+    return connection && (connection.loggedIn || connection.state.name === 'LoggedIn');
   }
 }
 

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -412,14 +412,18 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     ].join(' ');
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes) {
+  removeIndexQuery(tableName, indexNameOrAttributes, options) {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
       indexName = Utils.underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
     }
 
-    return `DROP INDEX IF EXISTS ${this.quoteIdentifiers(indexName)}`;
+    return [
+      'DROP INDEX',
+      options && options.concurrently && 'CONCURRENTLY',
+      `IF EXISTS ${this.quoteIdentifiers(indexName)}`
+    ].filter(Boolean).join(' ');
   }
 
   addLimitAndOffset(options) {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -1102,8 +1102,14 @@ if (dialect.startsWith('postgres')) {
           arguments: ['User', ['foo', 'bar']],
           expectation: 'DROP INDEX IF EXISTS "user_foo_bar"'
         }, {
+          arguments: ['User', ['foo', 'bar'], { concurrently: true }],
+          expectation: 'DROP INDEX CONCURRENTLY IF EXISTS "user_foo_bar"'
+        }, {
           arguments: ['User', 'mySchema.user_foo_bar'],
           expectation: 'DROP INDEX IF EXISTS "mySchema"."user_foo_bar"'
+        }, {
+          arguments: ['User', 'mySchema.user_foo_bar', { concurrently: true }],
+          expectation: 'DROP INDEX CONCURRENTLY IF EXISTS "mySchema"."user_foo_bar"'
         },
 
         // Variants when quoteIdentifiers is false
@@ -1118,6 +1124,10 @@ if (dialect.startsWith('postgres')) {
         }, {
           arguments: ['User', 'mySchema.user_foo_bar'],
           expectation: 'DROP INDEX IF EXISTS mySchema.user_foo_bar',
+          context: { options: { quoteIdentifiers: false } }
+        }, {
+          arguments: ['User', 'mySchema.user_foo_bar', { concurrently: true }],
+          expectation: 'DROP INDEX CONCURRENTLY IF EXISTS mySchema.user_foo_bar',
           context: { options: { quoteIdentifiers: false } }
         }
       ],


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This is a follow up to the [feature request](https://github.com/sequelize/sequelize/issues/13901).
On `removeIndex` it now extends the `options` object
to take in a new attribute, `concurrently`, which
will ensure that the the SQL statement being run
includes `DROP INDEX CONCURRENTLY`...

Having this is nice so developers can use the ORM settings
when dropping an index, safely, instead of having to write
raw SQL.

`concurrently` is a supported attribute on addIndex

Closes https://github.com/sequelize/sequelize/issues/13901
