### PR TITLE
fix: return type of static increment and decrement functions

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -2216,7 +2216,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     this: ModelStatic<M>,
     field: keyof Attributes<M>,
     options: IncrementDecrementOptionsWithBy<Attributes<M>>
-  ): Promise<M>;
+  ): Promise<[M[], number?]>;
 
   /**
    * Increments multiple fields by the same value.
@@ -2225,7 +2225,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     this: ModelStatic<M>,
     fields: ReadonlyArray<keyof Attributes<M>>,
     options: IncrementDecrementOptionsWithBy<Attributes<M>>
-  ): Promise<M>;
+  ): Promise<[M[], number?]>;
 
   /**
    * Increments multiple fields by different values.
@@ -2234,7 +2234,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     this: ModelStatic<M>,
     fields: { [key in keyof Attributes<M>]?: number },
     options: IncrementDecrementOptions<Attributes<M>>
-  ): Promise<M>;
+  ): Promise<[M[], number?]>;
 
   /**
    * Decrements a single field.
@@ -2243,7 +2243,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     this: ModelStatic<M>,
     field: keyof Attributes<M>,
     options: IncrementDecrementOptionsWithBy<Attributes<M>>
-  ): Promise<M>;
+  ): Promise<[M[], number?]>;
 
   /**
    * Decrements multiple fields by the same value.
@@ -2252,7 +2252,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     this: ModelStatic<M>,
     fields: (keyof Attributes<M>)[],
     options: IncrementDecrementOptionsWithBy<Attributes<M>>
-  ): Promise<M>;
+  ): Promise<[M[], number?]>;
 
   /**
    * Decrements multiple fields by different values.
@@ -2261,7 +2261,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     this: ModelStatic<M>,
     fields: { [key in keyof Attributes<M>]?: number },
     options: IncrementDecrementOptions<Attributes<M>>
-  ): Promise<M>;
+  ): Promise<[M[], number?]>;
 
   /**
    * Run a describe query on the table. The result will be return to the listener as a hash of attributes and

--- a/test/types/model.ts
+++ b/test/types/model.ts
@@ -80,6 +80,30 @@ MyModel.count({ group: 'type' }).then((result) => {
   expectTypeOf(result[0]).toMatchTypeOf<{ count: number }>();
 });
 
+MyModel.increment('num', { by: 1 }).then((result) => {
+  expectTypeOf(result).toEqualTypeOf<[MyModel[], number?]>();
+});
+
+MyModel.increment({ num: 2 }, {}).then((result) => {
+  expectTypeOf(result).toEqualTypeOf<[MyModel[], number?]>();
+});
+
+MyModel.increment(['num'], { by: 3 }).then((result) => {
+  expectTypeOf(result).toEqualTypeOf<[MyModel[], number?]>();
+});
+
+MyModel.decrement('num', { by: 1 }).then((result) => {
+  expectTypeOf(result).toEqualTypeOf<[MyModel[], number?]>();
+});
+
+MyModel.decrement({ num: 2 }, {}).then((result) => {
+  expectTypeOf(result).toEqualTypeOf<[MyModel[], number?]>();
+});
+
+MyModel.decrement(['num'], { by: 3 }).then((result) => {
+  expectTypeOf(result).toEqualTypeOf<[MyModel[], number?]>();
+});
+
 MyModel.build({ int: 10 }, { include: OtherModel });
 
 MyModel.bulkCreate([{ int: 10 }], { include: OtherModel, searchPath: 'public' });
@@ -88,7 +112,7 @@ MyModel.update({}, { where: { foo: 'bar' }, paranoid: false});
 
 const sequelize = new Sequelize('mysql://user:user@localhost:3306/mydb');
 
-const model: typeof MyModel = MyModel.init({
+MyModel.init({
   virtual: {
     type: new DataTypes.VIRTUAL(DataTypes.BOOLEAN, ['num']),
     get() {


### PR DESCRIPTION
Static model methods `increment` and `decrement` returns array. But typescript is implemented differently.