### PR TITLE
feat: setup aliasing in dialects

### DIFF
--- a/src/dialects/abstract/index.ts
+++ b/src/dialects/abstract/index.ts
@@ -347,6 +347,7 @@ export abstract class AbstractDialect {
   abstract readonly queryGenerator: AbstractQueryGenerator;
   abstract readonly connectionManager: AbstractConnectionManager<any>;
   abstract readonly dataTypesDocumentationUrl: string;
+  abstract readonly MAX_ALIAS_LENGTH: number;
 
   readonly name: Dialect;
   readonly DataTypes: Record<string, Class<AbstractDataType<any>>>;

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1880,7 +1880,7 @@ export class AbstractQueryGenerator {
       }
     }
 
-    if (this.options.minifyAliases && asRight.length > 63) {
+    if (this.options.minifyAliases && asRight.length > this.dialect.MAX_ALIAS_LENGTH) {
       const alias = `%${topLevelInfo.options.includeAliases.size}`;
 
       topLevelInfo.options.includeAliases.set(alias, asRight);

--- a/src/dialects/db2/index.ts
+++ b/src/dialects/db2/index.ts
@@ -39,6 +39,12 @@ export class Db2Dialect extends AbstractDialect {
   readonly queryGenerator: Db2QueryGenerator;
   readonly queryInterface: Db2QueryInterface;
   readonly Query = Db2Query;
+  /**
+   * Db2 trucates aliases and column name length to 30 if more than 30 UNICODE bytes
+   *
+   * @see https://www.ibm.com/docs/en/db2-for-zos/11?topic=sql-limits-in-db2-zos
+   */
+  readonly MAX_ALIAS_LENGTH = 30;
 
   /** @deprecated */
   readonly TICK_CHAR = '"';

--- a/src/dialects/ibmi/index.ts
+++ b/src/dialects/ibmi/index.ts
@@ -44,6 +44,12 @@ export class IBMiDialect extends AbstractDialect {
   readonly TICK_CHAR = '"';
   readonly TICK_CHAR_LEFT = '"';
   readonly TICK_CHAR_RIGHT = '"';
+  /**
+   * IBMI can take most object names upto 128 characters
+   *
+   * @see https://www.ibm.com/docs/en/informix-servers/12.10?topic=SSGU8G_12.1.0/com.ibm.dbdk.doc/ids_dbdk_078.html
+   */
+  readonly MAX_ALIAS_LENGTH = 128;
 
   constructor(sequelize: Sequelize) {
     super(sequelize, DataTypes, 'ibmi');

--- a/src/dialects/mariadb/index.ts
+++ b/src/dialects/mariadb/index.ts
@@ -64,6 +64,12 @@ export class MariaDbDialect extends AbstractDialect {
   readonly TICK_CHAR_RIGHT = '`';
   readonly defaultVersion = '10.1.44'; // minimum supported version
   readonly dataTypesDocumentationUrl = 'https://mariadb.com/kb/en/library/resultset/#field-types';
+  /**
+   * MariaDB can take upto 64 characters.
+   *
+   * @see https://mariadb.com/kb/en/identifier-names/#maximum-length
+   */
+  readonly MAX_ALIAS_LENGTH = 64;
 
   readonly queryGenerator: MariaDbQueryGenerator;
   readonly connectionManager: MariaDbConnectionManager;

--- a/src/dialects/mssql/index.ts
+++ b/src/dialects/mssql/index.ts
@@ -66,6 +66,12 @@ export class MssqlDialect extends AbstractDialect {
   readonly TICK_CHAR = '"';
   readonly TICK_CHAR_LEFT = '[';
   readonly TICK_CHAR_RIGHT = ']';
+  /**
+   * Max identifier limit in MSSQL is 128 characters.
+   *
+   * @see https://learn.microsoft.com/en-us/answers/questions/264575/character-limit-exceeding-db-limit.html
+   */
+  readonly MAX_ALIAS_LENGTH = 128;
 
   constructor(sequelize: Sequelize) {
     super(sequelize, DataTypes, 'mssql');

--- a/src/dialects/mysql/index.ts
+++ b/src/dialects/mysql/index.ts
@@ -69,6 +69,12 @@ export class MysqlDialect extends AbstractDialect {
   readonly TICK_CHAR = '`';
   readonly TICK_CHAR_LEFT = '`';
   readonly TICK_CHAR_RIGHT = '`';
+  /**
+   * Max length allowed by MySQL for aliases
+   *
+   * @see https://dev.mysql.com/doc/refman/8.0/en/identifier-length.html
+   */
+  readonly MAX_ALIAS_LENGTH = 63;
 
   constructor(sequelize: Sequelize) {
     super(sequelize, DataTypes, 'mysql');

--- a/src/dialects/postgres/index.ts
+++ b/src/dialects/postgres/index.ts
@@ -79,6 +79,13 @@ export class PostgresDialect extends AbstractDialect {
   readonly TICK_CHAR = '"';
   readonly TICK_CHAR_LEFT = '"';
   readonly TICK_CHAR_RIGHT = '"';
+  /**
+   * Max length allowed by Postgres for aliases is 63
+   * Max allowed is 64 - 1 byte of type which boils down to 63
+   *
+   * @see https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+   */
+  readonly MAX_ALIAS_LENGTH = 63;
 
   constructor(sequelize: Sequelize) {
     super(sequelize, DataTypes, 'postgres');

--- a/src/dialects/snowflake/index.ts
+++ b/src/dialects/snowflake/index.ts
@@ -52,6 +52,12 @@ export class SnowflakeDialect extends AbstractDialect {
   readonly connectionManager: SnowflakeConnectionManager;
   readonly queryGenerator: SnowflakeQueryGenerator;
   readonly queryInterface: SnowflakeQueryInterface;
+  /**
+   * Maximum identifier length for snowflake is 255.
+   *
+   * @see https://docs.snowflake.com/en/sql-reference/identifiers.html#:~:text=An%20identifier%20is%20a%20string,queries%20and%20DDL%2FDML%20statements.
+   */
+  readonly MAX_ALIAS_LENGTH = 255;
 
   constructor(sequelize: Sequelize) {
     super(sequelize, DataTypes, 'snowflake');

--- a/src/dialects/sqlite/index.ts
+++ b/src/dialects/sqlite/index.ts
@@ -52,6 +52,12 @@ export class SqliteDialect extends AbstractDialect {
   readonly queryGenerator: SqliteQueryGenerator;
   readonly queryInterface: SqliteQueryInterface;
   readonly dataTypesDocumentationUrl = 'https://www.sqlite.org/datatype3.html';
+  /**
+   * There is no documentation for limits on SQLite.
+   *
+   * @see https://www.sqlite.org/limits.html#:~:text=The%20current%20implementation%20will%20only,231%2D1%20or%202147483647.
+   */
+  readonly MAX_ALIAS_LENGTH = 2_147_483_647;
 
   constructor(sequelize: Sequelize) {
     super(sequelize, DataTypes, 'sqlite');

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -190,7 +190,7 @@ export class Sequelize extends SequelizeTypeScript {
    * @param {boolean}  [options.noTypeValidation=false] Run built-in type validators on insert and update, and select with where clause, e.g. validate that arguments passed to integer fields are integer-like.
    * @param {object}   [options.operatorsAliases] String based operator alias. Pass object to limit set of aliased operators.
    * @param {object}   [options.hooks] An object of global hook functions that are called before and after certain lifecycle events. Global hooks will run after any model-specific hooks defined for the same event (See `Sequelize.Model.init()` for a list).  Additionally, `beforeConnect()`, `afterConnect()`, `beforeDisconnect()`, and `afterDisconnect()` hooks may be defined here.
-   * @param {boolean}  [options.minifyAliases=false] A flag that defines if aliases should be minified (mostly useful to avoid Postgres alias character limit of 64)
+   * @param {boolean}  [options.minifyAliases=false] A flag that defines if aliases should be minified (mostly useful to avoid Postgres alias character limit of 63)
    * @param {boolean}  [options.logQueryParameters=false] A flag that defines if show bind parameters in log.
    */
   constructor(database, username, password, options) {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

First reported in #14118
Since DBMSs are only able to support identifiers up until certain lengths therefore any identifier that crosses that limit should either be aliased or an error should be thrown.
