### PR TITLE
feat: throw if include.limit set, but not separate

### DIFF
--- a/docs/manual/other-topics/upgrade-to-v7.md
+++ b/docs/manual/other-topics/upgrade-to-v7.md
@@ -16,6 +16,36 @@ As a result, the manual typings that were formerly best-effort guesses on top of
 have been removed and all typings are now directly retrieved from the actual TypeScript code.
 You'll likely find many tiny differences which however should be easy to fix.
 
+### Changes to `include.limit` & `include.separate`
+
+Limiting how many eagerly-loaded entities must be returned always required turning the `include.separate` option on.
+
+When writing the following code, Sequelize v6 would silently turn the `separate` option on.
+
+```typescript
+await User.findAll({
+  include: [{
+    association: User.associations.projects,
+    limit: 1,
+  }],
+});
+```
+
+Due to the extra cost of sequentially running more than one query, Sequelize v7 now asks you
+to acknowledge that a second query must be run by setting `separate` to true yourself.
+
+Instead of the above code, write this:
+
+```typescript
+await User.findAll({
+  include: [{
+    association: User.associations.projects,
+    limit: 1,
+    separate: true,
+  }],
+});
+```
+
 ### Changes to `ConnectionManager`
 
 *This only impacts you if you used `ConnectionManager` directly.*

--- a/lib/model.js
+++ b/lib/model.js
@@ -728,8 +728,8 @@ class Model {
       include.where = include.where ? { [Op.and]: [include.where, include.association.scope] } : include.association.scope;
     }
 
-    if (include.limit && include.separate === undefined) {
-      include.separate = true;
+    if (include.limit && !include.separate) {
+      throw new TypeError('The "separate" option must be true when specifying the "limit" option on an include.');
     }
 
     if (include.separate === true) {

--- a/types/lib/model.d.ts
+++ b/types/lib/model.d.ts
@@ -451,6 +451,8 @@ export interface IncludeOptions extends Filterable<any>, Projectable, Paranoid {
 
   /**
    * Run include in separate queries.
+   *
+   * This must be true if {@link IncludeOptions#limit} is specified.
    */
   separate?: boolean;
 


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `npm run test` or `npm run test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

v7 only.

Specifying `limit` on an eagerly loaded association will silently turn the `separate` option on.

I'm making a small change where the user *must* enable `separate` manually instead. This is an opinionated change, but I believe running two queries sequentially has too much of a performance impact to not notify the user.

It also throws if `separate` is explicitly set to false even though `limit` is specified (whereas currently it will silently ignore `limit`).

---

Still working on this because if `separate` is false, it could generate this kind of query instead:

```sql
SELECT * FROM (SELECT * FROM users LIMIT 2) users 
LEFT JOIN (SELECT * FROM projects LIMIT 2) projects 
  ON projects.uid = users.id;
```