### PR TITLE
fix: don't discard commit message on lint fail

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,20 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn commitlint --edit $1
+BOLD_RED="\033[1;31m"
+BOLD_WHITE="\033[1;37m"
+YELLOW="\033[33m"
+WHITE="\033[37m"
+RESET="\033[0m"
+
+exitCode=0
+yarn commitlint --edit $1 || exitCode="$?"
+
+if [ $exitCode -ne 0 ]; then
+	echo "${BOLD_RED}!${BOLD_WHITE} Linting errors found in commit message!${RESET}"
+	echo "${YELLOW}❯${RESET} Commit stored in .git/COMMIT_EDITMESSAGE"
+	echo "${YELLOW}❯${RESET} You can run the following command to update your commit message:"
+	echo "npm run fix-commit"
+fi
+
+exit $exitCode

--- a/package.json
+++ b/package.json
@@ -268,6 +268,7 @@
     "test-mssql": "cross-env DIALECT=mssql npm test",
     "test-db2": "cross-env DIALECT=db2 npm test",
     "----------------------------------------- development ---------------------------------------------": "",
+    "fix-commit": "export TMPFILE=$(mktemp) && grep -v '^#' $(git rev-parse --git-dir)/COMMIT_EDITMSG > $TMPFILE && git commit -e -F $TMPFILE",
     "sscce": "node sscce.js",
     "sscce-mariadb": "cross-env DIALECT=mariadb node sscce.js",
     "sscce-mysql": "cross-env DIALECT=mysql node sscce.js",


### PR DESCRIPTION
### Pull Request Checklist

- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Per #13952, If we fail a commit message, we basically throw it away, which is
frustrating if the commit message was more than trivial, which good
commit messages often are.

Instead, offer the developer a command to recover and re-edit their
commit message.
