### PR TITLE
ci: ignore PRs for stale action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,6 +16,7 @@ jobs:
           days-before-stale: 14
           days-before-close: 14
           operations-per-run: 1000
+          days-before-pr-stale: -1
           days-before-pr-close: -1
           exempt-issue-labels: 'type: bug, type: docs, type: feature, type: other, type: performance, type: refactor, type: typescript' # All 'type: ' labels
       - name: Print outputs


### PR DESCRIPTION
It's just a stupid label, doesn't serve a purpose in my opinion.