### PR TITLE
test: disable deadlock test for mariadb 10.5.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,11 +258,11 @@ jobs:
             dialect: mariadb
             node-version: 16
           - name: MariaDB 10.5
-            image: mariadb:10.5.13
+            image: mariadb:10.5
             dialect: mariadb
             node-version: 12
           - name: MariaDB 10.5
-            image: mariadb:10.5.13
+            image: mariadb:10.5
             dialect: mariadb
             node-version: 16
     name: ${{ matrix.name }} (Node ${{ matrix.node-version }})

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -539,6 +539,15 @@ if (current.dialect.supports.transactions) {
         });
 
         it('should release the connection for a deadlocked transaction (2/2)', async function () {
+          // TODO [>=2022-06-01]: The following code is supposed to cause a deadlock in MariaDB,
+          //  but starting with MariaDB 10.5.15, this does not happen anymore.
+          //  We think it may be a bug in MariaDB, so we temporarily disable this test for that specific version
+          //  If this still happens on newer releases, update this check, or look into why this is not working.
+          //  See https://github.com/sequelize/sequelize/issues/14174
+          if (dialect === 'mariadb' && this.sequelize.options.databaseVersion === '10.5.15') {
+            return;
+          }
+
           const verifyDeadlock = async () => {
             const User = this.sequelize.define('user', {
               username: DataTypes.STRING,


### PR DESCRIPTION
Same PR as https://github.com/sequelize/sequelize/pull/14314, but for v7

With one difference: CI tests are now run against latest mariadb 10.5 again