### PR TITLE
fix: cleanup query generator

### DIFF
--- a/src/dialects/abstract/index.ts
+++ b/src/dialects/abstract/index.ts
@@ -505,6 +505,8 @@ export abstract class AbstractDialect {
     return this.#dataTypeParsers.get(databaseDataType);
   }
 
+  abstract getDefaultSchema(): string;
+
   static getDefaultPort(): number {
     throw new Error(`getDefaultPort not implemented in ${this.name}`);
   }

--- a/src/dialects/abstract/query-generator-typescript.ts
+++ b/src/dialects/abstract/query-generator-typescript.ts
@@ -1,0 +1,111 @@
+import NodeUtil from 'node:util';
+import isObject from 'lodash/isObject';
+import type { ModelStatic } from '../../model.js';
+import type { Sequelize } from '../../sequelize.js';
+import { isPlainObject, isString } from '../../utils/index.js';
+import { isModelStatic } from '../../utils/model-utils.js';
+import type { TableName } from './query-interface.js';
+import type { AbstractDialect } from './index.js';
+
+export type TableNameOrModel = TableName | ModelStatic;
+
+export interface QueryGeneratorOptions {
+  sequelize: Sequelize;
+  dialect: AbstractDialect;
+}
+
+/**
+ * Temporary class to ease the TypeScript migration
+ */
+export class AbstractQueryGeneratorTypeScript {
+
+  protected readonly dialect: AbstractDialect;
+  protected readonly sequelize: Sequelize;
+
+  constructor(options: QueryGeneratorOptions) {
+    if (!options.sequelize) {
+      throw new Error('QueryGenerator initialized without options.sequelize');
+    }
+
+    if (!options.dialect) {
+      throw new Error('QueryGenerator initialized without options.dialect');
+    }
+
+    this.sequelize = options.sequelize;
+    this.dialect = options.dialect;
+  }
+
+  get options() {
+    return this.sequelize.options;
+  }
+
+  extractTableDetails(tableNameOrModel: TableNameOrModel, options?: { schema?: string, delimiter?: string }) {
+    const tableNameObject = isModelStatic(tableNameOrModel) ? tableNameOrModel.getTableName()
+      : isString(tableNameOrModel) ? { tableName: tableNameOrModel }
+      : tableNameOrModel;
+
+    if (!isPlainObject(tableNameObject)) {
+      throw new Error(`Invalid input received, got ${NodeUtil.inspect(tableNameOrModel)}, expected a Model Class, a TableNameWithSchema object, or a table name string`);
+    }
+
+    return {
+      ...tableNameObject,
+      schema: options?.schema || tableNameObject.schema || this.options.schema || this.dialect.getDefaultSchema(),
+      delimiter: options?.delimiter || tableNameObject.delimiter || '.',
+    };
+  }
+
+  /**
+   * Quote table name with optional alias and schema attribution
+   *
+   * @param param table string or object
+   * @param alias alias name
+   */
+  quoteTable(param: TableNameOrModel, alias: boolean | string = false): string {
+    if (isModelStatic(param)) {
+      param = param.getTableName();
+    }
+
+    const tableName = this.extractTableDetails(param);
+
+    if (isObject(param) && ('as' in param || 'name' in param)) {
+      throw new Error('parameters "as" and "name" are not allowed in the first parameter of quoteTable, pass them as the second parameter.');
+    }
+
+    if (alias === true) {
+      alias = tableName.tableName;
+    }
+
+    let sql = '';
+
+    if (this.dialect.supports.schemas) {
+      if (tableName.schema && tableName.schema !== this.dialect.getDefaultSchema()) {
+        sql += `${this.quoteIdentifier(tableName.schema)}.`;
+      }
+
+      sql += this.quoteIdentifier(tableName.tableName);
+    } else {
+      if (tableName.schema && tableName.schema !== this.dialect.getDefaultSchema()) {
+        sql += tableName.schema + (tableName.delimiter || '.');
+      }
+
+      sql += tableName.tableName;
+    }
+
+    if (alias) {
+      sql += ` AS ${this.quoteIdentifier(alias)}`;
+    }
+
+    return sql;
+  }
+
+  /**
+   * Adds quotes to identifier
+   *
+   * @param _identifier
+   * @param _force
+   */
+  quoteIdentifier(_identifier: string, _force?: boolean): string {
+    throw new Error(`quoteIdentifier for Dialect "${this.dialect.name}" is not implemented`);
+  }
+}

--- a/src/dialects/abstract/query-generator.d.ts
+++ b/src/dialects/abstract/query-generator.d.ts
@@ -10,11 +10,11 @@ import type {
   WhereOptions,
 } from '../../model.js';
 import type { QueryTypes } from '../../query-types.js';
-import type { Sequelize } from '../../sequelize.js';
 import type { Literal, SequelizeMethod } from '../../utils/index.js';
 import type { DataType } from './data-types.js';
+import type { QueryGeneratorOptions } from './query-generator-typescript.js';
+import { AbstractQueryGeneratorTypeScript } from './query-generator-typescript.js';
 import type { TableName } from './query-interface.js';
