### PR TITLE
docs: fix typedoc link to `Sequelize#define`

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1799,7 +1799,7 @@ export type Identifier = number | bigint | string | Buffer;
 /**
  * Options for model definition.
  *
- * Used by {@link Sequelize#define} and {@link Model.init}
+ * Used by {@link Sequelize.define} and {@link Model.init}
  *
  * @see https://sequelize.org/docs/v7/core-concepts/model-basics/
  */


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

<!-- Please provide a description of the change here. -->

Fixes a link directive so that it correctly displays as it currently does not link to the correct attribute.

### Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
