### PR TITLE
fix(postgres): reuse `searchPath` in `extractTableDetails`

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -86,9 +86,10 @@ export class AbstractQueryGenerator {
   extractTableDetails(tableName, options) {
     options = options || {};
     tableName = tableName || {};
+    const schema = tableName.schema || options.schema || this.options.schema || options.schema !== false && this.sequelize.options.searchPath || 'public';
 
     return {
-      schema: tableName.schema || options.schema || this.options.schema || 'public',
+      schema,
       tableName: _.isPlainObject(tableName) ? tableName.tableName : tableName,
       delimiter: tableName.delimiter || options.delimiter || '.',
     };

--- a/test/unit/sql/enum.test.js
+++ b/test/unit/sql/enum.test.js
@@ -17,6 +17,10 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         schema: 'foo',
       });
 
+      const FooUser2 = current.define('user', {
+        mood: DataTypes.ENUM('happy', 'sad'),
+      }, {});
+
       const PublicUser = current.define('user', {
         mood: {
           type: DataTypes.ENUM('happy', 'sad'),
@@ -45,6 +49,14 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           expectsql(sql.pgEnum(FooUser.getTableName(), 'mood', FooUser.rawAttributes.mood.type), {
             postgres: 'CREATE TYPE "foo"."enum_users_mood" AS ENUM(\'happy\', \'sad\');',
           });
+        });
+
+        it('uses schema from Sequelize searchPath', () => {
+          current.options.searchPath = 'nonPublicSchema';
+          expectsql(sql.pgEnum(FooUser2.getTableName(), 'mood', FooUser.rawAttributes.mood.type), {
+            postgres: 'CREATE TYPE "nonPublicSchema"."enum_users_mood" AS ENUM(\'happy\', \'sad\');',
+          });
+          current.options.searchPath = null;
         });
 
         it('does add schema when public', () => {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

This PR is just a simple recreation of #13045 but for `main`. Additional information can be found there

Closes #13045 