### PR TITLE
meta: add core team members to the contacts list

### DIFF
--- a/CONTACT.md
+++ b/CONTACT.md
@@ -6,8 +6,8 @@ You can use the information below to contact maintainers directly. We will try t
 ## Via Email
 
 - **Sascha Depold** sascha@depold.com
-- **Fauzan** developerfauzan@gmail.com (security reports, dependencies vulnerabilities)
 - **Zoé Cox** zoe@ephys.dev (accepts CoC violation reports, security reports)
+- **Rik Smale** sequelize@riksmale.info (accepts CoC violation reports, security reports)
 
 ## Via Slack
 


### PR DESCRIPTION
In order to react to pressing concerns swiftly, we are swapping the contacts with the core team only