### PR TITLE
fix(postgres): add custom order direction to subQuery ordering with minified alias

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -2206,7 +2206,21 @@ export class AbstractQueryGenerator {
           const field = model.rawAttributes[order[0]]?.field || order[0];
           const subQueryAlias = this._getAliasForField(this.quoteIdentifier(model.name), field, options);
 
-          subQueryOrder.push(this.quote(subQueryAlias === null ? order : subQueryAlias, model, '->', options));
+          let parent = null;
+          let orderToQuote = [];
+
+          // we need to ensure that the parent is null if we use the subquery alias, else we'll get an exception since
+          // "model_name"."alias" doesn't exist - only "alias" does. we also need to ensure that we preserve order direction
+          // by pushing order[1] to the subQueryOrder as well - in case it doesn't exist, we want to push "ASC"
+          if (subQueryAlias === null) {
+            orderToQuote = order;
+            parent = model;
+          } else {
+            orderToQuote = [subQueryAlias, order.length > 1 ? order[1] : 'ASC'];
+            parent = null;
+          }
+
+          subQueryOrder.push(this.quote(orderToQuote, parent, '->', options));
         }
 
         // Handle case where renamed attributes are used to order by,

--- a/test/integration/dialects/postgres/query.test.js
+++ b/test/integration/dialects/postgres/query.test.js
@@ -157,13 +157,25 @@ if (dialect.startsWith('postgres')) {
       await Foo.create({ name: 'record1' });
       await Foo.create({ name: 'record2' });
 
-      const thisWorks = (await Foo.findAll({
+      const baseTest = (await Foo.findAll({
         subQuery: false,
         order: sequelizeMinifyAliases.literal(`"Foo".my_name`),
       })).map(f => f.name);
-      expect(thisWorks[0]).to.equal('record1');
+      expect(baseTest[0]).to.equal('record1');
 
-      const thisShouldAlsoWork = (await Foo.findAll({
+      const orderByAscSubquery = (await Foo.findAll({
+        attributes: {
+          include: [
+            [sequelizeMinifyAliases.literal(`"Foo".my_name`), 'customAttribute'],
+          ],
+        },
+        subQuery: true,
+        order: [['customAttribute']],
+        limit: 1,
+      })).map(f => f.name);
+      expect(orderByAscSubquery[0]).to.equal('record1');
+
+      const orderByDescSubquery = (await Foo.findAll({
         attributes: {
           include: [
             [sequelizeMinifyAliases.literal(`"Foo".my_name`), 'customAttribute'],
@@ -173,7 +185,7 @@ if (dialect.startsWith('postgres')) {
         order: [['customAttribute', 'DESC']],
         limit: 1,
       })).map(f => f.name);
-      expect(thisShouldAlsoWork[0]).to.equal('record2');
+      expect(orderByDescSubquery[0]).to.equal('record2');
     });
 
     it('returns the minified aliased attributes', async () => {

--- a/test/integration/dialects/postgres/query.test.js
+++ b/test/integration/dialects/postgres/query.test.js
@@ -170,9 +170,10 @@ if (dialect.startsWith('postgres')) {
           ],
         },
         subQuery: true,
-        order: ['customAttribute'],
+        order: [['customAttribute', 'DESC']],
+        limit: 1,
       })).map(f => f.name);
-      expect(thisShouldAlsoWork[0]).to.equal('record1');
+      expect(thisShouldAlsoWork[0]).to.equal('record2');
     });
 
     it('returns the minified aliased attributes', async () => {


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

Fix for new issue raised at https://github.com/sequelize/sequelize/issues/14723.

Essentially, we weren't pushing the order direction when pushing the alias for the sub-query field. This PR adds logic to do so, as well as tests for ascending/descending subquery ordering with aliases.