### PR TITLE
docs: fix comment in data-types.d.ts

### DIFF
--- a/src/data-types.d.ts
+++ b/src/data-types.d.ts
@@ -365,7 +365,7 @@ export interface DateOnlyDataType extends AbstractDataType {
 export const HSTORE: AbstractDataTypeConstructor;
 
 /**
- * A JSON string column. Only available in postgres.
+ * A JSON string column. Available in MySQL, Postgres and SQLite.
  */
 export const JSON: AbstractDataTypeConstructor;
 /**


### PR DESCRIPTION

### Description Of Change

[The actual file(data-types.js)](https://github.com/sequelize/sequelize/blob/main/src/data-types.js#L585
) says JSON type available for MySQL, Postgres, and SQLite. But the `d.ts` file says JSON is only available in Postgres.

Is this too tiny problem to open PR?