### PR TITLE
feat(types): infer nullable creation attributes as optional

### DIFF
--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -75,6 +75,24 @@ Important things to know about `InferAttributes` & `InferCreationAttributes` wor
 
 `InferCreationAttributes` works the same way as `AttributesOf` with one exception: Properties typed using the `CreationOptional` type
 will be marked as optional.
+Note that attributes that accept `null`, or `undefined` do not need to use `CreationOptional`:
+
+```typescript
+class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+  declare firstName: string;
+
+  // there is no need to use CreationOptional on firstName because nullable attributes
+  // are always optional in User.create()
+  declare lastName: string | null;
+}
+
+// ...
+
+await User.create({
+  firstName: 'Zoé',
+  // last name omitted, but this is still valid!
+});
+```
 
 You only need to use `CreationOptional` & `NonAttribute` on class instance fields or getters.
 
@@ -109,7 +127,7 @@ class User extends Model<InferAttributes<User, { omit: 'projects' }>, InferCreat
   // Since TS cannot determine model association at compile time
   // we have to declare them here purely virtually
   // these will not exist until `Model.init` was called.
-  declare getProjects: HasManyGetAssociationsMixin<Project>; // Note the null assertions!
+  declare getProjects: HasManyGetAssociationsMixin<Project>;
   declare addProject: HasManyAddAssociationMixin<Project, number>;
   declare addProjects: HasManyAddAssociationsMixin<Project, number>;
   declare setProjects: HasManySetAssociationsMixin<Project, number>;

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -6,7 +6,7 @@ import { HookReturn, Hooks, ModelHooks } from './hooks';
 import { ValidationOptions } from './instance-validator';
 import { IndexesOptions, QueryOptions, TableName } from './dialects/abstract/query-interface';
 import { Sequelize, SyncOptions } from './sequelize';
-import { Col, Fn, Literal, Where, MakeUndefinedOptional, AnyFunction } from './utils';
+import { Col, Fn, Literal, Where, MakeNullishOptional, AnyFunction } from './utils';
 import { LOCK, Transaction, Op } from './index';
 import { SetRequired } from './utils/set-required';
 
@@ -2784,7 +2784,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    *
    * @param values an object of key value pairs
    */
-  constructor(values?: MakeUndefinedOptional<TCreationAttributes>, options?: BuildOptions);
+  constructor(values?: MakeNullishOptional<TCreationAttributes>, options?: BuildOptions);
 
   /**
    * Get an object representing the query for this instance, use with `options.where`
@@ -3174,7 +3174,7 @@ type InternalInferAttributeKeysFromFields<M extends Model, Key extends keyof M, 
  * @example
  * function buildModel<M extends Model>(modelClass: ModelStatic<M>, attributes: CreationAttributes<M>) {}
  */
-export type CreationAttributes<M extends Model | Hooks> = MakeUndefinedOptional<M['_creationAttributes']>;
+export type CreationAttributes<M extends Model | Hooks> = MakeNullishOptional<M['_creationAttributes']>;
 
 /**
  * Returns the creation attributes of a given Model.

--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -127,32 +127,35 @@ export class Where extends SequelizeMethod {
 export type AnyFunction = (...args: any[]) => any;
 
 /**
- * Returns all shallow properties that accept `undefined`.
- * Does not include Optional properties, only `undefined`.
+ * Returns all shallow properties that accept `undefined` or `null`.
+ * Does not include Optional properties, only `undefined` or `null`.
  *
  * @example
- * type UndefinedProps = UndefinedPropertiesOf<{
+ * type UndefinedProps = NullishPropertiesOf<{
  *   id: number | undefined,
  *   createdAt: string | undefined,
- *   firstName: string,
+ *   firstName: string | null, // nullable properties are included
  *   lastName?: string, // optional properties are not included.
  * }>;
  *
  * // is equal to
  *
- * type UndefinedProps = 'id' | 'createdAt';
+ * type UndefinedProps = 'id' | 'createdAt' | 'firstName';
  */
-export type UndefinedPropertiesOf<T> = {
-  [P in keyof T]-?: undefined extends T[P] ? P : never
+export type NullishPropertiesOf<T> = {
+  [P in keyof T]-?: undefined extends T[P] ? P
+    : null extends T[P] ? P
+    : never
 }[keyof T];
 
 /**
- * Makes all shallow properties of an object `optional` if they accept `undefined` as a value.
+ * Makes all shallow properties of an object `optional` if they accept `undefined` or `null` as a value.
  *
  * @example
  * type MyOptionalType = MakeUndefinedOptional<{
  *   id: number | undefined,
- *   name: string,
+ *   firstName: string,
+ *   lastName: string | null,
  * }>;
  *
  * // is equal to
@@ -160,7 +163,9 @@ export type UndefinedPropertiesOf<T> = {
  * type MyOptionalType = {
  *   // this property is optional.
  *   id?: number | undefined,
- *   name: string,
+ *   firstName: string,
+ *   // this property is optional.
+ *   lastName?: string | null,
  * };
  */
-export type MakeUndefinedOptional<T extends object> = Optional<T, UndefinedPropertiesOf<T>>;
+export type MakeNullishOptional<T extends object> = Optional<T, NullishPropertiesOf<T>>;

--- a/test/types/infer-attributes.ts
+++ b/test/types/infer-attributes.ts
@@ -21,6 +21,7 @@ class User extends Model<InferAttributes<User, { omit: 'omittedAttribute' | 'omi
   declare optionalArrayAttribute: CreationOptional<string[]>;
   declare mandatoryArrayAttribute: string[];
 
+  // note: using CreationOptional here is unnecessary, but we still ensure that it works.
   declare nullableOptionalAttribute: CreationOptional<string | null>;
 
   declare nonAttribute: NonAttribute<string>;
@@ -117,4 +118,13 @@ expectTypeOf<UserCreationAttributes>().not.toHaveProperty('staticMethod');
 {
   // ensure branding does not break null
   const brandedString: NonAttribute<string | null> = null;
+}
+
+{
+  class User2 extends Model<InferAttributes<User2>, InferCreationAttributes<User2>> {
+    declare nullableAttribute: string | null;
+  }
+
+  // this should work, all null attributes are optional in Model.create
+  User2.create({});
 }


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Small change in how we infer CreationAttributes.

`nullable` columns don't require explicitly setting them to `null` when inserting a new row.

This PR reflects this behavior by making all nullable attributes automatically optional in `Model.create`, without needing to use `CreationOptional`.

The following code:

```typescript
class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
  firstName: CreationOptional<string | null>;
}

User.create({});
```

can be simplified to

```typescript
class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
  firstName: string | null;
}

User.create({});
```

Of couse, `CreationOptional` must still be used on other non-nullable attributes that have default values.