### PR TITLE
fix(postgres): correctly re-acquire connection while using pg-native

### DIFF
--- a/src/dialects/abstract/connection-manager.d.ts
+++ b/src/dialects/abstract/connection-manager.d.ts
@@ -38,4 +38,8 @@ export interface ConnectionManager {
    * Release a pooled connection so it can be utilized by other connection requests
    */
   releaseConnection(conn: Connection): Promise<void>;
+  /**
+   * Destroys a pooled connection so it can be utilized by other connection requests
+   */
+  destroyConnection(conn: Connection): Promise<void>;
 }

--- a/src/dialects/abstract/connection-manager.js
+++ b/src/dialects/abstract/connection-manager.js
@@ -322,6 +322,18 @@ class ConnectionManager {
   }
 
   /**
+   * Destroy a pooled connection so it can be utilized by other connection requests
+   *
+   * @param {Connection} connection
+   *
+   * @returns {Promise}
+   */
+  async destroyConnection(connection) {
+    this.pool.destroy(connection);
+    debug('connection destroyed');
+  }
+
+  /**
    * Call dialect library to get connection
    *
    * @param {*} config Connection config


### PR DESCRIPTION
Unfortunately https://github.com/sequelize/sequelize/pull/14090 didn't resolve it as code could get into situation where all dead connections are considered as in use and sequelize-pool acquire() was stuck in infinite loop.

![issue](https://user-images.githubusercontent.com/46269759/159697096-2aee9034-f76b-4b99-b2da-5f4169fb506b.png)

I have tested against local PostgreSQL database with pg-native plugin enabled.

Fixes https://github.com/sequelize/sequelize/issues/14086