### PR TITLE
feat: use native `Error#cause` in Sequelize errors

### DIFF
--- a/src/dialects/db2/query.js
+++ b/src/dialects/db2/query.js
@@ -413,7 +413,7 @@ export class Db2Query extends AbstractQuery {
         ));
       });
 
-      return new sequelizeErrors.UniqueConstraintError({ message, errors, parent: err, fields, stack: errStack });
+      return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
     }
 
     match = err.message.match(/SQL0532N {2}A parent row cannot be deleted because the relationship "(.*)" restricts the deletion/)
@@ -423,7 +423,7 @@ export class Db2Query extends AbstractQuery {
       return new sequelizeErrors.ForeignKeyConstraintError({
         fields: null,
         index: match[1],
-        parent: err,
+        cause: err,
         stack: errStack,
       });
     }
@@ -438,7 +438,7 @@ export class Db2Query extends AbstractQuery {
         message: match[0],
         constraint,
         table,
-        parent: err,
+        cause: err,
         stack: errStack,
       });
     }

--- a/src/dialects/ibmi/query.js
+++ b/src/dialects/ibmi/query.js
@@ -243,7 +243,7 @@ export class IBMiQuery extends AbstractQuery {
 
       if (foreignKeyConstraintCodes.includes(odbcError.code)) {
         return new sequelizeErrors.ForeignKeyConstraintError({
-          parent: err,
+          cause: err,
           sql: {},
           fields: {},
           stack: stacktrace,
@@ -253,7 +253,7 @@ export class IBMiQuery extends AbstractQuery {
       if (uniqueConstraintCodes.includes(odbcError.code)) {
         return new sequelizeErrors.UniqueConstraintError({
           errors: err.odbcErrors,
-          parent: err,
+          cause: err,
           sql: {},
           fields: {},
           stack: stacktrace,
@@ -271,7 +271,7 @@ export class IBMiQuery extends AbstractQuery {
 
           if (type === '*N') {
             return new sequelizeErrors.UnknownConstraintError({
-              parent: err,
+              cause: err,
               constraint: constraintName,
             });
           }

--- a/src/dialects/mariadb/query.js
+++ b/src/dialects/mariadb/query.js
@@ -280,7 +280,7 @@ export class MariaDbQuery extends AbstractQuery {
           ));
         });
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, parent: err, fields, stack: errStack });
+        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
       }
 
       case ER_ROW_IS_REFERENCED:
@@ -298,7 +298,7 @@ export class MariaDbQuery extends AbstractQuery {
           fields,
           value: fields && fields.length && this.instance && this.instance[fields[0]] || undefined,
           index: match ? match[2] : undefined,
-          parent: err,
+          cause: err,
           stack: errStack,
         });
       }

--- a/src/dialects/mssql/query.js
+++ b/src/dialects/mssql/query.js
@@ -334,7 +334,7 @@ export class MsSqlQuery extends AbstractQuery {
         ));
       });
 
-      return new sequelizeErrors.UniqueConstraintError({ message, errors, parent: err, fields, stack: errStack });
+      return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
     }
 
     match = err.message.match(/Failed on step '(.*)'.Could not create constraint. See previous errors./)
@@ -344,7 +344,7 @@ export class MsSqlQuery extends AbstractQuery {
       return new sequelizeErrors.ForeignKeyConstraintError({
         fields: null,
         index: match[1],
-        parent: err,
+        cause: err,
         stack: errStack,
       });
     }
@@ -360,7 +360,7 @@ export class MsSqlQuery extends AbstractQuery {
         message: match[1],
         constraint,
         table,
-        parent: err,
+        cause: err,
         stack: errStack,
       });
     }

--- a/src/dialects/mysql/query.js
+++ b/src/dialects/mysql/query.js
@@ -260,7 +260,7 @@ export class MySqlQuery extends AbstractQuery {
           ));
         });
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, parent: err, fields, stack: errStack });
+        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
       }
 
       case ER_ROW_IS_REFERENCED:
@@ -278,7 +278,7 @@ export class MySqlQuery extends AbstractQuery {
           fields,
           value: fields && fields.length && this.instance && this.instance[fields[0]] || undefined,
           index: match ? match[2] : undefined,
-          parent: err,
+          cause: err,
           stack: errStack,
         });
       }

