### PR TITLE
feat(postgres): support for adding foreign keys with NOT VALID

### DIFF
--- a/lib/dialects/abstract/query-generator.js
+++ b/lib/dialects/abstract/query-generator.js
@@ -729,6 +729,10 @@ class QueryGenerator {
           constraintSnippet += ` ON DELETE ${options.onDelete.toUpperCase()}`;
         }
 
+        if (this._dialect.supports.notValid && references.notValid) {
+          constraintSnippet += ' NOT VALID';
+        }
+
         break;
       }
 

--- a/lib/dialects/abstract/query-interface.js
+++ b/lib/dialects/abstract/query-interface.js
@@ -466,10 +466,11 @@ class QueryInterface {
   /**
    * Change a column definition
    *
-   * @param {string} tableName          Table name to change from
-   * @param {string} attributeName      Column name
-   * @param {object} dataTypeOrOptions  Attribute definition for new column
-   * @param {object} [options]          Query options
+   * @param {string} tableName                                Table name to change from
+   * @param {string} attributeName                            Column name
+   * @param {object} dataTypeOrOptions                        Attribute definition for new column
+   * @param {object} [dataTypeOrOptions.references.notValid]  Mark the foreign key being added as NOT VALID to skip validation check. PostgreSQL Only.
+   * @param {object} [options]                                Query options
    */
   async changeColumn(tableName, attributeName, dataTypeOrOptions, options) {
     options = options || {};
@@ -480,7 +481,7 @@ class QueryInterface {
       context: 'changeColumn',
       table: tableName,
     });
-    const sql = this.queryGenerator.changeColumnQuery(tableName, query);
+    const sql = this.queryGenerator.changeColumnQuery(tableName, query, dataTypeOrOptions);
 
     return this.sequelize.query(sql, options);
   }
@@ -730,18 +731,19 @@ class QueryInterface {
    *   onUpdate: 'cascade'
    * });
    *
-   * @param {string} tableName                   Table name where you want to add a constraint
-   * @param {object} options                     An object to define the constraint name, type etc
-   * @param {string} options.type                Type of constraint. One of the values in available constraints(case insensitive)
-   * @param {Array}  options.fields              Array of column names to apply the constraint over
-   * @param {string} [options.name]              Name of the constraint. If not specified, sequelize automatically creates a named constraint based on constraint type, table & column names
-   * @param {string} [options.defaultValue]      The value for the default constraint
-   * @param {object} [options.where]             Where clause/expression for the CHECK constraint
-   * @param {object} [options.references]        Object specifying target table, column name to create foreign key constraint
-   * @param {string} [options.references.table]  Target table name
-   * @param {string} [options.references.field]  Target column name
-   * @param {string} [options.references.fields] Target column names for a composite primary key. Must match the order of fields in options.fields.
-   * @param {string} [options.deferrable]        Sets the constraint to be deferred or immediately checked. See Sequelize.Deferrable. PostgreSQL Only
+   * @param {string} tableName                      Table name where you want to add a constraint
+   * @param {object} options                        An object to define the constraint name, type etc
+   * @param {string} options.type                   Type of constraint. One of the values in available constraints(case insensitive)
+   * @param {Array}  options.fields                 Array of column names to apply the constraint over
+   * @param {string} [options.name]                 Name of the constraint. If not specified, sequelize automatically creates a named constraint based on constraint type, table & column names
+   * @param {string} [options.defaultValue]         The value for the default constraint
+   * @param {object} [options.where]                Where clause/expression for the CHECK constraint
+   * @param {object} [options.references]           Object specifying target table, column name to create foreign key constraint
+   * @param {string} [options.references.table]     Target table name
+   * @param {string} [options.references.field]     Target column name
+   * @param {string} [options.references.fields]    Target column names for a composite primary key. Must match the order of fields in options.fields.
+   * @param {object} [options.references.notValid]  Mark the foreign key being added as NOT VALID to skip validation check. PostgreSQL Only.
+   * @param {string} [options.deferrable]           Sets the constraint to be deferred or immediately checked. See Sequelize.Deferrable. PostgreSQL Only
    *
    * @returns {Promise}
    */

--- a/lib/dialects/postgres/index.js
+++ b/lib/dialects/postgres/index.js
@@ -49,6 +49,7 @@ class PostgresDialect extends AbstractDialect {
     TSVECTOR: true,
     deferrableConstraints: true,
     searchPath: true,
+    notValid: true,
   });
 
   constructor(sequelize) {

--- a/lib/dialects/postgres/query-generator.js
+++ b/lib/dialects/postgres/query-generator.js
@@ -281,7 +281,7 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     return `ALTER TABLE ${quotedTableName} DROP COLUMN ${quotedAttributeName};`;
   }
 
