### PR TITLE
fix(types): add TypeScript 4.8 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts-version: ["4.4", "4.5", "4.6", "4.7"]
+        ts-version: ["4.5", "4.6", "4.7", "4.8"]
     name: TS Typings (${{ matrix.ts-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "tedious": "15.1.0",
     "ts-node": "10.9.1",
     "typedoc": "0.23.14",
-    "typescript": "4.7.4"
+    "typescript": "4.8.3"
   },
   "peerDependenciesMeta": {
     "pg": {

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -74,8 +74,8 @@ export interface ModelHooks<M extends Model = Model, TAttributes = any> {
 
 export interface SequelizeHooks<
   M extends Model<TAttributes, TCreationAttributes> = Model,
-  TAttributes = any,
-  TCreationAttributes = TAttributes,
+  TAttributes extends {} = any,
+  TCreationAttributes extends {} = TAttributes,
 > extends ModelHooks<M, TAttributes> {
   beforeDefine(attributes: ModelAttributes<M, TCreationAttributes>, options: ModelOptions<M>): void;
   afterDefine(model: ModelStatic): void;

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -3592,7 +3592,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   isSoftDeleted(): boolean;
 }
 
-export type ModelDefined<S, T> = ModelStatic<Model<S, T>>;
+export type ModelDefined<S extends {}, T extends {}> = ModelStatic<Model<S, T>>;
 
 // remove the existing constructor that tries to return `Model<{},{}>` which would be incompatible with models that have typing defined & replace with proper constructor.
 export type ModelStatic<M extends Model = Model> = OmitConstructors<typeof Model> & { new(): M };

--- a/src/utils/object.ts
+++ b/src/utils/object.ts
@@ -125,7 +125,7 @@ export function cloneDeep<T extends object>(obj: T, onlyPlain?: boolean): T {
  * @returns a flattened object
  * @private
  */
-export function flattenObjectDeep<T>(value: T): T extends object ? Flatten<T> : T {
+export function flattenObjectDeep<T extends {}>(value: T): T extends object ? Flatten<T> : T {
   if (!isPlainObject(value)) {
     // TypeScript doesn't know T is an object due to isPlainObject's typings. Cast to any.
     return value as any;
@@ -218,6 +218,6 @@ export function camelizeObjectKeys(obj: { [key: string]: any }) {
 
 type NoUndefinedField<T> = { [P in keyof T]: Exclude<T[P], null | undefined> };
 
-export function removeUndefined<T>(val: T): NoUndefinedField<T> {
+export function removeUndefined<T extends {}>(val: T): NoUndefinedField<T> {
   return omitBy(val, isUndefined) as NoUndefinedField<T>;
 }

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -242,6 +242,7 @@ function mapBindParametersAndReplacements(
         throw new Error(`Positional replacement (?) ${replacementIndex} has no entry in the replacement map (replacements[${replacementIndex}] is undefined).`);
       }
 
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       const escapedReplacement = escapeSqlValue(replacementValue as any, undefined, dialect.name, true);
 
       // add everything before the bind parameter name

--- a/test/support.ts
+++ b/test/support.ts
@@ -58,7 +58,7 @@ function inlineErrorCause(error: Error) {
   // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
   // @ts-ignore -- TS < 4.6 doesn't include the typings for this property, but TS 4.6+ does.
   const cause = error.cause;
-  if (cause) {
+  if (cause instanceof Error) {
     message += `\nCaused by: ${inlineErrorCause(cause)}`;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8607,10 +8607,10 @@ typedoc@0.23.14:
     minimatch "^5.1.0"
     shiki "^0.11.1"
 
-typescript@4.7.4:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@4.8.3:
+  version "4.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.3.tgz#d59344522c4bc464a65a730ac695007fdb66dd88"
+  integrity sha512-goMHfm00nWPa8UvR/CPSvykqf6dVV8x/dp0c5mFTMTIu0u0FlGWRioyy7Nn0PGAdHxpJZnuO/ut+PpQ8UiHAig==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [ ] Have you added new tests to prevent regressions?
- [ ] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

Sequelize typings are affected in a few places by a TypeScript 4.8 breaking change (https://devblogs.microsoft.com/typescript/announcing-typescript-4-8/#unconstrained-generics-no-longer-assignable-to).

The PR brings changes from https://github.com/sequelize/sequelize/pull/14990 (which closes #14934) to `main` branch.