### PR TITLE
test: add unit tests for every datatype

### DIFF
--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -131,6 +131,52 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
+    describe('CITEXT', () => {
+      testsql('CITEXT', DataTypes.CITEXT, {
+        default: 'CITEXT', // TODO: dialects that don't support CITEXT should throw
+        postgres: 'CITEXT',
+        sqlite: 'TEXT COLLATE NOCASE',
+      });
+
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
+          const type = DataTypes.CITEXT();
+
+          expect(() => {
+            type.validate(12_345);
+          }).to.throw(Sequelize.ValidationError, '12345 is not a valid string');
+        });
+
+        it('should return `true` if `value` is a string', () => {
+          const type = DataTypes.CITEXT();
+
+          expect(type.validate('foobar')).to.equal(true);
+        });
+      });
+    });
+
+    describe('TSVECTOR', () => {
+      testsql('TSVECTOR', DataTypes.TSVECTOR, {
+        default: 'TSVECTOR', // TODO: dialects that don't support TSVECTOR should throw
+      });
+
+      describe('validate', () => {
+        it('should throw an error if `value` is invalid', () => {
+          const type = DataTypes.TSVECTOR();
+
+          expect(() => {
+            type.validate(12_345);
+          }).to.throw(Sequelize.ValidationError, '12345 is not a valid string');
+        });
+
+        it('should return `true` if `value` is a string', () => {
+          const type = DataTypes.TSVECTOR();
+
+          expect(type.validate('foobar')).to.equal(true);
+        });
+      });
+    });
+
     describe('CHAR', () => {
       testsql('CHAR', DataTypes.CHAR, {
         default: 'CHAR(255)',
@@ -230,6 +276,18 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
           expect(type.validate(new Date())).to.equal(true);
         });
+      });
+    });
+
+    describe('DATEONLY', () => {
+      testsql('DATEONLY', DataTypes.DATEONLY, {
+        default: 'DATE',
+      });
+    });
+
+    describe('TIME', () => {
+      testsql('TIME', DataTypes.TIME, {
+        default: 'TIME',
       });
     });
 
@@ -1510,6 +1568,21 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
 
+    describe('JSON', () => {
+      // TODO: types that don't support JSON should use an equivalent to DataTypes.TEXT
+      //  and add a CHECK(ISJSON) when possible.
+      testsql('JSON', DataTypes.JSON, {
+        default: 'JSON',
+      });
+    });
+
+    describe('JSONB', () => {
+      // TODO: types that don't support JSONB should throw an error.
+      testsql('JSONB', DataTypes.JSONB, {
+        default: 'JSONB',
+      });
+    });
+
     if (current.dialect.supports.ARRAY) {
       describe('ARRAY', () => {
         testsql('ARRAY(VARCHAR)', DataTypes.ARRAY(DataTypes.STRING), {
@@ -1604,7 +1677,6 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       describe('GEOMETRY', () => {
         testsql('GEOMETRY', DataTypes.GEOMETRY, {
           default: 'GEOMETRY',
-          snowflake: 'GEOGRAPHY',
         });
 
         testsql('GEOMETRY(\'POINT\')', DataTypes.GEOMETRY('POINT'), {
@@ -1632,5 +1704,17 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         });
       });
     }
+
+    describe('GEOGRAPHY', () => {
+      testsql('GEOGRAPHY', DataTypes.GEOGRAPHY, {
+        default: 'GEOGRAPHY',
+      });
+    });
+
+    describe('HSTORE', () => {
+      testsql('HSTORE', DataTypes.HSTORE, {
+        default: 'HSTORE',
+      });
+    });
   });
 });


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This PR is related to documentation PR https://github.com/sequelize/website/pull/11

It adds a small set of DataType unit tests that were previously missing.

They're still lacking but cleaning up the DataTypes is something that can be done in a future PR (unless someone wants to take up the torch).