### PR TITLE
fix(types): drop excess argument for upsert

### DIFF
--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -485,13 +485,12 @@ export class QueryInterface {
   /**
    * Inserts or Updates a record in the database
    */
-  public upsert(
+  public upsert<M extends Model>(
     tableName: TableName,
     insertValues: object,
     updateValues: object,
     where: object,
-    model: ModelType,
-    options?: QueryOptions
+    options?: QueryOptionsWithModel<M>
   ): Promise<object>;
 
   /**

--- a/test/types/query-interface.ts
+++ b/test/types/query-interface.ts
@@ -223,7 +223,7 @@ async function test() {
 
   class TestModel extends Model {}
 
-  await queryInterface.upsert("test", {"a": 1}, {"b": 2}, {"c": 3}, TestModel, {});
+  await queryInterface.upsert("test", {"a": 1}, {"b": 2}, {"c": 3}, {model: TestModel});
 
   await queryInterface.insert(null, 'test', {});
 }


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Corresponding JavaScript file [query-interface.js](https://github.com/sequelize/sequelize/blob/main/src/dialects/abstract/query-interface.js#L808) doesn't require model attribute to be passed. Instead it is passed inside `options`.
