### PR TITLE
fix(sqlite): don't use mkdirp if the file already exists, to fix windows error

### DIFF
--- a/src/dialects/sqlite/connection-manager.js
+++ b/src/dialects/sqlite/connection-manager.js
@@ -67,7 +67,7 @@ export class SqliteConnectionManager extends ConnectionManager {
       return this.connections[options.inMemory || options.uuid];
     }
 
-    if (!options.inMemory && (options.readWriteMode & this.lib.OPEN_CREATE) !== 0) {
+    if (!options.inMemory && (options.readWriteMode & this.lib.OPEN_CREATE) !== 0 && !fs.existsSync(path.dirname(options.storage)) ) {
       // automatic path provision for `options.storage`
       fs.mkdirSync(path.dirname(options.storage), { recursive: true });
     }


### PR DESCRIPTION

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

On Windows, using fs.mkdir() on the root directory even with recursion will result in an error

https://nodejs.org/dist/latest-v16.x/docs/api/fs.html#fsmkdirpath-options-callback#:~:text=on%20the%20root%20directory%20even%20with%20recursion%20will%20result%20in%20an%20error


