### PR TITLE
Update connection-manager.d.ts

### DIFF
--- a/src/dialects/abstract/connection-manager.d.ts
+++ b/src/dialects/abstract/connection-manager.d.ts
@@ -33,7 +33,7 @@ export interface ConnectionManager {
    * Get connection from pool. It sets database version if it's not already set.
    * Call pool.acquire to get a connection.
    */
-  getConnection(opts: GetConnectionOptions): Promise<Connection>;
+  getConnection(opts?: GetConnectionOptions): Promise<Connection>;
   /**
    * Release a pooled connection so it can be utilized by other connection requests
    */


### PR DESCRIPTION
Received an error in typescript that "an argument for 'opts' was not provided. This argument is not required .

src/services/notificationService/notificationService.ts:127:68 - error TS2554: Expected 1 arguments, but got 0.

127       const connection = await this.db.sequelize.connectionManager.getConnection();
                                                                       ~~~~~~~~~~~~~~~

  node_modules/sequelize/types/dialects/abstract/connection-manager.d.ts:29:17
    29   getConnection(opts: GetConnectionOptions): Promise<Connection>;
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
    An argument for 'opts' was not provided.

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->

### Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
