### PR TITLE
fix(types): allow `Op.not` and `Op.col` in `WhereOptions`

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -115,6 +115,8 @@ export type WhereOptions<TAttributes = any> =
   | OrOperator<TAttributes>
   | Literal
   | Fn
+  | { [Op.not]: WhereOptions<TAttributes> }
+  | { [Op.col]: string }
   | Where;
 
 /**

--- a/test/types/model.ts
+++ b/test/types/model.ts
@@ -11,6 +11,7 @@ import {
   CreationOptional,
   InferAttributes,
   InferCreationAttributes,
+  Op,
 } from 'sequelize';
 
 expectTypeOf<HasOne>().toMatchTypeOf<Association>();
@@ -50,6 +51,18 @@ MyModel.findOne({
     { model: OtherModel, paranoid: true }
   ]
 });
+
+MyModel.findOne({
+  where: {
+    [Op.not]: { foo: 'bar' }
+  }
+})
+
+MyModel.findOne({
+  where: {
+    foo: { [Op.col]: 'MyModel.bar' },
+  }
+})
 
 MyModel.hasOne(OtherModel, { as: 'OtherModelAlias' });
 


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Define `Op.not` and `Op.col` in `WhereOptions`.

### Todos

- [x] N/A