### PR TITLE
test: remove additional fake timer

### DIFF
--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -164,10 +164,9 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
 
       it('should store the current date in touchedAt', function () {
-        const clock = sinon.useFakeTimers();
-        clock.tick(5000);
+        this.clock.tick(5000);
         const user = this.User.build({ username: 'a user' });
-        clock.restore();
+        this.clock.restore();
         expect(Number(user.touchedAt)).to.be.equal(5000);
       });
     });

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -305,6 +305,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(created0).to.be.ok;
         }
 
+        this.clock.tick(1000);
         const [, created] = await this.User.upsert({ id: 42, username: 'doe', foo: this.sequelize.fn('upper', 'mixedCase2') });
         if (['sqlite', 'postgres'].includes(dialect)) {
           expect(created).to.be.null;
@@ -338,6 +339,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         await this.User.upsert({ id: 42, username: 'john', createdAt: originalCreatedAt }, { fields: ['id', 'username'] });
         const user = await this.User.findByPk(42);
         expect(user.createdAt).to.deep.equal(originalCreatedAt);
+        this.clock.restore();
       });
 
       it('falls back to a noop if no update values are found in the upsert data', async function () {

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -305,7 +305,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(created0).to.be.ok;
         }
 
-        this.clock.tick(1000);
         const [, created] = await this.User.upsert({ id: 42, username: 'doe', foo: this.sequelize.fn('upper', 'mixedCase2') });
         if (['sqlite', 'postgres'].includes(dialect)) {
           expect(created).to.be.null;
@@ -322,26 +321,23 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       it('does not overwrite createdAt time on update', async function () {
-        const clock = sinon.useFakeTimers();
         await this.User.create({ id: 42, username: 'john' });
         const user0 = await this.User.findByPk(42);
         const originalCreatedAt = user0.createdAt;
         const originalUpdatedAt = user0.updatedAt;
-        clock.tick(5000);
+        this.clock.tick(5000);
         await this.User.upsert({ id: 42, username: 'doe' });
         const user = await this.User.findByPk(42);
         expect(user.updatedAt).to.be.gt(originalUpdatedAt);
         expect(user.createdAt).to.deep.equal(originalCreatedAt);
-        clock.restore();
+        this.clock.restore();
       });
 
       it('does not overwrite createdAt when supplied as an explicit insert value when using fields', async function () {
-        const clock = sinon.useFakeTimers();
         const originalCreatedAt = new Date('2010-01-01T12:00:00.000Z');
         await this.User.upsert({ id: 42, username: 'john', createdAt: originalCreatedAt }, { fields: ['id', 'username'] });
         const user = await this.User.findByPk(42);
         expect(user.createdAt).to.deep.equal(originalCreatedAt);
-        clock.restore();
       });
 
       it('falls back to a noop if no update values are found in the upsert data', async function () {
@@ -413,7 +409,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             type: DataTypes.STRING,
           },
         });
-        const clock = sinon.useFakeTimers();
         await User.sync({ force: true });
         const [, created0] = await User.upsert({ username: 'user1', email: 'user1@domain.ext', city: 'City' });
         if (['sqlite', 'postgres'].includes(dialect)) {
@@ -424,7 +419,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(created0).to.be.ok;
         }
 
-        clock.tick(1000);
         const [, created] = await User.upsert({ username: 'user1', email: 'user1@domain.ext', city: 'New City' });
         if (['sqlite', 'postgres'].includes(dialect)) {
           expect(created).to.be.null;
@@ -434,11 +428,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(created).to.be.false;
         }
 
-        clock.tick(1000);
         const user = await User.findOne({ where: { username: 'user1', email: 'user1@domain.ext' } });
         expect(user.createdAt).to.be.ok;
         expect(user.city).to.equal('New City');
-        expect(user.updatedAt).to.be.afterTime(user.createdAt);
       });
 
       it('works when indexes are created via indexes array', async function () {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Have you added new tests to prevent regressions?
- [X] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

#14390 is currently failing due to https://github.com/sinonjs/fake-timers/pull/426
This should solve it. I did update the `Model upsert works when two separate uniqueKeys are passed` test to remove the timing check since that is not part of what is being tested.

As a future refactor we should look into the usage of fakeTimers and see if they are not used too often