-import type { AbstractDialect } from './index.js';
 
 type ParameterOptions = {
   // only named replacements are allowed
@@ -74,11 +74,6 @@ type HandleSequelizeMethodOptions = ParameterOptions & {
 
 };
 
-interface QueryGeneratorOptions {
-  sequelize: Sequelize;
-  dialect: AbstractDialect;
-}
-
 // keep CREATE_DATABASE_QUERY_OPTION_NAMES updated when modifying this
 export interface CreateDatabaseQueryOptions {
   collate?: string;
@@ -108,9 +103,7 @@ export interface RemoveColumnQueryOptions {
   ifExists?: boolean;
 }
 
-export class AbstractQueryGenerator {
-  dialect: AbstractDialect;
-
+export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   constructor(options: QueryGeneratorOptions);
 
   setImmediateQuery(constraints: string[]): string;
@@ -118,7 +111,6 @@ export class AbstractQueryGenerator {
   generateTransactionId(): string;
   whereQuery(where: object, options?: ParameterOptions): string;
   whereItemsQuery(where: WhereOptions, options: WhereItemsQueryOptions, binding?: string): string;
-  quoteTable(param: TableName, alias?: string | boolean): string;
   validate(value: unknown, field?: BuiltModelAttributeColumnOptions): void;
   escape(value: unknown, field?: BuiltModelAttributeColumnOptions, options?: EscapeOptions): string;
   quoteIdentifier(identifier: string, force?: boolean): string;

--- a/src/dialects/abstract/query-interface.js
+++ b/src/dialects/abstract/query-interface.js
@@ -243,6 +243,8 @@ export class QueryInterface {
       table: tableName,
       context: 'createTable',
       withoutForeignKeyConstraints: options.withoutForeignKeyConstraints,
+      // schema override for multi-tenancy
+      schema: options.schema,
     });
     sql = this.queryGenerator.createTableQuery(tableName, attributes, options);
 

--- a/src/dialects/db2/index.ts
+++ b/src/dialects/db2/index.ts
@@ -72,6 +72,11 @@ export class Db2Dialect extends AbstractDialect {
     return `BLOB(${this.queryGenerator.escape(buffer.toString())})`;
   }
 
+  getDefaultSchema(): string {
+    // TODO: what is the default schema in DB2?
+    return '';
+  }
+
   static getDefaultPort() {
     return 3306;
   }

--- a/src/dialects/ibmi/index.ts
+++ b/src/dialects/ibmi/index.ts
@@ -64,6 +64,11 @@ export class IBMiDialect extends AbstractDialect {
     return `BLOB(X'${buffer.toString('hex')}')`;
   }
 
+  getDefaultSchema(): string {
+    // TODO: what is the default schema in IBMi?
+    return '';
+  }
+
   static getDefaultPort() {
     return 25_000;
   }

--- a/src/dialects/mariadb/index.ts
+++ b/src/dialects/mariadb/index.ts
@@ -102,6 +102,10 @@ export class MariaDbDialect extends AbstractDialect {
     return true;
   }
 
+  getDefaultSchema(): string {
+    return this.sequelize.options.database ?? '';
+  }
+
   static getDefaultPort() {
     return 3306;
   }

--- a/src/dialects/mssql/index.ts
+++ b/src/dialects/mssql/index.ts
@@ -100,6 +100,10 @@ export class MssqlDialect extends AbstractDialect {
     return `N'${value}'`;
   }
 
+  getDefaultSchema(): string {
+    return 'dbo';
+  }
+
   static getDefaultPort() {
     return 1433;
   }

--- a/src/dialects/mysql/index.ts
+++ b/src/dialects/mysql/index.ts
@@ -97,6 +97,10 @@ export class MysqlDialect extends AbstractDialect {
     return true;
   }
 
+  getDefaultSchema(): string {
+    return this.sequelize.options.database ?? '';
+  }
+
   static getDefaultPort() {
     return 3306;
   }

--- a/src/dialects/postgres/index.ts
+++ b/src/dialects/postgres/index.ts
@@ -124,6 +124,10 @@ export class PostgresDialect extends AbstractDialect {
     return !this.sequelize.options.standardConformingStrings;
   }
 
+  getDefaultSchema() {
+    return 'public';
+  }
+
   static getDefaultPort() {
     return 5432;
   }

--- a/src/dialects/snowflake/index.ts
+++ b/src/dialects/snowflake/index.ts
@@ -67,6 +67,11 @@ export class SnowflakeDialect extends AbstractDialect {
     return createUnspecifiedOrderedBindCollector();
   }
 
+  getDefaultSchema(): string {
+    // TODO: what is the default schema in Snowflake?
+    return '';
+  }
+
   static getDefaultPort() {
     return 3306;
   }

--- a/src/dialects/sqlite/index.ts
+++ b/src/dialects/sqlite/index.ts
@@ -71,6 +71,11 @@ export class SqliteDialect extends AbstractDialect {
     return createNamedParamBindCollector('$');
   }
 
+  getDefaultSchema(): string {
+    // Our SQLite implementation doesn't support schemas
+    return '';
+  }
+
   static getDefaultPort() {
     return 0;
   }

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -12,7 +12,7 @@ import type {
 } from './associations/index';
 import type { Deferrable } from './deferrable';
 import type { AbstractDataType, DataType } from './dialects/abstract/data-types.js';
-import type { IndexOptions, TableName } from './dialects/abstract/query-interface';
+import type { IndexOptions, TableName, TableNameWithSchema } from './dialects/abstract/query-interface';
 import type { IndexHints } from './index-hints';
 import type { ValidationOptions } from './instance-validator';
 import type { ModelHooks } from './model-typescript.js';
@@ -2380,11 +2380,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    * The method will return The name as a string if the model has no schema,
    * or an object with `tableName`, `schema` and `delimiter` properties.
    */
-  static getTableName(): string | {
-    tableName: string,
-    schema: string,
-    delimiter: string,
-  };
+  static getTableName(): TableNameWithSchema;
 
   /**
    * Creates a copy of this model, with one or more scopes applied.

--- a/src/utils/dialect.ts
+++ b/src/utils/dialect.ts
@@ -46,14 +46,43 @@ export function toDefaultValue(value: unknown, dialect: AbstractDialect): unknow
   return value;
 }
 
-// Note: Use the `quoteIdentifier()` and `escape()` methods on the
-// `QueryInterface` instead for more portable code.
+/**
+ * @deprecated use {@link AbstractDialect#TICK_CHAR_LEFT} and {@link AbstractDialect#TICK_CHAR_RIGHT},
+ * or {@link AbstractQueryGenerator#quoteIdentifier}
+ */
 export const TICK_CHAR = '`';
 
+/**
+ * @deprecated this is a bad way to quote identifiers and it should not be used anymore.
+ * it mangles the input if the input contains identifier quotes, which should not happen.
+ * Use {@link quoteIdentifier} instead
+ *
+ * @param s
+ * @param tickChar
+ * @returns
+ */
 export function addTicks(s: string, tickChar: string = TICK_CHAR): string {
   return tickChar + removeTicks(s, tickChar) + tickChar;
 }
 
+/**
+ * @deprecated this is a bad way to quote identifiers and it should not be used anymore.
+ * Use {@link quoteIdentifier} instead
+ *
+ * @param s
+ * @param tickChar
+ * @returns
+ */
 export function removeTicks(s: string, tickChar: string = TICK_CHAR): string {
   return s.replace(new RegExp(tickChar, 'g'), '');
+}
+
+export function quoteIdentifier(identifier: string, leftTick: string, rightTick: string): string {
+  if (leftTick === rightTick) {
+    return leftTick + identifier.replaceAll(leftTick, leftTick + leftTick) + rightTick;
+  }
+
+  return leftTick
+    + identifier.replaceAll(leftTick, leftTick + leftTick).replaceAll(rightTick, rightTick + rightTick)
+    + rightTick;
 }

--- a/test/unit/associations/has-one.test.ts
+++ b/test/unit/associations/has-one.test.ts
@@ -1,7 +1,9 @@
+import assert from 'node:assert';
 import type { ModelStatic } from '@sequelize/core';
 import { DataTypes } from '@sequelize/core';
 import { expect } from 'chai';
 import each from 'lodash/each';
+import omit from 'lodash/omit';
 import sinon from 'sinon';
 import { sequelize, getTestDialectTeaser } from '../../support';
 
@@ -79,7 +81,7 @@ describe(getTestDialectTeaser('hasOne'), () => {
   });
 
   describe('allows the user to provide an attribute definition object as foreignKey', () => {
-    it('works with a column that hasn\'t been defined before', () => {
+    it(`works with a column that hasn't been defined before`, () => {
       const User = sequelize.define('user', {});
       const Profile = sequelize.define('project', {});
 
@@ -91,7 +93,12 @@ describe(getTestDialectTeaser('hasOne'), () => {
       });
 
       expect(Profile.rawAttributes.uid).to.be.ok;
-      expect(Profile.rawAttributes.uid.references?.model).to.equal(User.getTableName());
+
+      const model = Profile.rawAttributes.uid.references?.model;
+      assert(typeof model === 'object');
+
+      expect(omit(model, ['toString'])).to.deep.equal(omit(User.getTableName(), ['toString']));
+
       expect(Profile.rawAttributes.uid.references?.key).to.equal('id');
       expect(Profile.rawAttributes.uid.allowNull).to.be.false;
     });
@@ -113,7 +120,10 @@ describe(getTestDialectTeaser('hasOne'), () => {
       User.hasOne(Profile, { foreignKey: Profile.rawAttributes.user_id });
 
       expect(Profile.rawAttributes.user_id).to.be.ok;
-      expect(Profile.rawAttributes.user_id.references?.model).to.equal(User.getTableName());
+      const targetTable = Profile.rawAttributes.user_id.references?.model;
+      assert(typeof targetTable === 'object');
+
+      expect(omit(targetTable, 'toString')).to.deep.equal(omit(User.getTableName(), 'toString'));
       expect(Profile.rawAttributes.user_id.references?.key).to.equal('uid');
       expect(Profile.rawAttributes.user_id.allowNull).to.be.false;
     });
@@ -136,7 +146,10 @@ describe(getTestDialectTeaser('hasOne'), () => {
 
       expect(Project.rawAttributes.userUid).to.be.ok;
       expect(Project.rawAttributes.userUid.allowNull).to.be.false;
-      expect(Project.rawAttributes.userUid.references?.model).to.equal(User.getTableName());
+      const targetTable = Project.rawAttributes.userUid.references?.model;
+      assert(typeof targetTable === 'object');
+
+      expect(omit(targetTable, 'toString')).to.deep.equal(omit(User.getTableName(), 'toString'));
       expect(Project.rawAttributes.userUid.references?.key).to.equal('uid');
       expect(Project.rawAttributes.userUid.defaultValue).to.equal(42);
     });

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -208,7 +208,7 @@ if (dialect.startsWith('postgres')) {
         },
         {
           arguments: ['myTable', { title: 'ENUM("A", "B", "C")', name: 'VARCHAR(255)' }],
-          expectation: 'CREATE TABLE IF NOT EXISTS myTable (title public."enum_myTable_title", name VARCHAR(255));',
+          expectation: 'CREATE TABLE IF NOT EXISTS myTable (title public.enum_myTable_title, name VARCHAR(255));',
           context: { options: { quoteIdentifiers: false } },
         },
         {
@@ -1231,31 +1231,27 @@ if (dialect.startsWith('postgres')) {
 
     _.each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
-        beforeEach(function () {
-          this.queryGenerator = new QueryGenerator({
-            sequelize: this.sequelize,
-            dialect: this.sequelize.dialect,
-          });
-        });
-
         for (const test of tests) {
           const query = test.expectation.query || test.expectation;
           const title = test.title || `Postgres correctly returns ${query} for ${JSON.stringify(test.arguments)}`;
-          it(title, function () {
+          it(title, () => {
+            const newSequelize = Support.createSequelizeInstance({
+              ...test.context?.options,
+            });
+
+            const queryGenerator = newSequelize.queryInterface.queryGenerator;
+
             if (test.needsSequelize) {
               if (typeof test.arguments[1] === 'function') {
-                test.arguments[1] = test.arguments[1](this.sequelize);
+                test.arguments[1] = test.arguments[1](newSequelize);
               }
 
               if (typeof test.arguments[2] === 'function') {
-                test.arguments[2] = test.arguments[2](this.sequelize);
+                test.arguments[2] = test.arguments[2](newSequelize);
               }
             }
 
-            // Options would normally be set by the query interface that instantiates the query-generator, but here we specify it explicitly
-            this.queryGenerator.options = { ...this.queryGenerator.options, ...test.context && test.context.options };
-
-            const conditions = this.queryGenerator[suiteTitle](...test.arguments);
+            const conditions = queryGenerator[suiteTitle](...test.arguments);
             expect(conditions).to.deep.equal(test.expectation);
           });
         }

--- a/test/unit/model/schema.test.ts
+++ b/test/unit/model/schema.test.ts
@@ -19,7 +19,9 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
 
     describe('schema', () => {
       it('should work with no default schema', () => {
-        expect(Project._schema).to.eq('');
+        Support.expectsql(Project._schema, {
+          postgres: 'public',
+        });
       });
 
       it('should apply default schema from define', () => {
@@ -45,7 +47,9 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('should be able nullify schema', () => {
-        expect(Company.schema(null)._schema).to.eq('');
+        Support.expectsql(Company.schema(null)._schema, {
+          postgres: 'public',
+        });
       });
 
       it('should support multiple, coexistent schema models', () => {

--- a/test/unit/query-generator/add-column-query.test.ts
+++ b/test/unit/query-generator/add-column-query.test.ts
@@ -17,7 +17,7 @@ describe('QueryGenerator#addColumnQuery', () => {
     }), {
       default: `ALTER TABLE [Users] ADD [age] INTEGER;`,
       mssql: `ALTER TABLE [Users] ADD [age] INTEGER NULL;`,
-      postgres: `ALTER TABLE "public"."Users" ADD COLUMN "age" INTEGER;`,
+      postgres: `ALTER TABLE "Users" ADD COLUMN "age" INTEGER;`,
     });
   });
 
@@ -27,7 +27,7 @@ describe('QueryGenerator#addColumnQuery', () => {
     }, { ifNotExists: true }), {
       default: buildInvalidOptionReceivedError('addColumnQuery', dialectName, ['ifNotExists']),
       mariadb: 'ALTER TABLE `Users` ADD IF NOT EXISTS `age` INTEGER;',
-      postgres: `ALTER TABLE "public"."Users" ADD COLUMN IF NOT EXISTS "age" INTEGER;`,
+      postgres: `ALTER TABLE "Users" ADD COLUMN IF NOT EXISTS "age" INTEGER;`,
     });
   });
 });

--- a/test/unit/query-generator/remove-column-query.test.ts
+++ b/test/unit/query-generator/remove-column-query.test.ts
@@ -15,7 +15,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
   it('generates a DROP COLUMN query in supported dialects', () => {
     expectsql(() => queryGenerator.removeColumnQuery(User.tableName, 'age'), {
       default: `ALTER TABLE [Users] DROP COLUMN [age];`,
-      postgres: `ALTER TABLE "public"."Users" DROP COLUMN "age";`,
+      postgres: `ALTER TABLE "Users" DROP COLUMN "age";`,
       snowflake: `ALTER TABLE "Users" DROP "age";`,
       sqlite: 'CREATE TABLE IF NOT EXISTS `Users_backup` (`0` a, `1` g, `2` e);INSERT INTO `Users_backup` SELECT `0`, `1`, `2` FROM `Users`;DROP TABLE `Users`;ALTER TABLE `Users_backup` RENAME TO `Users`;',
       'mariadb mysql': 'ALTER TABLE `Users` DROP `age`;',
@@ -27,7 +27,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
       default: buildInvalidOptionReceivedError('removeColumnQuery', dialectName, ['ifExists']),
       mariadb: 'ALTER TABLE `Users` DROP IF EXISTS `age`;',
       mssql: 'ALTER TABLE [Users] DROP COLUMN IF EXISTS [age];',
-      postgres: `ALTER TABLE "public"."Users" DROP COLUMN IF EXISTS "age";`,
+      postgres: `ALTER TABLE "Users" DROP COLUMN IF EXISTS "age";`,
     });
   });
 });

--- a/test/unit/sql/add-column.test.js
+++ b/test/unit/sql/add-column.test.js
@@ -14,15 +14,9 @@ const customSql = customSequelize.dialect.queryGenerator;
 
 describe(Support.getTestDialectTeaser('SQL'), () => {
   describe('addColumn', () => {
-    const User = current.define('User', {
-      id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
-        autoIncrement: true,
-      },
-    }, { timestamps: false });
-    if (['mysql', 'mariadb'].includes(current.dialect.name)) {
+    const User = current.define('User', {}, { timestamps: false });
 
+    if (['mysql', 'mariadb'].includes(current.dialect.name)) {
       it('properly generate alter queries', () => {
         return expectsql(sql.addColumnQuery(User.getTableName(), 'level_id', current.normalizeAttribute({
           type: DataTypes.FLOAT,
@@ -70,18 +64,19 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     }
 
     it('defaults the schema to the one set in the Sequelize options', () => {
+      const User = customSequelize.define('User', {}, { timestamps: false });
+
       return expectsql(customSql.addColumnQuery(User.getTableName(), 'level_id', customSequelize.normalizeAttribute({
         type: DataTypes.FLOAT,
         allowNull: false,
       })), {
-        mariadb: 'ALTER TABLE `Users` ADD `level_id` FLOAT NOT NULL;',
-        mysql: 'ALTER TABLE `Users` ADD `level_id` FLOAT NOT NULL;',
+        'mariadb mysql': 'ALTER TABLE `custom`.`Users` ADD `level_id` FLOAT NOT NULL;',
         postgres: 'ALTER TABLE "custom"."Users" ADD COLUMN "level_id" REAL NOT NULL;',
         sqlite: 'ALTER TABLE `Users` ADD `level_id` REAL NOT NULL;',
-        mssql: 'ALTER TABLE [Users] ADD [level_id] REAL NOT NULL;',
-        db2: 'ALTER TABLE "Users" ADD "level_id" REAL NOT NULL;',
-        snowflake: 'ALTER TABLE "Users" ADD "level_id" FLOAT NOT NULL;',
-        ibmi: 'ALTER TABLE "Users" ADD "level_id" REAL NOT NULL',
+        mssql: 'ALTER TABLE [custom].[Users] ADD [level_id] REAL NOT NULL;',
+        db2: 'ALTER TABLE "custom"."Users" ADD "level_id" REAL NOT NULL;',
+        snowflake: 'ALTER TABLE "custom"."Users" ADD "level_id" FLOAT NOT NULL;',
+        ibmi: 'ALTER TABLE "custom"."Users" ADD "level_id" REAL NOT NULL',
       });
     });
   });

--- a/test/unit/sql/add-constraint.test.js
+++ b/test/unit/sql/add-constraint.test.js
@@ -9,222 +9,222 @@ const expect = require('chai').expect;
 const sinon = require('sinon');
 const { Op } = require('@sequelize/core');
 
-if (current.dialect.supports.constraints.addConstraint) {
-  describe(Support.getTestDialectTeaser('SQL'), () => {
-    describe('addConstraint', () => {
-      describe('unique', () => {
-        it('naming', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            name: 'unique_mytable_mycolumn',
-            type: 'UNIQUE',
-            fields: ['myColumn'],
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [unique_mytable_mycolumn] UNIQUE ([myColumn]);',
-          });
-        });
+describe(Support.getTestDialectTeaser('QueryGenerator#addConstraint'), () => {
+  if (!current.dialect.supports.constraints.addConstraint) {
+    return;
+  }
 
-        it('should create constraint name if not passed', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            type: 'UNIQUE',
-            fields: ['myColumn'],
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_uk] UNIQUE ([myColumn]);',
-          });
-        });
-
-        it('should work with multiple columns', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            type: 'UNIQUE',
-            fields: ['myColumn1', 'myColumn2'],
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn1_myColumn2_uk] UNIQUE ([myColumn1], [myColumn2]);',
-          });
-        });
+  describe('unique', () => {
+    it('naming', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        name: 'unique_mytable_mycolumn',
+        type: 'UNIQUE',
+        fields: ['myColumn'],
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [unique_mytable_mycolumn] UNIQUE ([myColumn]);',
       });
+    });
 
-      describe('check', () => {
-        it('naming', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            type: 'CHECK',
-            fields: ['myColumn'],
-            where: {
-              myColumn: ['value1', 'value2', 'value3'],
-            },
-          }), {
-            mssql: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_ck] CHECK ([myColumn] IN (N\'value1\', N\'value2\', N\'value3\'));',
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_ck] CHECK ([myColumn] IN (\'value1\', \'value2\', \'value3\'));',
-          });
-        });
-
-        it('where', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            type: 'CHECK',
-            fields: ['myColumn'],
-            name: 'check_mycolumn_where',
-            where: {
-              myColumn: {
-                [Op.and]: {
-                  [Op.gt]: 50,
-                  [Op.lt]: 100,
-                },
-              },
-            },
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [check_mycolumn_where] CHECK (([myColumn] > 50 AND [myColumn] < 100));',
-          });
-        });
-
+    it('should create constraint name if not passed', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        type: 'UNIQUE',
+        fields: ['myColumn'],
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_uk] UNIQUE ([myColumn]);',
       });
+    });
 
-      if (current.dialect.supports.constraints.default) {
-        describe('default', () => {
-          it('naming', () => {
-            expectsql(sql.addConstraintQuery('myTable', {
-              type: 'default',
-              fields: ['myColumn'],
-              defaultValue: 0,
-            }), {
-              mssql: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_df] DEFAULT (0) FOR [myColumn];',
-            });
-          });
-
-          it('string', () => {
-            expectsql(sql.addConstraintQuery('myTable', {
-              type: 'default',
-              fields: ['myColumn'],
-              defaultValue: 'some default value',
-              name: 'default_mytable_null',
-            }), {
-              mssql: 'ALTER TABLE [myTable] ADD CONSTRAINT [default_mytable_null] DEFAULT (N\'some default value\') FOR [myColumn];',
-            });
-          });
-
-          it('validation', () => {
-            expect(sql.addConstraintQuery.bind(sql, {
-              tableName: 'myTable',
-              schema: 'mySchema',
-            }, {
-              type: 'default',
-              fields: [{
-                attribute: 'myColumn',
-              }],
-            })).to.throw('Default value must be specified for DEFAULT CONSTRAINT');
-          });
-
-        });
-      }
-
-      describe('primary key', () => {
-        it('naming', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            name: 'primary_mytable_mycolumn',
-            type: 'primary key',
-            fields: ['myColumn'],
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [primary_mytable_mycolumn] PRIMARY KEY ([myColumn]);',
-          });
-        });
-
-        it('should create constraint name if not passed', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            type: 'PRIMARY KEY',
-            fields: ['myColumn'],
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_pk] PRIMARY KEY ([myColumn]);',
-          });
-        });
-
-        it('should work with multiple columns', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            type: 'PRIMARY KEY',
-            fields: ['myColumn1', 'myColumn2'],
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn1_myColumn2_pk] PRIMARY KEY ([myColumn1], [myColumn2]);',
-          });
-        });
-      });
-
-      describe('foreign key', () => {
-        it('naming', () => {
-          expectsql(sql.addConstraintQuery('myTable', {
-            name: 'foreignkey_mytable_mycolumn',
-            type: 'foreign key',
-            fields: ['myColumn'],
-            references: {
-              table: 'myOtherTable',
-              field: 'id',
-            },
-          }), {
-            default: 'ALTER TABLE [myTable] ADD CONSTRAINT [foreignkey_mytable_mycolumn] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]);',
-          });
-        });
-
-        it('supports composite keys', () => {
-          expectsql(
-            sql.addConstraintQuery('myTable', {
-              type: 'foreign key',
-              fields: ['myColumn', 'anotherColumn'],
-              references: {
-                table: 'myOtherTable',
-                fields: ['id1', 'id2'],
-              },
-              onDelete: 'cascade',
-            }),
-            {
-              db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_anotherColumn_myOtherTable_fk" FOREIGN KEY ("myColumn", "anotherColumn") REFERENCES "myOtherTable" ("id1", "id2") ON DELETE CASCADE;',
-              ibmi: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_anotherColumn_myOtherTable_fk" FOREIGN KEY ("myColumn", "anotherColumn") REFERENCES "myOtherTable" ("id1", "id2") ON DELETE CASCADE',
-              default:
-                'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_anotherColumn_myOtherTable_fk] FOREIGN KEY ([myColumn], [anotherColumn]) REFERENCES [myOtherTable] ([id1], [id2]) ON DELETE CASCADE;',
-            },
-          );
-        });
-
-        if (current.dialect.name !== 'ibmi') {
-          it('uses onDelete, onUpdate', () => {
-            expectsql(sql.addConstraintQuery('myTable', {
-              type: 'foreign key',
-              fields: ['myColumn'],
-              references: {
-                table: 'myOtherTable',
-                field: 'id',
-              },
-              onUpdate: 'cascade',
-              onDelete: 'cascade',
-            }), {
-              db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON DELETE CASCADE;',
-              default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_myOtherTable_fk] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;',
-            });
-          });
-        }
-
-        it('errors if references object is not passed', () => {
-          expect(sql.addConstraintQuery.bind(sql, 'myTable', {
-            type: 'foreign key',
-            fields: ['myColumn'],
-          })).to.throw('references object with table and field must be specified');
-        });
-
-      });
-
-      describe('validation', () => {
-        it('throw error on invalid type', () => {
-          expect(sql.addConstraintQuery.bind(sql, 'myTable', { type: 'some type', fields: [] })).to.throw('some type is invalid');
-        });
-
-        it('calls getConstraintSnippet function', () => {
-          const options = { type: 'unique', fields: ['myColumn'] };
-          const addConstraintQuerySpy = sinon.stub(sql, 'addConstraintQuery');
-          sql.addConstraintQuery('myTable', options);
-          expect(sql.addConstraintQuery).to.have.been.calledWith('myTable', options);
-          addConstraintQuerySpy.restore();
-        });
-
-        if (!current.dialect.supports.constraints.default) {
-          it('should throw error if default constraints are used in other dialects', () => {
-            expect(sql.addConstraintQuery.bind(sql, 'myTable', { type: 'default', defaultValue: 0, fields: [] })).to.throw('Default constraints are supported only for MSSQL dialect.');
-          });
-        }
+    it('should work with multiple columns', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        type: 'UNIQUE',
+        fields: ['myColumn1', 'myColumn2'],
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn1_myColumn2_uk] UNIQUE ([myColumn1], [myColumn2]);',
       });
     });
   });
