### PR TITLE
docs(postgres): clarify pg version for Node >=14

### DIFF
--- a/docs/manual/other-topics/dialect-specific-things.md
+++ b/docs/manual/other-topics/dialect-specific-things.md
@@ -61,7 +61,7 @@ The following fields may be passed to SQLite `dialectOptions`:
 
 ### PostgreSQL
 
-The underlying connector library used by Sequelize for PostgreSQL is the [pg](https://www.npmjs.com/package/pg) package (version 7.0.0 or above). The module [pg-hstore](https://www.npmjs.com/package/pg-hstore) is also necessary.
+The underlying connector library used by Sequelize for PostgreSQL is the [pg](https://www.npmjs.com/package/pg) package. For usage in Node 14 and above you need to use pg version 8.2.x or above, as per [the documentation](https://node-postgres.com/#version-compatibility). The module [pg-hstore](https://www.npmjs.com/package/pg-hstore) is also necessary.
 
 You can provide custom options to it using the `dialectOptions` in the Sequelize constructor:
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->

Fixes #14056 by clarifying that pg@>=8.2.x needs to be used with Node 14 as mentioned in the documentation linked. I removed the minimum version for now but that can return if we also know our CI policy for that (like if we want to run tests on pg@7 as well or not)