### PR TITLE
test(db2): remove db2-specific expectations

### DIFF
--- a/test/integration/sequelize/query.test.js
+++ b/test/integration/sequelize/query.test.js
@@ -386,12 +386,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             error = error_;
           }
 
-          if (dialect === 'db2') {
-            expect(error).to.be.instanceOf(DatabaseError);
-          } else {
-            expect(error).to.be.instanceOf(DatabaseError);
-            expect(error.stack).to.contain('query.test');
-          }
+          expect(error).to.be.instanceOf(DatabaseError);
+          expect(error.stack).to.contain('query.test');
         });
 
         it('emits full stacktraces for unique constraint error', async function () {
@@ -416,12 +412,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             error = error_;
           }
 
-          if (dialect === 'db2') {
-            expect(error).to.be.instanceOf(DatabaseError);
-          } else {
-            expect(error).to.be.instanceOf(UniqueConstraintError);
-            expect(error.stack).to.contain('query.test');
-          }
+          expect(error).to.be.instanceOf(UniqueConstraintError);
+          expect(error.stack).to.contain('query.test');
         });
 
         it('emits full stacktraces for constraint validation error', async function () {
@@ -447,12 +439,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             error = error_;
           }
 
-          if (dialect === 'db2') {
-            expect(error).to.be.instanceOf(DatabaseError);
-          } else {
-            expect(error).to.be.instanceOf(ForeignKeyConstraintError);
-            expect(error.stack).to.contain('query.test');
-          }
+          expect(error).to.be.instanceOf(ForeignKeyConstraintError);
+          expect(error.stack).to.contain('query.test');
         });
       });
     }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [X] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

I noticed in #14284 that a test failed because it was returning UniqueConstraintError instead of DatabaseError. Then I tested the others in that group as well and they all return what they also do for other dialects. So that was probably fixed in a later stage of the db2 PR. 
