### PR TITLE
feat: exports types to support typescript >= 4.5 nodenext module

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,13 @@
   "exports": {
     ".": {
       "import": "./lib/index.mjs",
-      "require": "./lib/index.js"
+      "require": "./lib/index.js",
+      "types": "./types/index.d.ts"
     },
-    "./_non-semver-use-at-your-own-risk_/*": "./lib/*",
+    "./_non-semver-use-at-your-own-risk_/*": {
+      "default": "./lib/*",
+      "types": "./types/*.d.ts"
+    },
     "./package.json": "./package.json"
   },
   "engines": {


### PR DESCRIPTION
### Description Of Change

typescript has released [version >=4.5.x](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/ )，when use the latest `typescript@4.7.3` and `nodenext` moduleResolution throw this error.

![image](https://user-images.githubusercontent.com/13284978/172792195-c6710b69-4cc4-43fd-9718-b0a17501c4c8.png)

my  tsconfig.json 
```json
"compilerOptions": {
    "module": "NodeNext",
    "moduleResolution": "NodeNext",
    "rootDir": ".",
    "outDir": "output"
 },
```


This is because the `types` field needs to be added to the `exports` field of package.json when module is `nodenext`. like this.

![image](https://user-images.githubusercontent.com/13284978/172791140-abd245f3-7022-412b-a8aa-fbb6daacd3b7.png)

hope this new feature add in next v6 patch version and the we can enjoin the "nodenext".
