### PR TITLE
ci(unit-test): split unit test per dialect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,22 @@ jobs:
           name: install-build-artifact-node-${{ matrix.node-version }}
       - name: Extract artifact
         run: tar -xf install-build-node-${{ matrix.node-version }}.tar
-      - name: Unit tests
-        run: yarn test-unit-all
+      - name: Unit tests (mariadb)
+        run: yarn test-unit-mariadb
+      - name: Unit tests (mysql)
+        run: yarn test-unit-mysql
+      - name: Unit tests (postgres)
+        run: yarn test-unit-postgres
+      - name: Unit tests (postgres-native)
+        run: yarn test-unit-postgres-native
+      - name: Unit tests (mssql)
+        run: yarn test-unit-mssql
+      - name: Unit tests (db2)
+        run: yarn test-unit-db2
+      - name: Unit tests (ibmi)
+        run: yarn test-unit-ibmi
+      - name: Unit tests (snowflake)
+        run: yarn test-unit-snowflake
   docs:
     name: Generate docs
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [X] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->
After #14171 the unit tests were combined in one job, but if it fails it is not clear for which dialect. This PR is to improve this.
One example of failing unit tests is https://github.com/sequelize/sequelize/runs/5345885855?check_suite_focus=true

Do note that if one of the unit tests fails the others will not be executed, that's done purposefully.