### PR TITLE
feat: merge scope where conditions using the and operator

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1586,6 +1586,16 @@ export interface ModelOptions<M extends Model = Model> {
    * @default false
    */
   version?: boolean | string;
+
+  /**
+   * Enable where scopes merging using Op.and operator.
+   * When enabled, scopes containing the same attribute in a where clause will be grouped with the Op.and operator
+   * For instance merging scopes containing `{ where: { myField: 1 }}` and `{ where: { myField: 2 }}` will result in
+   * `{ where: { [Op.and]: [1, 2] }}`.
+   *
+   * @default false
+   */
+  mergeWhereScopesWithAndOperator?: boolean;
 }
 
 /**

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1586,16 +1586,6 @@ export interface ModelOptions<M extends Model = Model> {
    * @default false
    */
   version?: boolean | string;
-
-  /**
-   * Enable where scopes merging using Op.and operator.
-   * When enabled, scopes containing the same attribute in a where clause will be grouped with the Op.and operator
-   * For instance merging scopes containing `{ where: { myField: 1 }}` and `{ where: { myField: 2 }}` will result in
-   * `{ where: { [Op.and]: [{ myField: 1 }, { myField: 2 }] } }`.
-   *
-   * @default false
-   */
-  mergeWhereScopesWithAndOperator?: boolean;
 }
 
 /**

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1591,7 +1591,7 @@ export interface ModelOptions<M extends Model = Model> {
    * Enable where scopes merging using Op.and operator.
    * When enabled, scopes containing the same attribute in a where clause will be grouped with the Op.and operator
    * For instance merging scopes containing `{ where: { myField: 1 }}` and `{ where: { myField: 2 }}` will result in
-   * `{ where: { [Op.and]: [1, 2] }}`.
+   * `{ where: { [Op.and]: [{ myField: 1 }, { myField: 2 }] } }`.
    *
    * @default false
    */

