### PR TITLE
fix(types): fix QueryInterface#bulkInsert attribute arg type

### DIFF
--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -366,13 +366,15 @@ export const HSTORE: AbstractDataTypeConstructor;
 /**
  * A JSON string column. Only available in postgres.
  */
-export const JSON: AbstractDataTypeConstructor;
-
+ export interface JSON extends AbstractDataTypeConstructor {
+  new (): JSON;
+}
 /**
  * A pre-processed JSON data column. Only available in postgres.
  */
-export const JSONB: AbstractDataTypeConstructor;
-
+export interface JSONB extends AbstractDataTypeConstructor {
+  new (): JSONB;
+}
 /**
  * A default value of the current timestamp
  */

--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -52,6 +52,8 @@ export const ABSTRACT: AbstractDataTypeConstructor;
 interface AbstractDataTypeConstructor {
   key: string;
   warn(link: string, text: string): void;
+  new (): AbstractDataType;
+  (): AbstractDataType;
 }
 
 export interface AbstractDataType {
@@ -366,16 +368,11 @@ export const HSTORE: AbstractDataTypeConstructor;
 /**
  * A JSON string column. Only available in postgres.
  */
-export const JSON: JSONDataTypeConstructor;
+export const JSON: AbstractDataTypeConstructor;
 /**
  * A pre-processed JSON data column. Only available in postgres.
  */
-export const JSONB: JSONDataTypeConstructor;
-
-interface JSONDataTypeConstructor extends AbstractDataTypeConstructor {
-  new (): AbstractDataType;
-  (): AbstractDataType;
-}
+export const JSONB: AbstractDataTypeConstructor;
 
 /**
  * A default value of the current timestamp

--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -367,13 +367,13 @@ export const HSTORE: AbstractDataTypeConstructor;
  * A JSON string column. Only available in postgres.
  */
  export interface JSON extends AbstractDataTypeConstructor {
-  new (): JSON;
+  new (): AbstractDataType;
 }
 /**
  * A pre-processed JSON data column. Only available in postgres.
  */
 export interface JSONB extends AbstractDataTypeConstructor {
-  new (): JSONB;
+  new (): AbstractDataType;
 }
 /**
  * A default value of the current timestamp

--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -336,7 +336,7 @@ interface DateDataTypeConstructor extends AbstractDataTypeConstructor {
   (options?: DateDataTypeOptions): DateDataType;
 }
 
-export interface DateDataType extends AbstractDataTypeConstructor {
+export interface DateDataType extends AbstractDataType {
   options: DateDataTypeOptions;
 }
 

--- a/types/lib/data-types.d.ts
+++ b/types/lib/data-types.d.ts
@@ -366,15 +366,17 @@ export const HSTORE: AbstractDataTypeConstructor;
 /**
  * A JSON string column. Only available in postgres.
  */
- export interface JSON extends AbstractDataTypeConstructor {
-  new (): AbstractDataType;
-}
+export const JSON: JSONDataTypeConstructor;
 /**
  * A pre-processed JSON data column. Only available in postgres.
  */
-export interface JSONB extends AbstractDataTypeConstructor {
+export const JSONB: JSONDataTypeConstructor;
+
+interface JSONDataTypeConstructor extends AbstractDataTypeConstructor {
   new (): AbstractDataType;
+  (): AbstractDataType;
 }
+
 /**
  * A default value of the current timestamp
  */

--- a/types/lib/query-interface.d.ts
+++ b/types/lib/query-interface.d.ts
@@ -497,7 +497,7 @@ export class QueryInterface {
     tableName: TableName,
     records: object[],
     options?: QueryOptions,
-    attributes?: string[] | string
+    attributes?: Record<string, ModelAttributeColumnOptions>
   ): Promise<object | number>;
 
   /**

--- a/types/test/data-types.ts
+++ b/types/test/data-types.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'expect-type';
 import { DataTypes } from 'sequelize';
 
-const { TINYINT, SMALLINT, MEDIUMINT, BIGINT, INTEGER } = DataTypes;
+const { TINYINT, SMALLINT, MEDIUMINT, BIGINT, INTEGER, JSON, JSONB } = DataTypes;
 
 // TINYINT
 expectTypeOf(TINYINT()).toEqualTypeOf<DataTypes.TinyIntegerDataType>();
@@ -32,3 +32,11 @@ expectTypeOf(INTEGER()).toEqualTypeOf<DataTypes.IntegerDataType>();
 expectTypeOf(new INTEGER()).toEqualTypeOf<DataTypes.IntegerDataType>();
 expectTypeOf(INTEGER.UNSIGNED.ZEROFILL()).toEqualTypeOf<DataTypes.IntegerDataType>();
 expectTypeOf(new INTEGER.UNSIGNED.ZEROFILL()).toEqualTypeOf<DataTypes.IntegerDataType>();
+
+// JSON
+expectTypeOf(new JSON()).toEqualTypeOf<DataTypes.AbstractDataType>();
+expectTypeOf(JSON()).toEqualTypeOf<DataTypes.AbstractDataType>();
+
+// JSONB
+expectTypeOf(new JSONB()).toEqualTypeOf<DataTypes.AbstractDataType>();
+expectTypeOf(JSONB()).toEqualTypeOf<DataTypes.AbstractDataType>();

--- a/types/test/data-types.ts
+++ b/types/test/data-types.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from 'expect-type';
 import { DataTypes } from 'sequelize';
 
-const { TINYINT, SMALLINT, MEDIUMINT, BIGINT, INTEGER, JSON, JSONB } = DataTypes;
+const { TINYINT, SMALLINT, MEDIUMINT, BIGINT, INTEGER, JSON, JSONB, CITEXT, MACADDR, TSVECTOR, CIDR, INET } = DataTypes;
 
 // TINYINT
 expectTypeOf(TINYINT()).toEqualTypeOf<DataTypes.TinyIntegerDataType>();
@@ -40,3 +40,23 @@ expectTypeOf(JSON()).toEqualTypeOf<DataTypes.AbstractDataType>();
 // JSONB
 expectTypeOf(new JSONB()).toEqualTypeOf<DataTypes.AbstractDataType>();
 expectTypeOf(JSONB()).toEqualTypeOf<DataTypes.AbstractDataType>();
+
+// CITEXT
+expectTypeOf(new CITEXT()).toEqualTypeOf<DataTypes.AbstractDataType>();
+expectTypeOf(CITEXT()).toEqualTypeOf<DataTypes.AbstractDataType>();
+
+// MACADDR
+expectTypeOf(new MACADDR()).toEqualTypeOf<DataTypes.AbstractDataType>();
+expectTypeOf(MACADDR()).toEqualTypeOf<DataTypes.AbstractDataType>();
+
+// TSVECTOR
+expectTypeOf(new TSVECTOR()).toEqualTypeOf<DataTypes.AbstractDataType>();
+expectTypeOf(TSVECTOR()).toEqualTypeOf<DataTypes.AbstractDataType>();
+
+// CIDR
+expectTypeOf(new CIDR()).toEqualTypeOf<DataTypes.AbstractDataType>();
+expectTypeOf(CIDR()).toEqualTypeOf<DataTypes.AbstractDataType>();
+
+// INET
+expectTypeOf(new INET()).toEqualTypeOf<DataTypes.AbstractDataType>();
+expectTypeOf(INET()).toEqualTypeOf<DataTypes.AbstractDataType>();

--- a/types/test/query-interface.ts
+++ b/types/test/query-interface.ts
@@ -67,6 +67,8 @@ async function test() {
 
   const bulkInsertRes: Promise<number | object> = queryInterface.bulkInsert({ tableName: 'foo', as: 'bar', name: 'as' }, [{}], {});
 
+  const bulkInsertResWithAttrs: Promise<number | object> = queryInterface.bulkInsert('foo', [{}], {}, { bar: { type: DataTypes.JSON } });
+
   await queryInterface.bulkUpdate({ tableName: 'foo', delimiter: 'bar', as: 'baz', name: 'quz' }, {}, {});
 
   await queryInterface.dropTrigger({ tableName: 'foo', as: 'bar', name: 'baz' }, 'foo', {});


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] (N/A) Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This is a very small PR to improve the typings to `bulkInsert` and the `JSON`/`JSONB` data types.

**Motivation:** I have a typescript seeders file that is seeding some JSONB columns in a postgres database. The seed file uses `queryInterface.bulkInsert` to insert a bunch of rows read from a file. But since `queryInterface` does not know the model column types, it does know to convert a few specific columns to JSONB. It was suggested in https://github.com/sequelize/sequelize/issues/8310#issuecomment-430287656 to pass `attributes` as a 4th arg to `bulkInsert`. But the existing types for `attributes` seems to be incorrect. (Additionally I discovered `new Sequelize.JSONB()` was throwing a "not constructable" type error.)

*PS: I'm pretty new to ORMs. Sequelize has been great so far. That's for it!*