### PR TITLE
fix: maintains previousDataValues for update when returning or individual hooks are true

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -3302,7 +3302,8 @@ class Model {
     // Get instances and run beforeUpdate hook on each record individually
     let instances;
     let updateDoneRowByRow = false;
-    if (options.individualHooks) {
+
+    if (options.individualHooks || options.returning) {
       instances = await this.findAll({
         where: options.where,
         transaction: options.transaction,
@@ -3311,63 +3312,67 @@ class Model {
         paranoid: options.paranoid,
       });
 
-      if (instances.length > 0) {
-        // Run beforeUpdate hooks on each record and check whether beforeUpdate hook changes values uniformly
-        // i.e. whether they change values for each record in the same way
-        let changedValues;
-        let different = false;
+      instances = await Promise.all(instances.map(async instance => {
+        // Record updates in instances dataValues
+        Object.assign(instance.dataValues, values);
+        // Set the changed fields on the instance
+        _.forIn(valuesUse, (newValue, attr) => {
+          if (newValue !== instance._previousDataValues[attr]) {
+            instance.setDataValue(attr, newValue);
+          }
+        });
 
-        instances = await Promise.all(instances.map(async instance => {
-          // Record updates in instances dataValues
-          Object.assign(instance.dataValues, values);
-          // Set the changed fields on the instance
-          _.forIn(valuesUse, (newValue, attr) => {
+        return instance;
+      }));
+    }
+
+    if (options.individualHooks && instances.length) {
+      // Run beforeUpdate hooks on each record and check whether beforeUpdate hook changes values uniformly
+      // i.e. whether they change values for each record in the same way
+      let changedValues;
+      let different = false;
+
+      instances = await Promise.all(instances.map(async instance => {
+        // Run beforeUpdate hook
+        await this.runHooks('beforeUpdate', instance, options);
+        if (!different) {
+          const thisChangedValues = {};
+          _.forIn(instance.dataValues, (newValue, attr) => {
             if (newValue !== instance._previousDataValues[attr]) {
-              instance.setDataValue(attr, newValue);
+              thisChangedValues[attr] = newValue;
             }
           });
 
-          // Run beforeUpdate hook
-          await this.runHooks('beforeUpdate', instance, options);
-          if (!different) {
-            const thisChangedValues = {};
-            _.forIn(instance.dataValues, (newValue, attr) => {
-              if (newValue !== instance._previousDataValues[attr]) {
-                thisChangedValues[attr] = newValue;
-              }
-            });
-
-            if (!changedValues) {
-              changedValues = thisChangedValues;
-            } else {
-              different = !_.isEqual(changedValues, thisChangedValues);
-            }
+          if (!changedValues) {
+            changedValues = thisChangedValues;
+          } else {
+            different = !_.isEqual(changedValues, thisChangedValues);
           }
-
-          return instance;
-        }));
-
-        if (!different) {
-          const keys = Object.keys(changedValues);
-          // Hooks do not change values or change them uniformly
-          if (keys.length > 0) {
-            // Hooks change values - record changes in valuesUse so they are executed
-            valuesUse = changedValues;
-            options.fields = _.union(options.fields, keys);
-          }
-        } else {
-          instances = await Promise.all(instances.map(async instance => {
-            const individualOptions = {
-              ...options,
-              hooks: false,
-              validate: false,
-            };
-            delete individualOptions.individualHooks;
-
-            return instance.save(individualOptions);
-          }));
-          updateDoneRowByRow = true;
         }
+
+        return instance;
+      }));
+
+      if (!different) {
+        const keys = Object.keys(changedValues);
+        // Hooks do not change values or change them uniformly
+        if (keys.length > 0) {
+          // Hooks change values - record changes in valuesUse so they are executed
+          valuesUse = changedValues;
+          options.fields = _.union(options.fields, keys);
+        }
+      } else {
+        instances = await Promise.all(instances.map(async instance => {
+          const individualOptions = {
+            ...options,
+            hooks: false,
+            validate: false,
+          };
+          delete individualOptions.individualHooks;
+
+          return instance.save(individualOptions);
+        }));
+        updateDoneRowByRow = true;
       }
     }
 

--- a/src/model.js
+++ b/src/model.js
@@ -3390,8 +3390,7 @@ class Model {
 
       const affectedRows = await this.queryInterface.bulkUpdate(this.getTableName(options), valuesUse, options.where, options, this.tableAttributes);
       if (options.returning) {
-        result = [affectedRows.length, affectedRows];
-        instances = affectedRows;
+        result = [affectedRows.length, instances];
       } else {
         result = [affectedRows];
       }

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -118,6 +118,28 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(account.ownerId).to.be.equal(ownerId);
     });
 
+    it('_previousDataValues should match previous data when returning = true', async function () {
+      const initialDataValues1 = { ownerId: 4, name: 'foo' };
+      const initialDataValues2 = { ownerId: 5, name: 'foo' };
+      await this.Account.bulkCreate([initialDataValues1, initialDataValues2]);
+
+      const [rowCount, [updatedAccount1, updatedAccount2]] = await this.Account.update({ name: 'bar' }, { where: { name: 'foo' }, returning: true });
+
+      expect(updatedAccount1._previousDataValues).to.deep.include({ ownerId: 4, name: 'foo' });
+      expect(updatedAccount2._previousDataValues).to.deep.include({ ownerId: 5, name: 'foo' });
+    });
+
+    it('_previousDataValues should match previous data when individualHooks = true', async function () {
+      const initialDataValues1 = { ownerId: 4, name: 'foo' };
+      const initialDataValues2 = { ownerId: 5, name: 'foo' };
+      await this.Account.bulkCreate([initialDataValues1, initialDataValues2]);
+
+      const [rowCount, [updatedAccount1, updatedAccount2]] = await this.Account.update({ name: 'bar' }, { where: { name: 'foo' }, individualHooks: true });
+
+      expect(updatedAccount1._previousDataValues).to.deep.include({ ownerId: 4, name: 'foo' });
+      expect(updatedAccount2._previousDataValues).to.deep.include({ ownerId: 5, name: 'foo' });
+    });
+
     if (_.get(current.dialect.supports, 'returnValues.returning')) {
       it('should return the updated record', async function () {
         const account = await this.Account.create({ ownerId: 2 });

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -130,14 +130,14 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     it('_previousDataValues should match previous data when individualHooks = true', async function () {
-      const initialDataValues1 = { ownerId: 4, name: 'foo' };
-      const initialDataValues2 = { ownerId: 5, name: 'foo' };
+      const initialDataValues1 = { ownerId: 6, name: 'foo' };
+      const initialDataValues2 = { ownerId: 7, name: 'foo' };
       await this.Account.bulkCreate([initialDataValues1, initialDataValues2]);
 
       const [rowCount, [updatedAccount1, updatedAccount2]] = await this.Account.update({ name: 'bar' }, { where: { name: 'foo' }, individualHooks: true });
 
-      expect(updatedAccount1._previousDataValues).to.deep.include({ ownerId: 4, name: 'foo' });
-      expect(updatedAccount2._previousDataValues).to.deep.include({ ownerId: 5, name: 'foo' });
+      expect(updatedAccount1._previousDataValues).to.deep.include({ ownerId: 6, name: 'foo' });
+      expect(updatedAccount2._previousDataValues).to.deep.include({ ownerId: 7, name: 'foo' });
     });
 
     if (_.get(current.dialect.supports, 'returnValues.returning')) {


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Closes #8803

There is some inconsistency in instance properties on update when `returning: true` and `individualHooks: true`. When returning = true the pre-read instances that get built are overwritten with the returned models from the update (https://github.com/sequelize/sequelize/blob/a729c4df41fa3a58fbecaf879265d2fb73d80e5f/src/model.js#L3389). This causes all the instance properties (e.g. _previousDataValues) to be reset. This is specifically an issue when you have afterUpdate hooks that require the previous data to make a decision. 

I took the approach of expanding pre-read to both individualHooks = true and returning = true. There may be a better approach but not being super familiar with the codebase, this seemed the most obvious. I'm definitely open to suggestions/feedback.


