### PR TITLE
meta: renovate typo on ignorePaths

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,5 @@
     ":semanticCommitTypeAll(meta)",
     ":semanticCommitScopeDisabled"
   ],
-  "ignorePaths:": "dev/**/oldest/docker-compose.yml"
+  "ignorePaths": "dev/**/oldest/docker-compose.yml"
 }


### PR DESCRIPTION
Delete extra `:`, this is very soft, we missed it

Closes #15025 