### PR TITLE
ci: enable sqlite unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
         run: yarn test-unit-postgres
       - name: Unit tests (postgres-native)
         run: yarn test-unit-postgres-native
+      - name: Unit tests (sqlite)
+        run: yarn test-unit-sqlite
       - name: Unit tests (mssql)
         run: yarn test-unit-mssql
       - name: Unit tests (db2)

--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -163,7 +163,7 @@ export interface Config {
   readonly replication: ReplicationOptions | false;
   readonly dialectModulePath: null | string;
   readonly keepDefaultTimezone?: boolean;
-  readonly dialectOptions?: Readonly<DialectOptions>;
+  readonly dialectOptions: Readonly<DialectOptions>;
 }
 
 export type Dialect = 'mysql' | 'postgres' | 'sqlite' | 'mariadb' | 'mssql' | 'db2' | 'snowflake' | 'ibmi';
@@ -409,7 +409,7 @@ export interface DialectOptions {
   odbcConnectionString?: string;
   charset?: string;
   timeout?: number;
-  options?: object;
+  options?: Record<string, any>;
 }
 
 export interface QueryOptionsTransactionRequired { }
@@ -952,7 +952,7 @@ export class Sequelize extends Hooks {
    */
   public readonly config: Config;
 
-  public readonly options: PartlyRequired<Options, 'transactionType' | 'isolationLevel'>;
+  public readonly options: PartlyRequired<Options, 'transactionType' | 'isolationLevel' | 'dialectOptions'>;
 
   public readonly dialect: AbstractDialect;
 

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -192,7 +192,7 @@ export class Sequelize {
       config = {};
       options = username || {};
 
-      _.merge(options, parseConnectionString(arguments[0]));
+      _.defaultsDeep(options, parseConnectionString(arguments[0]));
     } else {
       // new Sequelize(database, username, password, { ... options })
       options = options || {};
@@ -205,6 +205,7 @@ export class Sequelize {
       dialect: null,
       dialectModule: null,
       dialectModulePath: null,
+      dialectOptions: Object.create(null),
       host: 'localhost',
       protocol: 'tcp',
       define: {},

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -21,7 +21,7 @@ export function parseConnectionString(connectionString: string): Options {
     options.dialect = protocol as Dialect;
   }
 
-  if (urlParts.hostname) {
+  if (urlParts.hostname != null) {
     options.host = urlParts.hostname;
   }
 

--- a/test/unit/configuration.test.ts
+++ b/test/unit/configuration.test.ts
@@ -1,15 +1,9 @@
-'use strict';
+import path from 'node:path';
+import { Sequelize } from '@sequelize/core';
+import { expect } from 'chai';
+import { getTestDialect } from '../support';
 
-const chai = require('chai');
-
-const expect = chai.expect;
-const Support = require('./support');
-
-const { Sequelize } = require('@sequelize/core');
-
-const dialect = Support.getTestDialect();
-const path = require('path');
-
+const dialect = getTestDialect();
 describe('Sequelize', () => {
   describe('dialect is required', () => {
     it('throw error when no dialect is supplied', () => {
@@ -31,6 +25,7 @@ describe('Sequelize', () => {
     expect(() => {
       new Sequelize('localhost', 'test', 'test', {
         dialect: 'mysql',
+        // @ts-expect-error -- we're testing that this throws an error
         pool: false,
       });
     }).to.throw('Support for pool:false was removed in v4.0');
@@ -73,9 +68,8 @@ describe('Sequelize', () => {
       expect(config.port).to.equal('9821');
     });
 
-    describe('sqllite path inititalization', () => {
-      const current   = Support.sequelize;
-      if (current.dialect.name === 'sqlite') {
+    describe('SQLite path inititalization', () => {
+      if (dialect === 'sqlite') {
         it('should accept relative paths for sqlite', () => {
           const sequelize = new Sequelize('sqlite:subfolder/dbname.db');
           const options = sequelize.options;
@@ -179,13 +173,13 @@ describe('Sequelize', () => {
 
       expect(options.storage).to.equal('/completely/different/path.db');
       expect(dialectOptions.supportBigNumbers).to.be.true;
-      expect(dialectOptions.application_name).to.equal('client');
+      expect(dialectOptions.application_name).to.equal('server');
       expect(dialectOptions.ssl).to.equal('true');
     });
 
     it('should handle JSON options', () => {
       const sequelizeWithOptions = new Sequelize('mysql://example.com:9821/dbname?options={"encrypt":true}&anotherOption=1');
-      expect(sequelizeWithOptions.options.dialectOptions.options.encrypt).to.be.true;
+      expect(sequelizeWithOptions.options.dialectOptions.options?.encrypt).to.be.true;
       expect(sequelizeWithOptions.options.dialectOptions.anotherOption).to.equal('1');
     });
 


### PR DESCRIPTION
SQLite's unit tests were missing from the CI.

This PR enables these unit tests & fixes a (unreleased) regression introduced in https://github.com/sequelize/sequelize/pull/14501