### PR TITLE
fix(mariadb): do not automatically parse JSON fields

### DIFF
--- a/src/dialects/mariadb/query.js
+++ b/src/dialects/mariadb/query.js
@@ -188,7 +188,9 @@ export class MariaDbQuery extends AbstractQuery {
       if (modelField.type instanceof DataTypes.JSON) {
         // Value is returned as String, not JSON
         rows = rows.map(row => {
-          if (row[modelField.fieldName] && typeof row[modelField.fieldName] === 'string') {
+          // JSON fields for MariaDB server 10.5.2+ already results in JSON format, skip JSON.parse
+          // this is due to this https://jira.mariadb.org/browse/MDEV-17832 and how mysql2 connector interacts with MariaDB and JSON fields
+          if (row[modelField.fieldName] && typeof row[modelField.fieldName] === 'string' && !this.connection.info.hasMinVersion(10, 5, 2)) {
             row[modelField.fieldName] = JSON.parse(row[modelField.fieldName]);
           }
 

--- a/test/integration/json.test.js
+++ b/test/integration/json.test.js
@@ -200,6 +200,12 @@ describe('model', () => {
         expect(user.username).to.equal('anna');
       });
 
+      it('should be able to store strings', async function () {
+        await this.User.create({ username: 'swen', emergency_contact: 'joe' });
+        const user = await this.User.findOne({ where: { username: 'swen' } });
+        expect(user.emergency_contact).to.equal('joe');
+      });
+
       it('should be able to store values that require JSON escaping', async function () {
         const text = 'Multi-line \'$string\' needing "escaping" for $$ and $1 type values';
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

This PR ports #14800 to `main` and unblocks #14505
