### PR TITLE
meta: replace slack links

### DIFF
--- a/CONTACT.md
+++ b/CONTACT.md
@@ -11,4 +11,4 @@ You can use the information below to contact maintainers directly. We will try t
 
 ## Via Slack
 
-Most of the team is also reachable privately through [our Slack](https://sequelize-slack.herokuapp.com/)
+Most of the team is also reachable privately through [our Slack](https://join.slack.com/t/sequelize/shared_invite/zt-1igt9hx8h-tGWU4AI1bRPvkRdEK5wnuQ)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We are happy to see that you might be interested in contributing to Sequelize! T
 - Reviewing (i.e. commenting on) open Pull Requests, to help their creators improve it if needed and allow maintainers to take less time looking into them
 - Helping to clarify issues opened by others, commenting and asking for clarification
 - Answering [questions tagged with `sequelize.js` on StackOverflow](https://stackoverflow.com/questions/tagged/sequelize.js)
-- Helping people in our [public Slack channel](https://sequelize.slack.com/) (note: if you don't have access, get yourself an invite automatically via [this link](http://sequelize-slack.herokuapp.com/))
+- Helping people in our [public Slack channel](https://sequelize.slack.com/) (note: if you don't have access, get yourself an invite automatically via [this link](https://join.slack.com/t/sequelize/shared_invite/zt-1igt9hx8h-tGWU4AI1bRPvkRdEK5wnuQ))
 
 Sequelize is strongly moved by contributions from people like you. All maintainers also work on their free time here.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Please find upgrade information to major versions here:
 - [Databases Compatibility Table](https://sequelize.org/releases/)
 - [Changelog](https://github.com/sequelize/sequelize/releases)
 - [Discussions](https://github.com/sequelize/sequelize/discussions)
-- [Slack Inviter](http://sequelize-slack.herokuapp.com/)
+- [Slack](https://join.slack.com/t/sequelize/shared_invite/zt-1igt9hx8h-tGWU4AI1bRPvkRdEK5wnuQ)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/sequelize.js)
 
 ### :wrench: Tools


### PR DESCRIPTION
As discussed, we have to get rid of Heroku and hence swap the invite links with the direct Slack powered feature.