### PR TITLE
fix(types): add missing properties to RetryOptions

### DIFF
--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -178,6 +178,11 @@ export type Dialect = 'mysql' | 'postgres' | 'sqlite' | 'mariadb' | 'mssql' | 'd
 export interface RetryOptions {
   match?: Array<RegExp | string | Function>;
   max?: number;
+  timeout?: number;
+  backoffBase?: number;
+  backoffExponent?: number;
+  report?(msg: string, options: RetryOptions & { $current: number }): void;
+  name?: string;
 }
 
 /**

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -178,6 +178,11 @@ export class Sequelize {
    * @param {object}   [options.retry] Set of flags that control when a query is automatically retried. Accepts all options for [`retry-as-promised`](https://github.com/mickhansen/retry-as-promised).
    * @param {Array}    [options.retry.match] Only retry a query if the error matches one of these strings.
    * @param {number}   [options.retry.max] How many times a failing query is automatically retried.  Set to 0 to disable retrying on SQL_BUSY error.
+   * @param {number}   [options.retry.timeout] Maximum duration, in milliseconds, to retry until an error is thrown.
+   * @param {number}   [options.retry.backoffBase=100] Initial backoff duration, in milliseconds.
+   * @param {number}   [options.retry.backoffExponent=1.1] Exponent to increase backoff duration after each retry.
+   * @param {Function} [options.retry.report] Function that is executed after each retry, called with a message and the current retry options.
+   * @param {string}   [options.retry.name='unknown'] Name used when composing error/reporting messages.
    * @param {boolean}  [options.typeValidation=false] Run built-in type validators on insert and update, and select with where clause, e.g. validate that arguments passed to integer fields are integer-like.
    * @param {object}   [options.operatorsAliases] String based operator alias. Pass object to limit set of aliased operators.
    * @param {object}   [options.hooks] An object of global hook functions that are called before and after certain lifecycle events. Global hooks will run after any model-specific hooks defined for the same event (See `Sequelize.Model.init()` for a list).  Additionally, `beforeConnect()`, `afterConnect()`, `beforeDisconnect()`, and `afterDisconnect()` hooks may be defined here.

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -540,6 +540,11 @@ export class Sequelize {
    * @param {object}          [options.retry] Set of flags that control when a query is automatically retried. Accepts all options for [`retry-as-promised`](https://github.com/mickhansen/retry-as-promised).
    * @param {Array}           [options.retry.match] Only retry a query if the error matches one of these strings.
    * @param {Integer}         [options.retry.max] How many times a failing query is automatically retried.
+   * @param {number}          [options.retry.timeout] Maximum duration, in milliseconds, to retry until an error is thrown.
+   * @param {number}          [options.retry.backoffBase=100] Initial backoff duration, in milliseconds.
+   * @param {number}          [options.retry.backoffExponent=1.1] Exponent to increase backoff duration after each retry.
+   * @param {Function}        [options.retry.report] Function that is executed after each retry, called with a message and the current retry options.
+   * @param {string}          [options.retry.name='unknown'] Name used when composing error/reporting messages.
    * @param {string}          [options.searchPath=DEFAULT] An optional parameter to specify the schema search_path (Postgres only)
    * @param {boolean}         [options.supportsSearchPath] If false do not prepend the query with the search_path (Postgres only)
    * @param {boolean}         [options.mapToModel=false] Map returned fields to model's fields if `options.model` or `options.instance` is present. Mapping will occur before building the model instance.

--- a/test/types/connection.ts
+++ b/test/types/connection.ts
@@ -25,6 +25,7 @@ sequelize.transaction<void>(async transaction => {
     await sequelize.query('SELECT * FROM `user`', {
       retry: {
         max: 123,
+        report: (msg, options) => {},
       },
       model: User,
       transaction,

--- a/test/types/sequelize.ts
+++ b/test/types/sequelize.ts
@@ -17,6 +17,11 @@ export const sequelize = new Sequelize({
   retry: {
     max: 123,
     match: ['hurr'],
+    timeout: 3000,
+    backoffBase: 1000,
+    backoffExponent: 1.2,
+    report: (msg, options) => {},
+    name: 'durr',
   },
   dialectModule: {},
   keepDefaultTimezone: false,


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Sequelize passes on all retry options to `retry-as-promised` but the `RetryOptions` type was missing some properties ([reference](https://github.com/mickhansen/retry-as-promised#configuration)). This PR adds the missing properties and updates the necessary documentation. 