-  changeColumnQuery(tableName, attributes) {
+  changeColumnQuery(tableName, attributes, dataTypeOrOptions) {
     const query = subQuery => `ALTER TABLE ${this.quoteTable(tableName)} ALTER COLUMN ${subQuery};`;
     const sql = [];
     for (const attributeName in attributes) {
@@ -317,6 +317,10 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
 
       if (definition.includes('REFERENCES')) {
         definition = definition.replace(/.+?(?=REFERENCES)/, '');
+        if (dataTypeOrOptions.references && dataTypeOrOptions.references.notValid) {
+          definition = definition.concat(' NOT VALID');
+        }
+
         attrSql += query(`ADD FOREIGN KEY (${this.quoteIdentifier(attributeName)}) ${definition}`).replace('ALTER COLUMN', '');
       } else {
         attrSql += query(`${this.quoteIdentifier(attributeName)} TYPE ${definition}`);

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -181,6 +181,47 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           expect(newForeignKeys).to.be.an('array');
           expect(newForeignKeys).to.have.lengthOf(1);
           expect(newForeignKeys[0].columnName).to.be.equal('level_id');
+
+          if (dialect === 'postgres') {
+            const updatedForeignKeys = await this.sequelize.query(
+              this.queryInterface.queryGenerator.getForeignKeysQuery('users', this.sequelize.config.database),
+              { type: this.sequelize.QueryTypes.FOREIGNKEYS },
+            );
+            expect(Object.keys(updatedForeignKeys[0])).to.have.length(8);
+            expect(updatedForeignKeys[0].condef).to.equal('FOREIGN KEY (level_id) REFERENCES level(id) ON UPDATE CASCADE ON DELETE CASCADE');
+          }
+        });
+
+        it('able to change column to foreign key with notValid', async function () {
+          const foreignKeys = await this.queryInterface.getForeignKeyReferencesForTable('users');
+          expect(foreignKeys).to.be.an('array');
+          expect(foreignKeys).to.be.empty;
+
+          await this.queryInterface.changeColumn('users', 'level_id', {
+            type: DataTypes.INTEGER,
+            references: {
+              model: 'level',
+              key: 'id',
+              notValid: true,
+            },
+            notValid: true,
+            onUpdate: 'cascade',
+            onDelete: 'cascade',
+          });
+
+          const newForeignKeys = await this.queryInterface.getForeignKeyReferencesForTable('users');
+          expect(newForeignKeys).to.be.an('array');
+          expect(newForeignKeys).to.have.lengthOf(1);
+          expect(newForeignKeys[0].columnName).to.be.equal('level_id');
+
+          if (dialect === 'postgres') {
+            const updatedForeignKeys = await this.sequelize.query(
+              this.queryInterface.queryGenerator.getForeignKeysQuery('users', this.sequelize.config.database),
+              { type: this.sequelize.QueryTypes.FOREIGNKEYS },
+            );
+            expect(Object.keys(updatedForeignKeys[0])).to.have.length(8);
+            expect(updatedForeignKeys[0].condef).to.equal('FOREIGN KEY (level_id) REFERENCES level(id) ON UPDATE CASCADE ON DELETE CASCADE NOT VALID');
+          }
         });
 
         it('able to change column property without affecting other properties', async function () {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -307,6 +307,27 @@ if (dialect.startsWith('postgres')) {
           }],
           expectation: 'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(\'value 1\', \'value 2\');ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(\'value 3\', \'value 4\');ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");',
         },
+        {
+          arguments: ['myTable', {
+            col_1: 'ENUM(\'value 1\', \'value 2\') NOT NULL',
+            col_2: 'ENUM(\'value 3\', \'value 4\') NOT NULL',
+          }, { references: { notValid: true, model: 'level', key: 'id'  } }],
+          expectation: 'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(\'value 1\', \'value 2\');ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(\'value 3\', \'value 4\');ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");',
+        },
+        {
+          arguments: ['myTable', {
+            col_1: 'ENUM(\'value 1\', \'value 2\') NOT NULL',
+            col_2: 'INTEGER REFERENCES "level" ("id")',
+          }, { references: { model: 'level', key: 'id'  } }],
+          expectation: 'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(\'value 1\', \'value 2\');ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable"  ADD FOREIGN KEY ("col_2") REFERENCES "level" ("id");',
+        },
+        {
+          arguments: ['myTable', {
+            col_1: 'ENUM(\'value 1\', \'value 2\') NOT NULL',
+            col_2: 'INTEGER REFERENCES "level" ("id")',
+          }, { references: { notValid: true, model: 'level', key: 'id'  } }],
+          expectation: 'ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(\'value 1\', \'value 2\');ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable"  ADD FOREIGN KEY ("col_2") REFERENCES "level" ("id") NOT VALID;',
+        },
       ],
 
       selectQuery: [

--- a/test/unit/sql/add-constraint.test.js
+++ b/test/unit/sql/add-constraint.test.js
@@ -159,6 +159,22 @@ if (current.dialect.supports.constraints.addConstraint) {
           });
         });
 
