### PR TITLE
refactor: normalize imports in tests

### DIFF
--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -4,12 +4,10 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 const _ = require('lodash');
 const sinon = require('sinon');
 
-const Op = Sequelize.Op;
 const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -5,8 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const dialect = Support.getTestDialect();
@@ -63,8 +62,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
-        const Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
+        const Group = sequelize.define('Group', { name: DataTypes.STRING });
 
         Group.belongsTo(User);
 
@@ -167,8 +166,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
-        const Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
+        const Group = sequelize.define('Group', { name: DataTypes.STRING });
 
         Group.belongsTo(User);
 
@@ -344,8 +343,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
-        const Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
+        const Group = sequelize.define('Group', { name: DataTypes.STRING });
 
         Group.belongsTo(User);
 

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -4,12 +4,10 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 const moment = require('moment');
 const sinon = require('sinon');
 
-const Op = Sequelize.Op;
 const current = Support.sequelize;
 const _ = require('lodash');
 

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const dialect = Support.getTestDialect();
@@ -61,8 +61,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
-        const Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
+        const Group = sequelize.define('Group', { name: DataTypes.STRING });
 
         Group.hasOne(User);
 
@@ -100,8 +100,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
     });
 
     it('supports schemas', async function () {
-      const User = this.sequelize.define('User', { username: Support.Sequelize.STRING }).schema('admin');
-      const Group = this.sequelize.define('Group', { name: Support.Sequelize.STRING }).schema('admin');
+      const User = this.sequelize.define('User', { username: DataTypes.STRING }).schema('admin');
+      const Group = this.sequelize.define('Group', { name: DataTypes.STRING }).schema('admin');
 
       Group.hasOne(User);
 
@@ -134,8 +134,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
-        const Group = sequelize.define('Group', { name: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
+        const Group = sequelize.define('Group', { name: DataTypes.STRING });
 
         Group.hasOne(User);
 

--- a/test/integration/associations/multiple-level-filters.test.js
+++ b/test/integration/associations/multiple-level-filters.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
   it('can filter through belongsTo', async function () {

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -4,11 +4,9 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 const current = Support.sequelize;
-const Op = Sequelize.Op;
 const semver = require('semver');
 
 describe(Support.getTestDialectTeaser('associations'), () => {

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Self'), () => {
   it('supports freezeTableName', async function () {

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -5,7 +5,7 @@ const chai      = require('chai');
 const expect    = chai.expect;
 const Support   = require('./support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const cls       = require('cls-hooked');
 
 const current = Support.sequelize;

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -7,7 +7,7 @@ const config = require('../config/config');
 const Support = require('./support');
 
 const dialect = Support.getTestDialect();
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('./support');
@@ -10,9 +9,8 @@ const _ = require('lodash');
 const moment = require('moment');
 
 const current = Support.sequelize;
-const Op = Sequelize.Op;
 const uuid = require('uuid');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const semver = require('semver');

--- a/test/integration/dialects/mariadb/associations.test.js
+++ b/test/integration/dialects/mariadb/associations.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect !== 'mariadb') {
   return;

--- a/test/integration/dialects/mariadb/connector-manager.test.js
+++ b/test/integration/dialects/mariadb/connector-manager.test.js
@@ -7,7 +7,7 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const env = process.env;
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 
 if (dialect !== 'mariadb') {
   return;
@@ -64,7 +64,7 @@ describe('[MARIADB Specific] Connection Manager', () => {
     });
 
     it('ER_ACCESS_DENIED_ERROR | ELOGIN', async () => {
-      const sequelize = new Support.Sequelize('localhost', 'was', 'ddsd', Support.sequelize.options);
+      const sequelize = new Sequelize('localhost', 'was', 'ddsd', Support.sequelize.options);
       await expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(Sequelize.AccessDeniedError);
     });
   });

--- a/test/integration/dialects/mariadb/dao-factory.test.js
+++ b/test/integration/dialects/mariadb/dao-factory.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect !== 'mariadb') {
   return;

--- a/test/integration/dialects/mariadb/dao.test.js
+++ b/test/integration/dialects/mariadb/dao.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect !== 'mariadb') {
   return;

--- a/test/integration/dialects/mariadb/errors.test.js
+++ b/test/integration/dialects/mariadb/errors.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect !== 'mariadb') {
   return;

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {
@@ -29,7 +30,7 @@ if (dialect.startsWith('mssql')) {
       });
 
       it('ER_ACCESS_DENIED_ERROR | ELOGIN', async () => {
-        const sequelize = new Support.Sequelize('localhost', 'was', 'ddsd', Support.sequelize.options);
+        const sequelize = new Sequelize('localhost', 'was', 'ddsd', Support.sequelize.options);
         await expect(sequelize.connectionManager.getConnection()).to.have.been.rejectedWith(Sequelize.AccessDeniedError);
       });
     });

--- a/test/integration/dialects/mssql/query-queue.test.js
+++ b/test/integration/dialects/mssql/query-queue.test.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, ConnectionError } = require('@sequelize/core');
 const Support = require('../../support');
-const Sequelize = require('@sequelize/core/lib/sequelize');
-const ConnectionError = require('@sequelize/core/lib/errors/connection-error');
 const { AsyncQueueError } = require('@sequelize/core/lib/dialects/mssql/async-queue');
 
 const expect = chai.expect;

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -6,8 +6,8 @@ const expect = chai.expect;
 const sinon =  require('sinon');
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
-const Op = Sequelize.Op;
+const { Sequelize, Op } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {

--- a/test/integration/dialects/mysql/associations.test.js
+++ b/test/integration/dialects/mysql/associations.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Associations', () => {

--- a/test/integration/dialects/mysql/connector-manager.test.js
+++ b/test/integration/dialects/mysql/connector-manager.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Connection Manager', () => {

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] DAOFactory', () => {

--- a/test/integration/dialects/mysql/errors.test.js
+++ b/test/integration/dialects/mysql/errors.test.js
@@ -6,8 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const Sequelize = require('@sequelize/core');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Errors', () => {

--- a/test/integration/dialects/mysql/warning.test.js
+++ b/test/integration/dialects/mysql/warning.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../../support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] associations', () => {

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Sequelize', () => {

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -5,11 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
-const Op = Sequelize.Op;
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
-const sequelize = require('@sequelize/core/lib/sequelize');
+const { DataTypes, Op, json } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] DAO', () => {
@@ -98,7 +95,7 @@ if (dialect.startsWith('postgres')) {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })]);
 
-        const user = await this.User.findOne({ where: sequelize.json('emergency_contact->>\'name\'', 'kate'), attributes: ['username', 'emergency_contact'] });
+        const user = await this.User.findOne({ where: json('emergency_contact->>\'name\'', 'kate'), attributes: ['username', 'emergency_contact'] });
         expect(user.emergency_contact.name).to.equal('kate');
       });
 
@@ -108,7 +105,7 @@ if (dialect.startsWith('postgres')) {
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })]);
 
         const user = await this.User.findOne({
-          where: sequelize.json({ emergency_contact: { name: 'kate' } }),
+          where: json({ emergency_contact: { name: 'kate' } }),
         });
 
         expect(user.emergency_contact.name).to.equal('kate');
@@ -119,7 +116,7 @@ if (dialect.startsWith('postgres')) {
           this.User.create({ username: 'swen', emergency_contact: { name: 'kate' } }),
           this.User.create({ username: 'anna', emergency_contact: { name: 'joe' } })]);
 
-        const user = await this.User.findOne({ where: sequelize.json('emergency_contact.name', 'joe') });
+        const user = await this.User.findOne({ where: json('emergency_contact.name', 'joe') });
         expect(user.emergency_contact.name).to.equal('joe');
       });
 
@@ -129,8 +126,8 @@ if (dialect.startsWith('postgres')) {
           this.User.create({ username: 'anna', emergencyContact: { name: 'joe' } })]);
 
         const user = await this.User.findOne({
-          attributes: [[sequelize.json('emergencyContact.name'), 'contactName']],
-          where: sequelize.json('emergencyContact.name', 'joe'),
+          attributes: [[json('emergencyContact.name'), 'contactName']],
+          where: json('emergencyContact.name', 'joe'),
         });
 
         expect(user.get('contactName')).to.equal('joe');
@@ -142,7 +139,7 @@ if (dialect.startsWith('postgres')) {
         const user0 = await this.User.create({ username: 'swen', emergency_contact: { value: text } });
         expect(user0.isNewRecord).to.equal(false);
         await this.User.findOne({ where: { username: 'swen' } });
-        const user = await this.User.findOne({ where: sequelize.json('emergency_contact.value', text) });
+        const user = await this.User.findOne({ where: json('emergency_contact.value', text) });
         expect(user.username).to.equal('swen');
       });
 
@@ -152,7 +149,7 @@ if (dialect.startsWith('postgres')) {
         const user0 = await this.User.findOrCreate({ where: { username: 'swen' }, defaults: { emergency_contact: { value: text } } });
         expect(!user0.isNewRecord).to.equal(true);
         await this.User.findOne({ where: { username: 'swen' } });
-        const user = await this.User.findOne({ where: sequelize.json('emergency_contact.value', text) });
+        const user = await this.User.findOne({ where: json('emergency_contact.value', text) });
         expect(user.username).to.equal('swen');
       });
     });

