### PR TITLE
fix: failing test for upsert with class getter

### DIFF
--- a/test/unit/model/upsert.test.js
+++ b/test/unit/model/upsert.test.js
@@ -92,6 +92,32 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           'name', 'value', 'updatedAt',
         ]);
       });
+
+      it('should work with objects with getters', async function () {
+        await this.UserNoTime.upsert({
+          get name() {
+            return 'Silly Cat';
+          },
+        });
+
+        expect(this.stub.getCall(0).args[2]).to.deep.equal({
+          name: 'Silly Cat',
+        });
+      });
+
+      it('should work with instances of classes with getters', async function () {
+        class MyUserDTO {
+          get name() {
+            return 'Silly Cat';
+          }
+        }
+
+        await this.UserNoTime.upsert(new MyUserDTO());
+
+        expect(this.stub.getCall(0).args[2]).to.deep.equal({
+          name: 'Silly Cat',
+        });
+      });
     });
   }
 });


### PR DESCRIPTION
Refs #15337.

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Added two unit tests for upsert. One uses objects with getter property (passes), the other uses a class instance with a getter method (fails).

## Todos

- [ ] Confirm with maintainers that this is a bug rather than an intentional design limitation (e.g., for performance reasons).
- [ ] Fix the bug if the issue is accepted 😄 