### PR TITLE
fix: accept replacements in `ARRAY[]` & followed by `;`

### DIFF
--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -134,14 +134,14 @@ export function injectReplacements(
     if (isNamedReplacements && char === ':') {
       const previousChar = sqlString[i - 1];
       // we want to be conservative with what we consider to be a replacement to avoid risk of conflict with potential operators
-      // users need to add a space before the bind parameter (except after '(', ',', and '=')
-      if (previousChar !== undefined && !/[\s(,=]/.test(previousChar)) {
+      // users need to add a space before the bind parameter (except after '(', ',', and '=', '[' (for arrays))
+      if (previousChar !== undefined && !/[\s(,=[]/.test(previousChar)) {
         continue;
       }
 
       const remainingString = sqlString.slice(i, sqlString.length);
 
-      const match = remainingString.match(/^:(?<name>[a-z_][0-9a-z_]*)(?:\)|,|$|\s|::)/i);
+      const match = remainingString.match(/^:(?<name>[a-z_][0-9a-z_]*)(?:\)|,|$|\s|::|;|])/i);
       const replacementName = match?.groups?.name;
       if (!replacementName) {
         continue;
@@ -169,8 +169,8 @@ export function injectReplacements(
       const previousChar = sqlString[i - 1];
 
       // we want to be conservative with what we consider to be a replacement to avoid risk of conflict with potential operators
-      // users need to add a space before the bind parameter (except after '(', ',', and '=')
-      if (previousChar !== undefined && !/[\s(,=]/.test(previousChar)) {
+      // users need to add a space before the bind parameter (except after '(', ',', and '=', '[' (for arrays))
+      if (previousChar !== undefined && !/[\s(,=[]/.test(previousChar)) {
         continue;
       }
 

--- a/test/unit/utils/sql.test.js
+++ b/test/unit/utils/sql.test.js
@@ -46,16 +46,18 @@ describe('injectReplacements (named replacements)', () => {
 
   // this is a workaround.
   // The right way to support ARRAY in replacement is https://github.com/sequelize/sequelize/issues/14410
-  it('parses named replacements inside ARRAY[]', () => {
-    const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[:id1]::int[] OR id = ARRAY[:id1,:id2]::int[] OR id = ARRAY[:id1, :id2]::int[];', dialect, {
-      id1: 1,
-      id2: 4
-    });
+  if (sequelize.dialect.supports.ARRAY) {
+    it('parses named replacements inside ARRAY[]', () => {
+      const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[:id1]::int[] OR id = ARRAY[:id1,:id2]::int[] OR id = ARRAY[:id1, :id2]::int[];', dialect, {
+        id1: 1,
+        id2: 4
+      });
 
-    expectsql(sql, {
-      default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR id = ARRAY[1,4]::int[] OR id = ARRAY[1, 4]::int[];'
+      expectsql(sql, {
+        default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR id = ARRAY[1,4]::int[] OR id = ARRAY[1, 4]::int[];'
+      });
     });
-  });
+  }
 
   it('parses single letter named replacements', () => {
     const sql = injectReplacements('SELECT * FROM users WHERE id = :a', dialect, {
@@ -215,13 +217,15 @@ describe('injectReplacements (positional replacements)', () => {
 
   // this is a workaround.
   // The right way to support ARRAY in replacement is https://github.com/sequelize/sequelize/issues/14410
-  it('parses positional replacements inside ARRAY[]', () => {
-    const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[?]::int[] OR ARRAY[?,?]::int[] OR ARRAY[?, ?]::int[];', dialect, [1, 1, 4, 1, 4]);
+  if (sequelize.dialect.supports.ARRAY) {
+    it('parses positional replacements inside ARRAY[]', () => {
+      const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[?]::int[] OR ARRAY[?,?]::int[] OR ARRAY[?, ?]::int[];', dialect, [1, 1, 4, 1, 4]);
 
-    expectsql(sql, {
-      default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR ARRAY[1,4]::int[] OR ARRAY[1, 4]::int[];'
+      expectsql(sql, {
+        default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR ARRAY[1,4]::int[] OR ARRAY[1, 4]::int[];'
+      });
     });
-  });
+  }
 
   it('does not consider the token to be a replacement if it does not follow \'(\', \',\', \'=\' or whitespace', () => {
     const sql = injectReplacements('SELECT * FROM users WHERE id = fn(?) OR id = fn(\'a\',?) OR id=? OR id = ?', dialect, [2, 1, 3, 4]);

--- a/test/unit/utils/sql.test.js
+++ b/test/unit/utils/sql.test.js
@@ -34,6 +34,29 @@ describe('injectReplacements (named replacements)', () => {
     });
   });
 
+  it('parses named replacements followed by a semicolon', () => {
+    const sql = injectReplacements('SELECT * FROM users WHERE id = :id;', dialect, {
+      id: 1
+    });
+
+    expectsql(sql, {
+      default: 'SELECT * FROM users WHERE id = 1;'
+    });
+  });
+
+  // this is a workaround.
+  // The right way to support ARRAY in replacement is https://github.com/sequelize/sequelize/issues/14410
+  it('parses named replacements inside ARRAY[]', () => {
+    const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[:id1]::int[] OR id = ARRAY[:id1,:id2]::int[] OR id = ARRAY[:id1, :id2]::int[];', dialect, {
+      id1: 1,
+      id2: 4
+    });
+
+    expectsql(sql, {
+      default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR id = ARRAY[1,4]::int[] OR id = ARRAY[1, 4]::int[];'
+    });
+  });
+
   it('parses single letter named replacements', () => {
     const sql = injectReplacements('SELECT * FROM users WHERE id = :a', dialect, {
       a: 1
@@ -179,6 +202,24 @@ describe('injectReplacements (positional replacements)', () => {
 
     expectsql(sql, {
       default: 'SELECT * FROM users WHERE id = 1::string'
+    });
+  });
+
+  it('parses positional replacements followed by a semicolon', () => {
+    const sql = injectReplacements('SELECT * FROM users WHERE id = ?;', dialect, [1]);
+
+    expectsql(sql, {
+      default: 'SELECT * FROM users WHERE id = 1;'
+    });
+  });
+
+  // this is a workaround.
+  // The right way to support ARRAY in replacement is https://github.com/sequelize/sequelize/issues/14410
+  it('parses positional replacements inside ARRAY[]', () => {
+    const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[?]::int[] OR ARRAY[?,?]::int[] OR ARRAY[?, ?]::int[];', dialect, [1, 1, 4, 1, 4]);
+
+    expectsql(sql, {
+      default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR ARRAY[1,4]::int[] OR ARRAY[1, 4]::int[];'
     });
   });
 


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Closes: https://github.com/sequelize/sequelize/issues/14517
Other bug report: https://github.com/sequelize/sequelize/pull/14472#issuecomment-1129661928

This PR fixes the replacement parser to replace them in the following two queries:

```sql
-- replacements were not transformed in arrays
SELECT * FROM users WHERE id = ARRAY[:id]::int[];
SELECT * FROM users WHERE id = ARRAY[?]::int[];
```

```sql
-- replacements were not transformed if followed by ';'
SELECT * FROM users WHERE id = :id;
SELECT * FROM users WHERE id = ?;
```