### PR TITLE
fix(postgres): prevent crash if postgres connection fails immediately (v6)

### DIFF
--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -200,6 +200,13 @@ class ConnectionManager extends AbstractConnectionManager {
       });
     });
 
+    // Don't let a Postgres restart (or error) to take down the whole app
+    connection.once('error', error => {
+      connection._invalid = true;
+      debug(`connection error ${error.code || error.message}`);
+      this.pool.destroy(connection);
+    });
+
     let query = '';
 
     if (this.sequelize.options.standardConformingStrings !== false && connection['standard_conforming_strings'] !== 'on') {
@@ -240,12 +247,6 @@ class ConnectionManager extends AbstractConnectionManager {
       this.enumOids.arrayOids.length === 0) {
       await this._refreshDynamicOIDs(connection);
     }
-    // Don't let a Postgres restart (or error) to take down the whole app
-    connection.on('error', error => {
-      connection._invalid = true;
-      debug(`connection error ${error.code || error.message}`);
-      this.pool.destroy(connection);
-    });
 
     return connection;
   }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

We recently observed a crash due to an unhandled `Connection terminated unexpectedly` exception originating from the `pg` library.  As best as I've been able to tell, this _shouldn't_ be possible, and I've had difficulty reproducing it.  

However, upon reading through the current implementation of the Postgres connection-manager, I noticed that we don't immediately attach an error-handler to the `pg` connection.  

Based off of my reading of this code, it actually seems reasonably possible that an error emitted during either of the setup queries could trigger a hard crash.  Moving the error-handler to an earlier phase of the connection's lifecycle should, in theory, make this a bit safer, and guard against any errors that are emitted very early in the connection's lifecycle.

Given the difficulty associated with reproducing this issue, I haven't been able to write an automated test-case to reproduce the issue or validate the fix.  However, I'm reasonably confident that this fix is safe, and unlikely to make anything _worse_. 

### Todos

- [ ] Add an automated test (if possible)