### PR TITLE
fix(postgres-test): insert record with enums array into schema (#14161)

### DIFF
--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -464,9 +464,10 @@ if (dialect.startsWith('postgres')) {
           expect(user.length).to.equal(1);
         });
 
-        it('should be able to insert a new record even with an array of enums in a schema', async function () {
+        it('should be able to insert a new record with an array of enums in a schema', async function () {
           const schema = 'special_schema';
-          this.sequelize.createSchema(schema);
+          await this.sequelize.createSchema(schema);
+
           const User = this.sequelize.define('UserEnums', {
             name: DataTypes.STRING,
             type: DataTypes.ENUM('A', 'B', 'C'),


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

  - User.sync(), which references the schema, was executed before the schema exists
  - add an `await` before the schema is created to enforce sequencing/synchronocity
Subtle style change:
  - remove word 'even' from test description

Addresses only PostgreSQL-portion of issue #14161

