### PR TITLE
docs on JSON updated

### DIFF
--- a/src/data-types.d.ts
+++ b/src/data-types.d.ts
@@ -361,12 +361,12 @@ export interface DateOnlyDataType extends AbstractDataType {
 
 
 /**
- * A key / value column. Only available in postgres.
+ * A key / value column. Only available in SQLite, MySQL, MariaDB and PostgreSQL.
  */
 export const HSTORE: AbstractDataTypeConstructor;
 
 /**
- * A JSON string column. Only available in postgres.
+ * A JSON string column. Only available in SQLite, MySQL, MariaDB and PostgreSQL.
  */
 export const JSON: AbstractDataTypeConstructor;
 /**

--- a/src/data-types.js
+++ b/src/data-types.js
@@ -573,7 +573,7 @@ class DATEONLY extends ABSTRACT {
 }
 
 /**
- * A key / value store column. Only available in Postgres.
+ * A key / value store column. Only available in SQLite, MySQL, MariaDB and PostgreSQL.
  */
 class HSTORE extends ABSTRACT {
   validate(value) {
@@ -586,7 +586,7 @@ class HSTORE extends ABSTRACT {
 }
 
 /**
- * A JSON string column. Available in MySQL, Postgres and SQLite
+ * A JSON string column. Available in SQLite, MySQL, MariaDB and PostgreSQL.
  */
 class JSONTYPE extends ABSTRACT {
   validate() {


### PR DESCRIPTION
[here](https://sequelize.org/v6/manual/other-data-types.html) it is said that JSON is supported by other database but on data-types it is not mentioned.

I have a doubt on snowflake. It is said this about JSON. Does it mean it is supported by snowflake?
```
types: {
    postgres: [ 'json' ],
    mysql: [ 'JSON' ],
    mariadb: [ 'JSON' ],
    sqlite: [ 'JSON', 'JSONB' ],
    snowflake: [ 'JSON' ]
  },
```