### PR TITLE
feat: return null if no defaultValue is specified

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1271,6 +1271,10 @@ Use Sequelize#query if you wish to use replacements.`);
       }
     }
 
+    if (attribute.allowNull !== false && !attribute.defaultValue) {
+      attribute.defaultValue = null;
+    }
+
     return attribute;
   }
 }

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -1395,6 +1395,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(newTasks[3].title).to.equal('SAVE TRANSACTION');
     });
 
+    it('should return null value when defaultValue is not defined', async function () {
+      const user = await this.User.create();
+
+      expect(user.username).to.equal(null);
+    });
+
     describe('enums', () => {
       it('correctly restores enum values', async function () {
         const Item = this.sequelize.define('Item', {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change
This PR adds a defaultValue of `null` if there is no defaultValue specified when creating a model and the attribute allows `null`.
This fixes #14671.

@ephys I'm not so sure about this change. As you can see the unit tests fail because it also adds `DEFAULT NULL` to the SQL query. Is that wanted behaviour? This might even qualify as a breaking change

### Todos

- [ ] See what to do about the failing tests
