### PR TITLE
fix(types): update 'replication' option property

### DIFF
--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -161,7 +161,7 @@ export interface Config {
   readonly protocol: 'tcp';
   readonly native: boolean;
   readonly ssl: boolean;
-  readonly replication?: ReplicationOptions | false;
+  readonly replication: ReplicationOptions | false;
   readonly dialectModulePath: null | string;
   readonly keepDefaultTimezone?: boolean;
   readonly dialectOptions?: {

--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -161,7 +161,7 @@ export interface Config {
   readonly protocol: 'tcp';
   readonly native: boolean;
   readonly ssl: boolean;
-  readonly replication: boolean;
+  readonly replication?: ReplicationOptions | false;
   readonly dialectModulePath: null | string;
   readonly keepDefaultTimezone?: boolean;
   readonly dialectOptions?: {
@@ -308,7 +308,7 @@ export interface Options extends Logging {
    *
    * @default false
    */
-  replication?: ReplicationOptions;
+  replication?: ReplicationOptions | false;
 
   /**
    * Connection pool options


### PR DESCRIPTION
### Description Of Change

Type adjustments according **'replication'** option.

I am trying do setup *replication* option asynchronous using for it hook [beforeConnect](https://sequelize.org/master/manual/hooks.html). According types definition hook receive as parameter [Config](https://github.com/sequelize/sequelize/blob/main/src/sequelize.d.ts#L690). As You can see there is no *replication* defined for [Config Interface](https://github.com/sequelize/sequelize/blob/main/src/sequelize.d.ts#L148), which is wrong.

As result in typescript project, when we try define replication  asynchronous in hook

```javascript
const myReplicationConfig = {...};
new Sequelize({
  ...defautlOptions
  hooks: {
    beforeConnect: (config: DeepWriteable<Config>) => {
       // ts error here >>>
       // Type 'false | ReplicationOptions' is not assignable to type 'DeepWriteable<boolean>'.
       // Type 'ReplicationOptions' is not assignable to type 'DeepWriteable<boolean>'
       config.replication = myReplicationConfig;
    },
  },
});
```