### PR TITLE
fix(types): fix TS 4.9 excessive depth error on `InferAttributes` (v6)

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -3446,12 +3446,12 @@ export type InferCreationAttributes<
 type InternalInferAttributeKeysFromFields<M extends Model, Key extends keyof M, Options extends InferAttributesOptions<keyof M | never | ''>> =
   // fields inherited from Model are all excluded
   Key extends keyof Model ? never
-  // check 'omit' option is provided & exclude those listed in it
-  : Options['omit'] extends string ? (Key extends Options['omit'] ? never : Key)
   // functions are always excluded
   : M[Key] extends AnyFunction ? never
   // fields branded with NonAttribute are excluded
   : IsBranded<M[Key], typeof NonAttributeBrand> extends true ? never
+  // check 'omit' option is provided & exclude those listed in it
+  : Options['omit'] extends string ? (Key extends Options['omit'] ? never : Key)
   : Key;
 
 // in v7, we should be able to drop InferCreationAttributes and InferAttributes,

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -3444,15 +3444,15 @@ export type InferCreationAttributes<
  * - Excluded manually using {@link InferAttributesOptions#omit}
  */
 type InternalInferAttributeKeysFromFields<M extends Model, Key extends keyof M, Options extends InferAttributesOptions<keyof M | never | ''>> =
-  // functions are always excluded
-  M[Key] extends AnyFunction ? never
   // fields inherited from Model are all excluded
-  : Key extends keyof Model ? never
-  // fields branded with NonAttribute are excluded
-  : IsBranded<M[Key], typeof NonAttributeBrand> extends true ? never
+  Key extends keyof Model ? never
   // check 'omit' option is provided & exclude those listed in it
   : Options['omit'] extends string ? (Key extends Options['omit'] ? never : Key)
-  : Key
+  // functions are always excluded
+  : M[Key] extends AnyFunction ? never
+  // fields branded with NonAttribute are excluded
+  : IsBranded<M[Key], typeof NonAttributeBrand> extends true ? never
+  : Key;
 
 // in v7, we should be able to drop InferCreationAttributes and InferAttributes,
 //  resolving this confusion.


### PR DESCRIPTION
This is the same PR as #15134, but for v6

Closes https://github.com/sequelize/sequelize/issues/15133