### PR TITLE
feat: add `isModelStatic`, `isSameInitialModel`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,7 @@ export * from './dialects/abstract/query-interface';
 export * from './sequelize';
 export { Sequelize as default } from './sequelize';
 export { useInflection } from './utils';
+export { isModelStatic, isSameInitialModel } from './utils/model-utils';
 export { Validator } from './utils/validator-extras';
 export { Deferrable } from './deferrable';
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -122,4 +122,7 @@ export const Validator = Pkg.Validator;
 export const ValidationErrorItemOrigin = Pkg.ValidationErrorItemOrigin;
 export const ValidationErrorItemType = Pkg.ValidationErrorItemType;
 
+export const isModelStatic = Pkg.isModelStatic;
+export const isSameInitialModel = Pkg.isSameInitialModel;
+
 export { default } from './index.js';

--- a/src/model.js
+++ b/src/model.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { isModelStatic } from './utils/model-utils';
+
 const assert = require('assert');
 const _ = require('lodash');
 const Dottie = require('dottie');
@@ -381,7 +383,7 @@ export class Model {
         return { model, association: include, as: include.as };
       }
 
-      if (include.prototype && include.prototype instanceof Model) {
+      if (isModelStatic(include)) {
         return { model: include };
       }
 

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import { isSameInitialModel, isModelStatic } from './utils/model-utils';
+
 const url = require('url');
 const path = require('path');
 const pgConnectionString = require('pg-connection-string');
@@ -943,6 +945,10 @@ export class Sequelize {
   static json = json;
 
   static where = where;
+
+  static isModelStatic = isModelStatic;
+
+  static isSameInitialModel = isSameInitialModel;
 
   /**
    * Start a transaction. When using transactions, you should pass the transaction in the options argument in order for the query to happen under that transaction @see {@link Transaction}

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -1,0 +1,27 @@
+import type { ModelStatic } from '../model';
+import { Model } from '../model';
+
+/**
+ * Returns true if the value is a model subclass.
+ *
+ * @param val The value whose type will be checked
+ */
+export function isModelStatic<M extends Model>(val: any): val is ModelStatic<M> {
+  return typeof val === 'function' && val.prototype instanceof Model;
+}
+
+/**
+ * Returns true if a & b are the same model.
+ * The difference with doing `a === b` is that this method will also
+ * return true if one of the models is scoped, or a variant with a different schema.
+ *
+ * @example
+ * isSameModel(a, a.scope('myScope')) // true;
+ *
+ * @param a
+ * @param b
+ */
+export function isSameInitialModel(a: ModelStatic<any>, b: ModelStatic<any>): boolean {
+  return isModelStatic(a) && isModelStatic(b)
+    && (a.getInitialModel() === b.getInitialModel());
+}

--- a/src/utils/model-utils.ts
+++ b/src/utils/model-utils.ts
@@ -11,12 +11,13 @@ export function isModelStatic<M extends Model>(val: any): val is ModelStatic<M> 
 }
 
 /**
- * Returns true if a & b are the same model.
+ * Returns true if a & b are the same initial model, ignoring variants created by {@link Model.withSchema}, {@link Model.withScope}, and the like.
+ *
  * The difference with doing `a === b` is that this method will also
  * return true if one of the models is scoped, or a variant with a different schema.
  *
  * @example
- * isSameModel(a, a.scope('myScope')) // true;
+ * isSameInitialModel(a, a.withScope('myScope')) // true;
  *
  * @param a
  * @param b

--- a/test/unit/utils/model-utils.test.ts
+++ b/test/unit/utils/model-utils.test.ts
@@ -1,0 +1,54 @@
+import type { Sequelize } from '@sequelize/core';
+import { isModelStatic, isSameInitialModel, Model } from '@sequelize/core';
+// eslint-disable-next-line import/order
+import { expect } from 'chai';
+
+const sequelize: Sequelize = require('../../support').sequelize;
+
+describe('isModelStatic', () => {
+  it('returns true for model subclasses', () => {
+    const MyModel = sequelize.define('myModel', {});
+
+    expect(isModelStatic(MyModel)).to.be.true;
+  });
+
+  it('returns true for model instances', () => {
+    const MyModel = sequelize.define('myModel', {});
+
+    expect(isModelStatic(new MyModel())).to.be.false;
+  });
+
+  it('returns false for the Model class', () => {
+    expect(isModelStatic(Model)).to.be.false;
+  });
+
+  it('returns false for the anything else', () => {
+    expect(isModelStatic(Date)).to.be.false;
+  });
+});
+
+describe('isSameInitialModel', () => {
+  it('returns true if both models have the same initial model', () => {
+    const MyModel = sequelize.define('myModel', {}, {
+      scopes: {
+        scope1: {
+          where: { id: 1 },
+        },
+      },
+    });
+
+    expect(
+      isSameInitialModel(MyModel.withSchema('abc'), MyModel.withScope('scope1')),
+    ).to.be.true;
+  });
+
+  it('returns false if the models are different', () => {
+    const MyModel1 = sequelize.define('myModel1', {});
+
+    const MyModel2 = sequelize.define('myModel2', {});
+
+    expect(
+      isSameInitialModel(MyModel1, MyModel2),
+    ).to.be.false;
+  });
+});

--- a/test/unit/utils/model-utils.test.ts
+++ b/test/unit/utils/model-utils.test.ts
@@ -27,7 +27,7 @@ describe('isModelStatic', () => {
   });
 });
 
-describe('areSameInitialModel', () => {
+describe('isSameInitialModel', () => {
   it('returns true if both models have the same initial model', () => {
     const MyModel = sequelize.define('myModel', {}, {
       scopes: {

--- a/test/unit/utils/model-utils.test.ts
+++ b/test/unit/utils/model-utils.test.ts
@@ -12,7 +12,7 @@ describe('isModelStatic', () => {
     expect(isModelStatic(MyModel)).to.be.true;
   });
 
-  it('returns true for model instances', () => {
+  it('returns false for model instances', () => {
     const MyModel = sequelize.define('myModel', {});
 
     expect(isModelStatic(new MyModel())).to.be.false;

--- a/test/unit/utils/model-utils.test.ts
+++ b/test/unit/utils/model-utils.test.ts
@@ -27,7 +27,7 @@ describe('isModelStatic', () => {
   });
 });
 
-describe('isSameInitialModel', () => {
+describe('areSameInitialModel', () => {
   it('returns true if both models have the same initial model', () => {
     const MyModel = sequelize.define('myModel', {}, {
       scopes: {


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This PR adds two new utility methods:

- `isModelStatic`: returns true if the value is a subclass (not instance) of model
- `isSameInitialModel`: returns true if two models are variants of the same model

Both were initially created for https://github.com/sequelize/sequelize/pull/14280, but this PR also refactors the existing codebase to use them where it makes sense