### PR TITLE
fix(types): support union in CreationAttributes

### DIFF
--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -163,4 +163,6 @@ export type UndefinedPropertiesOf<T> = {
  *   name: string,
  * };
  */
-export type MakeUndefinedOptional<T extends object> = Optional<T, UndefinedPropertiesOf<T>>;
+// 'T extends any' is done to support https://github.com/sequelize/sequelize/issues/14129
+// source: https://stackoverflow.com/questions/51691235/typescript-map-union-type-to-another-union-type
+export type MakeUndefinedOptional<T extends object> = T extends any ? Optional<T, UndefinedPropertiesOf<T>> : never;

--- a/test/types/create.ts
+++ b/test/types/create.ts
@@ -1,5 +1,7 @@
 import { expectTypeOf } from 'expect-type'
 import { User } from './models/User';
+import { Model } from 'sequelize';
+import { UserGroup } from './models/UserGroup.js';
 
 (async () => {
     const user = await User.create({
@@ -71,4 +73,31 @@ import { User } from './models/User';
         // @ts-expect-error unknown attribute
         unknown: '<unknown>',
     });
+})();
+
+// reasons for this test: https://github.com/sequelize/sequelize/issues/14129
+(async () => {
+  interface User2Attributes {
+    groupId: number;
+  }
+
+  type User2CreationAttributes = { id: number } & (
+    | { groupId: number }
+    | { group: { id: number } }
+  );
+
+  class User2 extends Model<User2Attributes, User2CreationAttributes> {
+    declare groupId: number;
+    declare group?: UserGroup;
+  }
+
+  await User2.create({
+    id: 1,
+    groupId: 1,
+  });
+
+  await User2.create({
+    id: 2,
+    group: { id: 1 },
+  }, { include: [User2.associations.group] });
 })();


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

PR https://github.com/sequelize/sequelize/pull/13909 introduced a change where creation attributes that accept `undefined` were also as being `optional` in typings.

The way this change was implemented is incompatible with TS unions and broke with the following example https://github.com/sequelize/sequelize/issues/14129

closes https://github.com/sequelize/sequelize/issues/14129

I'm bringing this change in v6 only for backward compatibility. I will bring a different solution in v7, see https://github.com/sequelize/sequelize/pull/14091#issuecomment-1046227092 for more