### PR TITLE
ci: cancel old run on new push in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 on:
   push:
     branches:
-      - v6
       - v7
   pull_request:
 
@@ -10,6 +9,13 @@ env:
   SEQ_DB: sequelize_test
   SEQ_USER: sequelize_test
   SEQ_PW: sequelize_test
+
+# This configuration cancels previous runs if a new run is started on the same PR. Only one run at a time per PR.
+# This does not affect pushes to the v7 branch itself, only PRs.
+# from https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-using-a-fallback-value
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   install-and-build:


### PR DESCRIPTION
This PR makes sure PRs only run one workflow at a time by cancelling the previous workflow if a new commit is added.

This doesn't impact doing multiple pushes to the v7 branch, only PRs are impacted.

I also removed the mention of the v6 branch in the workflow triggers, as the configuration present in the v6 branch is used instead.