--- a/src/dialects/postgres/query.js
+++ b/src/dialects/postgres/query.js
@@ -357,7 +357,7 @@ export class PostgresQuery extends AbstractQuery {
           fields: null,
           index,
           table,
-          parent: err,
+          cause: err,
           stack: errStack,
         });
       case '23505':
@@ -389,12 +389,12 @@ export class PostgresQuery extends AbstractQuery {
             });
           }
 
-          return new sequelizeErrors.UniqueConstraintError({ message, errors, parent: err, fields, stack: errStack });
+          return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
         }
 
         return new sequelizeErrors.UniqueConstraintError({
           message: errMessage,
-          parent: err,
+          cause: err,
           stack: errStack,
         });
 
@@ -412,7 +412,7 @@ export class PostgresQuery extends AbstractQuery {
           constraint: err.constraint,
           fields,
           table: err.table,
-          parent: err,
+          cause: err,
           stack: errStack,
         });
 
@@ -429,7 +429,7 @@ export class PostgresQuery extends AbstractQuery {
             constraint: index,
             fields,
             table,
-            parent: err,
+            cause: err,
             stack: errStack,
           });
         }

--- a/src/dialects/snowflake/query.js
+++ b/src/dialects/snowflake/query.js
@@ -273,7 +273,7 @@ export class SnowflakeQuery extends AbstractQuery {
           ));
         });
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, parent: err, fields });
+        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields });
       }
 
       case ER_ROW_IS_REFERENCED:
@@ -291,7 +291,7 @@ export class SnowflakeQuery extends AbstractQuery {
           fields,
           value: fields && fields.length && this.instance && this.instance[fields[0]] || undefined,
           index: match ? match[2] : undefined,
-          parent: err,
+          cause: err,
         });
       }
 

--- a/src/dialects/sqlite/query.js
+++ b/src/dialects/sqlite/query.js
@@ -392,7 +392,7 @@ export class SqliteQuery extends AbstractQuery {
       case 'SQLITE_CONSTRAINT': {
         if (err.message.includes('FOREIGN KEY constraint failed')) {
           return new sequelizeErrors.ForeignKeyConstraintError({
-            parent: err,
+            cause: err,
             stack: errStack,
           });
         }
@@ -436,7 +436,7 @@ export class SqliteQuery extends AbstractQuery {
           });
         }
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, parent: err, fields, stack: errStack });
+        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
       }
 
       case 'SQLITE_BUSY':

