### PR TITLE
feat: add support for add/drop column IF [NOT] EXISTS for `mssql` and `mariadb`

### DIFF
--- a/src/dialects/abstract/query-interface.js
+++ b/src/dialects/abstract/query-interface.js
@@ -475,7 +475,7 @@ export class QueryInterface {
     options = options || {};
 
     const { ifExists, ...rawQueryOptions } = options;
-    const removeColumnQueryOptions = ifExists ? { ifExists } : null;
+    const removeColumnQueryOptions = ifExists ? { ifExists } : undefined;
 
     return this.sequelize.queryRaw(this.queryGenerator.removeColumnQuery(tableName, attributeName, removeColumnQueryOptions), rawQueryOptions);
   }

--- a/src/dialects/mariadb/query-generator.js
+++ b/src/dialects/mariadb/query-generator.js
@@ -12,9 +12,7 @@ export class MariaDbQueryGenerator extends MySqlQueryGenerator {
     return ['MYSQL', 'INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA', 'mysql', 'information_schema', 'performance_schema'];
   }
 
-  addColumnQuery(table, key, dataType, options) {
-    options = options || {};
-
+  addColumnQuery(table, key, dataType, options = {}) {
     const ifNotExists = options.ifNotExists ? 'IF NOT EXISTS' : '';
 
     dataType = {
@@ -37,9 +35,7 @@ export class MariaDbQueryGenerator extends MySqlQueryGenerator {
     ]);
   }
 
-  removeColumnQuery(tableName, attributeName, options) {
-    options = options || {};
-
+  removeColumnQuery(tableName, attributeName, options = {}) {
     const ifExists = options.ifExists ? 'IF EXISTS' : '';
 
     return joinSQLFragments([

--- a/src/dialects/mariadb/query-generator.js
+++ b/src/dialects/mariadb/query-generator.js
@@ -1,10 +1,10 @@
 'use strict';
 
 import { normalizeDataType } from '../abstract/data-types-utils';
+import { joinSQLFragments } from '../../utils';
 
 const { MySqlQueryGenerator } = require('../mysql/query-generator');
 const _ = require('lodash');
-const Utils = require('../../utils');
 
 export class MariaDbQueryGenerator extends MySqlQueryGenerator {
 
@@ -15,14 +15,14 @@ export class MariaDbQueryGenerator extends MySqlQueryGenerator {
   addColumnQuery(table, key, dataType, options) {
     options = options || {};
 
-    const ifNotExists = options.ifNotExists ? ' IF NOT EXISTS' : '';
+    const ifNotExists = options.ifNotExists ? 'IF NOT EXISTS' : '';
 
     dataType = {
       ...dataType,
       type: normalizeDataType(dataType.type, this.dialect),
     };
 
-    return Utils.joinSQLFragments([
+    return joinSQLFragments([
       'ALTER TABLE',
       this.quoteTable(table),
       'ADD',
@@ -40,9 +40,9 @@ export class MariaDbQueryGenerator extends MySqlQueryGenerator {
   removeColumnQuery(tableName, attributeName, options) {
     options = options || {};
 
-    const ifExists = options.ifExists ? ' IF EXISTS' : '';
+    const ifExists = options.ifExists ? 'IF EXISTS' : '';
 
-    return Utils.joinSQLFragments([
+    return joinSQLFragments([
       'ALTER TABLE',
       this.quoteTable(tableName),
       'DROP',

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -342,20 +342,15 @@ export class MsSqlQueryGenerator extends AbstractQueryGenerator {
   }
 
   removeColumnQuery(tableName, attributeName, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'removeColumnQuery',
-        this.dialect.name,
-        REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTION,
-        REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
+    options = options || {};
+
+    const ifExists = options.ifExists ? ' IF EXISTS' : '';
 
     return Utils.joinSQLFragments([
       'ALTER TABLE',
       this.quoteTable(tableName),
       'DROP COLUMN',
+      ifExists,
       this.quoteIdentifier(attributeName),
       ';',
     ]);

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -339,9 +339,7 @@ export class MsSqlQueryGenerator extends AbstractQueryGenerator {
         + `@level2type = N'Column', @level2name = ${this.quoteIdentifier(column)};`;
   }
 
-  removeColumnQuery(tableName, attributeName, options) {
-    options = options || {};
-
+  removeColumnQuery(tableName, attributeName, options = {}) {
     const ifExists = options.ifExists ? 'IF EXISTS' : '';
 
     return Utils.joinSQLFragments([

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -342,19 +342,7 @@ export class MsSqlQueryGenerator extends AbstractQueryGenerator {
   removeColumnQuery(tableName, attributeName, options) {
     options = options || {};
 
-    const dbVersion = this.sequelize.options.databaseVersion;
-    const isGreaterThanSQLServer2016 = semver.valid(dbVersion) && semver.gte(dbVersion, '13.0.0');
-    if (options && !isGreaterThanSQLServer2016) {
-      rejectInvalidOptions(
-        'addColumnQuery',
-        this.dialect.name,
-        ADD_COLUMN_QUERY_SUPPORTABLE_OPTION,
-        ADD_COLUMN_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    const ifExists = options.ifExists ? ' IF EXISTS' : '';
+    const ifExists = options.ifExists ? 'IF EXISTS' : '';
 
     return Utils.joinSQLFragments([
       'ALTER TABLE',

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -7,7 +7,6 @@ import {
   CREATE_DATABASE_QUERY_SUPPORTABLE_OPTION,
   CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTION,
   ADD_COLUMN_QUERY_SUPPORTABLE_OPTION,
-  REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTION,
 } from '../abstract/query-generator';
 
 const _ = require('lodash');
@@ -27,7 +26,6 @@ function throwMethodUndefined(methodName) {
 const CREATE_DATABASE_SUPPORTED_OPTIONS = new Set(['collate']);
 const CREATE_SCHEMA_SUPPORTED_OPTIONS = new Set();
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set([]);
-const REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set([]);
 
 export class MsSqlQueryGenerator extends AbstractQueryGenerator {
   createDatabaseQuery(databaseName, options) {
@@ -343,6 +341,18 @@ export class MsSqlQueryGenerator extends AbstractQueryGenerator {
 
   removeColumnQuery(tableName, attributeName, options) {
     options = options || {};
+
+    const dbVersion = this.sequelize.options.databaseVersion;
+    const isGreaterThanSQLServer2016 = semver.valid(dbVersion) && semver.gte(dbVersion, '13.0.0');
+    if (options && !isGreaterThanSQLServer2016) {
+      rejectInvalidOptions(
+        'addColumnQuery',
+        this.dialect.name,
+        ADD_COLUMN_QUERY_SUPPORTABLE_OPTION,
+        ADD_COLUMN_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
 
     const ifExists = options.ifExists ? ' IF EXISTS' : '';
 

--- a/test/unit/query-generator/add-column-query.test.ts
+++ b/test/unit/query-generator/add-column-query.test.ts
@@ -26,6 +26,7 @@ describe('QueryGenerator#addColumnQuery', () => {
       type: DataTypes.INTEGER,
     }, { ifNotExists: true }), {
       default: buildInvalidOptionReceivedError('addColumnQuery', dialectName, ['ifNotExists']),
+      mariadb: 'ALTER TABLE `Users` ADD IF NOT EXISTS `age` INTEGER;',
       postgres: `ALTER TABLE "public"."Users" ADD COLUMN IF NOT EXISTS "age" INTEGER;`,
     });
   });

--- a/test/unit/query-generator/remove-column-query.test.ts
+++ b/test/unit/query-generator/remove-column-query.test.ts
@@ -26,6 +26,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
     expectsql(() => queryGenerator.removeColumnQuery(User.tableName, 'age', { ifExists: true }), {
       default: buildInvalidOptionReceivedError('removeColumnQuery', dialectName, ['ifExists']),
       mariadb: 'ALTER TABLE `Users` DROP IF EXISTS `age`;',
+      mssql: 'ALTER TABLE [Users] DROP COLUMN IF EXISTS [age];',
       postgres: `ALTER TABLE "public"."Users" DROP COLUMN IF EXISTS "age";`,
     });
   });

--- a/test/unit/query-generator/remove-column-query.test.ts
+++ b/test/unit/query-generator/remove-column-query.test.ts
@@ -25,6 +25,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
   it('generates a DROP COLUMN IF EXISTS query in supported dialects', () => {
     expectsql(() => queryGenerator.removeColumnQuery(User.tableName, 'age', { ifExists: true }), {
       default: buildInvalidOptionReceivedError('removeColumnQuery', dialectName, ['ifExists']),
+      mariadb: 'ALTER TABLE `Users` DROP IF EXISTS `age`;',
       postgres: `ALTER TABLE "public"."Users" DROP COLUMN IF EXISTS "age";`,
     });
   });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Reported in #14928 

MariaDB seems to support both `DROP COLUMN IF EXISTS` and `ADD COLUMN IF NOT EXISTS` therefore support for it is supposed to be added.

MSSQL also seems to support `DROP COLUMN IF EXISTS` however there seems to be no support for `ADD COLUMN IF NOT EXISTS`. There are possible workarounds.

Closes #14928
Closes #11774

## Todos

- [x] Update with same for MSSQL supported features