### PR TITLE
fix(types): expose legacy "types" folder in export alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
       "default": "./lib/errors/index.js",
       "types": "./types/errors/index.d.ts"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./types/*": {
+      "types": "./types/*.d.ts"
+    }
   },
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
## Description Of Problem

Imports of things like 'sequelize/types/hooks' (which is used by sequelize-typescript) is broken when using Typescript's "nodenext" or "node16" module resolution strategies. One could update the imports to 'sequelize/lib/hooks', but doing so breaks the default Typescript module resolution. So projects like sequelize-typescript can't easily make that change.

**Currently anyone using the newer module resolution strategies along with sequelize-typescript have no upgrade path to a version of sequelize without the vulnerability mentioned in #14519** 

## Description Of Change

This is a different approach to #14719.

Instead of adding hooks to the exports in index.d.ts, we can just add a  "/types/" alias to the exports in package.json. Doing so allows imports of 'sequelize/types/hooks' to properly resolve using both older and newer Typescript module resolution strategies. In essence, importing /types/* will work as it always has regardless of module resolution strategy.

