### PR TITLE
meta: only clear database once per file

### DIFF
--- a/test/integration/associations/alias.test.js
+++ b/test/integration/associations/alias.test.js
@@ -6,7 +6,7 @@ const expect = chai.expect;
 const Support = require('../support');
 
 describe(Support.getTestDialectTeaser('Alias'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/associations/alias.test.js
+++ b/test/integration/associations/alias.test.js
@@ -6,6 +6,10 @@ const expect = chai.expect;
 const Support = require('../support');
 
 describe(Support.getTestDialectTeaser('Alias'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   it('should uppercase the first letter in alias getter, but not in eager loading', async function () {
     const User = this.sequelize.define('user', {});
     const Task = this.sequelize.define('task', {});

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -13,6 +13,10 @@ const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(() => {
     Support.resetSequelizeInstance();
   });

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -13,7 +13,7 @@ const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -11,7 +11,7 @@ const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('BelongsTo'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -11,6 +11,10 @@ const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('BelongsTo'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('Model.associations', () => {
     it('should store all associations when associating to the same table multiple times', function () {
       const User = this.sequelize.define('User', {});

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -14,7 +14,7 @@ const _ = require('lodash');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('HasMany'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -14,6 +14,10 @@ const _ = require('lodash');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('HasMany'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('Model.associations', () => {
     it('should store all assocations when associting to the same table multiple times', function () {
       const User = this.sequelize.define('User', {});

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -10,7 +10,7 @@ const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('HasOne'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -10,6 +10,10 @@ const current = Support.sequelize;
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('HasOne'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('get', () => {
     describe('multiple', () => {
       it('should fetch associations for multiple instances', async function () {

--- a/test/integration/associations/multiple-level-filters.test.js
+++ b/test/integration/associations/multiple-level-filters.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   it('can filter through belongsTo', async function () {
     const User = this.sequelize.define('User', { username: DataTypes.STRING });
     const Task = this.sequelize.define('Task', { title: DataTypes.STRING });

--- a/test/integration/associations/multiple-level-filters.test.js
+++ b/test/integration/associations/multiple-level-filters.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Multiple Level Filters'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -11,7 +11,7 @@ const semver = require('semver');
 const upperFirst = require('lodash/upperFirst');
 
 describe(Support.getTestDialectTeaser('associations'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/associations/scope.test.js
+++ b/test/integration/associations/scope.test.js
@@ -11,6 +11,10 @@ const semver = require('semver');
 const upperFirst = require('lodash/upperFirst');
 
 describe(Support.getTestDialectTeaser('associations'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     beforeEach(function () {
       this.Post = this.sequelize.define('post', {});

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Self'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   it('supports freezeTableName', async function () {
     const Group = this.sequelize.define('Group', {}, {
       tableName: 'user_group',

--- a/test/integration/associations/self.test.js
+++ b/test/integration/associations/self.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Self'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -14,6 +14,10 @@ const sinon = require('sinon');
 
 if (current.dialect.supports.transactions) {
   describe(Support.getTestDialectTeaser('CLS (Async hooks)'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     before(() => {
       current.constructor.useCLS(cls.createNamespace('sequelize'));
     });

--- a/test/integration/cls.test.js
+++ b/test/integration/cls.test.js
@@ -14,7 +14,7 @@ const sinon = require('sinon');
 
 if (current.dialect.supports.transactions) {
   describe(Support.getTestDialectTeaser('CLS (Async hooks)'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -18,7 +18,7 @@ if (dialect === 'sqlite') {
 }
 
 describe(Support.getTestDialectTeaser('Configuration'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/configuration.test.js
+++ b/test/integration/configuration.test.js
@@ -18,6 +18,10 @@ if (dialect === 'sqlite') {
 }
 
 describe(Support.getTestDialectTeaser('Configuration'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('Connections problems should fail with a nice message', () => {
     if (dialect !== 'db2') {
       it('when we don\'t have the correct server details', async () => {

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -16,6 +16,10 @@ const dialect = Support.getTestDialect();
 const semver = require('semver');
 
 describe(Support.getTestDialectTeaser('DataTypes'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   afterEach(function () {
     // Restore some sanity by resetting all parsers
     this.sequelize.connectionManager._clearTypeParser();

--- a/test/integration/data-types.test.js
+++ b/test/integration/data-types.test.js
@@ -16,7 +16,7 @@ const dialect = Support.getTestDialect();
 const semver = require('semver');
 
 describe(Support.getTestDialectTeaser('DataTypes'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/dialects/abstract/connection-manager.test.ts
+++ b/test/integration/dialects/abstract/connection-manager.test.ts
@@ -6,7 +6,7 @@ import { Pool } from 'sequelize-pool';
 import type { SinonSandbox } from 'sinon';
 import sinon from 'sinon';
 import { Config } from '../../../config/config';
-import { getTestDialect, getTestDialectTeaser, createSequelizeInstance, clearDatabase, sequelize } from '../../support';
+import { getTestDialect, getTestDialectTeaser, createSequelizeInstance } from '../../support';
 
 const expect = chai.expect;
 const baseConf = Config[getTestDialect()];
@@ -19,10 +19,6 @@ const poolEntry = {
 const dialect = getTestDialect();
 
 describe(getTestDialectTeaser('Connection Manager'), () => {
-  beforeEach(async () => {
-    await clearDatabase(sequelize);
-  });
-
   let sandbox: SinonSandbox;
 
   beforeEach(() => {
@@ -38,10 +34,10 @@ describe(getTestDialectTeaser('Connection Manager'), () => {
       replication: null,
     };
 
-    const sequelizeInstance = createSequelizeInstance(options);
-    expect(sequelizeInstance.connectionManager.pool).to.be.instanceOf(ReplicationPool);
-    expect(sequelizeInstance.connectionManager.pool.read).to.be.null;
-    expect(sequelizeInstance.connectionManager.pool.write).to.be.instanceOf(Pool);
+    const sequelize = createSequelizeInstance(options);
+    expect(sequelize.connectionManager.pool).to.be.instanceOf(ReplicationPool);
+    expect(sequelize.connectionManager.pool.read).to.be.null;
+    expect(sequelize.connectionManager.pool.write).to.be.instanceOf(Pool);
   });
 
   it('initializes a readOnly pool with replication', () => {
@@ -52,10 +48,10 @@ describe(getTestDialectTeaser('Connection Manager'), () => {
       },
     };
 
-    const sequelizeInstance = createSequelizeInstance(options);
-    expect(sequelizeInstance.connectionManager.pool).to.be.instanceOf(ReplicationPool);
-    expect(sequelizeInstance.connectionManager.pool.read).to.be.instanceOf(Pool);
-    expect(sequelizeInstance.connectionManager.pool.write).to.be.instanceOf(Pool);
+    const sequelize = createSequelizeInstance(options);
+    expect(sequelize.connectionManager.pool).to.be.instanceOf(ReplicationPool);
+    expect(sequelize.connectionManager.pool.read).to.be.instanceOf(Pool);
+    expect(sequelize.connectionManager.pool.write).to.be.instanceOf(Pool);
   });
 
   it('should round robin calls to the read pool', async () => {
@@ -75,14 +71,14 @@ describe(getTestDialectTeaser('Connection Manager'), () => {
       },
     };
 
-    const sequelizeInstance = createSequelizeInstance(options);
-    const connectionManager = sequelizeInstance.connectionManager;
+    const sequelize = createSequelizeInstance(options);
+    const connectionManager = sequelize.connectionManager;
 
     const res: Connection = {};
 
     const connectStub = sandbox.stub(connectionManager, '_connect').resolves(res);
     sandbox.stub(connectionManager, '_disconnect').resolves();
-    sandbox.stub(sequelizeInstance, 'databaseVersion').resolves(sequelizeInstance.dialect.defaultVersion);
+    sandbox.stub(sequelize, 'databaseVersion').resolves(sequelize.dialect.defaultVersion);
 
     const queryOptions: GetConnectionOptions = {
       type: 'read',
@@ -110,10 +106,10 @@ describe(getTestDialectTeaser('Connection Manager'), () => {
   if (dialect !== 'sqlite') {
     it('should trigger deprecation for non supported engine version', async () => {
       const stub = sandbox.stub(process, 'emitWarning');
-      const sequelizeInstance = createSequelizeInstance();
-      const connectionManager = sequelizeInstance.connectionManager;
+      const sequelize = createSequelizeInstance();
+      const connectionManager = sequelize.connectionManager;
 
-      sandbox.stub(sequelizeInstance, 'databaseVersion').resolves('0.0.1');
+      sandbox.stub(sequelize, 'databaseVersion').resolves('0.0.1');
 
       const res: Connection = {};
 
@@ -148,8 +144,8 @@ describe(getTestDialectTeaser('Connection Manager'), () => {
           read: [{ ...poolEntry }],
         },
       };
-      const sequelizeInstance = createSequelizeInstance(options);
-      const connectionManager = sequelizeInstance.connectionManager;
+      const sequelize = createSequelizeInstance(options);
+      const connectionManager = sequelize.connectionManager;
 
       const res: Connection = {};
 
@@ -158,8 +154,8 @@ describe(getTestDialectTeaser('Connection Manager'), () => {
         .resolves(res);
       sandbox.stub(connectionManager, '_disconnect').resolves();
       sandbox
-        .stub(sequelizeInstance, 'databaseVersion')
-        .resolves(sequelizeInstance.dialect.defaultVersion);
+        .stub(sequelize, 'databaseVersion')
+        .resolves(sequelize.dialect.defaultVersion);
 
       const queryOptions: GetConnectionOptions = {
         type: 'read',
@@ -177,8 +173,8 @@ describe(getTestDialectTeaser('Connection Manager'), () => {
     const options = {
       replication: null,
     };
-    const sequelizeInstance = createSequelizeInstance(options);
-    const connectionManager = sequelizeInstance.connectionManager;
+    const sequelize = createSequelizeInstance(options);
+    const connectionManager = sequelize.connectionManager;
 
     const poolDrainSpy = sandbox.spy(connectionManager.pool, 'drain');
     const poolClearSpy = sandbox.spy(connectionManager.pool, 'destroyAllNow');

--- a/test/integration/dialects/mariadb/associations.test.js
+++ b/test/integration/dialects/mariadb/associations.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] Associations', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mariadb/associations.test.js
+++ b/test/integration/dialects/mariadb/associations.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] Associations', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('many-to-many', () => {
       describe('where tables have the same prefix', () => {
         it('should create a table wp_table1wp_table2s', async function () {

--- a/test/integration/dialects/mariadb/connection-manager.test.js
+++ b/test/integration/dialects/mariadb/connection-manager.test.js
@@ -11,7 +11,7 @@ const { Sequelize } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MARIADB Specific] Connection Manager', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mariadb/connection-manager.test.js
+++ b/test/integration/dialects/mariadb/connection-manager.test.js
@@ -11,6 +11,9 @@ const { Sequelize } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MARIADB Specific] Connection Manager', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
 
     it('has existing init SQL', async () => {
       const sequelize = Support.createSequelizeInstance(

--- a/test/integration/dialects/mariadb/dao-factory.test.js
+++ b/test/integration/dialects/mariadb/dao-factory.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] DAOFactory', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mariadb/dao-factory.test.js
+++ b/test/integration/dialects/mariadb/dao-factory.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] DAOFactory', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('constructor', () => {
       it('handles extended attributes (unique)', function () {
         const User = this.sequelize.define(`User${Support.rand()}`, {

--- a/test/integration/dialects/mariadb/dao.test.js
+++ b/test/integration/dialects/mariadb/dao.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] DAO', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(async function () {
       this.sequelize.options.quoteIdentifiers = true;
       this.User = this.sequelize.define('User', {

--- a/test/integration/dialects/mariadb/dao.test.js
+++ b/test/integration/dialects/mariadb/dao.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] DAO', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mariadb/errors.test.js
+++ b/test/integration/dialects/mariadb/errors.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] Errors', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mariadb/errors.test.js
+++ b/test/integration/dialects/mariadb/errors.test.js
@@ -10,6 +10,9 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mariadb') {
   describe('[MariaDB Specific] Errors', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
 
     const validateError = async (promise, errClass, errValues) => {
       const wanted = { ...errValues };

--- a/test/integration/dialects/mariadb/query-interface.test.js
+++ b/test/integration/dialects/mariadb/query-interface.test.js
@@ -9,7 +9,7 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mariadb')) {
   describe('QueryInterface', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mariadb/query-interface.test.js
+++ b/test/integration/dialects/mariadb/query-interface.test.js
@@ -9,6 +9,9 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mariadb')) {
   describe('QueryInterface', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
 
     describe('databases', () => {
       it('should create and drop database', async function () {

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -11,7 +11,7 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {
   describe('[MSSQL Specific] Connection Manager', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mssql/connection-manager.test.js
+++ b/test/integration/dialects/mssql/connection-manager.test.js
@@ -11,6 +11,10 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {
   describe('[MSSQL Specific] Connection Manager', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('Errors', () => {
       // TODO [>=7.0.0-beta]: Refactor so this is the only connection it tries to connect with
       it.skip('ECONNREFUSED', async () => {

--- a/test/integration/dialects/mssql/query-queue.test.js
+++ b/test/integration/dialects/mssql/query-queue.test.js
@@ -9,6 +9,10 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {
   describe('[MSSQL Specific] Query Queue', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(async function () {
       const User = this.User = this.sequelize.define('User', {
         username: DataTypes.STRING,

--- a/test/integration/dialects/mssql/query-queue.test.js
+++ b/test/integration/dialects/mssql/query-queue.test.js
@@ -9,7 +9,7 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {
   describe('[MSSQL Specific] Query Queue', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -12,6 +12,10 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {
   describe(Support.getTestDialectTeaser('Regressions'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('does not duplicate columns in ORDER BY statement, #9008', async function () {
       const LoginLog = this.sequelize.define('LoginLog', {
         ID: {

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -12,7 +12,7 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('mssql')) {
   describe(Support.getTestDialectTeaser('Regressions'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mysql/associations.test.js
+++ b/test/integration/dialects/mysql/associations.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Associations', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('many-to-many', () => {
       describe('where tables have the same prefix', () => {
         it('should create a table wp_table1wp_table2s', async function () {

--- a/test/integration/dialects/mysql/associations.test.js
+++ b/test/integration/dialects/mysql/associations.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Associations', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mysql/connection-manager.test.js
+++ b/test/integration/dialects/mysql/connection-manager.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Connection Manager', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('-FOUND_ROWS can be suppressed to get back legacy behavior', async () => {
       const sequelize = Support.createSequelizeInstance({ dialectOptions: { flags: '' } });
       const User = sequelize.define('User', { username: DataTypes.STRING });

--- a/test/integration/dialects/mysql/connection-manager.test.js
+++ b/test/integration/dialects/mysql/connection-manager.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Connection Manager', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] DAOFactory', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mysql/dao-factory.test.js
+++ b/test/integration/dialects/mysql/dao-factory.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] DAOFactory', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('constructor', () => {
       it('handles extended attributes (unique)', function () {
         const User = this.sequelize.define(`User${Support.rand()}`, {

--- a/test/integration/dialects/mysql/errors.test.js
+++ b/test/integration/dialects/mysql/errors.test.js
@@ -10,7 +10,7 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Errors', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/mysql/errors.test.js
+++ b/test/integration/dialects/mysql/errors.test.js
@@ -10,6 +10,9 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 
 if (dialect === 'mysql') {
   describe('[MYSQL Specific] Errors', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
 
     const validateError = async (promise, errClass, errValues) => {
       const wanted = { ...errValues };

--- a/test/integration/dialects/mysql/warning.test.js
+++ b/test/integration/dialects/mysql/warning.test.js
@@ -11,6 +11,10 @@ const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Warning'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   // We can only test MySQL warnings when using MySQL.
   if (dialect === 'mysql') {
     describe('logging', () => {

--- a/test/integration/dialects/mysql/warning.test.js
+++ b/test/integration/dialects/mysql/warning.test.js
@@ -11,7 +11,7 @@ const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Warning'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] associations', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('many-to-many', () => {
       describe('where tables have the same prefix', () => {
         it('should create a table wp_table1wp_table2s', function () {

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] associations', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Sequelize', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     async function checkTimezoneParsing(baseOptions) {
       const options = { ...baseOptions, timezone: 'Asia/Kolkata', timestamps: true };
       const sequelize = Support.createSequelizeInstance(options);

--- a/test/integration/dialects/postgres/connection-manager.test.js
+++ b/test/integration/dialects/postgres/connection-manager.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Sequelize', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -10,6 +10,10 @@ const { DataTypes, Op, json } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] DAO', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(async function () {
       this.sequelize.options.quoteIdentifiers = true;
       this.User = this.sequelize.define('User', {

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -10,7 +10,7 @@ const { DataTypes, Op, json } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] DAO', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/data-types.test.js
+++ b/test/integration/dialects/postgres/data-types.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'postgres') {
   describe('[POSTGRES Specific] Data Types', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('DATE/DATEONLY Validate and Stringify', () => {
       const now = new Date();
       const nowString = now.toISOString();

--- a/test/integration/dialects/postgres/data-types.test.js
+++ b/test/integration/dialects/postgres/data-types.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'postgres') {
   describe('[POSTGRES Specific] Data Types', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/error.test.js
+++ b/test/integration/dialects/postgres/error.test.js
@@ -11,7 +11,7 @@ const _ = require('lodash');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] ExclusionConstraintError', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/error.test.js
+++ b/test/integration/dialects/postgres/error.test.js
@@ -11,6 +11,10 @@ const _ = require('lodash');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] ExclusionConstraintError', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     const constraintName = 'overlap_period';
     beforeEach(async function () {
       this.Booking = this.sequelize.define('Booking', {

--- a/test/integration/dialects/postgres/hstore.test.js
+++ b/test/integration/dialects/postgres/hstore.test.js
@@ -10,7 +10,7 @@ const hstore = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialec
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] hstore', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/hstore.test.js
+++ b/test/integration/dialects/postgres/hstore.test.js
@@ -10,6 +10,10 @@ const hstore = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialec
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] hstore', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('stringify', () => {
       it('should handle empty objects correctly', () => {
         expect(hstore.stringify({})).to.equal('');

--- a/test/integration/dialects/postgres/query-interface.test.js
+++ b/test/integration/dialects/postgres/query-interface.test.js
@@ -83,7 +83,6 @@ if (dialect.startsWith('postgres')) {
     });
 
     describe('createFunction', () => {
-
       beforeEach(async function () {
         // make sure we don't have a pre-existing function called create_job
         // this is needed to cover the edge case of afterEach not getting called because of an unexpected issue or stopage with the
@@ -185,6 +184,7 @@ if (dialect.startsWith('postgres')) {
           .to.be.rejectedWith(/function variable must have a name and type/);
       });
 
+      // TODO: figure out why before does not work here
       it('uses declared variables', async function () {
         const body = 'RETURN myVar + 1;';
         const options = { variables: [{ type: 'integer', name: 'myVar', default: 100 }] };

--- a/test/integration/dialects/postgres/query-interface.test.js
+++ b/test/integration/dialects/postgres/query-interface.test.js
@@ -11,6 +11,10 @@ const _ = require('lodash');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] QueryInterface', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(function () {
       this.sequelize.options.quoteIdenifiers = true;
       this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/dialects/postgres/query.test.js
+++ b/test/integration/dialects/postgres/query.test.js
@@ -10,6 +10,9 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Query', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
 
     const taskAlias = 'AnActualVeryLongAliasThatShouldBreakthePostgresLimitOfSixtyFourCharacters';
     const teamAlias = 'Toto';

--- a/test/integration/dialects/postgres/query.test.js
+++ b/test/integration/dialects/postgres/query.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES] Query', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -14,6 +14,10 @@ if (dialect.startsWith('postgres')) {
   const pg = require('pg');
 
   describe('[POSTGRES Specific] range datatype', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('stringify', () => {
       it('should handle empty objects correctly', () => {
         expect(range.stringify([])).to.equal('empty');

--- a/test/integration/dialects/postgres/range.test.js
+++ b/test/integration/dialects/postgres/range.test.js
@@ -14,7 +14,7 @@ if (dialect.startsWith('postgres')) {
   const pg = require('pg');
 
   describe('[POSTGRES Specific] range datatype', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/regressions.test.js
+++ b/test/integration/dialects/postgres/regressions.test.js
@@ -11,7 +11,7 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] Regressions', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/postgres/regressions.test.js
+++ b/test/integration/dialects/postgres/regressions.test.js
@@ -11,6 +11,10 @@ const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] Regressions', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('properly fetch OIDs after sync, #8749', async function () {
       const User = this.sequelize.define('User', {
         active: DataTypes.BOOLEAN,

--- a/test/integration/dialects/snowflake/connection-manager.test.js
+++ b/test/integration/dialects/snowflake/connection-manager.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'snowflake') {
   describe('[SNOWFLAKE Specific] Connection Manager', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('-FOUND_ROWS can be suppressed to get back legacy behavior', async () => {
       const sequelize = Support.createSequelizeInstance();
       const User = sequelize.define('User', { username: DataTypes.STRING });

--- a/test/integration/dialects/snowflake/smoke.test.js
+++ b/test/integration/dialects/snowflake/smoke.test.js
@@ -8,6 +8,10 @@ const dayjs = require('dayjs');
 
 if (dialect === 'snowflake') {
   describe('[SNOWFLAKE Specific] Smoke test', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('[SNOWFLAKE Specific] Basic test for one table', () => {
       let User;
 

--- a/test/integration/dialects/sqlite/connection-manager.test.js
+++ b/test/integration/dialects/sqlite/connection-manager.test.js
@@ -15,6 +15,10 @@ const nestedFileName = jetpack.path(directoryName, 'subdirectory', 'test.sqlite'
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] Connection Manager', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     after(() => {
       jetpack.remove(fileName);
       jetpack.remove(directoryName);

--- a/test/integration/dialects/sqlite/connection-manager.test.js
+++ b/test/integration/dialects/sqlite/connection-manager.test.js
@@ -15,7 +15,7 @@ const nestedFileName = jetpack.path(directoryName, 'subdirectory', 'test.sqlite'
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] Connection Manager', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -12,7 +12,7 @@ const storages = [dbFile];
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAOFactory', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/sqlite/dao-factory.test.js
+++ b/test/integration/dialects/sqlite/dao-factory.test.js
@@ -12,6 +12,10 @@ const storages = [dbFile];
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAOFactory', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     after(function () {
       this.sequelize.options.storage = ':memory:';
     });

--- a/test/integration/dialects/sqlite/dao.test.js
+++ b/test/integration/dialects/sqlite/dao.test.js
@@ -10,6 +10,10 @@ const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAO', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(async function () {
       this.User = this.sequelize.define('User', {
         username: DataTypes.STRING,

--- a/test/integration/dialects/sqlite/dao.test.js
+++ b/test/integration/dialects/sqlite/dao.test.js
@@ -10,7 +10,7 @@ const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] DAO', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/sqlite/sqlite-master.test.js
+++ b/test/integration/dialects/sqlite/sqlite-master.test.js
@@ -10,7 +10,7 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] sqlite_master raw queries', () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/dialects/sqlite/sqlite-master.test.js
+++ b/test/integration/dialects/sqlite/sqlite-master.test.js
@@ -10,6 +10,10 @@ const { DataTypes } = require('@sequelize/core');
 
 if (dialect === 'sqlite') {
   describe('[SQLITE Specific] sqlite_master raw queries', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(async function () {
       this.sequelize.define('SomeTable', {
         someColumn: DataTypes.INTEGER,

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -14,6 +14,10 @@ const {
 } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('API Surface', () => {
     it('Should have the Error constructors exposed', () => {
       expect(Sequelize).to.have.property('Error');

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -14,7 +14,7 @@ const {
 } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Sequelize Errors'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/associations.test.js
+++ b/test/integration/hooks/associations.test.js
@@ -10,6 +10,10 @@ const sinon = require('sinon');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/associations.test.js
+++ b/test/integration/hooks/associations.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/bulkOperation.test.js
+++ b/test/integration/hooks/bulkOperation.test.js
@@ -8,7 +8,7 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/bulkOperation.test.js
+++ b/test/integration/hooks/bulkOperation.test.js
@@ -8,6 +8,10 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/count.test.js
+++ b/test/integration/hooks/count.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/count.test.js
+++ b/test/integration/hooks/count.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/create.test.js
+++ b/test/integration/hooks/create.test.js
@@ -9,7 +9,7 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/create.test.js
+++ b/test/integration/hooks/create.test.js
@@ -9,6 +9,10 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/destroy.test.js
+++ b/test/integration/hooks/destroy.test.js
@@ -8,7 +8,7 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/destroy.test.js
+++ b/test/integration/hooks/destroy.test.js
@@ -8,6 +8,10 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/find.test.js
+++ b/test/integration/hooks/find.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -10,6 +10,10 @@ const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/hooks.test.js
+++ b/test/integration/hooks/hooks.test.js
@@ -10,7 +10,7 @@ const dialect = Support.getTestDialect();
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/restore.test.js
+++ b/test/integration/hooks/restore.test.js
@@ -8,7 +8,7 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/restore.test.js
+++ b/test/integration/hooks/restore.test.js
@@ -8,6 +8,10 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/updateAttributes.test.js
+++ b/test/integration/hooks/updateAttributes.test.js
@@ -8,7 +8,7 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/updateAttributes.test.js
+++ b/test/integration/hooks/updateAttributes.test.js
@@ -8,6 +8,10 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/hooks/upsert.test.js
+++ b/test/integration/hooks/upsert.test.js
@@ -9,7 +9,7 @@ const sinon = require('sinon');
 
 if (Support.sequelize.dialect.supports.upserts) {
   describe(Support.getTestDialectTeaser('Hooks'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/hooks/upsert.test.js
+++ b/test/integration/hooks/upsert.test.js
@@ -9,6 +9,10 @@ const sinon = require('sinon');
 
 if (Support.sequelize.dialect.supports.upserts) {
   describe(Support.getTestDialectTeaser('Hooks'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(async function () {
       this.User = this.sequelize.define('User', {
         username: {

--- a/test/integration/hooks/validate.test.js
+++ b/test/integration/hooks/validate.test.js
@@ -8,7 +8,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/hooks/validate.test.js
+++ b/test/integration/hooks/validate.test.js
@@ -8,6 +8,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Hooks'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: {

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -16,6 +16,10 @@ const sortById = function (a, b) {
 };
 
 describe(Support.getTestDialectTeaser('Include'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('find', () => {
     it('supports a model+alias includeable', async function () {
       const Company = this.sequelize.define('Company', {});

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -16,7 +16,7 @@ const sortById = function (a, b) {
 };
 
 describe(Support.getTestDialectTeaser('Include'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -13,7 +13,7 @@ const sortById = function (a, b) {
 };
 
 describe(Support.getTestDialectTeaser('Include'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -13,6 +13,10 @@ const sortById = function (a, b) {
 };
 
 describe(Support.getTestDialectTeaser('Include'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('findAll', () => {
     beforeEach(function () {
       this.fixtureA = async function () {

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -9,6 +9,10 @@ const Support = require('../support');
 const { DataTypes, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -9,7 +9,7 @@ const Support = require('../support');
 const { DataTypes, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/include/findOne.test.js
+++ b/test/integration/include/findOne.test.js
@@ -8,6 +8,10 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('findOne', () => {
     it('should include a non required model, with conditions and two includes N:M 1:M', async function () {
       const A = this.sequelize.define('A', { name: DataTypes.STRING(40) }, { paranoid: true });

--- a/test/integration/include/findOne.test.js
+++ b/test/integration/include/findOne.test.js
@@ -8,7 +8,7 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/include/limit.test.js
+++ b/test/integration/include/limit.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/include/limit.test.js
+++ b/test/integration/include/limit.test.js
@@ -7,6 +7,9 @@ const Support = require('../support');
 const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
 
   describe('LIMIT', () => {
     /*

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -8,6 +8,9 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Paranoid'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
 
   beforeEach(async function () {
     const S = this.sequelize;

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -8,7 +8,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Paranoid'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -15,6 +15,10 @@ const sortById = function (a, b) {
 };
 
 describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('findAll', () => {
     afterEach(async function () {
       await this.sequelize.dropSchema('account');

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -15,7 +15,7 @@ const sortById = function (a, b) {
 };
 
 describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/include/separate.test.js
+++ b/test/integration/include/separate.test.js
@@ -12,6 +12,10 @@ const dialect = Support.getTestDialect();
 
 if (current.dialect.supports.groupedLimit) {
   describe(Support.getTestDialectTeaser('Include'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('separate', () => {
       it('should run a hasMany association in a separate query', async function () {
         const User = this.sequelize.define('User', {});

--- a/test/integration/include/separate.test.js
+++ b/test/integration/include/separate.test.js
@@ -12,7 +12,7 @@ const dialect = Support.getTestDialect();
 
 if (current.dialect.supports.groupedLimit) {
   describe(Support.getTestDialectTeaser('Include'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -11,6 +11,10 @@ const sinon = require('sinon');
 const isUUID = require('validator').isUUID;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/instance.test.js
+++ b/test/integration/instance.test.js
@@ -11,7 +11,7 @@ const sinon = require('sinon');
 const isUUID = require('validator').isUUID;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -7,6 +7,10 @@ const { Sequelize, DataTypes } = require('@sequelize/core');
 const Support = require('./support');
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('#update', () => {
     it('should allow us to update specific columns without tripping the validations', async function () {
       const User = this.sequelize.define('model', {

--- a/test/integration/instance.validations.test.js
+++ b/test/integration/instance.validations.test.js
@@ -7,7 +7,7 @@ const { Sequelize, DataTypes } = require('@sequelize/core');
 const Support = require('./support');
 
 describe(Support.getTestDialectTeaser('InstanceValidator'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/decrement.test.js
+++ b/test/integration/instance/decrement.test.js
@@ -10,6 +10,10 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/instance/decrement.test.js
+++ b/test/integration/instance/decrement.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/destroy.test.js
+++ b/test/integration/instance/destroy.test.js
@@ -12,7 +12,7 @@ const dialect = Support.getTestDialect();
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/destroy.test.js
+++ b/test/integration/instance/destroy.test.js
@@ -12,6 +12,10 @@ const dialect = Support.getTestDialect();
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('destroy', () => {
     if (current.dialect.supports.transactions) {
       it('supports transactions', async function () {

--- a/test/integration/instance/increment.test.js
+++ b/test/integration/instance/increment.test.js
@@ -10,6 +10,10 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/instance/increment.test.js
+++ b/test/integration/instance/increment.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/reload.test.js
+++ b/test/integration/instance/reload.test.js
@@ -10,6 +10,10 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/instance/reload.test.js
+++ b/test/integration/instance/reload.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/save.test.js
+++ b/test/integration/instance/save.test.js
@@ -10,6 +10,10 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/instance/save.test.js
+++ b/test/integration/instance/save.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/to-json.test.js
+++ b/test/integration/instance/to-json.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/to-json.test.js
+++ b/test/integration/instance/to-json.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('toJSON', () => {
     beforeEach(async function () {
       this.User = this.sequelize.define('User', {

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -10,9 +10,14 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });
+
   after(function () {
     this.clock.restore();
   });

--- a/test/integration/instance/update.test.js
+++ b/test/integration/instance/update.test.js
@@ -10,7 +10,7 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Instance'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -9,6 +9,10 @@ const dialect = Support.getTestDialect();
 const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('DAO'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('Values', () => {
     describe('set', () => {
       it('doesn\'t overwrite generated primary keys', function () {

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -9,7 +9,7 @@ const dialect = Support.getTestDialect();
 const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('DAO'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -11,7 +11,7 @@ const { Sequelize, DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe('model', () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -11,6 +11,10 @@ const { Sequelize, DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe('model', () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   if (current.dialect.supports.JSON) {
     describe('json', () => {
       beforeEach(async function () {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -17,6 +17,10 @@ const pMap = require('p-map');
 const { expectsql } = require('../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   let isMySQL8;
 
   before(function () {

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -17,7 +17,7 @@ const pMap = require('p-map');
 const { expectsql } = require('../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/attributes.test.js
+++ b/test/integration/model/attributes.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('attributes', () => {
     describe('set', () => {
       it('should only be called once when used on a join model called with an association getter', async function () {

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -10,6 +10,9 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
 
   before(function () {
     this.clock = sinon.useFakeTimers();

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -10,7 +10,7 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -9,6 +9,10 @@ const Support = require('../../support');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('attributes', () => {
     describe('types', () => {
       describe('VIRTUAL', () => {

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -9,7 +9,7 @@ const Support = require('../../support');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -10,6 +10,10 @@ const dialect = Support.getTestDialect();
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     const sequelize = await Support.prepareTransactionTest(this.sequelize);
     this.sequelize = sequelize;

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -10,7 +10,7 @@ const dialect = Support.getTestDialect();
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/bulk-create/include.test.js
+++ b/test/integration/model/bulk-create/include.test.js
@@ -7,7 +7,7 @@ const Support = require('../../support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/bulk-create/include.test.js
+++ b/test/integration/model/bulk-create/include.test.js
@@ -7,6 +7,10 @@ const Support = require('../../support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('bulkCreate', () => {
     describe('include', () => {
       it('should bulkCreate data for BelongsTo relations', async function () {

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('count', () => {
     beforeEach(async function () {
       this.User = this.sequelize.define('User', {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -16,7 +16,7 @@ const current = Support.sequelize;
 const pTimeout = require('p-timeout');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -16,6 +16,10 @@ const current = Support.sequelize;
 const pTimeout = require('p-timeout');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     const sequelize = await Support.prepareTransactionTest(this.sequelize);
     this.sequelize = sequelize;

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -7,7 +7,7 @@ const Support = require('../../support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/create/include.test.js
+++ b/test/integration/model/create/include.test.js
@@ -7,6 +7,10 @@ const Support = require('../../support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('create', () => {
     describe('include', () => {
       it('should create data for BelongsTo relations', async function () {

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -16,6 +16,10 @@ const current = Support.sequelize;
 const promiseProps = require('p-props');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: DataTypes.STRING,

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -16,7 +16,7 @@ const current = Support.sequelize;
 const promiseProps = require('p-props');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/findAll/group.test.js
+++ b/test/integration/model/findAll/group.test.js
@@ -10,6 +10,10 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('findAll', () => {
     describe('group', () => {
       it('should correctly group with attributes, #3009', async () => {

--- a/test/integration/model/findAll/group.test.js
+++ b/test/integration/model/findAll/group.test.js
@@ -10,7 +10,7 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -13,7 +13,7 @@ const _ = require('lodash');
 
 if (current.dialect.supports['UNION ALL']) {
   describe(Support.getTestDialectTeaser('Model'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -13,6 +13,10 @@ const _ = require('lodash');
 
 if (current.dialect.supports['UNION ALL']) {
   describe(Support.getTestDialectTeaser('Model'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('findAll', () => {
       describe('groupedLimit', () => {
         before(function () {

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('findAll', () => {
     describe('order', () => {
       describe('Sequelize.literal()', () => {

--- a/test/integration/model/findAll/order.test.js
+++ b/test/integration/model/findAll/order.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/findAll/separate.test.js
+++ b/test/integration/model/findAll/separate.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('findAll', () => {
     describe('separate with limit', () => {
       it('should not throw syntax error (union)', async () => {

--- a/test/integration/model/findAll/separate.test.js
+++ b/test/integration/model/findAll/separate.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -12,6 +12,10 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: DataTypes.STRING,

--- a/test/integration/model/findOne.test.js
+++ b/test/integration/model/findOne.test.js
@@ -12,7 +12,7 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/findOrBuild.test.js
+++ b/test/integration/model/findOrBuild.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/findOrBuild.test.js
+++ b/test/integration/model/findOrBuild.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.User = this.sequelize.define('User', {
       username: DataTypes.STRING,

--- a/test/integration/model/geography.test.js
+++ b/test/integration/model/geography.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   if (current.dialect.supports.GEOGRAPHY) {
     describe('GEOGRAPHY', () => {
       beforeEach(async function () {

--- a/test/integration/model/geography.test.js
+++ b/test/integration/model/geography.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/geometry.test.js
+++ b/test/integration/model/geometry.test.js
@@ -12,7 +12,7 @@ const semver = require('semver');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/geometry.test.js
+++ b/test/integration/model/geometry.test.js
@@ -12,6 +12,10 @@ const semver = require('semver');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   if (current.dialect.supports.GEOMETRY) {
     describe('GEOMETRY', () => {
       beforeEach(async function () {

--- a/test/integration/model/increment.test.js
+++ b/test/integration/model/increment.test.js
@@ -8,7 +8,7 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/increment.test.js
+++ b/test/integration/model/increment.test.js
@@ -8,6 +8,10 @@ const { DataTypes } = require('@sequelize/core');
 const sinon = require('sinon');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -10,7 +10,7 @@ const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/json.test.js
+++ b/test/integration/model/json.test.js
@@ -10,6 +10,10 @@ const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   if (current.dialect.supports.JSON) {
     describe('JSON', () => {
       beforeEach(async function () {

--- a/test/integration/model/notExist.test.js
+++ b/test/integration/model/notExist.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/notExist.test.js
+++ b/test/integration/model/notExist.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.Order = this.sequelize.define('Order', {
       id: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },

--- a/test/integration/model/optimistic_locking.test.js
+++ b/test/integration/model/optimistic_locking.test.js
@@ -7,7 +7,7 @@ const chai = require('chai');
 const expect = chai.expect;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/optimistic_locking.test.js
+++ b/test/integration/model/optimistic_locking.test.js
@@ -7,6 +7,10 @@ const chai = require('chai');
 const expect = chai.expect;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('optimistic locking', () => {
     let Account;
     beforeEach(async function () {

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -10,7 +10,7 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/paranoid.test.js
+++ b/test/integration/model/paranoid.test.js
@@ -10,6 +10,10 @@ const sinon = require('sinon');
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('paranoid', () => {
     before(function () {
       this.clock = sinon.useFakeTimers();

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -16,7 +16,7 @@ const SCHEMA_TWO = 'schema_two';
 let locationId;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -16,6 +16,10 @@ const SCHEMA_TWO = 'schema_two';
 let locationId;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   if (current.dialect.supports.schemas) {
 
     describe('global schema', () => {

--- a/test/integration/model/scope.test.js
+++ b/test/integration/model/scope.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope.test.js
+++ b/test/integration/model/scope.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     beforeEach(async function () {
       this.ScopeMe = this.sequelize.define('ScopeMe', {

--- a/test/integration/model/scope/aggregate.test.js
+++ b/test/integration/model/scope/aggregate.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/aggregate.test.js
+++ b/test/integration/model/scope/aggregate.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     describe('aggregate', () => {
       beforeEach(async function () {

--- a/test/integration/model/scope/associations.test.js
+++ b/test/integration/model/scope/associations.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     describe('associations', () => {
       beforeEach(async function () {

--- a/test/integration/model/scope/associations.test.js
+++ b/test/integration/model/scope/associations.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/count.test.js
+++ b/test/integration/model/scope/count.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/count.test.js
+++ b/test/integration/model/scope/count.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     describe('count', () => {
       beforeEach(async function () {

--- a/test/integration/model/scope/destroy.test.js
+++ b/test/integration/model/scope/destroy.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     describe('destroy', () => {
       beforeEach(async function () {

--- a/test/integration/model/scope/destroy.test.js
+++ b/test/integration/model/scope/destroy.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scopes', () => {
     beforeEach(async function () {
       this.ScopeMe = this.sequelize.define('ScopeMe', {

--- a/test/integration/model/scope/findAndCountAll.test.js
+++ b/test/integration/model/scope/findAndCountAll.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/findAndCountAll.test.js
+++ b/test/integration/model/scope/findAndCountAll.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
 
     describe('findAndCountAll', () => {

--- a/test/integration/model/scope/merge.test.js
+++ b/test/integration/model/scope/merge.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/merge.test.js
+++ b/test/integration/model/scope/merge.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     describe('simple merge', () => {
       beforeEach(async function () {

--- a/test/integration/model/scope/update.test.js
+++ b/test/integration/model/scope/update.test.js
@@ -7,7 +7,7 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/scope/update.test.js
+++ b/test/integration/model/scope/update.test.js
@@ -7,6 +7,10 @@ const expect = chai.expect;
 const Support = require('../../support');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('scope', () => {
     describe('update', () => {
       beforeEach(async function () {

--- a/test/integration/model/searchPath.test.js
+++ b/test/integration/model/searchPath.test.js
@@ -18,7 +18,7 @@ const current = Support.createSequelizeInstance({
 let locationId;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/searchPath.test.js
+++ b/test/integration/model/searchPath.test.js
@@ -18,6 +18,10 @@ const current = Support.createSequelizeInstance({
 let locationId;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   if (current.dialect.supports.searchPath) {
     describe('SEARCH PATH', () => {
       before(function () {

--- a/test/integration/model/sum.test.js
+++ b/test/integration/model/sum.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/sum.test.js
+++ b/test/integration/model/sum.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.Payment = this.sequelize.define('Payment', {
       amount: DataTypes.DECIMAL,

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -2,11 +2,15 @@
 
 const { expect } = require('chai');
 const { DataTypes, Deferrable, Model } = require('@sequelize/core');
-const { sequelize, getTestDialect, getTestDialectTeaser } = require('../support');
+const { clearDatabase, sequelize, getTestDialect, getTestDialectTeaser } = require('../support');
 
 const dialect = getTestDialect();
 
 describe(getTestDialectTeaser('Model.sync & Sequelize#sync'), () => {
+  beforeEach(async () => {
+    await clearDatabase(sequelize);
+  });
+
   it('removes a column if it exists in the databases schema but not the model', async () => {
     const User = sequelize.define('testSync', {
       name: DataTypes.STRING,

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -7,7 +7,7 @@ const { clearDatabase, sequelize, getTestDialect, getTestDialectTeaser } = requi
 const dialect = getTestDialect();
 
 describe(getTestDialectTeaser('Model.sync & Sequelize#sync'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await clearDatabase(sequelize);
   });
 

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -10,7 +10,7 @@ const current = Support.sequelize;
 const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -10,6 +10,10 @@ const current = Support.sequelize;
 const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('update', () => {
     beforeEach(async function () {
       this.Account = this.sequelize.define('Account', {

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -11,7 +11,7 @@ const dialect = Support.getTestDialect();
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -11,6 +11,10 @@ const dialect = Support.getTestDialect();
 const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   before(function () {
     this.clock = sinon.useFakeTimers();
   });

--- a/test/integration/operators.test.js
+++ b/test/integration/operators.test.js
@@ -9,6 +9,10 @@ const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Operators'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('REGEXP', () => {
     beforeEach(async function () {
       this.User = this.sequelize.define('user', {

--- a/test/integration/operators.test.js
+++ b/test/integration/operators.test.js
@@ -9,7 +9,7 @@ const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Operators'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/pool.test.ts
+++ b/test/integration/pool.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import delay from 'delay';
 import type { SinonSandbox } from 'sinon';
 import sinon from 'sinon';
-import { clearDatabase, sequelize, createSequelizeInstance, getTestDialect, getTestDialectTeaser } from './support';
+import { createSequelizeInstance, getTestDialect, getTestDialectTeaser } from './support';
 
 const dialect = getTestDialect();
 
@@ -91,10 +91,6 @@ afterEach(() => {
 });
 
 describe(getTestDialectTeaser('Pooling'), () => {
-  beforeEach(async () => {
-    await clearDatabase(sequelize);
-  });
-
   if (dialect === 'sqlite' || process.env.DIALECT === 'postgres-native') {
     return;
   }
@@ -108,7 +104,7 @@ describe(getTestDialectTeaser('Pooling'), () => {
         }
 
         if (dialect === 'db2') {
-          await sequelizeInstance.connectionManager.pool.destroy(connection);
+          await sequelize.connectionManager.pool.destroy(connection);
         } else {
           const error: NodeJS.ErrnoException = new Error('Test ECONNRESET Error');
           error.code = 'ECONNRESET';
@@ -117,11 +113,11 @@ describe(getTestDialectTeaser('Pooling'), () => {
         }
       }
 
-      const sequelizeInstance = createSequelizeInstance({
+      const sequelize = createSequelizeInstance({
         pool: { max: 1, idle: 5000 },
       });
-      const cm = sequelizeInstance.connectionManager;
-      await sequelizeInstance.sync();
+      const cm = sequelize.connectionManager;
+      await sequelize.sync();
 
       const firstConnection = await cm.getConnection();
       await simulateUnexpectedError(firstConnection);
@@ -168,11 +164,11 @@ describe(getTestDialectTeaser('Pooling'), () => {
         }
       }
 
-      const sequelizeInstance = createSequelizeInstance({
+      const sequelize = createSequelizeInstance({
         pool: { max: 1, idle: 5000 },
       });
-      const cm = sequelizeInstance.connectionManager;
-      await sequelizeInstance.sync();
+      const cm = sequelize.connectionManager;
+      await sequelize.sync();
 
       const oldConnection = await cm.getConnection();
       await cm.releaseConnection(oldConnection);
@@ -189,11 +185,11 @@ describe(getTestDialectTeaser('Pooling'), () => {
 
   describe('idle', () => {
     it('should maintain connection within idle range', async () => {
-      const sequelizeInstance = createSequelizeInstance({
+      const sequelize = createSequelizeInstance({
         pool: { max: 1, idle: 100 },
       });
-      const cm = sequelizeInstance.connectionManager;
-      await sequelizeInstance.sync();
+      const cm = sequelize.connectionManager;
+      await sequelize.sync();
 
       const firstConnection = await cm.getConnection();
 
@@ -214,11 +210,11 @@ describe(getTestDialectTeaser('Pooling'), () => {
     });
 
     it('[MSSQL Flaky] should get new connection beyond idle range', async () => {
-      const sequelizeInstance = createSequelizeInstance({
+      const sequelize = createSequelizeInstance({
         pool: { max: 1, idle: 100, evict: 10 },
       });
-      const cm = sequelizeInstance.connectionManager;
-      await sequelizeInstance.sync();
+      const cm = sequelize.connectionManager;
+      await sequelize.sync();
 
       const firstConnection = await cm.getConnection();
 

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -11,7 +11,7 @@ const current = Support.sequelize;
 const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -11,6 +11,10 @@ const current = Support.sequelize;
 const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/query-interface/describeTable.test.js
+++ b/test/integration/query-interface/describeTable.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/query-interface/describeTable.test.js
+++ b/test/integration/query-interface/describeTable.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/query-interface/dropEnum.test.js
+++ b/test/integration/query-interface/dropEnum.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/query-interface/dropEnum.test.js
+++ b/test/integration/query-interface/dropEnum.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/query-interface/getForeignKeyReferencesForTable.test.js
+++ b/test/integration/query-interface/getForeignKeyReferencesForTable.test.js
@@ -7,6 +7,10 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/query-interface/getForeignKeyReferencesForTable.test.js
+++ b/test/integration/query-interface/getForeignKeyReferencesForTable.test.js
@@ -7,7 +7,7 @@ const Support = require('../support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/query-interface/removeColumn.test.js
+++ b/test/integration/query-interface/removeColumn.test.js
@@ -9,6 +9,10 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(function () {
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();

--- a/test/integration/query-interface/removeColumn.test.js
+++ b/test/integration/query-interface/removeColumn.test.js
@@ -9,7 +9,7 @@ const { DataTypes } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/replication.test.ts
+++ b/test/integration/replication.test.ts
@@ -2,8 +2,6 @@ import { DataTypes } from '@sequelize/core';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import {
-  clearDatabase,
-  sequelize,
   beforeEach2,
   getConnectionOptionsWithoutPool,
   getSequelizeInstance,
@@ -13,10 +11,6 @@ import {
 
 const dialect = getTestDialect();
 describe(getTestDialectTeaser('Replication'), () => {
-  beforeEach(async () => {
-    await clearDatabase(sequelize);
-  });
-
   if (['sqlite', 'ibmi'].includes(dialect)) {
     return;
   }
@@ -24,17 +18,17 @@ describe(getTestDialectTeaser('Replication'), () => {
   describe('connection objects', () => {
     const deps = beforeEach2(async () => {
       const sandbox = sinon.createSandbox();
-      const sequelizeInstance = getSequelizeInstance('', '', '', {
+      const sequelize = getSequelizeInstance('', '', '', {
         replication: {
           write: getConnectionOptionsWithoutPool(),
           read: [getConnectionOptionsWithoutPool()],
         },
       });
 
-      expect(sequelizeInstance.connectionManager.pool.write).to.be.ok;
-      expect(sequelizeInstance.connectionManager.pool.read).to.be.ok;
+      expect(sequelize.connectionManager.pool.write).to.be.ok;
+      expect(sequelize.connectionManager.pool.read).to.be.ok;
 
-      const User = sequelizeInstance.define('User', {
+      const User = sequelize.define('User', {
         firstName: {
           type: DataTypes.STRING,
           field: 'first_name',
@@ -42,12 +36,12 @@ describe(getTestDialectTeaser('Replication'), () => {
       });
 
       await User.sync({ force: true });
-      const readSpy = sandbox.spy(sequelizeInstance.connectionManager.pool.read!, 'acquire');
-      const writeSpy = sandbox.spy(sequelizeInstance.connectionManager.pool.write, 'acquire');
+      const readSpy = sandbox.spy(sequelize.connectionManager.pool.read!, 'acquire');
+      const writeSpy = sandbox.spy(sequelize.connectionManager.pool.write, 'acquire');
 
       return {
         User,
-        sequelizeInstance,
+        sequelize,
         sandbox,
         readSpy,
         writeSpy,
@@ -82,7 +76,7 @@ describe(getTestDialectTeaser('Replication'), () => {
     });
 
     it('should run read-only transactions on the replica', async () => {
-      await deps.sequelizeInstance.transaction({ readOnly: true }, async transaction => {
+      await deps.sequelize.transaction({ readOnly: true }, async transaction => {
         return deps.User.findAll({ transaction });
       });
 
@@ -90,7 +84,7 @@ describe(getTestDialectTeaser('Replication'), () => {
     });
 
     it('should run non-read-only transactions on the primary', async () => {
-      await deps.sequelizeInstance.transaction(async transaction => {
+      await deps.sequelize.transaction(async transaction => {
         return deps.User.findAll({ transaction });
       });
 

--- a/test/integration/schema.test.js
+++ b/test/integration/schema.test.js
@@ -7,7 +7,7 @@ const Support = require('./support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Schema'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/schema.test.js
+++ b/test/integration/schema.test.js
@@ -7,6 +7,10 @@ const Support = require('./support');
 const { DataTypes } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Schema'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   beforeEach(async function () {
     await this.sequelize.createSchema('testschema');
   });

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -24,7 +24,7 @@ const qq = str => {
 };
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -24,6 +24,10 @@ const qq = str => {
 };
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('constructor', () => {
     it('should pass the global options correctly', () => {
       const sequelize = Support.createSequelizeInstance({ logging: false, define: { underscored: true } });

--- a/test/integration/sequelize.transaction.test.ts
+++ b/test/integration/sequelize.transaction.test.ts
@@ -9,7 +9,7 @@ import { clearDatabase, sequelize, getTestDialectTeaser, getTestDialect, prepare
 const dialectName = sequelize.dialect.name;
 
 describe(getTestDialectTeaser('Sequelize#transaction'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await clearDatabase(sequelize);
   });
 

--- a/test/integration/sequelize.transaction.test.ts
+++ b/test/integration/sequelize.transaction.test.ts
@@ -4,11 +4,15 @@ import { expect } from 'chai';
 import delay from 'delay';
 import type { SinonStub } from 'sinon';
 import sinon from 'sinon';
-import { sequelize, getTestDialectTeaser, getTestDialect, prepareTransactionTest } from './support';
+import { clearDatabase, sequelize, getTestDialectTeaser, getTestDialect, prepareTransactionTest } from './support';
 
 const dialectName = sequelize.dialect.name;
 
 describe(getTestDialectTeaser('Sequelize#transaction'), () => {
+  beforeEach(async () => {
+    await clearDatabase(sequelize);
+  });
+
   if (!sequelize.dialect.supports.transactions) {
     return;
   }

--- a/test/integration/sequelize/deferrable.test.js
+++ b/test/integration/sequelize/deferrable.test.js
@@ -8,6 +8,10 @@ const { Sequelize, DataTypes } = require('@sequelize/core');
 
 if (Support.sequelize.dialect.supports.deferrableConstraints) {
   describe(Support.getTestDialectTeaser('Sequelize'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('Deferrable', () => {
       const describeDeferrableTest = (title, defineModels) => {
         describe(title, () => {

--- a/test/integration/sequelize/deferrable.test.js
+++ b/test/integration/sequelize/deferrable.test.js
@@ -8,7 +8,7 @@ const { Sequelize, DataTypes } = require('@sequelize/core');
 
 if (Support.sequelize.dialect.supports.deferrableConstraints) {
   describe(Support.getTestDialectTeaser('Sequelize'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/sequelize/drop.test.ts
+++ b/test/integration/sequelize/drop.test.ts
@@ -1,10 +1,14 @@
 import type { ReferentialAction } from '@sequelize/core';
 import { DataTypes, Deferrable } from '@sequelize/core';
-import { sequelize } from '../support';
+import { clearDatabase, sequelize } from '../support';
 
 const dialect = sequelize.getDialect();
 
 describe('Sequelize#drop', () => {
+  beforeEach(async () => {
+    await clearDatabase(sequelize);
+  });
+
   it('supports dropping cyclic associations', async () => {
     const A = sequelize.define('A', {
       BId: {

--- a/test/integration/sequelize/drop.test.ts
+++ b/test/integration/sequelize/drop.test.ts
@@ -5,7 +5,7 @@ import { clearDatabase, sequelize } from '../support';
 const dialect = sequelize.getDialect();
 
 describe('Sequelize#drop', () => {
-  beforeEach(async () => {
+  before(async () => {
     await clearDatabase(sequelize);
   });
 

--- a/test/integration/sequelize/log.test.js
+++ b/test/integration/sequelize/log.test.js
@@ -8,6 +8,10 @@ const { Sequelize } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('log', () => {
     beforeEach(function () {
       this.stub = stub(console, 'debug');

--- a/test/integration/sequelize/log.test.js
+++ b/test/integration/sequelize/log.test.js
@@ -8,7 +8,7 @@ const { Sequelize } = require('@sequelize/core');
 const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/sequelize/query.test.js
+++ b/test/integration/sequelize/query.test.js
@@ -23,6 +23,10 @@ const qq = str => {
 };
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('query', () => {
     afterEach(function () {
       this.sequelize.options.quoteIdentifiers = true;

--- a/test/integration/sequelize/query.test.js
+++ b/test/integration/sequelize/query.test.js
@@ -23,7 +23,7 @@ const qq = str => {
 };
 
 describe(Support.getTestDialectTeaser('Sequelize'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/sequelize/truncate.test.ts
+++ b/test/integration/sequelize/truncate.test.ts
@@ -14,7 +14,7 @@ interface IB extends Model<InferAttributes<IB>, InferCreationAttributes<IB>> {
 }
 
 describe('Sequelize#truncate', () => {
-  beforeEach(async () => {
+  before(async () => {
     await clearDatabase(sequelize);
   });
 

--- a/test/integration/sequelize/truncate.test.ts
+++ b/test/integration/sequelize/truncate.test.ts
@@ -1,7 +1,7 @@
 import type { CreationOptional, InferAttributes, InferCreationAttributes, Model } from '@sequelize/core';
 import { DataTypes, Deferrable } from '@sequelize/core';
 import { expect } from 'chai';
-import { sequelize } from '../support';
+import { clearDatabase, sequelize } from '../support';
 
 interface IA extends Model<InferAttributes<IA>, InferCreationAttributes<IA>> {
   id: CreationOptional<number>;
@@ -14,6 +14,10 @@ interface IB extends Model<InferAttributes<IB>, InferCreationAttributes<IB>> {
 }
 
 describe('Sequelize#truncate', () => {
+  beforeEach(async () => {
+    await clearDatabase(sequelize);
+  });
+
   // These dialects do not support the CASCADE option on TRUNCATE, so it's impossible to clear
   //  tables that reference each-other.
   if (!['mysql', 'mariadb', 'mssql', 'db2'].includes(sequelize.dialect.name)) {

--- a/test/integration/support.ts
+++ b/test/integration/support.ts
@@ -46,10 +46,6 @@ before(async () => {
   });
 });
 
-beforeEach(async () => {
-  await Support.clearDatabase(Support.sequelize);
-});
-
 afterEach(async function checkRunningQueries() {
   // Note: recall that throwing an error from a `beforeEach` or `afterEach` hook in Mocha causes the entire test suite to abort.
 

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -11,6 +11,10 @@ if (dialect !== 'sqlite' && dialect !== 'ibmi') {
   // Sqlite does not support setting timezone
 
   describe(Support.getTestDialectTeaser('Timezone'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(function () {
       this.sequelizeWithTimezone = Support.createSequelizeInstance({
         timezone: '+07:00',

--- a/test/integration/timezone.test.js
+++ b/test/integration/timezone.test.js
@@ -11,7 +11,7 @@ if (dialect !== 'sqlite' && dialect !== 'ibmi') {
   // Sqlite does not support setting timezone
 
   describe(Support.getTestDialectTeaser('Timezone'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -16,6 +16,10 @@ const pSettle = require('p-settle');
 if (current.dialect.supports.transactions) {
 
   describe(Support.getTestDialectTeaser('Transaction'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     beforeEach(function () {
       this.sinon = sinon.createSandbox();
     });

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -16,7 +16,7 @@ const pSettle = require('p-settle');
 if (current.dialect.supports.transactions) {
 
   describe(Support.getTestDialectTeaser('Transaction'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/trigger.test.js
+++ b/test/integration/trigger.test.js
@@ -11,6 +11,10 @@ const current = Support.sequelize;
 
 if (current.dialect.supports.tmpTableTrigger) {
   describe(Support.getTestDialectTeaser('Model'), () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     describe('trigger', () => {
       let User;
       let triggerQuery = 'create trigger User_ChangeTracking on [users] for insert,update, delete \n'

--- a/test/integration/trigger.test.js
+++ b/test/integration/trigger.test.js
@@ -11,7 +11,7 @@ const current = Support.sequelize;
 
 if (current.dialect.supports.tmpTableTrigger) {
   describe(Support.getTestDialectTeaser('Model'), () => {
-    beforeEach(async () => {
+    before(async () => {
       await Support.clearDatabase(Support.sequelize);
     });
 

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -7,6 +7,10 @@ const Support = require('./support');
 const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Utils'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   describe('Sequelize.fn', () => {
     let Airplane;
 

--- a/test/integration/utils.test.js
+++ b/test/integration/utils.test.js
@@ -7,7 +7,7 @@ const Support = require('./support');
 const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
 describe(Support.getTestDialectTeaser('Utils'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 

--- a/test/integration/vectors.test.js
+++ b/test/integration/vectors.test.js
@@ -9,6 +9,10 @@ const Support = require('./support');
 chai.should();
 
 describe(Support.getTestDialectTeaser('Vectors'), () => {
+  beforeEach(async () => {
+    await Support.clearDatabase(Support.sequelize);
+  });
+
   it('should not allow insert backslash', async function () {
     const Student = this.sequelize.define('student', {
       name: DataTypes.STRING,

--- a/test/integration/vectors.test.js
+++ b/test/integration/vectors.test.js
@@ -9,7 +9,7 @@ const Support = require('./support');
 chai.should();
 
 describe(Support.getTestDialectTeaser('Vectors'), () => {
-  beforeEach(async () => {
+  before(async () => {
     await Support.clearDatabase(Support.sequelize);
   });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This PR improves the performance of our test suite. Initially it moves the global `beforeEach` to every test suite (as per [a comment](https://github.com/sequelize/sequelize/pull/14345#issuecomment-1133188810) of @ephys ) and replaced by a `before` so it only runs once per file.

The smoke test file seems to be outdated so is not part of this PR. The snowflake specific tests are also out of scope for further improvement since we cannot test on those.

Relates to #14562

### Todos

- [ ] Further limit the number of times the database will be cleared by doing it once and then only when necessary