### PR TITLE
fix(types): export `GroupedCountResultItem` interface

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -677,7 +677,7 @@ export type CountWithOptions<TAttributes = any> = SetRequired<CountOptions<TAttr
 
 export interface FindAndCountOptions<TAttributes = any> extends CountOptions<TAttributes>, FindOptions<TAttributes> { }
 
-interface GroupedCountResultItem {
+export interface GroupedCountResultItem {
   [key: string]: unknown // projected attributes
   count: number // the count for each group
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change
Needed to use this type but it wasn't exported. And since the rest of the types are, it feels like it would be more consistent to also export this one

<!-- Please provide a description of the change here. -->
