### PR TITLE
feat!: block access to `/lib`

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,8 @@
       "import": "./lib/index.mjs",
       "require": "./lib/index.js"
     },
-    "./lib/*": "./lib/*.js",
-    "./lib/errors": "./lib/errors/index.js",
-    "./*": "./*"
+    "./_non-semver-use-at-your-own-risk_/*": "./lib/*",
+    "./package.json": "./package.json"
   },
   "engines": {
     "node": "^14.17.0 || >=16.0.0"

--- a/test/integration/dialects/abstract/connection-manager.test.js
+++ b/test/integration/dialects/abstract/connection-manager.test.js
@@ -1,7 +1,7 @@
 const chai = require('chai');
 const Support = require('../../support');
 const sinon = require('sinon');
-const { ConnectionManager } = require('@sequelize/core/lib/dialects/abstract/connection-manager');
+const { ConnectionManager } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/connection-manager.js');
 const { Pool } = require('sequelize-pool');
 const Config = require('../../../config/config');
 

--- a/test/integration/dialects/postgres/hstore.test.js
+++ b/test/integration/dialects/postgres/hstore.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const hstore = require('@sequelize/core/lib/dialects/postgres/hstore');
+const hstore = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/postgres/hstore.js');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] hstore', () => {

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -7,7 +7,7 @@ const Support = require('../../support');
 const { DataTypes } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
-const range   = require('@sequelize/core/lib/dialects/postgres/range');
+const range   = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/postgres/range.js');
 
 if (dialect.startsWith('postgres')) {
   // Don't try to load pg until we know we're running on postgres.

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -3,9 +3,8 @@
 const chai = require('chai');
 
 const expect = chai.expect;
-const Utils = require('@sequelize/core/lib/utils/index');
 const Support = require('./support');
-const { DataTypes, Sequelize, Op } = require('@sequelize/core');
+const { DataTypes, Sequelize, Op, Utils } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Utils'), () => {
   describe('underscore', () => {

--- a/test/registerEsbuild.js
+++ b/test/registerEsbuild.js
@@ -1,25 +1,8 @@
 'use strict';
 
-const path = require('path');
 const hook = require('node-hook');
 const esbuild = require('esbuild');
-const moduleAlias = require('module-alias');
 const sourceMapSupport = require('source-map-support');
-
-const nodeMajorVersion = Number(process.version.match(/(?<=^v)\d+/));
-
-// for node >= 12, we use the package.json "export" property to
-//  map imports to dist (except package.json)
-//  so '@sequelize/core/lib/errors" is actually mapped to "@sequelize/core/dist/errors/index.js'
-//  (see package.json).
-if (nodeMajorVersion < 12) {
-  const jsonFile = path.join(__dirname, '..', 'package.json');
-  moduleAlias.addAlias('@sequelize/core/package.json', jsonFile);
-
-  const distDir = path.join(__dirname, '..');
-  // make imports from `@sequelize/core/` go to `../dist/`
-  moduleAlias.addAlias('@sequelize/core', distDir);
-}
 
 const maps = {};
 

--- a/test/support.js
+++ b/test/support.js
@@ -10,7 +10,7 @@ const Config = require('./config/config');
 const chai = require('chai');
 
 const expect = chai.expect;
-const { AbstractQueryGenerator } = require('@sequelize/core/lib/dialects/abstract/query-generator');
+const { AbstractQueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator.js');
 
 const distDir = path.resolve(__dirname, '../lib');
 

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -5,8 +5,8 @@
     "baseUrl": ".",
     "paths": {
       "@sequelize/core": ["../types/index.d.ts"],
-      "@sequelize/core/lib/*": ["../types/*"],
-      "@sequelize/core/*": ["../*"]
+      "@sequelize/core/_non-semver-use-at-your-own-risk_/*": ["../types/*"],
+      "@sequelize/core/package.json": ["../package.json"]
     },
     "types": ["node", "mocha", "sinon", "chai"],
     "noEmit": true,

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -1,7 +1,7 @@
 import { expectTypeOf } from "expect-type";
 import { FindOptions, Model, QueryOptions, SaveOptions, Sequelize, UpsertOptions, Config, Utils } from '@sequelize/core';
-import { ModelHooks } from '@sequelize/core/lib/hooks';
-import { AbstractQuery } from '@sequelize/core/lib/dialects/abstract/query';
+import { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/hooks.js';
+import { AbstractQuery } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query.js';
 import { SemiDeepWritable } from "./type-helpers/deep-writable";
 
 {

--- a/test/unit/connection-manager.test.js
+++ b/test/unit/connection-manager.test.js
@@ -5,7 +5,7 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { ConnectionManager } = require('@sequelize/core/lib/dialects/abstract/connection-manager');
+const { ConnectionManager } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/connection-manager.js');
 
 describe('connection manager', () => {
   describe('_connect', () => {

--- a/test/unit/deep-exports.test.js
+++ b/test/unit/deep-exports.test.js
@@ -1,31 +1,25 @@
-const chai = require('chai');
-
-const expect = chai.expect;
+const { expect } = require('chai');
 
 /**
  * Tests whether users can import files deeper than '@sequelize/core" (eg. "@sequelize/core/package.json').
  * Context: https://github.com/sequelize/sequelize/issues/13787
  */
 
-const nodeMajorVersion = Number(process.version.match(/(?<=^v)\d+/));
-
 describe('exports', () => {
   it('exposes /package.json', async () => {
     // TODO: uncomment test once https://nodejs.org/api/esm.html#json-modules are stable
-    // if (nodeMajorVersion >= 16) {
-    //   await import('@sequelize/core/package.json', {
-    //     assert: { type: 'json' }
-    //   });
-    // }
+    // await import('@sequelize/core/package.json', {
+    //   assert: { type: 'json' }
+    // });
 
     require('@sequelize/core/package.json');
   });
 
-  it('exposes lib files', async () => {
-    if (nodeMajorVersion >= 12) {
-      await import('@sequelize/core/lib/model');
-    }
+  it('blocks access to lib files', async () => {
+    await expect(import('@sequelize/core/lib/model')).to.be.rejectedWith('Package subpath \'./lib/model\' is not defined by "exports"');
+  });
 
-    require('@sequelize/core/lib/model');
+  it('allows access to lib if the user acknowledges that it is unsafe', async () => {
+    await import('@sequelize/core/_non-semver-use-at-your-own-risk_/model.js');
   });
 });

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -7,7 +7,7 @@ const { Op } = require('@sequelize/core');
 const Support = require('../../support');
 
 const getAbstractQueryGenerator = Support.getAbstractQueryGenerator;
-const { AbstractQueryGenerator } = require('@sequelize/core/lib/dialects/abstract/query-generator');
+const { AbstractQueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator.js');
 
 describe('QueryGenerator', () => {
   describe('whereItemQuery', () => {

--- a/test/unit/dialects/abstract/query.test.js
+++ b/test/unit/dialects/abstract/query.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { AbstractQuery: Query } = require('@sequelize/core/lib/dialects/abstract/query');
+const { AbstractQuery: Query } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query.js');
 
 const Support = require(path.join(__dirname, './../../support'));
 const chai = require('chai');

--- a/test/unit/dialects/db2/query-generator.test.js
+++ b/test/unit/dialects/db2/query-generator.test.js
@@ -8,7 +8,7 @@ const Support = require('../../support');
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
 const { Op } = require('@sequelize/core');
-const { Db2QueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/db2/query-generator');
+const { Db2QueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/db2/query-generator.js');
 
 if (dialect === 'db2') {
   describe('[DB2 Specific] QueryGenerator', () => {

--- a/test/unit/dialects/db2/query-json-path-extraction.test.js
+++ b/test/unit/dialects/db2/query-json-path-extraction.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { Db2QueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/db2/query-generator');
+const { Db2QueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/db2/query-generator.js');
 
 if (dialect === 'db2') {
   describe('[DB2 Specific] jsonPathExtractionQuery', () => {

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -8,7 +8,7 @@ const Support = require('../../support');
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
 const { Op, IndexHints } = require('@sequelize/core');
-const { MariaDbQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/mariadb/query-generator');
+const { MariaDbQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mariadb/query-generator.js');
 
 if (dialect === 'mariadb') {
   describe('[MARIADB Specific] QueryGenerator', () => {

--- a/test/unit/dialects/mariadb/query-json-path-extraction.test.js
+++ b/test/unit/dialects/mariadb/query-json-path-extraction.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { MariaDbQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/mariadb/query-generator');
+const { MariaDbQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mariadb/query-generator.js');
 
 if (dialect === 'mariadb') {
   describe('[MARIADB Specific] jsonPathExtractionQuery', () => {

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -5,7 +5,7 @@ const Support = require('../../support');
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
 const { DataTypes, Op, TableHints } = require('@sequelize/core');
-const { MsSqlQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/mssql/query-generator');
+const { MsSqlQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mssql/query-generator.js');
 
 if (current.dialect.name === 'mssql') {
   describe('[MSSQL Specific] QueryGenerator', () => {

--- a/test/unit/dialects/mssql/query-json-path-extraction.test.js
+++ b/test/unit/dialects/mssql/query-json-path-extraction.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { MsSqlQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/mssql/query-generator');
+const { MsSqlQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mssql/query-generator.js');
 
 if (dialect === 'mssql') {
   describe('[MSSQL Specific] jsonPathExtractionQuery', () => {

--- a/test/unit/dialects/mssql/query.test.js
+++ b/test/unit/dialects/mssql/query.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { MsSqlQuery: Query } = require('@sequelize/core/lib/dialects/mssql/query');
+const { MsSqlQuery: Query } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mssql/query.js');
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -8,7 +8,7 @@ const Support = require('../../support');
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
 const { Op, IndexHints } = require('@sequelize/core');
-const { MySqlQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/mysql/query-generator');
+const { MySqlQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mysql/query-generator.js');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] QueryGenerator', () => {

--- a/test/unit/dialects/mysql/query-json-path-extraction.test.js
+++ b/test/unit/dialects/mysql/query-json-path-extraction.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { MySqlQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/mysql/query-generator');
+const { MySqlQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mysql/query-generator.js');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] jsonPathExtractionQuery', () => {

--- a/test/unit/dialects/mysql/query.test.js
+++ b/test/unit/dialects/mysql/query.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { MySqlQuery: Query } = require('@sequelize/core/lib/dialects/mysql/query');
+const { MySqlQuery: Query } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mysql/query.js');
 
 const Support = require(path.join(__dirname, './../../support'));
 const chai = require('chai');

--- a/test/unit/dialects/postgres/data-types.test.js
+++ b/test/unit/dialects/postgres/data-types.test.js
@@ -7,8 +7,8 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const { DataTypes: BaseTypes } = require('@sequelize/core');
-const DataTypes = require('@sequelize/core/lib/dialects/postgres/data-types')(BaseTypes);
-const { PostgresQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/postgres/query-generator');
+const DataTypes = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/postgres/data-types.js')(BaseTypes);
+const { PostgresQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/postgres/query-generator.js');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] DataTypes', () => {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const { Op, DataTypes } = require('@sequelize/core');
-const { PostgresQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/postgres/query-generator');
+const { PostgresQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/postgres/query-generator.js');
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();

--- a/test/unit/dialects/postgres/query-json-path-extraction.test.js
+++ b/test/unit/dialects/postgres/query-json-path-extraction.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { PostgresQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/postgres/query-generator');
+const { PostgresQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/postgres/query-generator.js');
 
 if (dialect === 'postgres') {
   describe('[POSTGRES Specific] jsonPathExtractionQuery', () => {

--- a/test/unit/dialects/snowflake/query-generator.test.js
+++ b/test/unit/dialects/snowflake/query-generator.test.js
@@ -8,7 +8,7 @@ const Support = require('../../support');
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
 const { Op, IndexHints } = require('@sequelize/core');
-const { SnowflakeQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/snowflake/query-generator');
+const { SnowflakeQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/snowflake/query-generator.js');
 
 if (dialect === 'snowflake') {
   describe('[SNOWFLAKE Specific] QueryGenerator', () => {

--- a/test/unit/dialects/snowflake/query-json-path-extraction.test.js
+++ b/test/unit/dialects/snowflake/query-json-path-extraction.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { SnowflakeQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/snowflake/query-generator');
+const { SnowflakeQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/snowflake/query-generator.js');
 
 if (dialect === 'snowflake') {
   describe('[SNOWFLAKE Specific] jsonPathExtractionQuery', () => {

--- a/test/unit/dialects/snowflake/query.test.js
+++ b/test/unit/dialects/snowflake/query.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('path');
-const { SnowflakeQuery: Query } = require('@sequelize/core/lib/dialects/snowflake/query');
+const { SnowflakeQuery: Query } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/snowflake/query.js');
 
 const Support = require(path.join(__dirname, './../../support'));
 const chai = require('chai');

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -9,7 +9,7 @@ const { DataTypes, Op } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
 const moment = require('moment');
-const { SqliteQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/sqlite/query-generator');
+const { SqliteQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/sqlite/query-generator.js');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] QueryGenerator', () => {

--- a/test/unit/dialects/sqlite/query-json-path-extraction.test.js
+++ b/test/unit/dialects/sqlite/query-json-path-extraction.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
-const { SqliteQueryGenerator: QueryGenerator } = require('@sequelize/core/lib/dialects/sqlite/query-generator');
+const { SqliteQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/sqlite/query-generator.js');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] jsonPathExtractionQuery', () => {

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const errors = require('@sequelize/core/lib/errors');
+const errors = require('@sequelize/core/_non-semver-use-at-your-own-risk_/errors/index.js');
 
 const { AggregateError } = errors;
 

--- a/test/unit/instance-validator.test.js
+++ b/test/unit/instance-validator.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { InstanceValidator } = require('@sequelize/core/lib/instance-validator');
+const { InstanceValidator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator.js');
 const sinon = require('sinon');
 const { ValidationError: SequelizeValidationError, DataTypes } = require('@sequelize/core');
 

--- a/test/unit/logger.test.ts
+++ b/test/unit/logger.test.ts
@@ -1,5 +1,5 @@
 import { inspect as nodeInspect } from 'util';
-import { Logger, logger as defaultLogger } from '@sequelize/core/lib/utils/logger';
+import { Logger, logger as defaultLogger } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/logger.js';
 import { expect } from 'chai';
 import sinon from 'sinon';
 

--- a/test/unit/model/find-all.test.js
+++ b/test/unit/model/find-all.test.js
@@ -8,7 +8,7 @@ const Support = require('../support');
 const current = Support.sequelize;
 const sinon = require('sinon');
 const { DataTypes, QueryError } = require('@sequelize/core');
-const { Logger } = require('@sequelize/core/lib/utils/logger');
+const { Logger } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/utils/logger.js');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('warnOnInvalidOptions', () => {

--- a/test/unit/utils.test.js
+++ b/test/unit/utils.test.js
@@ -4,8 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { DataTypes, Op } = require('@sequelize/core');
-const Utils = require('@sequelize/core/lib/utils/index');
+const { DataTypes, Op, Utils } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Utils'), () => {
   describe('merge', () => {

--- a/test/unit/utils/check.test.ts
+++ b/test/unit/utils/check.test.ts
@@ -1,12 +1,13 @@
-import Sequelize from '@sequelize/core';
-import {
+import { Sequelize, Utils } from '@sequelize/core';
+import { expect } from 'chai';
+
+const {
   canTreatArrayAsAnd,
   defaultValueSchemable,
   isColString,
   isPrimitive,
   isWhereEmpty,
-} from '@sequelize/core/lib/utils/check';
-import { expect } from 'chai';
+} = Utils;
 
 describe('utils / check', () => {
   describe('isColString', () => {


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This PR prevents users from importing anything other than `@sequelize/core` and `@sequelize/core/package.json`.

With this change, it is safe to rework our internal source code without risking to introduce a breaking change.

If users need to access our internals, they should open a feature request so we can expose a properly tested solution.

Breaking change documented: https://github.com/sequelize/website/pull/78/ 

As a last resort, if a user *really* needs to access them, I added `@sequelize/core/_non-semver-use-at-your-own-risk_` as an alias for `@sequelize/core/lib`. Hopefully it is clear enough that these imports should only be used as a last resort and are not officially supported, and could break in any release, including patch releases.