### PR TITLE
feat: stop testing against TypeScript < 4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts-version: ["4.3", "4.4", "4.5", "4.6"]
+        ts-version: ["4.4", "4.5", "4.6"]
     name: TS Typings (${{ matrix.ts-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts-version: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6"]
+        ts-version: ["4.3", "4.4", "4.5", "4.6"]
     name: TS Typings (${{ matrix.ts-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -2,7 +2,7 @@
 
 Sequelize provides its own TypeScript definitions.
 
-Please note that only **TypeScript >= 4.3** is supported.
+Please note that only **TypeScript >= 4.4** is supported.
 Our TypeScript support does not follow SemVer. We will support TypeScript releases for at least one year, after which they may be dropped in a SemVer MINOR release.
 
 As Sequelize heavily relies on runtime property assignments, TypeScript won't be very useful out of the box.

--- a/docs/manual/other-topics/typescript.md
+++ b/docs/manual/other-topics/typescript.md
@@ -2,7 +2,7 @@
 
 Sequelize provides its own TypeScript definitions.
 
-Please note that only **TypeScript >= 4.1** is supported.
+Please note that only **TypeScript >= 4.3** is supported.
 Our TypeScript support does not follow SemVer. We will support TypeScript releases for at least one year, after which they may be dropped in a SemVer MINOR release.
 
 As Sequelize heavily relies on runtime property assignments, TypeScript won't be very useful out of the box.


### PR DESCRIPTION
TypeScript 4.2 has been out for a little over a year now.

Based on our policy that offers one year of support for a given TypeScript version, we can now stop testing against TypeScript 4.1 & 4.2.

We now only officially support TypeScript 4.4, 4.5, and 4.6