### PR TITLE
fix(types): add missing model hooks types

### DIFF
--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -68,8 +68,8 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   afterBulkSync(options: SyncOptions): HookReturn;
   beforeQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
   afterQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
-  beforeAssociate(data: BeforeAssociateEventData, options: AssociationOptions<unknown>): HookReturn;
-  afterAssociate(data: AfterAssociateEventData, options: AssociationOptions<unknown>): HookReturn;
+  beforeAssociate(data: BeforeAssociateEventData, options: AssociationOptions<any>): HookReturn;
+  afterAssociate(data: AfterAssociateEventData, options: AssociationOptions<any>): HookReturn;
 }
 
 export interface SequelizeHooks<

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -68,7 +68,7 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   afterBulkSync(options: SyncOptions): HookReturn;
   beforeQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
   afterQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
-  beforeAssociate(data: BeforeAssociateEventData, options: AssociationOptions<any>): HookReturn;
+  beforeAssociate(data: BeforeAssociateEventData, options: AssociationOptions<unknown>): HookReturn;
   afterAssociate(data: AfterAssociateEventData, options: AssociationOptions<any>): HookReturn;
 }
 

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -15,6 +15,11 @@ import type {
 } from './model';
 import type { Config, Options, Sequelize, SyncOptions, QueryOptions } from './sequelize';
 import type { DeepWriteable } from './utils';
+import type {
+  BeforeAssociateEventData,
+  AfterAssociateEventData,
+  AssociationOptions,
+} from './associations';
 
 export type HookReturn = Promise<void> | void;
 
@@ -25,6 +30,7 @@ export type HookReturn = Promise<void> | void;
 export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   beforeValidate(instance: M, options: ValidationOptions): HookReturn;
   afterValidate(instance: M, options: ValidationOptions): HookReturn;
+  validationFailed(instance: M, options: ValidationOptions, error: unknown): HookReturn;
   beforeCreate(attributes: M, options: CreateOptions<TAttributes>): HookReturn;
   afterCreate(attributes: M, options: CreateOptions<TAttributes>): HookReturn;
   beforeDestroy(instance: M, options: InstanceDestroyOptions): HookReturn;
@@ -62,6 +68,8 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   afterBulkSync(options: SyncOptions): HookReturn;
   beforeQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
   afterQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
