### PR TITLE
meta: limit database clearing

### DIFF
--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -19,6 +19,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
   describe('getAssociations', () => {
     beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.User = this.sequelize.define('User', { username: DataTypes.STRING });
       this.Task = this.sequelize.define('Task', { title: DataTypes.STRING, active: DataTypes.BOOLEAN });
 
@@ -2274,7 +2276,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   }); // end optimization using bulk create, destroy and update
 
   describe('join table creation', () => {
-    beforeEach(function () {
+    beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.User = this.sequelize.define('User',
         { username: DataTypes.STRING },
         { tableName: 'users' });
@@ -2412,7 +2416,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   });
 
   describe('foreign key with fields specified', () => {
-    beforeEach(function () {
+    beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.User = this.sequelize.define('User', { name: DataTypes.STRING });
       this.Project = this.sequelize.define('Project', { name: DataTypes.STRING });
       this.Puppy = this.sequelize.define('Puppy', { breed: DataTypes.STRING });
@@ -2625,6 +2631,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
     describe('without sync', () => {
       beforeEach(async function () {
+        await Support.clearDatabase(Support.sequelize);
+
         await this.sequelize.queryInterface.createTable('users', {
           id: {
             type: DataTypes.INTEGER,
@@ -2670,6 +2678,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   describe('through', () => {
     describe('paranoid', () => {
       beforeEach(async function () {
+        await Support.clearDatabase(Support.sequelize);
+
         this.User = this.sequelize.define('User', {});
         this.Project = this.sequelize.define('Project', {});
         this.UserProjects = this.sequelize.define('UserProjects', {}, {
@@ -2747,7 +2757,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     describe('fetching from join table', () => {
-      beforeEach(function () {
+      beforeEach(async function () {
+        await Support.clearDatabase(Support.sequelize);
+
         this.User = this.sequelize.define('User', {});
         this.Project = this.sequelize.define('Project', {});
         this.UserProjects = this.sequelize.define('UserProjects', {
@@ -2821,7 +2833,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
     });
 
     describe('inserting in join table', () => {
-      beforeEach(function () {
+      beforeEach(async function () {
+        await Support.clearDatabase(Support.sequelize);
+
         this.User = this.sequelize.define('User', {});
         this.Project = this.sequelize.define('Project', {});
         this.UserProjects = this.sequelize.define('UserProjects', {
@@ -3077,6 +3091,10 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   });
 
   describe('alias', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('creates the join table when through is a string', async function () {
       const User = this.sequelize.define('User', {});
       const Group = this.sequelize.define('Group', {});
@@ -3138,7 +3156,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   });
 
   describe('multiple hasMany', () => {
-    beforeEach(function () {
+    beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.User = this.sequelize.define('user', { name: DataTypes.STRING });
       this.Project = this.sequelize.define('project', { projectName: DataTypes.STRING });
     });
@@ -3169,7 +3189,9 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   });
 
   describe('Foreign key constraints', () => {
-    beforeEach(function () {
+    beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.Task = this.sequelize.define('task', { title: DataTypes.STRING });
       this.User = this.sequelize.define('user', { username: DataTypes.STRING });
       this.UserTasks = this.sequelize.define('tasksusers', { userId: DataTypes.INTEGER, taskId: DataTypes.INTEGER });
@@ -3387,6 +3409,10 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
   });
 
   describe('thisAssociations', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('should work with this reference', async function () {
       const User = this.sequelize.define('User', {
         name: DataTypes.STRING(100),

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -327,6 +327,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
   });
 
   describe('createAssociation', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('creates an associated model instance', async function () {
       const User = this.sequelize.define('User', { username: DataTypes.STRING });
       const Task = this.sequelize.define('Task', { title: DataTypes.STRING });
@@ -522,6 +526,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
   });
 
   describe('foreign key constraints', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('are enabled by default', async function () {
       const Task = this.sequelize.define('Task', { title: DataTypes.STRING });
       const User = this.sequelize.define('User', { username: DataTypes.STRING });
@@ -639,6 +647,10 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
   });
 
   describe('association column', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('has correct type and name for non-id primary keys with non-integer type', async function () {
       const User = this.sequelize.define('UserPKBT', {
         username: {

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -1542,7 +1542,9 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
   });
 
   describe('sourceKey with where clause in include', () => {
-    beforeEach(function () {
+    beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.User = this.sequelize.define('User',
         { username: DataTypes.STRING, email: { type: DataTypes.STRING, field: 'mail', allowNull: false } },
         { indexes: [{ fields: ['mail'], unique: true }] });

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -12,6 +12,10 @@ const dialect = Support.getTestDialect();
 describe(Support.getTestDialectTeaser('HasOne'), () => {
   describe('get', () => {
     describe('multiple', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('should fetch associations for multiple instances', async function () {
         const User = this.sequelize.define('User', {});
         const Player = this.sequelize.define('Player', {});
@@ -368,6 +372,10 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
   });
 
   describe('foreign key constraints', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('are enabled by default', async function () {
       const Task = this.sequelize.define('Task', { title: DataTypes.STRING });
       const User = this.sequelize.define('User', { username: DataTypes.STRING });

--- a/test/integration/dialects/postgres/associations.test.js
+++ b/test/integration/dialects/postgres/associations.test.js
@@ -24,7 +24,9 @@ if (dialect.startsWith('postgres')) {
       });
 
       describe('when join table name is specified', () => {
-        beforeEach(function () {
+        beforeEach(async function () {
+          await Support.clearDatabase(Support.sequelize);
+
           const Table2 = this.sequelize.define('ms_table1', { foo: DataTypes.STRING });
           const Table1 = this.sequelize.define('ms_table2', { foo: DataTypes.STRING });
 
@@ -79,6 +81,10 @@ if (dialect.startsWith('postgres')) {
       });
 
       describe('removeDAO', () => {
+        beforeEach(async () => {
+          await Support.clearDatabase(Support.sequelize);
+        });
+
         it('should correctly remove associated objects', async function () {
           const users = [];
           const tasks = [];

--- a/test/integration/dialects/postgres/dao.test.js
+++ b/test/integration/dialects/postgres/dao.test.js
@@ -236,6 +236,10 @@ if (dialect.startsWith('postgres')) {
     });
 
     describe('enums', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('should be able to create enums with escape values', async function () {
         const User = this.sequelize.define('UserEnums', {
           mood: DataTypes.ENUM('happy', 'sad', '1970\'s'),

--- a/test/integration/hooks/associations.test.js
+++ b/test/integration/hooks/associations.test.js
@@ -440,6 +440,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
     describe('M:M', () => {
       describe('cascade', () => {
         beforeEach(async function () {
+          await Support.clearDatabase(Support.sequelize);
+
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING,
           });
@@ -518,6 +520,8 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
       describe('no cascade', () => {
         beforeEach(async function () {
+          await Support.clearDatabase(Support.sequelize);
+
           this.Projects = this.sequelize.define('Project', {
             title: DataTypes.STRING,
           });

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -17,6 +17,10 @@ const sortById = function (a, b) {
 
 describe(Support.getTestDialectTeaser('Include'), () => {
   describe('find', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('supports a model+alias includeable', async function () {
       const Company = this.sequelize.define('Company', {});
       const User = this.sequelize.define('User', {});

--- a/test/integration/include/findAll.test.js
+++ b/test/integration/include/findAll.test.js
@@ -14,7 +14,9 @@ const sortById = function (a, b) {
 
 describe(Support.getTestDialectTeaser('Include'), () => {
   describe('findAll', () => {
-    beforeEach(function () {
+    beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.fixtureA = async function () {
         const User = this.sequelize.define('User', {});
         const Company = this.sequelize.define('Company', {

--- a/test/integration/include/findOne.test.js
+++ b/test/integration/include/findOne.test.js
@@ -9,6 +9,10 @@ const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
   describe('findOne', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('should include a non required model, with conditions and two includes N:M 1:M', async function () {
       const A = this.sequelize.define('A', { name: DataTypes.STRING(40) }, { paranoid: true });
       const B = this.sequelize.define('B', { name: DataTypes.STRING(40) }, { paranoid: true });

--- a/test/integration/include/limit.test.js
+++ b/test/integration/include/limit.test.js
@@ -32,7 +32,9 @@ describe(Support.getTestDialectTeaser('Include'), () => {
      *                            N
      *                        [Footnote]
      */
-    beforeEach(function () {
+    beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.Project = this.sequelize.define('Project', {
         name: {
           type: DataTypes.STRING,

--- a/test/integration/include/paranoid.test.js
+++ b/test/integration/include/paranoid.test.js
@@ -10,6 +10,8 @@ const { DataTypes } = require('@sequelize/core');
 describe(Support.getTestDialectTeaser('Paranoid'), () => {
 
   beforeEach(async function () {
+    await Support.clearDatabase(Support.sequelize);
+
     const S = this.sequelize;
     const DT = DataTypes;
 

--- a/test/integration/include/schema.test.js
+++ b/test/integration/include/schema.test.js
@@ -21,6 +21,8 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
     });
 
     beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.fixtureA = async function () {
         await this.sequelize.dropSchema('account');
         await this.sequelize.createSchema('account');

--- a/test/integration/instance/save.test.js
+++ b/test/integration/instance/save.test.js
@@ -403,6 +403,10 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     describe('without timestamps option', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('doesn\'t update the updatedAt column', async function () {
         const User2 = this.sequelize.define('User2', {
           username: DataTypes.STRING,
@@ -416,6 +420,10 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
     });
 
     describe('with custom timestamp options', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('updates the createdAt column if updatedAt is disabled', async function () {
         const now = new Date();
         this.clock.tick(1000);

--- a/test/integration/instance/values.test.js
+++ b/test/integration/instance/values.test.js
@@ -429,6 +429,10 @@ describe(Support.getTestDialectTeaser('DAO'), () => {
     });
 
     describe('changed', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('should return false if object was built from database', async function () {
         const User = this.sequelize.define('User', {
           name: { type: DataTypes.STRING },

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -28,6 +28,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   });
 
   beforeEach(async function () {
+    await Support.clearDatabase(Support.sequelize);
+
     isMySQL8 = dialect === 'mysql' && semver.satisfies(current.options.databaseVersion, '>=8.0.0');
 
     this.User = this.sequelize.define('User', {

--- a/test/integration/model/attributes/field.test.js
+++ b/test/integration/model/attributes/field.test.js
@@ -22,6 +22,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   describe('attributes', () => {
     describe('field', () => {
       beforeEach(async function () {
+        await Support.clearDatabase(Support.sequelize);
+
         const queryInterface = this.sequelize.getQueryInterface();
 
         this.User = this.sequelize.define('user', {

--- a/test/integration/model/attributes/types.test.js
+++ b/test/integration/model/attributes/types.test.js
@@ -13,6 +13,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     describe('types', () => {
       describe('VIRTUAL', () => {
         beforeEach(async function () {
+          await Support.clearDatabase(Support.sequelize);
+
           this.User = this.sequelize.define('user', {
             storage: DataTypes.STRING,
             field1: {

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -11,6 +11,8 @@ const current = Support.sequelize;
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   beforeEach(async function () {
+    await Support.clearDatabase(Support.sequelize);
+
     const sequelize = await Support.prepareTransactionTest(this.sequelize);
     this.sequelize = sequelize;
 

--- a/test/integration/model/bulk-create/include.test.js
+++ b/test/integration/model/bulk-create/include.test.js
@@ -9,6 +9,10 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('bulkCreate', () => {
     describe('include', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('should bulkCreate data for BelongsTo relations', async function () {
         const Product = this.sequelize.define('Product', {
           title: DataTypes.STRING,

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -17,6 +17,8 @@ const pTimeout = require('p-timeout');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   beforeEach(async function () {
+    await Support.clearDatabase(Support.sequelize);
+
     const sequelize = await Support.prepareTransactionTest(this.sequelize);
     this.sequelize = sequelize;
 

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -884,6 +884,8 @@ The following associations are defined on "Worker": "ToDos"`);
 
       describe('include all', () => {
         beforeEach(async function () {
+          await Support.clearDatabase(Support.sequelize);
+
           this.Continent = this.sequelize.define('continent', { name: DataTypes.STRING });
           this.Country = this.sequelize.define('country', { name: DataTypes.STRING });
           this.Industry = this.sequelize.define('industry', { name: DataTypes.STRING });

--- a/test/integration/model/findAll/groupedLimit.test.js
+++ b/test/integration/model/findAll/groupedLimit.test.js
@@ -28,6 +28,8 @@ if (current.dialect.supports['UNION ALL']) {
         });
 
         beforeEach(async function () {
+          await Support.clearDatabase(Support.sequelize);
+
           this.User = this.sequelize.define('user', {
             age: DataTypes.INTEGER,
           });

--- a/test/integration/model/scope/associations.test.js
+++ b/test/integration/model/scope/associations.test.js
@@ -10,6 +10,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
   describe('scope', () => {
     describe('associations', () => {
       beforeEach(async function () {
+        await Support.clearDatabase(Support.sequelize);
+
         const sequelize = this.sequelize;
 
         this.ScopeMe = this.sequelize.define('ScopeMe', {

--- a/test/integration/model/sync.test.js
+++ b/test/integration/model/sync.test.js
@@ -2,11 +2,15 @@
 
 const { expect } = require('chai');
 const { DataTypes, Deferrable, Model } = require('@sequelize/core');
-const { sequelize, getTestDialect, getTestDialectTeaser } = require('../support');
+const { clearDatabase, sequelize, getTestDialect, getTestDialectTeaser } = require('../support');
 
 const dialect = getTestDialect();
 
 describe(getTestDialectTeaser('Model.sync & Sequelize#sync'), () => {
+  beforeEach(async () => {
+    await clearDatabase(sequelize);
+  });
+
   it('removes a column if it exists in the databases schema but not the model', async () => {
     const User = sequelize.define('testSync', {
       name: DataTypes.STRING,

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -19,7 +19,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
     this.clock.restore();
   });
 
-  beforeEach(function () {
+  beforeEach(async function () {
+    await Support.clearDatabase(Support.sequelize);
     this.clock.reset();
   });
 

--- a/test/integration/operators.test.js
+++ b/test/integration/operators.test.js
@@ -11,6 +11,8 @@ const dialect = Support.getTestDialect();
 describe(Support.getTestDialectTeaser('Operators'), () => {
   describe('REGEXP', () => {
     beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.User = this.sequelize.define('user', {
         id: {
           type: DataTypes.INTEGER,

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -38,6 +38,10 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   });
 
   describe('showAllTables', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('should not contain views', async function () {
       async function cleanup(sequelize) {
         if (dialect === 'db2') {
@@ -517,6 +521,8 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
 
   describe('constraints', () => {
     beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       this.User = this.sequelize.define('users', {
         // Db2 does not allow unique constraint for a nullable column, Db2
         // throws SQL0542N error if we create constraint on nullable column.

--- a/test/integration/query-interface/changeColumn.test.js
+++ b/test/integration/query-interface/changeColumn.test.js
@@ -10,6 +10,8 @@ const dialect = Support.getTestDialect();
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   beforeEach(async function () {
+    await Support.clearDatabase(Support.sequelize);
+
     this.sequelize.options.quoteIdenifiers = true;
     this.queryInterface = this.sequelize.getQueryInterface();
     await Support.dropTestSchemas(this.sequelize);

--- a/test/integration/query-interface/createTable.test.js
+++ b/test/integration/query-interface/createTable.test.js
@@ -98,6 +98,10 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     });
 
     describe('enums', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('should work with enums (1)', async function () {
         await this.queryInterface.createTable('SomeTable', {
           someEnum: DataTypes.ENUM('value1', 'value2', 'value3'),

--- a/test/integration/query-interface/dropEnum.test.js
+++ b/test/integration/query-interface/dropEnum.test.js
@@ -20,6 +20,8 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
 
   describe('dropEnum', () => {
     beforeEach(async function () {
+      await Support.clearDatabase(Support.sequelize);
+
       await this.queryInterface.createTable('menus',  {
         structuretype: DataTypes.ENUM('menus', 'submenu', 'routine'),
         sequence: DataTypes.INTEGER,

--- a/test/integration/query-interface/removeColumn.test.js
+++ b/test/integration/query-interface/removeColumn.test.js
@@ -21,6 +21,8 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   describe('removeColumn', () => {
     describe('(without a schema)', () => {
       beforeEach(async function () {
+        await Support.clearDatabase(Support.sequelize);
+
         await this.queryInterface.createTable('users', {
           id: {
             type: DataTypes.INTEGER,

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -205,6 +205,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   });
 
   describe('isDefined', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('returns false if the dao wasn\'t defined before', function () {
       expect(this.sequelize.isDefined('Project')).to.be.false;
     });
@@ -218,6 +222,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   });
 
   describe('model', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('throws an error if the dao being accessed is undefined', function () {
       expect(() => {
         this.sequelize.model('Project');
@@ -375,6 +383,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   });
 
   describe('truncate', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('truncates all models', async function () {
       const Project = this.sequelize.define(`project${Support.rand()}`, {
         id: {
@@ -398,6 +410,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   });
 
   describe('sync', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('synchronizes all models', async function () {
       const Project = this.sequelize.define(`project${Support.rand()}`, { title: DataTypes.STRING });
       const Task = this.sequelize.define(`task${Support.rand()}`, { title: DataTypes.STRING });
@@ -773,6 +789,8 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
 
         describe('supports rolling back to savepoints', () => {
           beforeEach(async function () {
+            await Support.clearDatabase(Support.sequelize);
+
             this.User = this.sequelizeWithTransaction.define('user', {});
             await this.sequelizeWithTransaction.sync({ force: true });
           });
@@ -865,6 +883,10 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
   });
 
   describe('paranoid deletedAt non-null default value', () => {
+    beforeEach(async () => {
+      await Support.clearDatabase(Support.sequelize);
+    });
+
     it('should use defaultValue of deletedAt in paranoid clause and restore', async function () {
       const epochObj = new Date(0);
       const epoch = Number(epochObj);

--- a/test/integration/sequelize.transaction.test.ts
+++ b/test/integration/sequelize.transaction.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import delay from 'delay';
 import type { SinonStub } from 'sinon';
 import sinon from 'sinon';
-import { sequelize, getTestDialectTeaser, getTestDialect, prepareTransactionTest } from './support';
+import { clearDatabase, sequelize, getTestDialectTeaser, getTestDialect, prepareTransactionTest } from './support';
 
 const dialectName = sequelize.dialect.name;
 
@@ -14,6 +14,10 @@ describe(getTestDialectTeaser('Sequelize#transaction'), () => {
   }
 
   let stubs: SinonStub[] = [];
+
+  beforeEach(async () => {
+    await clearDatabase(sequelize);
+  });
 
   afterEach(() => {
     for (const stub of stubs) {

--- a/test/integration/support.ts
+++ b/test/integration/support.ts
@@ -15,6 +15,8 @@ const CLEANUP_TIMEOUT = Number.parseInt(process.env.SEQ_TEST_CLEANUP_TIMEOUT ?? 
 let runningQueries = new Set<AbstractQuery>();
 
 before(async () => {
+  await Support.clearDatabase(Support.sequelize);
+
   if (Support.getTestDialect() === 'db2') {
     const res = await Support.sequelize.query<{ TBSPACE: string }>(`SELECT TBSPACE FROM SYSCAT.TABLESPACES WHERE TBSPACE = 'SYSTOOLSPACE'`, {
       type: QueryTypes.SELECT,
@@ -46,13 +48,7 @@ before(async () => {
   });
 });
 
-beforeEach(async () => {
-  await Support.clearDatabase(Support.sequelize);
-});
-
-afterEach(async function checkRunningQueries() {
-  // Note: recall that throwing an error from a `beforeEach` or `afterEach` hook in Mocha causes the entire test suite to abort.
-
+after(async function checkRunningQueries() {
   let runningQueriesProblem;
 
   if (runningQueries.size > 0) {

--- a/test/integration/transaction.test.js
+++ b/test/integration/transaction.test.js
@@ -751,6 +751,10 @@ if (current.dialect.supports.transactions) {
     }
 
     describe('isolation levels', () => {
+      beforeEach(async () => {
+        await Support.clearDatabase(Support.sequelize);
+      });
+
       it('should read the most recent committed rows when using the READ COMMITTED isolation level', async function () {
         const User = this.sequelize.define('user', {
           username: DataTypes.STRING,
@@ -829,6 +833,10 @@ if (current.dialect.supports.transactions) {
 
     if (current.dialect.supports.lock) {
       describe('row locking', () => {
+        beforeEach(async () => {
+          await Support.clearDatabase(Support.sequelize);
+        });
+
         it('supports for update', async function () {
           const User = this.sequelize.define('user', {
             username: DataTypes.STRING,


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

This PR improves the performance of our test suite. Initially it moves the global `beforeEach` to every test suite (as per [a comment](https://github.com/sequelize/sequelize/pull/14345#issuecomment-1133188810) of @ephys ) and replaced by a `before` so it only runs once per file.

The smoke test file seems to be outdated so is not part of this PR. The snowflake specific tests are also out of scope for further improvement since we cannot test on those.

Relates to #14562
Superseeds #14751 

### Todos

- [ ] Further limit the number of times the database will be cleared by doing it once and then only when necessary
