### PR TITLE
feat(types): add typescript 4.8 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts-version: ["4.1", "4.2", "4.3", "4.4", "4.5"]
+        ts-version: ["4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8"]
     name: TS Typings (${{ matrix.ts-version }})
     runs-on: ubuntu-latest
     steps:

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -67,8 +67,8 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
 
 export interface SequelizeHooks<
   M extends Model<TAttributes, TCreationAttributes> = Model,
-  TAttributes = any,
-  TCreationAttributes = TAttributes
+  TAttributes extends {} = any,
+  TCreationAttributes extends {} = TAttributes
 > extends ModelHooks<M, TAttributes> {
   beforeDefine(attributes: ModelAttributes<M, TCreationAttributes>, options: ModelOptions<M>): void;
   afterDefine(model: ModelType): void;

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -3260,7 +3260,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
 }
 
 /** @deprecated use ModelStatic */
-export type ModelType<TModelAttributes = any, TCreationAttributes = TModelAttributes> = new () => Model<TModelAttributes, TCreationAttributes>;
+export type ModelType<TModelAttributes extends {} = any, TCreationAttributes extends {} = TModelAttributes> = new () => Model<TModelAttributes, TCreationAttributes>;
 
 type NonConstructorKeys<T> = ({[P in keyof T]: T[P] extends new () => any ? never : P })[keyof T];
 type NonConstructor<T> = Pick<T, NonConstructorKeys<T>>;
@@ -3268,7 +3268,7 @@ type NonConstructor<T> = Pick<T, NonConstructorKeys<T>>;
 /** @deprecated use ModelStatic */
 export type ModelCtor<M extends Model> = ModelStatic<M>;
 
-export type ModelDefined<S, T> = ModelStatic<Model<S, T>>;
+export type ModelDefined<S extends {}, T extends {}> = ModelStatic<Model<S, T>>;
 
 // remove the existing constructor that tries to return `Model<{},{}>` which would be incompatible with models that have typing defined & replace with proper constructor.
 export type ModelStatic<M extends Model> = NonConstructor<typeof Model> & { new(): M };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8322,9 +8322,9 @@ typescript@^4.4.3:
   integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 typescript@^4.5.4:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Sequelize typings are affected in a few places by a TypeScript 4.8 breaking change (https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to).

This PR addresses #14934.
