### PR TITLE
fix(typings): remove `escape` & `quoteTable` from query-interface typings

### DIFF
--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -657,11 +657,6 @@ export class QueryInterface {
   public quoteIdentifiers(identifiers: string): string;
 
   /**
-   * Escape a value (e.g. a string, number or date)
-   */
-  public escape(value?: string | number | Date): string;
-
-  /**
    * Set option for autocommit of a transaction
    */
   public setAutocommit(transaction: Transaction, value: boolean, options?: QueryOptions): Promise<void>;

--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -641,11 +641,6 @@ export class QueryInterface {
   ): Promise<void>;
 
   /**
-   * Escape a table name
-   */
-  public quoteTable(identifier: TableName): string;
-
-  /**
    * Escape an identifier (e.g. a table or attribute name). If force is true, the identifier will be quoted
    * even if the `quoteIdentifiers` option is false.
    */

--- a/test/types/query-interface.ts
+++ b/test/types/query-interface.ts
@@ -71,8 +71,6 @@ async function test() {
 
   await queryInterface.dropTrigger({ tableName: 'foo', as: 'bar', name: 'baz' }, 'foo', {});
 
-  await queryInterface.quoteTable({ tableName: 'foo', delimiter: 'bar' });
-
   queryInterface.quoteIdentifier("foo");
   queryInterface.quoteIdentifier("foo", true);
   queryInterface.quoteIdentifiers("table.foo");


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->
It feels a bit stupid to just do this, but I think this is all we require. The escape function is part of the queryGenerator.

Backport of #14229

Fixes #13225 