### PR TITLE
build(renovate): enable lockfile maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "config:base"
-  ],
-  "semanticCommitType": "build"
+    "config:base",
+    ":semanticCommitType(build)",
+    ":maintainLockFilesWeekly"
+  ]
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Have you added new tests to prevent regressions?
- [X] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This PR enables [lockfile maintenance](https://docs.renovatebot.com/configuration-options/#lockfilemaintenance) for Renovate. It should also fix the issue we had with PRs not being marked as `build` but as `chore`
