### PR TITLE
meta: reduce TypeDoc warnings

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -80,7 +80,7 @@ export interface Filterable<TAttributes = any> {
   /**
    * The `WHERE` clause. Can be many things from a hash of attributes to raw SQL.
    *
-   * Visit {@link https://sequelize.org/docs/v7/core-concepts/model-querying-basics/} for more information.
+   * Visit https://sequelize.org/docs/v7/core-concepts/model-querying-basics/ for more information.
    */
   where?: WhereOptions<TAttributes>;
 }
@@ -1816,7 +1816,7 @@ export interface ModelOptions<M extends Model = Model> {
    * Define the default search scope to use for this model. Scopes have the same form as the options passed to
    * find / findAll.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    */
   defaultScope?: FindOptions<Attributes<M>>;
 
@@ -1824,7 +1824,7 @@ export interface ModelOptions<M extends Model = Model> {
    * More scopes, defined in the same way as {@link ModelOptions.defaultScope} above.
    * See {@link Model.scope} for more information about how scopes are defined, and what you can do with them.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    */
   scopes?: ModelScopeOptions<Attributes<M>>;
 
@@ -2348,7 +2348,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   /**
    * Creates a copy of this model, with one or more scopes applied.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    *
    * @param scopes The scopes to apply.
    *   Scopes can either be passed as consecutive arguments, or as an array of arguments.
@@ -2381,7 +2381,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   /**
    * Returns a model without scope. The default scope is also omitted.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    *
    * If you want to access the Model Class in its state before any scope was applied, use {@link Model.withInitialScope}.
    */
@@ -2407,7 +2407,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * By default, this will throw an error if a scope with that name already exists.
    * Use {@link AddScopeOptions.override} in the options object to silence this error.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    */
   static addScope<M extends Model>(
     this: ModelStatic<M>,
@@ -2420,7 +2420,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
 
   /**
    * Search for multiple instances.
-   * See {@link https://sequelize.org/docs/v7/core-concepts/model-querying-basics/} for more information about querying.
+   * See https://sequelize.org/docs/v7/core-concepts/model-querying-basics/ for more information about querying.
    *
    * __Example of a simple search:__
    * ```js
@@ -2773,7 +2773,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Restores multiple paranoid instances.
    * Only usable if {@link ModelOptions.paranoid} is true.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/paranoid/} to learn more about soft deletion / paranoid models.
+   * See https://sequelize.org/docs/v7/core-concepts/paranoid/ to learn more about soft deletion / paranoid models.
    */
   static restore<M extends Model>(
     this: ModelStatic<M>,
@@ -3240,7 +3240,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Creates a 1:1 association between this model (the source) and the provided target.
    * The foreign key is added on the target model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript
@@ -3262,7 +3262,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Creates an association between this (the source) and the provided target.
    * The foreign key is added on the source Model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript
@@ -3284,7 +3284,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Defines a 1:n association between two models.
    * The foreign key is added on the target model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript
@@ -3306,7 +3306,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Create an N:M association with a join table. Defining `through` is required.
    * The foreign key is added on the through model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript
@@ -3512,7 +3512,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Restores the row corresponding to this instance.
    * Only available for paranoid models.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/paranoid/} to learn more about soft deletion / paranoid models.
+   * See https://sequelize.org/docs/v7/core-concepts/paranoid/ to learn more about soft deletion / paranoid models.
    */
   restore(options?: InstanceRestoreOptions): Promise<void>;
 
@@ -3587,7 +3587,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Returns true if this instance is "soft deleted".
    * Throws an error if {@link ModelOptions.paranoid} is not enabled.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/paranoid/} to learn more about soft deletion / paranoid models.
+   * See https://sequelize.org/docs/v7/core-concepts/paranoid/ to learn more about soft deletion / paranoid models.
    */
   isSoftDeleted(): boolean;
 }

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -170,7 +170,7 @@ type InvalidInSqlArray = ColumnReference | Fn | Cast | null | Literal;
  * It also supports using a plain Array as an alias for `Op.and`. (unlike {@link AllowNotOrAndRecursive}).
  *
  * Example of plain-array treated as `Op.and`:
- * User.findAll({ where: [{ id: 1 }, { id: 2 }] });
+ * User.findAll(\{ where: [\{ id: 1 \}, \{ id: 2 \}] \});
  *
  * Meant to be used by {@link WhereOptions}.
  */
@@ -187,7 +187,7 @@ type AllowNotOrAndWithImplicitAndArrayRecursive<T> = AllowArray<
  * Unlike {@link AllowNotOrAndWithImplicitAndArrayRecursive}, it does not allow the 'implicit AND Array'.
  *
  * Example of plain-array NOT treated as Op.and:
- * User.findAll({ where: { id: [1, 2] } });
+ * User.findAll(\{ where: \{ id: [1, 2] \} \});
  *
  * Meant to be used by {@link WhereAttributeHashValue}.
  */
@@ -3150,7 +3150,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   ): void;
 
   /**
-   * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
+   * A hook that is run before a find (select) query, after any \{ include: \{all: ...\} \} options are expanded
    *
    * @param name
    * @param fn   A callback function that is called with options
@@ -3482,7 +3482,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * Validate the attribute of this instance according to validation rules set in the model definition.
    *
    * Emits null if and only if validation successful; otherwise an Error instance containing
-   * { field name : [error msgs] } entries.
+   * \{ field name : [error msgs] \} entries.
    */
   validate(options?: ValidationOptions): Promise<void>;
 

