### PR TITLE
meta: reduce usage of deprecated code in tests

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -1512,14 +1512,14 @@ Specify a different name for either index to resolve this issue.`);
   }
 
   // TODO [>=2023-01-01]: remove in Sequelize 8
-  static schema(schema, options) {
-    schemaRenamedToWithSchema();
+  // static schema(schema, options) {
+  //   schemaRenamedToWithSchema();
 
-    return this.withSchema({
-      schema,
-      schemaDelimiter: typeof options === 'string' ? options : options?.schemaDelimiter,
-    });
-  }
+  //   return this.withSchema({
+  //     schema,
+  //     schemaDelimiter: typeof options === 'string' ? options : options?.schemaDelimiter,
+  //   });
+  // }
 
   /**
    * Returns the initial model, the one returned by {@link Model.init} or {@link Sequelize#define},

--- a/test/integration/associations/belongs-to-many.test.js
+++ b/test/integration/associations/belongs-to-many.test.js
@@ -169,15 +169,15 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
       it('should support schemas', async function () {
         const AcmeUser = this.sequelize.define('User', {
           username: DataTypes.STRING,
-        }).schema('acme', '_');
+        }).withSchema('acme', '_');
         const AcmeProject = this.sequelize.define('Project', {
           title: DataTypes.STRING,
           active: DataTypes.BOOLEAN,
-        }).schema('acme', '_');
+        }).withSchema('acme', '_');
         const AcmeProjectUsers = this.sequelize.define('ProjectUsers', {
           status: DataTypes.STRING,
           data: DataTypes.INTEGER,
-        }).schema('acme', '_');
+        }).withSchema('acme', '_');
 
         AcmeUser.belongsToMany(AcmeProject, { through: AcmeProjectUsers });
         AcmeProject.belongsToMany(AcmeUser, { through: AcmeProjectUsers });

--- a/test/integration/associations/belongs-to.test.js
+++ b/test/integration/associations/belongs-to.test.js
@@ -107,8 +107,8 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
 
     if (current.dialect.supports.schemas) {
       it('supports schemas', async function () {
-        const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING, gender: DataTypes.STRING }).schema('archive');
-        const Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING, status: DataTypes.STRING }).schema('archive');
+        const User = this.sequelize.define('UserXYZ', { username: DataTypes.STRING, gender: DataTypes.STRING }).withSchema('archive');
+        const Task = this.sequelize.define('TaskXYZ', { title: DataTypes.STRING, status: DataTypes.STRING }).withSchema('archive');
 
         Task.belongsTo(User);
 
@@ -140,13 +140,13 @@ describe(Support.getTestDialectTeaser('BelongsTo'), () => {
             autoIncrement: true,
             allowNull: false,
           },
-        }).schema('archive');
+        }).withSchema('archive');
         const Task = this.sequelize.define('TaskXYZ', {
           user_id: {
             type: DataTypes.INTEGER,
             references: { model: User, key: 'uid' },
           },
-        }).schema('archive');
+        }).withSchema('archive');
 
         Task.belongsTo(User, { foreignKey: 'user_id' });
 

--- a/test/integration/associations/has-many.test.js
+++ b/test/integration/associations/has-many.test.js
@@ -341,13 +341,13 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         });
 
         it('supports schemas', async function () {
-          const User = this.sequelize.define('User', {}).schema('work');
+          const User = this.sequelize.define('User', {}).withSchema('work');
           const Task = this.sequelize.define('Task', {
             title: DataTypes.STRING,
-          }).schema('work');
+          }).withSchema('work');
           const SubTask = this.sequelize.define('SubTask', {
             title: DataTypes.STRING,
-          }).schema('work');
+          }).withSchema('work');
 
           User.Tasks = User.hasMany(Task, { as: 'tasks' });
           Task.SubTasks = Task.hasMany(SubTask, { as: 'subtasks' });

--- a/test/integration/associations/has-one.test.js
+++ b/test/integration/associations/has-one.test.js
@@ -90,8 +90,8 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
 
     if (current.dialect.supports.schemas) {
       it('supports schemas', async function () {
-        const User = this.sequelize.define('User', { username: DataTypes.STRING }).schema('admin');
-        const Group = this.sequelize.define('Group', { name: DataTypes.STRING }).schema('admin');
+        const User = this.sequelize.define('User', { username: DataTypes.STRING }).withSchema('admin');
+        const Group = this.sequelize.define('Group', { name: DataTypes.STRING }).withSchema('admin');
 
         Group.hasOne(User);
 

--- a/test/integration/model.test.js
+++ b/test/integration/model.test.js
@@ -1720,7 +1720,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           { username: 'Paul', secretValue: '42' },
           { username: 'Bob', secretValue: '43' },
         ];
-        const prefixUser = this.User.schema('prefix');
+        const prefixUser = this.User.withSchema('prefix');
 
         await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.queryInterface.createSchema('prefix');
@@ -2142,7 +2142,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         await Support.dropTestSchemas(this.sequelize);
         await this.sequelize.createSchema('schema_test');
         await this.sequelize.createSchema('special');
-        this.UserSpecialSync = await this.UserSpecial.schema('special').sync({ force: true });
+        this.UserSpecialSync = await this.UserSpecial.withSchema('special').sync({ force: true });
       });
 
       afterEach(async function () {
@@ -2182,7 +2182,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         let test = 0;
 
         await UserPublic.sync({ force: true });
-        await UserPublic.schema('special').sync({ force: true });
+        await UserPublic.withSchema('special').sync({ force: true });
 
         let table = await this.sequelize.queryInterface.describeTable('Publics', {
           logging(sql) {
@@ -2318,7 +2318,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           },
         });
 
-        const UserSpecial = await this.UserSpecialSync.schema('special').create({ age: 3 }, {
+        const UserSpecial = await this.UserSpecialSync.withSchema('special').create({ age: 3 }, {
           logging(UserSpecial) {
             logged++;
             switch (dialectName) {
@@ -2396,7 +2396,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           age: DataTypes.INTEGER,
         });
         const User = await UserSpecialUnderscore.sync({ force: true });
-        const DblUser = await UserSpecialDblUnderscore.schema('hello', '__').sync({ force: true });
+        const DblUser = await UserSpecialDblUnderscore.withSchema('hello', '__').sync({ force: true });
         await DblUser.create({ age: 3 }, {
           logging(sql) {
             test++;

--- a/test/integration/model/schema.test.js
+++ b/test/integration/model/schema.test.js
@@ -20,7 +20,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
     describe('global schema', () => {
       before(function () {
-        current.options.schema = null;
+        current.options.withSchema = null;
         this.RestaurantOne = current.define('restaurant', {
           foo: DataTypes.STRING,
           bar: DataTypes.STRING,
@@ -32,7 +32,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           foreignKey: 'location_id',
           foreignKeyConstraints: false,
         });
-        current.options.schema = SCHEMA_TWO;
+        current.options.withSchema = SCHEMA_TWO;
         this.RestaurantTwo = current.define('restaurant', {
           foo: DataTypes.STRING,
           bar: DataTypes.STRING,
@@ -44,7 +44,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           foreignKey: 'location_id',
           foreignKeyConstraints: false,
         });
-        current.options.schema = null;
+        current.options.withSchema = null;
       });
 
       beforeEach('build restaurant tables', async function () {
@@ -172,10 +172,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           foreignKeyConstraints: false,
         });
 
-        this.EmployeeOne = this.Employee.schema(SCHEMA_ONE);
-        this.EmployeeTwo = this.Employee.schema(SCHEMA_TWO);
-        this.RestaurantOne = this.Restaurant.schema(SCHEMA_ONE);
-        this.RestaurantTwo = this.Restaurant.schema(SCHEMA_TWO);
+        this.EmployeeOne = this.Employee.withSchema(SCHEMA_ONE);
+        this.EmployeeTwo = this.Employee.withSchema(SCHEMA_TWO);
+        this.RestaurantOne = this.Restaurant.withSchema(SCHEMA_ONE);
+        this.RestaurantTwo = this.Restaurant.withSchema(SCHEMA_TWO);
       });
 
       beforeEach('build restaurant tables', async function () {
@@ -242,7 +242,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       describe('Persist and retrieve data', () => {
         it('should be able to insert data into both schemas using instance.save and retrieve/count it', async function () {
           // building and saving in random order to make sure calling
-          // .schema doesn't impact model prototype
+          // .withSchema doesn't impact model prototype
           let restaurauntModel = this.RestaurantOne.build({ bar: 'one.1' });
 
           await restaurauntModel.save();
@@ -438,7 +438,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(employees.length).to.equal(1);
           expect(employees[0].last_name).to.equal('two');
 
-          const obj = await this.Employee.schema(SCHEMA_TWO).findOne({
+          const obj = await this.Employee.withSchema(SCHEMA_TWO).findOne({
             where: { last_name: 'two' }, include: [{
               model: this.RestaurantTwo, as: 'restaurant',
             }],
@@ -457,21 +457,21 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         it('should build and persist instances to 2 schemas concurrently in any order', async function () {
           const Restaurant = this.Restaurant;
 
-          let restaurauntModelSchema1 = Restaurant.schema(SCHEMA_ONE).build({ bar: 'one.1' });
-          const restaurauntModelSchema2 = Restaurant.schema(SCHEMA_TWO).build({ bar: 'two.1' });
+          let restaurauntModelSchema1 = Restaurant.withSchema(SCHEMA_ONE).build({ bar: 'one.1' });
+          const restaurauntModelSchema2 = Restaurant.withSchema(SCHEMA_TWO).build({ bar: 'two.1' });
 
           await restaurauntModelSchema1.save();
-          restaurauntModelSchema1 = Restaurant.schema(SCHEMA_ONE).build({ bar: 'one.2' });
+          restaurauntModelSchema1 = Restaurant.withSchema(SCHEMA_ONE).build({ bar: 'one.2' });
           await restaurauntModelSchema2.save();
           await restaurauntModelSchema1.save();
-          const restaurantsOne = await Restaurant.schema(SCHEMA_ONE).findAll();
+          const restaurantsOne = await Restaurant.withSchema(SCHEMA_ONE).findAll();
           expect(restaurantsOne).to.not.be.null;
           expect(restaurantsOne.length).to.equal(2);
           for (const restaurant of restaurantsOne) {
             expect(restaurant.bar).to.contain('one');
           }
 
-          const restaurantsTwo = await Restaurant.schema(SCHEMA_TWO).findAll();
+          const restaurantsTwo = await Restaurant.withSchema(SCHEMA_TWO).findAll();
           expect(restaurantsTwo).to.not.be.null;
           expect(restaurantsTwo.length).to.equal(1);
           for (const restaurant of restaurantsTwo) {

--- a/test/integration/query-interface.test.js
+++ b/test/integration/query-interface.test.js
@@ -30,9 +30,6 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
         const schemaNames = await this.queryInterface.showAllSchemas();
         await this.queryInterface.createSchema('newSchema');
         const newSchemaNames = await this.queryInterface.showAllSchemas();
-        if (!current.dialect.supports.schemas) {
-          return;
-        }
 
         expect(newSchemaNames).to.have.length(schemaNames.length + 1);
         await this.queryInterface.dropSchema('newSchema');

--- a/test/unit/model/schema.test.ts
+++ b/test/unit/model/schema.test.ts
@@ -1,16 +1,12 @@
 import assert from 'node:assert';
-import { literal } from '@sequelize/core';
-// eslint-disable-next-line import/order
 import { expect } from 'chai';
+import { literal } from '@sequelize/core';
+import { sequelize } from '../../support';
 
-const Support = require('../../support');
-
-const current = Support.sequelize;
-
-describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
-  if (current.dialect.supports.schemas) {
-    const Project = current.define('project');
-    const Company = current.define('company', {}, {
+describe('Model Schemas', () => {
+  if (sequelize.dialect.supports.schemas) {
+    const Project = sequelize.define('project');
+    const Company = sequelize.define('company', {}, {
       schema: 'default',
       schemaDelimiter: '&',
     });
@@ -19,7 +15,7 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
 
     describe('schema', () => {
       it('should work with no default schema', () => {
-        expect(Project._schema).to.equal(current.dialect.getDefaultSchema());
+        expect(Project._schema).to.equal(sequelize.dialect.getDefaultSchema());
       });
 
       it('should apply default schema from define', () => {
@@ -41,19 +37,37 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('should be able to override the default schema', () => {
-        expect(Company.schema('newSchema')._schema).to.equal('newSchema');
+        expect(Company.withSchema('newSchema')._schema).to.equal('newSchema');
       });
 
       it('should be able nullify schema', () => {
-        expect(Company.schema(null)._schema).to.equal(current.dialect.getDefaultSchema());
+        expect(Company.withSchema(null)._schema).to.equal(sequelize.dialect.getDefaultSchema());
       });
 
       it('should support multiple, coexistent schema models', () => {
-        const schema1 = Company.schema('schema1');
-        const schema2 = Company.schema('schema1');
+        const schema1 = Company.withSchema('schema1');
+        const schema2 = Company.withSchema('schema1');
 
         expect(schema1._schema).to.equal('schema1');
         expect(schema2._schema).to.equal('schema1');
+      });
+
+      describe('schema (deprecated)', () => {
+        it('should be able to override the default schema', () => {
+          expect(Company.schema('newSchema')._schema).to.equal('newSchema');
+        });
+
+        it('should be able nullify schema', () => {
+          expect(Company.schema(null)._schema).to.equal(sequelize.dialect.getDefaultSchema());
+        });
+
+        it('should support multiple, coexistent schema models', () => {
+          const schema1 = Company.schema('schema1');
+          const schema2 = Company.schema('schema1');
+
+          expect(schema1._schema).to.equal('schema1');
+          expect(schema2._schema).to.equal('schema1');
+        });
       });
     });
 
@@ -67,15 +81,29 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('should be able to override the default schema delimiter', () => {
-        expect(Company.schema(Company._schema, '^')._schemaDelimiter).to.equal('^');
+        expect(Company.withSchema(Company._schema, '^')._schemaDelimiter).to.equal('^');
       });
 
       it('should support multiple, coexistent schema delimiter models', () => {
-        const schema1 = Company.schema(Company._schema, '$');
-        const schema2 = Company.schema(Company._schema, '#');
+        const schema1 = Company.withSchema(Company._schema, '$');
+        const schema2 = Company.withSchema(Company._schema, '#');
 
         expect(schema1._schemaDelimiter).to.equal('$');
         expect(schema2._schemaDelimiter).to.equal('#');
+      });
+
+      describe('schema (deprecated)', () => {
+        it('should be able to override the default schema delimiter', () => {
+          expect(Company.schema(Company._schema, '^')._schemaDelimiter).to.equal('^');
+        });
+
+        it('should support multiple, coexistent schema delimiter models', () => {
+          const schema1 = Company.schema(Company._schema, '$');
+          const schema2 = Company.schema(Company._schema, '#');
+
+          expect(schema1._schemaDelimiter).to.equal('$');
+          expect(schema2._schemaDelimiter).to.equal('#');
+        });
       });
     });
   }

--- a/test/unit/model/schema.test.ts
+++ b/test/unit/model/schema.test.ts
@@ -52,7 +52,7 @@ describe('Model Schemas', () => {
         expect(schema2._schema).to.equal('schema1');
       });
 
-      describe('schema (deprecated)', () => {
+      describe.skip('schema (deprecated)', () => {
         it('should be able to override the default schema', () => {
           expect(Company.schema('newSchema')._schema).to.equal('newSchema');
         });
@@ -92,7 +92,7 @@ describe('Model Schemas', () => {
         expect(schema2._schemaDelimiter).to.equal('#');
       });
 
-      describe('schema (deprecated)', () => {
+      describe.skip('schema (deprecated)', () => {
         it('should be able to override the default schema delimiter', () => {
           expect(Company.schema(Company._schema, '^')._schemaDelimiter).to.equal('^');
         });

--- a/test/unit/sql/create-table.test.js
+++ b/test/unit/sql/create-table.test.js
@@ -39,7 +39,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     });
 
     describe('with references', () => {
-      const BarUser = current.define('user', {}, { timestamps: false }).schema('bar');
+      const BarUser = current.define('user', {}, { timestamps: false }).withSchema('bar');
 
       const BarProject = current.define('project', {
         user_id: {
@@ -50,7 +50,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         },
       }, {
         timestamps: false,
-      }).schema('bar');
+      }).withSchema('bar');
 
       BarProject.belongsTo(BarUser, { foreignKey: 'user_id' });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

This is an opinionated PR that reduces the amount of tests that uses deprecated code. The scope is to be determined by the following deprecations have been dealt with;
- schemaRenamedToWithSchema (only schema unit tests are checking if the basic behaviour still works)

It's in draft because it's not done but also because it's easier to do the various integration tests through CI instead of running it all locally.

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
