### PR TITLE
feat: fix multiple bugs related to `sync()` and indexes. Add `Model.getIndexes()`

### DIFF
--- a/src/dialects/abstract/index.ts
+++ b/src/dialects/abstract/index.ts
@@ -79,6 +79,12 @@ export type DialectSupports = {
   },
   groupedLimit: boolean,
   indexViaAlter: boolean,
+  alterColumn: {
+    /**
+     * Can "ALTER TABLE x ALTER COLUMN y" add UNIQUE to the column in this dialect?
+     */
+    unique: boolean,
+  },
   JSON: boolean,
   JSONB: boolean,
   ARRAY: boolean,
@@ -168,6 +174,9 @@ export abstract class AbstractDialect {
     },
     groupedLimit: true,
     indexViaAlter: false,
+    alterColumn: {
+      unique: true,
+    },
     JSON: false,
     JSONB: false,
     NUMERIC: false,

--- a/src/dialects/abstract/query-interface.js
+++ b/src/dialects/abstract/query-interface.js
@@ -839,7 +839,7 @@ export class QueryInterface {
     if (options.upsertKeys.length === 0) {
       const primaryKeys = Object.values(model.primaryKeys).map(item => item.field);
       const uniqueKeys = Object.values(model.uniqueKeys).filter(c => c.fields.length > 0).map(c => c.fields);
-      const indexKeys = Object.values(model._indexes).filter(c => c.unique && c.fields.length > 0).map(c => c.fields);
+      const indexKeys = Object.values(model.getIndexes()).filter(c => c.unique && c.fields.length > 0).map(c => c.fields);
       // For fields in updateValues, try to find a constraint or unique index
       // that includes given field. Only first matching upsert key is used.
       for (const field of options.updateOnDuplicate) {

--- a/src/dialects/db2/index.js
+++ b/src/dialects/db2/index.js
@@ -18,6 +18,9 @@ export class Db2Dialect extends AbstractDialect {
     autoIncrement: {
       defaultValue: false,
     },
+    alterColumn: {
+      unique: false,
+    },
     index: {
       collate: false,
       using: false,

--- a/src/dialects/db2/query-generator.js
+++ b/src/dialects/db2/query-generator.js
@@ -616,8 +616,7 @@ export class Db2QueryGenerator extends AbstractQueryGenerator {
 
     if (options && options.context === 'changeColumn' && attribute.type) {
       template = `DATA TYPE ${template}`;
-    } else if (attribute.allowNull === false || attribute.primaryKey === true
-             || attribute.unique) {
+    } else if (attribute.allowNull === false || attribute.primaryKey === true) {
       template += ' NOT NULL';
       changeNull = 0;
     }

--- a/src/dialects/db2/query-generator.js
+++ b/src/dialects/db2/query-generator.js
@@ -432,7 +432,7 @@ export class Db2QueryGenerator extends AbstractQueryGenerator {
     }
 
     // Add unique indexes defined by indexes option to uniqueAttrs
-    for (const index of model._indexes) {
+    for (const index of model.getIndexes()) {
       if (index.unique && index.fields) {
         for (const field of index.fields) {
           const fieldName = typeof field === 'string' ? field : field.name || field.attribute;

--- a/src/dialects/db2/query-generator.js
+++ b/src/dialects/db2/query-generator.js
@@ -637,7 +637,7 @@ export class Db2QueryGenerator extends AbstractQueryGenerator {
       template += ` DEFAULT ${this.escape(attribute.defaultValue, undefined, { replacements: options?.replacements })}`;
     }
 
-    if (attribute.unique === true) {
+    if (attribute.unique === true && (options.context !== 'changeColumn' || this._dialect.supports.alterColumn.unique)) {
       template += ' UNIQUE';
     }
 

--- a/src/dialects/db2/query-generator.js
+++ b/src/dialects/db2/query-generator.js
@@ -637,7 +637,7 @@ export class Db2QueryGenerator extends AbstractQueryGenerator {
       template += ` DEFAULT ${this.escape(attribute.defaultValue, undefined, { replacements: options?.replacements })}`;
     }
 
-    if (attribute.unique === true && (options.context !== 'changeColumn' || this._dialect.supports.alterColumn.unique)) {
+    if (attribute.unique === true && (options?.context !== 'changeColumn' || this._dialect.supports.alterColumn.unique)) {
       template += ' UNIQUE';
     }
 

--- a/src/dialects/db2/query-interface.js
+++ b/src/dialects/db2/query-interface.js
@@ -45,7 +45,7 @@ export class Db2QueryInterface extends QueryInterface {
       return value.fields;
     });
 
-    for (const value of model._indexes) {
+    for (const value of model.getIndexes()) {
       if (value.unique) {
         // fields in the index may both the strings or objects with an attribute property - lets sanitize that
         indexFields = value.fields.map(field => {

--- a/src/dialects/db2/query-interface.js
+++ b/src/dialects/db2/query-interface.js
@@ -105,35 +105,6 @@ export class Db2QueryInterface extends QueryInterface {
       attributes,
       attribute => this.sequelize.normalizeAttribute(attribute),
     );
-    if (options.indexes) {
-      for (const fields of options.indexes) {
-        const fieldArr = fields.fields;
-        if (fieldArr.length === 1) {
-          for (const field of fieldArr) {
-            for (const property in attributes) {
-              if (field === attributes[property].field) {
-                attributes[property].unique = true;
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (options.alter && options.indexes) {
-      for (const fields of options.indexes) {
-        const fieldArr = fields.fields;
-        if (fieldArr.length === 1) {
-          for (const field of fieldArr) {
-            for (const property in attributes) {
-              if (field === attributes[property].field && attributes[property].unique) {
-                attributes[property].unique = false;
-              }
-            }
-          }
-        }
-      }
-    }
 
     if (
       !tableName.schema

--- a/src/dialects/mssql/index.js
+++ b/src/dialects/mssql/index.js
@@ -24,6 +24,9 @@ export class MssqlDialect extends AbstractDialect {
       defaultValue: false,
       update: false,
     },
+    alterColumn: {
+      unique: false,
+    },
     constraints: {
       restrict: false,
       default: true,

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -153,7 +153,7 @@ export class MsSqlQueryGenerator extends AbstractQueryGenerator {
       _.each(options.uniqueKeys, (columns, indexName) => {
         if (columns.customIndex) {
           if (typeof indexName !== 'string') {
-            indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
+            indexName = Utils.generateIndexName(tableName, columns);
           }
 
           attributesClauseParts.push(`CONSTRAINT ${

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -623,7 +623,7 @@ export class MsSqlQueryGenerator extends AbstractQueryGenerator {
       template += ` DEFAULT ${this.escape(attribute.defaultValue, undefined, options)}`;
     }
 
-    if (attribute.unique === true) {
+    if (attribute.unique === true && (options?.context !== 'changeColumn' || this._dialect.supports.alterColumn.unique)) {
       template += ' UNIQUE';
     }
 

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -441,7 +441,7 @@ export class MsSqlQueryGenerator extends AbstractQueryGenerator {
     }
 
     // Add unique indexes defined by indexes option to uniqueAttrs
-    for (const index of model._indexes) {
+    for (const index of model.getIndexes()) {
       if (index.unique && index.fields) {
         for (const field of index.fields) {
           const fieldName = typeof field === 'string' ? field : field.name || field.attribute;

--- a/src/dialects/mssql/query-interface.js
+++ b/src/dialects/mssql/query-interface.js
@@ -69,7 +69,7 @@ export class MsSqlQueryInterface extends QueryInterface {
 
     // Lets combine unique keys and indexes into one
     let indexes = Object.values(model.uniqueKeys).map(item => item.fields);
-    indexes = indexes.concat(Object.values(model._indexes).filter(item => item.unique).map(item => item.fields));
+    indexes = indexes.concat(Object.values(model.getIndexes()).filter(item => item.unique).map(item => item.fields));
 
     const attributes = Object.keys(insertValues);
     for (const index of indexes) {

--- a/src/dialects/postgres/query-generator.js
+++ b/src/dialects/postgres/query-generator.js
@@ -96,9 +96,17 @@ export class PostgresQueryGenerator extends AbstractQueryGenerator {
     let attributesClause = attrStr.join(', ');
 
     if (options.uniqueKeys) {
-      _.each(options.uniqueKeys, columns => {
+      _.each(options.uniqueKeys, (columns, indexName) => {
         if (columns.customIndex) {
-          attributesClause += `, UNIQUE (${columns.fields.map(field => this.quoteIdentifier(field)).join(', ')})`;
+          if (typeof indexName !== 'string') {
+            indexName = Utils.generateIndexName(tableName, columns);
+          }
+
+          attributesClause += `, CONSTRAINT ${
+            this.quoteIdentifier(indexName)
+          } UNIQUE (${
+            columns.fields.map(field => this.quoteIdentifier(field)).join(', ')
+          })`;
         }
       });
     }
@@ -422,7 +430,7 @@ export class PostgresQueryGenerator extends AbstractQueryGenerator {
     let indexName = indexNameOrAttributes;
 
     if (typeof indexName !== 'string') {
-      indexName = Utils.underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
+      indexName = Utils.generateIndexName(tableName, { fields: indexNameOrAttributes });
     }
 
     return [

--- a/src/dialects/sqlite/query-generator.js
+++ b/src/dialects/sqlite/query-generator.js
@@ -60,13 +60,26 @@ export class SqliteQueryGenerator extends MySqlQueryGenerator {
     let attrStr = attrArray.join(', ');
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
 
-    if (options.uniqueKeys) {
-      _.each(options.uniqueKeys, columns => {
-        if (columns.customIndex) {
-          attrStr += `, UNIQUE (${columns.fields.map(field => this.quoteIdentifier(field)).join(', ')})`;
-        }
-      });
-    }
+    // sqlite has a bug where using CONSTRAINT constraint_name UNIQUE during CREATE TABLE
+    //  does not respect the provided constraint name
+    //  and uses sqlite_autoindex_ as the name of the constraint instead.
+    //  CREATE UNIQUE INDEX does not have this issue, so we're using that instead
+    //
+    // if (options.uniqueKeys) {
+    //   _.each(options.uniqueKeys, (columns, indexName) => {
+    //     if (columns.customIndex) {
+    //       if (typeof indexName !== 'string') {
+    //         indexName = Utils.generateIndexName(tableName, columns);
+    //       }
+    //
+    //       attrStr += `, CONSTRAINT ${
+    //         this.quoteIdentifier(indexName)
+    //       } UNIQUE (${
+    //         columns.fields.map(field => this.quoteIdentifier(field)).join(', ')
+    //       })`;
+    //     }
+    //   });
+    // }
 
     if (pkString.length > 0) {
       attrStr += `, PRIMARY KEY (${pkString})`;

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -2160,6 +2160,8 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
     readonly [Key in keyof Attributes<M>]: BuiltModelAttributeColumOptions
   };
 
+  public static getIndexes(): readonly IndexOptions[];
+
   /**
    * Reference to the sequelize instance the model was initialized with.
    *

--- a/src/model.js
+++ b/src/model.js
@@ -2730,12 +2730,6 @@ Specify a different name for either index to resolve this issue.`);
             }
           }
 
-          const firstUniqueKey = Object.values(model.uniqueKeys).find(c => c.fields.length > 0);
-
-          if (firstUniqueKey && firstUniqueKey.fields) {
-            upsertKeys.push(...firstUniqueKey.fields);
-          }
-
           options.upsertKeys = upsertKeys.length > 0
             ? upsertKeys
             : Object.values(model.primaryKeys).map(x => x.field);

--- a/src/model.js
+++ b/src/model.js
@@ -789,6 +789,10 @@ ${associationOwner._getAssociationDebugList()}`);
     ];
   }
 
+  static get _indexes() {
+    throw new Error('Model._indexes has been replaced with Model.getIndexes()');
+  }
+
   static _nameIndex(newIndex) {
     if (Object.prototype.hasOwnProperty.call(newIndex, 'name')) {
       return newIndex;

--- a/src/model.js
+++ b/src/model.js
@@ -783,12 +783,34 @@ ${associationOwner._getAssociationDebugList()}`);
 
   static getIndexes() {
     return [
-      ...this._manualIndexes,
-      ...this._attributeIndexes,
-      // TODO: (during TS migration) stop using 'uniqueKeys' internally in favor of '_attributeIndexes'
-      //       make 'uniqueKeys' a getter the filters getIndexes?
-      ...Object.values(this.uniqueKeys),
+      ...(this._manualIndexes ?? []),
+      ...(this._attributeIndexes ?? []),
+      ...(this.uniqueKeys ? Object.values(this.uniqueKeys) : []),
     ];
+  }
+
+  static _nameIndex(newIndex) {
+    if (Object.prototype.hasOwnProperty.call(newIndex, 'name')) {
+      return newIndex;
+    }
+
+    const newName = Utils.generateIndexName(this.getTableName(), newIndex);
+
+    // TODO: check for collisions on *all* models, not just this one, as index names are global.
+    for (const index of this.getIndexes()) {
+      if (index.name === newName) {
+        throw new Error(`Sequelize tried to give the name "${newName}" to index:
+${NodeUtil.inspect(newIndex)}
+on model "${this.name}", but that name is already taken by index:
+${NodeUtil.inspect(index)}
+
+Specify a different name for either index to resolve this issue.`);
+      }
+    }
+
+    newIndex.name = newName;
+
+    return newIndex;
   }
 
   /**
@@ -950,13 +972,12 @@ ${associationOwner._getAssociationDebugList()}`);
       return attribute;
     });
 
-    const tableName = this.getTableName();
     this._manualIndexes = this.options.indexes
-      .map(index => Utils.nameIndex(this._conformIndex(index), tableName));
+      .map(index => this._nameIndex(this._conformIndex(index)));
 
-    this.primaryKeys = {};
+    this.primaryKeys = Object.create(null);
     this._readOnlyAttributes = new Set();
-    this._timestampAttributes = {};
+    this._timestampAttributes = Object.create(null);
 
     // setup names of timestamp attributes
     if (this.options.timestamps) {
@@ -1124,28 +1145,36 @@ ${associationOwner._getAssociationDebugList()}`);
       }
 
       if (Object.prototype.hasOwnProperty.call(definition, 'unique') && definition.unique) {
-        let idxName;
-        if (
-          typeof definition.unique === 'object'
-          && Object.prototype.hasOwnProperty.call(definition.unique, 'name')
-        ) {
-          idxName = definition.unique.name;
-        } else if (typeof definition.unique === 'string') {
-          idxName = definition.unique;
-        } else {
-          idxName = `${this.tableName}_${name}_unique`;
+        if (typeof definition.unique === 'string') {
+          definition.unique = {
+            name: definition.unique,
+          };
+        } else if (definition.unique === true) {
+          definition.unique = {};
         }
 
-        const idx = this.uniqueKeys[idxName] || { fields: [] };
+        const index = definition.unique.name && this.uniqueKeys[definition.unique.name]
+          ? this.uniqueKeys[definition.unique.name]
+          : { fields: [] };
 
-        idx.fields.push(definition.field);
-        idx.msg = idx.msg || definition.unique.msg || null;
-        idx.name = idxName || false;
-        idx.column = name;
-        idx.customIndex = definition.unique !== true;
-        idx.unique = true;
+        index.fields.push(definition.field);
+        index.msg = index.msg || definition.unique.msg || null;
 
-        this.uniqueKeys[idxName] = idx;
+        // TODO: remove this 'column'? It does not work with composite indexes, and is only used by db2 which should use fields instead.
+        index.column = name;
+
+        index.customIndex = definition.unique !== true;
+        index.unique = true;
+
+        if (definition.unique.name) {
+          index.name = definition.unique.name;
+        } else {
+          this._nameIndex(index);
+        }
+
+        definition.unique.name ??= index.name;
+
+        this.uniqueKeys[index.name] = index;
       }
 
       if (Object.prototype.hasOwnProperty.call(definition, 'validate')) {
@@ -1154,12 +1183,11 @@ ${associationOwner._getAssociationDebugList()}`);
 
       if (definition.index === true && definition.type instanceof DataTypes.JSONB) {
         this._attributeIndexes.push(
-          Utils.nameIndex(
+          this._nameIndex(
             this._conformIndex({
               fields: [definition.field || name],
               using: 'gin',
             }),
-            this.getTableName(),
           ),
         );
 
@@ -1331,6 +1359,7 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     let indexes = await this.queryInterface.showIndex(tableName, options);
+
     indexes = this.getIndexes().filter(item1 => !indexes.some(item2 => item1.name === item2.name)).sort((index1, index2) => {
       if (this.sequelize.options.dialect === 'postgres') {
       // move concurrent indexes to the bottom to avoid weird deadlocks
@@ -1347,7 +1376,7 @@ ${associationOwner._getAssociationDebugList()}`);
     });
 
     for (const index of indexes) {
-      await this.queryInterface.addIndex(tableName, { ...options, ...index });
+      await this.queryInterface.addIndex(tableName, index, options);
     }
 
     if (options.hooks) {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,4 +1,7 @@
+import NodeUtil from 'node:util';
 import _inflection from 'inflection';
+import type { IndexOptions, TableName } from '../dialects/abstract/query-interface.js';
+import { SequelizeMethod } from './sequelize-method.js';
 
 /* Inflection */
 type Inflection = typeof _inflection;
@@ -60,7 +63,6 @@ type NameIndexIndex = {
   fields: Array<{ name: string, attribute: string }>,
   name: string,
 };
-type NameIndexTableName = string | { tableName: string };
 
 /**
  *
@@ -73,18 +75,51 @@ type NameIndexTableName = string | { tableName: string };
  */
 export function nameIndex(
   index: NameIndexIndex,
-  tableName: NameIndexTableName,
+  tableName: TableName,
 ) {
+  if (Object.prototype.hasOwnProperty.call(index, 'name')) {
+    return index;
+  }
+
+  index.name = generateIndexName(tableName, index);
+
+  return index;
+}
+
+export function generateIndexName(tableName: TableName, index: IndexOptions): string {
   if (typeof tableName !== 'string' && tableName.tableName) {
     tableName = tableName.tableName;
   }
 
-  if (!Object.prototype.hasOwnProperty.call(index, 'name')) {
-    const fields = index.fields.map(field => (typeof field === 'string' ? field : field.name || field.attribute));
-    index.name = underscore(`${tableName}_${fields.join('_')}`);
+  if (!index.fields) {
+    throw new Error(`Index on table ${tableName} has not fields:
+${NodeUtil.inspect(index)}`);
   }
 
-  return index;
+  const fields = index.fields.map(field => {
+    if (typeof field === 'string') {
+      return field;
+    }
+
+    if (field instanceof SequelizeMethod) {
+      // eslint-disable-next-line unicorn/prefer-type-error -- not a type error.
+      throw new Error(`Index on table ${tableName} uses Sequelize's ${field.constructor.name} as one of its fields. You need to name this index manually.`);
+    }
+
+    if ('attribute' in field) {
+      throw new Error('Property "attribute" in IndexField has been renamed to "name"');
+    }
+
+    return field.name;
+  });
+
+  let out = `${tableName}:${fields.join('+')}`;
+
+  if (index.unique) {
+    out += ':unique';
+  }
+
+  return out;
 }
 
 /**

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -113,13 +113,13 @@ ${NodeUtil.inspect(index)}`);
     return field.name;
   });
 
-  let out = `${tableName}:${fields.join('+')}`;
+  let out = `${tableName}_${fields.join('_')}`;
 
   if (index.unique) {
-    out += ':unique';
+    out += '_unique';
   }
 
-  return out;
+  return underscore(out);
 }
 
 /**

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -740,6 +740,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           {
             unique: true,
             fields: ['UserUserSecondId', 'GroupGroupSecondId'],
+            name: 'UserHasGroup_Second_Unique',
           },
         ],
       });

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -3348,8 +3348,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
       await this.sequelize.sync({ force: true });
 
-      expect(UserTasksLong.rawAttributes.id_user_very_long_field.unique).to.equal('custom_user_group_unique');
-      expect(UserTasksLong.rawAttributes.id_task_very_long_field.unique).to.equal('custom_user_group_unique');
+      expect(UserTasksLong.rawAttributes.id_user_very_long_field.unique).to.deep.equal({ name: 'custom_user_group_unique' });
+      expect(UserTasksLong.rawAttributes.id_task_very_long_field.unique).to.deep.equal({ name: 'custom_user_group_unique' });
     });
   });
 

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -1407,7 +1407,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
   describe('sourceKey', () => {
     beforeEach(function () {
       const User = this.sequelize.define('UserXYZ',
-        { username: DataTypes.STRING, email: DataTypes.STRING },
+        { username: DataTypes.STRING, email: { type: DataTypes.STRING, allowNull: false } },
         { indexes: [{ fields: ['email'], unique: true }] });
       const Task = this.sequelize.define('TaskXYZ',
         { title: DataTypes.STRING, userEmail: { type: DataTypes.STRING, field: 'user_email_xyz' } });
@@ -1544,7 +1544,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
   describe('sourceKey with where clause in include', () => {
     beforeEach(function () {
       this.User = this.sequelize.define('User',
-        { username: DataTypes.STRING, email: { type: DataTypes.STRING, field: 'mail' } },
+        { username: DataTypes.STRING, email: { type: DataTypes.STRING, field: 'mail', allowNull: false } },
         { indexes: [{ fields: ['mail'], unique: true }] });
       this.Task = this.sequelize.define('Task',
         { title: DataTypes.STRING, userEmail: DataTypes.STRING, taskStatus: DataTypes.STRING });

--- a/test/integration/dialects/mariadb/dao-factory.test.js
+++ b/test/integration/dialects/mariadb/dao-factory.test.js
@@ -16,12 +16,12 @@ if (dialect === 'mariadb') {
           username: { type: DataTypes.STRING, unique: true },
         }, { timestamps: false });
 
-        expect(
-          this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(
-            User.rawAttributes,
-          ),
-        ).to.deep.equal({
-          username: 'VARCHAR(255) UNIQUE',
+        expect(this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({
+          // note: UNIQUE is not specified here because it is only specified if the option passed to attributesToSQL is
+          //  'unique: true'.
+          // Model.init normalizes the 'unique' to ensure a consistent index, and createTableQuery handles adding
+          //  a named UNIQUE constraint
+          username: 'VARCHAR(255)',
           id: 'INTEGER NOT NULL auto_increment PRIMARY KEY',
         });
       });

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -16,7 +16,14 @@ if (dialect === 'mysql') {
           username: { type: DataTypes.STRING, unique: true },
         }, { timestamps: false });
 
-        expect(this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({ username: 'VARCHAR(255) UNIQUE', id: 'INTEGER NOT NULL auto_increment PRIMARY KEY' });
+        expect(this.sequelize.getQueryInterface().queryGenerator.attributesToSQL(User.rawAttributes)).to.deep.equal({
+          // note: UNIQUE is not specified here because it is only specified if the option passed to attributesToSQL is
+          //  'unique: true'.
+          // Model.init normalizes the 'unique' to ensure a consistent index, and createTableQuery handles adding
+          //  a named UNIQUE constraint
+          username: 'VARCHAR(255)',
+          id: 'INTEGER NOT NULL auto_increment PRIMARY KEY',
+        });
       });
 
       it('handles extended attributes (default)', function () {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -284,6 +284,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(index.name).to.equal('user_name_unique');
 
       switch (dialect) {
+        case 'mariadb':
         case 'mysql': {
           expect(index.fields).to.deep.equal([{ attribute: 'user_name', length: undefined, order: 'ASC' }]);
           expect(index.type).to.equal('BTREE');

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -298,6 +298,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           break;
         }
 
+        case 'db2':
         case 'mssql': {
           expect(index.fields).to.deep.equal([{ attribute: 'user_name', collate: undefined, length: undefined, order: 'ASC' }]);
 

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -623,7 +623,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(idx1.unique).to.be.ok;
 
       if (!['mssql', 'db2', 'ibmi'].includes(dialect)) {
-        expect(idx2.name).to.equal('models_field_c');
+        expect(idx2.name).to.equal('models:fieldC');
         expect(idx2.unique).not.to.be.ok;
       }
     });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -623,7 +623,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(idx1.unique).to.be.ok;
 
       if (!['mssql', 'db2', 'ibmi'].includes(dialect)) {
-        expect(idx2.name).to.equal('models:fieldC');
+        expect(idx2.name).to.equal('models_field_c');
         expect(idx2.unique).not.to.be.ok;
       }
     });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -268,27 +268,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(await UserTable.count()).to.equal(1);
     });
 
-    it('allows multiple column unique keys to be defined', async function () {
-      const User = this.sequelize.define('UserWithUniqueUsername', {
-        username: { type: DataTypes.STRING, unique: 'user_and_email' },
-        email: { type: DataTypes.STRING, unique: 'user_and_email' },
-        aCol: { type: DataTypes.STRING, unique: 'a_and_b' },
-        bCol: { type: DataTypes.STRING, unique: 'a_and_b' },
-      });
-
-      await User.sync({
-        force: true, logging: _.after(2, _.once(sql => {
-          if (dialect === 'mssql') {
-            expect(sql).to.match(/CONSTRAINT\s*(["[`]?user_and_email["\]`]?)?\s*UNIQUE\s*\(["[`]?username["\]`]?, ["[`]?email["\]`]?\)/);
-            expect(sql).to.match(/CONSTRAINT\s*(["[`]?a_and_b["\]`]?)?\s*UNIQUE\s*\(["[`]?aCol["\]`]?, ["[`]?bCol["\]`]?\)/);
-          } else {
-            expect(sql).to.match(/UNIQUE\s*(["`]?user_and_email["`]?)?\s*\(["`]?username["`]?, ["`]?email["`]?\)/);
-            expect(sql).to.match(/UNIQUE\s*(["`]?a_and_b["`]?)?\s*\(["`]?aCol["`]?, ["`]?bCol["`]?\)/);
-          }
-        })),
-      });
-    });
-
     it('allows unique on column with field aliases', async function () {
       const User = this.sequelize.define('UserWithUniqueFieldAlias', {
         userName: { type: DataTypes.STRING, unique: 'user_name_unique', field: 'user_name' },
@@ -2848,44 +2827,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
   }
-
-  describe('Unique', () => {
-    it('should set unique when unique is true', async function () {
-      const uniqueTrue = this.sequelize.define('uniqueTrue', {
-        str: { type: DataTypes.STRING, unique: true },
-      });
-
-      await uniqueTrue.sync({
-        force: true, logging: _.after(2, _.once(s => {
-          expect(s).to.match(/UNIQUE/);
-        })),
-      });
-    });
-
-    it('should not set unique when unique is false', async function () {
-      const uniqueFalse = this.sequelize.define('uniqueFalse', {
-        str: { type: DataTypes.STRING, unique: false },
-      });
-
-      await uniqueFalse.sync({
-        force: true, logging: _.after(2, _.once(s => {
-          expect(s).not.to.match(/UNIQUE/);
-        })),
-      });
-    });
-
-    it('should not set unique when unique is unset', async function () {
-      const uniqueUnset = this.sequelize.define('uniqueUnset', {
-        str: { type: DataTypes.STRING },
-      });
-
-      await uniqueUnset.sync({
-        force: true, logging: _.after(2, _.once(s => {
-          expect(s).not.to.match(/UNIQUE/);
-        })),
-      });
-    });
-  });
 
   it('should be possible to use a key named UUID as foreign key', async function () {
     this.sequelize.define('project', {

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -1,511 +1,392 @@
 'use strict';
 
-const chai = require('chai');
+const { expect } = require('chai');
 const { DataTypes } = require('@sequelize/core');
+const { sequelize, getTestDialect, getTestDialectTeaser } = require('../support');
 
-const expect = chai.expect;
-const Support = require('../support');
+const dialect = getTestDialect();
 
-const dialect = Support.getTestDialect();
-
-describe(Support.getTestDialectTeaser('Model'), () => {
-  describe('sync', () => {
-    beforeEach(async function () {
-      this.testSync = this.sequelize.define('testSync', {
-        dummy: DataTypes.STRING,
-      });
-      await this.testSync.drop();
+describe(getTestDialectTeaser('Model.sync & Sequelize.sync'), () => {
+  it('removes a column if it exists in the databases schema but not the model', async () => {
+    const User = sequelize.define('testSync', {
+      name: DataTypes.STRING,
+      age: DataTypes.INTEGER,
+      badgeNumber: { type: DataTypes.INTEGER, field: 'badge_number' },
     });
 
-    it('should remove a column if it exists in the databases schema but not the model', async function () {
-      const User = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-        age: DataTypes.INTEGER,
-        badgeNumber: { type: DataTypes.INTEGER, field: 'badge_number' },
-      });
-      await this.sequelize.sync();
-      this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-      });
-      await this.sequelize.sync({ alter: true });
-      const data = await User.describe();
-      expect(data).to.not.have.ownProperty('age');
-      expect(data).to.not.have.ownProperty('badge_number');
-      expect(data).to.not.have.ownProperty('badgeNumber');
-      expect(data).to.have.ownProperty('name');
+    await sequelize.sync();
+
+    const descr1 = await User.describe();
+    expect(descr1).to.have.ownProperty('name');
+    expect(descr1).to.have.ownProperty('age');
+    expect(descr1).to.have.ownProperty('badge_number');
+
+    sequelize.define('testSync', {
+      name: DataTypes.STRING,
     });
 
-    it('should add a column if it exists in the model but not the database', async function () {
-      const testSync = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-      });
-      await this.sequelize.sync();
+    await sequelize.sync({ alter: true });
 
-      await this.sequelize.define('testSync', {
+    const descr2 = await User.describe();
+    expect(descr2).to.have.ownProperty('name');
+    expect(descr2).to.not.have.ownProperty('age');
+    expect(descr2).to.not.have.ownProperty('badge_number');
+  });
+
+  it('adds a column if it exists in the model but not the database', async () => {
+    const testSync = sequelize.define('testSync', {
+      name: DataTypes.STRING,
+    });
+
+    await sequelize.sync();
+
+    const descr1 = await testSync.describe();
+    expect(descr1).to.have.ownProperty('name');
+
+    await sequelize.define('testSync', {
+      name: DataTypes.STRING,
+      age: DataTypes.INTEGER,
+      height: { type: DataTypes.INTEGER, field: 'height_cm' },
+    });
+
+    await sequelize.sync({ alter: true });
+    const descr2 = await testSync.describe();
+    expect(descr2).to.have.ownProperty('name');
+    expect(descr2).to.have.ownProperty('age');
+    expect(descr2).to.have.ownProperty('height_cm');
+    expect(descr2).not.to.have.ownProperty('height');
+  });
+
+  it('does not remove columns if drop is set to false in alter configuration', async () => {
+    const testSync = sequelize.define('testSync', {
+      name: DataTypes.STRING,
+      age: DataTypes.INTEGER,
+    });
+    await sequelize.sync();
+
+    await sequelize.define('testSync', {
+      name: DataTypes.STRING,
+    });
+
+    await sequelize.sync({ alter: { drop: false } });
+    const data = await testSync.describe();
+    expect(data).to.have.ownProperty('name');
+    expect(data).to.have.ownProperty('age');
+  });
+
+  it('removes columns if drop is set to true in alter configuration', async () => {
+    const testSync = sequelize.define('testSync', {
+      name: DataTypes.STRING,
+      age: DataTypes.INTEGER,
+    });
+    await sequelize.sync();
+
+    await sequelize.define('testSync', {
+      name: DataTypes.STRING,
+    });
+
+    await sequelize.sync({ alter: { drop: true } });
+    const data = await testSync.describe();
+    expect(data).to.have.ownProperty('name');
+    expect(data).not.to.have.ownProperty('age');
+  });
+
+  it('alters a column using the correct column name (#9515)', async () => {
+    const testSync = sequelize.define('testSync', {
+      name: DataTypes.STRING,
+    });
+
+    await sequelize.sync();
+
+    await sequelize.define('testSync', {
+      name: DataTypes.STRING,
+      badgeNumber: { type: DataTypes.INTEGER, field: 'badge_number' },
+    });
+
+    await sequelize.sync({ alter: true });
+    const data = await testSync.describe();
+    expect(data).to.have.ownProperty('badge_number');
+    expect(data).not.to.have.ownProperty('badgeNumber');
+  });
+
+  // IBM i can't alter INTEGER -> STRING
+  if (dialect !== 'ibmi') {
+    it('changes a column if it exists in the model but is different in the database', async () => {
+      const testSync = sequelize.define('testSync', {
         name: DataTypes.STRING,
         age: DataTypes.INTEGER,
-        height: { type: DataTypes.INTEGER, field: 'height_cm' },
+      });
+      await sequelize.sync();
+
+      await sequelize.define('testSync', {
+        name: DataTypes.STRING,
+        age: DataTypes.STRING,
       });
 
-      await this.sequelize.sync({ alter: true });
+      await sequelize.sync({ alter: true });
       const data = await testSync.describe();
       expect(data).to.have.ownProperty('age');
-      expect(data).to.have.ownProperty('height_cm');
-      expect(data).not.to.have.ownProperty('height');
+      expect(data.age.type).to.have.string('VAR'); // CHARACTER VARYING, VARCHAR(n)
+    });
+  }
+
+  it('does not alter table if data type does not change', async () => {
+    const testSync = sequelize.define('testSync', {
+      name: DataTypes.STRING,
+      age: DataTypes.STRING,
+    });
+    await sequelize.sync();
+    await testSync.create({ name: 'test', age: '1' });
+    await sequelize.sync({ alter: true });
+    const data = await testSync.findOne();
+    expect(data.dataValues.name).to.eql('test');
+    expect(data.dataValues.age).to.eql('1');
+  });
+
+  it('should properly alter tables when there are foreign keys', async () => {
+    const foreignKeyTestSyncA = sequelize.define('foreignKeyTestSyncA', {
+      dummy: DataTypes.STRING,
     });
 
-    it('should not remove columns if drop is set to false in alter configuration', async function () {
-      const testSync = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-        age: DataTypes.INTEGER,
-      });
-      await this.sequelize.sync();
-
-      await this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-      });
-
-      await this.sequelize.sync({ alter: { drop: false } });
-      const data = await testSync.describe();
-      expect(data).to.have.ownProperty('name');
-      expect(data).to.have.ownProperty('age');
+    const foreignKeyTestSyncB = sequelize.define('foreignKeyTestSyncB', {
+      dummy: DataTypes.STRING,
     });
 
-    it('should remove columns if drop is set to true in alter configuration', async function () {
-      const testSync = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-        age: DataTypes.INTEGER,
-      });
-      await this.sequelize.sync();
+    foreignKeyTestSyncA.hasMany(foreignKeyTestSyncB);
+    foreignKeyTestSyncB.belongsTo(foreignKeyTestSyncA);
 
-      await this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-      });
+    await sequelize.sync({ alter: true });
+    await sequelize.sync({ alter: true });
+  });
 
-      await this.sequelize.sync({ alter: { drop: true } });
-      const data = await testSync.describe();
-      expect(data).to.have.ownProperty('name');
-      expect(data).not.to.have.ownProperty('age');
+  it('creates one unique index for unique:true column', async () => {
+    const User = sequelize.define('testSync', {
+      email: {
+        type: DataTypes.STRING,
+        unique: true,
+      },
     });
 
-    it('should alter a column using the correct column name (#9515)', async function () {
-      const testSync = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-      });
-      await this.sequelize.sync();
+    await User.sync({ force: true });
 
-      await this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-        badgeNumber: { type: DataTypes.INTEGER, field: 'badge_number' },
-      });
+    const syncResults = await getNonPrimaryIndexes(User);
+    expect(syncResults).to.have.length(1);
 
-      await this.sequelize.sync({ alter: true });
-      const data = await testSync.describe();
-      expect(data).to.have.ownProperty('badge_number');
-      expect(data).not.to.have.ownProperty('badgeNumber');
+    await User.sync({ alter: true });
+
+    const alterResults = await getNonPrimaryIndexes(User);
+    expect(syncResults).to.deep.eq(alterResults, '"alter" should not create new indexes if they already exist.');
+  });
+
+  it('creates one unique index per unique:true columns, and per entry in options.indexes', async () => {
+    const User = sequelize.define('testSync', {
+      email: {
+        type: DataTypes.STRING,
+        unique: true,
+      },
+      phone: {
+        type: DataTypes.STRING,
+        unique: true,
+      },
+    }, {
+      timestamps: false,
+      indexes: [
+        { name: 'wow_my_index', fields: ['email', 'phone'], unique: true },
+      ],
     });
 
-    // IBM i can't alter INTEGER -> STRING
-    if (dialect !== 'ibmi') {
-      it('should change a column if it exists in the model but is different in the database', async function () {
-        const testSync = this.sequelize.define('testSync', {
-          name: DataTypes.STRING,
-          age: DataTypes.INTEGER,
-        });
-        await this.sequelize.sync();
+    await User.sync({ force: true });
 
-        await this.sequelize.define('testSync', {
-          name: DataTypes.STRING,
-          age: DataTypes.STRING,
-        });
+    const syncResults = await getNonPrimaryIndexes(User);
 
-        await this.sequelize.sync({ alter: true });
-        const data = await testSync.describe();
-        expect(data).to.have.ownProperty('age');
-        expect(data.age.type).to.have.string('VAR'); // CHARACTER VARYING, VARCHAR(n)
-      });
-    }
+    syncResults.sort((a, b) => a.name.localeCompare(b.name));
 
-    it('should not alter table if data type does not change', async function () {
-      const testSync = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-        age: DataTypes.STRING,
-      });
-      await this.sequelize.sync();
-      await testSync.create({ name: 'test', age: '1' });
-      await this.sequelize.sync({ alter: true });
-      const data = await testSync.findOne();
-      expect(data.dataValues.name).to.eql('test');
-      expect(data.dataValues.age).to.eql('1');
+    expect(syncResults).to.have.length(3);
+    expect(syncResults[0].name).to.eq('test_syncs_email_unique');
+    expect(syncResults[0].fields.map(f => f.attribute)).to.deep.eq(['email']);
+
+    expect(syncResults[1].name).to.eq('test_syncs_phone_unique');
+    expect(syncResults[1].fields.map(f => f.attribute)).to.deep.eq(['phone']);
+
+    expect(syncResults[2].name).to.eq('wow_my_index');
+    expect(syncResults[2].fields.map(f => f.attribute).sort()).to.deep.eq(['email', 'phone']);
+
+    expect(syncResults.filter(r => r.name === 'wow_my_index')).to.have.length(1);
+
+    await User.sync({ alter: true });
+
+    const alterResults = await getNonPrimaryIndexes(User);
+    expect(syncResults).to.deep.eq(alterResults, '"alter" should not create new indexes if they already exist.');
+  });
+
+  it('creates one unique index per unique:name column (1 column)', async () => {
+    const User = sequelize.define('testSync', {
+      email: {
+        type: DataTypes.STRING,
+        unique: 'wow_my_index',
+      },
     });
 
-    it('should properly create composite index without affecting individual fields', async function () {
-      const testSync = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-        age: DataTypes.STRING,
-      }, { indexes: [{ unique: true, fields: ['name', 'age'] }] });
-      await this.sequelize.sync();
-      await testSync.create({ name: 'test' });
-      await testSync.create({ name: 'test2' });
-      await testSync.create({ name: 'test3' });
-      await testSync.create({ age: '1' });
-      await testSync.create({ age: '2' });
-      await testSync.create({ name: 'test', age: '1' });
-      await testSync.create({ name: 'test', age: '2' });
-      await testSync.create({ name: 'test2', age: '2' });
-      await testSync.create({ name: 'test3', age: '2' });
-      const data = await testSync.create({ name: 'test3', age: '1' });
-      expect(data.dataValues.name).to.eql('test3');
-      expect(data.dataValues.age).to.eql('1');
+    await User.sync({ force: true });
+
+    const syncResults = await getNonPrimaryIndexes(User);
+
+    expect(syncResults).to.have.length(1);
+    expect(syncResults[0].name).to.eq('wow_my_index');
+    expect(syncResults[0].fields.map(field => field.attribute).sort()).to.deep.eq(['email']);
+
+    await User.sync({ alter: true });
+
+    const alterResults = await getNonPrimaryIndexes(User);
+    expect(syncResults).to.deep.eq(alterResults, '"alter" should not create new indexes if they already exist.');
+  });
+
+  it('creates one unique index per unique:name column (multiple columns)', async () => {
+    const User = sequelize.define('testSync', {
+      email: {
+        type: DataTypes.STRING,
+        unique: 'wow_my_index',
+      },
+      phone: {
+        type: DataTypes.STRING,
+        unique: 'wow_my_index',
+      },
     });
 
-    it('should properly create composite index that fails on constraint violation', async function () {
-      const testSync = this.sequelize.define('testSync', {
-        name: DataTypes.STRING,
-        age: DataTypes.STRING,
-      }, { indexes: [{ unique: true, fields: ['name', 'age'] }] });
+    await User.sync({ force: true });
 
-      try {
-        await this.sequelize.sync();
-        await testSync.create({ name: 'test', age: '1' });
-        const data = await testSync.create({ name: 'test', age: '1' });
-        await expect(data).not.to.be.ok;
-      } catch (error) {
-        await expect(error).to.be.ok;
-      }
+    const syncResults = await getNonPrimaryIndexes(User);
+
+    expect(syncResults).to.have.length(1);
+    expect(syncResults[0].name).to.eq('wow_my_index');
+    expect(syncResults[0].fields.map(field => field.attribute).sort()).to.deep.eq(['email', 'phone']);
+
+    await User.sync({ alter: true });
+
+    const alterResults = await getNonPrimaryIndexes(User);
+    expect(syncResults).to.deep.eq(alterResults, '"alter" should not create new indexes if they already exist.');
+  });
+
+  it('throws if a name collision occurs between two indexes', async () => {
+    expect(() => {
+      sequelize.define('testSync', {
+        email: {
+          type: DataTypes.STRING,
+          unique: true,
+        },
+      }, {
+        timestamps: false,
+        indexes: [
+          { fields: ['email'], unique: true },
+        ],
+      });
+    }).to.throw('Sequelize tried to give the name "test_syncs_email_unique" to index');
+  });
+
+  it('adds missing unique indexes to existing tables (unique attribute option)', async () => {
+    const User1 = sequelize.define('User', {
+      email: {
+        type: DataTypes.STRING,
+      },
+    }, { timestamps: false });
+
+    // create without the unique index
+    await User1.sync({ force: true });
+
+    // replace model (to emulate code changes)
+    const User2 = sequelize.define('User', {
+      email: {
+        type: DataTypes.STRING,
+        unique: true,
+      },
+    }, { timestamps: false });
+
+    const out1 = await getNonPrimaryIndexes(User1);
+    expect(out1).to.have.length(0);
+
+    // alter to add the unique index
+    await User2.sync({ alter: true });
+
+    const out2 = await getNonPrimaryIndexes(User1);
+    expect(out2).to.have.length(1);
+
+    const uniques = out2.filter(index => index.primary !== true);
+    expect(uniques).to.have.length(1);
+    expect(uniques[0].unique).to.eq(true, 'index should be unique');
+  });
+
+  it('should be able to add a unique index to an existing table (index option)', async () => {
+    const User1 = sequelize.define('User', {
+      email: {
+        type: DataTypes.STRING,
+      },
+    }, { timestamps: false });
+
+    // create without the unique index
+    await User1.sync({ force: true });
+
+    // replace model (to emulate code changes)
+    const User2 = sequelize.define('User', {
+      email: {
+        type: DataTypes.STRING,
+      },
+    }, {
+      timestamps: false,
+      indexes: [
+        { fields: ['email'], unique: true },
+      ],
     });
 
-    it('should properly alter tables when there are foreign keys', async function () {
-      const foreignKeyTestSyncA = this.sequelize.define('foreignKeyTestSyncA', {
-        dummy: DataTypes.STRING,
-      });
+    const out1 = await getNonPrimaryIndexes(User1);
+    expect(out1).to.have.length(0);
 
-      const foreignKeyTestSyncB = this.sequelize.define('foreignKeyTestSyncB', {
-        dummy: DataTypes.STRING,
-      });
+    // alter to add the unique index
+    await User2.sync({ alter: true });
 
-      foreignKeyTestSyncA.hasMany(foreignKeyTestSyncB);
-      foreignKeyTestSyncB.belongsTo(foreignKeyTestSyncA);
+    const out2 = await getNonPrimaryIndexes(User1);
+    expect(out2).to.have.length(1);
+    const uniques = out2.filter(index => index.primary !== true);
+    expect(uniques).to.have.length(1);
+    expect(uniques[0].unique).to.be.true;
+  });
 
-      await this.sequelize.sync({ alter: true });
-      await this.sequelize.sync({ alter: true });
+  it('should be able to add a non-unique index to an existing table', async () => {
+    const User1 = sequelize.define('User', {
+      email: {
+        type: DataTypes.STRING,
+      },
+    }, { timestamps: false });
+
+    // create without the unique index
+    await User1.sync({ force: true });
+
+    // replace model (to emulate code changes)
+    const User2 = sequelize.define('User', {
+      email: {
+        type: DataTypes.STRING,
+      },
+    }, {
+      timestamps: false,
+      indexes: [
+        { fields: ['email'] },
+      ],
     });
 
-    describe('indexes', () => {
-      describe('with alter:true', () => {
-        it('should not duplicate named indexes after multiple sync calls', async function () {
-          const User = this.sequelize.define('testSync', {
-            email: {
-              type: DataTypes.STRING,
-            },
-            phone: {
-              type: DataTypes.STRING,
-            },
-            mobile: {
-              type: DataTypes.STRING,
-            },
-          }, {
-            indexes: [
-              { name: 'another_index_email_mobile', fields: ['email', 'mobile'] },
-              { name: 'another_index_phone_mobile', fields: ['phone', 'mobile'], unique: true },
-              { name: 'another_index_email', fields: ['email'] },
-              { name: 'another_index_mobile', fields: ['mobile'] },
-            ],
-          });
+    const out1 = await getNonPrimaryIndexes(User1);
+    expect(out1).to.have.length(0);
 
-          await User.sync();
-          await User.sync({ alter: true });
-          await User.sync({ alter: true });
-          await User.sync({ alter: true });
-          const results = await this.sequelize.getQueryInterface().showIndex(User.getTableName());
-          if (dialect === 'sqlite') {
-            // SQLite doesn't treat primary key as index
-            // However it does create an extra "autoindex", except primary == false
-            expect(results).to.have.length(4 + 1);
-          } else {
-            expect(results).to.have.length(4 + 1);
-            expect(results.filter(r => r.primary)).to.have.length(1);
-          }
+    // alter to add the unique index
+    await User2.sync({ alter: true });
 
-          if (dialect === 'sqlite') {
-            expect(results.filter(r => r.name === 'sqlite_autoindex_testSyncs_1')).to.have.length(1);
-          }
-
-          expect(results.filter(r => r.name === 'another_index_email_mobile')).to.have.length(1);
-          expect(results.filter(r => r.name === 'another_index_phone_mobile')).to.have.length(1);
-          expect(results.filter(r => r.name === 'another_index_email')).to.have.length(1);
-          expect(results.filter(r => r.name === 'another_index_mobile')).to.have.length(1);
-        });
-
-        it('should not duplicate unnamed indexes after multiple sync calls', async function () {
-          const User = this.sequelize.define('testSync', {
-            email: {
-              type: DataTypes.STRING,
-            },
-            phone: {
-              type: DataTypes.STRING,
-            },
-            mobile: {
-              type: DataTypes.STRING,
-            },
-          }, {
-            indexes: [
-              { fields: ['email', 'mobile'] },
-              { fields: ['phone', 'mobile'], unique: true },
-              { fields: ['email'] },
-              { fields: ['mobile'] },
-            ],
-          });
-
-          const initialEmailUnique = User.rawAttributes.email.unique;
-          expect(initialEmailUnique).not.to.be.ok;
-
-          await User.sync();
-
-          // db2 had a broken implementation which marked all attributes that were part of an index as 'unique'
-          //  during the call to QueryInterface#createTable
-          // This was a terrible idea with unpredictable side effects, this test is there to ensure it's not added back.
-          // https://github.com/sequelize/sequelize/pull/14572#issuecomment-1152578770
-          expect(User.rawAttributes.email.unique).to.eq(initialEmailUnique, 'User.sync should not modify attributes!');
-
-          await User.sync({ alter: true });
-          await User.sync({ alter: true });
-          await User.sync({ alter: true });
-
-          expect(User.rawAttributes.email.unique).to.eq(initialEmailUnique);
-
-          const results = await this.sequelize.getQueryInterface().showIndex(User.getTableName());
-          if (dialect === 'sqlite') {
-            // SQLite doesn't treat primary key as index
-            // However it does create an extra "autoindex", except primary == false
-            expect(results).to.have.length(4 + 1);
-          } else {
-            expect(results).to.have.length(4 + 1);
-            expect(results.filter(r => r.primary)).to.have.length(1);
-          }
-        });
-
-        it('should be able to add a unique index to an existing table (unique attribute option)', async function () {
-          const User1 = this.sequelize.define('User', {
-            email: {
-              type: DataTypes.STRING,
-            },
-          }, { timestamps: false });
-
-          // create without the unique index
-          await User1.sync({ force: true });
-
-          // replace model (to emulate code changes)
-          const User2 = this.sequelize.define('User', {
-            email: {
-              type: DataTypes.STRING,
-              unique: true,
-            },
-          }, { timestamps: false });
-
-          const out1 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
-            .filter(r => !r.primary);
-          expect(out1).to.have.length(0);
-
-          // alter to add the unique index
-          await User2.sync({ alter: true });
-
-          const out2 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
-            .filter(r => !r.primary);
-          expect(out2).to.have.length(1);
-
-          const uniques = out2.filter(index => index.primary !== true);
-          expect(uniques).to.have.length(1);
-          expect(uniques[0].unique).to.eq(true, 'index should be unique');
-        });
-
-        it('should be able to add a unique index to an existing table (index option)', async function () {
-          const User1 = this.sequelize.define('User', {
-            email: {
-              type: DataTypes.STRING,
-            },
-          }, { timestamps: false });
-
-          // create without the unique index
-          await User1.sync({ force: true });
-
-          // replace model (to emulate code changes)
-          const User2 = this.sequelize.define('User', {
-            email: {
-              type: DataTypes.STRING,
-            },
-          }, {
-            timestamps: false,
-            indexes: [
-              { fields: ['email'], unique: true },
-            ],
-          });
-
-          const out1 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
-            .filter(r => !r.primary);
-          expect(out1).to.have.length(0);
-
-          // alter to add the unique index
-          await User2.sync({ alter: true });
-
-          const out2 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
-            .filter(r => !r.primary);
-          expect(out2).to.have.length(1);
-          const uniques = out2.filter(index => index.primary !== true);
-          expect(uniques).to.have.length(1);
-          expect(uniques[0].unique).to.be.true;
-        });
-
-        it('should be able to add a non-unique index to an existing table', async function () {
-          const User1 = this.sequelize.define('User', {
-            email: {
-              type: DataTypes.STRING,
-            },
-          }, { timestamps: false });
-
-          // create without the unique index
-          await User1.sync({ force: true });
-
-          // replace model (to emulate code changes)
-          const User2 = this.sequelize.define('User', {
-            email: {
-              type: DataTypes.STRING,
-            },
-          }, {
-            timestamps: false,
-            indexes: [
-              { fields: ['email'] },
-            ],
-          });
-
-          const out1 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
-            .filter(r => !r.primary);
-          expect(out1).to.have.length(0);
-
-          // alter to add the unique index
-          await User2.sync({ alter: true });
-
-          const out2 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
-            .filter(r => !r.primary);
-          expect(out2).to.have.length(1);
-          const nonUniques = out2.filter(index => index.primary !== true);
-          expect(nonUniques).to.have.length(1);
-          expect(nonUniques[0].unique).to.be.false;
-        });
-      });
-
-      it('creates one unique index for unique:true column', async function () {
-        const User = this.sequelize.define('testSync', {
-          email: {
-            type: DataTypes.STRING,
-            unique: true,
-          },
-        });
-
-        await User.sync({ force: true });
-        await User.sync({ alter: true });
-
-        const results = (await this.sequelize.getQueryInterface().showIndex(User.getTableName()))
-          .filter(r => !r.primary);
-
-        expect(results).to.have.length(1);
-      });
-
-      it('throws if a name collision occurs between two indexes', async function () {
-        expect(() => {
-          this.sequelize.define('testSync', {
-            email: {
-              type: DataTypes.STRING,
-              unique: true,
-            },
-          }, {
-            timestamps: false,
-            indexes: [
-              { fields: ['email'], unique: true },
-            ],
-          });
-        }).to.throw('Sequelize tried to give the name "test_syncs_email_unique" to index');
-      });
-
-      it('creates one unique index per unique:true columns, and per entry in options.indexes', async function () {
-        const User = this.sequelize.define('testSync', {
-          email: {
-            type: DataTypes.STRING,
-            unique: true,
-          },
-          phone: {
-            type: DataTypes.STRING,
-            unique: true,
-          },
-        }, {
-          timestamps: false,
-          indexes: [
-            { name: 'wow_my_index', fields: ['email', 'phone'], unique: true },
-          ],
-        });
-
-        await User.sync({ force: true });
-        await User.sync({ alter: true });
-
-        const results = (await this.sequelize.getQueryInterface().showIndex(User.getTableName()))
-          .filter(r => !r.primary);
-
-        results.sort((a, b) => a.name.localeCompare(b.name));
-
-        expect(results).to.have.length(3);
-        expect(results[0].name).to.eq('test_syncs_email_unique');
-        expect(results[0].fields.map(f => f.attribute)).to.deep.eq(['email']);
-
-        expect(results[1].name).to.eq('test_syncs_phone_unique');
-        expect(results[1].fields.map(f => f.attribute)).to.deep.eq(['phone']);
-
-        expect(results[2].name).to.eq('wow_my_index');
-        expect(results[2].fields.map(f => f.attribute).sort()).to.deep.eq(['email', 'phone']);
-
-        expect(results.filter(r => r.name === 'wow_my_index')).to.have.length(1);
-      });
-
-      it('should create only one unique index for unique:name column', async function () {
-        const User = this.sequelize.define('testSync', {
-          email: {
-            type: DataTypes.STRING,
-            unique: 'wow_my_index',
-          },
-        });
-
-        await User.sync({ force: true });
-        await User.sync({ alter: true });
-
-        const results = (await this.sequelize.getQueryInterface().showIndex(User.getTableName()))
-          .filter(r => !r.primary);
-
-        expect(results).to.have.length(1);
-        expect(results[0].name).to.eq('wow_my_index');
-        expect(results[0].fields.map(field => field.attribute).sort()).to.deep.eq(['email']);
-      });
-
-      it('should create only one unique index for unique:name columns', async function () {
-        const User = this.sequelize.define('testSync', {
-          email: {
-            type: DataTypes.STRING,
-            unique: 'wow_my_index',
-          },
-          phone: {
-            type: DataTypes.STRING,
-            unique: 'wow_my_index',
-          },
-        });
-
-        await User.sync({ force: true });
-        await User.sync({ alter: true });
-
-        const results = (await this.sequelize.getQueryInterface().showIndex(User.getTableName()))
-          .filter(r => !r.primary);
-
-        expect(results).to.have.length(1);
-        expect(results[0].name).to.eq('wow_my_index');
-        expect(results[0].fields.map(field => field.attribute).sort()).to.deep.eq(['email', 'phone']);
-      });
-    });
+    const out2 = await getNonPrimaryIndexes(User1);
+    expect(out2).to.have.length(1);
+    const nonUniques = out2.filter(index => index.primary !== true);
+    expect(nonUniques).to.have.length(1);
+    expect(nonUniques[0].unique).to.be.false;
   });
 });
+
+async function getNonPrimaryIndexes(model) {
+  return (await sequelize.getQueryInterface().showIndex(model.getTableName()))
+    .filter(r => !r.primary);
+}

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -418,7 +418,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               { fields: ['email'], unique: true },
             ],
           });
-        }).to.throw('Sequelize tried to give the name "testSyncs:email:unique" to index');
+        }).to.throw('Sequelize tried to give the name "test_syncs_email_unique" to index');
       });
 
       it('creates one unique index per unique:true columns, and per entry in options.indexes', async function () {
@@ -447,10 +447,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         results.sort((a, b) => a.name.localeCompare(b.name));
 
         expect(results).to.have.length(3);
-        expect(results[0].name).to.eq('testSyncs:email:unique');
+        expect(results[0].name).to.eq('test_syncs_email_unique');
         expect(results[0].fields.map(f => f.attribute)).to.deep.eq(['email']);
 
-        expect(results[1].name).to.eq('testSyncs:phone:unique');
+        expect(results[1].name).to.eq('test_syncs_phone_unique');
         expect(results[1].fields.map(f => f.attribute)).to.deep.eq(['phone']);
 
         expect(results[2].name).to.eq('wow_my_index');

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -303,14 +303,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             },
           }, { timestamps: false });
 
-          const out1 = await this.sequelize.getQueryInterface().showIndex(User1.getTableName());
-          expect(out1).to.have.length(1);
+          const out1 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
+            .filter(r => !r.primary);
+          expect(out1).to.have.length(0);
 
           // alter to add the unique index
           await User2.sync({ alter: true });
 
-          const out2 = await this.sequelize.getQueryInterface().showIndex(User1.getTableName());
-          expect(out2).to.have.length(2);
+          const out2 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
+            .filter(r => !r.primary);
+          expect(out2).to.have.length(1);
 
           const uniques = out2.filter(index => index.primary !== true);
           expect(uniques).to.have.length(1);
@@ -339,14 +341,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ],
           });
 
-          const out1 = await this.sequelize.getQueryInterface().showIndex(User1.getTableName());
-          expect(out1).to.have.length(1);
+          const out1 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
+            .filter(r => !r.primary);
+          expect(out1).to.have.length(0);
 
           // alter to add the unique index
           await User2.sync({ alter: true });
 
-          const out2 = await this.sequelize.getQueryInterface().showIndex(User1.getTableName());
-          expect(out2).to.have.length(2);
+          const out2 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
+            .filter(r => !r.primary);
+          expect(out2).to.have.length(1);
           const uniques = out2.filter(index => index.primary !== true);
           expect(uniques).to.have.length(1);
           expect(uniques[0].unique).to.be.true;
@@ -374,14 +378,16 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ],
           });
 
-          const out1 = await this.sequelize.getQueryInterface().showIndex(User1.getTableName());
-          expect(out1).to.have.length(1);
+          const out1 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
+            .filter(r => !r.primary);
+          expect(out1).to.have.length(0);
 
           // alter to add the unique index
           await User2.sync({ alter: true });
 
-          const out2 = await this.sequelize.getQueryInterface().showIndex(User1.getTableName());
-          expect(out2).to.have.length(2);
+          const out2 = (await this.sequelize.getQueryInterface().showIndex(User1.getTableName()))
+            .filter(r => !r.primary);
+          expect(out2).to.have.length(1);
           const nonUniques = out2.filter(index => index.primary !== true);
           expect(nonUniques).to.have.length(1);
           expect(nonUniques[0].unique).to.be.false;

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -388,5 +388,6 @@ describe(getTestDialectTeaser('Model.sync & Sequelize.sync'), () => {
 
 async function getNonPrimaryIndexes(model) {
   return (await sequelize.getQueryInterface().showIndex(model.getTableName()))
-    .filter(r => !r.primary);
+    .filter(r => !r.primary)
+    .sort((a, b) => a.name.localeCompare(b.name));
 }

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -139,8 +139,8 @@ describe(getTestDialectTeaser('Model.sync & Sequelize.sync'), () => {
     await testSync.create({ name: 'test', age: '1' });
     await sequelize.sync({ alter: true });
     const data = await testSync.findOne();
-    expect(data.dataValues.name).to.eql('test');
-    expect(data.dataValues.age).to.eql('1');
+    expect(data.name).to.eql('test');
+    expect(data.age).to.eql('1');
   });
 
   it('should properly alter tables when there are foreign keys', async () => {
@@ -410,7 +410,7 @@ describe(getTestDialectTeaser('Model.sync & Sequelize.sync'), () => {
     });
 
     // alter to add the unique index
-    await User2.sync({ alter: true, logging: true });
+    await User2.sync({ alter: true });
 
     // db2 had a bug which re-created the table in some circumstances.
     // this ensures the table is not recreated, but altered.

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -175,7 +175,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       await this.queryInterface.addIndex('Group', ['username', 'isAdmin']);
       let indexes = await this.queryInterface.showIndex('Group');
       let indexColumns = _.uniq(indexes.map(index => index.name));
-      expect(indexColumns).to.include('Group:username+isAdmin');
+      expect(indexColumns).to.include('group_username_is_admin');
       await this.queryInterface.removeIndex('Group', ['username', 'isAdmin']);
       indexes = await this.queryInterface.showIndex('Group');
       indexColumns = _.uniq(indexes.map(index => index.name));
@@ -205,7 +205,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         tableName: 'table',
       });
       expect(indexes.length).to.eq(1);
-      expect(indexes[0].name).to.eq('table:name+isAdmin');
+      expect(indexes[0].name).to.eq('table_name_is_admin');
     });
 
     it('does not fail on reserved keywords', async function () {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -175,7 +175,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       await this.queryInterface.addIndex('Group', ['username', 'isAdmin']);
       let indexes = await this.queryInterface.showIndex('Group');
       let indexColumns = _.uniq(indexes.map(index => index.name));
-      expect(indexColumns).to.include('group_username_is_admin');
+      expect(indexColumns).to.include('Group:username+isAdmin');
       await this.queryInterface.removeIndex('Group', ['username', 'isAdmin']);
       indexes = await this.queryInterface.showIndex('Group');
       indexColumns = _.uniq(indexes.map(index => index.name));
@@ -205,7 +205,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         tableName: 'table',
       });
       expect(indexes.length).to.eq(1);
-      expect(indexes[0].name).to.eq('table_name_is_admin');
+      expect(indexes[0].name).to.eq('table:name+isAdmin');
     });
 
     it('does not fail on reserved keywords', async function () {

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -61,47 +61,22 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         },
       });
 
-      const indexes = await this.queryInterface.showIndex('MyTable');
-      switch (dialect) {
-        case 'postgres':
-        case 'postgres-native':
-        case 'sqlite':
-        case 'mssql':
+      const indexes = (await this.queryInterface.showIndex('MyTable'))
+        .filter(index => !index.primary)
+        .sort((a, b) => a.name.localeCompare(b.name));
 
-          // name + email
-          expect(indexes[0].unique).to.be.true;
-          expect(indexes[0].fields[0].attribute).to.equal('name');
-          expect(indexes[0].fields[1].attribute).to.equal('email');
-
-          // name
-          expect(indexes[1].unique).to.be.true;
-          expect(indexes[1].fields[0].attribute).to.equal('name');
-          break;
-        case 'mariadb':
-        case 'mysql':
-        case 'db2':
-          // name + email
-          expect(indexes[1].unique).to.be.true;
-          expect(indexes[1].fields[0].attribute).to.equal('name');
-          expect(indexes[1].fields[1].attribute).to.equal('email');
-
-          // name
-          expect(indexes[2].unique).to.be.true;
-          expect(indexes[2].fields[0].attribute).to.equal('name');
-          break;
-        case 'ibmi':
-          // name + email
-          expect(indexes[1].unique).to.be.true;
-          expect(indexes[1].fields[0].attribute).to.equal('email');
-          expect(indexes[1].fields[1].attribute).to.equal('name');
-
-          // name
-          expect(indexes[2].unique).to.be.true;
-          expect(indexes[2].fields[0].attribute).to.equal('name');
-          break;
-        default:
-          throw new Error(`Not implemented fpr ${dialect}`);
+      for (const index of indexes) {
+        index.fields.sort((a, b) => a.attribute.localeCompare(b.attribute));
       }
+
+      // name + email
+      expect(indexes[0].unique).to.be.true;
+      expect(indexes[0].fields[0].attribute).to.equal('email');
+      expect(indexes[0].fields[1].attribute).to.equal('name');
+
+      // name
+      expect(indexes[1].unique).to.be.true;
+      expect(indexes[1].fields[0].attribute).to.equal('name');
     });
 
     it('should work with schemas', async function () {

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -37,47 +37,53 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       }
     });
 
-    it('should create unique constraint with uniqueKeys', async function () {
-      await this.queryInterface.createTable('MyTable', {
-        id: {
-          type: DataTypes.INTEGER,
-          primaryKey: true,
-          autoIncrement: true,
-        },
-        name: {
-          type: DataTypes.STRING,
-        },
-        email: {
-          type: DataTypes.STRING,
-        },
-      }, {
-        uniqueKeys: {
-          myCustomIndex: {
-            fields: ['name', 'email'],
+    // SQLITE does not respect the index name when the index is created through CREATE TABLE
+    // As such, Sequelize's createTable does not add the constraint in the Sequelize Dialect.
+    // Instead, `sequelize.sync` calls CREATE INDEX after the table has been created,
+    // as that query *does* respect the index name.
+    if (dialect !== 'sqlite') {
+      it('should create unique constraint with uniqueKeys', async function () {
+        await this.queryInterface.createTable('MyTable', {
+          id: {
+            type: DataTypes.INTEGER,
+            primaryKey: true,
+            autoIncrement: true,
           },
-          myOtherIndex: {
-            fields: ['name'],
+          name: {
+            type: DataTypes.STRING,
           },
-        },
+          email: {
+            type: DataTypes.STRING,
+          },
+        }, {
+          uniqueKeys: {
+            myCustomIndex: {
+              fields: ['name', 'email'],
+            },
+            myOtherIndex: {
+              fields: ['name'],
+            },
+          },
+        });
+
+        const indexes = (await this.queryInterface.showIndex('MyTable'))
+          .filter(index => !index.primary)
+          .sort((a, b) => a.name.localeCompare(b.name));
+
+        for (const index of indexes) {
+          index.fields.sort((a, b) => a.attribute.localeCompare(b.attribute));
+        }
+
+        // name + email
+        expect(indexes[0].unique).to.be.true;
+        expect(indexes[0].fields[0].attribute).to.equal('email');
+        expect(indexes[0].fields[1].attribute).to.equal('name');
+
+        // name
+        expect(indexes[1].unique).to.be.true;
+        expect(indexes[1].fields[0].attribute).to.equal('name');
       });
-
-      const indexes = (await this.queryInterface.showIndex('MyTable'))
-        .filter(index => !index.primary)
-        .sort((a, b) => a.name.localeCompare(b.name));
-
-      for (const index of indexes) {
-        index.fields.sort((a, b) => a.attribute.localeCompare(b.attribute));
-      }
-
-      // name + email
-      expect(indexes[0].unique).to.be.true;
-      expect(indexes[0].fields[0].attribute).to.equal('email');
-      expect(indexes[0].fields[1].attribute).to.equal('name');
-
-      // name
-      expect(indexes[1].unique).to.be.true;
-      expect(indexes[1].fields[0].attribute).to.equal('name');
-    });
+    }
 
     it('should work with schemas', async function () {
       await this.sequelize.createSchema('hero');

--- a/test/integration/query-interface/removeColumn.test.js
+++ b/test/integration/query-interface/removeColumn.test.js
@@ -43,6 +43,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           },
           email: {
             type: DataTypes.STRING,
+            allowNull: false,
             unique: true,
           },
         });
@@ -111,6 +112,7 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
           email: {
             type: DataTypes.STRING,
             unique: true,
+            allowNull: false,
           },
         });
       });

--- a/test/unit/associations/belongs-to-many.test.ts
+++ b/test/unit/associations/belongs-to-many.test.ts
@@ -968,8 +968,8 @@ describe(getTestDialectTeaser('belongsToMany'), () => {
       expect(Through === MyGroups.through.model);
 
       expect(Object.keys(Through.rawAttributes).sort()).to.deep.equal(['id', 'createdAt', 'updatedAt', 'id_user_very_long_field', 'id_group_very_long_field'].sort());
-      expect(Through.rawAttributes.id_user_very_long_field.unique).to.equal('table_user_group_with_very_long_name_id_group_very_long_field_id_user_very_long_field_unique');
-      expect(Through.rawAttributes.id_group_very_long_field.unique).to.equal('table_user_group_with_very_long_name_id_group_very_long_field_id_user_very_long_field_unique');
+      expect(Through.rawAttributes.id_user_very_long_field.unique).to.deep.equal({ name: 'table_user_group_with_very_long_name_id_group_very_long_field_id_user_very_long_field_unique' });
+      expect(Through.rawAttributes.id_group_very_long_field.unique).to.deep.equal({ name: 'table_user_group_with_very_long_name_id_group_very_long_field_id_user_very_long_field_unique' });
     });
 
     it('generates unique identifier with custom name', () => {
@@ -1010,8 +1010,8 @@ describe(getTestDialectTeaser('belongsToMany'), () => {
 
       expect(MyUsers.through.model === UserGroup);
       expect(MyGroups.through.model === UserGroup);
-      expect(UserGroup.rawAttributes.id_user_very_long_field.unique).to.equal('custom_user_group_unique');
-      expect(UserGroup.rawAttributes.id_group_very_long_field.unique).to.equal('custom_user_group_unique');
+      expect(UserGroup.rawAttributes.id_user_very_long_field.unique).to.deep.equal({ name: 'custom_user_group_unique' });
+      expect(UserGroup.rawAttributes.id_group_very_long_field.unique).to.deep.equal({ name: 'custom_user_group_unique' });
     });
   });
 

--- a/test/unit/dialects/db2/query-generator.test.js
+++ b/test/unit/dialects/db2/query-generator.test.js
@@ -76,7 +76,7 @@ if (dialect === 'db2') {
         },
         {
           arguments: [{ id: { type: 'INTEGER', unique: true } }],
-          expectation: { id: 'INTEGER NOT NULL UNIQUE' },
+          expectation: { id: 'INTEGER UNIQUE' },
         },
         {
           arguments: [{ id: { type: 'INTEGER', after: 'Bar' } }],

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -153,7 +153,11 @@ if (dialect === 'sqlite') {
         },
         {
           arguments: ['myTable', { id: 'INTEGER PRIMARY KEY AUTOINCREMENT', name: 'VARCHAR(255)', surname: 'VARCHAR(255)' }, { uniqueKeys: { uniqueConstraint: { fields: ['name', 'surname'], customIndex: true } } }],
-          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255), `surname` VARCHAR(255), UNIQUE (`name`, `surname`));',
+          // SQLITE does not respect the index name when the index is created through CREATE TABLE
+          // As such, Sequelize's createTable does not add the constraint in the Sequelize Dialect.
+          // Instead, `sequelize.sync` calls CREATE INDEX after the table has been created,
+          // as that query *does* respect the index name.
+          expectation: 'CREATE TABLE IF NOT EXISTS `myTable` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` VARCHAR(255), `surname` VARCHAR(255));',
         },
         {
           arguments: ['myTable', { foo1: 'INTEGER PRIMARY KEY NOT NULL', foo2: 'INTEGER PRIMARY KEY NOT NULL' }],

--- a/test/unit/model/indexes.test.js
+++ b/test/unit/model/indexes.test.js
@@ -20,9 +20,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
 
       expect(Model.rawAttributes.eventData.index).not.to.equal(true);
-      expect(Model._indexes.length).to.equal(1);
-      expect(Model._indexes[0].fields).to.eql(['data']);
-      expect(Model._indexes[0].using).to.equal('gin');
+      expect(Model.getIndexes().length).to.equal(1);
+      expect(Model.getIndexes()[0].fields).to.eql(['data']);
+      expect(Model.getIndexes()[0].using).to.equal('gin');
     });
 
     it('should set the unique property when type is unique', () => {
@@ -39,8 +39,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         ],
       });
 
-      expect(Model._indexes[0].unique).to.eql(true);
-      expect(Model._indexes[1].unique).to.eql(true);
+      expect(Model.getIndexes()[0].unique).to.eql(true);
+      expect(Model.getIndexes()[1].unique).to.eql(true);
     });
 
     it('should not set rawAttributes when indexes are defined via options', () => {

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -81,7 +81,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     });
 
     it('POJO field', () => {
-      expectsql(sql.addIndexQuery('table', [{ attribute: 'column', collate: 'BINARY', length: 5, order: 'DESC' }], {}, 'table'), {
+      expectsql(sql.addIndexQuery('table', [{ name: 'column', collate: 'BINARY', length: 5, order: 'DESC' }], {}, 'table'), {
         default: 'CREATE INDEX [table_column] ON [table] ([column] COLLATE [BINARY] DESC)',
         mssql: 'CREATE INDEX [table_column] ON [table] ([column] DESC)',
         db2: 'CREATE INDEX "table_column" ON "table" ("column" DESC)',


### PR DESCRIPTION
### Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Closes https://github.com/sequelize/sequelize/issues/12889

This PR fixes the following bugs:

- DB2 forced columns that had a unique index to be non-null, this has been removed (you still need to make your column non-null, but we don't silently make that happen).
- When defining an index through the `indexes` option on a model, then calling `sync()`, the dialect would *modify* the model to mark all attributes that are part of the index as unique. (DB2 only)
- Calling `sync({ alter: true })` with an attribute that has `unique: true` set would generate a query such as `ALTER TABLE users ALTER COLUMN emails SET VARCHAR UNIQUE`. DB2 and MSSQL do not allow `UNIQUE` to be specified there. This has been changed to use a separate `CREATE INDEX` query.
- SQLite supports specifying an index name during `CREATE TABLE`, but that name is ignored by sqlite. Causing subsequent `sync()` to try to recreate the index. The first `sync` does not try to create the index as part of `CREATE TABLE` anymore, but executes `CREATE INDEX` afterwards to create them (sqlite only, other dialects still do it during `CREATE TABLE`).
- This PR adds `Model.getIndexes()` which lists all indexes defined on the model (it regroups all indexes, the ones defined through `ModelOptions.indexes`, as well as the ones coming from `ModelAttributeColumnOptions.unique`)

This PR blocks https://github.com/sequelize/sequelize/pull/14572#issuecomment-1152578770

### TODO

- [x] Add tests for https://github.com/sequelize/sequelize/issues/12889
- [x] Add `sync(alter)` tests for *adding* unique constraints after the first `sync()`