-}
+
+  describe('check', () => {
+    it('naming', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        type: 'CHECK',
+        fields: ['myColumn'],
+        where: {
+          myColumn: ['value1', 'value2', 'value3'],
+        },
+      }), {
+        mssql: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_ck] CHECK ([myColumn] IN (N\'value1\', N\'value2\', N\'value3\'));',
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_ck] CHECK ([myColumn] IN (\'value1\', \'value2\', \'value3\'));',
+      });
+    });
+
+    it('where', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        type: 'CHECK',
+        fields: ['myColumn'],
+        name: 'check_mycolumn_where',
+        where: {
+          myColumn: {
+            [Op.and]: {
+              [Op.gt]: 50,
+              [Op.lt]: 100,
+            },
+          },
+        },
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [check_mycolumn_where] CHECK (([myColumn] > 50 AND [myColumn] < 100));',
+      });
+    });
+
+  });
+
+  if (current.dialect.supports.constraints.default) {
+    describe('default', () => {
+      it('naming', () => {
+        expectsql(sql.addConstraintQuery('myTable', {
+          type: 'default',
+          fields: ['myColumn'],
+          defaultValue: 0,
+        }), {
+          mssql: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_df] DEFAULT (0) FOR [myColumn];',
+        });
+      });
+
+      it('string', () => {
+        expectsql(sql.addConstraintQuery('myTable', {
+          type: 'default',
+          fields: ['myColumn'],
+          defaultValue: 'some default value',
+          name: 'default_mytable_null',
+        }), {
+          mssql: 'ALTER TABLE [myTable] ADD CONSTRAINT [default_mytable_null] DEFAULT (N\'some default value\') FOR [myColumn];',
+        });
+      });
+
+      it('validation', () => {
+        expect(sql.addConstraintQuery.bind(sql, {
+          tableName: 'myTable',
+          schema: 'mySchema',
+        }, {
+          type: 'default',
+          fields: [{
+            attribute: 'myColumn',
+          }],
+        })).to.throw('Default value must be specified for DEFAULT CONSTRAINT');
+      });
+
+    });
+  }
+
+  describe('primary key', () => {
+    it('naming', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        name: 'primary_mytable_mycolumn',
+        type: 'primary key',
+        fields: ['myColumn'],
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [primary_mytable_mycolumn] PRIMARY KEY ([myColumn]);',
+      });
+    });
+
+    it('should create constraint name if not passed', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        type: 'PRIMARY KEY',
+        fields: ['myColumn'],
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_pk] PRIMARY KEY ([myColumn]);',
+      });
+    });
+
+    it('should work with multiple columns', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        type: 'PRIMARY KEY',
+        fields: ['myColumn1', 'myColumn2'],
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn1_myColumn2_pk] PRIMARY KEY ([myColumn1], [myColumn2]);',
+      });
+    });
+  });
+
+  describe('foreign key', () => {
+    it('naming', () => {
+      expectsql(sql.addConstraintQuery('myTable', {
+        name: 'foreignkey_mytable_mycolumn',
+        type: 'foreign key',
+        fields: ['myColumn'],
+        references: {
+          table: 'myOtherTable',
+          field: 'id',
+        },
+      }), {
+        default: 'ALTER TABLE [myTable] ADD CONSTRAINT [foreignkey_mytable_mycolumn] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]);',
+      });
+    });
+
+    it('supports composite keys', () => {
+      expectsql(
+        sql.addConstraintQuery('myTable', {
+          type: 'foreign key',
+          fields: ['myColumn', 'anotherColumn'],
+          references: {
+            table: 'myOtherTable',
+            fields: ['id1', 'id2'],
+          },
+          onDelete: 'cascade',
+        }),
+        {
+          db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_anotherColumn_myOtherTable_fk" FOREIGN KEY ("myColumn", "anotherColumn") REFERENCES "myOtherTable" ("id1", "id2") ON DELETE CASCADE;',
+          ibmi: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_anotherColumn_myOtherTable_fk" FOREIGN KEY ("myColumn", "anotherColumn") REFERENCES "myOtherTable" ("id1", "id2") ON DELETE CASCADE',
+          default:
+                'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_anotherColumn_myOtherTable_fk] FOREIGN KEY ([myColumn], [anotherColumn]) REFERENCES [myOtherTable] ([id1], [id2]) ON DELETE CASCADE;',
+        },
+      );
+    });
+
+    if (current.dialect.name !== 'ibmi') {
+      it('uses onDelete, onUpdate', () => {
+        expectsql(sql.addConstraintQuery('myTable', {
+          type: 'foreign key',
+          fields: ['myColumn'],
+          references: {
+            table: 'myOtherTable',
+            field: 'id',
+          },
+          onUpdate: 'cascade',
+          onDelete: 'cascade',
+        }), {
+          db2: 'ALTER TABLE "myTable" ADD CONSTRAINT "myTable_myColumn_myOtherTable_fk" FOREIGN KEY ("myColumn") REFERENCES "myOtherTable" ("id") ON DELETE CASCADE;',
+          default: 'ALTER TABLE [myTable] ADD CONSTRAINT [myTable_myColumn_myOtherTable_fk] FOREIGN KEY ([myColumn]) REFERENCES [myOtherTable] ([id]) ON UPDATE CASCADE ON DELETE CASCADE;',
+        });
+      });
+    }
+
+    it('errors if references object is not passed', () => {
+      expect(sql.addConstraintQuery.bind(sql, 'myTable', {
+        type: 'foreign key',
+        fields: ['myColumn'],
+      })).to.throw('references object with table and field must be specified');
+    });
+
+  });
+
+  describe('validation', () => {
+    it('throw error on invalid type', () => {
+      expect(sql.addConstraintQuery.bind(sql, 'myTable', { type: 'some type', fields: [] })).to.throw('some type is invalid');
+    });
+
+    it('calls getConstraintSnippet function', () => {
+      const options = { type: 'unique', fields: ['myColumn'] };
+      const addConstraintQuerySpy = sinon.stub(sql, 'addConstraintQuery');
+      sql.addConstraintQuery('myTable', options);
+      expect(sql.addConstraintQuery).to.have.been.calledWith('myTable', options);
+      addConstraintQuerySpy.restore();
+    });
+
+    if (!current.dialect.supports.constraints.default) {
+      it('should throw error if default constraints are used in other dialects', () => {
+        expect(sql.addConstraintQuery.bind(sql, 'myTable', { type: 'default', defaultValue: 0, fields: [] })).to.throw('Default constraints are supported only for MSSQL dialect.');
+      });
+    }
+  });
+});