--- a/src/model.js
+++ b/src/model.js
@@ -861,20 +861,7 @@ class Model {
     }
 
     if (['where', 'having'].includes(key)) {
-      let objKeysToKeep;
-      if (objValue) {
-        const objKeys = Object.getOwnPropertyNames(objValue).concat(Object.getOwnPropertySymbols(objValue));
-        objKeysToKeep = _.filter(objKeys, key => key !== Op.and);
-      }
-
-      return {
-        [Op.and]: _.compact([
-          ...(objValue?.[Op.and] ?? []),
-          !_.isEmpty(objKeysToKeep) && _.pick(objValue, objKeysToKeep),
-          srcValue,
-        ]),
-      };
-
+      return combineWheresWithAnd(objValue, srcValue);
     } else if (key === 'attributes' && _.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
       return _.assignWith(objValue, srcValue, (objValue, srcValue) => {
         if (Array.isArray(objValue) && Array.isArray(srcValue)) {
@@ -4770,6 +4757,58 @@ class Model {
    * Profile.belongsTo(User) // This will add userId to the profile table
    */
   static belongsTo(target, options) {}
+}
+
+/**
+ * Unpacks an object that only contains a single Op.and key to the value of Op.and
+ *
+ * Internal method used by {@link combineWheresWithAnd}
+ *
+ * @param {WhereOptions} where The object to unpack
+ * @example `{ [Op.and]: [a, b] }` becomes `[a, b]`
+ * @example `{ [Op.and]: { key: val } }` becomes `{ key: val }`
+ * @example `{ [Op.or]: [a, b] }` remains as `{ [Op.or]: [a, b] }`
+ * @example `{ [Op.and]: [a, b], key: c }` remains as `{ [Op.and]: [a, b], key: c }`
+ * @private
+ */
+function unpackAnd(where) {
+  if (!_.isObject(where)) {
+    return where;
+  }
+
+  const keys = Utils.getComplexKeys(where);
+
+  // object is empty, remove it.
+  if (keys.length === 0) {
+    return;
+  }
+
+  // we have more than just Op.and, keep as-is
+  if (keys.length !== 1 || keys[0] !== Op.and) {
+    return where;
+  }
+
+  const andParts = where[Op.and];
+
+  return andParts;
+}
+
+function combineWheresWithAnd(whereA, whereB) {
+  const unpackedA = unpackAnd(whereA);
+
+  if (unpackedA === undefined) {
+    return whereB;
+  }
+
+  const unpackedB = unpackAnd(whereB);
+
+  if (unpackedB === undefined) {
+    return whereA;
+  }
+
+  return {
+    [Op.and]: [unpackedA, unpackedB].flat(),
+  };
 }
 
 Object.assign(Model, associationsMixin);

--- a/src/model.js
+++ b/src/model.js
@@ -997,7 +997,7 @@ class Model {
    * @param {string}                  [options.initialAutoIncrement] Set the initial AUTO_INCREMENT value for the table in MySQL.
    * @param {object}                  [options.hooks] An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, validationFailed, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, beforeSave, afterDestroy, afterUpdate, afterBulkCreate, afterSave, afterBulkDestroy and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions.
    * @param {object}                  [options.validate] An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error.
-   * @param {boolean}                 [options.mergeWhereScopesWithAndOperator] Merge `where` properties of scopes by merging similar attributes together with `Op.and`.
+   * @param {boolean}                 [options.mergeWhereScopesWithAndOperator] Merge `where` properties of scopes together by adding `Op.and` at the top-most level.
    *
    * @returns {Model}
    */

--- a/src/model.js
+++ b/src/model.js
@@ -855,6 +855,54 @@ class Model {
     return args[0];
   }
 
+  static _mergeOverlappingAttributeConditions(objValue, srcValue) {
+    const srcValueKeys = Object.getOwnPropertyNames(srcValue).concat(Object.getOwnPropertySymbols(srcValue));
+    srcValueKeys.forEach(key => {
+      switch (key) {
+        case Op.or:
+          if (!objValue[Op.or] && !objValue[Op.and]) {
+            return;
+          }
+
+          objValue[Op.and] = _(objValue[Op.and] || [])
+            .concat([
+              objValue[Op.or] ? { [Op.or]: objValue[Op.or] } : null,
+              { [Op.or]: srcValue[Op.or] },
+            ])
+            .compact()
+            .value();
+          delete objValue[Op.or];
+          break;
+        case Op.and:
+          if (!objValue[key]) {
+            return;
+          }
+
+          objValue[key] = objValue[key].concat(srcValue[key]);
+
+          break;
+        default:
+          if (!objValue[key]) {
+            return;
+          }
+
+          if (objValue[key][Op.and]) {
+            objValue[key] = {
+              [Op.and]: (objValue[key][Op.and]).concat(srcValue[key]),
+            };
+          } else {
+            objValue[key] = {
+              [Op.and]: [objValue[key], srcValue[key]],
+            };
+          }
+
+          break;
+      }
+
+      delete srcValue[key];
+    });
+  }
+
   static _mergeFunction(objValue, srcValue, key) {
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
       return _.union(objValue, srcValue);
@@ -866,6 +914,10 @@ class Model {
       }
 
       if (_.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
+        if (this.options?.mergeWhereScopesWithAndOperator) {
+          this._mergeOverlappingAttributeConditions(objValue, srcValue);
+        }
+
         return Object.assign(objValue, srcValue);
       }
     } else if (key === 'attributes' && _.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
@@ -887,7 +939,7 @@ class Model {
   }
 
   static _assignOptions(...args) {
-    return this._baseMerge(...args, this._mergeFunction);
+    return this._baseMerge(...args, this._mergeFunction.bind(this));
   }
 
   static _defaultsOptions(target, opts) {
@@ -984,6 +1036,7 @@ class Model {
    * @param {string}                  [options.initialAutoIncrement] Set the initial AUTO_INCREMENT value for the table in MySQL.
    * @param {object}                  [options.hooks] An object of hook function that are called before and after certain lifecycle events. The possible hooks are: beforeValidate, afterValidate, validationFailed, beforeBulkCreate, beforeBulkDestroy, beforeBulkUpdate, beforeCreate, beforeDestroy, beforeUpdate, afterCreate, beforeSave, afterDestroy, afterUpdate, afterBulkCreate, afterSave, afterBulkDestroy and afterBulkUpdate. See Hooks for more information about hook functions and their signatures. Each property can either be a function, or an array of functions.
    * @param {object}                  [options.validate] An object of model wide validations. Validations have access to all model values via `this`. If the validator function takes an argument, it is assumed to be async, and is called with a callback that accepts an optional error.
+   * @param {boolean}                 [options.mergeWhereScopesWithAndOperator] Merge `where` properties of scopes by merging similar attributes together with `Op.and`.
    *
    * @returns {Model}
    */
@@ -1033,6 +1086,7 @@ class Model {
       defaultScope: {},
       scopes: {},
       indexes: [],
+      mergeWhereScopesWithAndOperator: false,
       ...options,
     };
 

--- a/test/integration/model/scope/destroy.test.js
+++ b/test/integration/model/scope/destroy.test.js
@@ -54,14 +54,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(users[1].get('username')).to.equal('fred');
       });
 
-      it('should be able to override default scope', async function () {
-        await this.ScopeMe.destroy({ where: { access_level: { [Op.lt]: 5 } } });
-        const users = await this.ScopeMe.unscoped().findAll();
-        expect(users).to.have.length(2);
-        expect(users[0].get('username')).to.equal('tobi');
-        expect(users[1].get('username')).to.equal('dan');
-      });
-
       it('should be able to unscope destroy', async function () {
         await this.ScopeMe.unscoped().destroy({ where: {} });
         await expect(this.ScopeMe.unscoped().findAll()).to.eventually.have.length(0);
@@ -76,6 +68,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       it('should be able to merge scopes with where', async function () {
         await this.ScopeMe.scope('lowAccess').destroy({ where: { username: 'dan' } });
+        const users = await this.ScopeMe.unscoped().findAll();
+        expect(users).to.have.length(3);
+        expect(users[0].get('username')).to.equal('tony');
+        expect(users[1].get('username')).to.equal('tobi');
+        expect(users[2].get('username')).to.equal('fred');
+      });
+
+      it('should be able to merge scopes with similar where', async function () {
+        await this.ScopeMe.scope('defaultScope', 'lowAccess').destroy();
         const users = await this.ScopeMe.unscoped().findAll();
         expect(users).to.have.length(3);
         expect(users[0].get('username')).to.equal('tony');

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -87,6 +87,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(['tony', 'fred'].includes(users[1].username)).to.be.true;
     });
 
+    it('should be able to combine multiple scopes', async function () {
+      const users = await this.ScopeMe.scope('defaultScope', 'highValue').findAll();
+      expect(users).to.have.length(2);
+      expect(['tobi', 'dan'].includes(users[0].username)).to.be.true;
+      expect(['tobi', 'dan'].includes(users[1].username)).to.be.true;
+    });
+
     it('should be able to use a defaultScope if declared', async function () {
       const users = await this.ScopeMe.findAll();
       expect(users).to.have.length(2);

--- a/test/integration/model/scope/findAndCountAll.test.js
+++ b/test/integration/model/scope/findAndCountAll.test.js
@@ -82,6 +82,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(result.count).to.equal(1);
       });
 
+      it('should be able to merge multiple scopes', async function () {
+        const result = await this.ScopeMe.scope('defaultScope', 'lowAccess')
+          .findAndCountAll();
+
+        expect(result.count).to.equal(1);
+      });
+
       it('should ignore the order option if it is found within the scope', async function () {
         const result = await this.ScopeMe.scope('withOrder').findAndCountAll();
         expect(result.count).to.equal(4);

--- a/test/integration/model/scope/update.test.js
+++ b/test/integration/model/scope/update.test.js
@@ -54,14 +54,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         expect(users[1].get('email')).to.equal('dan@sequelizejs.com');
       });
 
-      it('should be able to override default scope', async function () {
-        await this.ScopeMe.update({ username: 'ruben' }, { where: { access_level: { [Op.lt]: 5 } } });
-        const users = await this.ScopeMe.unscoped().findAll({ where: { username: 'ruben' } });
-        expect(users).to.have.length(2);
-        expect(users[0].get('email')).to.equal('tony@sequelizejs.com');
-        expect(users[1].get('email')).to.equal('fred@foobar.com');
-      });
-
       it('should be able to unscope destroy', async function () {
         await this.ScopeMe.unscoped().update({ username: 'ruben' }, { where: {} });
         const rubens = await this.ScopeMe.unscoped().findAll();
@@ -78,6 +70,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       it('should be able to merge scopes with where', async function () {
         await this.ScopeMe.scope('lowAccess').update({ username: 'ruben' }, { where: { username: 'dan' } });
         const users = await this.ScopeMe.unscoped().findAll({ where: { username: 'ruben' } });
+        expect(users).to.have.length(1);
+        expect(users[0].get('email')).to.equal('dan@sequelizejs.com');
+      });
+
+      it('should be able to merge scopes with similar where', async function () {
+        await this.ScopeMe.scope('defaultScope', 'lowAccess').update({ username: 'fakeName' });
+        const users = await this.ScopeMe.unscoped().findAll({ where: { username: 'fakeName' } });
         expect(users).to.have.length(1);
         expect(users[0].get('email')).to.equal('dan@sequelizejs.com');
       });

--- a/test/support.js
+++ b/test/support.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { isDeepStrictEqual } = require('util');
+const { inspect, isDeepStrictEqual } = require('util');
 const _ = require('lodash');
 
 const Sequelize = require('@sequelize/core');
@@ -17,6 +17,12 @@ const distDir = path.resolve(__dirname, '../lib');
 chai.use(require('chai-datetime'));
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
+
+// Using util.inspect to correctly assert objects with symbols
+// Because expect.deep.equal does not test non iterator keys such as symbols (https://github.com/chaijs/chai/issues/1054)
+chai.Assertion.addMethod('deepEqual', function (expected, depth = 5) {
+  expect(inspect(this._obj, { depth })).to.deep.equal(inspect(expected, { depth }));
+});
 
 chai.config.includeStack = true;
 chai.should();

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -1,14 +1,23 @@
 'use strict';
 
 const chai = require('chai');
+const util = require('util');
 
 const expect = chai.expect;
 const Support   = require('../support');
 const Sequelize = require('@sequelize/core');
 
+const Op = Sequelize.Op;
+
 const current   = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  // Using util.inspect to correctly assert objects with symbols
+  // Because expect.deep.equal does not test non iterator keys such as symbols (https://github.com/chaijs/chai/issues/1054)
+  chai.Assertion.addMethod('deepEquals', function (expected, depth = 5) {
+    expect(util.inspect(this._obj, { depth })).to.deep.equal(util.inspect(expected, { depth }));
+  });
+
   describe('all', () => {
     const Referral = current.define('referal');
 
@@ -179,7 +188,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deep.equals({ active: true });
+        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ active: true }] });
       });
 
       it('adds the where from a scoped model', function () {
@@ -188,7 +197,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project.scope('that') }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deep.equals({ that: false });
+        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ that: false }] });
         expect(options.include[0]).to.have.property('limit').which.equals(12);
       });
 
@@ -198,7 +207,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project.scope('attr') }],
         });
 
