### PR TITLE
fix: expand where `$bind` & `:replacements` can be used

### DIFF
--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -138,7 +138,7 @@ function mapBindParametersAndReplacements(
         }
 
         // detect the bind param if it's a valid identifier and it's followed either by '::' (=cast), ')', whitespace of it's the end of the query.
-        const match = remainingString.match(/^\$(?<name>([a-z_][0-9a-z_]*|[1-9][0-9]*))(?:\)|,|$|\s|::)/i);
+        const match = remainingString.match(/^\$(?<name>([a-z_][0-9a-z_]*|[1-9][0-9]*))(?:\)|,|$|\s|::|;)/i);
         const bindParamName = match?.groups?.name;
         if (!bindParamName) {
           continue;
@@ -161,14 +161,14 @@ function mapBindParametersAndReplacements(
     if (isNamedReplacements && char === ':') {
       const previousChar = sqlString[i - 1];
       // we want to be conservative with what we consider to be a replacement to avoid risk of conflict with potential operators
-      // users need to add a space before the bind parameter (except after '(', ',', and '=')
-      if (previousChar !== undefined && !/[\s(,=]/.test(previousChar)) {
+      // users need to add a space before the bind parameter (except after '(', ',', '=', and '[' (for arrays))
+      if (previousChar !== undefined && !/[\s(,=[]/.test(previousChar)) {
         continue;
       }
 
       const remainingString = sqlString.slice(i, sqlString.length);
 
-      const match = remainingString.match(/^:(?<name>[a-z_][0-9a-z_]*)(?:\)|,|$|\s|::)/i);
+      const match = remainingString.match(/^:(?<name>[a-z_][0-9a-z_]*)(?:\)|,|$|\s|::|;|])/i);
       const replacementName = match?.groups?.name;
       if (!replacementName) {
         continue;
@@ -196,8 +196,8 @@ function mapBindParametersAndReplacements(
       const previousChar = sqlString[i - 1];
 
       // we want to be conservative with what we consider to be a replacement to avoid risk of conflict with potential operators
-      // users need to add a space before the bind parameter (except after '(', ',', and '=')
-      if (previousChar !== undefined && !/[\s(,=]/.test(previousChar)) {
+      // users need to add a space before the bind parameter (except after '(', ',', '=', and '[' (for arrays))
+      if (previousChar !== undefined && !/[\s(,=[]/.test(previousChar)) {
         continue;
       }
 

--- a/test/unit/utils/sql.test.ts
+++ b/test/unit/utils/sql.test.ts
@@ -62,6 +62,7 @@ describe('mapBindParameters', () => {
       postgres: `SELECT * FROM users WHERE id = $1;`,
       sqlite: `SELECT * FROM users WHERE id = $id;`,
       mssql: `SELECT * FROM users WHERE id = @id;`,
+      ibmi: `SELECT * FROM users WHERE id = ?;`, // 'default' removes the ; for ibmi
     });
   });
 
@@ -324,6 +325,7 @@ describe('injectReplacements (named replacements)', () => {
 
     expectsql(sql, {
       default: 'SELECT * FROM users WHERE id = 1;',
+      ibmi: `SELECT * FROM users WHERE id = 1;`, // 'default' removes the ; for ibmi
     });
   });
 
@@ -495,6 +497,7 @@ describe('injectReplacements (positional replacements)', () => {
 
     expectsql(sql, {
       default: 'SELECT * FROM users WHERE id = 1;',
+      ibmi: 'SELECT * FROM users WHERE id = 1;', // 'default' removes the ; for ibmi
     });
   });
 

--- a/test/unit/utils/sql.test.ts
+++ b/test/unit/utils/sql.test.ts
@@ -54,6 +54,28 @@ describe('mapBindParameters', () => {
     });
   });
 
+  it('parses bind parameters followed by a semicolon', () => {
+    const { sql } = mapBindParameters('SELECT * FROM users WHERE id = $id;', dialect);
+
+    expectsql(sql, {
+      default: `SELECT * FROM users WHERE id = ?;`,
+      postgres: `SELECT * FROM users WHERE id = $1;`,
+      sqlite: `SELECT * FROM users WHERE id = $id;`,
+      mssql: `SELECT * FROM users WHERE id = @id;`,
+    });
+  });
+
+  if (sequelize.dialect.supports.ARRAY) {
+    it('does not parse bind parameters inside ARRAY[]', () => {
+      const { sql } = mapBindParameters('SELECT * FROM users WHERE id = ARRAY[$id1]::int[];', dialect);
+
+      expectsql(sql, {
+        // it's a syntax error, but we still check because we accept this in replacements.
+        default: 'SELECT * FROM users WHERE id = ARRAY[$id1]::int[];',
+      });
+    });
+  }
+
   it('parses single letter bind parameters', () => {
     const { sql, bindOrder, parameterSet } = mapBindParameters(`SELECT * FROM users WHERE id = $a`, dialect);
 
@@ -295,6 +317,31 @@ describe('injectReplacements (named replacements)', () => {
     });
   });
 
+  it('parses named replacements followed by a semicolon', () => {
+    const sql = injectReplacements('SELECT * FROM users WHERE id = :id;', dialect, {
+      id: 1,
+    });
+
+    expectsql(sql, {
+      default: 'SELECT * FROM users WHERE id = 1;',
+    });
+  });
+
+  // this is an officially supported workaround.
+  // The right way to support ARRAY in replacement is https://github.com/sequelize/sequelize/issues/14410
+  if (sequelize.dialect.supports.ARRAY) {
+    it('parses named replacements inside ARRAY[]', () => {
+      const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[:id1]::int[] OR id = ARRAY[:id1,:id2]::int[] OR id = ARRAY[:id1, :id2]::int[];', dialect, {
+        id1: 1,
+        id2: 4,
+      });
+
+      expectsql(sql, {
+        default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR id = ARRAY[1,4]::int[] OR id = ARRAY[1, 4]::int[];',
+      });
+    });
+  }
+
   it('parses single letter named replacements', () => {
     const sql = injectReplacements(`SELECT * FROM users WHERE id = :a`, dialect, {
       a: 1,
@@ -442,6 +489,26 @@ describe('injectReplacements (positional replacements)', () => {
       default: `SELECT * FROM users WHERE id = 1::string`,
     });
   });
+
+  it('parses positional replacements followed by a semicolon', () => {
+    const sql = injectReplacements('SELECT * FROM users WHERE id = ?;', dialect, [1]);
+
+    expectsql(sql, {
+      default: 'SELECT * FROM users WHERE id = 1;',
+    });
+  });
+
+  // this is an officially supported workaround.
+  // The right way to support ARRAY in replacement is https://github.com/sequelize/sequelize/issues/14410
+  if (sequelize.dialect.supports.ARRAY) {
+    it('parses positional replacements inside ARRAY[]', () => {
+      const sql = injectReplacements('SELECT * FROM users WHERE id = ARRAY[?]::int[] OR ARRAY[?,?]::int[] OR ARRAY[?, ?]::int[];', dialect, [1, 1, 4, 1, 4]);
+
+      expectsql(sql, {
+        default: 'SELECT * FROM users WHERE id = ARRAY[1]::int[] OR ARRAY[1,4]::int[] OR ARRAY[1, 4]::int[];',
+      });
+    });
+  }
 
   it(`does not consider the token to be a replacement if it does not follow '(', ',', '=' or whitespace`, () => {
     const sql = injectReplacements(`SELECT * FROM users WHERE id = fn(?) OR id = fn('a',?) OR id=? OR id = ?`, dialect, [2, 1, 3, 4]);


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Ports https://github.com/sequelize/sequelize/pull/14518 to v7.
`$bind` parameters can be followed by `;` but, unlike `:replacements` cannot be used inside of an array literal.

With this PR, these are all processed correctly:

```sql
SELECT * FROM users WHERE id = ARRAY[:id]::int[];
SELECT * FROM users WHERE id = ARRAY[?]::int[];
SELECT * FROM users WHERE id = :id;
SELECT * FROM users WHERE id = ?;
SELECT * FROM users WHERE id = $bind;
```
