### PR TITLE
meta: automatically merge renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,11 @@
     ":semanticCommitScopeDisabled"
   ],
   "semanticCommitType": "meta",
-  "ignorePaths": [ "dev/**/oldest/docker-compose.yml" ]
+  "ignorePaths": ["dev/**/oldest/docker-compose.yml"],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This should theoretically enable automatic merges of renovate PRs. In the main branch protection rules, I have also configured this now. 

<img width="765" alt="image" src="https://user-images.githubusercontent.com/79163/194613681-35c4401e-d71b-4638-8e5c-06a0f53e0f75.png">

I think that might work?
