### PR TITLE
fix: override order problem with default scope

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -741,9 +741,10 @@ ${associationOwner._getAssociationDebugList()}`);
 
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
       if (key === 'order') {
-        return _.union(objValue, srcValue);
+        return srcValue;
       }
-      return srcValue;
+
+      return _.union(objValue, srcValue);
     }
 
     if (['where', 'having'].includes(key)) {

--- a/src/model.js
+++ b/src/model.js
@@ -740,7 +740,10 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
-      return _.union(objValue, srcValue);
+      if (key === 'order') {
+        return _.union(objValue, srcValue);
+      }
+      return srcValue;
     }
 
     if (['where', 'having'].includes(key)) {

--- a/sscce.js
+++ b/sscce.js
@@ -1,35 +1,22 @@
 'use strict';
 
-/* eslint-disable no-console -- the point of this file is to debug :) */
+module.exports = async function (createSequelizeInstance, log) {
+  // SSCCE for #10914
+  const { Sequelize, Op, Model, DataTypes } = require('sequelize');
+  const sequelize = createSequelizeInstance({ benchmark: true });
+  await sequelize.authenticate();
 
-// See https://github.com/papb/sequelize-sscce as another option for running SSCCEs.
-
-const { expect } = require('chai'); // You can use `expect` on your SSCCE!
-const { createSequelizeInstance } = require('./dev/sscce-helpers');
-const { Model, DataTypes } = require('.');
-
-const sequelize = createSequelizeInstance({ benchmark: true });
-
-class User extends Model {}
-
-User.init({
-  username: DataTypes.STRING,
-  birthday: DataTypes.DATE,
-}, { sequelize, modelName: 'user' });
-
-(async () => {
-  await sequelize.sync({ force: true });
-
-  const jane = await User.create({
-    username: 'janedoe',
-    birthday: new Date(1980, 6, 20),
+  const Foo = sequelize.define('foo', {
+    name: Sequelize.STRING,
+  }, {
+    defaultScope: {
+      order: [['name', 'ASC']],
+    },
   });
 
-  console.log('\nJane:', jane.toJSON());
+  await sequelize.sync();
 
-  await sequelize.close();
-
-  expect(jane.username).to.equal('janedoe');
-})();
-
-/* eslint-enable no-console -- the point of this file is to debug :) */
+  await Foo.findAll({
+    order: [['name', 'DESC']],
+  });
+};

--- a/sscce.js
+++ b/sscce.js
@@ -1,22 +1,35 @@
 'use strict';
 
-module.exports = async function (createSequelizeInstance, log) {
-  // SSCCE for #10914
-  const { Sequelize, Op, Model, DataTypes } = require('sequelize');
-  const sequelize = createSequelizeInstance({ benchmark: true });
-  await sequelize.authenticate();
+/* eslint-disable no-console -- the point of this file is to debug :) */
 
-  const Foo = sequelize.define('foo', {
-    name: Sequelize.STRING,
-  }, {
-    defaultScope: {
-      order: [['name', 'ASC']],
-    },
+// See https://github.com/papb/sequelize-sscce as another option for running SSCCEs.
+
+const { expect } = require('chai'); // You can use `expect` on your SSCCE!
+const { createSequelizeInstance } = require('./dev/sscce-helpers');
+const { Model, DataTypes } = require('.');
+
+const sequelize = createSequelizeInstance({ benchmark: true });
+
+class User extends Model {}
+
+User.init({
+  username: DataTypes.STRING,
+  birthday: DataTypes.DATE,
+}, { sequelize, modelName: 'user' });
+
+(async () => {
+  await sequelize.sync({ force: true });
+
+  const jane = await User.create({
+    username: 'janedoe',
+    birthday: new Date(1980, 6, 20),
   });
 
-  await sequelize.sync();
+  console.log('\nJane:', jane.toJSON());
 
-  await Foo.findAll({
-    order: [['name', 'DESC']],
-  });
-};
+  await sequelize.close();
+
+  expect(jane.username).to.equal('janedoe');
+})();
+
+/* eslint-enable no-console -- the point of this file is to debug :) */

--- a/test/integration/model/scope/find.test.js
+++ b/test/integration/model/scope/find.test.js
@@ -43,6 +43,9 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               ],
             },
           },
+          orderScope: {
+            order: [['access_level', 'ASC'], ['email', 'ASC']],
+          },
         },
       });
 
@@ -137,6 +140,20 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       await this.ScopeMe.findOne({
         include: [this.DefaultScopeExclude],
       });
+    });
+
+    it('should work when override order with a scope', async function () {
+      const rows_asc = await this.ScopeMe.scope('orderScope').findAll();
+      expect(rows_asc).to.have.length(4);
+      expect(rows_asc[0].access_level).to.equal(3);
+      expect(rows_asc[3].access_level).to.equal(10);
+
+      const rows_desc = await this.ScopeMe.scope('orderScope').findAll({
+        order: [['access_level', 'DESC'], ['email', 'DESC']],
+      });
+      expect(rows_desc).to.have.length(4);
+      expect(rows_desc[0].access_level).to.equal(10);
+      expect(rows_desc[3].access_level).to.equal(3);
     });
   });
 


### PR DESCRIPTION
## Pull Request Checklist


- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

Make it possible to override defaultScope order. At the moment it's being added and that can lead to not overridable order bys or contradictory ASC and DESC of same field.

Fix this issue: #11415 & #10914