--- a/test/unit/sql/delete.test.js
+++ b/test/unit/sql/delete.test.js
@@ -35,7 +35,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             options,
           ), {
             ibmi: 'TRUNCATE TABLE "public"."test_users" IMMEDIATE',
-            postgres: 'TRUNCATE "public"."test_users" CASCADE',
+            postgres: 'TRUNCATE "test_users" CASCADE',
             mssql: 'TRUNCATE TABLE [public].[test_users]',
             mariadb: 'TRUNCATE `public`.`test_users`',
             mysql: 'TRUNCATE `public`.`test_users`',
@@ -65,7 +65,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             options,
           ), {
             ibmi: 'TRUNCATE TABLE "public"."test_users" IMMEDIATE',
-            postgres: 'TRUNCATE "public"."test_users" RESTART IDENTITY CASCADE',
+            postgres: 'TRUNCATE "test_users" RESTART IDENTITY CASCADE',
             mssql: 'TRUNCATE TABLE [public].[test_users]',
             mariadb: 'TRUNCATE `public`.`test_users`',
             mysql: 'TRUNCATE `public`.`test_users`',
@@ -93,14 +93,14 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             options,
             User,
           ), {
-            default: 'DELETE FROM [public].[test_users] WHERE [name] = \'foo\'',
-            postgres: 'DELETE FROM "public"."test_users" WHERE "name" = \'foo\'',
+            default: `DELETE FROM [public].[test_users] WHERE [name] = 'foo'`,
+            postgres: `DELETE FROM "test_users" WHERE "name" = 'foo'`,
             mariadb: 'DELETE FROM `public`.`test_users` WHERE `name` = \'foo\'',
             sqlite: 'DELETE FROM `public.test_users` WHERE `name` = \'foo\'',
-            db2: 'DELETE FROM "public"."test_users" WHERE "name" = \'foo\'',
-            mssql: 'DELETE FROM [public].[test_users] WHERE [name] = N\'foo\'; SELECT @@ROWCOUNT AS AFFECTEDROWS;',
-            snowflake: 'DELETE FROM "public"."test_users" WHERE "name" = \'foo\'',
-            ibmi: 'DELETE FROM "public"."test_users" WHERE "name" = \'foo\'',
+            db2: `DELETE FROM "public"."test_users" WHERE "name" = 'foo'`,
+            mssql: `DELETE FROM [public].[test_users] WHERE [name] = N'foo'; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
+            snowflake: `DELETE FROM "public"."test_users" WHERE "name" = 'foo'`,
+            ibmi: `DELETE FROM "public"."test_users" WHERE "name" = 'foo'`,
           },
         );
       });
@@ -124,7 +124,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           ), {
             default: `DELETE FROM [public].[test_users] WHERE [name] = 'foo\\';DROP TABLE mySchema.myTable;' LIMIT 10`,
             ibmi: `DELETE FROM "public"."test_users" WHERE "name" = 'foo'';DROP TABLE mySchema.myTable;' FETCH NEXT 10 ROWS ONLY`,
-            postgres: `DELETE FROM "public"."test_users" WHERE "id" IN (SELECT "id" FROM "public"."test_users" WHERE "name" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)`,
+            postgres: `DELETE FROM "test_users" WHERE "id" IN (SELECT "id" FROM "test_users" WHERE "name" = 'foo'';DROP TABLE mySchema.myTable;' LIMIT 10)`,
             sqlite: 'DELETE FROM `public.test_users` WHERE rowid IN (SELECT rowid FROM `public.test_users` WHERE `name` = \'foo\'\';DROP TABLE mySchema.myTable;\' LIMIT 10)',
             mssql: `DELETE TOP(10) FROM [public].[test_users] WHERE [name] = N'foo'';DROP TABLE mySchema.myTable;'; SELECT @@ROWCOUNT AS AFFECTEDROWS;`,
             db2: `DELETE FROM "public"."test_users" WHERE "name" = 'foo'';DROP TABLE mySchema.myTable;' FETCH NEXT 10 ROWS ONLY`,

--- a/test/unit/sql/enum.test.js
+++ b/test/unit/sql/enum.test.js
@@ -73,13 +73,19 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       describe('pgListEnums', () => {
         it('works with schema #3563', () => {
           expectsql(sql.pgListEnums(FooUser.getTableName(), 'mood'), {
-            postgres: 'SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname = \'foo\' AND t.typname=\'enum_users_mood\' GROUP BY 1',
+            postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname = 'foo' AND t.typname='enum_users_mood' GROUP BY 1`,
           });
         });
 
         it('uses the default schema if no options given', () => {
           expectsql(sql.pgListEnums(), {
-            postgres: 'SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname = \'public\' GROUP BY 1',
+            postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname = 'public' GROUP BY 1`,
+          });
+        });
+
+        it('is not vulnerable to sql injection', () => {
+          expectsql(sql.pgListEnums({ tableName: `ta'"ble`, schema: `sche'"ma` }, `attri'"bute`), {
+            postgres: `SELECT t.typname enum_name, array_agg(e.enumlabel ORDER BY enumsortorder) enum_value FROM pg_type t JOIN pg_enum e ON t.oid = e.enumtypid JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace WHERE n.nspname = 'sche''"ma' AND t.typname='enum_ta''"ble_attri''"bute' GROUP BY 1`,
           });
         });
       });

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -9,6 +9,9 @@ const sql = current.dialect.queryGenerator;
 
 // Notice: [] will be replaced by dialect specific tick/quote character when there is not dialect specific expectation but only a default expectation
 
+const TICK_LEFT = Support.sequelize.dialect.TICK_CHAR_LEFT;
+const TICK_RIGHT = Support.sequelize.dialect.TICK_CHAR_RIGHT;
+
 describe(Support.getTestDialectTeaser('SQL'), () => {
   if (current.dialect.name === 'snowflake') {
     return;
@@ -23,7 +26,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
       if (current.dialect.supports.schemas) {
         expectsql(sql.addIndexQuery('schema.table', ['column1', 'column2'], {}), {
-          default: 'CREATE INDEX [schema_table_column1_column2] ON [schema].[table] ([column1], [column2])',
+          default: 'CREATE INDEX [schema_table_column1_column2] ON [schema.table] ([column1], [column2])',
           'mariadb mysql': 'ALTER TABLE `schema`.`table` ADD INDEX `schema_table_column1_column2` (`column1`, `column2`)',
         });
 
@@ -36,12 +39,20 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           'mariadb mysql': 'ALTER TABLE `schema`.`table` ADD INDEX `schema_table_column1_column2` (`column1`, `column2`)',
         });
 
-        expectsql(sql.addIndexQuery(sql.quoteTable(sql.addSchema({
-          _schema: 'schema',
-          tableName: 'table',
-        })), ['column1', 'column2'], {}), {
-          default: 'CREATE INDEX [schema_table_column1_column2] ON [schema].[table] ([column1], [column2])',
-          'mariadb mysql': 'ALTER TABLE `schema`.`table` ADD INDEX `schema_table_column1_column2` (`column1`, `column2`)',
+        expectsql(sql.addIndexQuery(
+          // quoteTable will produce '"schema"."table"'
+          // that is a perfectly valid table name, so passing it to quoteTable again (through addIndexQuery) must produce this:
+          // '"""schema"".""table"""'
+          // the double-quotes are duplicated because they are escaped
+          sql.quoteTable({
+            schema: 'schema',
+            tableName: 'table',
+          }),
+          ['column1', 'column2'], {},
+        ), {
+          // using TICK variables directly because it's impossible for expectsql to know whether the TICK inside ticks is meant to be a tick or just part of the string
+          default: `CREATE INDEX [schema_table_column1_column2] ON ${TICK_LEFT}${TICK_LEFT}${TICK_LEFT}schema${TICK_RIGHT}${TICK_RIGHT}.${TICK_LEFT}${TICK_LEFT}table${TICK_RIGHT}${TICK_RIGHT}${TICK_RIGHT} ([column1], [column2])`,
+          'mariadb mysql': 'ALTER TABLE ```schema``.``table``` ADD INDEX `schema_table_column1_column2` (`column1`, `column2`)',
         });
       }
     });


### PR DESCRIPTION
## Description Of Change

This PR is yet-another preliminary PR for https://github.com/sequelize/sequelize/pull/14687 in order to prevent that other PR from growing endlessly.

The goal of this PR is to:

- Introduce `AbstractQueryGeneratorTypeScript` and migrate some base QueryGenerator methods to TypeScript
- Normalize which schema is used by introducing `getDefaultSchema`, and rewriting `extractTableDetails`. We should eventually arrive at a state where all query generator methods default the table schema to either the schema set through Sequelize's options, or the per-dialect default schema.
- change `quoteIdentifier` with one very important change:
  `queryGenerator.quoteIdentifier(`"abc"`)` previously *unquoted* then quoted its input. Quotes are actually valid as identifiers, as long as they're escaped. Instead of returning `"abc"`, this method will now return `"""abc"""` (triple " because one is the actual identifier delimiter, and two consecutive `""` is how we escape `"`).
- deprecate `addTicks`, `removeTicks`, and `TICK_CHAR` for the above reason