### PR TITLE
fix(sequelize.d) fix type of `options` arg in `Sequelize.define` method

### DIFF
--- a/types/lib/sequelize.d.ts
+++ b/types/lib/sequelize.d.ts
@@ -1184,7 +1184,7 @@ export class Sequelize extends Hooks {
   public define<M extends Model, TAttributes = M['_attributes']>(
     modelName: string,
     attributes: ModelAttributes<M, TAttributes>,
-    options?: ModelOptions
+    options?: ModelOptions<M>
   ): ModelCtor<M>;
 
   /**


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->
Fix missing `<M>` association in `ModelOptions` argument in `Sequelize.define`method

Closes #13906