### PR TITLE
feat: allow attribute removal from model instance

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -3413,6 +3413,13 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   setDataValue<K extends keyof TModelAttributes>(key: K, value: TModelAttributes[K]): void;
 
   /**
+   * Removes the underlying data value.
+   *
+   * @param key The name of the attribute to remove.
+   */
+  removeDataValue<K extends keyof TModelAttributes>(key: K): void;
+
+  /**
    * If no key is given, returns all values of the instance, also invoking virtual getters. If an object has child objects or if options.clone===true, the object will be a copy. Otherwise, it will reference instance.dataValues.
    *
    * If key is given and a field or virtual getter is present for the key it will call that getter - else it

--- a/src/model.js
+++ b/src/model.js
@@ -3567,6 +3567,17 @@ Instead of specifying a Model, either:
   }
 
   /**
+   * Removes the underlying data value
+   *
+   * @param {string} key The name of the attribute to remove.
+   */
+  removeDataValue(key) {
+    this.changed(key, true);
+
+    delete this.dataValues[key];
+  }
+
+  /**
    * If no key is given, returns all values of the instance, also invoking virtual getters.
    *
    * If key is given and a field or virtual getter is present for the key it will call that getter - else it will return the


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Added a method named `removeDataValue(key)` on the model instance to allow removing attributes from the instance after querying the database.

### Example

```
const jane = await User.create({ firstName: "Jane", lastName: "Doe" });
```

Using the `removeDataValue` method to remove `firstName` from the instance
```
console.log(jane.firstName); // Jane
jane.removeDataValue("firstName");
console.log(jane.firstName); // undefined
```