### PR TITLE
refactor: convert multiple dialect checks to use Array.includes

### DIFF
--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -183,7 +183,7 @@ describe(Support.getTestDialectTeaser('DataTypes'), () => {
     // mssql has a _bindParam function that checks if STRING was created with
     // the boolean param (if so it outputs a Buffer bind param). This override
     // isn't needed for other dialects
-    if (dialect === 'mssql' || dialect === 'db2') {
+    if (['mssql', 'db2'].includes(dialect)) {
       await testSuccess(Type, 'foobar',  { useBindParam: true });
     } else {
       await testSuccess(Type, 'foobar');

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -385,7 +385,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
         await expect(User.create({ name: 'jan' })).to.be.rejectedWith(Sequelize.UniqueConstraintError);
 
         // And when the model is not passed at all
-        if (dialect === 'db2' || dialect === 'ibmi') {
+        if (['db2', 'ibmi'].includes(dialect)) {
           await expect(this.sequelize.query('INSERT INTO "users" ("name") VALUES (\'jan\')')).to.be.rejectedWith(Sequelize.UniqueConstraintError);
         } else {
           await expect(this.sequelize.query('INSERT INTO users (name) VALUES (\'jan\')')).to.be.rejectedWith(Sequelize.UniqueConstraintError);

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1057,7 +1057,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         fields: ['secretValue'],
         logging(sql) {
           test = true;
-          if (dialect === 'mssql' || dialect === 'ibmi') {
+          if (['mssql', 'ibmi'].includes(dialect)) {
             expect(sql).to.not.contain('createdAt');
           } else {
             expect(sql).to.match(/UPDATE\s+["`]+User1s["`]+\s+SET\s+["`]+secretValue["`]=(\$1|\?),["`]+updatedAt["`]+=(\$2|\?)\s+WHERE ["`]+id["`]+\s=\s(\$3|\?)/);

--- a/test/integration/pool.test.js
+++ b/test/integration/pool.test.js
@@ -65,7 +65,7 @@ function assertNewConnection(newConnection, oldConnection) {
 }
 
 function attachMSSQLUniqueId(connection) {
-  if (dialect === 'mssql' || dialect === 'ibmi') {
+  if (['mssql', 'ibmi'].includes(dialect)) {
     connection.dummyId = Math.random();
   }
 
@@ -89,7 +89,7 @@ describe(Support.getTestDialectTeaser('Pooling'), () => {
     it('should obtain new connection when old connection is abruptly closed', async () => {
       function simulateUnexpectedError(connection) {
         // should never be returned again
-        if (dialect === 'mssql' || dialect === 'ibmi') {
+        if (['mssql', 'ibmi'].includes(dialect)) {
           connection = attachMSSQLUniqueId(connection);
         }
 

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -50,7 +50,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
 
       await this.queryInterface.createTable('my_test_table', { name: DataTypes.STRING });
       await cleanup(this.sequelize);
-      const sql = `CREATE VIEW V_Fail AS SELECT 1 Id${dialect === 'db2' || dialect === 'ibmi' ? ' FROM SYSIBM.SYSDUMMY1' : ''}`;
+      const sql = `CREATE VIEW V_Fail AS SELECT 1 Id${['db2', 'ibmi'].includes(dialect) ? ' FROM SYSIBM.SYSDUMMY1' : ''}`;
       await this.sequelize.query(sql);
       let tableNames = await this.queryInterface.showAllTables();
       await cleanup(this.sequelize);
@@ -61,7 +61,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       expect(tableNames).to.deep.equal(['my_test_table']);
     });
 
-    if (dialect !== 'sqlite' && dialect !== 'postgres' && dialect !== 'db2' && dialect !== 'ibmi') {
+    if (!['sqlite', 'postgres', 'db2', 'ibmi'].includes(dialect)) {
       // NOTE: sqlite doesn't allow querying between databases and
       // postgres requires creating a new connection to create a new table.
       it('should not show tables in other databases', async function () {

--- a/test/integration/sequelize/query.test.js
+++ b/test/integration/sequelize/query.test.js
@@ -514,14 +514,14 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       it('reject when binds passed with object and numeric $1 is also present', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
 
         await this.sequelize.query(`select $one${typeCast} as foo, $two${typeCast} as bar, '$1' as baz`, {  raw: true, bind: { one: 1, two: 2 } })
           .should.be.rejectedWith(Error, /Named bind parameter "\$\w+" has no value in the given object\./g);
       });
 
       it('reject when binds passed as array and $alpha is also present', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
 
         await this.sequelize.query(`select $1${typeCast} as foo, $2${typeCast} as bar, '$foo' as baz`, { raw: true, bind: [1, 2] })
           .should.be.rejectedWith(Error, /Named bind parameter "\$\w+" has no value in the given object\./g);
@@ -656,7 +656,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     // ad hoc like "SELECT ? AS col"
     if (dialect !== 'ibmi') {
       it('uses properties `query` and `bind` if query is tagged', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
         let logSql;
         const result = await this.sequelize.query({ query: `select $1${typeCast} as foo, $2${typeCast} as bar`, bind: [1, 2] }, {
           type: this.sequelize.QueryTypes.SELECT, logging(s) {
@@ -723,7 +723,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     // tests
     if (dialect !== 'ibmi') {
       it('binds token with the passed array', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
         let logSql;
         const result = await this.sequelize.query(`select $1${typeCast} as foo, $2${typeCast} as bar${dialect === 'ibmi' ? ' FROM SYSIBM.SYSDUMMY1' : ''}`, {
           type: this.sequelize.QueryTypes.SELECT, bind: [1, 2], logging(s) {
@@ -737,7 +737,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       it('binds named parameters with the passed object', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
         let logSql;
         const result = await this.sequelize.query(`select $one${typeCast} as foo, $two${typeCast} as bar${dialect === 'ibmi' ? ' FROM SYSIBM.SYSDUMMY1' : ''}`, {
           raw: true, bind: { one: 1, two: 2 }, logging(s) {
@@ -785,7 +785,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       it('binds named parameters array handles escaped $$', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
         let logSql;
         const result = await this.sequelize.query(`select $1${typeCast} as foo, '$$ / $$1' as bar${dialect === 'ibmi' ? ' FROM SYSIBM.SYSDUMMY1' : ''}`, {
           raw: true, bind: [1], logging(s) {
@@ -800,14 +800,14 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       it('binds named parameters object handles escaped $$', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
         const result = await this.sequelize.query(`select $one${typeCast} as foo, '$$ / $$one' as bar${dialect === 'ibmi' ? ' FROM SYSIBM.SYSDUMMY1' : ''}`, { raw: true, bind: { one: 1 } });
         const expected = ['db2', 'ibmi'].includes(dialect) ? [{ FOO: 1, BAR: '$ / $one' }] : [{ foo: 1, bar: '$ / $one' }];
         expect(result[0]).to.deep.equal(expected);
       });
 
       it('escape where has $ on the middle of characters', async function () {
-        const typeCast = dialect === 'postgres' || dialect === 'db2' ? '::int' : '';
+        const typeCast = ['postgres', 'db2'].includes(dialect) ? '::int' : '';
         const result = await this.sequelize.query(`select $one${typeCast} as foo$bar${dialect === 'ibmi' ? ' FROM SYSIBM.SYSDUMMY1' : ''}`, { raw: true, bind: { one: 1 } });
         const expected = ['db2', 'ibmi'].includes(dialect) ? [{ FOO$BAR: 1 }] : [{ foo$bar: 1 }];
         expect(result[0]).to.deep.equal(expected);


### PR DESCRIPTION
Signed-off-by: Mark Irish <mirish@ibm.com>

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Fixes https://github.com/sequelize/sequelize/issues/14196

I wasn't sure if this should only apply to current instances where multiple dialects are checked, or if single dialects should be checked as well (more function overhead, but future-proof changes?)