--- a/test/integration/dialects/postgres/data-types.test.js
+++ b/test/integration/dialects/postgres/data-types.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'postgres') {
   describe('[POSTGRES Specific] Data Types', () => {

--- a/test/integration/dialects/postgres/error.test.js
+++ b/test/integration/dialects/postgres/error.test.js
@@ -3,10 +3,9 @@
 const chai      = require('chai');
 
 const expect    = chai.expect;
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const Support   = require('../../support');
 
-const Sequelize = Support.Sequelize;
 const dialect   = Support.getTestDialect();
 const _ = require('lodash');
 

--- a/test/integration/dialects/postgres/query-interface.test.js
+++ b/test/integration/dialects/postgres/query-interface.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const _ = require('lodash');
 
 if (dialect.startsWith('postgres')) {

--- a/test/integration/dialects/postgres/query.test.js
+++ b/test/integration/dialects/postgres/query.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Query', () => {

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -4,7 +4,7 @@ const chai    = require('chai');
 
 const expect  = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const range   = require('@sequelize/core/lib/dialects/postgres/range');

--- a/test/integration/dialects/postgres/regressions.test.js
+++ b/test/integration/dialects/postgres/regressions.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('postgres')) {

--- a/test/integration/dialects/snowflake/connector-manager.test.js
+++ b/test/integration/dialects/snowflake/connector-manager.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'snowflake') {
   describe('[SNOWFLAKE Specific] Connection Manager', () => {

--- a/test/integration/dialects/snowflake/smoke.test.js
+++ b/test/integration/dialects/snowflake/smoke.test.js
@@ -3,7 +3,7 @@
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const moment = require('moment');
 
 if (dialect === 'snowflake') {

--- a/test/integration/dialects/sqlite/connection-manager.test.js
+++ b/test/integration/dialects/sqlite/connection-manager.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const fileName = `${Math.random()}_test.sqlite`;
 const directoryName = `${Math.random()}_test_directory`;

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const dbFile = 'test.sqlite';

--- a/test/integration/dialects/sqlite/dao.test.js
+++ b/test/integration/dialects/sqlite/dao.test.js
@@ -5,10 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
-const Op = Sequelize.Op;
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAO', () => {

--- a/test/integration/dialects/sqlite/sqlite-master.test.js
+++ b/test/integration/dialects/sqlite/sqlite-master.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] sqlite_master raw queries', () => {

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -7,7 +7,11 @@ const expect = chai.expect;
 const Support = require('./support');
 
 const dialect   = Support.getTestDialect();
-const Sequelize = Support.Sequelize;
+const {
+  Sequelize, OptimisticLockError, UniqueConstraintError, ValidationError, ValidationErrorItem, DatabaseError,
+  ConnectionRefusedError, AccessDeniedError, HostNotFoundError, HostNotReachableError, InvalidConnectionError,
+  ConnectionTimedOutError, DataTypes, ValidationErrorItemOrigin, ConnectionError,
+} = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
   describe('API Surface', () => {
@@ -20,32 +24,32 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     it('Sequelize Errors instances should be instances of Error', () => {
       const error = new Sequelize.Error();
       const errorMessage = 'error message';
-      const validationError = new Sequelize.ValidationError(errorMessage, [
-        new Sequelize.ValidationErrorItem('<field name> cannot be null', 'notNull Violation', '<field name>', null),
-        new Sequelize.ValidationErrorItem('<field name> cannot be an array or an object', 'string violation', '<field name>', null),
+      const validationError = new ValidationError(errorMessage, [
+        new ValidationErrorItem('<field name> cannot be null', 'notNull Violation', '<field name>', null),
+        new ValidationErrorItem('<field name> cannot be an array or an object', 'string violation', '<field name>', null),
       ]);
-      const optimisticLockError = new Sequelize.OptimisticLockError();
+      const optimisticLockError = new OptimisticLockError();
 
       expect(error).to.be.instanceOf(Sequelize.Error);
       expect(error).to.be.instanceOf(Error);
       expect(error).to.have.property('name', 'SequelizeBaseError');
 
-      expect(validationError).to.be.instanceOf(Sequelize.ValidationError);
+      expect(validationError).to.be.instanceOf(ValidationError);
       expect(validationError).to.be.instanceOf(Error);
       expect(validationError).to.have.property('name', 'SequelizeValidationError');
       expect(validationError.message).to.equal(errorMessage);
 
-      expect(optimisticLockError).to.be.instanceOf(Sequelize.OptimisticLockError);
+      expect(optimisticLockError).to.be.instanceOf(OptimisticLockError);
       expect(optimisticLockError).to.be.instanceOf(Error);
       expect(optimisticLockError).to.have.property('name', 'SequelizeOptimisticLockError');
     });
 
     it('SequelizeValidationError should find errors by path', () => {
       const errorItems = [
-        new Sequelize.ValidationErrorItem('invalid', 'type', 'first_name', null),
-        new Sequelize.ValidationErrorItem('invalid', 'type', 'last_name', null),
+        new ValidationErrorItem('invalid', 'type', 'first_name', null),
+        new ValidationErrorItem('invalid', 'type', 'last_name', null),
       ];
-      const validationError = new Sequelize.ValidationError('Validation error', errorItems);
+      const validationError = new ValidationError('Validation error', errorItems);
       expect(validationError).to.have.property('get');
       expect(validationError.get).to.be.a('function');
 
@@ -57,11 +61,11 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('SequelizeValidationError should override message property when message parameter is specified', () => {
       const errorItems = [
-        new Sequelize.ValidationErrorItem('invalid', 'type', 'first_name', null),
-        new Sequelize.ValidationErrorItem('invalid', 'type', 'last_name', null),
+        new ValidationErrorItem('invalid', 'type', 'first_name', null),
+        new ValidationErrorItem('invalid', 'type', 'last_name', null),
       ];
       const customErrorMessage = 'Custom validation error message';
-      const validationError = new Sequelize.ValidationError(customErrorMessage, errorItems);
+      const validationError = new ValidationError(customErrorMessage, errorItems);
 
       expect(validationError).to.have.property('name', 'SequelizeValidationError');
       expect(validationError.message).to.equal(customErrorMessage);
@@ -69,26 +73,26 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('SequelizeValidationError should concatenate an error messages from given errors if no explicit message is defined', () => {
       const errorItems = [
-        new Sequelize.ValidationErrorItem('<field name> cannot be null', 'notNull Violation', '<field name>', null),
-        new Sequelize.ValidationErrorItem('<field name> cannot be an array or an object', 'string violation', '<field name>', null),
+        new ValidationErrorItem('<field name> cannot be null', 'notNull Violation', '<field name>', null),
+        new ValidationErrorItem('<field name> cannot be an array or an object', 'string violation', '<field name>', null),
       ];
-      const validationError = new Sequelize.ValidationError(null, errorItems);
+      const validationError = new ValidationError(null, errorItems);
 
       expect(validationError).to.have.property('name', 'SequelizeValidationError');
       expect(validationError.message).to.match(/notNull Violation: <field name> cannot be null,\nstring violation: <field name> cannot be an array or an object/);
     });
 
     it('SequelizeValidationErrorItem does not require instance & validator constructor parameters', () => {
-      const error = new Sequelize.ValidationErrorItem('error!', null, 'myfield');
+      const error = new ValidationErrorItem('error!', null, 'myfield');
 
-      expect(error).to.be.instanceOf(Sequelize.ValidationErrorItem);
+      expect(error).to.be.instanceOf(ValidationErrorItem);
     });
 
     it('SequelizeValidationErrorItem should have instance, key & validator properties when given to constructor', () => {
       const inst  = { foo: 'bar' };
       const vargs = [4];
 
-      const error = new Sequelize.ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar', inst, 'klen', 'len', vargs);
+      const error = new ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar', inst, 'klen', 'len', vargs);
 
       expect(error).to.have.property('instance');
       expect(error.instance).to.equal(inst);
@@ -99,7 +103,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     });
 
     it('SequelizeValidationErrorItem.getValidatorKey() should return a string', () => {
-      const error = new Sequelize.ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar', null, 'klen', 'len', [4]);
+      const error = new ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar', null, 'klen', 'len', [4]);
 
       expect(error).to.have.property('getValidatorKey');
       expect(error.getValidatorKey).to.be.a('function');
@@ -110,7 +114,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       expect(error.getValidatorKey(1, ':')).to.equal('function:klen');
       expect(error.getValidatorKey(true, '-:-')).to.equal('function-:-klen');
 
-      const empty = new Sequelize.ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar');
+      const empty = new ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar');
 
       expect(empty.getValidatorKey()).to.equal('');
       expect(empty.getValidatorKey(false)).to.equal('');
@@ -120,7 +124,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     });
 
     it('SequelizeValidationErrorItem.getValidatorKey() should throw if namespace separator is invalid (only if NS is used & available)', () => {
-      const error = new Sequelize.ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar', null, 'klen', 'len', [4]);
+      const error = new ValidationErrorItem('error!', 'FUNCTION', 'foo', 'bar', null, 'klen', 'len', [4]);
 
       expect(() => error.getValidatorKey(false, {})).to.not.throw();
       expect(() => error.getValidatorKey(false, [])).to.not.throw();
@@ -148,7 +152,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       };
 
       for (const k of Object.keys(data)) {
-        const error = new Sequelize.ValidationErrorItem('error!', k, 'foo', null);
+        const error = new ValidationErrorItem('error!', k, 'foo', null);
 
         expect(error).to.have.property('origin', data[k]);
         expect(error).to.have.property('type', k);
@@ -156,7 +160,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     });
 
     it('SequelizeValidationErrorItemOrigin is valid', () => {
-      const ORIGINS = Sequelize.ValidationErrorItemOrigin;
+      const ORIGINS = ValidationErrorItemOrigin;
 
       expect(ORIGINS).to.have.property('CORE', 'CORE');
       expect(ORIGINS).to.have.property('DB', 'DB');
@@ -165,7 +169,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     });
 
     it('SequelizeValidationErrorItem.Origins is valid', () => {
-      const ORIGINS = Sequelize.ValidationErrorItem.Origins;
+      const ORIGINS = ValidationErrorItem.Origins;
 
       expect(ORIGINS).to.have.property('CORE', 'CORE');
       expect(ORIGINS).to.have.property('DB', 'DB');
@@ -175,7 +179,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('SequelizeDatabaseError should keep original message', () => {
       const orig = new Error('original database error message');
-      const databaseError = new Sequelize.DatabaseError(orig);
+      const databaseError = new DatabaseError(orig);
 
       expect(databaseError).to.have.property('parent');
       expect(databaseError).to.have.property('original');
@@ -187,7 +191,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       const orig = new Error();
       orig.sql = 'SELECT * FROM table WHERE id = $1';
       orig.parameters = ['1'];
-      const databaseError = new Sequelize.DatabaseError(orig);
+      const databaseError = new DatabaseError(orig);
 
       expect(databaseError).to.have.property('sql');
       expect(databaseError).to.have.property('parameters');
@@ -197,7 +201,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('ConnectionError should keep original message', () => {
       const orig = new Error('original connection error message');
-      const connectionError = new Sequelize.ConnectionError(orig);
+      const connectionError = new ConnectionError(orig);
 
       expect(connectionError).to.have.property('parent');
       expect(connectionError).to.have.property('original');
@@ -207,7 +211,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('ConnectionRefusedError should keep original message', () => {
       const orig = new Error('original connection error message');
-      const connectionError = new Sequelize.ConnectionRefusedError(orig);
+      const connectionError = new ConnectionRefusedError(orig);
 
       expect(connectionError).to.have.property('parent');
       expect(connectionError).to.have.property('original');
@@ -217,7 +221,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('AccessDeniedError should keep original message', () => {
       const orig = new Error('original connection error message');
-      const connectionError = new Sequelize.AccessDeniedError(orig);
+      const connectionError = new AccessDeniedError(orig);
 
       expect(connectionError).to.have.property('parent');
       expect(connectionError).to.have.property('original');
@@ -227,7 +231,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('HostNotFoundError should keep original message', () => {
       const orig = new Error('original connection error message');
-      const connectionError = new Sequelize.HostNotFoundError(orig);
+      const connectionError = new HostNotFoundError(orig);
 
       expect(connectionError).to.have.property('parent');
       expect(connectionError).to.have.property('original');
@@ -237,7 +241,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('HostNotReachableError should keep original message', () => {
       const orig = new Error('original connection error message');
-      const connectionError = new Sequelize.HostNotReachableError(orig);
+      const connectionError = new HostNotReachableError(orig);
 
       expect(connectionError).to.have.property('parent');
       expect(connectionError).to.have.property('original');
@@ -247,7 +251,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('InvalidConnectionError should keep original message', () => {
       const orig = new Error('original connection error message');
-      const connectionError = new Sequelize.InvalidConnectionError(orig);
+      const connectionError = new InvalidConnectionError(orig);
 
       expect(connectionError).to.have.property('parent');
       expect(connectionError).to.have.property('original');
@@ -257,7 +261,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
 
     it('ConnectionTimedOutError should keep original message', () => {
       const orig = new Error('original connection error message');
-      const connectionError = new Sequelize.ConnectionTimedOutError(orig);
+      const connectionError = new ConnectionTimedOutError(orig);
 
       expect(connectionError).to.have.property('parent');
       expect(connectionError).to.have.property('original');
@@ -270,7 +274,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     it('got correct error type and message', async function () {
       const Account = this.sequelize.define('Account', {
         number: {
-          type: Sequelize.INTEGER,
+          type: DataTypes.INTEGER,
         },
       }, {
         version: true,
@@ -289,7 +293,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       })();
 
       await Promise.all([
-        expect(result).to.eventually.be.rejectedWith(Support.Sequelize.OptimisticLockError),
+        expect(result).to.eventually.be.rejectedWith(OptimisticLockError),
         expect(result).to.eventually.be.rejectedWith('Attempting to update a stale model instance: Account'),
       ]);
     });
@@ -299,11 +303,11 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     for (const constraintTest of [
       {
         type: 'UniqueConstraintError',
-        exception: Sequelize.UniqueConstraintError,
+        exception: UniqueConstraintError,
       },
       {
         type: 'ValidationError',
-        exception: Sequelize.ValidationError,
+        exception: ValidationError,
       },
     ]) {
 
@@ -311,11 +315,11 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
         const spy = sinon.spy();
         const User = this.sequelize.define('user', {
           first_name: {
-            type: Sequelize.STRING,
+            type: DataTypes.STRING,
             unique: 'unique_name',
           },
           last_name: {
-            type: Sequelize.STRING,
+            type: DataTypes.STRING,
             unique: 'unique_name',
           },
         });
@@ -345,7 +349,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
         const spy = sinon.spy();
         const User = this.sequelize.define('user', {
           name: {
-            type: Sequelize.STRING,
+            type: DataTypes.STRING,
             unique: 'unique \n unique',
           },
         });
@@ -356,7 +360,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
         try {
           await User.create({ name: 'jan' });
         } catch (error) {
-          if (!(error instanceof Sequelize.UniqueConstraintError)) {
+          if (!(error instanceof UniqueConstraintError)) {
             throw error;
           }
 
@@ -369,7 +373,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       it('Works when unique keys are not defined in sequelize', async function () {
         let User = this.sequelize.define('user', {
           name: {
-            type: Sequelize.STRING,
+            type: DataTypes.STRING,
             unique: 'unique \n unique',
           },
         }, { timestamps: false });
@@ -377,18 +381,18 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
         await this.sequelize.sync({ force: true });
         // Now let's pretend the index was created by someone else, and sequelize doesn't know about it
         User = this.sequelize.define('user', {
-          name: Sequelize.STRING,
+          name: DataTypes.STRING,
         }, { timestamps: false });
 
         await User.create({ name: 'jan' });
         // It should work even though the unique key is not defined in the model
-        await expect(User.create({ name: 'jan' })).to.be.rejectedWith(Sequelize.UniqueConstraintError);
+        await expect(User.create({ name: 'jan' })).to.be.rejectedWith(UniqueConstraintError);
 
         // And when the model is not passed at all
         if (['db2', 'ibmi'].includes(dialect)) {
-          await expect(this.sequelize.query('INSERT INTO "users" ("name") VALUES (\'jan\')')).to.be.rejectedWith(Sequelize.UniqueConstraintError);
+          await expect(this.sequelize.query('INSERT INTO "users" ("name") VALUES (\'jan\')')).to.be.rejectedWith(UniqueConstraintError);
         } else {
-          await expect(this.sequelize.query('INSERT INTO users (name) VALUES (\'jan\')')).to.be.rejectedWith(Sequelize.UniqueConstraintError);
+          await expect(this.sequelize.query('INSERT INTO users (name) VALUES (\'jan\')')).to.be.rejectedWith(UniqueConstraintError);
         }
       });
     }
@@ -396,7 +400,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
     it('adds parent and sql properties', async function () {
       const User = this.sequelize.define('user', {
         name: {
-          type: Sequelize.STRING,
+          type: DataTypes.STRING,
           unique: 'unique',
         },
       }, { timestamps: false });
@@ -405,7 +409,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       await User.create({ name: 'jan' });
       // Unique key
       const error0 = await expect(User.create({ name: 'jan' })).to.be.rejected;
-      expect(error0).to.be.instanceOf(Sequelize.UniqueConstraintError);
+      expect(error0).to.be.instanceOf(UniqueConstraintError);
       expect(error0).to.have.property('parent');
       expect(error0).to.have.property('original');
       expect(error0).to.have.property('sql');
@@ -413,7 +417,7 @@ describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
       await User.create({ id: 2, name: 'jon' });
       // Primary key
       const error = await expect(User.create({ id: 2, name: 'jon' })).to.be.rejected;
-      expect(error).to.be.instanceOf(Sequelize.UniqueConstraintError);
+      expect(error).to.be.instanceOf(UniqueConstraintError);
       expect(error).to.have.property('parent');
       expect(error).to.have.property('original');
       expect(error).to.have.property('sql');

--- a/test/integration/hooks/associations.test.js
+++ b/test/integration/hooks/associations.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 const dialect = Support.getTestDialect();

--- a/test/integration/hooks/bulkOperation.test.js
+++ b/test/integration/hooks/bulkOperation.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {

--- a/test/integration/hooks/count.test.js
+++ b/test/integration/hooks/count.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(async function () {

--- a/test/integration/hooks/create.test.js
+++ b/test/integration/hooks/create.test.js
@@ -4,9 +4,8 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
-const Sequelize = Support.Sequelize;
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {

--- a/test/integration/hooks/destroy.test.js
+++ b/test/integration/hooks/destroy.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(async function () {

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -4,9 +4,8 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
-const Sequelize = Support.Sequelize;
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 

--- a/test/integration/hooks/restore.test.js
+++ b/test/integration/hooks/restore.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {

--- a/test/integration/hooks/updateAttributes.test.js
+++ b/test/integration/hooks/updateAttributes.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {

--- a/test/integration/hooks/upsert.test.js
+++ b/test/integration/hooks/upsert.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 if (Support.sequelize.dialect.supports.upserts) {

--- a/test/integration/hooks/validate.test.js
+++ b/test/integration/hooks/validate.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
   beforeEach(async function () {

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const _ = require('lodash');
 
 const dialect = Support.getTestDialect();

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 const _ = require('lodash');
 const promiseProps = require('p-props');
 

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -6,8 +6,7 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const Support = require('../support');
 
-const Op = Support.Sequelize.Op;
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
   before(function () {

--- a/test/integration/include/findOne.test.js
+++ b/test/integration/include/findOne.test.js
@@ -4,8 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const Sequelize = require('@sequelize/core');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Include'), () => {

--- a/test/integration/include/limit.test.js
+++ b/test/integration/include/limit.test.js
@@ -1,13 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-
-const Op = Sequelize.Op;
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
 

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const sinon = require('sinon');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Paranoid'), () => {
 

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');

--- a/test/integration/include/separate.test.js
+++ b/test/integration/include/separate.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const sinon = require('sinon');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const dialect = Support.getTestDialect();

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 const Support = require('./support');
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {

--- a/test/integration/instance/decrement.test.js
+++ b/test/integration/instance/decrement.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 const current = Support.sequelize;
@@ -65,7 +65,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { number: Support.Sequelize.INTEGER });
+        const User = sequelize.define('User', { number: DataTypes.INTEGER });
 
         await User.sync({ force: true });
         const user = await User.create({ number: 3 });

--- a/test/integration/instance/destroy.test.js
+++ b/test/integration/instance/destroy.test.js
@@ -6,6 +6,7 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const moment = require('moment');
 const Support = require('../support');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const current = Support.sequelize;
@@ -15,7 +16,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
 
         await User.sync({ force: true });
         const user = await User.create({ username: 'foo' });
@@ -31,8 +32,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('does not set the deletedAt date in subsequent destroys if dao is paranoid', async function () {
       const UserDestroy = this.sequelize.define('UserDestroy', {
-        name: Support.Sequelize.STRING,
-        bio: Support.Sequelize.TEXT,
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
       }, { paranoid: true });
 
       await UserDestroy.sync({ force: true });
@@ -48,8 +49,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('does not update deletedAt with custom default in subsequent destroys', async function () {
       const ParanoidUser = this.sequelize.define('ParanoidUser', {
-        username: Support.Sequelize.STRING,
-        deletedAt: { type: Support.Sequelize.DATE, defaultValue: new Date(0) },
+        username: DataTypes.STRING,
+        deletedAt: { type: DataTypes.DATE, defaultValue: new Date(0) },
       }, { paranoid: true });
 
       await ParanoidUser.sync({ force: true });
@@ -71,8 +72,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('deletes a record from the database if dao is not paranoid', async function () {
       const UserDestroy = this.sequelize.define('UserDestroy', {
-        name: Support.Sequelize.STRING,
-        bio: Support.Sequelize.TEXT,
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
       });
 
       await UserDestroy.sync({ force: true });
@@ -86,7 +87,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('allows updating soft deleted instance', async function () {
       const ParanoidUser = this.sequelize.define('ParanoidUser', {
-        username: Support.Sequelize.STRING,
+        username: DataTypes.STRING,
       }, { paranoid: true });
 
       await ParanoidUser.sync({ force: true });
@@ -116,8 +117,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('supports custom deletedAt field', async function () {
       const ParanoidUser = this.sequelize.define('ParanoidUser', {
-        username: Support.Sequelize.STRING,
-        destroyTime: Support.Sequelize.DATE,
+        username: DataTypes.STRING,
+        destroyTime: DataTypes.DATE,
       }, { paranoid: true, deletedAt: 'destroyTime' });
 
       await ParanoidUser.sync({ force: true });
@@ -144,8 +145,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('supports custom deletedAt database column', async function () {
       const ParanoidUser = this.sequelize.define('ParanoidUser', {
-        username: Support.Sequelize.STRING,
-        deletedAt: { type: Support.Sequelize.DATE, field: 'deleted_at' },
+        username: DataTypes.STRING,
+        deletedAt: { type: DataTypes.DATE, field: 'deleted_at' },
       }, { paranoid: true });
 
       await ParanoidUser.sync({ force: true });
@@ -172,8 +173,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('supports custom deletedAt field and database column', async function () {
       const ParanoidUser = this.sequelize.define('ParanoidUser', {
-        username: Support.Sequelize.STRING,
-        destroyTime: { type: Support.Sequelize.DATE, field: 'destroy_time' },
+        username: DataTypes.STRING,
+        destroyTime: { type: DataTypes.DATE, field: 'destroy_time' },
       }, { paranoid: true, deletedAt: 'destroyTime' });
 
       await ParanoidUser.sync({ force: true });
@@ -200,7 +201,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('persists other model changes when soft deleting', async function () {
       const ParanoidUser = this.sequelize.define('ParanoidUser', {
-        username: Support.Sequelize.STRING,
+        username: DataTypes.STRING,
       }, { paranoid: true });
 
       await ParanoidUser.sync({ force: true });
@@ -249,8 +250,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('allows sql logging of delete statements', async function () {
       const UserDelete = this.sequelize.define('UserDelete', {
-        name: Support.Sequelize.STRING,
-        bio: Support.Sequelize.TEXT,
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
       });
 
       const logging = sinon.spy();
@@ -268,8 +269,8 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
 
     it('allows sql logging of update statements', async function () {
       const UserDelete = this.sequelize.define('UserDelete', {
-        name: Support.Sequelize.STRING,
-        bio: Support.Sequelize.TEXT,
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
       }, { paranoid: true });
 
       const logging = sinon.spy();
@@ -290,7 +291,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       const afterSave = sinon.spy();
 
       const ParanoidUser = this.sequelize.define('ParanoidUser', {
-        username: Support.Sequelize.STRING,
+        username: DataTypes.STRING,
       }, {
         paranoid: true,
         hooks: {
@@ -323,12 +324,12 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     it('delete a record of multiple primary keys table', async function () {
       const MultiPrimary = this.sequelize.define('MultiPrimary', {
         bilibili: {
-          type: Support.Sequelize.CHAR(2),
+          type: DataTypes.CHAR(2),
           primaryKey: true,
         },
 
         guruguru: {
-          type: Support.Sequelize.CHAR(2),
+          type: DataTypes.CHAR(2),
           primaryKey: true,
         },
       });
@@ -359,11 +360,11 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
         const Date = this.sequelize.define('Date',
           {
             date: {
-              type: Support.Sequelize.DATE,
+              type: DataTypes.DATE,
               primaryKey: true,
             },
             deletedAt: {
-              type: Support.Sequelize.DATE,
+              type: DataTypes.DATE,
               defaultValue: Number.POSITIVE_INFINITY,
             },
           },

--- a/test/integration/instance/increment.test.js
+++ b/test/integration/instance/increment.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 const current = Support.sequelize;
@@ -66,7 +66,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { number: Support.Sequelize.INTEGER });
+        const User = sequelize.define('User', { number: DataTypes.INTEGER });
 
         await User.sync({ force: true });
         const user = await User.create({ number: 1 });

--- a/test/integration/instance/reload.test.js
+++ b/test/integration/instance/reload.test.js
@@ -3,9 +3,8 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const Sequelize = require('@sequelize/core');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const sinon = require('sinon');
 
 const current = Support.sequelize;
@@ -62,7 +61,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
 
         await User.sync({ force: true });
         const user = await User.create({ username: 'foo' });

--- a/test/integration/instance/save.test.js
+++ b/test/integration/instance/save.test.js
@@ -3,9 +3,8 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const Sequelize = require('@sequelize/core');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const sinon = require('sinon');
 
 const current = Support.sequelize;
@@ -62,7 +61,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
         await User.sync({ force: true });
         const t = await sequelize.transaction();
         await User.build({ username: 'foo' }).save({ transaction: t });

--- a/test/integration/instance/to-json.test.js
+++ b/test/integration/instance/to-json.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
   describe('toJSON', () => {

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -2,11 +2,10 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
 
@@ -65,7 +64,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
 
         await User.sync({ force: true });
         const user = await User.create({ username: 'foo' });

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('DAO'), () => {
   describe('Values', () => {

--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -6,9 +6,9 @@ const expect = chai.expect;
 const Support = require('./support');
 
 const dialect = Support.getTestDialect();
-const Sequelize = Support.Sequelize;
+const { Sequelize, DataTypes } = require('@sequelize/core');
+
 const current = Support.sequelize;
-const DataTypes = Sequelize.DataTypes;
 
 describe('model', () => {
   if (current.dialect.supports.JSON) {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1,20 +1,17 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize, Op, AggregateError } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
-const errors = require('@sequelize/core/lib/errors');
 const sinon = require('sinon');
 const _ = require('lodash');
 const moment = require('moment');
 
 const current = Support.sequelize;
-const Op = Sequelize.Op;
 const semver = require('semver');
 const pMap = require('p-map');
 
@@ -2936,7 +2933,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(user.bulkCreate(data, {
         validate: true,
         individualHooks: true,
-      })).to.be.rejectedWith(errors.AggregateError);
+      })).to.be.rejectedWith(AggregateError);
     });
 
     it('should not use setter when renaming fields in dataValues', async function () {

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -2,11 +2,10 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../../support');

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -1,13 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
-const AggregateError = require('@sequelize/core/lib/errors/aggregate-error');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const current = Support.sequelize;

--- a/test/integration/model/bulk-create/include.test.js
+++ b/test/integration/model/bulk-create/include.test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('bulkCreate', () => {

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('count', () => {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -2,14 +2,12 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
-const Op = Sequelize.Op;
 const _ = require('lodash');
 const delay = require('delay');
 const assert = require('assert');

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('create', () => {

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -2,13 +2,11 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
 
-const Op = Sequelize.Op;
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');

--- a/test/integration/model/findAll/group.test.js
+++ b/test/integration/model/findAll/group.test.js
@@ -5,8 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -6,8 +6,7 @@ const sinon = require('sinon');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const _ = require('lodash');

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/integration/model/findAll/separate.test.js
+++ b/test/integration/model/findAll/separate.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -2,13 +2,12 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/integration/model/findOrBuild.test.js
+++ b/test/integration/model/findOrBuild.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   beforeEach(async function () {

--- a/test/integration/model/geography.test.js
+++ b/test/integration/model/geography.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/integration/model/geometry.test.js
+++ b/test/integration/model/geometry.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const semver = require('semver');

--- a/test/integration/model/increment.test.js
+++ b/test/integration/model/increment.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Model'), () => {

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -1,14 +1,11 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
-
-const Op = Sequelize.Op;
 const moment = require('moment');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/integration/model/notExist.test.js
+++ b/test/integration/model/notExist.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   beforeEach(async function () {

--- a/test/integration/model/optimistic_locking.test.js
+++ b/test/integration/model/optimistic_locking.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, OptimisticLockError } = require('@sequelize/core');
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -49,7 +49,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         accountB.number += 1;
 
         return await accountB.save();
-      })()).to.eventually.be.rejectedWith(Support.Sequelize.OptimisticLockError);
+      })()).to.eventually.be.rejectedWith(OptimisticLockError);
     });
 
     it('increment() also increments the version', async () => {

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const chai = require('chai');
 
 const expect = chai.expect;

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -6,10 +6,9 @@ const expect = chai.expect;
 const Support = require('../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op } = require('@sequelize/core');
 
 const current = Support.sequelize;
-const Op = Support.Sequelize.Op;
 
 const SCHEMA_ONE = 'schema_one';
 const SCHEMA_TWO = 'schema_two';

--- a/test/integration/model/scope.test.js
+++ b/test/integration/model/scope.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../support');
 

--- a/test/integration/model/scope/aggregate.test.js
+++ b/test/integration/model/scope/aggregate.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../../support');
 

--- a/test/integration/model/scope/associations.test.js
+++ b/test/integration/model/scope/associations.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../../support');
 

--- a/test/integration/model/scope/count.test.js
+++ b/test/integration/model/scope/count.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../../support');
 

--- a/test/integration/model/scope/destroy.test.js
+++ b/test/integration/model/scope/destroy.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../../support');
 

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
 const expect = chai.expect;
-const Op = Sequelize.Op;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {

--- a/test/integration/model/scope/findAndCountAll.test.js
+++ b/test/integration/model/scope/findAndCountAll.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../../support');
 

--- a/test/integration/model/scope/merge.test.js
+++ b/test/integration/model/scope/merge.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../../support');

--- a/test/integration/model/scope/update.test.js
+++ b/test/integration/model/scope/update.test.js
@@ -1,10 +1,9 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
 const expect = chai.expect;
-const Op = Sequelize.Op;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {

--- a/test/integration/model/searchPath.test.js
+++ b/test/integration/model/searchPath.test.js
@@ -4,9 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-
-const Op = Support.Sequelize.Op;
+const { DataTypes, Op } = require('@sequelize/core');
 
 const SEARCH_PATH_ONE = 'schema_one,public';
 const SEARCH_PATH_TWO = 'schema_two,public';

--- a/test/integration/model/sum.test.js
+++ b/test/integration/model/sum.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   beforeEach(async function () {

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const chai = require('chai');
 const sinon = require('sinon');
 

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -2,11 +2,10 @@
 
 const chai = require('chai');
 const sinon = require('sinon');
-const Sequelize = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const current = Support.sequelize;

--- a/test/integration/operators.test.js
+++ b/test/integration/operators.test.js
@@ -1,12 +1,10 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 

--- a/test/integration/pool.test.js
+++ b/test/integration/pool.test.js
@@ -8,7 +8,7 @@ const Support = require('./support');
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const delay = require('delay');
 
 function assertSameConnection(newConnection, oldConnection) {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -4,10 +4,9 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
-const Sequelize = Support.Sequelize;
 const current = Support.sequelize;
 const _ = require('lodash');
 

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 

--- a/test/integration/query-interface/describeTable.test.js
+++ b/test/integration/query-interface/describeTable.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 

--- a/test/integration/query-interface/dropEnum.test.js
+++ b/test/integration/query-interface/dropEnum.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 

--- a/test/integration/query-interface/getForeignKeyReferencesForTable.test.js
+++ b/test/integration/query-interface/getForeignKeyReferencesForTable.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('../../../lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   beforeEach(function () {

--- a/test/integration/query-interface/removeColumn.test.js
+++ b/test/integration/query-interface/removeColumn.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 

--- a/test/integration/replication.test.js
+++ b/test/integration/replication.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');

--- a/test/integration/schema.test.js
+++ b/test/integration/schema.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Schema'), () => {
   beforeEach(async function () {

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -2,13 +2,11 @@
 
 const { expect, assert } = require('chai');
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Transaction, Sequelize } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
-const Sequelize = require('@sequelize/core');
 const config = require('../config/config');
-const { Transaction } = require('@sequelize/core/lib/transaction');
 const sinon = require('sinon');
 
 const current = Support.sequelize;
@@ -716,7 +714,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
         });
 
         it('is a transaction method available', () => {
-          expect(Support.Sequelize).to.respondTo('transaction');
+          expect(Sequelize).to.respondTo('transaction');
         });
 
         it('passes a transaction object to the callback', async function () {

--- a/test/integration/sequelize.transaction.test.js
+++ b/test/integration/sequelize.transaction.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { Transaction } = require('@sequelize/core/lib/transaction');
+const { Transaction, DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const delay = require('delay');
@@ -45,7 +45,7 @@ if (current.dialect.supports.transactions) {
           this.sequelize = sequelize;
 
           this.User = sequelize.define('User', {
-            name: Support.Sequelize.STRING,
+            name: DataTypes.STRING,
           }, { timestamps: false });
 
           await sequelize.sync({ force: true });
@@ -81,8 +81,8 @@ if (current.dialect.supports.transactions) {
       it('works with promise syntax', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
         const Test = sequelize.define('Test', {
-          id: { type: Support.Sequelize.INTEGER, primaryKey: true, autoIncrement: true },
-          name: { type: Support.Sequelize.STRING },
+          id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },
+          name: { type: DataTypes.STRING },
         });
 
         await sequelize.sync({ force: true });
@@ -109,7 +109,7 @@ if (current.dialect.supports.transactions) {
           this.sequelize = sequelize;
 
           this.Model = sequelize.define('Model', {
-            name: { type: Support.Sequelize.STRING, unique: true },
+            name: { type: DataTypes.STRING, unique: true },
           }, {
             timestamps: false,
           });

--- a/test/integration/sequelize/deferrable.test.js
+++ b/test/integration/sequelize/deferrable.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 
 if (!Support.sequelize.dialect.supports.deferrableConstraints) {
   return;

--- a/test/integration/sequelize/log.test.js
+++ b/test/integration/sequelize/log.test.js
@@ -3,6 +3,7 @@
 const { expect } = require('chai');
 const { stub, spy } = require('sinon');
 const Support = require('../support');
+const { Sequelize } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 
@@ -18,7 +19,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
     describe('with disabled logging', () => {
       beforeEach(function () {
-        this.sequelize = new Support.Sequelize('db', 'user', 'pw', { dialect, logging: false });
+        this.sequelize = new Sequelize('db', 'user', 'pw', { dialect, logging: false });
       });
 
       it('does not call the log method of the logger', function () {
@@ -29,7 +30,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
     describe('with default logging options', () => {
       beforeEach(function () {
-        this.sequelize = new Support.Sequelize('db', 'user', 'pw', { dialect });
+        this.sequelize = new Sequelize('db', 'user', 'pw', { dialect });
       });
 
       describe('called with no arguments', () => {
@@ -62,7 +63,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
     describe('with a custom function for logging', () => {
       beforeEach(function () {
         this.spy = spy();
-        this.sequelize = new Support.Sequelize('db', 'user', 'pw', { dialect, logging: this.spy });
+        this.sequelize = new Sequelize('db', 'user', 'pw', { dialect, logging: this.spy });
       });
 
       it('calls the custom logger method', function () {

--- a/test/integration/sequelize/query.test.js
+++ b/test/integration/sequelize/query.test.js
@@ -3,13 +3,11 @@
 const { expect } = require('chai');
 const Support = require('../support');
 
-const Sequelize = Support.Sequelize;
-const DataTypes = Support.Sequelize.DataTypes;
+const { Sequelize, DataTypes, DatabaseError, UniqueConstraintError, ForeignKeyConstraintError } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 const moment = require('moment');
-
-const { DatabaseError, UniqueConstraintError, ForeignKeyConstraintError } = Support.Sequelize;
 
 const qq = str => {
   if (['postgres', 'mssql', 'db2', 'ibmi'].includes(dialect)) {

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -523,7 +523,7 @@ if (current.dialect.supports.transactions) {
           // back.
           // Otherwise, this READ_COMMITTED doesn't work as expected.
           const User = this.sequelize.define('user', {
-            username: Support.Sequelize.STRING,
+            username: DataTypes.STRING,
           });
           await this.sequelize.sync({ force: true });
           await this.sequelize.transaction(
@@ -663,10 +663,10 @@ if (current.dialect.supports.transactions) {
 
     if (dialect === 'sqlite') {
       it('provides persistent transactions', async () => {
-        const sequelize = new Support.Sequelize('database', 'username', 'password', { dialect: 'sqlite' });
+        const sequelize = new Sequelize('database', 'username', 'password', { dialect: 'sqlite' });
         const User = sequelize.define('user', {
-          username: Support.Sequelize.STRING,
-          awesome: Support.Sequelize.BOOLEAN,
+          username: DataTypes.STRING,
+          awesome: DataTypes.BOOLEAN,
         });
 
         const t1 = await sequelize.transaction();
@@ -709,10 +709,10 @@ if (current.dialect.supports.transactions) {
     if (dialect === 'sqlite') {
       it('automatically retries on SQLITE_BUSY failure', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { username: DataTypes.STRING });
         await User.sync({ force: true });
         const newTransactionFunc = async function () {
-          const t = await sequelize.transaction({ type: Support.Sequelize.Transaction.TYPES.EXCLUSIVE });
+          const t = await sequelize.transaction({ type: Transaction.TYPES.EXCLUSIVE });
           await User.create({}, { transaction: t });
 
           return t.commit();
@@ -725,10 +725,10 @@ if (current.dialect.supports.transactions) {
 
       it('fails with SQLITE_BUSY when retry.match is changed', async function () {
         const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { id: { type: Support.Sequelize.INTEGER, primaryKey: true }, username: Support.Sequelize.STRING });
+        const User = sequelize.define('User', { id: { type: DataTypes.INTEGER, primaryKey: true }, username: DataTypes.STRING });
         await User.sync({ force: true });
         const newTransactionFunc = async function () {
-          const t = await sequelize.transaction({ type: Support.Sequelize.Transaction.TYPES.EXCLUSIVE, retry: { match: ['NO_MATCH'] } });
+          const t = await sequelize.transaction({ type: Transaction.TYPES.EXCLUSIVE, retry: { match: ['NO_MATCH'] } });
           // introduce delay to force the busy state race condition to fail
           await delay(1000);
           await User.create({ id: null, username: `test ${t.id}` }, { transaction: t });
@@ -744,7 +744,7 @@ if (current.dialect.supports.transactions) {
     describe('isolation levels', () => {
       it('should read the most recent committed rows when using the READ COMMITTED isolation level', async function () {
         const User = this.sequelize.define('user', {
-          username: Support.Sequelize.STRING,
+          username: DataTypes.STRING,
         });
 
         await expect(
@@ -767,7 +767,7 @@ if (current.dialect.supports.transactions) {
       if (!['sqlite', 'mssql', 'db2'].includes(dialect)) {
         it('should not read newly committed rows when using the REPEATABLE READ isolation level', async function () {
           const User = this.sequelize.define('user', {
-            username: Support.Sequelize.STRING,
+            username: DataTypes.STRING,
           });
 
           await expect(
@@ -789,7 +789,7 @@ if (current.dialect.supports.transactions) {
       if (!['sqlite', 'postgres', 'postgres-native', 'db2'].includes(dialect)) {
         it('should block updates after reading a row using SERIALIZABLE', async function () {
           const User = this.sequelize.define('user', {
-            username: Support.Sequelize.STRING,
+            username: DataTypes.STRING,
           });
           const transactionSpy = sinon.spy();
 
@@ -822,8 +822,8 @@ if (current.dialect.supports.transactions) {
       describe('row locking', () => {
         it('supports for update', async function () {
           const User = this.sequelize.define('user', {
-            username: Support.Sequelize.STRING,
-            awesome: Support.Sequelize.BOOLEAN,
+            username: DataTypes.STRING,
+            awesome: DataTypes.BOOLEAN,
           });
           const t1Spy = sinon.spy();
           const t2Spy = sinon.spy();
@@ -873,8 +873,8 @@ if (current.dialect.supports.transactions) {
         if (current.dialect.supports.skipLocked) {
           it('supports for update with skip locked', async function () {
             const User = this.sequelize.define('user', {
-              username: Support.Sequelize.STRING,
-              awesome: Support.Sequelize.BOOLEAN,
+              username: DataTypes.STRING,
+              awesome: DataTypes.BOOLEAN,
             });
 
             await this.sequelize.sync({ force: true });
@@ -916,8 +916,8 @@ if (current.dialect.supports.transactions) {
         }
 
         it('fail locking with outer joins', async function () {
-          const User = this.sequelize.define('User', { username: Support.Sequelize.STRING });
-          const Task = this.sequelize.define('Task', { title: Support.Sequelize.STRING, active: Support.Sequelize.BOOLEAN });
+          const User = this.sequelize.define('User', { username: DataTypes.STRING });
+          const Task = this.sequelize.define('Task', { title: DataTypes.STRING, active: DataTypes.BOOLEAN });
 
           User.belongsToMany(Task, { through: 'UserTasks' });
           Task.belongsToMany(User, { through: 'UserTasks' });
@@ -958,8 +958,8 @@ if (current.dialect.supports.transactions) {
 
         if (current.dialect.supports.lockOf) {
           it('supports for update of table', async function () {
-            const User = this.sequelize.define('User', { username: Support.Sequelize.STRING }, { tableName: 'Person' });
-            const Task = this.sequelize.define('Task', { title: Support.Sequelize.STRING, active: Support.Sequelize.BOOLEAN });
+            const User = this.sequelize.define('User', { username: DataTypes.STRING }, { tableName: 'Person' });
+            const Task = this.sequelize.define('Task', { title: DataTypes.STRING, active: DataTypes.BOOLEAN });
 
             User.belongsToMany(Task, { through: 'UserTasks' });
             Task.belongsToMany(User, { through: 'UserTasks' });
@@ -1009,8 +1009,8 @@ if (current.dialect.supports.transactions) {
         if (current.dialect.supports.lockKey) {
           it('supports for key share', async function () {
             const User = this.sequelize.define('user', {
-              username: Support.Sequelize.STRING,
-              awesome: Support.Sequelize.BOOLEAN,
+              username: DataTypes.STRING,
+              awesome: DataTypes.BOOLEAN,
             });
             const t1Spy = sinon.spy();
             const t2Spy = sinon.spy();

--- a/test/integration/trigger.test.js
+++ b/test/integration/trigger.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 
 const expect = chai.expect;
 const Support = require('../support');

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -5,10 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Utils = require('@sequelize/core/lib/utils/index');
 const Support = require('./support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core');
-
-const Op = Sequelize.Op;
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Utils'), () => {
   describe('underscore', () => {

--- a/test/integration/vectors.test.js
+++ b/test/integration/vectors.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 const Support = require('./support');
 
 chai.should();

--- a/test/smoke/smoketests.test.js
+++ b/test/smoke/smoketests.test.js
@@ -4,13 +4,10 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../integration/support');
-const DataTypes = require('sequelize/lib/data-types');
-const Sequelize = require('sequelize');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const _ = require('lodash');
 const sinon = require('sinon');
 
-const Op = Sequelize.Op;
-const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Smoke Tests'), () => {

--- a/test/support.js
+++ b/test/support.js
@@ -5,7 +5,7 @@ const path = require('path');
 const { inspect, isDeepStrictEqual } = require('util');
 const _ = require('lodash');
 
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 const Config = require('./config/config');
 const chai = require('chai');
 
@@ -65,8 +65,6 @@ if (global.afterEach) {
 let lastSqliteInstance;
 
 const Support = {
-  Sequelize,
-
   /**
    * Returns a Promise that will reject with the next unhandled rejection that occurs
    * during this test (instead of failing the test)

--- a/test/unit/associations/association.test.js
+++ b/test/unit/associations/association.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../support');
 
 const current = Support.sequelize;
-const AssociationError = require('@sequelize/core/lib/errors').AssociationError;
+const { AssociationError } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('belongsTo'), () => {
   it('should throw an AssociationError when two associations have the same alias', () => {

--- a/test/unit/associations/belongs-to-many.test.js
+++ b/test/unit/associations/belongs-to-many.test.js
@@ -7,13 +7,9 @@ const expect = chai.expect;
 const stub = sinon.stub;
 const _ = require('lodash');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const BelongsTo = require('@sequelize/core/lib/associations/belongs-to');
-const HasMany = require('@sequelize/core/lib/associations/has-many');
-const HasOne = require('@sequelize/core/lib/associations/has-one');
+const { DataTypes, AssociationError, BelongsTo, HasMany, HasOne } = require('@sequelize/core');
 
 const current = Support.sequelize;
-const AssociationError = require('@sequelize/core/lib/errors').AssociationError;
 
 describe(Support.getTestDialectTeaser('belongsToMany'), () => {
   it('throws when invalid model is passed', () => {

--- a/test/unit/associations/belongs-to.test.js
+++ b/test/unit/associations/belongs-to.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const sinon = require('sinon');
 const _         = require('lodash');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const Support   = require('../support');
 
 const current   = Support.sequelize;

--- a/test/unit/associations/dont-modify-options.test.js
+++ b/test/unit/associations/dont-modify-options.test.js
@@ -4,8 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('associations'), () => {
   describe('Test options.foreignKey', () => {

--- a/test/unit/associations/has-many.test.js
+++ b/test/unit/associations/has-many.test.js
@@ -7,9 +7,7 @@ const expect = chai.expect;
 const stub = sinon.stub;
 const _ = require('lodash');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const HasMany = require('@sequelize/core/lib/associations/has-many');
-const { Op } = require('@sequelize/core/lib/operators');
+const { DataTypes, Op, HasMany } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/unit/associations/has-one.test.js
+++ b/test/unit/associations/has-one.test.js
@@ -6,7 +6,7 @@ const expect    = chai.expect;
 const sinon = require('sinon');
 const _         = require('lodash');
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current   = Support.sequelize;
 

--- a/test/unit/configuration.test.js
+++ b/test/unit/configuration.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('./support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const path = require('path');
 

--- a/test/unit/dialect-module-configuration.test.js
+++ b/test/unit/dialect-module-configuration.test.js
@@ -6,7 +6,8 @@ const expect = chai.expect;
 const path = require('path');
 
 const Support = require(`${__dirname}/support`);
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {

--- a/test/unit/dialects/db2/query-generator.test.js
+++ b/test/unit/dialects/db2/query-generator.test.js
@@ -7,8 +7,7 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
-const { Op } = require('@sequelize/core/lib/operators');
-const { IndexHints } = require('@sequelize/core/lib/index-hints');
+const { Op } = require('@sequelize/core');
 const QueryGenerator = require('@sequelize/core/lib/dialects/db2/query-generator');
 
 if (dialect === 'db2') {

--- a/test/unit/dialects/mariadb/errors.test.js
+++ b/test/unit/dialects/mariadb/errors.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const queryProto = Support.sequelize.dialect.Query.prototype;
 

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -7,8 +7,7 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
-const { Op } = require('@sequelize/core/lib/operators');
-const { IndexHints } = require('@sequelize/core/lib/index-hints');
+const { Op, IndexHints } = require('@sequelize/core');
 const QueryGenerator = require('@sequelize/core/lib/dialects/mariadb/query-generator');
 
 if (dialect === 'mariadb') {

--- a/test/unit/dialects/mssql/connection-manager.test.js
+++ b/test/unit/dialects/mssql/connection-manager.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const Sequelize = require('@sequelize/core');
+const { Sequelize } = require('@sequelize/core');
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -4,9 +4,7 @@ const Support = require('../../support');
 
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
-const DataTypes = require('@sequelize/core/lib/data-types');
-const { Op } = require('@sequelize/core/lib/operators');
-const { TableHints } = require('@sequelize/core/lib/table-hints');
+const { DataTypes, Op, TableHints } = require('@sequelize/core');
 const QueryGenerator = require('@sequelize/core/lib/dialects/mssql/query-generator');
 
 if (current.dialect.name === 'mssql') {

--- a/test/unit/dialects/mssql/query.test.js
+++ b/test/unit/dialects/mssql/query.test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const path = require('path');
 const Query = require('@sequelize/core/lib/dialects/mssql/query');
 const Support = require('../../support');
 

--- a/test/unit/dialects/mysql/errors.test.js
+++ b/test/unit/dialects/mysql/errors.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const queryProto = Support.sequelize.dialect.Query.prototype;
 

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -7,8 +7,7 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
-const { Op } = require('@sequelize/core/lib/operators');
-const { IndexHints } = require('@sequelize/core/lib/index-hints');
+const { Op, IndexHints } = require('@sequelize/core');
 const QueryGenerator = require('@sequelize/core/lib/dialects/mysql/query-generator');
 
 if (dialect === 'mysql') {

--- a/test/unit/dialects/postgres/data-types.test.js
+++ b/test/unit/dialects/postgres/data-types.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const BaseTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes: BaseTypes } = require('@sequelize/core');
 const DataTypes = require('@sequelize/core/lib/dialects/postgres/data-types')(BaseTypes);
 const QueryGenerator = require('@sequelize/core/lib/dialects/postgres/query-generator');
 

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -3,12 +3,11 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const { Op } = require('@sequelize/core/lib/operators');
+const { Op, DataTypes } = require('@sequelize/core');
 const QueryGenerator = require('@sequelize/core/lib/dialects/postgres/query-generator');
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const DataTypes = require('@sequelize/core/lib/data-types');
 const moment = require('moment');
 
 const current = Support.sequelize;

--- a/test/unit/dialects/snowflake/errors.test.js
+++ b/test/unit/dialects/snowflake/errors.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const queryProto = Support.sequelize.dialect.Query.prototype;
 

--- a/test/unit/dialects/snowflake/query-generator.test.js
+++ b/test/unit/dialects/snowflake/query-generator.test.js
@@ -7,8 +7,7 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
-const { Op } = require('@sequelize/core/lib/operators');
-const { IndexHints } = require('@sequelize/core/lib/index-hints');
+const { Op, IndexHints } = require('@sequelize/core');
 const QueryGenerator = require('@sequelize/core/lib/dialects/snowflake/query-generator');
 
 if (dialect === 'snowflake') {

--- a/test/unit/dialects/sqlite/connection-manager.test.js
+++ b/test/unit/dialects/sqlite/connection-manager.test.js
@@ -5,7 +5,8 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../../support');
 
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -4,12 +4,11 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
 const moment = require('moment');
-const { Op } = require('@sequelize/core/lib/operators');
 const QueryGenerator = require('@sequelize/core/lib/dialects/sqlite/query-generator');
 
 if (dialect === 'sqlite') {

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const errors = require('@sequelize/core/lib/errors');
 const expect = require('chai').expect;
+const errors = require('@sequelize/core/lib/errors');
+
+const { AggregateError } = errors;
 
 describe('errors', () => {
   it('should maintain stack trace with message', () => {
@@ -59,7 +61,6 @@ describe('errors', () => {
 
   describe('AggregateError', () => {
     it('get .message works', () => {
-      const { AggregateError } = errors;
       expect(String(
         new AggregateError([
           new Error('foo'),

--- a/test/unit/hooks.test.js
+++ b/test/unit/hooks.test.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('./support');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const _ = require('lodash');
 
 const current = Support.sequelize;
@@ -51,7 +52,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.afterCreateHook = sinon.spy();
 
         this.Model = current.define('m', {
-          name: Support.Sequelize.STRING,
+          name: DataTypes.STRING,
         }, {
           hooks: {
             beforeSave: this.beforeSaveHook,
@@ -75,7 +76,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.afterSaveHook = sinon.spy();
 
         this.Model = current.define('m', {
-          name: Support.Sequelize.STRING,
+          name: DataTypes.STRING,
         });
 
         this.Model.addHook('beforeSave', this.beforeSaveHook);
@@ -95,7 +96,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
         this.afterSaveHook = sinon.spy();
 
         this.Model = current.define('m', {
-          name: Support.Sequelize.STRING,
+          name: DataTypes.STRING,
         });
 
         this.Model.addHook('beforeSave', this.beforeSaveHook);
@@ -378,10 +379,10 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     });
 
     it('runs all beforInit/afterInit hooks', function () {
-      Support.Sequelize.addHook('beforeInit', 'h1', this.hook1);
-      Support.Sequelize.addHook('beforeInit', 'h2', this.hook2);
-      Support.Sequelize.addHook('afterInit', 'h3', this.hook3);
-      Support.Sequelize.addHook('afterInit', 'h4', this.hook4);
+      Sequelize.addHook('beforeInit', 'h1', this.hook1);
+      Sequelize.addHook('beforeInit', 'h2', this.hook2);
+      Sequelize.addHook('afterInit', 'h3', this.hook3);
+      Sequelize.addHook('afterInit', 'h4', this.hook4);
 
       Support.createSequelizeInstance();
 
@@ -390,11 +391,11 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
       expect(this.hook3).to.have.been.calledOnce;
       expect(this.hook4).to.have.been.calledOnce;
 
-      // cleanup hooks on Support.Sequelize
-      Support.Sequelize.removeHook('beforeInit', 'h1');
-      Support.Sequelize.removeHook('beforeInit', 'h2');
-      Support.Sequelize.removeHook('afterInit', 'h3');
-      Support.Sequelize.removeHook('afterInit', 'h4');
+      // cleanup hooks on Sequelize
+      Sequelize.removeHook('beforeInit', 'h1');
+      Sequelize.removeHook('beforeInit', 'h2');
+      Sequelize.removeHook('afterInit', 'h3');
+      Sequelize.removeHook('afterInit', 'h4');
 
       Support.createSequelizeInstance();
 

--- a/test/unit/increment.test.js
+++ b/test/unit/increment.test.js
@@ -4,20 +4,20 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support   = require('../support');
+const { DataTypes } = require('@sequelize/core');
 
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('increment', () => {
     describe('options tests', () => {
       const Model = current.define('User', {
         id: {
-          type: Sequelize.BIGINT,
+          type: DataTypes.BIGINT,
           primaryKey: true,
           autoIncrement: true,
         },
-        count: Sequelize.BIGINT,
+        count: DataTypes.BIGINT,
       });
 
       it('should reject if options are missing', async () => {

--- a/test/unit/instance-validator.test.js
+++ b/test/unit/instance-validator.test.js
@@ -6,13 +6,13 @@ const expect = chai.expect;
 const Support = require('./support');
 const InstanceValidator = require('@sequelize/core/lib/instance-validator');
 const sinon = require('sinon');
-const SequelizeValidationError = require('@sequelize/core/lib/errors').ValidationError;
+const { ValidationError: SequelizeValidationError, DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
   beforeEach(function () {
     this.User = Support.sequelize.define('user', {
       fails: {
-        type: Support.Sequelize.BOOLEAN,
+        type: DataTypes.BOOLEAN,
         validate: {
           isNotTrue(value) {
             if (value) {
@@ -69,7 +69,7 @@ describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
     it('has a useful default error message for not null validation failures', async () => {
       const User = Support.sequelize.define('user', {
         name: {
-          type: Support.Sequelize.STRING,
+          type: DataTypes.STRING,
           allowNull: false,
         },
       });

--- a/test/unit/instance/build.test.js
+++ b/test/unit/instance/build.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current   = Support.sequelize;
 

--- a/test/unit/instance/changed.test.js
+++ b/test/unit/instance/changed.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current   = Support.sequelize;
 

--- a/test/unit/instance/decrement.test.js
+++ b/test/unit/instance/decrement.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support   = require('../support');
 
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const sinon     = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/instance/destroy.test.js
+++ b/test/unit/instance/destroy.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support   = require('../support');
 
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const sinon     = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/instance/get.test.js
+++ b/test/unit/instance/get.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current   = Support.sequelize;
 

--- a/test/unit/instance/increment.test.js
+++ b/test/unit/instance/increment.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support   = require('../support');
 
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const sinon     = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/instance/is-soft-deleted.test.js
+++ b/test/unit/instance/is-soft-deleted.test.js
@@ -6,9 +6,8 @@ const expect = chai.expect;
 const Support   = require('../support');
 
 const current   = Support.sequelize;
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
-const Sequelize = Support.Sequelize;
 const moment    = require('moment');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/instance/previous.test.js
+++ b/test/unit/instance/previous.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/unit/instance/reload.test.js
+++ b/test/unit/instance/reload.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support   = require('../support');
 
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const sinon     = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/instance/restore.test.js
+++ b/test/unit/instance/restore.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support   = require('../support');
 
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const sinon     = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/instance/save.test.js
+++ b/test/unit/instance/save.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support   = require('../support');
 
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
+const { Sequelize } = require('@sequelize/core');
 const sinon     = require('sinon');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {

--- a/test/unit/instance/set.test.js
+++ b/test/unit/instance/set.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const sinon = require('sinon');

--- a/test/unit/instance/to-json.test.js
+++ b/test/unit/instance/to-json.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current   = Support.sequelize;
 

--- a/test/unit/model/bulk-create.test.js
+++ b/test/unit/model/bulk-create.test.js
@@ -5,7 +5,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const sinon = require('sinon');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const current = Support.sequelize;
 

--- a/test/unit/model/count.test.js
+++ b/test/unit/model/count.test.js
@@ -5,18 +5,17 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../support');
 
-const Sequelize = Support.Sequelize;
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Model } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method count', () => {
     before(function () {
-      this.oldFindAll = Sequelize.Model.findAll;
-      this.oldAggregate = Sequelize.Model.aggregate;
+      this.oldFindAll = Model.findAll;
+      this.oldAggregate = Model.aggregate;
 
-      Sequelize.Model.findAll = sinon.stub().resolves();
+      Model.findAll = sinon.stub().resolves();
 
       this.User = current.define('User', {
         username: DataTypes.STRING,
@@ -31,12 +30,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     });
 
     after(function () {
-      Sequelize.Model.findAll = this.oldFindAll;
-      Sequelize.Model.aggregate = this.oldAggregate;
+      Model.findAll = this.oldFindAll;
+      Model.aggregate = this.oldAggregate;
     });
 
     beforeEach(function () {
-      this.stub = Sequelize.Model.aggregate = sinon.stub().resolves();
+      this.stub = Model.aggregate = sinon.stub().resolves();
     });
 
     describe('should pass the same options to model.aggregate as findAndCountAll', () => {

--- a/test/unit/model/define.test.js
+++ b/test/unit/model/define.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 const current = Support.sequelize;

--- a/test/unit/model/destroy.test.js
+++ b/test/unit/model/destroy.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
 

--- a/test/unit/model/find-all.test.js
+++ b/test/unit/model/find-all.test.js
@@ -7,9 +7,8 @@ const Support = require('../support');
 
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, QueryError } = require('@sequelize/core');
 const { Logger } = require('@sequelize/core/lib/utils/logger');
-const sequelizeErrors = require('@sequelize/core/lib/errors');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('warnOnInvalidOptions', () => {
@@ -68,7 +67,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('Throws an error when the attributes option is formatted incorrectly', async () => {
-        await expect(Model.findAll({ attributes: 'name' })).to.be.rejectedWith(sequelizeErrors.QueryError);
+        await expect(Model.findAll({ attributes: 'name' })).to.be.rejectedWith(QueryError);
       });
     });
 

--- a/test/unit/model/find-and-count-all.test.js
+++ b/test/unit/model/find-and-count-all.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('findAndCountAll', () => {

--- a/test/unit/model/find-by-pk.test.js
+++ b/test/unit/model/find-by-pk.test.js
@@ -5,11 +5,9 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../support');
 
-const Sequelize = Support.Sequelize;
-const Op = Sequelize.Op;
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('../../../lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method findByPk', () => {

--- a/test/unit/model/find-create-find.test.js
+++ b/test/unit/model/find-create-find.test.js
@@ -3,7 +3,7 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const { EmptyResultError, UniqueConstraintError } = require('@sequelize/core/lib/errors');
+const { EmptyResultError, UniqueConstraintError } = require('@sequelize/core');
 const Support = require('../support');
 
 const current = Support.sequelize;

--- a/test/unit/model/find-one.test.js
+++ b/test/unit/model/find-one.test.js
@@ -5,11 +5,9 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../support');
 
-const Sequelize = Support.Sequelize;
-const Op = Sequelize.Op;
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method findOne', () => {

--- a/test/unit/model/get-attributes.test.js
+++ b/test/unit/model/get-attributes.test.js
@@ -6,8 +6,7 @@ const expect = chai.expect;
 const Support = require('../support');
 
 const current = Support.sequelize;
-const _ = require('lodash');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 function assertDataType(property, dataType) {
   expect(property.type.constructor.key).to.equal(dataType.key);

--- a/test/unit/model/indexes.test.js
+++ b/test/unit/model/indexes.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../support');
 
 const current = Support.sequelize;
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('indexes', () => {

--- a/test/unit/model/overwriting-builtins.test.js
+++ b/test/unit/model/overwriting-builtins.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
 

--- a/test/unit/model/remove-attribute.test.js
+++ b/test/unit/model/remove-attribute.test.js
@@ -7,7 +7,7 @@ const Support   = require('../support');
 
 const current   = Support.sequelize;
 const _ = require('lodash');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('removeAttribute', () => {

--- a/test/unit/model/scope.test.js
+++ b/test/unit/model/scope.test.js
@@ -3,10 +3,9 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const { Sequelize, Op } = require('@sequelize/core');
+const { Sequelize, Op, DataTypes } = require('@sequelize/core');
 
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
 
 const current   = Support.sequelize;
 

--- a/test/unit/model/underscored.test.js
+++ b/test/unit/model/underscored.test.js
@@ -4,8 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core');
+const { Sequelize, DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('options.underscored', () => {

--- a/test/unit/model/update.test.js
+++ b/test/unit/model/update.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('method update', () => {

--- a/test/unit/model/upsert.test.js
+++ b/test/unit/model/upsert.test.js
@@ -3,12 +3,11 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const Sequelize = require('@sequelize/core');
 const Support = require('../support');
 
 const current = Support.sequelize;
 const sinon = require('sinon');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   if (current.dialect.supports.upserts) {

--- a/test/unit/model/validation.test.js
+++ b/test/unit/model/validation.test.js
@@ -4,9 +4,8 @@ const chai = require('chai');
 const sinon = require('sinon');
 
 const expect = chai.expect;
-const Sequelize = require('@sequelize/core');
+const { Sequelize, Op } = require('@sequelize/core');
 
-const Op = Sequelize.Op;
 const Support = require('../support');
 
 const current = Support.sequelize;

--- a/test/unit/sql/add-column.test.js
+++ b/test/unit/sql/add-column.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;

--- a/test/unit/sql/add-constraint.test.js
+++ b/test/unit/sql/add-constraint.test.js
@@ -5,9 +5,9 @@ const Support = require('../support');
 const current = Support.sequelize;
 const expectsql = Support.expectsql;
 const sql = current.dialect.queryGenerator;
-const Op = Support.Sequelize.Op;
 const expect = require('chai').expect;
 const sinon = require('sinon');
+const { Op } = require('@sequelize/core');
 
 if (current.dialect.supports.constraints.addConstraint) {
   describe(Support.getTestDialectTeaser('SQL'), () => {

--- a/test/unit/sql/change-column.test.js
+++ b/test/unit/sql/change-column.test.js
@@ -2,7 +2,7 @@
 
 const sinon = require('sinon');
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current = Support.sequelize;

--- a/test/unit/sql/create-table.test.js
+++ b/test/unit/sql/create-table.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;

--- a/test/unit/sql/data-types.test.js
+++ b/test/unit/sql/data-types.test.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 
-const Sequelize = Support.Sequelize;
 const chai = require('chai');
 const util = require('util');
 const uuid = require('uuid');

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const Support   = require('../support');
-const { QueryTypes } = require('@sequelize/core/lib/query-types');
+const { QueryTypes, Sequelize } = require('@sequelize/core');
 const util = require('util');
 const _ = require('lodash');
 
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;
-const Sequelize = Support.Sequelize;
 const sql       = current.dialect.queryGenerator;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation

--- a/test/unit/sql/enum.test.js
+++ b/test/unit/sql/enum.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;

--- a/test/unit/sql/generateJoin.test.js
+++ b/test/unit/sql/generateJoin.test.js
@@ -1,15 +1,13 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Sequelize = require('@sequelize/core/lib/sequelize');
+const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 const util = require('util');
 const _ = require('lodash');
 
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
 const sql = current.dialect.queryGenerator;
-const Op = Sequelize.Op;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 

--- a/test/unit/sql/get-constraint-snippet.test.js
+++ b/test/unit/sql/get-constraint-snippet.test.js
@@ -1,13 +1,12 @@
 'use strict';
 
 const Support = require('../support');
+const { Op } = require('@sequelize/core');
 
 const current = Support.sequelize;
 const expectsql = Support.expectsql;
 const sql = current.dialect.queryGenerator;
 const expect = require('chai').expect;
-
-const Op = Support.Sequelize.Op;
 
 describe(Support.getTestDialectTeaser('SQL'), () => {
   describe('getConstraintSnippet', () => {

--- a/test/unit/sql/group.test.js
+++ b/test/unit/sql/group.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes   = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 const util        = require('util');
 
 const expectsql   = Support.expectsql;

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const Support = require('../support');
+const { Op } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
 const sql = current.dialect.queryGenerator;
-const Op = Support.Sequelize.Op;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;

--- a/test/unit/sql/json.test.js
+++ b/test/unit/sql/json.test.js
@@ -1,11 +1,10 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes, Sequelize } = require('@sequelize/core');
 const expect = require('chai').expect;
 
 const expectsql = Support.expectsql;
-const Sequelize = Support.Sequelize;
 const current = Support.sequelize;
 const sql = current.dialect.queryGenerator;
 

--- a/test/unit/sql/order.test.js
+++ b/test/unit/sql/order.test.js
@@ -5,8 +5,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Model = require('@sequelize/core/lib/model');
+const { DataTypes, Model } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current = Support.sequelize;

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const Support = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
-const Model = require('@sequelize/core/lib/model');
+const { DataTypes, Model, Op } = require('@sequelize/core');
 const util = require('util');
 const chai = require('chai');
 
@@ -10,7 +9,6 @@ const expect = chai.expect;
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
 const sql = current.dialect.queryGenerator;
-const Op = Support.Sequelize.Op;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 

--- a/test/unit/sql/update.test.js
+++ b/test/unit/sql/update.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Support   = require('../support');
-const DataTypes = require('@sequelize/core/lib/data-types');
+const { DataTypes } = require('@sequelize/core');
 
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;

--- a/test/unit/transaction.test.js
+++ b/test/unit/transaction.test.js
@@ -6,7 +6,8 @@ const expect = chai.expect;
 const sinon = require('sinon');
 const Support = require('./support');
 
-const Sequelize = Support.Sequelize;
+const { Transaction } = require('@sequelize/core');
+
 const dialect = Support.getTestDialect();
 const current = Support.sequelize;
 
@@ -79,7 +80,7 @@ if (dialect !== 'ibmi') {
         ],
       };
 
-      await current.transaction({ isolationLevel: Sequelize.Transaction.ISOLATION_LEVELS.READ_UNCOMMITTED }, async () => {
+      await current.transaction({ isolationLevel: Transaction.ISOLATION_LEVELS.READ_UNCOMMITTED }, async () => {
         expect(this.stub.args.map(arg => arg[0])).to.deep.equal(expectations[dialect] || expectations.all);
       });
     });

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -6,7 +6,6 @@ const expect = chai.expect;
 const Support = require('./support');
 const { DataTypes, Op } = require('@sequelize/core');
 const Utils = require('@sequelize/core/lib/utils/index');
-const { logger } = require('@sequelize/core/lib/utils/logger');
 
 describe(Support.getTestDialectTeaser('Utils'), () => {
   describe('merge', () => {


### PR DESCRIPTION
## Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?


### Description Of Change

This PR updates how Sequelize is imported from tests to reduce accessing `/lib` as much as possible for two reasons:

- We plan on removing the ability to import `/lib`
- We often have to update them as the TS migration continues, this will reduce that noise by accessing the public API as much as possible.

After this PR, `/lib` will only be referenced 42 times in tests (instead of hundred of times). The remaining exports are things that cannot be imported from the root package, such as dialects.

In the future, these exports will be imported through the `/_use-at-your-own-risk_/` package (inspired by https://github.com/eslint/eslint/blob/main/package.json#L13):

```
require('@sequelize/core/lib/dialects/abstract/query-generator');
// becomes
require('@sequelize/core/_use-at-your-own-risk_/dialects/abstract/query-generator');
```

This PR is part of a series of PR that reduce the size of https://github.com/sequelize/sequelize/pull/14280