### PR TITLE
test: disable mysql/mariadb deadlock test

### DIFF
--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -422,7 +422,11 @@ if (current.dialect.supports.transactions) {
     });
 
     if (['mysql', 'mariadb'].includes(dialect)) {
-      describe('deadlock handling', () => {
+      // Both MariaDB and MySQL (probably innoDB) seem to have changed the way they handle this deadlock
+      //  and the deadlock does not occur anymore.
+      // We have not managed to recreate this deadlock and, for now, are disabling this test.
+      // See https://github.com/sequelize/sequelize/issues/14174
+      describe.skip('deadlock handling', () => {
         // Create the `Task` table and ensure it's initialized with 2 rows
         const getAndInitializeTaskModel = async sequelize => {
           const Task = sequelize.define('task', {


### PR DESCRIPTION
See https://github.com/sequelize/sequelize/issues/14174 for context.

We already disabled this [deadlock test for MariaDB 10.5.15](https://github.com/sequelize/sequelize/pull/14315), but the exact same issue now occurs with MySQL 8.0.29.

This PR disables the deadlock test altogether (it only ran for MariaDB, MySQL). 
While it is unfortunate that we have not managed to understand why the deadlock did not occur anymore, this test is blocking the whole CI and we have looked into it extensively.

This PR targets v6.