### PR TITLE
feat(scopes): add whereScopeStrategy to merge where scopes with Op.and

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1579,6 +1579,19 @@ export interface ModelOptions<M extends Model = Model> {
    * @default false
    */
   version?: boolean | string;
+
+  /**
+   * Specify the scopes merging strategy (default 'overwrite'). Valid values are 'and' and 'overwrite'.
+   * When the 'and' strategy is set, scopes will be grouped using the Op.and operator.
+   * For instance merging scopes containing `{ where: { myField: 1 }}` and `{ where: { myField: 2 }}` will result in
+   * `{ where: { [Op.and]: [{ myField: 1 }, { myField: 2 }] } }`.
+   * When the 'overwrite' strategy is set, scopes containing the same attribute in a where clause will be overwritten by the lastly defined one.
+   * For instance merging scopes containing `{ where: { myField: 1 }}` and `{ where: { myField: 2 }}` will result in
+   * `{ where: { myField: 2 } }`.
+   *
+   * @default false
+   */
+  whereMergeStrategy?: 'and' | 'overwrite';
 }
 
 /**

--- a/test/support.js
+++ b/test/support.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { isDeepStrictEqual } = require('util');
+const { inspect, isDeepStrictEqual } = require('util');
 const _ = require('lodash');
 
 const Sequelize = require('sequelize');
@@ -15,6 +15,13 @@ const distDir = path.resolve(__dirname, '../lib');
 chai.use(require('chai-datetime'));
 chai.use(require('chai-as-promised'));
 chai.use(require('sinon-chai'));
+
+// Using util.inspect to correctly assert objects with symbols
+// Because expect.deep.equal does not test non iterator keys such as symbols (https://github.com/chaijs/chai/issues/1054)
+chai.Assertion.addMethod('deepEqual', function(expected, depth = 5) {
+  expect(inspect(this._obj, { depth })).to.deep.equal(inspect(expected, { depth }));
+});
+
 chai.config.includeStack = true;
 chai.should();
 

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -6,9 +6,16 @@ const chai = require('chai'),
   Op = Sequelize.Op,
   Support   = require('../support'),
   DataTypes = require('sequelize/lib/data-types'),
-  current   = Support.sequelize;
+  current   = Support.sequelize,
+  util      = require('util');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  // Using util.inspect to correctly assert objects with symbols
+  // Because expect.deep.equal does not test non iterator keys such as symbols (https://github.com/chaijs/chai/issues/1054)
+  chai.Assertion.addMethod('deepEqual', function(expected, depth = 5) {
+    expect(util.inspect(this._obj, { depth })).to.deep.equal(util.inspect(expected, { depth }));
+  });
+
   const Project = current.define('project'),
     User = current.define('user');
 
@@ -239,6 +246,232 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           active: true,
           other_value: 11
         }
+      });
+    });
+
+    describe('merging scopes using `and` whereMergeStrategy', () => {
+      const testModelScopes = {
+        whereAttributeIs1: {
+          where: {
+            field: 1
+          }
+        },
+        whereAttributeIs2: {
+          where: {
+            field: 2
+          }
+        },
+        whereAttributeIs3: {
+          where: {
+            field: 3
+          }
+        },
+        whereOtherAttributeIs4: {
+          where: {
+            otherField: 4
+          }
+        },
+        whereOpAnd1: {
+          where: {
+            [Op.and]: [{ field: 1 }, { field: 1 }]
+          }
+        },
+        whereOpAnd2: {
+          where: {
+            [Op.and]: [{ field: 2 }, { field: 2 }]
+          }
+        },
+        whereOpAnd3: {
+          where: {
+            [Op.and]: [{ field: 3 }, { field: 3 }]
+          }
+        },
+        whereOpOr1: {
+          where: {
+            [Op.or]: [{ field: 1 }, { field: 1 }]
+          }
+        },
+        whereOpOr2: {
+          where: {
+            [Op.or]: [{ field: 2 }, { field: 2 }]
+          }
+        },
+        whereOpOr3: {
+          where: {
+            [Op.or]: [{ field: 3 }, { field: 3 }]
+          }
+        },
+        whereSequelizeWhere1: {
+          where: Sequelize.where('field', Op.is, 1)
+        },
+        whereSequelizeWhere2: {
+          where: Sequelize.where('field', Op.is, 2)
+        }
+      };
+
+      const TestModel = current.define('testModel', {}, {
+        whereMergeStrategy: 'and',
+        scopes: testModelScopes
+      });
+
+      describe('attributes', () => {
+        it('should group 2 similar attributes with an Op.and', () => {
+          const scope = TestModel.scope(['whereAttributeIs1', 'whereAttributeIs2'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { field: 1 },
+                { field: 2 }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+
+        it('should group multiple similar attributes with an unique Op.and', () => {
+          const scope = TestModel.scope(['whereAttributeIs1', 'whereAttributeIs2', 'whereAttributeIs3'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { field: 1 },
+                { field: 2 },
+                { field: 3 }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+
+        it('should group different attributes with an Op.and', () => {
+          const scope = TestModel.scope(['whereAttributeIs1', 'whereOtherAttributeIs4'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { field: 1 },
+                { otherField: 4 }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+      });
+
+      describe('and operators', () => {
+        it('should concatenate 2 Op.and into an unique one', () => {
+          const scope = TestModel.scope(['whereOpAnd1', 'whereOpAnd2'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+
+        it('should concatenate multiple Op.and into an unique one', () => {
+          const scope = TestModel.scope(['whereOpAnd1', 'whereOpAnd2', 'whereOpAnd3'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] },
+                { [Op.and]: [{ field: 3 }, { field: 3 }] }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+      });
+
+      describe('or operators', () => {
+        it('should group 2 Op.or with an Op.and', () => {
+          const scope = TestModel.scope(['whereOpOr1', 'whereOpOr2'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
+                { [Op.or]: [{ field: 2 }, { field: 2 }] }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+
+        it('should group multiple Op.or with an unique Op.and', () => {
+          const scope = TestModel.scope(['whereOpOr1', 'whereOpOr2', 'whereOpOr3'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
+                { [Op.or]: [{ field: 2 }, { field: 2 }] },
+                { [Op.or]: [{ field: 3 }, { field: 3 }] }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+
+        it('should group multiple Op.or and Op.and with an unique Op.and', () => {
+          const scope = TestModel.scope(['whereOpOr1', 'whereOpOr2', 'whereOpAnd1', 'whereOpAnd2'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
+                { [Op.or]: [{ field: 2 }, { field: 2 }] },
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+
+        it('should group multiple Op.and and Op.or with an unique Op.and', () => {
+          const scope = TestModel.scope(['whereOpAnd1', 'whereOpAnd2', 'whereOpOr1', 'whereOpOr2'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.and]: [{ field: 2 }, { field: 2 }] },
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
+                { [Op.or]: [{ field: 2 }, { field: 2 }] }
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+      });
+
+      describe('sequelize where', () => {
+        it('should group 2 sequelize.where with an Op.and', () => {
+          const scope = TestModel.scope(['whereSequelizeWhere1', 'whereSequelizeWhere2'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                Sequelize.where('field', Op.is, 1),
+                Sequelize.where('field', Op.is, 2)
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
+
+        it('should group 2 sequelize.where and other scopes with an Op.and', () => {
+          const scope = TestModel.scope(['whereAttributeIs1', 'whereOpAnd1', 'whereOpOr1', 'whereSequelizeWhere1'])._scope;
+          const expected = {
+            where: {
+              [Op.and]: [
+                { field: 1 },
+                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { [Op.or]: [{ field: 1 }, { field: 1 }] },
+                Sequelize.where('field', Op.is, 1)
+              ]
+            }
+          };
+          expect(scope).to.deepEqual(expected);
+        });
       });
     });
 
@@ -492,6 +725,115 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(options.include).to.have.length(2);
       expect(options.include[0]).to.deep.equal({ model: Project, where: { something: false } });
       expect(options.include[1]).to.deep.equal({ model: User, where: { something: true } });
+    });
+
+    describe('using `and` whereMergeStrategy', () => {
+      before(() => {
+        Sequelize.Model.options = { whereMergeStrategy: 'and' };
+      });
+
+      after(() => {
+        Sequelize.Model.options = { whereMergeStrategy: 'overwrite' };
+      });
+
+      it('should be able to merge scope and where', () => {
+        Sequelize.Model._scope = {
+          where: { something: true, somethingElse: 42 },
+          limit: 15,
+          offset: 3
+        };
+        const options = {
+          where: {
+            something: false
+          },
+          limit: 9
+        };
+
+        Sequelize.Model._injectScope(options);
+
+        expect(options).to.deepEqual({
+          where: {
+            [Op.and]: [
+              { something: true, somethingElse: 42 },
+              { something: false }
+            ]
+          },
+          limit: 9,
+          offset: 3
+        });
+      });
+
+      it('should be able to merge scope and having', () => {
+        Sequelize.Model._scope = {
+          having: { something: true, somethingElse: 42 },
+          limit: 15,
+          offset: 3
+        };
+        const options = {
+          having: {
+            something: false
+          },
+          limit: 9
+        };
+
+        Sequelize.Model._injectScope(options);
+
+        expect(options).to.deepEqual({
+          having: {
+            [Op.and]: [
+              { something: true, somethingElse: 42 },
+              { something: false }
+            ]
+          },
+          limit: 9,
+          offset: 3
+        });
+      });
+
+      it('should be able to merge scopes with the same include', () => {
+        Sequelize.Model._scope = {
+          include: [
+            { model: Project, where: { something: false, somethingElse: 99 } },
+            { model: Project, where: { something: true }, limit: 1 }
+          ]
+        };
+        const options = {};
+        Sequelize.Model._injectScope(options);
+
+        expect(options.include).to.have.length(1);
+        expect(options.include[0]).to.deepEqual({
+          model: Project,
+          where: {
+            [Op.and]: [
+              { something: false, somethingElse: 99 },
+              { something: true }
+            ]
+          },
+          limit: 1
+        });
+      });
+
+      it('should be able to merge scoped include', () => {
+        Sequelize.Model._scope = {
+          include: [{ model: Project, where: { something: false, somethingElse: 99 } }]
+        };
+        const options = {
+          include: [{ model: Project, where: { something: true }, limit: 1 }]
+        };
+        Sequelize.Model._injectScope(options);
+
+        expect(options.include).to.have.length(1);
+        expect(options.include[0]).to.deepEqual({
+          model: Project,
+          where: {
+            [Op.and]: [
+              { something: false, somethingElse: 99 },
+              { something: true }
+            ]
+          },
+          limit: 1
+        });
+      });
     });
 
     describe('include all', () => {

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -6,16 +6,9 @@ const chai = require('chai'),
   Op = Sequelize.Op,
   Support   = require('../support'),
   DataTypes = require('sequelize/lib/data-types'),
-  current   = Support.sequelize,
-  util      = require('util');
+  current   = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  // Using util.inspect to correctly assert objects with symbols
-  // Because expect.deep.equal does not test non iterator keys such as symbols (https://github.com/chaijs/chai/issues/1054)
-  chai.Assertion.addMethod('deepEqual', function(expected, depth = 5) {
-    expect(util.inspect(this._obj, { depth })).to.deep.equal(util.inspect(expected, { depth }));
-  });
-
   const Project = current.define('project'),
     User = current.define('user');
 
@@ -362,8 +355,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { [Op.and]: [{ field: 1 }, { field: 1 }] },
-                { [Op.and]: [{ field: 2 }, { field: 2 }] }
+                { field: 1 },
+                { field: 1 },
+                { field: 2 },
+                { field: 2 }
               ]
             }
           };
@@ -375,9 +370,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { [Op.and]: [{ field: 1 }, { field: 1 }] },
-                { [Op.and]: [{ field: 2 }, { field: 2 }] },
-                { [Op.and]: [{ field: 3 }, { field: 3 }] }
+                { field: 1 },
+                { field: 1 },
+                { field: 2 },
+                { field: 2 },
+                { field: 3 },
+                { field: 3 }
               ]
             }
           };
@@ -420,8 +418,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               [Op.and]: [
                 { [Op.or]: [{ field: 1 }, { field: 1 }] },
                 { [Op.or]: [{ field: 2 }, { field: 2 }] },
-                { [Op.and]: [{ field: 1 }, { field: 1 }] },
-                { [Op.and]: [{ field: 2 }, { field: 2 }] }
+                { field: 1 },
+                { field: 1 },
+                { field: 2 },
+                { field: 2 }
               ]
             }
           };
@@ -433,8 +433,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           const expected = {
             where: {
               [Op.and]: [
-                { [Op.and]: [{ field: 1 }, { field: 1 }] },
-                { [Op.and]: [{ field: 2 }, { field: 2 }] },
+                { field: 1 },
+                { field: 1 },
+                { field: 2 },
+                { field: 2 },
                 { [Op.or]: [{ field: 1 }, { field: 1 }] },
                 { [Op.or]: [{ field: 2 }, { field: 2 }] }
               ]
@@ -464,7 +466,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             where: {
               [Op.and]: [
                 { field: 1 },
-                { [Op.and]: [{ field: 1 }, { field: 1 }] },
+                { field: 1 },
+                { field: 1 },
                 { [Op.or]: [{ field: 1 }, { field: 1 }] },
                 Sequelize.where('field', Op.is, 1)
               ]


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This pr is meant for the v6 of Sequelize. It has been motivated by this pr:
- https://github.com/sequelize/sequelize/pull/14110

This pr introduces the following elements:
- A way to merge scopes with where clauses using the `AND` operator instead of overwriting it with the last value.
- The flag `whereMergeStrategy` to choose between the `and` strategy and the `overwrite` one.

### TODO

- [x] Add documentation in the manual documentation (waiting for review)
