### PR TITLE
docs: restore Model api reference & make fail on error

### DIFF
--- a/docs.sh
+++ b/docs.sh
@@ -1,0 +1,23 @@
+set -e
+
+rimraf esdoc
+
+exec 5>&1
+OUT=$(esdoc -c docs/esdoc-config.js|tee /dev/fd/5)
+
+cp docs/favicon.ico esdoc/favicon.ico
+cp docs/ROUTER.txt esdoc/ROUTER
+
+node docs/run-docs-transforms.js
+node docs/redirects/create-redirects.js
+
+rimraf esdoc/file esdoc/source.html
+
+set +e
+GREP_RESULT=$(echo "$OUT" | grep -c 'could not parse the following code')
+set -e
+
+if [ "$GREP_RESULT" -ge 1 ]; then
+  echo "esdoc generation encountered an error. See above logging for details."
+  exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "lint-docs": "markdownlint docs",
     "test-typings": "tsc --noEmit --emitDeclarationOnly false && tsc -b test/tsconfig.json",
     "----------------------------------------- documentation -------------------------------------------": "",
-    "docs": "rimraf esdoc && esdoc -c docs/esdoc-config.js && cp docs/favicon.ico esdoc/favicon.ico && cp docs/ROUTER.txt esdoc/ROUTER && node docs/run-docs-transforms.js && node docs/redirects/create-redirects.js && rimraf esdoc/file esdoc/source.html",
+    "docs": "sh docs.sh",
     "----------------------------------------- tests ---------------------------------------------------": "",
     "mocha": "mocha -r ./test/registerEsbuild",
     "test-unit": "yarn mocha \"test/unit/**/*.test.[tj]s\"",

--- a/src/model.js
+++ b/src/model.js
@@ -826,7 +826,7 @@ class Model {
     }
 
     if (['where', 'having'].includes(key)) {
-      if (this.options?.whereMergeStrategy === 'and') {
+      if (this.options && this.options.whereMergeStrategy === 'and') {
         return combineWheresWithAnd(objValue, srcValue);
       }
 
@@ -1034,8 +1034,8 @@ class Model {
       }
     });
 
-    if (!_.includes(['and', 'overwrite'], this.options?.whereMergeStrategy)) {
-      throw new Error(`Invalid value ${this.options?.whereMergeStrategy} for whereMergeStrategy. Allowed values are 'and' and 'overwrite'.`);
+    if (!_.includes(['and', 'overwrite'], this.options && this.options.whereMergeStrategy)) {
+      throw new Error(`Invalid value ${this.options && this.options.whereMergeStrategy} for whereMergeStrategy. Allowed values are 'and' and 'overwrite'.`);
     }
 
 


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This PR modifies model.js to use syntax compatible with esdoc. This brings the Model api reference page back.

It also ensures the `docs` script fails if it's unable to parse a file again

Related to https://github.com/sequelize/website/issues/43