### PR TITLE
feat: Always add LIMIT 1 to `findOne` queries

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1875,18 +1875,8 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     options = Utils.cloneDeep(options);
-
-    if (options.limit === undefined) {
-      const uniqueSingleColumns = _.chain(this.uniqueKeys).values().filter(c => c.fields.length === 1)
-        .map('column')
-        .value();
-
-      // Don't add limit if querying directly on the pk or a unique column
-      if (!options.where || !_.some(options.where, (value, key) => (key === this.primaryKeyAttribute || uniqueSingleColumns.includes(key))
-          && (Utils.isPrimitive(value) || Buffer.isBuffer(value)))) {
-        options.limit = 1;
-      }
-    }
+    // findOne only ever needs one result
+    options.limit = 1;
 
     // Bypass a possible overloaded findAll.
     return await Model.findAll.call(this, (_.defaults(options, {

--- a/src/model.js
+++ b/src/model.js
@@ -1876,7 +1876,11 @@ ${associationOwner._getAssociationDebugList()}`);
 
     options = Utils.cloneDeep(options);
     // findOne only ever needs one result
-    options.limit = 1;
+    // conditional temporarily fixes 14618
+    // https://github.com/sequelize/sequelize/issues/14618
+    if (options.limit === undefined) {
+      options.limit = 1;
+    }
 
     // Bypass a possible overloaded findAll.
     return await Model.findAll.call(this, (_.defaults(options, {

--- a/test/unit/model/find-one.test.js
+++ b/test/unit/model/find-one.test.js
@@ -22,72 +22,11 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       this.stub = Sequelize.Model.findAll = sinon.stub().resolves();
     });
 
-    describe('should not add limit when querying on a primary key', () => {
-      it('with id primary key', async function () {
-        const Model = current.define('model');
-
-        await Model.findOne({ where: { id: 42 } });
-        expect(this.stub.getCall(0).args[0]).to.be.an('object').not.to.have.property('limit');
-      });
-
-      it('with custom primary key', async function () {
-        const Model = current.define('model', {
-          uid: {
-            type: DataTypes.INTEGER,
-            primaryKey: true,
-            autoIncrement: true,
-          },
-        });
-
-        await Model.findOne({ where: { uid: 42 } });
-        expect(this.stub.getCall(0).args[0]).to.be.an('object').not.to.have.property('limit');
-      });
-
-      it('with blob primary key', async function () {
-        const Model = current.define('model', {
-          id: {
-            type: DataTypes.BLOB,
-            primaryKey: true,
-            autoIncrement: true,
-          },
-        });
-
-        await Model.findOne({ where: { id: Buffer.from('foo') } });
-        expect(this.stub.getCall(0).args[0]).to.be.an('object').not.to.have.property('limit');
-      });
-    });
-
     it('should add limit when using { $ gt on the primary key', async function () {
       const Model = current.define('model');
 
       await Model.findOne({ where: { id: { [Op.gt]: 42 } } });
       expect(this.stub.getCall(0).args[0]).to.be.an('object').to.have.property('limit');
-    });
-
-    describe('should not add limit when querying on an unique key', () => {
-      it('with custom unique key', async function () {
-        const Model = current.define('model', {
-          unique: {
-            type: DataTypes.INTEGER,
-            unique: true,
-          },
-        });
-
-        await Model.findOne({ where: { unique: 42 } });
-        expect(this.stub.getCall(0).args[0]).to.be.an('object').not.to.have.property('limit');
-      });
-
-      it('with blob unique key', async function () {
-        const Model = current.define('model', {
-          unique: {
-            type: DataTypes.BLOB,
-            unique: true,
-          },
-        });
-
-        await Model.findOne({ where: { unique: Buffer.from('foo') } });
-        expect(this.stub.getCall(0).args[0]).to.be.an('object').not.to.have.property('limit');
-      });
     });
 
     it('should add limit when using multi-column unique key', async function () {


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions? **No, tests remove**
- [X] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? No this removes an undocumented behavior
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Remove conditional logic for adding `LIMIT 1` to `findOne` queries. Instead, always add it.

* Foreign keys should be used to ensure data integrity, and should not impact query performance.
* It's unclear how omitting `LIMIT 1` benefits any query that should return a single result.
* Models are imperfect representations of schema, making unnecessarily assumptions about their correctness can lead to severe issues.
  * see #14548 