### PR TITLE
docs: redirect engines.md to our website

### DIFF
--- a/ENGINE.md
+++ b/ENGINE.md
@@ -1,3 +1,0 @@
-# Database Engine Support
-
-You can find the information about which database each version of Sequelize supports on our [Versioning Page](https://sequelize.org/releases/)

--- a/ENGINE.md
+++ b/ENGINE.md
@@ -1,12 +1,3 @@
 # Database Engine Support
 
-## v6
-
-|        Engine        |                                 Minimum supported version                                 |
-| :------------------: | :---------------------------------------------------------------------------------------: |
-|      PostgreSQL      |                  [9.5.0](https://www.postgresql.org/docs/9.5/index.html)                  |
-|        MySQL         |                     [5.7.0](https://dev.mysql.com/doc/refman/5.7/en/)                     |
-|       MariaDB        |         [10.1.44](https://mariadb.com/kb/en/changes-improvements-in-mariadb-101/)         |
-| Microsoft SQL Server | [SQL Server 2014 Express](https://www.microsoft.com/en-US/download/details.aspx?id=42299) |
-|        SQLite        |                       [3.8.0](https://www.sqlite.org/version3.html)                       |
-|         db2          |                 [11.5](https://www.ibm.com/in-en/products/db2-database)                   |
+You can find the information about which database each version of Sequelize supports on our [Versioning Page](https://sequelize.org/releases/)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Please find upgrade information to major versions here:
 ## :book: Resources
 
 - [Documentation](https://sequelize.org)
+- [Databases Compatibility Table](https://sequelize.org/releases/)
 - [Changelog](https://github.com/sequelize/sequelize/releases)
 - [Discussions](https://github.com/sequelize/sequelize/discussions)
 - [Slack Inviter](http://sequelize-slack.herokuapp.com/)


### PR DESCRIPTION
This PR removes the Supported Database table from ENGINE.md, redirecting the user to https://sequelize.org/releases/ instead, to deduplicate the information that we have to maintain :)