### PR TITLE
feat: export hooks for types(v6)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,6 +14,7 @@ export * from './model';
 export * from './dialects/abstract/query-interface';
 export * from './sequelize';
 export * from './transaction';
+export * from './hooks';
 export { useInflection } from './utils';
 export { Validator } from './utils/validator-extras';
 export { Utils, QueryTypes, Op, TableHints, IndexHints, DataTypes, Deferrable };


### PR DESCRIPTION
### Description Of Change

We solved the problem of typescript `nodenext` in the [previous PR](https://github.com/sequelize/sequelize/pull/14620).But I found that `types/index.d.ts` does not export `hooks`, which will make references such as `import { SequelizeHooks } from 'sequelize/types/hooks';` inaccessible in `nodenext`. Here is a example in `sequelize-typescript`

```ts
import { SequelizeHooks } from 'sequelize/types/hooks';
export interface HookMeta {
    hookType: keyof SequelizeHooks;
    methodName: string;
    options?: HookOptions;
}
```

![image](https://user-images.githubusercontent.com/13284978/177268797-59cad54b-c673-4793-80e4-5924b2e87aaa.png)


### Todos

- [x] add `export * from './hooks'` in `index.d.ts`
- [ ] upgrade `sequelize-typescript`, change the import  `import { SequelizeHooks } from 'sequelize';`
