### PR TITLE
meta: ignore dependency updates on oldest Docker and use `meta` type

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,9 @@
 {
   "extends": [
     "config:base",
-    ":maintainLockFilesWeekly"
+    ":maintainLockFilesWeekly",
+    ":semanticCommitTypeAll(meta)",
+    ":semanticCommitScopeDisabled"
   ],
-  "semanticCommitType": "meta",
-  "semanticCommitScope": null
+  "ignorePaths:": "dev/**/oldest/docker-compose.yml"
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Yes, I've tried the scope thing multiple times now but I haven't tried this so hopefully it will work.
I've added the oldest docker-compose files to the ignorePaths so renovate won't update those.

Future PR will add renovate to v6, just like some other CI changes that we've done on main already.