--- a/src/errors/association-error.ts
+++ b/src/errors/association-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/association-error.ts
+++ b/src/errors/association-error.ts
@@ -4,8 +4,8 @@ import BaseError from './base-error';
  * Thrown when an association is improperly constructed (see message for details)
  */
 class AssociationError extends BaseError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SequelizeAssociationError';
   }
 }

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -13,7 +13,7 @@ export interface CommonErrorProperties {
 //  Remove me in Sequelize 8, where this is added natively by TypeScript (>= 4.6):
 //  This is a breaking change and must be done in a MAJOR release.
 export type ErrorOptions = {
-  cause?: unknown,
+  cause?: Error,
 };
 
 const supportsErrorCause = (() => {
@@ -33,7 +33,7 @@ const supportsErrorCause = (() => {
  * This means that errors can be accessed using `Sequelize.ValidationError`
  */
 abstract class BaseError extends Error {
-  declare cause: unknown;
+  declare cause: Error | undefined;
 
   get parent(): this['cause'] {
     useErrorCause();

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -1,14 +1,10 @@
-export interface ErrorOptions {
+import { useErrorCause } from '../utils/deprecations.js';
+
+export interface SequelizeErrorOptions {
   stack?: string;
 }
 
 export interface CommonErrorProperties {
-  /** The database specific error which triggered this one */
-  readonly parent: Error;
-
-  /** The database specific error which triggered this one */
-  readonly original: Error;
-
   /** The SQL that triggered the error */
   readonly sql: string;
 }
@@ -22,8 +18,20 @@ export interface CommonErrorProperties {
  * This means that errors can be accessed using `Sequelize.ValidationError`
  */
 abstract class BaseError extends Error {
-  constructor(message?: string) {
-    super(message);
+  get parent(): this['cause'] {
+    useErrorCause();
+
+    return this.cause;
+  }
+
+  get original(): this['cause'] {
+    useErrorCause();
+
+    return this.cause;
+  }
+
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SequelizeBaseError';
   }
 }

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -56,7 +56,7 @@ abstract class BaseError extends Error {
 
     if (!supportsErrorCause) {
       // TODO [>=2023-04-30]:
-      //  Once all supported node versions have support for Error.cause (added in node 16), delete this line:
+      //  Once all supported node versions have support for Error.cause (added in Node 16.9.0), delete this line:
       //  This is a breaking change and must be done in a MAJOR release.
       this.cause = options?.cause;
     }

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -9,6 +9,12 @@ export interface CommonErrorProperties {
   readonly sql: string;
 }
 
+const supportsErrorCause = (() => {
+  const err = new Error('Dummy 1', { cause: new Error('Dummy 2') });
+
+  return 'cause' in err;
+})();
+
 /**
  * The Base Error all Sequelize Errors inherit from.
  *
@@ -33,6 +39,11 @@ abstract class BaseError extends Error {
   constructor(message?: string, options?: ErrorOptions) {
     super(message, options);
     this.name = 'SequelizeBaseError';
+
+    if (!supportsErrorCause) {
+      // TODO [>=2024-04-30]: Once all supported node versions have support for Error.cause, delete this line:
+      this.cause = options?.cause;
+    }
   }
 }
 

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -9,7 +9,16 @@ export interface CommonErrorProperties {
   readonly sql: string;
 }
 
+// TODO [>=2023-04-30]:
+//  Remove me in Sequelize 8, where this is added natively by TypeScript (>= 4.6):
+//  This is a breaking change and must be done in a MAJOR release.
+export type ErrorOptions = {
+  cause?: unknown,
+};
+
 const supportsErrorCause = (() => {
+  // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- Supported in TS 4.6, not before
+  // @ts-ignore
   const err = new Error('Dummy 1', { cause: new Error('Dummy 2') });
 
   return 'cause' in err;
@@ -24,6 +33,8 @@ const supportsErrorCause = (() => {
  * This means that errors can be accessed using `Sequelize.ValidationError`
  */
 abstract class BaseError extends Error {
+  declare cause: unknown;
+
   get parent(): this['cause'] {
     useErrorCause();
 
@@ -37,6 +48,9 @@ abstract class BaseError extends Error {
   }
 
   constructor(message?: string, options?: ErrorOptions) {
+    // TODO [>=2023-04-30]: remove this ts-ignore (Sequelize 8)
+    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- Supported in TS 4.6, not before
+    // @ts-ignore
     super(message, options);
     this.name = 'SequelizeBaseError';
 

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -41,7 +41,9 @@ abstract class BaseError extends Error {
     this.name = 'SequelizeBaseError';
 
     if (!supportsErrorCause) {
-      // TODO [>=2024-04-30]: Once all supported node versions have support for Error.cause, delete this line:
+      // TODO [>=2023-04-30]:
+      //  Once all supported node versions have support for Error.cause (added in node 16), delete this line:
+      //  This is a breaking change and must be done in a MAJOR release.
       this.cause = options?.cause;
     }
   }

--- a/src/errors/bulk-record-error.ts
+++ b/src/errors/bulk-record-error.ts
@@ -12,8 +12,8 @@ class BulkRecordError extends BaseError {
   errors: Error;
   record: Model;
 
-  constructor(error: Error, record: Model) {
-    super(error.message);
+  constructor(error: Error, record: Model, options?: ErrorOptions) {
+    super(error.message, options);
     this.name = 'SequelizeBulkRecordError';
     this.errors = error;
     this.record = record;

--- a/src/errors/bulk-record-error.ts
+++ b/src/errors/bulk-record-error.ts
@@ -1,4 +1,5 @@
 import type { Model } from '..';
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/connection-error.ts
+++ b/src/errors/connection-error.ts
@@ -2,17 +2,13 @@ import BaseError from './base-error';
 
 /**
  * A base class for all connection related errors.
+ *
+ * The connection specific error which triggered this one is available as {@link Error.cause}
  */
 class ConnectionError extends BaseError {
-  /** The connection specific error which triggered this one */
-  parent: Error;
-  original: Error;
-
-  constructor(parent: Error) {
-    super(parent ? parent.message : '');
+  constructor(parent?: Error) {
+    super(parent ? parent.message : '', { cause: parent });
     this.name = 'SequelizeConnectionError';
-    this.parent = parent;
-    this.original = parent;
   }
 }
 

--- a/src/errors/connection/access-denied-error.ts
+++ b/src/errors/connection/access-denied-error.ts
@@ -4,8 +4,8 @@ import ConnectionError from '../connection-error';
  * Thrown when a connection to a database is refused due to insufficient privileges
  */
 class AccessDeniedError extends ConnectionError {
-  constructor(parent: Error) {
-    super(parent);
+  constructor(cause: Error) {
+    super(cause);
     this.name = 'SequelizeAccessDeniedError';
   }
 }

--- a/src/errors/connection/connection-acquire-timeout-error.ts
+++ b/src/errors/connection/connection-acquire-timeout-error.ts
@@ -4,8 +4,8 @@ import ConnectionError from '../connection-error';
  * Thrown when connection is not acquired due to timeout
  */
 class ConnectionAcquireTimeoutError extends ConnectionError {
-  constructor(parent: Error) {
-    super(parent);
+  constructor(cause: Error) {
+    super(cause);
     this.name = 'SequelizeConnectionAcquireTimeoutError';
   }
 }

--- a/src/errors/connection/connection-refused-error.ts
+++ b/src/errors/connection/connection-refused-error.ts
@@ -4,8 +4,8 @@ import ConnectionError from '../connection-error';
  * Thrown when a connection to a database is refused
  */
 class ConnectionRefusedError extends ConnectionError {
-  constructor(parent: Error) {
-    super(parent);
+  constructor(cause: Error) {
+    super(cause);
     this.name = 'SequelizeConnectionRefusedError';
   }
 }

--- a/src/errors/connection/connection-timed-out-error.ts
+++ b/src/errors/connection/connection-timed-out-error.ts
@@ -4,8 +4,8 @@ import ConnectionError from '../connection-error';
  * Thrown when a connection to a database times out
  */
 class ConnectionTimedOutError extends ConnectionError {
-  constructor(parent: Error) {
-    super(parent);
+  constructor(cause: Error) {
+    super(cause);
     this.name = 'SequelizeConnectionTimedOutError';
   }
 }

--- a/src/errors/connection/host-not-found-error.ts
+++ b/src/errors/connection/host-not-found-error.ts
@@ -4,8 +4,8 @@ import ConnectionError from '../connection-error';
  * Thrown when a connection to a database has a hostname that was not found
  */
 class HostNotFoundError extends ConnectionError {
-  constructor(parent: Error) {
-    super(parent);
+  constructor(cause: Error) {
+    super(cause);
     this.name = 'SequelizeHostNotFoundError';
   }
 }

--- a/src/errors/connection/host-not-reachable-error.ts
+++ b/src/errors/connection/host-not-reachable-error.ts
@@ -4,8 +4,8 @@ import ConnectionError from '../connection-error';
  * Thrown when a connection to a database has a hostname that was not reachable
  */
 class HostNotReachableError extends ConnectionError {
-  constructor(parent: Error) {
-    super(parent);
+  constructor(cause: Error) {
+    super(cause);
     this.name = 'SequelizeHostNotReachableError';
   }
 }

--- a/src/errors/connection/invalid-connection-error.ts
+++ b/src/errors/connection/invalid-connection-error.ts
@@ -4,8 +4,8 @@ import ConnectionError from '../connection-error';
  * Thrown when a connection to a database has invalid values for any of the connection parameters
  */
 class InvalidConnectionError extends ConnectionError {
-  constructor(parent: Error) {
-    super(parent);
+  constructor(cause: Error) {
+    super(cause);
     this.name = 'SequelizeInvalidConnectionError';
   }
 }

--- a/src/errors/database/exclusion-constraint-error.ts
+++ b/src/errors/database/exclusion-constraint-error.ts
@@ -1,3 +1,4 @@
+import { useErrorCause } from '../../utils/deprecations.js';
 import type { DatabaseErrorSubclassOptions } from '../database-error';
 import DatabaseError from '../database-error';
 
@@ -15,14 +16,15 @@ class ExclusionConstraintError extends DatabaseError implements ExclusionConstra
   fields: Record<string, string | number> | undefined;
   table: string | undefined;
 
-  constructor(
-    options: DatabaseErrorSubclassOptions & ExclusionConstraintErrorOptions,
-  ) {
-    options = options || {};
-    options.parent = options.parent || { sql: '', name: '', message: '' };
+  constructor(options: DatabaseErrorSubclassOptions & ExclusionConstraintErrorOptions = {}) {
+    if ('parent' in options) {
+      useErrorCause();
+    }
 
-    super(options.parent, { stack: options.stack });
-    this.message = options.message || options.parent.message || '';
+    const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
+
+    super(parent, { stack: options.stack });
+    this.message = options.message || parent.message;
     this.name = 'SequelizeExclusionConstraintError';
     this.constraint = options.constraint;
     this.fields = options.fields;

--- a/src/errors/database/foreign-key-constraint-error.ts
+++ b/src/errors/database/foreign-key-constraint-error.ts
@@ -1,3 +1,4 @@
+import { useErrorCause } from '../../utils/deprecations.js';
 import type { DatabaseErrorSubclassOptions } from '../database-error';
 import DatabaseError from '../database-error';
 
@@ -25,12 +26,15 @@ class ForeignKeyConstraintError extends DatabaseError {
   reltype: RelationshipType | undefined;
 
   constructor(
-    options: ForeignKeyConstraintErrorOptions & DatabaseErrorSubclassOptions,
+    options: ForeignKeyConstraintErrorOptions & DatabaseErrorSubclassOptions = {},
   ) {
-    options = options || {};
-    options.parent = options.parent || { sql: '', name: '', message: '' };
+    if ('parent' in options) {
+      useErrorCause();
+    }
 
-    super(options.parent, { stack: options.stack });
+    const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
+
+    super(parent, { stack: options.stack });
     this.name = 'SequelizeForeignKeyConstraintError';
     this.fields = options.fields;
     this.table = options.table;

--- a/src/errors/database/timeout-error.ts
+++ b/src/errors/database/timeout-error.ts
@@ -1,4 +1,4 @@
-import type { ErrorOptions } from '../base-error';
+import type { SequelizeErrorOptions } from '../base-error';
 import type { DatabaseErrorParent } from '../database-error';
 import DatabaseError from '../database-error';
 
@@ -6,7 +6,7 @@ import DatabaseError from '../database-error';
  * Thrown when a database query times out because of a deadlock
  */
 class TimeoutError extends DatabaseError {
-  constructor(parent: DatabaseErrorParent, options: ErrorOptions = {}) {
+  constructor(parent: DatabaseErrorParent, options?: SequelizeErrorOptions) {
     super(parent, options);
     this.name = 'SequelizeTimeoutError';
   }

--- a/src/errors/database/unknown-constraint-error.ts
+++ b/src/errors/database/unknown-constraint-error.ts
@@ -1,3 +1,4 @@
+import { useErrorCause } from '../../utils/deprecations.js';
 import type { DatabaseErrorSubclassOptions } from '../database-error';
 import DatabaseError from '../database-error';
 
@@ -16,12 +17,15 @@ class UnknownConstraintError extends DatabaseError implements UnknownConstraintE
   table: string | undefined;
 
   constructor(
-    options: UnknownConstraintErrorOptions & DatabaseErrorSubclassOptions,
+    options: UnknownConstraintErrorOptions & DatabaseErrorSubclassOptions = {},
   ) {
-    options = options || {};
-    options.parent = options.parent || { sql: '', name: '', message: '' };
+    if ('parent' in options) {
+      useErrorCause();
+    }
 
-    super(options.parent, { stack: options.stack });
+    const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
+
+    super(parent, { stack: options.stack });
     this.name = 'SequelizeUnknownConstraintError';
     this.constraint = options.constraint;
     this.fields = options.fields;

--- a/src/errors/eager-loading-error.ts
+++ b/src/errors/eager-loading-error.ts
@@ -4,8 +4,8 @@ import BaseError from './base-error';
  * Thrown when an include statement is improperly constructed (see message for details)
  */
 class EagerLoadingError extends BaseError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SequelizeEagerLoadingError';
   }
 }

--- a/src/errors/eager-loading-error.ts
+++ b/src/errors/eager-loading-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/empty-result-error.ts
+++ b/src/errors/empty-result-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/empty-result-error.ts
+++ b/src/errors/empty-result-error.ts
@@ -4,8 +4,8 @@ import BaseError from './base-error';
  * Thrown when a record was not found, Usually used with rejectOnEmpty mode (see message for details)
  */
 class EmptyResultError extends BaseError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SequelizeEmptyResultError';
   }
 }

--- a/src/errors/instance-error.ts
+++ b/src/errors/instance-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/instance-error.ts
+++ b/src/errors/instance-error.ts
@@ -4,8 +4,8 @@ import BaseError from './base-error';
  * Thrown when a some problem occurred with Instance methods (see message for details)
  */
 class InstanceError extends BaseError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SequelizeInstanceError';
   }
 }

--- a/src/errors/optimistic-lock-error.ts
+++ b/src/errors/optimistic-lock-error.ts
@@ -19,17 +19,15 @@ class OptimisticLockError extends BaseError {
   values: Record<string, unknown> | undefined;
   where: Record<string, unknown> | undefined;
 
-  constructor(options: OptimisticLockErrorOptions) {
-    options = options || {};
-    options.message
-      = options.message
-      || `Attempting to update a stale model instance: ${options.modelName}`;
+  constructor(options?: OptimisticLockErrorOptions, errorOptions?: ErrorOptions) {
+    const message = options?.message
+      || `Attempting to update a stale model instance: ${options?.modelName}`;
 
-    super(options.message);
+    super(message, errorOptions);
     this.name = 'SequelizeOptimisticLockError';
-    this.modelName = options.modelName;
-    this.values = options.values;
-    this.where = options.where;
+    this.modelName = options?.modelName;
+    this.values = options?.values;
+    this.where = options?.where;
   }
 }
 

--- a/src/errors/optimistic-lock-error.ts
+++ b/src/errors/optimistic-lock-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 interface OptimisticLockErrorOptions {

--- a/src/errors/query-error.ts
+++ b/src/errors/query-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/query-error.ts
+++ b/src/errors/query-error.ts
@@ -4,8 +4,8 @@ import BaseError from './base-error';
  * Thrown when a query is passed invalid options (see message for details)
  */
 class QueryError extends BaseError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SequelizeQueryError';
   }
 }

--- a/src/errors/sequelize-scope-error.ts
+++ b/src/errors/sequelize-scope-error.ts
@@ -1,3 +1,4 @@
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/sequelize-scope-error.ts
+++ b/src/errors/sequelize-scope-error.ts
@@ -4,8 +4,8 @@ import BaseError from './base-error';
  * Scope Error. Thrown when the sequelize cannot query the specified scope.
  */
 class SequelizeScopeError extends BaseError {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = 'SequelizeScopeError';
   }
 }

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -1,5 +1,5 @@
 import type { Model } from '..';
-import type { ErrorOptions } from './base-error';
+import type { SequelizeErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**
@@ -209,9 +209,12 @@ class ValidationError extends BaseError {
   constructor(
     message: string,
     errors: ValidationErrorItem[],
-    options: ErrorOptions = {},
+    options: SequelizeErrorOptions & ErrorOptions = {},
   ) {
-    super(message);
+    const { stack, ...passUp } = options;
+
+    super(message, passUp);
+
     this.name = 'SequelizeValidationError';
     this.errors = errors || [];
 
@@ -229,8 +232,8 @@ class ValidationError extends BaseError {
     }
 
     // Allow overriding the stack if the original stacktrace is uninformative
-    if (options.stack) {
-      this.stack = options.stack;
+    if (stack) {
+      this.stack = stack;
     }
   }
 

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -1,5 +1,5 @@
 import type { Model } from '..';
-import type { SequelizeErrorOptions } from './base-error';
+import type { ErrorOptions, SequelizeErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**

--- a/src/errors/validation/unique-constraint-error.ts
+++ b/src/errors/validation/unique-constraint-error.ts
@@ -1,14 +1,17 @@
-import type { CommonErrorProperties, ErrorOptions } from '../base-error';
+import { useErrorCause } from '../../utils/deprecations.js';
+import type { CommonErrorProperties, SequelizeErrorOptions } from '../base-error';
 import type { ValidationErrorItem } from '../validation-error';
 import ValidationError from '../validation-error';
 
-interface UniqueConstraintErrorParent
-  extends Error,
-    Pick<CommonErrorProperties, 'sql'> {}
+interface UniqueConstraintErrorParent extends Error, Pick<CommonErrorProperties, 'sql'> {}
 
-export interface UniqueConstraintErrorOptions extends ErrorOptions {
+export interface UniqueConstraintErrorOptions extends SequelizeErrorOptions {
+  cause?: UniqueConstraintErrorParent;
+
+  /**
+   * @deprecated use {@link UniqueConstraintErrorOptions.cause}
+   */
   parent?: UniqueConstraintErrorParent;
-  original?: UniqueConstraintErrorParent;
   errors?: ValidationErrorItem[];
   fields?: Record<string, unknown>;
   message?: string;
@@ -18,24 +21,25 @@ export interface UniqueConstraintErrorOptions extends ErrorOptions {
  * Thrown when a unique constraint is violated in the database
  */
 class UniqueConstraintError extends ValidationError implements CommonErrorProperties {
-  readonly parent: UniqueConstraintErrorParent;
-  readonly original: UniqueConstraintErrorParent;
+  /** The database specific error which triggered this one */
+  declare cause: UniqueConstraintErrorParent | undefined;
+
   readonly fields: Record<string, unknown>;
   readonly sql: string;
 
-  constructor(options: UniqueConstraintErrorOptions) {
-    options = options ?? {};
-    options.parent = options.parent ?? { sql: '', name: '', message: '' };
-    options.message
-      = options.message || options.parent.message || 'Validation Error';
-    options.errors = options.errors ?? [];
-    super(options.message, options.errors, { stack: options.stack });
+  constructor(options: UniqueConstraintErrorOptions = {}) {
+    if ('parent' in options) {
+      useErrorCause();
+    }
+
+    const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
+    const message = options.message || parent.message || 'Validation Error';
+    const errors = options.errors ?? [];
+    super(message, errors, { stack: options.stack, cause: parent });
 
     this.name = 'SequelizeUniqueConstraintError';
     this.fields = options.fields ?? {};
-    this.parent = options.parent;
-    this.original = options.parent;
-    this.sql = options.parent.sql;
+    this.sql = parent.sql;
   }
 }
 

--- a/src/utils/deprecations.ts
+++ b/src/utils/deprecations.ts
@@ -8,3 +8,4 @@ export const noStringOperators = deprecate(noop, 'String based operators are dep
 export const noBoolOperatorAliases = deprecate(noop, 'A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.', 'SEQUELIZE0004');
 export const noDoubleNestedGroup = deprecate(noop, 'Passing a double nested nested array to `group` is unsupported and will be removed in v6.', 'SEQUELIZE0005');
 export const unsupportedEngine = deprecate(noop, 'This database engine version is not supported, please update your database server. More information https://github.com/sequelize/sequelize/blob/main/ENGINE.md', 'SEQUELIZE0006');
+export const useErrorCause = deprecate(noop, 'The "parent" and "original" properties in Sequelize errors have been replaced with the native "cause" property. Use that one instead.', 'SEQUELIZE0007');


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This PR migrates our errors to use the native `Error#cause` property.

This was previously done by the `parent` property. It is still present but logs a deprecation warning when used.

This should lead to clearer error messages.

This is only available in node 16+. A workaround has been added for node 14.

![image](https://user-images.githubusercontent.com/1280915/161581999-9ba5b66b-e511-4784-812a-a49fc6e73547.png)

Closes https://github.com/sequelize/sequelize/issues/13978
