### PR TITLE
build(ci): don't run tests twice on v6 PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - v6
+  pull_request:
 
 env:
   SEQ_DB: sequelize_test


### PR DESCRIPTION
CI PR to stop the CI from testing PRs targetting v6 twice.

This is going to trigger a release. I don't know if the release will be aborted since the only change is tagged a build.