### PR TITLE
build: generate jsdoc from src instead of lib (v6)

### DIFF
--- a/docs/ROUTER.txt
+++ b/docs/ROUTER.txt
@@ -10,18 +10,18 @@
 301 /en/latest/docs/getting-started/ https://sequelize.org/master/manual/getting-started.html
 301 /en/latest/docs/:section/ https://sequelize.org/master/manual/:section.html
 
-301 /en/latest/api/sequelize/ https://sequelize.org/master/class/lib/sequelize.js~Sequelize.html
-301 /en/latest/api/model/ https://sequelize.org/master/class/lib/model.js~Model.html
-301 /en/latest/api/instance/ https://sequelize.org/master/class/lib/model.js~Model.html
-301 /en/latest/api/associations/ https://sequelize.org/master/class/lib/associations/base.js~Association.html
-301 /en/latest/api/associations/belongs-to/ https://sequelize.org/master/class/lib/associations/belongs-to.js~BelongsTo.html
-301 /en/latest/api/associations/belongs-to-many/ https://sequelize.org/master/class/lib/associations/belongs-to-.many.js~BelongsToMany.html
-301 /en/latest/api/associations/has-one/ https://sequelize.org/master/class/lib/associations/has-one.js~HasOne.html
-301 /en/latest/api/associations/has-many/ https://sequelize.org/master/class/lib/associations/has-many.js~HasMany.html
-301 /en/latest/api/transaction/ https://sequelize.org/master/class/lib/transaction.js~Transaction.html
+301 /en/latest/api/sequelize/ https://sequelize.org/master/class/src/sequelize.js~Sequelize.html
+301 /en/latest/api/model/ https://sequelize.org/master/class/src/model.js~Model.html
+301 /en/latest/api/instance/ https://sequelize.org/master/class/src/model.js~Model.html
+301 /en/latest/api/associations/ https://sequelize.org/master/class/src/associations/base.js~Association.html
+301 /en/latest/api/associations/belongs-to/ https://sequelize.org/master/class/src/associations/belongs-to.js~BelongsTo.html
+301 /en/latest/api/associations/belongs-to-many/ https://sequelize.org/master/class/src/associations/belongs-to-.many.js~BelongsToMany.html
+301 /en/latest/api/associations/has-one/ https://sequelize.org/master/class/src/associations/has-one.js~HasOne.html
+301 /en/latest/api/associations/has-many/ https://sequelize.org/master/class/src/associations/has-many.js~HasMany.html
+301 /en/latest/api/transaction/ https://sequelize.org/master/class/src/transaction.js~Transaction.html
 301 /en/latest/api/datatypes/ https://sequelize.org/master/variable/index.html#static-variable-DataTypes
 301 /en/latest/api/deferrable/ https://sequelize.org/master/variable/index.html#static-variable-Deferrable
-301 /en/latest/api/errors/ https://sequelize.org/master/class/lib/errors/base-error.js~BaseError.html
+301 /en/latest/api/errors/ https://sequelize.org/master/class/src/errors/base-error.js~BaseError.html
 
 301 /manual/tutorial/:section.html https://sequelize.org/master/manual/:section.html
 301 /manual/installation/:section.html https://sequelize.org/master/manual/:section.html

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -181,6 +181,6 @@ header a {
 }
 
 a[href="source.html"],
