### PR TITLE
changeColumn should not depend on column type

### DIFF
--- a/test/unit/sql/change-column.test.js
+++ b/test/unit/sql/change-column.test.js
@@ -53,7 +53,6 @@ if (current.dialect.name !== 'sqlite') {
 
       it('properly generate alter queries for foreign keys', () => {
         return current.getQueryInterface().changeColumn(Model.getTableName(), 'level_id', {
-          type: DataTypes.INTEGER,
           references: {
             model: 'level',
             key: 'id',


### PR DESCRIPTION
Following #14749, this PR adds a small change to #14687 to ensure `.changeColumn` does not need column type information if the column change is not changing the type itself.