### PR TITLE
ci(mariadb): add MariaDB 10.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,12 +153,12 @@ jobs:
             image: mysql:8.0
             dialect: mysql
             node-version: 16
-          - name: MariaDB 10.3
-            image: mariadb:10.3
+          - name: MariaDB 10.1
+            image: mariadb:10.1
             dialect: mariadb
             node-version: 10
-          - name: MariaDB 10.3
-            image: mariadb:10.3
+          - name: MariaDB 10.1
+            image: mariadb:10.1
             dialect: mariadb
             node-version: 16
           - name: MariaDB 10.5


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Adds MariaDB 10.1.44 to our CI since it should be supported by v6. See https://github.com/sequelize/website/pull/84 for context

<!-- Please provide a description of the change here. -->