-        expect(options.include[0]).to.have.property('attributes').which.deep.equals(['baz']);
+        expect(options.include[0]).to.have.property('attributes').which.deepEquals(['baz']);
       });
 
       it('merges where with the where from a scoped model', function () {
@@ -207,7 +216,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ where: { active: false }, model: this.Project.scope('that') }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deep.equals({ active: false, that: false });
+        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ that: false }, { active: false }] });
       });
 
       it('add the where from a scoped associated model', function () {
@@ -216,7 +225,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project, as: 'thisProject' }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deep.equals({ this: true });
+        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ this: true }] });
       });
 
       it('handles a scope with an aliased column (.field)', function () {
@@ -225,7 +234,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project.scope('foobar') }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deep.equals({ foo: 42 });
+        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ foo: 42 }] });
       });
     });
 

--- a/test/unit/model/include.test.js
+++ b/test/unit/model/include.test.js
@@ -1,23 +1,14 @@
 'use strict';
 
 const chai = require('chai');
-const util = require('util');
 
 const expect = chai.expect;
 const Support   = require('../support');
-const Sequelize = require('@sequelize/core');
-
-const Op = Sequelize.Op;
+const { Sequelize, Op, Utils } = require('@sequelize/core');
 
 const current   = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  // Using util.inspect to correctly assert objects with symbols