--- a/src/model.js
+++ b/src/model.js
@@ -1497,7 +1497,7 @@ Specify a different name for either index to resolve this issue.`);
    * By default, this will throw an error if a scope with that name already exists.
    * Use {@link AddScopeOptions.override} in the options object to silence this error.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    *
    * @param {string}          name The name of the scope. Use `defaultScope` to override the default scope
    * @param {object|Function} scope scope or options
@@ -1531,7 +1531,7 @@ Specify a different name for either index to resolve this issue.`);
   /**
    * Creates a copy of this model, with one or more scopes applied.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    *
    * @param {?Array|object|string} [scopes] The scope(s) to apply. Scopes can either be passed as consecutive arguments, or
    *   as an array of arguments. To apply simple scopes and scope functions with no arguments, pass them as strings. For
@@ -1600,7 +1600,7 @@ Specify a different name for either index to resolve this issue.`);
   /**
    * Returns a model without scope. The default scope is also omitted.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    */
   static unscoped() {
     scopeRenamedToWithScope();
@@ -1611,7 +1611,7 @@ Specify a different name for either index to resolve this issue.`);
   /**
    * Returns a model without scope. The default scope is also omitted.
    *
-   * See {@link https://sequelize.org/docs/v7/other-topics/scopes/} to learn more about scopes.
+   * See https://sequelize.org/docs/v7/other-topics/scopes/ to learn more about scopes.
    */
   static withoutScope() {
     return this.withScope(null);
@@ -1694,7 +1694,7 @@ Specify a different name for either index to resolve this issue.`);
 
   /**
    * Search for multiple instances.
-   * See {@link https://sequelize.org/docs/v7/core-concepts/model-querying-basics/} for more information about querying.
+   * See https://sequelize.org/docs/v7/core-concepts/model-querying-basics/ for more information about querying.
    *
    * __Example of a simple search:__
    * ```js
@@ -4356,7 +4356,7 @@ Instead of specifying a Model, either:
    * Returns true if this instance is "soft deleted".
    * Throws an error if {@link ModelOptions.paranoid} is not enabled.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/paranoid/} to learn more about soft deletion / paranoid models.
+   * See https://sequelize.org/docs/v7/core-concepts/paranoid/ to learn more about soft deletion / paranoid models.
    *
    * @returns {boolean}
    */
@@ -4377,7 +4377,7 @@ Instead of specifying a Model, either:
    * Restores the row corresponding to this instance.
    * Only available for paranoid models.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/paranoid/} to learn more about soft deletion / paranoid models.
+   * See https://sequelize.org/docs/v7/core-concepts/paranoid/ to learn more about soft deletion / paranoid models.
    *
    * @param {object}      [options={}] restore options
    * @returns {Promise}
@@ -4543,7 +4543,7 @@ Instead of specifying a Model, either:
    * Defines a 1:n association between two models.
    * The foreign key is added on the target model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript
