### PR TITLE
meta: make renovate merge using squash

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     ":semanticCommitTypeAll(meta)",
     ":semanticCommitScopeDisabled"
   ],
+  "automergeStrategy": "squash",
   "semanticCommitType": "meta",
   "ignorePaths": ["dev/**/oldest/docker-compose.yml"],
   "packageRules": [


### PR DESCRIPTION
Renovate tries to rebase merge its PRs, which we don't allow. This PR changes its configuration to squash & merge instead

Well, turns out this is not strictly needed (https://github.com/sequelize/sequelize/pull/15104), but still good to have as otherwise renovates tries all possible merge options until one works