### PR TITLE
fix(postgres): add custom order direction to subQuery ordering with minified alias (v6)

### DIFF
--- a/test/integration/dialects/postgres/query.test.js
+++ b/test/integration/dialects/postgres/query.test.js
@@ -124,22 +124,35 @@ if (dialect.match(/^postgres/)) {
       await Foo.create({ name: 'record1' });
       await Foo.create({ name: 'record2' });
 
-      const thisWorks = (await Foo.findAll({
+      const baseTest = (await Foo.findAll({
         subQuery: false,
         order: sequelizeMinifyAliases.literal('"Foo".my_name')
       })).map(f => f.name);
-      expect(thisWorks[0]).to.equal('record1');
+      expect(baseTest[0]).to.equal('record1');
 
-      const thisShouldAlsoWork = (await Foo.findAll({
+      const orderByAscSubquery = (await Foo.findAll({
         attributes: {
           include: [
             [sequelizeMinifyAliases.literal('"Foo".my_name'), 'customAttribute']
           ]
         },
         subQuery: true,
-        order: ['customAttribute']
+        order: [['customAttribute']],
+        limit: 1
       })).map(f => f.name);
-      expect(thisShouldAlsoWork[0]).to.equal('record1');
+      expect(orderByAscSubquery[0]).to.equal('record1');
+
+      const orderByDescSubquery = (await Foo.findAll({
+        attributes: {
+          include: [
+            [sequelizeMinifyAliases.literal('"Foo".my_name'), 'customAttribute']
+          ]
+        },
+        subQuery: true,
+        order: [['customAttribute', 'DESC']],
+        limit: 1
+      })).map(f => f.name);
+      expect(orderByDescSubquery[0]).to.equal('record2');
     });
 
     it('returns the minified aliased attributes', async () => {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->
As discussed with @evanrittenhouse , this backports #15046 to v6.
