### PR TITLE
feat(perf): use `->>` for single paths and strings

### DIFF
--- a/src/dialects/postgres/query-generator.js
+++ b/src/dialects/postgres/query-generator.js
@@ -985,8 +985,21 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
       ? column
       : this.quoteIdentifier(column);
 
-    const join = isJson ? '#>' : '#>>';
-    const pathStr = this.escape(`{${_.toPath(path).join(',')}}`);
+    const useSingular = !isJson && typeof path === 'string' || (Array.isArray(path) && path.length === 1);
+
+    const join = isJson
+      ? '#>'
+      : (useSingular
+        ? '->>'
+        : '#>>'
+      );
+
+    const pathStr = useSingular
+      ? (Array.isArray(path)
+        ? this.escape(path[0])
+        : this.escape(path)
+      )
+      : this.escape(`{${_.toPath(path).join(',')}}`);
 
     return `(${quotedColumn}${join}${pathStr})`;
   }

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -104,7 +104,7 @@ describe(Support.getTestDialectTeaser('Utils'), () => {
           },
           another_json_field: { x: 1 },
         };
-        const expected = '("metadata"#>>\'{language}\') = \'icelandic\' AND ("metadata"#>>\'{pg_rating,dk}\') = \'G\' AND ("another_json_field"#>>\'{x}\') = \'1\'';
+        const expected = '("metadata"->>\'language\') = \'icelandic\' AND ("metadata"#>>\'{pg_rating,dk}\') = \'G\' AND ("another_json_field"->>\'x\') = \'1\'';
         expect(this.queryGenerator.handleSequelizeMethod(new Utils.Json(conditions))).to.deep.equal(expected);
       });
 

--- a/test/unit/dialects/postgres/query-json-path-extraction.test.js
+++ b/test/unit/dialects/postgres/query-json-path-extraction.test.js
@@ -22,12 +22,20 @@ if (dialect === 'postgres') {
       expect(queryGenerator.jsonPathExtractionQuery('profile', 'id', true)).to.equal('("profile"#>\'{id}\')');
     });
 
-    it('should use default handling if isJson is false', async () => {
-      expect(queryGenerator.jsonPathExtractionQuery('profile', 'id', false)).to.equal('("profile"#>>\'{id}\')');
+    it('should use default handling if isJson is false with a string argument', async () => {
+      expect(queryGenerator.jsonPathExtractionQuery('profile', 'id', false)).to.equal('("profile"->>\'id\')');
+    });
+
+    it('should use default handling if isJson is false with a single array argument', async () => {
+      expect(queryGenerator.jsonPathExtractionQuery('profile', ['id'], false)).to.equal('("profile"->>\'id\')');
+    });
+
+    it('should use default handling if isJson is false with a multiple array argument', async () => {
+      expect(queryGenerator.jsonPathExtractionQuery('profile', ['id', 'value'], false)).to.equal('("profile"#>>\'{id,value}\')');
     });
 
     it('Should use default handling if isJson is not passed', async () => {
-      expect(queryGenerator.jsonPathExtractionQuery('profile', 'id')).to.equal('("profile"#>>\'{id}\')');
+      expect(queryGenerator.jsonPathExtractionQuery('profile', 'id')).to.equal('("profile"->>\'id\')');
     });
   });
 }

