### PR TITLE
fix: multiple $ in `fn` args now properly escaped

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -2243,7 +2243,7 @@ class QueryGenerator {
           if (_.isPlainObject(arg)) {
             return this.whereItemsQuery(arg);
           }
-          return this.escape(typeof arg === 'string' ? arg.replaceAll('$', '$$$') : arg);
+          return this.escape(typeof arg === 'string' ? arg.replace(/\$/g, '$$$') : arg);
         }).join(', ')
       })`;
     }

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -939,8 +939,8 @@ class QueryGenerator {
   /**
    * Split a list of identifiers by "." and quote each part.
    *
-   * @param {string} identifiers 
-   * 
+   * @param {string} identifiers
+   *
    * @returns {string}
    */
   quoteIdentifiers(identifiers) {
@@ -2243,7 +2243,7 @@ class QueryGenerator {
           if (_.isPlainObject(arg)) {
             return this.whereItemsQuery(arg);
           }
-          return this.escape(typeof arg === 'string' ? arg.replace('$', '$$$') : arg);
+          return this.escape(typeof arg === 'string' ? arg.replaceAll('$', '$$$') : arg);
         }).join(', ')
       })`;
     }

--- a/test/integration/instance/save.test.js
+++ b/test/integration/instance/save.test.js
@@ -401,6 +401,14 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       expect(userAfterUpdate.username).to.equal('$SEQUELIZE');
     });
 
+    it('updates with function that contains multiple escaped dollar symbols', async function() {
+      const user = await this.User.create({});
+      user.username = this.sequelize.fn('upper', '$sequelize and $sequelize2 and some money $42.69');
+      await user.save();
+      const userAfterUpdate = await this.User.findByPk(user.id);
+      expect(userAfterUpdate.username).to.equal('$SEQUELIZE AND $SEQUELIZE2 AND SOME MONEY $42.69');
+    });
+
     describe('without timestamps option', () => {
       it("doesn't update the updatedAt column", async function() {
         const User2 = this.sequelize.define('User2', {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -912,6 +912,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(user0.secretValue).to.equal('$SEQUELIZE');
     });
 
+    it('should escape multiple instances of $ in sequelize functions arguments', async function() {
+      const user = await this.User.create({
+        secretValue: this.sequelize.fn('upper', '$sequelize and $sequelize2 and some money $42.69')
+      });
+
+      const user0 = await this.User.findByPk(user.id);
+      expect(user0.secretValue).to.equal('$SEQUELIZE AND $SEQUELIZE2 AND SOME MONEY $42.69');
+    });
+
     it('should work with a non-id named uuid primary key columns', async function() {
       const Monkey = this.sequelize.define('Monkey', {
         monkeyId: { type: DataTypes.UUID, primaryKey: true, defaultValue: DataTypes.UUIDV4, allowNull: false }
@@ -1218,7 +1227,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(test).to.be.true;
     });
 
-    it('should only store the values passed in the whitelist', async function() {      
+    it('should only store the values passed in the whitelist', async function() {
       // A unique column do not accept NULL in Db2. Unique column must have value in insert statement.
       const data = { username: 'Peter', secretValue: '42', uniqueName: 'name' };
       const fields = dialect === 'db2' ? { fields: ['username', 'uniqueName'] } : { fields: ['username'] };

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -120,10 +120,16 @@ describe('QueryGenerator', () => {
         .should.be.equal('foo IS NOT NULL');
     });
 
-    it('should correctly escape $ in sequelize.fn arguments', function() {
+    it('should correctly escape a single $ in sequelize.fn arguments', function() {
       const QG = getAbstractQueryGenerator(this.sequelize);
       QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user'))
-        .should.include('$$user');
+        .should.be.equal("upper('$$user')");
+    });
+
+    it('should correctly escape multiple instances of "$" in sequelize.fn arguments', function() {
+      const QG = getAbstractQueryGenerator(this.sequelize);
+      QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user and then another $user and some dollars: $42.69'))
+        .should.be.equal('upper(\'$$user and then another $$user and some dollars: $$42.69\')');
     });
   });
 

--- a/test/unit/dialects/abstract/query-generator.test.js
+++ b/test/unit/dialects/abstract/query-generator.test.js
@@ -4,7 +4,8 @@ const chai = require('chai'),
   expect = chai.expect,
   Op = require('../../../../lib/operators'),
   Support = require('../../support'),
-  getAbstractQueryGenerator = Support.getAbstractQueryGenerator;
+  getAbstractQueryGenerator = Support.getAbstractQueryGenerator,
+  expectsql = Support.expectsql;
 const AbstractQueryGenerator = require('sequelize/lib/dialects/abstract/query-generator');
 
 describe('QueryGenerator', () => {
@@ -122,14 +123,20 @@ describe('QueryGenerator', () => {
 
     it('should correctly escape a single $ in sequelize.fn arguments', function() {
       const QG = getAbstractQueryGenerator(this.sequelize);
-      QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user'))
-        .should.be.equal("upper('$$user')");
+      const value = QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user'));
+      expectsql(value, {
+        mssql: "upper(N'$$user')",
+        default: "upper('$$user')"
+      });
     });
 
     it('should correctly escape multiple instances of "$" in sequelize.fn arguments', function() {
       const QG = getAbstractQueryGenerator(this.sequelize);
-      QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user and then another $user and some dollars: $42.69'))
-        .should.be.equal('upper(\'$$user and then another $$user and some dollars: $$42.69\')');
+      const value = QG.handleSequelizeMethod(this.sequelize.fn('upper', '$user and then another $user and some dollars: $42.69'));
+      expectsql(value, {
+        mssql: 'upper(N\'$$user and then another $$user and some dollars: $$42.69\')',
+        default: 'upper(\'$$user and then another $$user and some dollars: $$42.69\')'
+      });
     });
   });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change
Fixes improper escaping of multiple dollar signs in strings sent to `sequelize.fn` as detailed in https://github.com/sequelize/sequelize/issues/14601. Also removes some trailing whitespace, since my editor did it automatically 🤷 
