### PR TITLE
fix(postgres): attach postgres error-handler earlier in lifecycle

### DIFF
--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -219,6 +219,13 @@ export class PostgresConnectionManager extends AbstractConnectionManager {
       });
     });
 
+    // Don't let a Postgres restart (or error) to take down the whole app
+    connection.once('error', error => {
+      connection._invalid = true;
+      debug(`connection error ${error.code || error.message}`);
+      this.pool.destroy(connection);
+    });
+
     let query = '';
 
     if (this.sequelize.options.standardConformingStrings !== false && connection.standard_conforming_strings !== 'on') {
@@ -259,13 +266,6 @@ export class PostgresConnectionManager extends AbstractConnectionManager {
       && this.enumOids.arrayOids.length === 0) {
       await this._refreshDynamicOIDs(connection);
     }
-
-    // Don't let a Postgres restart (or error) to take down the whole app
-    connection.on('error', error => {
-      connection._invalid = true;
-      debug(`connection error ${error.code || error.message}`);
-      this.pool.destroy(connection);
-    });
 
     return connection;
   }


### PR DESCRIPTION
This is the corresponding v7 / `main` PR for https://github.com/sequelize/sequelize/pull/14731

Please see that PR for a discussion of the issue.  (tl;dr; There appears to be a brief window immediately after connecting to a Postgres database during which Sequelize may crash if the connection fails.  This change should close that window.)