-a[href^="file/lib/"] {
+a[href^="file/src/"] {
   display: none;
 }

--- a/docs/esdoc-config.js
+++ b/docs/esdoc-config.js
@@ -5,9 +5,10 @@ const { getDeclaredManuals, checkManuals } = require('./manual-utils');
 checkManuals();
 
 module.exports = {
-  source: './lib',
+  source: './src',
   destination: './esdoc',
   includes: ['\\.[tj]s$'],
+  excludes: ['\\.d.ts$'],
   plugins: [
     {
       name: 'esdoc-ecmascript-proposal-plugin',

--- a/docs/manual/core-concepts/assocs.md
+++ b/docs/manual/core-concepts/assocs.md
@@ -402,7 +402,7 @@ The above showed the basics on queries for fetching data involving associations.
 
 * Or use the *[special methods/mixins](#special-methods-mixins-added-to-instances)* available for associated models, which are explained later on this page.
 
-**Note:** The [`save()` instance method](../class/lib/model.js~Model.html#instance-method-save) is not aware of associations. In other words, if you change a value from a *child* object that was eager loaded along a *parent* object, calling `save()` on the parent will completely ignore the change that happened on the child.
+**Note:** The [`save()` instance method](../class/src/model.js~Model.html#instance-method-save) is not aware of associations. In other words, if you change a value from a *child* object that was eager loaded along a *parent* object, calling `save()` on the parent will completely ignore the change that happened on the child.
 
 ## Association Aliases & Custom Foreign Keys
 

--- a/docs/manual/core-concepts/getting-started.md
+++ b/docs/manual/core-concepts/getting-started.md
@@ -45,7 +45,7 @@ const sequelize = new Sequelize('database', 'username', 'password', {
 });
 ```
 
-The Sequelize constructor accepts a lot of options. They are documented in the [API Reference](../class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor).
+The Sequelize constructor accepts a lot of options. They are documented in the [API Reference](../class/src/sequelize.js~Sequelize.html#instance-constructor-constructor).
 
 ### Testing the connection
 

--- a/docs/manual/core-concepts/model-basics.md
+++ b/docs/manual/core-concepts/model-basics.md
@@ -4,7 +4,7 @@ In this tutorial you will learn what models are in Sequelize and how to use them
 
 ## Concept
 
-Models are the essence of Sequelize. A model is an abstraction that represents a table in your database. In Sequelize, it is a class that extends [Model](../class/lib/model.js~Model.html).
+Models are the essence of Sequelize. A model is an abstraction that represents a table in your database. In Sequelize, it is a class that extends [Model](../class/src/model.js~Model.html).
 
 The model tells Sequelize several things about the entity it represents, such as the name of the table in the database and which columns it has (and their data types).
 
@@ -14,8 +14,8 @@ A model in Sequelize has a name. This name does not have to be the same name of 
 
 Models can be defined in two equivalent ways in Sequelize:
 
-* Calling [`sequelize.define(modelName, attributes, options)`](../class/lib/sequelize.js~Sequelize.html#instance-method-define)
-* Extending [Model](../class/lib/model.js~Model.html) and calling [`init(attributes, options)`](../class/lib/model.js~Model.html#static-method-init)
+* Calling [`sequelize.define(modelName, attributes, options)`](../class/src/sequelize.js~Sequelize.html#instance-method-define)
+* Extending [Model](../class/src/model.js~Model.html) and calling [`init(attributes, options)`](../class/src/model.js~Model.html#static-method-init)
 
 After a model is defined, it is available within `sequelize.models` by its model name.
 
@@ -23,7 +23,7 @@ To learn with an example, we will consider that we want to create a model to rep
 
 Both ways to define this model are shown below. After being defined, we can access our model with `sequelize.models.User`.
 
-### Using [`sequelize.define`](../class/lib/sequelize.js~Sequelize.html#instance-method-define):
+### Using [`sequelize.define`](../class/src/sequelize.js~Sequelize.html#instance-method-define):
 
 ```js
 const { Sequelize, DataTypes } = require('sequelize');
@@ -47,7 +47,7 @@ const User = sequelize.define('User', {
 console.log(User === sequelize.models.User); // true
 ```
 
-### Extending [Model](../class/lib/model.js~Model.html)
+### Extending [Model](../class/src/model.js~Model.html)
 
 ```js
 const { Sequelize, DataTypes, Model } = require('sequelize');
@@ -190,7 +190,7 @@ sequelize.define('User', {
 
 When you define a model, you're telling Sequelize a few things about its table in the database. However, what if the table actually doesn't even exist in the database? What if it exists, but it has different columns, less columns, or any other difference?
 
-This is where model synchronization comes in. A model can be synchronized with the database by calling [`model.sync(options)`](https://sequelize.org/master/class/lib/model.js~Model.html#static-method-sync), an asynchronous function (that returns a Promise). With this call, Sequelize will automatically perform an SQL query to the database. Note that this changes only the table in the database, not the model in the JavaScript side.
+This is where model synchronization comes in. A model can be synchronized with the database by calling [`model.sync(options)`](https://sequelize.org/master/class/src/model.js~Model.html#static-method-sync), an asynchronous function (that returns a Promise). With this call, Sequelize will automatically perform an SQL query to the database. Note that this changes only the table in the database, not the model in the JavaScript side.
 
 * `User.sync()` - This creates the table if it doesn't exist (and does nothing if it already exists)
 * `User.sync({ force: true })` - This creates the table, dropping it first if it already existed
@@ -205,7 +205,7 @@ console.log("The table for the User model was just (re)created!");
 
 ### Synchronizing all models at once
 
-You can use [`sequelize.sync()`](../class/lib/sequelize.js~Sequelize.html#instance-method-sync) to automatically synchronize all models. Example:
+You can use [`sequelize.sync()`](../class/src/sequelize.js~Sequelize.html#instance-method-sync) to automatically synchronize all models. Example:
 
 ```js
 await sequelize.sync({ force: true });
@@ -318,7 +318,7 @@ sequelize.define('Foo', {
 
 ## Data Types
 
-Every column you define in your model must have a data type. Sequelize provides [a lot of built-in data types](https://github.com/sequelize/sequelize/blob/main/lib/data-types.js). To access a built-in data type, you must import `DataTypes`:
+Every column you define in your model must have a data type. Sequelize provides [a lot of built-in data types](https://github.com/sequelize/sequelize/blob/main/src/data-types.js). To access a built-in data type, you must import `DataTypes`:
 
 ```js
 const { DataTypes } = require("sequelize"); // Import the built-in data types

--- a/docs/manual/core-concepts/model-instances.md
+++ b/docs/manual/core-concepts/model-instances.md
@@ -26,7 +26,7 @@ const User = sequelize.define("user", {
 
 ## Creating an instance
 
-Although a model is a class, you should not create instances by using the `new` operator directly. Instead, the [`build`](../class/lib/model.js~Model.html#static-method-build) method should be used:
+Although a model is a class, you should not create instances by using the `new` operator directly. Instead, the [`build`](../class/src/model.js~Model.html#static-method-build) method should be used:
 
 ```js
 const jane = User.build({ name: "Jane" });
@@ -34,7 +34,7 @@ console.log(jane instanceof User); // true
 console.log(jane.name); // "Jane"
 ```
 
-However, the code above does not communicate with the database at all (note that it is not even asynchronous)! This is because the [`build`](../class/lib/model.js~Model.html#static-method-build) method only creates an object that *represents* data that *can* be mapped to a database. In order to really save (i.e. persist) this instance in the database, the [`save`](../class/lib/model.js~Model.html#instance-method-save) method should be used:
+However, the code above does not communicate with the database at all (note that it is not even asynchronous)! This is because the [`build`](../class/src/model.js~Model.html#static-method-build) method only creates an object that *represents* data that *can* be mapped to a database. In order to really save (i.e. persist) this instance in the database, the [`save`](../class/src/model.js~Model.html#instance-method-save) method should be used:
 
 ```js
 await jane.save();
@@ -45,7 +45,7 @@ Note, from the usage of `await` in the snippet above, that `save` is an asynchro
 
 ### A very useful shortcut: the `create` method
 
-Sequelize provides the [`create`](../class/lib/model.js~Model.html#static-method-create) method, which combines the `build` and `save` methods shown above into a single method:
+Sequelize provides the [`create`](../class/src/model.js~Model.html#static-method-create) method, which combines the `build` and `save` methods shown above into a single method:
 
 ```js
 const jane = await User.create({ name: "Jane" });
@@ -87,7 +87,7 @@ await jane.save();
 // Now the name was updated to "Ada" in the database!
 ```
 
-You can update several fields at once with the [`set`](../class/lib/model.js~Model.html#instance-method-set) method:
+You can update several fields at once with the [`set`](../class/src/model.js~Model.html#instance-method-set) method:
 
 ```js
 const jane = await User.create({ name: "Jane" });
@@ -101,7 +101,7 @@ await jane.save();
 // The database now has "Ada" and "blue" for name and favorite color
 ```
 
-Note that the `save()` here will also persist any other changes that have been made on this instance, not just those in the previous `set` call. If you want to update a specific set of fields, you can use [`update`](../class/lib/model.js~Model.html#instance-method-update):
+Note that the `save()` here will also persist any other changes that have been made on this instance, not just those in the previous `set` call. If you want to update a specific set of fields, you can use [`update`](../class/src/model.js~Model.html#instance-method-update):
 
 ```js
 const jane = await User.create({ name: "Jane" });
@@ -114,7 +114,7 @@ await jane.save()
 
 ## Deleting an instance
 
-You can delete an instance by calling [`destroy`](../class/lib/model.js~Model.html#instance-method-destroy):
+You can delete an instance by calling [`destroy`](../class/src/model.js~Model.html#instance-method-destroy):
 
 ```js
 const jane = await User.create({ name: "Jane" });
@@ -125,7 +125,7 @@ await jane.destroy();
 
 ## Reloading an instance
 
-You can reload an instance from the database by calling [`reload`](../class/lib/model.js~Model.html#instance-method-reload):
+You can reload an instance from the database by calling [`reload`](../class/src/model.js~Model.html#instance-method-reload):
 
 ```js
 const jane = await User.create({ name: "Jane" });
@@ -168,7 +168,7 @@ Also, if only a few attributes have changed when you call `save`, only those fie
 
 ## Incrementing and decrementing integer values
 
-In order to increment/decrement values of an instance without running into concurrency issues, Sequelize provides the [`increment`](../class/lib/model.js~Model.html#instance-method-increment) and [`decrement`](../class/lib/model.js~Model.html#instance-method-decrement) instance methods.
+In order to increment/decrement values of an instance without running into concurrency issues, Sequelize provides the [`increment`](../class/src/model.js~Model.html#instance-method-increment) and [`decrement`](../class/src/model.js~Model.html#instance-method-decrement) instance methods.
 
 ```js
 const jane = await User.create({ name: "Jane", age: 100 });

--- a/docs/manual/core-concepts/model-querying-basics.md
+++ b/docs/manual/core-concepts/model-querying-basics.md
@@ -16,7 +16,7 @@ const jane = await User.create({ firstName: "Jane", lastName: "Doe" });
 console.log("Jane's auto-generated ID:", jane.id);
 ```
 
-The [`Model.create()`](../class/lib/model.js~Model.html#static-method-create) method is a shorthand for building an unsaved instance with [`Model.build()`](../class/lib/model.js~Model.html#static-method-build) and saving the instance with [`instance.save()`](../class/lib/model.js~Model.html#instance-method-save).
+The [`Model.create()`](../class/src/model.js~Model.html#static-method-create) method is a shorthand for building an unsaved instance with [`Model.build()`](../class/src/model.js~Model.html#static-method-build) and saving the instance with [`instance.save()`](../class/src/model.js~Model.html#instance-method-save).
 
 It is also possible to define which attributes can be set in the `create` method. This can be especially useful if you create database entries based on a form which can be filled by a user. Using that would, for example, allow you to restrict the `User` model to set only an username but not an admin flag (i.e., `isAdmin`):
 
@@ -32,7 +32,7 @@ console.log(user.isAdmin); // false
 
 ## Simple SELECT queries
 
-You can read the whole table from the database with the [`findAll`](../class/lib/model.js~Model.html#static-method-findAll) method:
+You can read the whole table from the database with the [`findAll`](../class/src/model.js~Model.html#static-method-findAll) method:
 
 ```js
 // Find all users
@@ -71,7 +71,7 @@ Model.findAll({
 SELECT foo, bar AS baz, qux FROM ...
 ```
 
-You can use [`sequelize.fn`](../class/lib/sequelize.js~Sequelize.html#static-method-fn) to do aggregations:
+You can use [`sequelize.fn`](../class/src/sequelize.js~Sequelize.html#static-method-fn) to do aggregations:
 
 ```js
 Model.findAll({
@@ -375,7 +375,7 @@ Post.findAll({
 // SELECT ... FROM "posts" AS "post" WHERE char_length("content") = 7
 ```
 
-Note the usage of the  [`sequelize.fn`](../class/lib/sequelize.js~Sequelize.html#static-method-fn) and [`sequelize.col`](../class/lib/sequelize.js~Sequelize.html#static-method-col) methods, which should be used to specify an SQL function call and a table column, respectively. These methods should be used instead of passing a plain string (such as `char_length(content)`) because Sequelize needs to treat this situation differently (for example, using other symbol escaping approaches).
+Note the usage of the  [`sequelize.fn`](../class/src/sequelize.js~Sequelize.html#static-method-fn) and [`sequelize.col`](../class/src/sequelize.js~Sequelize.html#static-method-col) methods, which should be used to specify an SQL function call and a table column, respectively. These methods should be used instead of passing a plain string (such as `char_length(content)`) because Sequelize needs to treat this situation differently (for example, using other symbol escaping approaches).
 
 What if you need something even more complex?
 

--- a/docs/manual/core-concepts/raw-queries.md
+++ b/docs/manual/core-concepts/raw-queries.md
@@ -1,6 +1,6 @@
 # Raw Queries
 
-As there are often use cases in which it is just easier to execute raw / already prepared SQL queries, you can use the [`sequelize.query`](../class/lib/sequelize.js~Sequelize.html#instance-method-query) method.
+As there are often use cases in which it is just easier to execute raw / already prepared SQL queries, you can use the [`sequelize.query`](../class/src/sequelize.js~Sequelize.html#instance-method-query) method.
 
 By default the function will return two arguments - a results array, and an object containing metadata (such as amount of affected rows, etc). Note that since this is a raw query, the metadata are dialect specific. Some dialects return the metadata "within" the results object (as properties on an array). However, two arguments will always be returned, but for MSSQL and MySQL it will be two references to the same object.
 
@@ -30,7 +30,7 @@ const projects = await sequelize.query('SELECT * FROM projects', {
 // Each element of `projects` is now an instance of Project
 ```
 
-See more options in the [query API reference](../class/lib/sequelize.js~Sequelize.html#instance-method-query). Some examples:
+See more options in the [query API reference](../class/src/sequelize.js~Sequelize.html#instance-method-query). Some examples:
 
 ```js
 const { QueryTypes } = require('sequelize');

--- a/docs/manual/other-topics/aws-lambda.md
+++ b/docs/manual/other-topics/aws-lambda.md
@@ -455,20 +455,20 @@ presents a set of issues:
 
 1. Lambdas that wait for the event loop to be empty will always time out. `sequelize` connection
    pools schedule a `setTimeout` every
-   [`options.pool.evict`](../class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor)
+   [`options.pool.evict`](../class/src/sequelize.js~Sequelize.html#instance-constructor-constructor)
    ms until **all idle connections have been closed**. However, since `min` is set to `1`, there
    will always be at least one idle connection in the pool, resulting in an infinite event loop.
 1. Some operations like
-   [`Model.findAndCountAll()`](../class/lib/model.js~Model.html#static-method-findAndCountAll)
+   [`Model.findAndCountAll()`](../class/src/model.js~Model.html#static-method-findAndCountAll)
    execute multiple queries asynchronously (e.g.
-   [`Model.count()`](..class/lib/model.js~Model.html#static-method-count) and
-   [`Model.findAll()`](../class/lib/model.js~Model.html#static-method-findAll)). Using a maximum of
+   [`Model.count()`](..class/src/model.js~Model.html#static-method-count) and
+   [`Model.findAll()`](../class/src/model.js~Model.html#static-method-findAll)). Using a maximum of
    one connection forces the queries to be exectued serially (rather than in parallel using two
    connections). While this may be an acceptable performance compromise in order to
    maintain a manageable number of database connections, long running queries may result in
-   [`ConnectionAcquireTimeoutError`](../class/lib/errors/connection/connection-acquire-timeout-error.js~ConnectionAcquireTimeoutError.html)
+   [`ConnectionAcquireTimeoutError`](../class/src/errors/connection/connection-acquire-timeout-error.js~ConnectionAcquireTimeoutError.html)
    if a query takes more than the default or configured
-   [`options.pool.acquire`](../class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor)
+   [`options.pool.acquire`](../class/src/sequelize.js~Sequelize.html#instance-constructor-constructor)
    timeout to complete. This is because the serialized query will be stuck waiting on the pool until
    the connection used by the other query is released.
 1. If the AWS Lambda function times out (i.e. the configured AWS Lambda timeout is exceeded), the
@@ -566,7 +566,7 @@ new Runtime(client, handler, errorCallbacks).scheduleIteration();
 ```
 
 All SQL queries invoked by a Lambda handler using `sequelize` are ultimately executed using
-[Sequelize.prototype.query()](../class/lib/sequelize.js~Sequelize.html#instance-method-query).
+[Sequelize.prototype.query()](../class/src/sequelize.js~Sequelize.html#instance-method-query).
 This method is responsible for obtaining a connection from the pool, executing the query, and
 releasing the connection back to the pool when the query completes. The following snippet shows
 a simplification of the method's logic for queries without transactions:

--- a/docs/manual/other-topics/connection-pool.md
+++ b/docs/manual/other-topics/connection-pool.md
@@ -14,4 +14,4 @@ const sequelize = new Sequelize(/* ... */, {
 });
 ```
 
-Learn more in the [API Reference for the Sequelize constructor](../class/lib/sequelize.js~Sequelize.html#instance-constructor-constructor). If you're connecting to the database from multiple processes, you'll have to create one instance per process, but each instance should have a maximum connection pool size of such that the total maximum size is respected. For example, if you want a max connection pool size of 90 and you have three processes, the Sequelize instance of each process should have a max connection pool size of 30.
+Learn more in the [API Reference for the Sequelize constructor](../class/src/sequelize.js~Sequelize.html#instance-constructor-constructor). If you're connecting to the database from multiple processes, you'll have to create one instance per process, but each instance should have a maximum connection pool size of such that the total maximum size is respected. For example, if you want a max connection pool size of 90 and you have three processes, the Sequelize instance of each process should have a max connection pool size of 30.

--- a/docs/manual/other-topics/hooks.md
+++ b/docs/manual/other-topics/hooks.md
@@ -6,7 +6,7 @@ Hooks (also known as lifecycle events), are functions which are called before an
 
 ## Available hooks
 
-Sequelize provides a lot of hooks. The full list can be found in directly in the [source code - lib/hooks.js](https://github.com/sequelize/sequelize/blob/v6/lib/hooks.js#L7).
+Sequelize provides a lot of hooks. The full list can be found in directly in the [source code - src/hooks.js](https://github.com/sequelize/sequelize/blob/v6/src/hooks.js#L7).
 
 ## Hooks firing order
 

--- a/docs/manual/other-topics/indexes.md
+++ b/docs/manual/other-topics/indexes.md
@@ -1,6 +1,6 @@
 # Indexes
 
-Sequelize supports adding indexes to the model definition which will be created on [`sequelize.sync()`](../class/lib/sequelize.js~Sequelize.html#instance-method-sync).
+Sequelize supports adding indexes to the model definition which will be created on [`sequelize.sync()`](../class/src/sequelize.js~Sequelize.html#instance-method-sync).
 
 ```js
 const User = sequelize.define('User', { /* attributes */ }, {
@@ -35,7 +35,7 @@ const User = sequelize.define('User', { /* attributes */ }, {
       fields: [
         'author',
         {
-          attribute: 'title',
+          name: 'title',
           collate: 'en_US',
           order: 'DESC',
           length: 5

--- a/docs/manual/other-topics/query-interface.md
+++ b/docs/manual/other-topics/query-interface.md
@@ -4,11 +4,11 @@ An instance of Sequelize uses something called **Query Interface** to communicat
 
 The methods from the query interface are therefore lower-level methods; you should use them only if you do not find another way to do it with higher-level APIs from Sequelize. They are, of course, still higher-level than running raw queries directly (i.e., writing SQL by hand).
 
-This guide shows a few examples, but for the full list of what it can do, and for detailed usage of each method, check the [QueryInterface API](../class/lib/dialects/abstract/query-interface.js~QueryInterface.html).
+This guide shows a few examples, but for the full list of what it can do, and for detailed usage of each method, check the [QueryInterface API](../class/src/dialects/abstract/query-interface.js~QueryInterface.html).
 
 ## Obtaining the query interface
 
-From now on, we will call `queryInterface` the singleton instance of the [QueryInterface](../class/lib/dialects/abstract/query-interface.js~QueryInterface.html) class, which is available on your Sequelize instance:
+From now on, we will call `queryInterface` the singleton instance of the [QueryInterface](../class/src/dialects/abstract/query-interface.js~QueryInterface.html) class, which is available on your Sequelize instance:
 
 ```js
 const { Sequelize, DataTypes } = require('sequelize');
@@ -149,4 +149,4 @@ DROP TABLE `Person_backup`;
 
 ## Other
 
-As mentioned in the beginning of this guide, there is a lot more to the Query Interface available in Sequelize! Check the [QueryInterface API](../class/lib/dialects/abstract/query-interface.js~QueryInterface.html) for a full list of what can be done.
+As mentioned in the beginning of this guide, there is a lot more to the Query Interface available in Sequelize! Check the [QueryInterface API](../class/src/dialects/abstract/query-interface.js~QueryInterface.html) for a full list of what can be done.

--- a/docs/manual/other-topics/scopes.md
+++ b/docs/manual/other-topics/scopes.md
@@ -51,7 +51,7 @@ Project.init({
 });
 ```
 
-You can also add scopes after a model has been defined by calling [`YourModel.addScope`](../class/lib/model.js~Model.html#static-method-addScope). This is especially useful for scopes with includes, where the model in the include might not be defined at the time the other model is being defined.
+You can also add scopes after a model has been defined by calling [`YourModel.addScope`](../class/src/model.js~Model.html#static-method-addScope). This is especially useful for scopes with includes, where the model in the include might not be defined at the time the other model is being defined.
 
 The default scope is always applied. This means, that with the model definition above, `Project.findAll()` will create the following query:
 

--- a/docs/transforms/group-data-types.js
+++ b/docs/transforms/group-data-types.js
@@ -4,7 +4,7 @@ function groupDataTypes($, path) {
   let firstLi;
   $('nav a').each(function() {
     /* eslint-disable no-invalid-this */
-    if ($(this).attr('href').startsWith('class/lib/data-types.js~')) {
+    if ($(this).attr('href').startsWith('class/src/data-types.js~')) {
       const li = $(this).closest('li');
       if (!firstLi) {
         firstLi = li;
@@ -19,7 +19,7 @@ function groupDataTypes($, path) {
   if (path.endsWith('identifiers.html')) {
     const rowsToDelete = [];
     $('table.summary td a').each(function() {
-      if ($(this).attr('href').startsWith('class/lib/data-types.js~')) {
+      if ($(this).attr('href').startsWith('class/src/data-types.js~')) {
         rowsToDelete.push($(this).closest('tr'));
       }
     });


### PR DESCRIPTION
Cherry picks https://github.com/sequelize/sequelize/pull/14094 in v6

Fixes https://github.com/sequelize/sequelize/issues/14083 too