### PR TITLE
fix: correct `package.json` path to get version

### DIFF
--- a/lib/sequelize.js
+++ b/lib/sequelize.js
@@ -1308,7 +1308,7 @@ Sequelize.prototype.validate = Sequelize.prototype.authenticate;
 Object.defineProperty(Sequelize, 'version', {
   enumerable: true,
   get() {
-    return require('../../package.json').version;
+    return require('../package.json').version;
   },
 });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterward / while the PR is open. -->

### Description Of Change

This regression was introduced in https://github.com/sequelize/sequelize/commit/51bc05ae806ee11d36764bdafb4e4645d00e93be ( https://github.com/sequelize/sequelize/pull/13569 )

I found there was discussion around this too https://github.com/sequelize/sequelize/pull/13569/files#r734959627 

<img width="843" alt="Screenshot 2022-02-09 at 6 06 52 AM" src="https://user-images.githubusercontent.com/46647141/153099612-eb82a486-b7e3-41e3-ab2d-9c3d391440d9.png">


While upgrading to the latest version, tests in our project started failing with the following error.

<img width="770" alt="Screenshot 2022-02-09 at 6 01 37 AM" src="https://user-images.githubusercontent.com/46647141/153099946-e84cbd3a-c5ca-4c08-9fd3-917b9eadf85a.png">

<!-- Please provide a description of the change here. -->


