### PR TITLE
fix: inject scope in findAndCountAll

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -2137,6 +2137,8 @@ Specify a different name for either index to resolve this issue.`);
       throw new Error('The argument passed to findAndCountAll must be an options object, use findByPk if you wish to pass a single primary key value');
     }
 
+    this._injectScope(options);
+
     const countOptions = Utils.cloneDeep(options);
 
     if (countOptions.attributes) {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

`findAndCountAll` function if called with `scope` generates an ambiguous query clause. The issue was reported here #15067 and an reproduction was created here https://github.com/sequelize/sequelize-sscce/pull/238.

In the `findAndCountAll` we now call the `this._injectScope(options)` to inject the options provided by the scope for the query.

Closes #15067 

### Changes achieved

Previously if used with scope this was the query being generated:

```sql
SELECT count(DISTINCT("id")) AS "count" FROM "children" AS "child" LEFT OUTER JOIN "parents" AS "parent" ON "child"."parentId" = "parent"."id";
---> ambiguous column name: id
```

Query generated with the update:

```sql
SELECT count(DISTINCT("child"."id")) AS "count" FROM "children" AS "child" LEFT OUTER JOIN "parents" AS "parent" ON "child"."parentId" = "parent"."id";
---> ambiguous column name: id
```
