### PR TITLE
feat: simplify withSchema API

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -86,6 +86,8 @@ export interface DropOptions extends Logging {
  * Schema Options provided for applying a schema to a model
  */
 export interface SchemaOptions extends Logging {
+  schema: string;
+
   /**
    * The character(s) that separates the schema name from the table name
    */
@@ -1990,13 +1992,11 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * - `"schema"."tableName"`, while the schema will be prepended to the table name for mysql and
    * sqlite - `'schema.tablename'`.
    *
-   * @param schema The name of the schema
-   * @param options
+   * @param schema The name of the schema. Passing a string is equivalent to setting {@link SchemaOptions.schema}.
    */
   public static withSchema<M extends Model>(
     this: ModelStatic<M>,
-    schema: string,
-    options?: SchemaOptions
+    schema: string | SchemaOptions,
   ): ModelCtor<M>;
 
   /**
@@ -2006,7 +2006,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   public static schema<M extends Model>(
     this: ModelStatic<M>,
     schema: string,
-    options?: SchemaOptions
+    options?: { schemaDelimiter?: string } | string
   ): ModelCtor<M>;
 
   /**

--- a/src/model.js
+++ b/src/model.js
@@ -1039,8 +1039,8 @@ export class Model {
       this.tableName = this.options.tableName;
     }
 
-    this._schema = this.options.schema;
-    this._schemaDelimiter = this.options.schemaDelimiter;
+    this._schema = this.options.schema || '';
+    this._schemaDelimiter = this.options.schemaDelimiter || '';
 
     // error check options
     _.each(options.validate, (validator, validatorType) => {
@@ -1676,8 +1676,8 @@ export class Model {
     }
 
     return initialModel._withScopeAndSchema({
-      schema: this._schema,
-      schemaDelimiter: this._schemaDelimiter,
+      schema: this._schema || '',
+      schemaDelimiter: this._schemaDelimiter || '',
     }, mergedScope, scopeNames);
   }
 
@@ -1701,7 +1701,10 @@ export class Model {
     const initialModel = this.getInitialModel();
 
     if (this._schema !== initialModel._schema || this._schemaDelimiter !== initialModel._schemaDelimiter) {
-      return initialModel.withSchema(this._schema, this._schemaDelimiter);
+      return initialModel.withSchema({
+        schema: this._schema,
+        schemaDelimiter: this._schemaDelimiter,
+      });
     }
 
     return initialModel;
@@ -1722,11 +1725,11 @@ export class Model {
         continue;
       }
 
-      if (modelVariant._schema !== schemaOptions.schema) {
+      if (modelVariant._schema !== (schemaOptions.schema || '')) {
         continue;
       }
 
-      if (modelVariant._schemaDelimiter !== schemaOptions.schemaDelimiter) {
+      if (modelVariant._schemaDelimiter !== (schemaOptions.schemaDelimiter || '')) {
         continue;
       }
 
@@ -3500,7 +3503,7 @@ export class Model {
    * @returns {Promise} hash of attributes and their types
    */
   static async describe(schema, options) {
-    return await this.queryInterface.describeTable(this.tableName, { schema: schema || this._schema || undefined, ...options });
+    return await this.queryInterface.describeTable(this.tableName, { schema: schema || this._schema || '', ...options });
   }
 
   static _getDefaultTimestamp(attr) {

--- a/src/model.js
+++ b/src/model.js
@@ -1511,25 +1511,12 @@ export class Model {
    * If a single default schema per model is needed, set the `options.schema='schema'` parameter during the `define()` call
    * for the model.
    *
-   * @param {string}   schema The name of the schema
-   * @param {object}   [options] schema options
-   * @param {string}   [options.schemaDelimiter='.'] The character(s) that separates the schema name from the table name
-   * @param {Function} [options.logging=false] A function that gets executed while running the query to log the sql.
-   * @param {boolean}  [options.benchmark=false] Pass query execution time in milliseconds as second argument to logging function (options.logging).
-   *
-   * @see
-   * {@link Sequelize#define} for more information about setting a default schema.
+   * @param {string|object}   schema The name of the schema
    *
    * @returns {Model}
    */
-  static withSchema(schema, options) {
-
-    const schemaOptions = {
-      schema,
-      schemaDelimiter: !options ? ''
-        : typeof options === 'string' ? options
-        : options.schemaDelimiter,
-    };
+  static withSchema(schema) {
+    const schemaOptions = typeof schema === 'string' ? { schema } : schema;
 
     return this.getInitialModel()
       ._withScopeAndSchema(schemaOptions, this._scope, this._scopeNames);
@@ -1539,7 +1526,10 @@ export class Model {
   static schema(schema, options) {
     schemaRenamedToWithSchema();
 
-    return this.withSchema(schema, options);
+    return this.withSchema({
+      schema,
+      schemaDelimiter: typeof options === 'string' ? options : options?.schemaDelimiter,
+    });
   }
 
   static getInitialModel() {

--- a/src/model.js
+++ b/src/model.js
@@ -1516,6 +1516,10 @@ export class Model {
    * @returns {Model}
    */
   static withSchema(schema) {
+    if (arguments.length > 1) {
+      throw new TypeError('Unlike Model.schema, Model.withSchema only accepts 1 argument which may be either a string or an option bag.');
+    }
+
     const schemaOptions = typeof schema === 'string' ? { schema } : schema;
 
     return this.getInitialModel()

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -64,7 +64,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       describe('Add data via model.create, retrieve via model.findOne', () => {
         it('should be able to sync model without schema option', function () {
-          expect(this.RestaurantOne._schema).to.be.null;
+          expect(this.RestaurantOne._schema).to.eq('');
           expect(this.RestaurantTwo._schema).to.equal(SCHEMA_TWO);
         });
 

--- a/test/support.d.ts
+++ b/test/support.d.ts
@@ -1,0 +1,5 @@
+declare namespace Chai {
+  interface Assertion {
+    deepEqual(expected: any): Assertion;
+  }
+}

--- a/test/unit/model/schema.test.ts
+++ b/test/unit/model/schema.test.ts
@@ -1,10 +1,10 @@
-'use strict';
+import assert from 'assert';
+import { literal } from '@sequelize/core';
+// eslint-disable-next-line import/order
+import { expect } from 'chai';
 
-const chai = require('chai');
 const Support = require('../support');
-const { literal } = require('@sequelize/core');
 
-const expect = chai.expect;
 const current = Support.sequelize;
 
 describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
@@ -15,7 +15,7 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       schemaDelimiter: '&',
     });
 
-    Project.addScope('scope1', { where: literal() });
+    Project.addScope('scope1', { where: literal('') });
 
     describe('schema', () => {
       it('should work with no default schema', () => {
@@ -27,7 +27,8 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('returns the same model if the schema is equal', () => {
-        expect(Project.withSchema('newSchema')).to.equal(Project.withSchema('newSchema'));
+        // eslint-disable-next-line no-self-compare
+        assert(Project.withSchema('newSchema') === Project.withSchema('newSchema'));
       });
 
       it('returns a new model if the schema is equal, but scope is different', () => {
@@ -35,8 +36,8 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('returns the current model if the schema is identical', () => {
-        expect(Project.withSchema('')).to.equal(Project);
-        expect(Project.withSchema('test').withSchema('test')).to.equal(Project.withSchema('test'));
+        assert(Project.withSchema('') === Project);
+        assert(Project.withSchema('test').withSchema('test') === Project.withSchema('test'));
       });
 
       it('should be able to override the default schema', () => {


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

As a follow up to https://github.com/sequelize/sequelize/pull/14337. While we're renaming `Model.schema` to `Model.withSchema`, we might as well simplify its API. I changed it from:

```typescript
MyModel.schema('public');
MyModel.schema('public', /* schema delimiter */ '.');
MyModel.schema('public', { schemaDelimiter: '.' });
```

to

```typescript
MyModel.withSchema('public');
MyModel.withSchema({ schema: 'public', schemaDelimiter: '.' });
```

Not a breaking change because `.schema` keeps its old API and `.withSchema` hasn't been released yet