### PR TITLE
docs: fix dead link in API reference

### DIFF
--- a/docs/transforms/header-customization.js
+++ b/docs/transforms/header-customization.js
@@ -5,7 +5,8 @@ module.exports = function transform($) {
   const githubLogoImage = $('header a img[src="./image/github.png"]');
 
   apiReferenceLink
-    .text('API Reference')
+    .attr('href', '/docs/v6/intro/')
+    .text('Guides')
     .addClass('api-reference-link');
 
   githubLogoImage


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Fixes this comment https://github.com/sequelize/website/issues/43#issuecomment-1086796681

This PR replaces the dead 'API Reference' link with `<a href="/docs/v6/intro/" data-ice="manualHeaderLink" class="api-reference-link">Guides</a>`