### PR TITLE
ci: skip 'rm awaiting response' if label is absent

### DIFF
--- a/.github/workflows/auto-remove-awaiting-response-label.yml
+++ b/.github/workflows/auto-remove-awaiting-response-label.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   auto-remove-awaiting-response-label:
     name: Run
+    if: "${{ contains(github.event.issue.labels.*.name, 'status: awaiting response') }}"
     runs-on: ubuntu-latest
     env:
       # Case insensitive. Replace spaces with `%20`.


### PR DESCRIPTION
This PR aborts the 'remove awaiting response' action before its environment is set up if the issue/pr doesn't have the label the CI tries to remove.

I'm not sure how to test this without merging it