@@ -4562,7 +4562,7 @@ Instead of specifying a Model, either:
    * Create an N:M association with a join table. Defining `through` is required.
    * The foreign keys are added on the through model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript
@@ -4588,7 +4588,7 @@ Instead of specifying a Model, either:
    * Creates a 1:1 association between this model (the source) and the provided target.
    * The foreign key is added on the target model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript
@@ -4607,7 +4607,7 @@ Instead of specifying a Model, either:
    * Creates an association between this (the source) and the provided target.
    * The foreign key is added on the source Model.
    *
-   * See {@link https://sequelize.org/docs/v7/core-concepts/assocs/} to learn more about associations.
+   * See https://sequelize.org/docs/v7/core-concepts/assocs/ to learn more about associations.
    *
    * @example
    * ```javascript

--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -449,8 +449,8 @@ export interface QueryRawOptions extends Logging, Transactionable, Poolable {
 
   /**
    * If true, transforms objects with `.` separated property names into nested objects using
-   * [dottie.js](https://github.com/mickhansen/dottie.js). For example { 'user.username': 'john' } becomes
-   * { user: { username: 'john' }}. When `nest` is true, the query type is assumed to be `'SELECT'`,
+   * [dottie.js](https://github.com/mickhansen/dottie.js). For example \{ 'user.username': 'john' \} becomes
+   * \{ user: \{ username: 'john' \}\}. When `nest` is true, the query type is assumed to be `'SELECT'`,
    * unless otherwise specified
    *
    * @default false
@@ -851,7 +851,7 @@ export class Sequelize extends Hooks {
   afterDisconnect(fn: (connection: unknown) => void): void;
 
   /**
-   * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
+   * A hook that is run before a find (select) query, after any \{ include: \{all: ...\} \} options are expanded
    *
    * @param name
    * @param fn   A callback function that is called with options
@@ -1173,7 +1173,7 @@ export class Sequelize extends Hooks {
   beforeFind(fn: (options: FindOptions<any>) => void): void;
 
   /**
-   * A hook that is run before a find (select) query, after any { include: {all: ...} } options are expanded
+   * A hook that is run before a find (select) query, after any \{ include: \{all: ...\} \} options are expanded
    *
    * @param name
    * @param fn   A callback function that is called with options

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -101,25 +101,25 @@ export function cloneDeep<T extends object>(obj: T, onlyPlain?: boolean): T {
  *
  * - Input:
  *
- *  {
+ *  \{
  *    name: 'John',
- *    address: {
+ *    address: \{
  *      street: 'Fake St. 123',
- *      coordinates: {
+ *      coordinates: \{
  *        longitude: 55.6779627,
  *        latitude: 12.5964313
- *      }
- *    }
- *  }
+ *      \}
+ *    \}
+ *  \}
  *
  * - Output:
  *
- *  {
+ *  \{
  *    name: 'John',
  *    address.street: 'Fake St. 123',
  *    address.coordinates.latitude: 55.6779627,
  *    address.coordinates.longitude: 12.5964313
- *  }
+ *  \}
  *
  * @param value an Object
  * @returns a flattened object


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [X] Have you added new tests to prevent regressions?
- [X] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This PR aims to reduce the warnings for TypeDoc generation that occur on 0.23.
As of 2022-07-11 the only warnings reduced are for the usage of `{@link }` for external links and escaping curly brackets.

### Todos

1. Failed to resolve `link` in `type` with declaration references. This link will break in v0.24.

| link | type |
| --- | --- |
| Model#create | HasOne.create |
| BelongsToManyOptions.inverse.foreignKeyConstraints | BelongsToManyOptions.foreignKeyConstraints |
| Model.afterQuery | ModelOptions.hooks |
| Model.afterQuery | InitOptions.hooks |
| InferAttributesOptions#omit | InternalInferAttributeKeysFromFields |
| Op.eq | where.operator |
| Op.eq | Sequelize.__type.operator |

These might not even resolve using the [legacy method](https://typedoc.org/guides/link-resolution/).

2. After that there are still some warnings where types are referenced by others but are 'not included in the documentation'. This PR will probably not solve those.