### PR TITLE
fix(types): missing type for oracle dialect in v6

### DIFF
--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -169,7 +169,7 @@ export interface Config {
   };
 }
 
-export type Dialect = 'mysql' | 'postgres' | 'sqlite' | 'mariadb' | 'mssql' | 'db2' | 'snowflake';
+export type Dialect = 'mysql' | 'postgres' | 'sqlite' | 'mariadb' | 'mssql' | 'db2' | 'snowflake' | 'oracle';
 
 export interface RetryOptions {
   match?: (RegExp | string | Function)[];


### PR DESCRIPTION
Target patch releases of #14991
