### PR TITLE
fix(oracle): remove hardcoded maxRows value

### DIFF
--- a/src/dialects/oracle/connection-manager.js
+++ b/src/dialects/oracle/connection-manager.js
@@ -35,7 +35,6 @@ export class OracleConnectionManager extends AbstractConnectionManager {
    *
    */
   extendLib() {
-    this.lib.maxRows = 1000;
     if (this.sequelize.config && 'dialectOptions' in this.sequelize.config) {
       const dialectOptions = this.sequelize.config.dialectOptions;
       if (dialectOptions && 'maxRows' in dialectOptions) {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->
The Oracle dialect had the maxRows value hardcoded to 1000 so select queries returned only the first 1000 rows unless the user set the maxRows option. Fixing this would fetch all the rows from the table instead.

Fix to the issue raised in https://stackoverflow.com/questions/74357044/sequelize-have-a-limit-of-return-1000-rows-of-my-table-oracle-connection