### PR TITLE
build: accept `@typeParam` and `@internal` tags in  typedoc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,15 @@ module.exports = {
       tagNamePreference: {
         augments: 'extends',
       },
+      structuredTags: {
+        typeParam: {
+          type: false,
+          required: ['name'],
+        },
+        internal: {
+          type: false,
+        },
+      },
     },
   },
   parserOptions: {


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This PR makes our eslint config accept the [`@typeParam`](https://typedoc.org/guides/doccomments/#%40typeparam-%3Cparam-name%3E-or-%40template-%3Cparam-name%3E) and [`@internal`](https://www.typescriptlang.org/tsconfig/stripInternal.html) tags valid in typedoc

This PR is part of a series of PR that reduce the size of https://github.com/sequelize/sequelize/pull/14280

