### PR TITLE
fix(mssql): stop to automatically add `order by` when there is already one

### DIFF
--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -117,7 +117,7 @@ if (current.dialect.supports['UNION ALL']) {
             }
           });
 
-          it('works with computed order', async function() {
+          it('works with computed order', async function () {
             const users = await this.User.findAll({
               attributes: ['id'],
               groupedLimit: {
@@ -127,7 +127,7 @@ if (current.dialect.supports['UNION ALL']) {
               },
               order: [
                 Sequelize.fn('ABS', Sequelize.col('age')),
-                'id'
+                'id',
               ],
               include: [this.User.Tasks],
             });

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -117,7 +117,7 @@ if (current.dialect.supports['UNION ALL']) {
             }
           });
 
-          it('[Flaky] works with computed order', async function () {
+          it('works with computed order', async function() {
             const users = await this.User.findAll({
               attributes: ['id'],
               groupedLimit: {
@@ -127,6 +127,7 @@ if (current.dialect.supports['UNION ALL']) {
               },
               order: [
                 Sequelize.fn('ABS', Sequelize.col('age')),
+                'id'
               ],
               include: [this.User.Tasks],
             });
@@ -135,7 +136,6 @@ if (current.dialect.supports['UNION ALL']) {
              project1 - 1, 3, 4
              project2 - 3, 5, 4
            */
-            // Flaky test
             expect(users.map(u => u.get('id'))).to.deep.equal([1, 3, 5, 4]);
           });
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -343,11 +343,11 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         subQuery: true,
       }, {
         default: `${'SELECT [user].*, [POSTS].[id] AS [POSTS.id], [POSTS].[title] AS [POSTS.title] FROM ('
-                       + 'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC'}${
+                      + 'SELECT [user].[id_user] AS [id], [user].[email], [user].[first_name] AS [firstName], [user].[last_name] AS [lastName] FROM [users] AS [user] ORDER BY [user].[last_name] ASC'}${
           sql.addLimitAndOffset({ limit: 30, offset: 10, order: [['`user`.`last_name`', 'ASC']] })
         }) AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] ORDER BY [user].[last_name] ASC;`,
         ibmi: `${'SELECT "user".*, "POSTS"."id" AS "POSTS.id", "POSTS"."title" AS "POSTS.title" FROM ('
-                       + 'SELECT "user"."id_user" AS "id", "user"."email", "user"."first_name" AS "firstName", "user"."last_name" AS "lastName" FROM "users" AS "user" ORDER BY "user"."last_name" ASC'}${
+                      + 'SELECT "user"."id_user" AS "id", "user"."email", "user"."first_name" AS "firstName", "user"."last_name" AS "lastName" FROM "users" AS "user" ORDER BY "user"."last_name" ASC'}${
           sql.addLimitAndOffset({ limit: 30, offset: 10, order: [['`user`.`last_name`', 'ASC']] })
         }) AS "user" LEFT OUTER JOIN "post" AS "POSTS" ON "user"."id_user" = "POSTS"."user_id" ORDER BY "user"."last_name" ASC`,
       });

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -132,7 +132,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
               INNER JOIN [project_users] AS [project_user]
                 ON [user].[id_user] = [project_user].[user_id]
                 AND [project_user].[project_id] = 1
-              ORDER BY [subquery_order_0] ASC${current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
+              ORDER BY [subquery_order_0] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
             ) AS sub`,
             `SELECT * FROM (
               SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_user].[user_id] AS [project_user.userId], [project_user].[project_id] AS [project_user.projectId]
@@ -140,7 +140,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
               INNER JOIN [project_users] AS [project_user]
                 ON [user].[id_user] = [project_user].[user_id]
                 AND [project_user].[project_id] = 5
-              ORDER BY [subquery_order_0] ASC${current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
+              ORDER BY [subquery_order_0] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
             ) AS sub`,
           ].join(current.dialect.supports['UNION ALL'] ? ' UNION ALL ' : ' UNION ')
         }) AS [user] ORDER BY [subquery_order_0] ASC;`,
@@ -178,7 +178,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
                 ON [user].[id_user] = [project_user].[user_id]
                 AND [project_user].[project_id] = 1
                 AND [project_user].[status] = 1
-              ORDER BY [subquery_order_0] ASC${current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
+              ORDER BY [subquery_order_0] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
             ) AS sub`,
             `SELECT * FROM (
               SELECT [user].[id_user] AS [id], [user].[last_name] AS [subquery_order_0], [project_user].[user_id] AS [project_user.userId], [project_user].[project_id] AS [project_user.projectId]
@@ -187,7 +187,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
                 ON [user].[id_user] = [project_user].[user_id]
                 AND [project_user].[project_id] = 5
                 AND [project_user].[status] = 1
-              ORDER BY [subquery_order_0] ASC${current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
+              ORDER BY [subquery_order_0] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
             ) AS sub`,
           ].join(current.dialect.supports['UNION ALL'] ? ' UNION ALL ' : ' UNION ')
         }) AS [user] ORDER BY [subquery_order_0] ASC;`,
@@ -225,7 +225,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
                  ON [user].[id_user] = [project_user].[user_id]
                  AND [project_user].[project_id] = 1
                WHERE [user].[age] >= 21
-               ORDER BY [subquery_order_0] ASC${current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
+               ORDER BY [subquery_order_0] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
             ) AS sub`,
             `SELECT * FROM (
               SELECT [user].[id_user] AS [id], [user].[id_user] AS [subquery_order_0], [project_user].[user_id] AS [project_user.userId], [project_user].[project_id] AS [project_user.projectId]
@@ -234,7 +234,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
                 ON [user].[id_user] = [project_user].[user_id]
                 AND [project_user].[project_id] = 5
               WHERE [user].[age] >= 21
-              ORDER BY [subquery_order_0] ASC${current.dialect.name === 'mssql' ? ', [user].[id_user]' : ''}${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
+              ORDER BY [subquery_order_0] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}
             ) AS sub`,
           ].join(current.dialect.supports['UNION ALL'] ? ' UNION ALL ' : ' UNION ')
         }) AS [user] ORDER BY [subquery_order_0] ASC;`,
@@ -418,6 +418,30 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             `SELECT * FROM (SELECT [id_user] AS [id], [email], [first_name] AS [firstName], [last_name] AS [lastName] FROM [users] AS [user] WHERE [user].[companyId] = 5 ORDER BY [user].[last_name] ASC${sql.addLimitAndOffset({ limit: 3, order: ['last_name', 'ASC'] })}) AS sub`,
           ].join(current.dialect.supports['UNION ALL'] ? ' UNION ALL ' : ' UNION ')
         }) AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id] LEFT OUTER JOIN [comment] AS [POSTS->COMMENTS] ON [POSTS].[id] = [POSTS->COMMENTS].[post_id];`,
+      });
+
+      const includeWithoutAttributes = Model._validateIncludedElements({
+        include: [{
+          attributes: [],
+          association: User.Posts,
+        }],
+        model: User,
+      }).include;
+
+      testsql({
+        table: User.getTableName(),
+        model: User,
+        include: includeWithoutAttributes,
+        attributes: [
+          [Support.sequelize.col('user.first_name'), 'userName'],
+          [Support.sequelize.fn('count', '*'), 'count'],
+        ],
+        order: [[Support.sequelize.fn('count', '*'), 'DESC']],
+        group: ['user.first_name'],
+        limit: 5,
+      }, {
+        default: 'SELECT [user].[first_name] AS [userName], count(\'*\') AS [count] FROM [users] AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] GROUP BY [user].[first_name] ORDER BY count(\'*\') DESC LIMIT 5;',
+        mssql: 'SELECT [user].[first_name] AS [userName], count(N\'*\') AS [count] FROM [users] AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] GROUP BY [user].[first_name] ORDER BY count(N\'*\') DESC OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY;',
       });
     }());
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -434,14 +434,13 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         include: includeWithoutAttributes,
         attributes: [
           [Support.sequelize.col('user.first_name'), 'userName'],
-          [Support.sequelize.fn('count', '*'), 'count'],
+          [Support.sequelize.fn('count', Support.sequelize.col('*')), 'count'],
         ],
-        order: [[Support.sequelize.fn('count', '*'), 'DESC']],
+        order: [[Support.sequelize.fn('count', Support.sequelize.col('*')), 'DESC']],
         group: ['user.first_name'],
         limit: 5,
       }, {
-        default: 'SELECT [user].[first_name] AS [userName], count(\'*\') AS [count] FROM [users] AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] GROUP BY [user].[first_name] ORDER BY count(\'*\') DESC LIMIT 5;',
-        mssql: 'SELECT [user].[first_name] AS [userName], count(N\'*\') AS [count] FROM [users] AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] GROUP BY [user].[first_name] ORDER BY count(N\'*\') DESC OFFSET 0 ROWS FETCH NEXT 5 ROWS ONLY;',
+        default: `SELECT [user].[first_name] AS [userName], count(*) AS [count] FROM [users] AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id_user] = [POSTS].[user_id] GROUP BY [user].[first_name] ORDER BY count(*) DESC${sql.addLimitAndOffset({ limit: 5, order: ['last_name', 'ASC'] })};`,
       });
     }());
 

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -420,7 +420,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         }) AS [user] LEFT OUTER JOIN [post] AS [POSTS] ON [user].[id] = [POSTS].[user_id] LEFT OUTER JOIN [comment] AS [POSTS->COMMENTS] ON [POSTS].[id] = [POSTS->COMMENTS].[post_id];`,
       });
 
-      const includeWithoutAttributes = Model._validateIncludedElements({
+      const includeWithoutAttributes = _validateIncludedElements({
         include: [{
           attributes: [],
           association: User.Posts,


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Have you added new tests to prevent regressions?
- [X] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Should fix #14185 

Should not auto adding `order by` clause when a `group` option is provided. Should avoid sql error
`[column] is invalid in the ORDER BY clause because it is not contained in either an aggregate function or the GROUP BY clause.`

<!-- Please provide a description of the change here. -->
