### PR TITLE
feat(types): drop TypeScript < 4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts-version: ["3.9", "4.0", "4.1", "4.2", "4.3", "4.4", "4.5"]
+        ts-version: ["4.1", "4.2", "4.3", "4.4", "4.5"]
     name: TS Typings (${{ matrix.ts-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -1,6 +1,9 @@
 # TypeScript
 
-Since v5, Sequelize provides its own TypeScript definitions. Please note that only TS >= 3.1 is supported.
+Sequelize provides its own TypeScript definitions.
+
+Please note that only **TypeScript >= 4.1** is supported.
+Our TypeScript support does not follow SemVer. We will support TypeScript releases for one year, after which they may be dropped in a SemVer MINOR release.
 
 As Sequelize heavily relies on runtime property assignments, TypeScript won't be very useful out of the box. A decent amount of manual type declarations are needed to make models workable.
 

--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -3,7 +3,7 @@
 Sequelize provides its own TypeScript definitions.
 
 Please note that only **TypeScript >= 4.1** is supported.
-Our TypeScript support does not follow SemVer. We will support TypeScript releases for one year, after which they may be dropped in a SemVer MINOR release.
+Our TypeScript support does not follow SemVer. We will support TypeScript releases for at least one year, after which they may be dropped in a SemVer MINOR release.
 
 As Sequelize heavily relies on runtime property assignments, TypeScript won't be very useful out of the box. A decent amount of manual type declarations are needed to make models workable.
 


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [no, the opposite actually] Have you added new tests to prevent regressions?
- [x] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [n/a] Did you update the typescript typings accordingly (if applicable)?
- [n/a] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

Follow-up to https://github.com/sequelize/meetings/issues/6#issuecomment-1013081721
This PR drops support for TypeScript < 4.1 and documents our TS support policy.

This release should cause a SemVer MINOR bump.