### PR TITLE
fix: kill connection on commit/rollback error

### DIFF
--- a/src/dialects/abstract/connection-manager.d.ts
+++ b/src/dialects/abstract/connection-manager.d.ts
@@ -28,7 +28,12 @@ export interface ConnectionManager {
    */
   getConnection(opts: GetConnectionOptions): Promise<Connection>;
   /**
-   * Release a pooled connection so it can be utilized by other connection requests
+   * Release a pooled connection, so it can be utilized by other connection requests
    */
-  releaseConnection(conn: Connection): Promise<void>;
+  releaseConnection(conn: Connection): void;
+
+  /**
+   * Destroys a pooled connection and removes it from the pool.
+   */
+  destroyConnection(conn: Connection): Promise<void>;
 }

--- a/src/dialects/abstract/connection-manager.js
+++ b/src/dialects/abstract/connection-manager.js
@@ -298,8 +298,6 @@ class ConnectionManager {
    * Release a pooled connection so it can be utilized by other connection requests
    *
    * @param {Connection} connection
-   *
-   * @returns {Promise}
    */
   releaseConnection(connection) {
     this.pool.release(connection);

--- a/src/dialects/abstract/connection-manager.js
+++ b/src/dialects/abstract/connection-manager.js
@@ -301,9 +301,19 @@ class ConnectionManager {
    *
    * @returns {Promise}
    */
-  async releaseConnection(connection) {
+  releaseConnection(connection) {
     this.pool.release(connection);
     debug('connection released');
+  }
+
+  /**
+   * Destroys a pooled connection and removes it from the pool.
+   *
+   * @param {Connection} connection
+   */
+  async destroyConnection(connection) {
+    await this.pool.destroy(connection);
+    debug(`connection ${connection.uuid} destroyed`);
   }
 
   /**

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1188,7 +1188,7 @@ class Sequelize {
       } catch (err) {
         try {
           await transaction.rollback();
-        } catch {
+        } catch (ignore) {
           // ignore, because 'rollback' will already print the error before killing the connection
         }
 

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -642,7 +642,7 @@ class Sequelize {
       } finally {
         await this.runHooks('afterQuery', options, query);
         if (!options.transaction) {
-          await this.connectionManager.releaseConnection(connection);
+          this.connectionManager.releaseConnection(connection);
         }
       }
     }, retryOptions);
@@ -1174,30 +1174,29 @@ class Sequelize {
     const transaction = new Transaction(this, options);
 
     if (!autoCallback) {
-      await transaction.prepareEnvironment(false);
+      await transaction.prepareEnvironment(/* cls */ false);
       return transaction;
     }
 
     // autoCallback provided
     return Sequelize._clsRun(async () => {
+      await transaction.prepareEnvironment(/* cls */ true);
+
+      let result;
       try {
-        await transaction.prepareEnvironment();
-        const result = await autoCallback(transaction);
-        await transaction.commit();
-        return await result;
+        result = await autoCallback(transaction);
       } catch (err) {
         try {
-          if (!transaction.finished) {
-            await transaction.rollback();
-          } else {
-            // release the connection, even if we don't need to rollback
-            await transaction.cleanup();
-          }
-        } catch (err0) {
-          // ignore
+          await transaction.rollback();
+        } catch {
+          // ignore, because 'rollback' will already print the error before killing the connection
         }
+
         throw err;
       }
+
+      await transaction.commit();
+      return result;
     });
   }
 

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -57,9 +57,8 @@ class Transaction {
     }
 
     try {
-      const out = await this.sequelize.getQueryInterface().commitTransaction(this, this.options);
+      await this.sequelize.getQueryInterface().commitTransaction(this, this.options);
       this.cleanup();
-      return out;
     } catch (e) {
       console.warn(`Committing transaction ${this.id} failed with error ${JSON.stringify(e.message)}. We are killing its connection as it is now in an undetermined state.`);
       await this.forceCleanup();
@@ -88,14 +87,12 @@ class Transaction {
     }
 
     try {
-      const out = await this
+      await this
         .sequelize
         .getQueryInterface()
         .rollbackTransaction(this, this.options);
 
       this.cleanup();
-
-      return out;
     } catch (e) {
       console.warn(`Rolling back transaction ${this.id} failed with error ${JSON.stringify(e.message)}. We are killing its connection as it is now in an undetermined state.`);
       await this.forceCleanup();

--- a/test/integration/sequelize.transaction.test.js
+++ b/test/integration/sequelize.transaction.test.js
@@ -16,14 +16,14 @@ describe(Support.getTestDialectTeaser('Sequelize#transaction'), () => {
     return;
   }
 
-  const stubs = [];
+  let stubs = [];
 
   afterEach(() => {
     for (const stub of stubs) {
       stub.restore();
     }
 
-    stubs.length = 0;
+    stubs = [];
   });
 
   describe('Transaction#commit', () => {


### PR DESCRIPTION
### Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

This is an attempt at fixing https://github.com/sequelize/sequelize/issues/10858. I don't know if it'll completely fix it, so in doubt I'm not closing that issue.

#### What was going on?

If an error occurred during a transaction commit or rollback (such as a network error), Sequelize would call `transaction.cleanup()`, which released the connection to the pool.

The problem is that if an error occurred, we cannot guarantee that the transaction did actually commit or roll back. It may still be active. Releasing the connection to the pool does not kill the connection, and it will end up used by other queries - unknowingly running in another transaction.

#### The fix

This PR changes that by taking the drastic approach of killing the connection if an error occurred during `COMMIT TRANSACTION` or `ROLLBACK TRANSACTION`.
