### PR TITLE
fix(types): update return type of Model.update

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -2213,7 +2213,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     values: {
         [key in keyof Attributes<M>]?: Attributes<M>[key] | Fn | Col | Literal;
     },
-    options: UpdateOptions<Attributes<M>> & { returning: true }
+    options: UpdateOptions<Attributes<M>> & { returning: true | (keyof Attributes<M>)[] }
   ): Promise<[affectedCount: number, affectedRows: M[]]>;
 
   /**


### PR DESCRIPTION
Fix breaking typescript change for postgres/mssql.
Added missing condition for returning affectedRows

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Fixes typings introduced by [#14155](https://github.com/sequelize/sequelize/pull/14155)