### PR TITLE
fix(typescript): type-checking fields  in WhereOptions

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -207,7 +207,7 @@ export type WhereOptions<TAttributes = any> = AllowNotOrAndWithImplicitAndArrayR
   | Fn
   | Where
   | Json
->;
+> & TAttributes;
 
 // number is always allowed because -Infinity & +Infinity are valid
 export type Rangable<T> = readonly [


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->
#### Before PR!

i have a `User` is model with `name` field is `string`

```
   const user = await User.findOne({
        where: {
            name: 123456789 // pass a number => typescript not error 
        }
   })
```

field `name` is `string` in model, but when i use `findOne` and pass a `number` type, typescript not have error and my program run still.

#### After PR!

show error as `No overload matches this call.` and  my program throw exception.
