### PR TITLE
docs: document breaking change from #13951

### DIFF
--- a/docs/manual/other-topics/upgrade-to-v7.md
+++ b/docs/manual/other-topics/upgrade-to-v7.md
@@ -36,3 +36,23 @@ sequelize.connectionManager.getConnection({ type: 'read' });
 Sequelize v7 fully supports MS SQL Server 2017 (version 14) onwards, up from 2012 (version 13) in
 Sequelize v6, as this matches Microsoft's own [mainstream support](
 https://docs.microsoft.com/en-us/sql/sql-server/end-of-support/sql-server-end-of-life-overview?view=sql-server-ver15#lifecycle-dates).
+
+### Overridden Model methods won't be called internally
+
+`Model.findOne` and `Model.findAll` are used respectively by `Model.findByPk` and `Model.findOne`.
+This is considered an implementation detail and as such, starting with Sequelize v7,
+overrides of either of these methods will not be called internally by `Model.findByPk` or `Model.findOne`.
+
+In other words, doing this won't break:
+
+```typescript
+class User extends Model {
+  static findOne() {
+    throw new Error('Do not call findOne');
+  }
+}
+
+// this would have thrown "Do not call findOne" in v6
+// but it works in v7
+User.findByPk(1);
+```


### PR DESCRIPTION
### Pull Request Checklist

- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

I did not realize #13951 was a breaking change. https://github.com/sequelize/sequelize/issues/14003 reported breakage following that change.

PR https://github.com/sequelize/sequelize/pull/14004 rolls back the change in v6.
We're keeping the change in v7, and this PR documents the change in `upgrade-to-v7.md`.