### PR TITLE
feat: add retry deadlocks by default

### DIFF
--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -245,6 +245,7 @@ export class Sequelize {
         max: 5,
         match: [
           'SQLITE_BUSY: database is locked',
+          /Deadlock/i,
         ],
       },
       transactionType: TRANSACTION_TYPES.DEFERRED,


### PR DESCRIPTION
Since deadlocks are classic problem in transactional databases and able to be retried, we should retry it by default from the start or am i missing something?

Ability to wrap entire query process is added in this PR: https://github.com/sequelize/sequelize/pull/8991/files