### PR TITLE
feat(postgresql): add connectionTimeoutMillis into dialectOptions

### DIFF
--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -135,6 +135,8 @@ class ConnectionManager extends AbstractConnectionManager {
           'statement_timeout',
           // Times out queries after a set time in milliseconds in client end, query would be still running in database end.
           'query_timeout',
+          // Number of milliseconds to wait for connection, default is no timeout
+          'connectionTimeoutMillis',
           // Terminate any session with an open transaction that has been idle for longer than the specified duration in milliseconds. Added in pg v7.17.0 only supported in postgres >= 10
           'idle_in_transaction_session_timeout',
           // Postgres allows additional session variables to be configured in the connection string in the `options` param.


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->
Add support of "connectionTimeoutMillis" option for PostgreSQL dialect

