### PR TITLE
feat(model): add manipulation functionality in find options to format result.

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -936,6 +936,12 @@ export interface FindOptions<TAttributes = any>
    * Use a table hint for the query, only supported in MSSQL.
    */
   tableHint?: TableHints;
+
+  /**
+   * Use to manipulate model instances.
+   * Get the results in the format you want in your mixed queries.
+   */
+  manipulate?: <M extends Model>(instancesOrInstance: M[] | M | null) => {}
 }
 
 export interface NonNullFindOptions<TAttributes = any> extends FindOptions<TAttributes> {

--- a/src/model.js
+++ b/src/model.js
@@ -1925,6 +1925,8 @@ Specify a different name for either index to resolve this issue.`);
     }
 
     await Promise.all(options.include.map(async include => {
+      const { manipulate } = include;
+
       if (!include.separate) {
         return await Model._findSeparate(
           results.reduce((memo, result) => {
@@ -1941,7 +1943,13 @@ Specify a different name for either index to resolve this issue.`);
             }
 
             for (let i = 0, len = associations.length; i !== len; ++i) {
-              memo.push(associations[i]);
+              const instance = associations[i];
+
+              if (manipulate) {
+                memo.push(manipulate(instance))
+              } else {
+                memo.push(instance)
+              }
             }
 
             return memo;
@@ -1961,9 +1969,13 @@ Specify a different name for either index to resolve this issue.`);
       });
 
       for (const result of results) {
+        const instance = map[result.get(include.association.sourceKey)];
+
         result.set(
           include.association.as,
-          map.get(result.get(include.association.sourceKey)),
+          manipulate
+            ? manipulate(instance)
+            : instance,
           { raw: true },
         );
       }

--- a/src/model.js
+++ b/src/model.js
@@ -1946,9 +1946,9 @@ Specify a different name for either index to resolve this issue.`);
               const instance = associations[i];
 
               if (manipulate) {
-                memo.push(manipulate(instance))
+                memo.push(manipulate(instance));
               } else {
-                memo.push(instance)
+                memo.push(instance);
               }
             }
 


### PR DESCRIPTION
Hello everyone. 
I am working on a project with Sequelize. In queries using Sequelize, eager loading and model structure are really nice.

The problem I encountered in my own project was that an external loop was needed to get the outputs in the format I wanted. I will explain with an example below.

## Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change
**Models**
```
const Layer = sequelize.define('Layer', { name: DataTypes.STRING });
const Station = sequelize.define('Station', { name: DataTypes.STRING, layer_id: DataTypes.INTEGER });

Layer.hasMany(Station, { as: 'stations', foreign_key: 'layer_id' });
Station.belongsTo(Layer, { as: 'layer', foreign_key: 'layer_id' });
```

<details><summary>Query</summary>
<p>

```ruby
Layer.findAll({
  include: [
    {
      attributes: ['name'],
      model: Station,
      as: 'stations',
    },
  ],
})

```

</p>
</details>

<details><summary>Result</summary>
<p>

```ruby
[
  {
    id: 1,
    name: 'Layer 1',
    stations: [
      { name: 'Station 1' },
      { name: 'Station 2' },
    ],
  },
  {
    id: 2,
    name: 'Layer 2',
    stations: [
      { name: 'Station 3' },
      { name: 'Station 4' },
    ],
  },
]

```

</p>
</details>

<details><summary>Expected Result</summary>
<p>

```ruby
[
  {
    id: 1,
    name: 'Layer 1',
    stations: [
      'Station 1', 'Station 2'
    ],
  },
  {
    id: 2,
    name: 'Layer 2',
    stations: [
      'Station 3', 'Station 4'
    ],
  },
]


```

</p>
</details>

We can achieve this expected result only by using a loop over the result.
This wastes time on large queries. 
To solve this problem, we are doing something like this.
Can take advantage of the functionality of orm and shape their data without using extra loops.

```ruby
Layer.findAll({
  include: [
    {
      attributes: ['name'],
      model: Station,
      as: 'stations',
      manipulate: (instance) => {
          instance.dataValues = instance.dataValues.name;
          return instance;
      },
    },
  ],
})

```

</p>
</details>

## Related Issues
I will update this field.
[Stackoverflow 1](https://stackoverflow.com/questions/52150349/can-you-hide-output-from-a-not-automatically-generated-join-table-using-sequel)
[Stackoverflow 2](https://stackoverflow.com/questions/59467396/sequelize-include-model-but-without-tablenamel)

## Todos

- [ ] e.g. #1 feature: Typescript types can be improved
- [ ] e.g. #2 test: Does it create side effects on queries?
