### PR TITLE
docs: update renamed field

### DIFF
--- a/docs/manual/other-topics/migrations.md
+++ b/docs/manual/other-topics/migrations.md
@@ -382,7 +382,7 @@ module.exports = {
         'Person',
         ['name', 'bool'],
         {
-          indicesType: 'UNIQUE',
+          type: 'UNIQUE',
           where: { bool : 'true' },
         }
       );


### PR DESCRIPTION
Update field to **type** instead of **indicesType** since it was renamed since v5  as it says here on issue _[#10831](https://github.com/sequelize/sequelize/issues/10831) Sequelize v5 renames addIndex(... { indicesType: ...}) to addIndex(... { type: ...})_
