### PR TITLE
meta: set access to public for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     ]
   },
   "publishConfig": {
+    "access": "public",
     "tag": "alpha"
   },
   "scripts": {


### PR DESCRIPTION
This should fix the publishing error we got on v7