### PR TITLE
build: fix esdoc

### DIFF
--- a/docs.sh
+++ b/docs.sh
@@ -14,7 +14,7 @@ node docs/redirects/create-redirects.js
 rimraf esdoc/file esdoc/source.html
 
 set +e
-GREP_RESULT=$(echo "$OUT" | grep -c 'could not parse the following code')
+GREP_RESULT=$(echo "$OUT" | grep -c 'could not parse the following code\|SyntaxError')
 set -e
 
 if [ "$GREP_RESULT" -ge 1 ]; then

--- a/src/utils.js
+++ b/src/utils.js
@@ -117,7 +117,7 @@ exports.pluralize = pluralize;
 /**
  * @deprecated use {@link injectReplacements} instead. This method has been removed in v7.
  *
- * @param {[string, ...unknown[]]} arr - first item is the SQL, following items are the positional replacements.
+ * @param {unknown[]} arr - first item is the SQL, following items are the positional replacements.
  * @param {AbstractDialect} dialect
  */
 function format(arr, dialect) {


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Closes https://github.com/sequelize/sequelize/issues/14509

This PR fixes the [JSDoc comment](https://github.com/sequelize/sequelize/pull/14472#discussion_r873211094) that causes esdoc to crash.

I also updated `docs.sh` to ensure such an error would cause the script to exit with a non-zero code. I can't guarantee it will catch every future esdoc crash, but it will catch this one if it happens again.