### PR TITLE
ci: disable CI on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 on:
   push:
     branches:
-      - main
       - v6
       - v7
   pull_request:


### PR DESCRIPTION
Proposal PR to disable running the CI on main.

As all changes on `main` are done through PRs, we already know the the main branch passes the CI. 
Nothing is released from the main branch either.

Disabling the CI on the main branch would reduce how many actions are being run concurrently and allow PRs to run faster.

I may be missing something so feel free to reject this PR