### PR TITLE
docs: clarify implications on models without primary keys

### DIFF
--- a/docs/manual/other-topics/legacy.md
+++ b/docs/manual/other-topics/legacy.md
@@ -52,7 +52,7 @@ Collection.init({
 }, { sequelize });
 ```
 
-And if your model has no primary key at all you can use `Model.removeAttribute('id');`
+And if your model has no primary key at all you can use `Model.removeAttribute('id');`.  Instances without primary keys, retrieved using `findOne()`, store the exact query criteria in the model class: once many instances are queried simultaneously, doing instance.save() on any of the instances, will always update the last retrieved instance.  The mitigation is to use `instance.update()` and provide there the search criteria.  [#13819](https://github.com/sequelize/sequelize/pull/13819) proposes a fix, storing the query per instance.
 
 ## Foreign keys
 


### PR DESCRIPTION
Puts warnings in the documentation for sequelize-usage when the tables have no primary key.

Targetting v6 branch, related to https://github.com/sequelize/sequelize/pull/14173#issuecomment-1065388719