-  // Because expect.deep.equal does not test non iterator keys such as symbols (https://github.com/chaijs/chai/issues/1054)
-  chai.Assertion.addMethod('deepEquals', function (expected, depth = 5) {
-    expect(util.inspect(this._obj, { depth })).to.deep.equal(util.inspect(expected, { depth }));
-  });
-
   describe('all', () => {
     const Referral = current.define('referal');
 
@@ -188,7 +179,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ active: true }] });
+        expect(options.include[0]).to.have.property('where').which.deep.equals({ active: true });
       });
 
       it('adds the where from a scoped model', function () {
@@ -197,7 +188,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project.scope('that') }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ that: false }] });
+        expect(options.include[0]).to.have.property('where').which.deep.equals({ that: false });
         expect(options.include[0]).to.have.property('limit').which.equals(12);
       });
 
@@ -207,7 +198,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project.scope('attr') }],
         });
 
-        expect(options.include[0]).to.have.property('attributes').which.deepEquals(['baz']);
+        expect(options.include[0]).to.have.property('attributes').which.deep.equals(['baz']);
       });
 
       it('merges where with the where from a scoped model', function () {
@@ -216,7 +207,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ where: { active: false }, model: this.Project.scope('that') }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ that: false }, { active: false }] });
+        // TODO [chai>5]: simplify once '.deep.equals' includes support for symbols (https://github.com/chaijs/chai/issues/1054)
+        expect(options.include[0]).to.have.property('where');
+        expect(Utils.getComplexKeys(options.include[0].where)).to.deep.equal([Op.and]);
+        expect(options.include[0].where[Op.and]).to.deep.equal([{ that: false }, { active: false }]);
       });
 
       it('add the where from a scoped associated model', function () {
@@ -225,7 +219,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project, as: 'thisProject' }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ this: true }] });
+        expect(options.include[0]).to.have.property('where').which.deep.equals({ this: true });
       });
 
       it('handles a scope with an aliased column (.field)', function () {
@@ -234,7 +228,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           include: [{ model: this.Project.scope('foobar') }],
         });
 
