### PR TITLE
fix(sqlite): alter constraints with schema

### DIFF
--- a/src/dialects/sqlite/query-generator.js
+++ b/src/dialects/sqlite/query-generator.js
@@ -348,7 +348,7 @@ export class SqliteQueryGenerator extends MySqlQueryGenerator {
   }
 
   showConstraintsQuery(tableName, constraintName) {
-    let sql = `SELECT sql FROM sqlite_master WHERE tbl_name='${tableName}'`;
+    let sql = `SELECT sql FROM sqlite_master WHERE tbl_name='${Utils.removeTicks(this.quoteTable(tableName))}'`;
 
     if (constraintName) {
       sql += ` AND sql LIKE '%${constraintName}%'`;
@@ -378,7 +378,11 @@ export class SqliteQueryGenerator extends MySqlQueryGenerator {
   }
 
   describeCreateTableQuery(tableName) {
-    return `SELECT sql FROM sqlite_master WHERE tbl_name='${tableName}';`;
+    return `SELECT sql FROM sqlite_master WHERE tbl_name='${Utils.removeTicks(this.quoteTable(tableName))}';`;
+  }
+
+  getConstraintSnippet(tableName, options) {
+    return super.getConstraintSnippet(Utils.removeTicks(this.quoteTable(tableName)), options);
   }
 
   removeColumnQuery(tableName, attributes) {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -724,4 +724,40 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
       });
     });
   });
+
+  describe('constraints in a schema', () => {
+    beforeEach(async function () {
+      this.queryInterface.createSchema('mySchema');
+
+      this.User = this.sequelize.define('users', {
+        // Db2 does not allow unique constraint for a nullable column, Db2
+        // throws SQL0542N error if we create constraint on nullable column.
+        username: dialect === 'db2' ? { type: DataTypes.STRING, allowNull: false } : DataTypes.STRING,
+        email: dialect === 'db2' ? { type: DataTypes.STRING, allowNull: false } : DataTypes.STRING,
+        roles: DataTypes.STRING,
+      }, { schema: 'mySchema' });
+
+      await this.sequelize.sync({ force: true });
+    });
+
+    describe('unique', () => {
+      it('should add, read & remove unique constraint', async function () {
+        await this.queryInterface.addConstraint({ schema: 'mySchema', tableName: 'users' }, { type: 'unique', fields: ['email'] });
+
+        let constraints = await this.queryInterface.showConstraint({ schema: 'mySchema', tableName: 'users' });
+
+        constraints = constraints.map(constraint => constraint.constraintName);
+
+        expect(constraints).to.include('mySchema.users_email_uk');
+
+        await this.queryInterface.removeConstraint({ schema: 'mySchema', tableName: 'users' }, 'mySchema.users_email_uk');
+
+        constraints = await this.queryInterface.showConstraint({ schema: 'mySchema', tableName: 'users' });
+
+        constraints = constraints.map(constraint => constraint.constraintName);
+
+        expect(constraints).to.not.include('mySchema.users_email_uk');
+      });
+    });
+  });
 });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Handle tableName argument as object in SQLite generated constraints related methods, so that the following works using SQLite driver:

```javascript
await queryInterface.addConstraint(
  {
    tableName: "table",
    schema: "schema",
  },
  {
    fields: ["targetId"],
    type: "foreign key",
    references: {
      field: "id",
      table: { schema: "schema", tableName: "otherTable" },
    },
    onDelete: "cascade",
    onUpdate: "cascade",
  }
);

```
