### PR TITLE
docs: update instructions for running databases in Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,9 +127,9 @@ If you're happy to run tests only against an SQLite database, you can skip this 
 
 If you have Docker installed, use any of the following commands to start fresh local databases of the dialect of your choice:
 
-- `yarn start-mariadb-oldest` (for MariaDB 10.3.0) or `yarn start-mariadb-latest` (for MariaDB 10.9.3)
-- `yarn start-mysql-oldest` (for MySQL 5.7.0) or `yarn start-mysql-latest` (for MySQL 8.0.30)
-- `yarn start-postgres-oldest` (for Postgres 10.21.1) or `yarn start-postgres-latest` (for Postgres 12.12.1)
+- `yarn start-mariadb-oldest` (for MariaDB 10.3) or `yarn start-mariadb-latest` (for MariaDB 10.9)
+- `yarn start-mysql-oldest` (for MySQL 5.7) or `yarn start-mysql-latest` (for MySQL 8.0)
+- `yarn start-postgres-oldest` (for Postgres 10) or `yarn start-postgres-latest` (for Postgres 12)
 - `yarn start-mssql-oldest` (for MSSQL 2017) or `yarn start-mssql-latest` (for MSSQL 2022)
 - `yarn start-db2-oldest`
 
@@ -149,7 +149,7 @@ docker run -d --name pgadmin4 -p 8888:80 -e 'PGADMIN_DEFAULT_EMAIL=test@example.
 
 #### 3.2. Without Docker
 
-You will have to manually install and configure each of database engines you want. Check the `dev/dialect-name` folder within this repository and look carefully at how it is defined via Docker and via the auxiliary bash script, and mimic that exactly (except for the database name, username, password, host and port, that you can customize via the `SEQ_DB`, `SEQ_USER`, `SEQ_PW`, `SEQ_HOST` and `SEQ_PORT` environment variables, respectively).
+You will have to manually install and configure each of database engines you want. Check the `dev/dialect-name` folder within this repository and look carefully at how it is defined via Docker and via the auxiliary bash script, and mimic that exactly (except for the database name, username, password, host and port, that you can customize via the `SEQ_DB`, `SEQ_USER`, `SEQ_PW`, `SEQ_HOST` and `SEQ_PORT` environment variables, respectively). Please refer to the [Version Policy](https://sequelize.org/releases/) for the oldest supported version of each database.
 
 ### 4. Running tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,11 +127,11 @@ If you're happy to run tests only against an SQLite database, you can skip this 
 
 If you have Docker installed, use any of the following commands to start fresh local databases of the dialect of your choice:
 
-- `yarn start-mariadb`
-- `yarn start-mysql`
-- `yarn start-postgres`
+- `yarn start-mariadb-oldest` (for MariaDB 10.3.0) or `yarn start-mariadb-latest` (for MariaDB 10.9.3)
+- `yarn start-mysql-oldest` (for MySQL 5.7.0) or `yarn start-mysql-latest` (for MySQL 8.0.30)
+- `yarn start-postgres-oldest` (for Postgres 10.21.1) or `yarn start-postgres-latest` (for Postgres 12.12.1)
 - `yarn start-mssql-oldest` (for MSSQL 2017) or `yarn start-mssql-latest` (for MSSQL 2022)
-- `yarn start-db2`
+- `yarn start-db2-oldest`
 
 _Note:_ if you're using Windows, make sure you run these from Git Bash (or another MinGW environment), since these commands will execute bash scripts. Recall that [it's very easy to include Git Bash as your default integrated terminal on Visual Studio Code](https://code.visualstudio.com/docs/editor/integrated-terminal).
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions? No,n/a
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? No, n/a
- [x] Did you update the typescript typings accordingly (if applicable)? No, n/a
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

Corrected `yarn` commands in contributions guidelines pertaining to running databases in Docker (for the purpose of testing). Updated commands now run either the `-oldest` or `-latest` version of a database, with version indicated.

Related to #14737
Closes #15078