### PR TITLE
feat(postgres): add returning option in delete query to return destroyed rows

### DIFF
--- a/src/dialects/abstract/query-generator.d.ts
+++ b/src/dialects/abstract/query-generator.d.ts
@@ -48,6 +48,7 @@ type UpdateOptions = ParameterOptions & {
 
 type DeleteOptions = ParameterOptions & {
   limit?: number | Literal | null | undefined,
+  returning?: boolean | string[],
 };
 
 type ArithmeticQueryOptions = ParameterOptions & {

--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -41,6 +41,7 @@ export interface QiUpdateOptions extends QueryRawOptions, Replaceable {
 
 export interface QiDeleteOptions extends QueryRawOptions, Replaceable {
   limit?: number | Literal | null | undefined;
+  returning?: boolean | string[];
 }
 
 export interface QiArithmeticOptions extends QueryRawOptions, Replaceable {

--- a/src/dialects/abstract/query-interface.js
+++ b/src/dialects/abstract/query-interface.js
@@ -995,7 +995,7 @@ export class QueryInterface {
   async delete(instance, tableName, identifier, options) {
     const cascades = [];
 
-    const sql = this.queryGenerator.deleteQuery(tableName, identifier, {}, instance.constructor);
+    const sql = this.queryGenerator.deleteQuery(tableName, identifier, options, instance.constructor);
 
     options = { ...options };
 

--- a/src/dialects/postgres/query.js
+++ b/src/dialects/postgres/query.js
@@ -251,7 +251,11 @@ export class PostgresQuery extends AbstractQuery {
     }
 
     if (QueryTypes.BULKDELETE === this.options.type) {
-      return Number.parseInt(rowCount, 10);
+      if (!this.options.returning) {
+        return Number.parseInt(rowCount, 10);
+      }
+
+      return this.handleSelectQuery(rows);
     }
 
     if (this.isInsertQuery() || this.isUpdateQuery() || this.isUpsertQuery()) {

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1202,6 +1202,11 @@ export interface DestroyOptions<TAttributes = any> extends TruncateOptions<TAttr
    * __Danger__: This will completely empty your table!
    */
   truncate?: boolean;
+
+  /**
+   * Return the destroyed rows (only for postgres)
+   */
+  returning?: boolean | Array<keyof TAttributes>;
 }
 
 /**
@@ -2762,12 +2767,19 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   /**
    * Deletes multiple instances, or set their deletedAt timestamp to the current time if `paranoid` is enabled.
    *
-   * @returns The number of destroyed rows
+   * The promise resolves with an array of one or two elements
+   * - The first element is always the number of destroyed rows
+   * - The second element is the list of destroyed entities (only supported in postgres)
    */
   static destroy<M extends Model>(
     this: ModelStatic<M>,
+    options: Omit<DestroyOptions<Attributes<M>>, 'returning'>
+      & { returning: Exclude<DestroyOptions<Attributes<M>>['returning'], undefined | false> }
+  ): Promise<[deletedCount: number, deletedRows: M[]]>;
+  static destroy<M extends Model>(
+    this: ModelStatic<M>,
     options?: DestroyOptions<Attributes<M>>
-  ): Promise<number>;
+  ): Promise<[deletedCount: number]>;
 
   /**
    * Restores multiple paranoid instances.

--- a/src/model.js
+++ b/src/model.js
@@ -2950,6 +2950,7 @@ Specify a different name for either index to resolve this issue.`);
       force: false,
       cascade: false,
       restartIdentity: false,
+      returing: false,
     });
 
     options.type = QueryTypes.BULKDELETE;
@@ -2971,6 +2972,7 @@ Specify a different name for either index to resolve this issue.`);
     }
 
     let result;
+    let affectedRows;
     // Run delete query (or update if paranoid)
     if (this._timestampAttributes.deletedAt && !options.force) {
       // Set query type appropriately when running soft delete
@@ -2984,9 +2986,15 @@ Specify a different name for either index to resolve this issue.`);
       };
 
       attrValueHash[field] = Utils.now(this.sequelize.options.dialect);
-      result = await this.queryInterface.bulkUpdate(this.getTableName(options), attrValueHash, Object.assign(where, options.where), options, this.rawAttributes);
+      affectedRows = await this.queryInterface.bulkUpdate(this.getTableName(options), attrValueHash, Object.assign(where, options.where), options, this.rawAttributes);
     } else {
-      result = await this.queryInterface.bulkDelete(this.getTableName(options), options.where, options, this);
+      affectedRows = await this.queryInterface.bulkDelete(this.getTableName(options), options.where, options, this);
+    }
+
+    if (options.returning) {
+      result = [affectedRows.length, affectedRows];
+    } else {
+      result = [affectedRows];
     }
 
     // Run afterDestroy hook on each record individually


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Postgresql has a facility to return the destroyed rows through `returning` clause. Why is this needed? Sometimes, we may need to update other tables after `deletion`. This PR has added `returning` option to deleteQuery which will eventually return the deleted records. This PR is applicable for `postgres` only . 

### Related issues 
#14750

### Todos

- [ ]  Add test cases for the proposed feature.
- [ ]  Code  cleanup.
