### PR TITLE
fix: correct path to `package.json` in Sequelize.version

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1287,7 +1287,7 @@ Sequelize.prototype.validate = Sequelize.prototype.authenticate;
 Object.defineProperty(Sequelize, 'version', {
   enumerable: true,
   get() {
-    return require('../../package.json').version;
+    return require('../package.json').version;
   }
 });
 

--- a/test/unit/sequelize.test.ts
+++ b/test/unit/sequelize.test.ts
@@ -1,0 +1,10 @@
+import { expect } from 'chai';
+import { Sequelize } from 'sequelize';
+
+describe('Sequelize', () => {
+  describe('version', () => {
+    it('should be a string', () => {
+      expect(typeof Sequelize.version).to.eq('string');
+    });
+  });
+});


### PR DESCRIPTION
Alternative PR  to https://github.com/sequelize/sequelize/pull/14071 that fixes the path to package.json in v6 & adds a unit test for it