### PR TITLE
feat(snowflake): Add support for `QueryGenerator#tableExistsQuery`

### DIFF
--- a/src/dialects/snowflake/query-generator.js
+++ b/src/dialects/snowflake/query-generator.js
@@ -170,6 +170,18 @@ class SnowflakeQueryGenerator extends AbstractQueryGenerator {
     ]);
   }
 
+  tableExistsQuery(table) {
+    const tableName = table.tableName ?? table;
+    const schema = table.schema;
+
+    return Utils.joinSQLFragments([
+      'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = \'BASE TABLE\'',
+      `AND TABLE_SCHEMA = ${schema !== undefined ? this.escape(schema) : 'CURRENT_SCHEMA()'}`,
+      `AND TABLE_NAME = ${this.escape(tableName)}`,
+      ';',
+    ]);
+  }
+
   addColumnQuery(table, key, dataType) {
     return Utils.joinSQLFragments([
       'ALTER TABLE',

--- a/src/dialects/snowflake/query-generator.js
+++ b/src/dialects/snowflake/query-generator.js
@@ -32,7 +32,7 @@ const FOREIGN_KEY_FIELDS = [
  * @private
  */
 const SNOWFLAKE_RESERVED_WORDS = 'account,all,alter,and,any,as,between,by,case,cast,check,column,connect,connections,constraint,create,cross,current,current_date,current_time,current_timestamp,current_user,database,delete,distinct,drop,else,exists,false,following,for,from,full,grant,group,gscluster,having,ilike,in,increment,inner,insert,intersect,into,is,issue,join,lateral,left,like,localtime,localtimestamp,minus,natural,not,null,of,on,or,order,organization,qualify,regexp,revoke,right,rlike,row,rows,sample,schema,select,set,some,start,table,tablesample,then,to,trigger,true,try_cast,union,unique,update,using,values,view,when,whenever,where,with'.split(',');
-  
+
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 class SnowflakeQueryGenerator extends AbstractQueryGenerator {
@@ -171,14 +171,14 @@ class SnowflakeQueryGenerator extends AbstractQueryGenerator {
   }
 
   tableExistsQuery(table) {
-    const tableName = table.tableName ?? table;
+    const tableName = table.tableName || table;
     const schema = table.schema;
 
     return Utils.joinSQLFragments([
       'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = \'BASE TABLE\'',
       `AND TABLE_SCHEMA = ${schema !== undefined ? this.escape(schema) : 'CURRENT_SCHEMA()'}`,
       `AND TABLE_NAME = ${this.escape(tableName)}`,
-      ';',
+      ';'
     ]);
   }
 

--- a/test/unit/dialects/snowflake/query-generator.test.js
+++ b/test/unit/dialects/snowflake/query-generator.test.js
@@ -354,6 +354,17 @@ if (dialect === 'snowflake') {
         }
       ],
 
+      tableExistsQuery: [
+        {
+          arguments: ['myTable'],
+          expectation: 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = \'BASE TABLE\' AND TABLE_SCHEMA = CURRENT_SCHEMA() AND TABLE_NAME = \'myTable\';',
+        },
+        {
+          arguments: [{ tableName: 'myTable', schema: 'mySchema' }],
+          expectation: 'SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = \'BASE TABLE\' AND TABLE_SCHEMA = \'mySchema\' AND TABLE_NAME = \'myTable\';',
+        },
+      ],
+
       selectQuery: [
         {
           arguments: ['myTable'],


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.

If your PR only contains changes to documentation, you may skip the template below.
-->

### Pull Request Checklist

_Please make sure to review and check all of these items:_

- [x] Have you added new tests to prevent regressions?
- [x] Does `yarn test` or `yarn test-DIALECT` pass with this change (including linting)?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Did you follow the commit message conventions explained in [CONTRIBUTING.md](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

### Description Of Change

**This is an additional PR to merge fix from https://github.com/sequelize/sequelize/pull/14930 (already merged into v7) into v6 branch**

Starting from version 6.20.0 a new method `tableExistsQuery` is introduced and used by the  sequelize`sync` method. Unfortunately this method is implemented in all dialects except snowflake. This causes `snowflake` dialect basically unusable. This PR fixes the issue by adding the implementation of `tableExistsQuery` in snowlake dialect.