### PR TITLE
fix: always escape string attributes

### DIFF
--- a/src/dialects/abstract/index.ts
+++ b/src/dialects/abstract/index.ts
@@ -63,10 +63,7 @@ export type DialectSupports = {
   finalTable: boolean,
 
   /* does the dialect support returning values for inserted/updated fields */
-  returnValues: false | {
-    output: boolean,
-    returning: boolean,
-  },
+  returnValues: false | 'output' | 'returning',
 
   /* features specific to autoIncrement values */
   autoIncrement: {

--- a/src/dialects/abstract/query-generator.d.ts
+++ b/src/dialects/abstract/query-generator.d.ts
@@ -10,7 +10,7 @@ import type {
   WhereOptions,
 } from '../../model.js';
 import type { QueryTypes } from '../../query-types.js';
-import type { Literal, SequelizeMethod } from '../../utils/sequelize-method.js';
+import type { Literal, SequelizeMethod, Col } from '../../utils/sequelize-method.js';
 import type { DataType } from './data-types.js';
 import type { QueryGeneratorOptions } from './query-generator-typescript.js';
 import { AbstractQueryGeneratorTypeScript } from './query-generator-typescript.js';
@@ -39,7 +39,7 @@ type InsertOptions = ParameterOptions & SearchPathable & {
   updateOnDuplicate?: string[],
   ignoreDuplicates?: boolean,
   upsertKeys?: string[],
-  returning?: boolean | string[],
+  returning?: boolean | Array<string | Literal | Col>,
 };
 
 type BulkInsertOptions = ParameterOptions & {
@@ -48,7 +48,7 @@ type BulkInsertOptions = ParameterOptions & {
   updateOnDuplicate?: string[],
   ignoreDuplicates?: boolean,
   upsertKeys?: string[],
-  returning?: boolean | string[],
+  returning?: boolean | Array<string | Literal | Col>,
 };
 
 type UpdateOptions = ParameterOptions & {
@@ -60,7 +60,7 @@ type DeleteOptions = ParameterOptions & {
 };
 
 type ArithmeticQueryOptions = ParameterOptions & {
-  returning?: boolean | string[],
+  returning?: boolean | Array<string | Literal | Col>,
 };
 
 export type WhereItemsQueryOptions = ParameterOptions & {

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import NodeUtil from 'node:util';
 import { getTextDataTypeForDialect } from '../../sql-string';
 import { rejectInvalidOptions, isNullish, canTreatArrayAsAnd, isColString } from '../../utils/check';
 import { TICK_CHAR } from '../../utils/dialect';
@@ -431,7 +432,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       outputFragment = returnValues.outputFragment || '';
 
       // ensure that the return output is properly mapped to model fields.
-      if (!this.dialect.supports.returnValues.output && options.returning) {
+      if (!this.dialect.supports.returnValues === 'output' && options.returning) {
         options.mapToModel = true;
       }
     }
@@ -1845,8 +1846,26 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     let returningFragment = '';
     let tmpTable = '';
 
+    const returnValuesType = this.dialect.supports.returnValues;
+
     if (Array.isArray(options.returning)) {
-      returnFields.push(...options.returning.map(field => this.quoteIdentifier(field)));
+      returnFields.push(...options.returning.map(field => {
+        if (typeof field === 'string') {
+          return this.quoteIdentifier(field);
+        } else if (field instanceof Literal) {
+          // Due to how the mssql query is built, using a literal would never result in a properly formed query.
+          // It's better to warn early.
+          if (returnValuesType === 'output') {
+            throw new Error(`literal() cannot be used in the "returning" option array in ${this.dialect.name}. Use col(), or a string instead.`);
+          }
+
+          return this.handleSequelizeMethod(field);
+        } else if (field instanceof Col) {
+          return this.handleSequelizeMethod(field);
+        }
+
+        throw new Error(`Unsupported value in "returning" option: ${NodeUtil.inspect(field)}. This option only accepts true, false, or an array of strings, col() or literal().`);
+      }));
     } else if (modelAttributes) {
       _.each(modelAttributes, attribute => {
         if (!(attribute.type instanceof DataTypes.VIRTUAL)) {
@@ -1857,13 +1876,13 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     }
 
     if (_.isEmpty(returnFields)) {
-      returnFields.push('*');
+      returnFields.push(`*`);
     }
 
-    if (this.dialect.supports.returnValues.returning) {
-      returningFragment = ` RETURNING ${returnFields.join(',')}`;
-    } else if (this.dialect.supports.returnValues.output) {
-      outputFragment = ` OUTPUT ${returnFields.map(field => `INSERTED.${field}`).join(',')}`;
+    if (returnValuesType === 'returning') {
+      returningFragment = ` RETURNING ${returnFields.join(', ')}`;
+    } else if (returnValuesType === 'output') {
+      outputFragment = ` OUTPUT ${returnFields.map(field => `INSERTED.${field}`).join(', ')}`;
 
       // To capture output rows when there is a trigger on MSSQL DB
       if (options.hasTrigger && this.dialect.supports.tmpTableTrigger) {

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1516,10 +1516,8 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         if (attr[0] instanceof SequelizeMethod) {
           attr[0] = this.handleSequelizeMethod(attr[0], undefined, undefined, options);
           addTable = false;
-        } else if (!attr[0].includes('(') && !attr[0].includes(')')) {
-          attr[0] = this.quoteIdentifier(attr[0]);
         } else {
-          deprecations.noRawAttributes();
+          attr[0] = this.quoteIdentifier(attr[0]);
         }
 
         let alias = attr[1];

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1008,6 +1008,10 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   /**
    * Split a list of identifiers by "." and quote each part.
    *
+   * ⚠️ You almost certainly want to use `quoteIdentifier` instead!
+   * This method splits the identifier by "." into multiple identifiers, and has special meaning for "*".
+   * This behavior should never be the default and should be explicitly opted into by using {@link Col}.
+   *
    * @param {string} identifiers
    *
    * @returns {string}
@@ -1019,7 +1023,11 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       const head = identifiers.slice(0, -1).join('->');
       const tail = identifiers[identifiers.length - 1];
 
-      return `${this.quoteIdentifier(head)}.${this.quoteIdentifier(tail)}`;
+      return `${this.quoteIdentifier(head)}.${tail === '*' ? '*' : this.quoteIdentifier(tail)}`;
+    }
+
+    if (identifiers === '*') {
+      return '*';
     }
 
     return this.quoteIdentifier(identifiers);

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -432,7 +432,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       outputFragment = returnValues.outputFragment || '';
 
       // ensure that the return output is properly mapped to model fields.
-      if (!this.dialect.supports.returnValues === 'output' && options.returning) {
+      if (this.dialect.supports.returnValues !== 'output' && options.returning) {
         options.mapToModel = true;
       }
     }

--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -14,7 +14,7 @@ import type {
 } from '../../model';
 import type { Sequelize, QueryRawOptions, QueryRawOptionsWithModel } from '../../sequelize';
 import type { Transaction } from '../../transaction';
-import type { Fn, Literal } from '../../utils/sequelize-method.js';
+import type { Fn, Literal, Col } from '../../utils/sequelize-method.js';
 import type { DataType } from './data-types.js';
 import type { TableNameOrModel } from './query-generator-typescript';
 import type { AbstractQueryGenerator, AddColumnQueryOptions, RemoveColumnQueryOptions } from './query-generator.js';
@@ -29,7 +29,7 @@ interface Replaceable {
 interface QiOptionsWithReplacements extends QueryRawOptions, Replaceable {}
 
 export interface QiInsertOptions extends QueryRawOptions, Replaceable {
-  returning?: boolean | string[];
+  returning?: boolean | Array<string | Literal | Col>;
 }
 
 export interface QiSelectOptions extends QueryRawOptions, Replaceable, Filterable<any> {
@@ -37,7 +37,7 @@ export interface QiSelectOptions extends QueryRawOptions, Replaceable, Filterabl
 }
 
 export interface QiUpdateOptions extends QueryRawOptions, Replaceable {
-  returning?: boolean | string[];
+  returning?: boolean | Array<string | Literal | Col>;
 }
 
 export interface QiDeleteOptions extends QueryRawOptions, Replaceable {
@@ -45,7 +45,7 @@ export interface QiDeleteOptions extends QueryRawOptions, Replaceable {
 }
 
 export interface QiArithmeticOptions extends QueryRawOptions, Replaceable {
-  returning?: boolean | string[];
+  returning?: boolean | Array<string | Literal | Col>;
 }
 
 export interface QiUpsertOptions<M extends Model> extends QueryRawOptionsWithModel<M>, Replaceable {

--- a/src/dialects/mssql/index.ts
+++ b/src/dialects/mssql/index.ts
@@ -13,9 +13,7 @@ export class MssqlDialect extends AbstractDialect {
     'DEFAULT VALUES': true,
     'LIMIT ON UPDATE': true,
     migrations: false,
-    returnValues: {
-      output: true,
-    },
+    returnValues: 'output',
     schemas: true,
     multiDatabases: true,
     autoIncrement: {

--- a/src/dialects/postgres/index.ts
+++ b/src/dialects/postgres/index.ts
@@ -14,9 +14,7 @@ export class PostgresDialect extends AbstractDialect {
     EXCEPTION: true,
     'ON DUPLICATE KEY': false,
     'ORDER NULLS': true,
-    returnValues: {
-      returning: true,
-    },
+    returnValues: 'returning',
     bulkDefault: true,
     schemas: true,
     multiDatabases: true,

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1038,7 +1038,7 @@ export interface CreateOptions<TAttributes = any>
   /**
    * Return the affected rows (only for postgres)
    */
-  returning?: boolean | Array<keyof TAttributes>;
+  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
 
   /**
    * If false, validations won't be run.
@@ -1096,7 +1096,7 @@ export interface UpsertOptions<TAttributes = any> extends Logging, Transactionab
   /**
    * Fetch back the affected rows (only for postgres)
    */
-  returning?: boolean | Array<keyof TAttributes>;
+  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
 
   /**
    * Run validations before the row is inserted
@@ -1157,7 +1157,7 @@ export interface BulkCreateOptions<TAttributes = any> extends Logging, Transacti
   /**
    * Return all columns or only the specified columns for the affected rows (only for postgres)
    */
-  returning?: boolean | Array<keyof TAttributes>;
+  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
 }
 
 /**
@@ -1273,7 +1273,7 @@ export interface UpdateOptions<TAttributes = any> extends Logging, Transactionab
    *
    * @default false
    */
-  returning?: boolean | Array<keyof TAttributes>;
+  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
 
   /**
    * How many rows to update
@@ -1326,7 +1326,7 @@ export interface IncrementDecrementOptions<TAttributes = any>
   /**
    * Return the affected rows (only for postgres)
    */
-  returning?: boolean | Array<keyof TAttributes>;
+  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
 }
 
 /**
@@ -1406,7 +1406,7 @@ export interface SaveOptions<TAttributes = any> extends Logging, Transactionable
   /**
    * Return the affected rows (only for postgres)
    */
-  returning?: boolean | Array<keyof TAttributes>;
+  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
 }
 
 /**

--- a/src/utils/deprecations.ts
+++ b/src/utils/deprecations.ts
@@ -2,7 +2,6 @@ import { deprecate } from 'node:util';
 
 const noop = () => { /* noop */ };
 
-export const noRawAttributes = deprecate(noop, 'Use sequelize.fn / sequelize.literal to construct attributes', 'SEQUELIZE0001');
 export const noTrueLogging = deprecate(noop, 'The logging-option should be either a function or false. Default: console.log', 'SEQUELIZE0002');
 export const noStringOperators = deprecate(noop, 'String based operators are deprecated. Please use Symbol based operators for better security, read more at https://sequelize.org/docs/v7/core-concepts/model-querying-basics/#deprecated-operator-aliases', 'SEQUELIZE0003');
 export const noBoolOperatorAliases = deprecate(noop, 'A boolean value was passed to options.operatorsAliases. This is a no-op with v5 and should be removed.', 'SEQUELIZE0004');

--- a/test/integration/data-types/methods.test.ts
+++ b/test/integration/data-types/methods.test.ts
@@ -162,7 +162,7 @@ describe('DataType Methods', () => {
     });
   }
 
-  if (dialect.supports.returnValues && dialect.supports.returnValues.returning) {
+  if (dialect.supports.returnValues === 'returning') {
     it(`updating a model calls 'parseDatabaseValue' on returned values`, async () => {
       const user = await models.User.create({ name: 'foo' });
       user.name = 'bob';

--- a/test/integration/instance/decrement.test.js
+++ b/test/integration/instance/decrement.test.js
@@ -79,7 +79,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
     }
 
-    if (current.dialect.supports.returnValues.returning) {
+    if (current.dialect.supports.returnValues === 'returning') {
       it('supports returning', async function () {
         const user1 = await this.User.findByPk(1);
         await user1.decrement('aNumber', { by: 2 });

--- a/test/integration/instance/increment.test.js
+++ b/test/integration/instance/increment.test.js
@@ -80,7 +80,7 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       });
     }
 
-    if (current.dialect.supports.returnValues.returning) {
+    if (current.dialect.supports.returnValues === 'returning') {
       it('supports returning', async function () {
         const user1 = await this.User.findByPk(1);
         await user1.increment('aNumber', { by: 2 });

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
-const { DataTypes, Sequelize, Op, AggregateError } = require('@sequelize/core');
+const { DataTypes, Sequelize, Op, AggregateError, col } = require('@sequelize/core');
 
 const dialectName = Support.getTestDialect();
 const dialect = Support.sequelize.dialect;
@@ -1054,7 +1054,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             ibmi: `UPDATE "users1" SET "secretValue"=?,"updatedAt"=? WHERE "id" = ?;`,
           });
         },
-        returning: ['*'],
+        returning: [col('*')],
       });
       expect(test).to.be.true;
     });

--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, Op } = require('@sequelize/core');
+const { DataTypes, Op, col } = require('@sequelize/core');
 
 const dialectName = Support.getTestDialect();
 const dialect = Support.sequelize.dialect;
@@ -845,7 +845,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             {},
             {},
           ], {
-            returning: ['*'],
+            returning: [col('*')],
           });
 
           const actualUsers0 = await User.findAll();

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -7,7 +7,6 @@ const sinon = require('sinon');
 
 const expect = chai.expect;
 const current = Support.sequelize;
-const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Model'), () => {
   describe('update', () => {

--- a/test/integration/model/update.test.js
+++ b/test/integration/model/update.test.js
@@ -118,7 +118,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       expect(account.ownerId).to.be.equal(ownerId);
     });
 
-    if (_.get(current.dialect.supports, 'returnValues.returning')) {
+    if (current.dialect.supports.returnValues === 'returning') {
       it('should return the updated record', async function () {
         const account = await this.Account.create({ ownerId: 2 });
 
@@ -135,7 +135,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     }
 
-    if (_.get(current.dialect.supports, 'returnValues.output')) {
+    if (current.dialect.supports.returnValues === 'output') {
       it('should output the updated record', async function () {
         const account = await this.Account.create({ ownerId: 2 });
 

--- a/test/integration/sequelize.test.js
+++ b/test/integration/sequelize.test.js
@@ -2,7 +2,7 @@
 
 const { expect, assert } = require('chai');
 const Support = require('./support');
-const { DataTypes, Transaction, Sequelize } = require('@sequelize/core');
+const { DataTypes, Transaction, Sequelize, literal } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
 const _ = require('lodash');
@@ -659,7 +659,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             const TransactionTest = this.sequelizeWithTransaction.define('TransactionTest', { name: DataTypes.STRING }, { timestamps: false });
 
             const count = async transaction => {
-              const sql = this.sequelizeWithTransaction.getQueryInterface().queryGenerator.selectQuery('TransactionTests', { attributes: [['count(*)', 'cnt']] });
+              const sql = this.sequelizeWithTransaction.getQueryInterface().queryGenerator.selectQuery('TransactionTests', { attributes: [[literal('count(*)'), 'cnt']] });
 
               const result = await this.sequelizeWithTransaction.query(sql, { plain: true, transaction });
 
@@ -682,7 +682,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
             const aliasesMapping = new Map([['_0', 'cnt']]);
 
             const count = async transaction => {
-              const sql = this.sequelizeWithTransaction.getQueryInterface().queryGenerator.selectQuery('TransactionTests', { attributes: [['count(*)', 'cnt']] });
+              const sql = this.sequelizeWithTransaction.getQueryInterface().queryGenerator.selectQuery('TransactionTests', { attributes: [[literal('count(*)'), 'cnt']] });
 
               const result = await this.sequelizeWithTransaction.query(sql, { plain: true, transaction, aliasesMapping  });
 

--- a/test/unit/dialects/db2/query-generator.test.js
+++ b/test/unit/dialects/db2/query-generator.test.js
@@ -163,10 +163,6 @@ if (dialect === 'db2') {
           expectation: 'SELECT * FROM "myTable" WHERE "myTable"."id" = 2;',
           context: QueryGenerator,
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS "count" FROM "foo";',
-          context: QueryGenerator,
-        }, {
           arguments: ['myTable', { order: ['id'] }],
           expectation: 'SELECT * FROM "myTable" ORDER BY "id";',
           context: QueryGenerator,

--- a/test/unit/dialects/db2/query-generator.test.js
+++ b/test/unit/dialects/db2/query-generator.test.js
@@ -275,18 +275,6 @@ if (dialect === 'db2') {
           expectation: 'SELECT * FROM "myTable" GROUP BY "name" ORDER BY "id" DESC;',
           context: QueryGenerator,
         }, {
-          title: 'HAVING clause works with where-like hash',
-          arguments: ['myTable', function (sequelize) {
-            return {
-              attributes: ['*', [sequelize.fn('YEAR', sequelize.col('createdAt')), 'creationYear']],
-              group: ['creationYear', 'title'],
-              having: { creationYear: { [Op.gt]: 2002 } },
-            };
-          }],
-          expectation: 'SELECT *, YEAR("createdAt") AS "creationYear" FROM "myTable" GROUP BY "creationYear", "title" HAVING "creationYear" > 2002;',
-          context: QueryGenerator,
-          needsSequelize: true,
-        }, {
           title: 'Combination of sequelize.fn, sequelize.col and { in: ... }',
           arguments: ['myTable', function (sequelize) {
             return {

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -289,18 +289,6 @@ if (dialect === 'mariadb') {
           expectation: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
           context: QueryGenerator,
         }, {
-          title: 'HAVING clause works with where-like hash',
-          arguments: ['myTable', function (sequelize) {
-            return {
-              attributes: ['*', [sequelize.fn('YEAR', sequelize.col('createdAt')), 'creationYear']],
-              group: ['creationYear', 'title'],
-              having: { creationYear: { [Op.gt]: 2002 } },
-            };
-          }],
-          expectation: 'SELECT *, YEAR(`createdAt`) AS `creationYear` FROM `myTable` GROUP BY `creationYear`, `title` HAVING `creationYear` > 2002;',
-          context: QueryGenerator,
-          needsSequelize: true,
-        }, {
           title: 'Combination of sequelize.fn, sequelize.col and { in: ... }',
           arguments: ['myTable', function (sequelize) {
             return {

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -177,10 +177,6 @@ if (dialect === 'mariadb') {
           expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
           context: QueryGenerator,
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS `count` FROM `foo`;',
-          context: QueryGenerator,
-        }, {
           arguments: ['myTable', { order: ['id'] }],
           expectation: 'SELECT * FROM `myTable` ORDER BY `id`;',
           context: QueryGenerator,

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -177,10 +177,6 @@ if (dialect === 'mysql') {
           expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
           context: QueryGenerator,
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS `count` FROM `foo`;',
-          context: QueryGenerator,
-        }, {
           arguments: ['myTable', { order: ['id'] }],
           expectation: 'SELECT * FROM `myTable` ORDER BY `id`;',
           context: QueryGenerator,

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -289,18 +289,6 @@ if (dialect === 'mysql') {
           expectation: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
           context: QueryGenerator,
         }, {
-          title: 'HAVING clause works with where-like hash',
-          arguments: ['myTable', function (sequelize) {
-            return {
-              attributes: ['*', [sequelize.fn('YEAR', sequelize.col('createdAt')), 'creationYear']],
-              group: ['creationYear', 'title'],
-              having: { creationYear: { [Op.gt]: 2002 } },
-            };
-          }],
-          expectation: 'SELECT *, YEAR(`createdAt`) AS `creationYear` FROM `myTable` GROUP BY `creationYear`, `title` HAVING `creationYear` > 2002;',
-          context: QueryGenerator,
-          needsSequelize: true,
-        }, {
           title: 'Combination of sequelize.fn, sequelize.col and { in: ... }',
           arguments: ['myTable', function (sequelize) {
             return {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -346,18 +346,6 @@ if (dialect.startsWith('postgres')) {
           arguments: ['myTable', { group: ['name', 'title'] }],
           expectation: 'SELECT * FROM "myTable" GROUP BY "name", "title";',
         }, {
-          title: 'HAVING clause works with where-like hash',
-          arguments: ['myTable', function (sequelize) {
-            return {
-              attributes: ['*', [sequelize.fn('YEAR', sequelize.col('createdAt')), 'creationYear']],
-              group: ['creationYear', 'title'],
-              having: { creationYear: { [Op.gt]: 2002 } },
-            };
-          }],
-          expectation: 'SELECT *, YEAR("createdAt") AS "creationYear" FROM "myTable" GROUP BY "creationYear", "title" HAVING "creationYear" > 2002;',
-          context: QueryGenerator,
-          needsSequelize: true,
-        }, {
           arguments: ['myTable', { limit: 10 }],
           expectation: 'SELECT * FROM "myTable" LIMIT 10;',
         }, {

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -702,7 +702,7 @@ if (dialect.startsWith('postgres')) {
           expectation: 'INSERT INTO "myTable" ("name") VALUES (\'foo\'),(\'bar\') RETURNING *;',
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { returning: ['id', 'sentToId'] }],
-          expectation: 'INSERT INTO "myTable" ("name") VALUES (\'foo\'),(\'bar\') RETURNING "id","sentToId";',
+          expectation: 'INSERT INTO "myTable" ("name") VALUES (\'foo\'),(\'bar\') RETURNING "id", "sentToId";',
         }, {
           arguments: ['myTable', [{ name: 'foo' }, { name: 'bar' }], { ignoreDuplicates: true, returning: true }],
           expectation: 'INSERT INTO "myTable" ("name") VALUES (\'foo\'),(\'bar\') ON CONFLICT DO NOTHING RETURNING *;',

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -215,9 +215,6 @@ if (dialect.startsWith('postgres')) {
           arguments: ['myTable', { where: 2 }],
           expectation: 'SELECT * FROM "myTable" WHERE "myTable"."id" = 2;',
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS "count" FROM "foo";',
-        }, {
           arguments: ['myTable', { order: ['id'] }],
           expectation: 'SELECT * FROM "myTable" ORDER BY "id";',
           context: QueryGenerator,
@@ -411,10 +408,6 @@ if (dialect.startsWith('postgres')) {
         }, {
           arguments: ['myTable', { where: 2 }],
           expectation: 'SELECT * FROM myTable WHERE myTable.id = 2;',
-          context: { options: { quoteIdentifiers: false } },
-        }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS count FROM foo;',
           context: { options: { quoteIdentifiers: false } },
         }, {
           arguments: ['myTable', { order: ['id DESC'] }],

--- a/test/unit/dialects/snowflake/query-generator.test.js
+++ b/test/unit/dialects/snowflake/query-generator.test.js
@@ -267,10 +267,6 @@ if (dialect === 'snowflake') {
           expectation: 'SELECT * FROM "myTable" WHERE "myTable"."id" = 2;',
           context: QueryGenerator,
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS "count" FROM "foo";',
-          context: QueryGenerator,
-        }, {
           arguments: ['myTable', { order: ['id'] }],
           expectation: 'SELECT * FROM "myTable" ORDER BY "id";',
           context: QueryGenerator,
@@ -545,10 +541,6 @@ if (dialect === 'snowflake') {
         }, {
           arguments: ['myTable', { where: 2 }],
           expectation: 'SELECT * FROM myTable WHERE myTable.id = 2;',
-          context: { options: { quoteIdentifiers: false } },
-        }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS count FROM foo;',
           context: { options: { quoteIdentifiers: false } },
         }, {
           arguments: ['myTable', { order: ['id'] }],

--- a/test/unit/dialects/snowflake/query-generator.test.js
+++ b/test/unit/dialects/snowflake/query-generator.test.js
@@ -379,18 +379,6 @@ if (dialect === 'snowflake') {
           expectation: 'SELECT * FROM "myTable" GROUP BY "name" ORDER BY "id" DESC;',
           context: QueryGenerator,
         }, {
-          title: 'HAVING clause works with where-like hash',
-          arguments: ['myTable', function (sequelize) {
-            return {
-              attributes: ['*', [sequelize.fn('YEAR', sequelize.col('createdAt')), 'creationYear']],
-              group: ['creationYear', 'title'],
-              having: { creationYear: { [Op.gt]: 2002 } },
-            };
-          }],
-          expectation: 'SELECT *, YEAR("createdAt") AS "creationYear" FROM "myTable" GROUP BY "creationYear", "title" HAVING "creationYear" > 2002;',
-          context: QueryGenerator,
-          needsSequelize: true,
-        }, {
           title: 'Combination of sequelize.fn, sequelize.col and { in: ... }',
           arguments: ['myTable', function (sequelize) {
             return {
@@ -654,18 +642,6 @@ if (dialect === 'snowflake') {
           arguments: ['myTable', { group: 'name', order: [['id', 'DESC']] }],
           expectation: 'SELECT * FROM myTable GROUP BY name ORDER BY id DESC;',
           context: { options: { quoteIdentifiers: false } },
-        }, {
-          title: 'HAVING clause works with where-like hash',
-          arguments: ['myTable', function (sequelize) {
-            return {
-              attributes: ['*', [sequelize.fn('YEAR', sequelize.col('createdAt')), 'creationYear']],
-              group: ['creationYear', 'title'],
-              having: { creationYear: { [Op.gt]: 2002 } },
-            };
-          }],
-          expectation: 'SELECT *, YEAR(createdAt) AS creationYear FROM myTable GROUP BY creationYear, title HAVING creationYear > 2002;',
-          context: { options: { quoteIdentifiers: false } },
-          needsSequelize: true,
         }, {
           title: 'Combination of sequelize.fn, sequelize.col and { in: ... }',
           arguments: ['myTable', function (sequelize) {

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -273,18 +273,6 @@ if (dialect === 'sqlite') {
           expectation: 'SELECT * FROM `myTable` GROUP BY `name` ORDER BY `id` DESC;',
           context: QueryGenerator,
         }, {
-          title: 'HAVING clause works with where-like hash',
-          arguments: ['myTable', function (sequelize) {
-            return {
-              attributes: ['*', [sequelize.fn('YEAR', sequelize.col('createdAt')), 'creationYear']],
-              group: ['creationYear', 'title'],
-              having: { creationYear: { [Op.gt]: 2002 } },
-            };
-          }],
-          expectation: 'SELECT *, YEAR(`createdAt`) AS `creationYear` FROM `myTable` GROUP BY `creationYear`, `title` HAVING `creationYear` > 2002;',
-          context: QueryGenerator,
-          needsSequelize: true,
-        }, {
           arguments: ['myTable', { limit: 10 }],
           expectation: 'SELECT * FROM `myTable` LIMIT 10;',
           context: QueryGenerator,

--- a/test/unit/dialects/sqlite/query-generator.test.js
+++ b/test/unit/dialects/sqlite/query-generator.test.js
@@ -157,10 +157,6 @@ if (dialect === 'sqlite') {
           expectation: 'SELECT * FROM `myTable` WHERE `myTable`.`id` = 2;',
           context: QueryGenerator,
         }, {
-          arguments: ['foo', { attributes: [['count(*)', 'count']] }],
-          expectation: 'SELECT count(*) AS `count` FROM `foo`;',
-          context: QueryGenerator,
-        }, {
           arguments: ['myTable', { order: ['id'] }],
           expectation: 'SELECT * FROM `myTable` ORDER BY `id`;',
           context: QueryGenerator,

--- a/test/unit/query-generator/insert-query.test.ts
+++ b/test/unit/query-generator/insert-query.test.ts
@@ -10,7 +10,7 @@ describe('QueryGenerator#insertQuery', () => {
   }, { timestamps: false });
 
   // you'll find more replacement tests in query-generator tests
-  it('parses named replacements in literals', async () => {
+  it('parses named replacements in literals', () => {
     const { query, bind } = queryGenerator.insertQuery(User.tableName, {
       firstName: literal(':name'),
     }, {}, {
@@ -28,7 +28,7 @@ describe('QueryGenerator#insertQuery', () => {
     expect(bind).to.deep.eq({});
   });
 
-  it('supports named bind parameters in literals', async () => {
+  it('supports named bind parameters in literals', () => {
     const { query, bind } = queryGenerator.insertQuery(User.tableName, {
       firstName: 'John',
       lastName: literal('$lastName'),
@@ -47,7 +47,7 @@ describe('QueryGenerator#insertQuery', () => {
     });
   });
 
-  it('parses positional bind parameters in literals', async () => {
+  it('parses positional bind parameters in literals', () => {
     const { query, bind } = queryGenerator.insertQuery(User.tableName, {
       firstName: 'John',
       lastName: literal('$1'),
@@ -66,7 +66,7 @@ describe('QueryGenerator#insertQuery', () => {
     });
   });
 
-  it('parses bind parameters in literals even with bindParams: false', async () => {
+  it('parses bind parameters in literals even with bindParams: false', () => {
     const { query, bind } = queryGenerator.insertQuery(User.tableName, {
       firstName: 'John',
       lastName: literal('$1'),
@@ -82,5 +82,67 @@ describe('QueryGenerator#insertQuery', () => {
       ibmi: `SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName","lastName","username") VALUES ('John',$1,'jd'))`,
     });
     expect(bind).to.be.undefined;
+  });
+
+  describe('returning', () => {
+    it('supports returning: true', () => {
+      const { query } = queryGenerator.insertQuery(User.tableName, {
+        firstName: 'John',
+      }, User.rawAttributes, {
+        returning: true,
+      });
+
+      expectsql(query, {
+        default: `INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1) RETURNING [id], [firstName];`,
+        // TODO: insertQuery should throw if returning is not supported
+        'mysql mariadb sqlite': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
+        // TODO: insertQuery should throw if returning is not supported
+        snowflake: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1);`,
+        mssql: 'INSERT INTO [Users] ([firstName]) OUTPUT INSERTED.[id], INSERTED.[firstName] VALUES ($sequelize_1);',
+        db2: 'SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1));',
+        ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1))',
+      });
+    });
+
+    it('supports array of strings (column names)', () => {
+      const { query } = queryGenerator.insertQuery(User.tableName, {
+        firstName: 'John',
+      }, User.rawAttributes, {
+        returning: ['*', 'myColumn'],
+      });
+
+      expectsql(query, {
+        default: `INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1) RETURNING [*], [myColumn];`,
+        // TODO: insertQuery should throw if returning is not supported
+        'mysql mariadb sqlite': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
+        // TODO: insertQuery should throw if returning is not supported
+        snowflake: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1);`,
+        mssql: 'INSERT INTO [Users] ([firstName]) OUTPUT INSERTED.[*], INSERTED.[myColumn] VALUES ($sequelize_1);',
+        // TODO: should only select specified columns
+        db2: 'SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1));',
+        ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1))',
+      });
+    });
+
+    it('supports array of literals', () => {
+
+      expectsql(() => {
+        return queryGenerator.insertQuery(User.tableName, {
+          firstName: 'John',
+        }, User.rawAttributes, {
+          returning: [literal('*')],
+        }).query;
+      }, {
+        default: `INSERT INTO [Users] ([firstName]) VALUES ($sequelize_1) RETURNING *;`,
+        // TODO: insertQuery should throw if returning is not supported
+        'mysql mariadb sqlite': `INSERT INTO \`Users\` (\`firstName\`) VALUES ($sequelize_1);`,
+        // TODO: insertQuery should throw if returning is not supported
+        snowflake: `INSERT INTO "Users" ("firstName") VALUES ($sequelize_1);`,
+        mssql: new Error('literal() cannot be used in the "returning" option array in mssql. Use col(), or a string instead.'),
+        // TODO: should only select specified columns
+        db2: 'SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1));',
+        ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName") VALUES ($sequelize_1))',
+      });
+    });
   });
 });

--- a/test/unit/query-generator/select-query.test.ts
+++ b/test/unit/query-generator/select-query.test.ts
@@ -447,11 +447,29 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         model: User,
         attributes: [
           ['count(*)', 'count'],
+          '.*',
+          '*',
         ],
       }, User);
 
       expectsql(sql, {
-        default: `SELECT [count(*)] AS [count] FROM [Users] AS [User];`,
+        default: `SELECT [count(*)] AS [count], [.*], [*] FROM [Users] AS [User];`,
+      });
+    });
+
+    it('supports a "having" option', () => {
+      const sql = queryGenerator.selectQuery(User.tableName, {
+        model: User,
+        attributes: [
+          literal('*'),
+          [fn('YEAR', col('createdAt')), 'creationYear'],
+        ],
+        group: ['creationYear', 'title'],
+        having: { creationYear: { [Op.gt]: 2002 } },
+      }, User);
+
+      expectsql(sql, {
+        default: `SELECT *, YEAR([createdAt]) AS [creationYear] FROM [Users] AS [User] GROUP BY [creationYear], [title] HAVING [creationYear] > 2002;`,
       });
     });
   });

--- a/test/unit/query-generator/select-query.test.ts
+++ b/test/unit/query-generator/select-query.test.ts
@@ -90,7 +90,7 @@ describe('QueryGenerator#selectQuery', () => {
   });
 
   describe('replacements', () => {
-    it('parses named replacements in literals', async () => {
+    it('parses named replacements in literals', () => {
       // The goal of this test is to test that :replacements are parsed in literals in as many places as possible
 
       const sql = queryGenerator.selectQuery(User.tableName, {
@@ -167,7 +167,7 @@ describe('QueryGenerator#selectQuery', () => {
     });
 
     // see the unit tests of 'injectReplacements' for more
-    it('does not parse replacements in strings in literals', async () => {
+    it('does not parse replacements in strings in literals', () => {
       // The goal of this test is to test that :replacements are parsed in literals in as many places as possible
 
       const sql = queryGenerator.selectQuery(User.tableName, {
@@ -184,7 +184,7 @@ describe('QueryGenerator#selectQuery', () => {
       });
     });
 
-    it('parses named replacements in literals in includes', async () => {
+    it('parses named replacements in literals in includes', () => {
       const sql = queryGenerator.selectQuery(User.tableName, {
         model: User,
         attributes: ['id'],
@@ -255,7 +255,7 @@ describe('QueryGenerator#selectQuery', () => {
       });
     });
 
-    it(`parses named replacements in belongsToMany includes' through tables`, async () => {
+    it(`parses named replacements in belongsToMany includes' through tables`, () => {
       const sql = queryGenerator.selectQuery(Project.tableName, {
         model: Project,
         attributes: ['id'],
@@ -308,7 +308,7 @@ describe('QueryGenerator#selectQuery', () => {
       });
     });
 
-    it('parses named replacements in literals in includes (subQuery)', async () => {
+    it('parses named replacements in literals in includes (subQuery)', () => {
       const sql = queryGenerator.selectQuery(User.tableName, {
         model: User,
         attributes: ['id'],
@@ -426,8 +426,8 @@ describe('QueryGenerator#selectQuery', () => {
       });
     });
 
-    it('rejects positional replacements, because their execution order is hard to determine', async () => {
-      await expect(
+    it('rejects positional replacements, because their execution order is hard to determine', () => {
+      expect(
         () => queryGenerator.selectQuery(User.tableName, {
           model: User,
           where: {
@@ -440,6 +440,19 @@ describe('QueryGenerator#selectQuery', () => {
       ).to.throw(`The following literal includes positional replacements (?).
 Only named replacements (:name) are allowed in literal() because we cannot guarantee the order in which they will be evaluated:
 ➜ literal("?")`);
+    });
+
+    it(`always escapes the attribute if it's provided as a string`, () => {
+      const sql = queryGenerator.selectQuery(User.tableName, {
+        model: User,
+        attributes: [
+          ['count(*)', 'count'],
+        ],
+      }, User);
+
+      expectsql(sql, {
+        default: `SELECT [count(*)] AS [count] FROM [Users] AS [User];`,
+      });
     });
   });
 

--- a/test/unit/sql/insert.test.js
+++ b/test/unit/sql/insert.test.js
@@ -33,8 +33,8 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         {
           query: {
             ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("user_name") VALUES ($sequelize_1))',
-            mssql: 'DECLARE @tmp TABLE ([id] INTEGER,[user_name] NVARCHAR(255)); INSERT INTO [users] ([user_name]) OUTPUT INSERTED.[id],INSERTED.[user_name] INTO @tmp VALUES ($sequelize_1); SELECT * FROM @tmp;',
-            postgres: 'INSERT INTO "users" ("user_name") VALUES ($sequelize_1) RETURNING "id","user_name";',
+            mssql: 'DECLARE @tmp TABLE ([id] INTEGER,[user_name] NVARCHAR(255)); INSERT INTO [users] ([user_name]) OUTPUT INSERTED.[id], INSERTED.[user_name] INTO @tmp VALUES ($sequelize_1); SELECT * FROM @tmp;',
+            postgres: 'INSERT INTO "users" ("user_name") VALUES ($sequelize_1) RETURNING "id", "user_name";',
             db2: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("user_name") VALUES ($sequelize_1));',
             snowflake: 'INSERT INTO "users" ("user_name") VALUES ($sequelize_1);',
             default: 'INSERT INTO `users` (`user_name`) VALUES ($sequelize_1);',

--- a/test/unit/sql/select.test.js
+++ b/test/unit/sql/select.test.js
@@ -710,17 +710,12 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       it('plain attributes (1)', () => {
         expectsql(sql.selectQuery('User', {
           attributes: [
-            '* FROM [User]; DELETE FROM [User];SELECT [id]'
+            '* FROM [User];'
               .replace(/\[/g, Support.sequelize.dialect.TICK_CHAR_LEFT)
-              .replace(/\]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT),
+              .replace(/]/g, Support.sequelize.dialect.TICK_CHAR_RIGHT),
           ],
         }), {
-          // TODO: the attribute should be escaped as an identifier, not a string
-          default: `SELECT '* FROM [User]; DELETE FROM [User];SELECT [id]' FROM [User];`,
-          ibmi: `SELECT '* FROM "User"; DELETE FROM "User";SELECT "id"' FROM "User"`,
-          db2: `SELECT '* FROM "User"; DELETE FROM "User";SELECT "id"' FROM "User";`,
-          snowflake: `SELECT '* FROM "User"; DELETE FROM "User";SELECT "id"' FROM "User";`,
-          mssql: 'SELECT [* FROM [[User]]; DELETE FROM [[User]];SELECT [[id]]] FROM [User];',
+          default: `SELECT ${TICK_LEFT}* FROM ${TICK_LEFT}${TICK_LEFT}User${TICK_RIGHT}${TICK_RIGHT};${TICK_RIGHT} FROM ${TICK_LEFT}User${TICK_RIGHT};`,
         });
       });
 

--- a/test/unit/sql/update.test.js
+++ b/test/unit/sql/update.test.js
@@ -56,8 +56,8 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         {
           query: {
             ibmi: 'UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2',
-            mssql: 'DECLARE @tmp TABLE ([id] INTEGER,[user_name] NVARCHAR(255)); UPDATE [users] SET [user_name]=$sequelize_1 OUTPUT INSERTED.[id],INSERTED.[user_name] INTO @tmp WHERE [id] = $sequelize_2; SELECT * FROM @tmp',
-            postgres: 'UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2 RETURNING "id","user_name"',
+            mssql: 'DECLARE @tmp TABLE ([id] INTEGER,[user_name] NVARCHAR(255)); UPDATE [users] SET [user_name]=$sequelize_1 OUTPUT INSERTED.[id], INSERTED.[user_name] INTO @tmp WHERE [id] = $sequelize_2; SELECT * FROM @tmp',
+            postgres: 'UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2 RETURNING "id", "user_name"',
             db2: 'SELECT * FROM FINAL TABLE (UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2);',
             snowflake: 'UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2',
             default: 'UPDATE `users` SET `user_name`=$sequelize_1 WHERE `id` = $sequelize_2',


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

This removes a security vulnerability we have where attributes would not be escaped if they included `(` and `)`, or where equal to `*`, and were split if they included the character `.`

Users must always use `literal` or `col` to inline something without escaping.

The special syntax is still available when using `col`. We'll need to provide something like [`identifier()`](https://github.com/sequelize/sequelize/issues/14299) that only escapes, and thoroughly document `col`.

The following

```ts
User.findAll({
  attributes: [
    '*',
    'a.*',
    ['count(id)', 'count']
  ]
});
```

used to return this:

```sql
SELECT *, "a".*, count(id) AS "count" FROM "users"
```

now it returns this:

```sql
SELECT "*", "a.*", "count(id)" AS "count" FROM "users"
```

The previous behavior can be restored by writing this instead:

```ts
User.findAll({
  attributes: [
    col('*'),
    col('a.*'),
    [literal('count(*)'), 'count'],
    // or
    // [fn('count', col('*')), 'count'],
  ],
});
```

---

This is also the case for the "returning" option. The following, which previously was equivalent to `returning: true`, now only returns the column `"*"`.

```ts
User.findAll({
  returning: ['*'],
});
```

If you want to return `*`, do this instead:

```ts
User.findAll({
  returning: [literal('*')], // col() works too
});
```