-        expect(options.include[0]).to.have.property('where').which.deepEquals({ [Op.and]: [{ foo: 42 }] });
+        expect(options.include[0]).to.have.property('where').which.deep.equals({ foo: 42 });
       });
     });
 

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -263,6 +263,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             field: 3,
           },
         },
+        whereOtherAttributeIs4: {
+          where: {
+            otherField: 4,
+          },
+        },
         whereOpAnd1: {
           where: {
             [Op.and]: [{ field: 1 }, { field: 1 }],
@@ -305,9 +310,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const scope = TestModel.scope(['whereAttributeIs1', 'whereAttributeIs2'])._scope;
           const expected = {
             where: {
-              field: {
-                [Op.and]: [1, 2],
-              },
+              [Op.and]: [
+                { field: 1 },
+                { field: 2 },
+              ],
             },
           };
           expect(util.inspect(scope, { depth: 3 })).to.deep.equal(util.inspect(expected, { depth: 3 }));
@@ -317,9 +323,24 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const scope = TestModel.scope(['whereAttributeIs1', 'whereAttributeIs2', 'whereAttributeIs3'])._scope;
           const expected = {
             where: {
-              field: {
-                [Op.and]: [1, 2, 3],
-              },
+              [Op.and]: [
+                { field: 1 },
+                { field: 2 },
+                { field: 3 },
+              ],
+            },
+          };
+          expect(util.inspect(scope, { depth: 3 })).to.deep.equal(util.inspect(expected, { depth: 3 }));
+        });
+
+        it('should group different attributes with an Op.and', () => {
+          const scope = TestModel.scope(['whereAttributeIs1', 'whereOtherAttributeIs4'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { field: 1 },
+                { otherField: 4 },
+              ],
             },
           };
           expect(util.inspect(scope, { depth: 3 })).to.deep.equal(util.inspect(expected, { depth: 3 }));
@@ -332,12 +353,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { field: 1 }, { field: 1 },
-                { field: 2 }, { field: 2 },
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] },
               ],
             },
           };
-          expect(util.inspect(scope, { depth: 3 })).to.deep.equal(util.inspect(expected, { depth: 3 }));
+          expect(util.inspect(scope, { depth: 5 })).to.deep.equal(util.inspect(expected, { depth: 5 }));
         });
 
         it('should concatenate multiple Op.and into an unique one', () => {
@@ -345,13 +366,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { field: 1 }, { field: 1 },
-                { field: 2 }, { field: 2 },
-                { field: 3 }, { field: 3 },
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] },
+                { [Op.and]: [{ field: 3 }, { field: 3 }] },
               ],
             },
           };
-          expect(util.inspect(scope, { depth: 3 })).to.deep.equal(util.inspect(expected, { depth: 3 }));
+          expect(util.inspect(scope, { depth: 5 })).to.deep.equal(util.inspect(expected, { depth: 5 }));
         });
       });
 
@@ -366,7 +387,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               ],
             },
           };
-          expect(util.inspect(scope, { depth: 4 })).to.deep.equal(util.inspect(expected, { depth: 4 }));
+          expect(util.inspect(scope, { depth: 5 })).to.deep.equal(util.inspect(expected, { depth: 5 }));
         });
 
         it('should group multiple Op.or with an unique Op.and', () => {
@@ -374,13 +395,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { [Op.or]: [{ field: 1 }, { field: 2 }] },
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
                 { [Op.or]: [{ field: 2 }, { field: 2 }] },
                 { [Op.or]: [{ field: 3 }, { field: 3 }] },
               ],
             },
           };
