### PR TITLE
ci(mariadb): add MariaDB 10.1.44

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,14 @@ jobs:
             image: mysql:8.0.28
             dialect: mysql
             node-version: 16
+          - name: MariaDB 10.1
+            image: mariadb:10.1.44
+            dialect: mariadb
+            node-version: 14
+          - name: MariaDB 10.1
+            image: mariadb:10.1.44
+            dialect: mariadb
+            node-version: 16
           - name: MariaDB 10.3
             image: mariadb:10.3.34
             dialect: mariadb


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Adds MariaDB 10.1.44 to our CI since it should be supported by v6, and possibly also v7. See https://github.com/sequelize/website/pull/84 for context
PR for v6 will be made later.

### Todos

- [ ] See if tests fail
