### PR TITLE
meta: remove CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 </p>
 
 [![npm version](https://badgen.net/npm/v/@sequelize/core)](https://www.npmjs.com/package/@sequelize/core)
-[![Build Status](https://github.com/sequelize/sequelize/workflows/CI/badge.svg)](https://github.com/sequelize/sequelize/actions?query=workflow%3ACI)
 [![npm downloads](https://badgen.net/npm/dm/@sequelize/core)](https://www.npmjs.com/package/@sequelize/core)
 [![contributors](https://img.shields.io/github/contributors/sequelize/sequelize)](https://github.com/sequelize/sequelize/graphs/contributors)
 [![Open Collective](https://img.shields.io/opencollective/backers/sequelize)](https://opencollective.com/sequelize#section-contributors)


### PR DESCRIPTION
Lets remove CI badge, this is somehow a mistake.

CI badge was checking all the PRs from the CI action: https://github.com/sequelize/sequelize/actions/workflows/ci.yml so instead of success it will always show `failing`

The correct way is to replace it by https://github.com/sequelize/sequelize/actions/workflows/notify.yml but the badge was looking like this after https://github.com/sequelize/sequelize/workflows/Notify%20release%20channels/badge.svg so I think we can remove it instead