-          expect(util.inspect(scope, { depth: 4 })).to.deep.equal(util.inspect(expected, { depth: 4 }));
+          expect(util.inspect(scope, { depth: 5 })).to.deep.equal(util.inspect(expected, { depth: 5 }));
         });
 
         it('should group multiple Op.or and Op.and with an unique Op.and', () => {
@@ -388,14 +409,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { [Op.or]: [{ field: 1 }, { field: 2 }] },
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
                 { [Op.or]: [{ field: 2 }, { field: 2 }] },
-                { field: 1 }, { field: 1 },
-                { field: 2 }, { field: 2 },
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] },
               ],
             },
           };
-          expect(util.inspect(scope)).to.deep.equal(util.inspect(expected));
+          expect(util.inspect(scope, { depth: 5 })).to.deep.equal(util.inspect(expected, { depth: 5 }));
         });
 
         it('should group multiple Op.and and Op.or with an unique Op.and', () => {
@@ -403,14 +424,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { field: 1 }, { field: 1 },
-                { field: 2 }, { field: 2 },
-                { [Op.or]: [{ field: 1 }, { field: 2 }] },
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] },
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
                 { [Op.or]: [{ field: 2 }, { field: 2 }] },
               ],
             },
           };
-          expect(util.inspect(scope, { depth: 4 })).to.deep.equal(util.inspect(expected, { depth: 4 }));
+          expect(util.inspect(scope, { depth: 5 })).to.deep.equal(util.inspect(expected, { depth: 5 }));
         });
       });
     });


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Issues related:
- https://github.com/sequelize/sequelize/issues/11588
- https://github.com/sequelize/sequelize/issues/10873

Pull request that tried to solve these issues:
- https://github.com/sequelize/sequelize/pull/11805

This pr adds the following elements:
- A way to merge scopes with where clauses using the `AND` operator instead of overwriting it with the last value. It supports merging attributes, `[Op.and]` and `[Op.or]`. 
- The flag `mergeWhereScopesWithAndOperator` to enable this behavior for a model or all the models.

Examples:
```js
// Attributes merging

// Scope 1
whereAttributeIs1: {
  where: {
    field: 1,
  },
},
// Scope 2
whereAttributeIs2: {
  where: {
    field: 2,
  },
}

// Current behavior (without mergeWhereScopesWithAndOperator)
myModel.scope('whereAttributeIs1', 'whereAttributeIs2') ._scope ===
{
  where: {
    field: 2,
  }
}

// Expected behavior (with mergeWhereScopesWithAndOperator)
myModel.scope('whereAttributeIs1', 'whereAttributeIs2') ._scope ===
{
  where: {
    field: {
      [Op.and]: [1, 2]
    }
  }
}
```

```js
// Op.and merging

// Scope 1
whereOpAnd1: {
  where: {
    [Op.and]: [{ field: 1 }],
  },
},
// Scope 2
whereOpAnd2: {
  where: {
    [Op.and]: [{ field: 2 }],
  },
},

// Current behavior (without mergeWhereScopesWithAndOperator)
myModel.scope('whereOpAnd1', 'whereOpAnd2') ._scope ===
{
  where: {
    [Op.and]: [{ field: 2 }],
  },
}

// Expected behavior (with mergeWhereScopesWithAndOperator)
myModel.scope('whereOpAnd1', 'whereOpAnd2') ._scope ===
{
  where: {
    [Op.and]: [{ field: 1 }, { field: 2 }],
  },
}
```

```js
// Op.or merging

// Scope 1
whereOpOr1: {
  where: {
    [Op.or]: [{ field: 1 }],
  },
},
// Scope 2
whereOpOr2: {
  where: {
    [Op.or]: [{ field: 2 }],
  },
},

// Current behavior (without mergeWhereScopesWithAndOperator)
myModel.scope('whereOpOr1', 'whereOpOr2') ._scope ===
{
  where: {
    [Op.or]: [{ field: 2 }]
  },
}

// Expected behavior (with mergeWhereScopesWithAndOperator)
myModel.scope('whereOpAnd1', 'whereOpAnd2') ._scope ===
{
  where: {
    [Op.and]: [
      { [Op.or]: [{ field: 1 }] }, 
      { [Op.or]: [{ field: 2 }] }
    ],
  },
}
```

Why should this be in Sequelize ?

The current behavior for merging different attributes already acts as an `AND` operator. Thus it is natural to expect the  
same behavior for different conditions on the same attribute.