### PR TITLE
feat(sqlite): enable `RIGHT JOIN` capability for sqlite

### DIFF
--- a/src/dialects/sqlite/index.js
+++ b/src/dialects/sqlite/index.js
@@ -15,7 +15,7 @@ export class SqliteDialect extends AbstractDialect {
     DEFAULT: false,
     'DEFAULT VALUES': true,
     'UNION ALL': false,
-    'RIGHT JOIN': false,
+    'RIGHT JOIN': true,
     inserts: {
       ignoreDuplicates: ' OR IGNORE',
       updateOnDuplicate: ' ON CONFLICT DO UPDATE SET',


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This issue was first mentioned by #14965 , SQLite now supports `RIGHT JOIN`s https://www.sqlite.org/releaselog/3_39_3.html. This PR enables RIGHT JOIN support for SQLite.

Closes #14965 
