### PR TITLE
meta: fix commit type for lockfile update PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
     ":semanticCommitTypeAll(meta)",
     ":semanticCommitScopeDisabled"
   ],
+  "semanticCommitType": "meta",
   "ignorePaths": [ "dev/**/oldest/docker-compose.yml" ]
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

For some reason `:semanticCommitTypeAll(meta)` is only for all dependency update PRs, not the lockfile update PR. I hope including both of them will finally work.
