### PR TITLE
fix(types): Instance can be null for update

### DIFF
--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -507,7 +507,7 @@ export class QueryInterface {
    * Updates a row
    */
   public update<M extends Model>(
-    instance: M,
+    instance: M | null,
     tableName: TableName,
     values: object,
     identifier: WhereOptions<Attributes<M>>,

--- a/src/dialects/abstract/query-interface.js
+++ b/src/dialects/abstract/query-interface.js
@@ -887,7 +887,7 @@ class QueryInterface {
     options = { ...options };
     options.hasTrigger = instance && instance.constructor.options.hasTrigger;
 
-    const sql = this.queryGenerator.updateQuery(tableName, values, identifier, options, instance.constructor.rawAttributes);
+    const sql = this.queryGenerator.updateQuery(tableName, values, identifier, options, instance && instance.constructor.rawAttributes);
 
     options.type = QueryTypes.UPDATE;
 

--- a/test/integration/query-interface/update.test.js
+++ b/test/integration/query-interface/update.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const chai = require('chai');
+
+const expect = chai.expect;
+const Support = require('../support');
+const DataTypes = require('@sequelize/core/lib/data-types');
+
+describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(function () {
+    this.sequelize.options.quoteIdenifiers = true;
+    this.queryInterface = this.sequelize.getQueryInterface();
+  });
+
+  afterEach(async function () {
+    await Support.dropTestSchemas(this.sequelize);
+  });
+
+  describe('update', () => {
+    it('should not require a model instance', async function () {
+      await this.sequelize.createSchema('archive');
+
+      const table = {
+        schema: 'archive',
+        tableName: 'test',
+      };
+
+      await this.queryInterface.createTable(table, {
+        id: {
+          type: DataTypes.INTEGER,
+          primaryKey: true,
+          autoIncrement: true,
+        },
+        value: DataTypes.INTEGER,
+      });
+
+      await this.queryInterface.insert(null, table, {
+        id: 1,
+        value: 1,
+      });
+
+      await this.queryInterface.update(null, table, {
+        value: 2,
+      }, {
+        id: 1,
+      });
+
+      const [helper] = await this.queryInterface.select(null, table);
+      expect(helper.value).to.equal(2);
+    });
+  });
+});


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Just like insert and delete, the update function of the query-interface shouldn't require an instance.