+        it('not valid', () => {
+          expectsql(sql.addConstraintQuery('myTable', {
+            name: 'foreignkey_mytable_mycolumn',
+            type: 'foreign key',
+            fields: ['myColumn'],
+            references: {
+              table: 'myOtherTable',
+              field: 'id',
+              notValid: true,
+            },
+          }), {
+            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [foreignkey_mytable_mycolumn] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]);',
+            postgres: 'ALTER TABLE "myTable" ADD CONSTRAINT "foreignkey_mytable_mycolumn" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") NOT VALID;',
+          });
+        });
+
         it('supports composite keys', () => {
           expectsql(
             sql.addConstraintQuery('myTable', {
@@ -192,6 +208,24 @@ if (current.dialect.supports.constraints.addConstraint) {
           }), {
             db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON DELETE CASCADE;',
             default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_myOtherTable_fk] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;',
+          });
+        });
+
+        it('uses onDelete, onUpdate with notValid', () => {
+          expectsql(sql.addConstraintQuery('myTable', {
+            type: 'foreign key',
+            fields: ['myColumn'],
+            references: {
+              table: 'myOtherTable',
+              field: 'id',
+              notValid: true,
+            },
+            onUpdate: 'cascade',
+            onDelete: 'cascade',
+          }), {
+            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_myOtherTable_fk] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;',
+            db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON DELETE CASCADE;',
+            postgres: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON UPDATE CASCADE ON DELETE CASCADE NOT VALID;',
           });
         });
 

--- a/test/unit/sql/change-column.test.js
+++ b/test/unit/sql/change-column.test.js
@@ -71,6 +71,28 @@ if (current.dialect.name !== 'sqlite') {
         });
       });
 
+      it('properly generate alter queries for foreign keys and marks that as NOT VALID for postgres', () => {
+        return current.getQueryInterface().changeColumn(Model.getTableName(), 'level_id', {
+          type: DataTypes.INTEGER,
+          references: {
+            model: 'level',
+            key: 'id',
+            notValid: true,
+          },
+          onUpdate: 'cascade',
+          onDelete: 'cascade',
+        }).then(sql => {
+          expectsql(sql, {
+            mssql: 'ALTER TABLE [users] ADD FOREIGN KEY ([level_id]) REFERENCES [level] ([id]) ON DELETE CASCADE;',
+            db2: 'ALTER TABLE "users" ADD CONSTRAINT "level_id_foreign_idx" FOREIGN KEY ("level_id") REFERENCES "level" ("id") ON DELETE CASCADE;',
+            mariadb: 'ALTER TABLE `users` ADD FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+            mysql: 'ALTER TABLE `users` ADD FOREIGN KEY (`level_id`) REFERENCES `level` (`id`) ON DELETE CASCADE ON UPDATE CASCADE;',
+            postgres: 'ALTER TABLE "users"  ADD FOREIGN KEY ("level_id") REFERENCES "level" ("id") ON DELETE CASCADE ON UPDATE CASCADE NOT VALID;',
+            snowflake: 'ALTER TABLE "users"  ADD FOREIGN KEY ("level_id") REFERENCES "level" ("id") ON DELETE CASCADE ON UPDATE CASCADE;',
+          });
+        });
+      });
+
     });
   });
 }

--- a/test/unit/sql/get-constraint-snippet.test.js
+++ b/test/unit/sql/get-constraint-snippet.test.js
@@ -137,6 +137,23 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
 
+      it('uses notValid', () => {
+        expectsql(sql.getConstraintSnippet('myTable', {
+          type: 'foreign key',
+          fields: ['myColumn'],
+          references: {
+            table: 'myOtherTable',
+            field: 'id',
+            notValid: true,
+          },
+          onUpdate: 'cascade',
+          onDelete: 'cascade',
+        }), {
+          postgres: 'CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON UPDATE CASCADE ON DELETE CASCADE NOT VALID',
+          default: 'CONSTRAINT [myTable_myColumn_myOtherTable_fk] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]) ON UPDATE CASCADE ON DELETE CASCADE',
+        });
+      });
+
       it('errors if references object is not passed', () => {
         expect(sql.getConstraintSnippet.bind(sql, 'myTable', {
           type: 'foreign key',

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -1285,6 +1285,13 @@ export interface ModelAttributeColumnReferencesOptions {
    * PostgreSQL only
    */
   deferrable?: Deferrable;
+
+  /**
+   * Mark the foreign key being added as NOT VALID to skip validation check and avoid locks on writes
+   *
+   * PostgreSQL only
+   */
+  notValid?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This extends `addConstraint` and `changeColumn` to support
adding foreign keys (via `ALTER` statements) with a `NOT VALID`
option. It does it by introducing a new attribute `notValid: true`
on the references object (`ModelAttributeColumnReferencesOptions` type).

This is specific to postgres dialect only. Added unit and integration specs,
and update type definition.

NOTE: This doesn't apply to `addColumn` or `createTable`
since PG doesn't support `NOT VALID` on `REFERENCES`,
which is the same syntax being shared by the engine itsefl. Ex: 
```sql
ALTER TABLE "public"."books" ADD COLUMN "usernamee" varchar(30) REFERENCES "users" ("name") ON DELETE SET NULL ON UPDATE CASCADE;
```

Closes https://github.com/sequelize/sequelize/issues/13905
