### PR TITLE
fix: throw if `where` receives an invalid value

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1,5 +1,6 @@
 'use strict';
 
+import NodeUtil from 'node:util';
 import { getTextDataTypeForDialect } from '../../sql-string';
 import { rejectInvalidOptions, isNullish, canTreatArrayAsAnd, isColString } from '../../utils/check';
 import { TICK_CHAR } from '../../utils/dialect';
@@ -2967,7 +2968,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
       });
     }
 
-    return '1=1';
+    throw new Error(`Unsupported where option value: ${NodeUtil.inspect(smth)}. Please refer to the Sequelize documentation to learn more about which values are accepted as part of the where option.`);
   }
 
   // A recursive parser for nested where conditions

--- a/test/unit/query-generator/get-where-conditions.test.ts
+++ b/test/unit/query-generator/get-where-conditions.test.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { sequelize } from '../../support';
+
+describe('QueryGenerator#getWhereConditions', () => {
+  const queryGenerator = sequelize.queryInterface.queryGenerator;
+
+  it('throws if called with invalid arguments', () => {
+    const User = sequelize.define('User');
+
+    expect(() => {
+      // TODO: https://github.com/sequelize/sequelize/pull/14020 - remove expect-error
+      // @ts-expect-error
+      queryGenerator.getWhereConditions(new Date(), User.getTableName(), User);
+    }).to.throw('Unsupported where option value');
+  });
+});


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Currently, setting the `where` option to an unsupported value makes it use `1=1` as the where condition. With this change, it will throw instead. The former doesn't make sense and is a security risk.

