### PR TITLE
fix: support TS 4.9 and drop support TS 4.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ts-version: ["4.5", "4.6", "4.7", "4.8"]
+        ts-version: ["4.6", "4.7", "4.8", "4.9"]
     name: TS Typings (${{ matrix.ts-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "tedious": "15.1.1",
     "ts-node": "10.9.1",
     "typedoc": "0.23.21",
-    "typescript": "4.8.4"
+    "typescript": "4.9.3"
   },
   "peerDependenciesMeta": {
     "pg": {

--- a/src/dialects/abstract/data-types-utils.ts
+++ b/src/dialects/abstract/data-types-utils.ts
@@ -42,9 +42,6 @@ export function normalizeDataType(
 
 export function dataTypeClassOrInstanceToInstance(Type: DataTypeClassOrInstance): DataTypeInstance {
   return typeof Type === 'function'
-    // TODO [2022-12-01]: Remove this eslint-disable once we drop support for TypeScript 4.5
-    // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error -- typescript 4.5 narrows Class to "never" here, but typescript 4.6 handles it correctly
-    // @ts-ignore
     ? new Type()
     : Type;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8707,10 +8707,10 @@ typedoc@0.23.21:
     minimatch "^5.1.0"
     shiki "^0.11.1"
 
-typescript@4.8.4:
-  version "4.8.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
-  integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
+typescript@4.9.3:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
+  integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Now TS 4.9 is out we need to add that to our CI. We also drop support for TS 4.5 per our version policy since it has been out for a year.
