### PR TITLE
fix(postgres): treat lowercase e as valid e-string prefix

### DIFF
--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -114,8 +114,8 @@ function mapBindParametersAndReplacements(
         // checking if this is a postgres-style E-prefixed string, which also supports backslash escaping
         || (
           dialect.supports.escapeStringConstants
-          // is this a E-prefixed string, such as `E'abc'` ?
-          && sqlString[i - 1] === 'E'
+          // is this a E-prefixed string, such as `E'abc'`, `e'abc'` ?
+          && (sqlString[i - 1] === 'E' || sqlString[i - 1] === 'e')
           // reject things such as `AE'abc'` (the prefix must be exactly E)
           && canPrecedeNewToken(sqlString[i - 2])
         );

--- a/test/unit/utils/sql.test.ts
+++ b/test/unit/utils/sql.test.ts
@@ -222,6 +222,22 @@ SELECT * FROM users WHERE id = E'\\' $id' OR id = $id`),
     });
   });
 
+  it('treats strings prefixed with a lowercase e as E-prefixed strings too', () => {
+    expectPerDialect(() => mapBindParameters(`SELECT * FROM users WHERE id = e'\\' $id' OR id = $id`, dialect), {
+      default: new Error(`The following SQL query includes an unterminated string literal:
+SELECT * FROM users WHERE id = e'\\' $id' OR id = $id`),
+
+      'mysql mariadb': toHaveProperties({
+        sql: toMatchSql(`SELECT * FROM users WHERE id = e'\\' $id' OR id = ?`),
+        bindOrder: ['id'],
+      }),
+      postgres: toHaveProperties({
+        sql: `SELECT * FROM users WHERE id = e'\\' $id' OR id = $1`,
+        bindOrder: ['id'],
+      }),
+    });
+  });
+
   it('considers the token to be a bind parameter if it is outside a string ending with an escaped backslash', () => {
     const { sql, bindOrder } = mapBindParameters(`SELECT * FROM users WHERE id = '\\\\' OR id = $id`, dialect);
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?

## Description Of Change

This PR is a follow up to https://github.com/sequelize/sequelize/pull/14700 which added support for postgres' E-prefixed strings.
That support now also considers lowercase "e" as a valid prefix for e-prefixed strings