### PR TITLE
fix: fix compatibility with exactOptionalPropertyTypes

### DIFF
--- a/src/associations/base.ts
+++ b/src/associations/base.ts
@@ -3,7 +3,7 @@ import type { Model, ModelStatic, Hookable, AttributeNames, ModelAttributeColumn
 import type { AllowArray } from '../utils';
 import * as Utils from '../utils';
 import type { NormalizeBaseAssociationOptions } from './helpers';
-import { AssociationConstructorSecret } from './helpers';
+import { AssociationSecret } from './helpers';
 
 /**
  * Creating associations in sequelize is done by calling one of the belongsTo / hasOne / hasMany / belongsToMany functions on a model (the source), and providing another model as the first argument to the function (the target).
@@ -148,7 +148,7 @@ export abstract class Association<
     options: Opts,
     parent?: Association<any>,
   ) {
-    if (secret !== AssociationConstructorSecret) {
+    if (secret !== AssociationSecret) {
       throw new Error(`Class ${this.constructor.name} cannot be instantiated directly due to it mutating the source model. Use one of the static methods on Model instead.`);
     }
 

--- a/src/associations/belongs-to.ts
+++ b/src/associations/belongs-to.ts
@@ -14,6 +14,7 @@ import type {
 } from '../model';
 import { Op } from '../operators';
 import * as Utils from '../utils';
+import { removeUndefined } from '../utils';
 import { isSameInitialModel } from '../utils/model-utils.js';
 import type { AssociationOptions, SingleAssociationAccessors } from './base';
 import { Association } from './base';
@@ -135,11 +136,11 @@ export class BelongsTo<
 
     this.foreignKey = foreignKey as SourceKey;
 
-    const newForeignKeyAttribute = {
+    const newForeignKeyAttribute = removeUndefined({
       type: this.target.rawAttributes[this.targetKey].type,
       ...foreignKeyAttributeOptions,
       allowNull: this.source.rawAttributes[this.foreignKey]?.allowNull ?? foreignKeyAttributeOptions?.allowNull,
-    };
+    });
 
     this.targetKeyField = Utils.getColumnName(this.target.getAttributes()[this.targetKey]);
     this.targetKeyIsPrimary = this.targetKey === this.target.primaryKeyAttribute;
@@ -164,13 +165,13 @@ export class BelongsTo<
     this.#mixin(source.prototype);
 
     if (options.inverse) {
-      const passDown = {
+      const passDown = removeUndefined({
         ...options,
         as: options.inverse.as,
         scope: options.inverse?.scope,
         sourceKey: options.targetKey,
         inverse: undefined,
-      };
+      });
 
       delete passDown.targetKey;
 

--- a/src/associations/has-many.ts
+++ b/src/associations/has-many.ts
@@ -15,6 +15,7 @@ import type {
 import { Op } from '../operators';
 import { col, fn } from '../sequelize';
 import type { AllowArray } from '../utils';
+import { removeUndefined } from '../utils';
 import { isSameInitialModel } from '../utils/model-utils.js';
 import type { MultiAssociationAccessors, MultiAssociationOptions, Association, AssociationOptions } from './base';
 import { MultiAssociation } from './base';
@@ -104,14 +105,14 @@ export class HasMany<
 
     super(secret, source, target, options, parent);
 
-    this.inverse = BelongsTo.associate(secret, target, source, {
+    this.inverse = BelongsTo.associate(secret, target, source, removeUndefined({
       as: options.inverse?.as,
       scope: options.inverse?.scope,
       foreignKey: options.foreignKey,
       targetKey: options.sourceKey,
       foreignKeyConstraints: options.foreignKeyConstraints,
       hooks: options.hooks,
-    }, this);
+    }), this);
 
     // Get singular and plural names
     // try to uppercase the first letter, unless the model forbids it

--- a/src/associations/has-one.ts
+++ b/src/associations/has-one.ts
@@ -12,6 +12,7 @@ import type {
 } from '../model';
 import { Op } from '../operators';
 import * as Utils from '../utils';
+import { removeUndefined } from '../utils';
 import { isSameInitialModel } from '../utils/model-utils.js';
 import type { AssociationOptions, SingleAssociationAccessors } from './base';
 import { Association } from './base';
@@ -104,14 +105,14 @@ export class HasOne<
 
     super(secret, source, target, options, parent);
 
-    this.inverse = BelongsTo.associate(secret, target, source, {
+    this.inverse = BelongsTo.associate(secret, target, source, removeUndefined({
       as: options.inverse?.as,
       scope: options.inverse?.scope,
       foreignKey: options.foreignKey,
       targetKey: options.sourceKey,
       foreignKeyConstraints: options.foreignKeyConstraints,
       hooks: options.hooks,
-    }, this);
+    }), this);
 
     // Get singular name, trying to uppercase the first letter, unless the model forbids it
     const singular = upperFirst(this.options.name.singular);

--- a/src/associations/helpers.ts
+++ b/src/associations/helpers.ts
@@ -2,19 +2,18 @@ import assert from 'assert';
 import NodeUtils from 'util';
 import isEqual from 'lodash/isEqual';
 import isPlainObject from 'lodash/isPlainObject.js';
-import isUndefined from 'lodash/isUndefined';
 import lowerFirst from 'lodash/lowerFirst';
 import omit from 'lodash/omit';
-import omitBy from 'lodash/omitBy';
 import type { Class } from 'type-fest';
 import { AssociationError } from '../errors/index.js';
 import type { Model, ModelAttributeColumnOptions, ModelStatic } from '../model';
 import type { Sequelize } from '../sequelize';
 import * as deprecations from '../utils/deprecations.js';
-import * as Utils from '../utils/index.js';
 import type { OmitConstructors } from '../utils/index.js';
+import * as Utils from '../utils/index.js';
+import { removeUndefined } from '../utils/index.js';
 import { isModelStatic, isSameInitialModel } from '../utils/model-utils.js';
-import type { Association, AssociationOptions, NormalizedAssociationOptions, ForeignKeyOptions } from './base';
+import type { Association, AssociationOptions, ForeignKeyOptions, NormalizedAssociationOptions } from './base';
 
 export function checkNamingCollision(source: ModelStatic<any>, associationName: string): void {
   if (Object.prototype.hasOwnProperty.call(source.getAttributes(), associationName)) {
@@ -98,7 +97,7 @@ export function mixinMethods<A extends Association, Aliases extends Record<strin
  * @internal
  * @private do not expose outside sequelize
  */
-export const AssociationConstructorSecret = Symbol('AssociationConstructorPrivateKey');
+export const AssociationSecret = Symbol('AssociationConstructorPrivateKey');
 
 export function getModel<M extends Model>(
   sequelize: Sequelize,
@@ -113,10 +112,6 @@ export function getModel<M extends Model>(
   }
 
   return model;
-}
-
-export function removeUndefined<T>(val: T): T {
-  return omitBy(val, isUndefined) as T;
 }
 
 export function assertAssociationUnique(

--- a/src/errors/base-error.ts
+++ b/src/errors/base-error.ts
@@ -1,7 +1,8 @@
 import { useErrorCause } from '../utils/deprecations.js';
+import type { Nullish } from '../utils/index.js';
 
 export interface SequelizeErrorOptions {
-  stack?: string;
+  stack?: Nullish<string>;
 }
 
 export interface CommonErrorProperties {
@@ -13,7 +14,7 @@ export interface CommonErrorProperties {
 //  Remove me in Sequelize 8, where this is added natively by TypeScript (>= 4.6):
 //  This is a breaking change and must be done in a MAJOR release.
 export type ErrorOptions = {
-  cause?: Error,
+  cause?: Nullish<Error>,
 };
 
 const supportsErrorCause = (() => {
@@ -33,7 +34,7 @@ const supportsErrorCause = (() => {
  * This means that errors can be accessed using `Sequelize.ValidationError`
  */
 abstract class BaseError extends Error {
-  declare cause: Error | undefined;
+  declare cause?: Error;
 
   get parent(): this['cause'] {
     useErrorCause();
@@ -54,11 +55,11 @@ abstract class BaseError extends Error {
     super(supportsErrorCause ? message : addCause(message, options?.cause), options);
     this.name = 'SequelizeBaseError';
 
-    if (!supportsErrorCause) {
+    if (!supportsErrorCause && options?.cause) {
       // TODO [>=2023-04-30]:
       //  Once all supported node versions have support for Error.cause (added in Node 16.9.0), delete this line:
       //  This is a breaking change and must be done in a MAJOR release.
-      this.cause = options?.cause;
+      this.cause = options.cause;
     }
   }
 }

--- a/src/errors/database/exclusion-constraint-error.ts
+++ b/src/errors/database/exclusion-constraint-error.ts
@@ -11,7 +11,7 @@ interface ExclusionConstraintErrorOptions {
 /**
  * Thrown when an exclusion constraint is violated in the database
  */
-class ExclusionConstraintError extends DatabaseError implements ExclusionConstraintErrorOptions {
+class ExclusionConstraintError extends DatabaseError {
   constraint: string | undefined;
   fields: Record<string, string | number> | undefined;
   table: string | undefined;

--- a/src/errors/database/unknown-constraint-error.ts
+++ b/src/errors/database/unknown-constraint-error.ts
@@ -11,7 +11,7 @@ interface UnknownConstraintErrorOptions {
 /**
  * Thrown when constraint name is not found in the database
  */
-class UnknownConstraintError extends DatabaseError implements UnknownConstraintErrorOptions {
+class UnknownConstraintError extends DatabaseError {
   constraint: string | undefined;
   fields: Record<string, string | number> | undefined;
   table: string | undefined;

--- a/src/errors/validation/unique-constraint-error.ts
+++ b/src/errors/validation/unique-constraint-error.ts
@@ -20,9 +20,9 @@ export interface UniqueConstraintErrorOptions extends SequelizeErrorOptions {
 /**
  * Thrown when a unique constraint is violated in the database
  */
-class UniqueConstraintError extends ValidationError implements CommonErrorProperties {
+class UniqueConstraintError extends ValidationError {
   /** The database specific error which triggered this one */
-  declare cause: UniqueConstraintErrorParent | undefined;
+  declare cause?: UniqueConstraintErrorParent;
 
   readonly fields: Record<string, unknown>;
   readonly sql: string;

--- a/src/model.js
+++ b/src/model.js
@@ -9,7 +9,7 @@ const Dottie = require('dottie');
 const Utils = require('./utils');
 const { logger } = require('./utils/logger');
 const { BelongsTo, BelongsToMany, Association, HasMany, HasOne } = require('./associations');
-const { AssociationConstructorSecret } = require('./associations/helpers');
+const { AssociationSecret } = require('./associations/helpers');
 const { InstanceValidator } = require('./instance-validator');
 const { QueryTypes } = require('./query-types');
 const sequelizeErrors = require('./errors');
@@ -4459,7 +4459,7 @@ Instead of specifying a Model, either:
    * @returns {HasMany} The newly defined association (also available in {@link Model.associations}).
    */
   static hasMany(target, options) {
-    return HasMany.associate(AssociationConstructorSecret, this, target, options);
+    return HasMany.associate(AssociationSecret, this, target, options);
   }
 
   /**
@@ -4485,7 +4485,7 @@ Instead of specifying a Model, either:
    * @returns {BelongsToMany} The newly defined association (also available in {@link Model.associations}).
    */
   static belongsToMany(target, options) {
-    return BelongsToMany.associate(AssociationConstructorSecret, this, target, options);
+    return BelongsToMany.associate(AssociationSecret, this, target, options);
   }
 
   /**
@@ -4504,7 +4504,7 @@ Instead of specifying a Model, either:
    * @returns {HasOne} The newly defined association (also available in {@link Model.associations}).
    */
   static hasOne(target, options) {
-    return HasOne.associate(AssociationConstructorSecret, this, target, options);
+    return HasOne.associate(AssociationSecret, this, target, options);
   }
 
   /**
@@ -4523,7 +4523,7 @@ Instead of specifying a Model, either:
    * @returns {BelongsTo} The newly defined association (also available in {@link Model.associations}).
    */
   static belongsTo(target, options) {
-    return BelongsTo.associate(AssociationConstructorSecret, this, target, options);
+    return BelongsTo.associate(AssociationSecret, this, target, options);
   }
 }
 

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -4,7 +4,9 @@ import getValue from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import isFunction from 'lodash/isFunction';
 import isPlainObject from 'lodash/isPlainObject';
+import isUndefined from 'lodash/isUndefined.js';
 import mergeWith from 'lodash/mergeWith';
+import omitBy from 'lodash/omitBy.js';
 import { getComplexKeys } from './format';
 // eslint-disable-next-line import/order -- caused by temporarily mixing require with import
 import { camelize } from './string';
@@ -212,4 +214,10 @@ export function camelizeObjectKeys(obj: { [key: string]: any }) {
   }
 
   return newObj;
+}
+
+type NoUndefinedField<T> = { [P in keyof T]: Exclude<T[P], null | undefined> };
+
+export function removeUndefined<T>(val: T): NoUndefinedField<T> {
+  return omitBy(val, isUndefined) as NoUndefinedField<T>;
 }

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -10,7 +10,8 @@
     },
     "types": ["node", "mocha", "sinon", "chai", "sinon-chai", "chai-as-promised", "chai-datetime"],
     "noEmit": true,
-    "emitDeclarationOnly": false
+    "emitDeclarationOnly": false,
+    "exactOptionalPropertyTypes": false
   },
   "include": ["./types/**/*", "./**/**/*.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "checkJs": false,
-    "removeComments": false
+    "exactOptionalPropertyTypes": true,
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Closes https://github.com/sequelize/sequelize/issues/14566

This PR turns on the `exactOptionalPropertyTypes` typescript option, to ensure our typings are compatible with it.