--- a/test/unit/sql/json.test.js
+++ b/test/unit/sql/json.test.js
@@ -91,7 +91,7 @@ if (current.dialect.supports.JSON) {
 
         it('nested condition object', () => {
           expectsql(sql.whereItemQuery(undefined, Sequelize.json({ profile: { id: 1 } })), {
-            postgres: '("profile"#>>\'{id}\') = \'1\'',
+            postgres: '("profile"->>\'id\') = \'1\'',
             sqlite: 'json_extract(`profile`,\'$.id\') = \'1\'',
             mariadb: 'json_unquote(json_extract(`profile`,\'$.id\')) = \'1\'',
             mysql: 'json_unquote(json_extract(`profile`,\'$.\\"id\\"\')) = \'1\'',
@@ -100,7 +100,7 @@ if (current.dialect.supports.JSON) {
 
         it('multiple condition object', () => {
           expectsql(sql.whereItemQuery(undefined, Sequelize.json({ property: { value: 1 }, another: { value: 'string' } })), {
-            postgres: '("property"#>>\'{value}\') = \'1\' AND ("another"#>>\'{value}\') = \'string\'',
+            postgres: '("property"->>\'value\') = \'1\' AND ("another"->>\'value\') = \'string\'',
             sqlite: 'json_extract(`property`,\'$.value\') = \'1\' AND json_extract(`another`,\'$.value\') = \'string\'',
             mariadb: 'json_unquote(json_extract(`property`,\'$.value\')) = \'1\' AND json_unquote(json_extract(`another`,\'$.value\')) = \'string\'',
             mysql: 'json_unquote(json_extract(`property`,\'$.\\"value\\"\')) = \'1\' AND json_unquote(json_extract(`another`,\'$.\\"value\\"\')) = \'string\'',
@@ -118,7 +118,7 @@ if (current.dialect.supports.JSON) {
 
         it('dot notation', () => {
           expectsql(sql.whereItemQuery(Sequelize.json('profile.id'), '1'), {
-            postgres: '("profile"#>>\'{id}\') = \'1\'',
+            postgres: '("profile"->>\'id\') = \'1\'',
             sqlite: 'json_extract(`profile`,\'$.id\') = \'1\'',
             mariadb: 'json_unquote(json_extract(`profile`,\'$.id\')) = \'1\'',
             mysql: 'json_unquote(json_extract(`profile`,\'$.\\"id\\"\')) = \'1\'',

--- a/test/unit/sql/where.test.js
+++ b/test/unit/sql/where.test.js
@@ -878,7 +878,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       describe('JSON', () => {
         it('sequelize.json("profile.id"), sequelize.cast(2, \'text\')")', function () {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.json('profile.id', this.sequelize.cast('12346-78912', 'text'))), {
-            postgres: '("profile"#>>\'{id}\') = CAST(\'12346-78912\' AS TEXT)',
+            postgres: '("profile"->>\'id\') = CAST(\'12346-78912\' AS TEXT)',
             sqlite: 'json_extract(`profile`,\'$.id\') = CAST(\'12346-78912\' AS TEXT)',
             mariadb: 'json_unquote(json_extract(`profile`,\'$.id\')) = CAST(\'12346-78912\' AS CHAR)',
             mysql: 'json_unquote(json_extract(`profile`,\'$.\\"id\\"\')) = CAST(\'12346-78912\' AS CHAR)',
@@ -887,7 +887,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
         it('sequelize.json({profile: {id: "12346-78912", name: "test"}})', function () {
           expectsql(sql.whereItemQuery(undefined, this.sequelize.json({ profile: { id: '12346-78912', name: 'test' } })), {
-            postgres: '("profile"#>>\'{id}\') = \'12346-78912\' AND ("profile"#>>\'{name}\') = \'test\'',
+            postgres: '("profile"->>\'id\') = \'12346-78912\' AND ("profile"->>\'name\') = \'test\'',
             sqlite: 'json_extract(`profile`,\'$.id\') = \'12346-78912\' AND json_extract(`profile`,\'$.name\') = \'test\'',
             mariadb: 'json_unquote(json_extract(`profile`,\'$.id\')) = \'12346-78912\' AND json_unquote(json_extract(`profile`,\'$.name\')) = \'test\'',
             mysql: 'json_unquote(json_extract(`profile`,\'$.\\"id\\"\')) = \'12346-78912\' AND json_unquote(json_extract(`profile`,\'$.\\"name\\"\')) = \'test\'',
@@ -921,7 +921,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         }, {
           mariadb: 'CAST(json_unquote(json_extract(`data`,\'$.nested\')) AS DECIMAL) IN (1, 2)',
           mysql: 'CAST(json_unquote(json_extract(`data`,\'$.\\"nested\\"\')) AS DECIMAL) IN (1, 2)',
-          postgres: 'CAST(("data"#>>\'{nested}\') AS DOUBLE PRECISION) IN (1, 2)',
+          postgres: 'CAST(("data"->>\'nested\') AS DOUBLE PRECISION) IN (1, 2)',
           sqlite: 'CAST(json_extract(`data`,\'$.nested\') AS DOUBLE PRECISION) IN (1, 2)',
         });
 
@@ -936,7 +936,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         }, {
           mariadb: 'CAST(json_unquote(json_extract(`data`,\'$.nested\')) AS DECIMAL) BETWEEN 1 AND 2',
           mysql: 'CAST(json_unquote(json_extract(`data`,\'$.\\"nested\\"\')) AS DECIMAL) BETWEEN 1 AND 2',
-          postgres: 'CAST(("data"#>>\'{nested}\') AS DOUBLE PRECISION) BETWEEN 1 AND 2',
+          postgres: 'CAST(("data"->>\'nested\') AS DOUBLE PRECISION) BETWEEN 1 AND 2',
           sqlite: 'CAST(json_extract(`data`,\'$.nested\') AS DOUBLE PRECISION) BETWEEN 1 AND 2',
         });
 
@@ -974,7 +974,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         }, {
           mariadb: '(json_unquote(json_extract(`User`.`data`,\'$.name.last\')) = \'Simpson\' AND json_unquote(json_extract(`User`.`data`,\'$.employment\')) != \'None\')',
           mysql: '(json_unquote(json_extract(`User`.`data`,\'$.\\"name\\".\\"last\\"\')) = \'Simpson\' AND json_unquote(json_extract(`User`.`data`,\'$.\\"employment\\"\')) != \'None\')',
-          postgres: '(("User"."data"#>>\'{name,last}\') = \'Simpson\' AND ("User"."data"#>>\'{employment}\') != \'None\')',
+          postgres: '(("User"."data"#>>\'{name,last}\') = \'Simpson\' AND ("User"."data"->>\'employment\') != \'None\')',
           sqlite: '(json_extract(`User`.`data`,\'$.name.last\') = \'Simpson\' AND json_extract(`User`.`data`,\'$.employment\') != \'None\')',
         });
 
@@ -988,7 +988,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         }, {
           mariadb: '(CAST(json_unquote(json_extract(`data`,\'$.price\')) AS DECIMAL) = 5 AND json_unquote(json_extract(`data`,\'$.name\')) = \'Product\')',
           mysql: '(CAST(json_unquote(json_extract(`data`,\'$.\\"price\\"\')) AS DECIMAL) = 5 AND json_unquote(json_extract(`data`,\'$.\\"name\\"\')) = \'Product\')',
-          postgres: '(CAST(("data"#>>\'{price}\') AS DOUBLE PRECISION) = 5 AND ("data"#>>\'{name}\') = \'Product\')',
+          postgres: '(CAST(("data"->>\'price\') AS DOUBLE PRECISION) = 5 AND ("data"->>\'name\') = \'Product\')',
           sqlite: '(CAST(json_extract(`data`,\'$.price\') AS DOUBLE PRECISION) = 5 AND json_extract(`data`,\'$.name\') = \'Product\')',
         });
 


### PR DESCRIPTION
Breaking change to switch to `->>` instead of `#>>` in the case of a
single element array or string

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->
Breaking change, closes #14066.  When a single element or a string are passed, use the single element JSONB operator `->>` instead of the pathing version `#>>`.

This is a change only for postgres.

### Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