+  beforeAssociate(data: BeforeAssociateEventData, options: AssociationOptions<any>): HookReturn;
+  afterAssociate(data: AfterAssociateEventData, options: AssociationOptions<any>): HookReturn;
 }
 
 export interface SequelizeHooks<

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -1,3 +1,8 @@
+import type {
+  BeforeAssociateEventData,
+  AfterAssociateEventData,
+  AssociationOptions,
+} from './associations';
 import type { AbstractQuery } from './dialects/abstract/query';
 import type { ValidationOptions } from './instance-validator';
 import type {
@@ -15,11 +20,6 @@ import type {
 } from './model';
 import type { Config, Options, Sequelize, SyncOptions, QueryOptions } from './sequelize';
 import type { DeepWriteable } from './utils';
-import type {
-  BeforeAssociateEventData,
-  AfterAssociateEventData,
-  AssociationOptions,
-} from './associations';
 
 export type HookReturn = Promise<void> | void;
 

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -69,7 +69,7 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
   beforeQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
   afterQuery(options: QueryOptions, query: AbstractQuery): HookReturn;
   beforeAssociate(data: BeforeAssociateEventData, options: AssociationOptions<unknown>): HookReturn;
-  afterAssociate(data: AfterAssociateEventData, options: AssociationOptions<any>): HookReturn;
+  afterAssociate(data: AfterAssociateEventData, options: AssociationOptions<unknown>): HookReturn;
 }
 
 export interface SequelizeHooks<

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -53,7 +53,7 @@ import type { SemiDeepWritable } from './type-helpers/deep-writable';
       expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
     },
     afterAssociate(data, options) {
-      expectTypeOf(data).toEqualTypeOf<BeforeAssociateEventData>();
+      expectTypeOf(data).toEqualTypeOf<AfterAssociateEventData>();
       expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
     },
   };

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -1,4 +1,4 @@
-import type { FindOptions, QueryOptions, SaveOptions, UpsertOptions, Config, Utils, ValidationOptions } from '@sequelize/core';
+import type { FindOptions, QueryOptions, SaveOptions, UpsertOptions, Config, Utils } from '@sequelize/core';
 import { Model, Sequelize } from '@sequelize/core';
 import type {
   BeforeAssociateEventData,
@@ -7,6 +7,7 @@ import type {
 } from '@sequelize/core/_non-semver-use-at-your-own-risk_/associations';
 import type { AbstractQuery } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query.js';
 import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/hooks.js';
+import type { ValidationOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator';
 import { expectTypeOf } from 'expect-type';
 import type { SemiDeepWritable } from './type-helpers/deep-writable';
 
@@ -49,11 +50,11 @@ import type { SemiDeepWritable } from './type-helpers/deep-writable';
     },
     beforeAssociate(data, options) {
       expectTypeOf(data).toEqualTypeOf<BeforeAssociateEventData>();
-      expectTypeOf(options).toEqualTypeOf<AssociationOptions>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
     },
     afterAssociate(data, options) {
       expectTypeOf(data).toEqualTypeOf<BeforeAssociateEventData>();
-      expectTypeOf(options).toEqualTypeOf<AssociationOptions>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
     },
   };
 

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -14,7 +14,7 @@ import type { SemiDeepWritable } from './type-helpers/deep-writable';
 {
   class TestModel extends Model {}
 
-  const hooks: Partial<ModelHooks> = {
+  const hooks: Partial<ModelHooks<TestModel>> = {
     validationFailed(m, options, error) {
       expectTypeOf(m).toEqualTypeOf<TestModel>();
       expectTypeOf(options).toEqualTypeOf<ValidationOptions>();

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -50,11 +50,11 @@ import type { SemiDeepWritable } from './type-helpers/deep-writable';
     },
     beforeAssociate(data, options) {
       expectTypeOf(data).toEqualTypeOf<BeforeAssociateEventData>();
-      expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions<unknown>>();
     },
     afterAssociate(data, options) {
       expectTypeOf(data).toEqualTypeOf<AfterAssociateEventData>();
-      expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions<unknown>>();
     },
   };
 

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -50,11 +50,11 @@ import type { SemiDeepWritable } from './type-helpers/deep-writable';
     },
     beforeAssociate(data, options) {
       expectTypeOf(data).toEqualTypeOf<BeforeAssociateEventData>();
-      expectTypeOf(options).toEqualTypeOf<AssociationOptions<unknown>>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
     },
     afterAssociate(data, options) {
       expectTypeOf(data).toEqualTypeOf<AfterAssociateEventData>();
-      expectTypeOf(options).toEqualTypeOf<AssociationOptions<unknown>>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions<any>>();
     },
   };
 

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -1,5 +1,10 @@
-import type { FindOptions, QueryOptions, SaveOptions, UpsertOptions, Config, Utils } from '@sequelize/core';
+import type { FindOptions, QueryOptions, SaveOptions, UpsertOptions, Config, Utils, ValidationOptions } from '@sequelize/core';
 import { Model, Sequelize } from '@sequelize/core';
+import type {
+  BeforeAssociateEventData,
+  AfterAssociateEventData,
+  AssociationOptions,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/associations';
 import type { AbstractQuery } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query.js';
 import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/hooks.js';
 import { expectTypeOf } from 'expect-type';
@@ -9,6 +14,11 @@ import type { SemiDeepWritable } from './type-helpers/deep-writable';
   class TestModel extends Model {}
 
   const hooks: Partial<ModelHooks> = {
+    validationFailed(m, options, error) {
+      expectTypeOf(m).toEqualTypeOf<TestModel>();
+      expectTypeOf(options).toEqualTypeOf<ValidationOptions>();
+      expectTypeOf(error).toEqualTypeOf<unknown>();
+    },
     beforeSave(m, options) {
       expectTypeOf(m).toEqualTypeOf<TestModel>();
       expectTypeOf(options).toMatchTypeOf<SaveOptions>(); // TODO consider `.toEqualTypeOf` instead ?
@@ -36,6 +46,14 @@ import type { SemiDeepWritable } from './type-helpers/deep-writable';
     afterQuery(options, query) {
       expectTypeOf(options).toEqualTypeOf<QueryOptions>();
       expectTypeOf(query).toEqualTypeOf<AbstractQuery>();
+    },
+    beforeAssociate(data, options) {
+      expectTypeOf(data).toEqualTypeOf<BeforeAssociateEventData>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions>();
+    },
+    afterAssociate(data, options) {
+      expectTypeOf(data).toEqualTypeOf<BeforeAssociateEventData>();
+      expectTypeOf(options).toEqualTypeOf<AssociationOptions>();
     },
   };
 


### PR DESCRIPTION
### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

### Description Of Change

Closes #14955

### Todos

- [x] Add missing `validationFailed`,`beforeAssociate` and `afterAssociate` types.
- [ ] Maybe add missing types tests?
