### PR TITLE
feat(types): use retry-as-promised types for retry options to match documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@types/mocha": "10.0.1",
     "@types/node": "18.11.11",
     "@types/pg": "8.6.5",
+    "@types/retry-as-promised": "^2.3.4",
     "@types/semver": "7.3.13",
     "@types/sinon": "10.0.13",
     "@types/sinon-chai": "3.2.9",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "inflection": "^2.0.0",
     "lodash": "^4.17.21",
     "pg-connection-string": "^2.5.0",
-    "retry-as-promised": "^7.0.2",
+    "retry-as-promised": "^7.0.3",
     "semver": "^7.3.7",
     "sequelize-pool": "^8.0.0",
     "toposort-class": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/debug": "^4.1.7",
+    "@types/retry-as-promised": "2.3.4",
     "@types/validator": "^13.7.5",
     "dayjs": "^1.11.5",
     "debug": "^4.3.4",
@@ -75,7 +76,6 @@
     "@types/mocha": "10.0.1",
     "@types/node": "18.11.11",
     "@types/pg": "8.6.5",
-    "@types/retry-as-promised": "2.3.4",
     "@types/semver": "7.3.13",
     "@types/sinon": "10.0.13",
     "@types/sinon-chai": "3.2.9",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "license": "MIT",
   "dependencies": {
     "@types/debug": "^4.1.7",
-    "@types/retry-as-promised": "2.3.4",
+    "@types/retry-as-promised": "^2.3.4",
     "@types/validator": "^13.7.5",
     "dayjs": "^1.11.5",
     "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@types/mocha": "10.0.1",
     "@types/node": "18.11.11",
     "@types/pg": "8.6.5",
-    "@types/retry-as-promised": "^2.3.4",
+    "@types/retry-as-promised": "2.3.4",
     "@types/semver": "7.3.13",
     "@types/sinon": "10.0.13",
     "@types/sinon-chai": "3.2.9",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "license": "MIT",
   "dependencies": {
     "@types/debug": "^4.1.7",
-    "@types/retry-as-promised": "^2.3.4",
     "@types/validator": "^13.7.5",
     "dayjs": "^1.11.5",
     "debug": "^4.3.4",
@@ -56,7 +55,7 @@
     "inflection": "^2.0.0",
     "lodash": "^4.17.21",
     "pg-connection-string": "^2.5.0",
-    "retry-as-promised": "^6.0.0",
+    "retry-as-promised": "^7.0.1",
     "semver": "^7.3.7",
     "sequelize-pool": "^8.0.0",
     "toposort-class": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "inflection": "^2.0.0",
     "lodash": "^4.17.21",
     "pg-connection-string": "^2.5.0",
-    "retry-as-promised": "^7.0.1",
+    "retry-as-promised": "^7.0.2",
     "semver": "^7.3.7",
     "sequelize-pool": "^8.0.0",
     "toposort-class": "^1.0.1",

--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -1,4 +1,4 @@
-import type { Options as RetryAsPromisedOptions } from 'retry-as-promised';
+import type { retryAsPromised } from 'retry-as-promised';
 import type { AbstractDialect } from './dialects/abstract';
 import type { AbstractConnectionManager } from './dialects/abstract/connection-manager';
 import type { AbstractDataType, DataTypeClassOrInstance } from './dialects/abstract/data-types.js';
@@ -25,6 +25,8 @@ import { SequelizeTypeScript } from './sequelize-typescript.js';
 import type { SequelizeHooks } from './sequelize-typescript.js';
 import type { Cast, Col, Fn, Json, Literal, Where } from './utils/sequelize-method.js';
 import type { QueryTypes, TRANSACTION_TYPES, ISOLATION_LEVELS, PartlyRequired, Op, DataTypes } from '.';
+
+export type RetryOptions = Parameters<typeof retryAsPromised>[1];
 
 /**
  * Additional options for table altering during sync
@@ -170,7 +172,6 @@ export interface Config {
 
 export type Dialect = 'mysql' | 'postgres' | 'sqlite' | 'mariadb' | 'mssql' | 'db2' | 'snowflake' | 'ibmi';
 
-export type RetryOptions = RetryAsPromisedOptions;
 /**
  * Options for the constructor of the {@link Sequelize} main class.
  */

--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -1,4 +1,4 @@
-import type { retryAsPromised } from 'retry-as-promised';
+import type { Options as RetryAsPromisedOptions } from 'retry-as-promised';
 import type { AbstractDialect } from './dialects/abstract';
 import type { AbstractConnectionManager } from './dialects/abstract/connection-manager';
 import type { AbstractDataType, DataTypeClassOrInstance } from './dialects/abstract/data-types.js';
@@ -26,7 +26,7 @@ import type { SequelizeHooks } from './sequelize-typescript.js';
 import type { Cast, Col, Fn, Json, Literal, Where } from './utils/sequelize-method.js';
 import type { QueryTypes, TRANSACTION_TYPES, ISOLATION_LEVELS, PartlyRequired, Op, DataTypes } from '.';
 
-export type RetryOptions = Parameters<typeof retryAsPromised>[1];
+export type RetryOptions = RetryAsPromisedOptions;
 
 /**
  * Additional options for table altering during sync

--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -1,3 +1,4 @@
+import type { Options as RetryAsPromisedOptions } from 'retry-as-promised';
 import type { AbstractDialect } from './dialects/abstract';
 import type { AbstractConnectionManager } from './dialects/abstract/connection-manager';
 import type { AbstractDataType, DataTypeClassOrInstance } from './dialects/abstract/data-types.js';
@@ -169,16 +170,7 @@ export interface Config {
 
 export type Dialect = 'mysql' | 'postgres' | 'sqlite' | 'mariadb' | 'mssql' | 'db2' | 'snowflake' | 'ibmi';
 
-export interface RetryOptions {
-  match?: Array<RegExp | string | Function>;
-  max?: number;
-  timeout?: number;
-  backoffBase?: number;
-  backoffExponent?: number;
-  report?(msg: string, options: RetryOptions & { $current: number }): void;
-  name?: string;
-}
-
+export type RetryOptions = RetryAsPromisedOptions;
 /**
  * Options for the constructor of the {@link Sequelize} main class.
  */

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import isPlainObject from 'lodash/isPlainObject';
+import retry from 'retry-as-promised';
 import { normalizeDataType } from './dialects/abstract/data-types-utils';
 import { SequelizeTypeScript } from './sequelize-typescript';
 import { withSqliteForeignKeysOff } from './dialects/sqlite/sqlite-utils';
@@ -13,7 +14,6 @@ import { useInflection } from './utils/string';
 import { parseConnectionString } from './utils/url';
 import { importModels } from './import-models.js';
 
-const retry = require('retry-as-promised');
 const _ = require('lodash');
 const { Model } = require('./model');
 const DataTypes = require('./data-types');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,7 +1334,7 @@
     pg-protocol "*"
     pg-types "^2.2.0"
 
-"@types/retry-as-promised@2.3.4":
+"@types/retry-as-promised@^2.3.4":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/retry-as-promised/-/retry-as-promised-2.3.4.tgz#4a9b5a062e985a5804813f1803a51fc4e74e8f60"
   integrity sha512-mupT8I391XnYRKpBPb8UMUPVNmd4b9dF+eLioB8apgJZGuzKAl6kdLIgQ/XPgyKKkX9QMJaLQHgBttjwPTTK4Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7351,10 +7351,10 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
-retry-as-promised@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-7.0.1.tgz#f47764a4edb25982df8e9a4617c7cd2fe546092a"
-  integrity sha512-dGP8c7GzVvo+QCDYyNjd6pFj5XBoAE4svMUTBcHjnOY5dJtMKayqQ54+BAYY1L/beEeJYkGGYgEzyzdjyzEElA==
+retry-as-promised@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-7.0.2.tgz#13115746736813e689d179f64b162666436bf6c2"
+  integrity sha512-grWu7vnuC5uSb3h+uehW4g0zSAMrGHOXeuQohLKmT9KMy1b/rM/gsiRGIXAvhUPJxEGgT9uhvoZ7DwESM/VPNg==
 
 retry@^0.12.0:
   version "0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,11 +1214,6 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
-"@types/bluebird@*":
-  version "3.5.38"
-  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.38.tgz#7a671e66750ccd21c9fc9d264d0e1e5330bc9908"
-  integrity sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==
-
 "@types/chai-as-promised@7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
@@ -1333,13 +1328,6 @@
     "@types/node" "*"
     pg-protocol "*"
     pg-types "^2.2.0"
-
-"@types/retry-as-promised@^2.3.4":
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/@types/retry-as-promised/-/retry-as-promised-2.3.4.tgz#4a9b5a062e985a5804813f1803a51fc4e74e8f60"
-  integrity sha512-mupT8I391XnYRKpBPb8UMUPVNmd4b9dF+eLioB8apgJZGuzKAl6kdLIgQ/XPgyKKkX9QMJaLQHgBttjwPTTK4Q==
-  dependencies:
-    "@types/bluebird" "*"
 
 "@types/retry@0.12.0":
   version "0.12.0"
@@ -7363,10 +7351,10 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
-retry-as-promised@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-6.1.0.tgz#11eca9a0f97804d552ec8e74bc4eb839bd226dc4"
-  integrity sha512-Hj/jY+wFC+SB9SDlIIFWiGOHnNG0swYbGYsOj2BJ8u2HKUaobNKab0OIC0zOLYzDy0mb7A4xA5BMo4LMz5YtEA==
+retry-as-promised@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-7.0.1.tgz#f47764a4edb25982df8e9a4617c7cd2fe546092a"
+  integrity sha512-dGP8c7GzVvo+QCDYyNjd6pFj5XBoAE4svMUTBcHjnOY5dJtMKayqQ54+BAYY1L/beEeJYkGGYgEzyzdjyzEElA==
 
 retry@^0.12.0:
   version "0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,6 +1214,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
   integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
+"@types/bluebird@*":
+  version "3.5.38"
+  resolved "https://registry.yarnpkg.com/@types/bluebird/-/bluebird-3.5.38.tgz#7a671e66750ccd21c9fc9d264d0e1e5330bc9908"
+  integrity sha512-yR/Kxc0dd4FfwtEoLZMoqJbM/VE/W7hXn/MIjb+axcwag0iFmSPK7OBUZq1YWLynJUoWQkfUrI7T0HDqGApNSg==
+
 "@types/chai-as-promised@7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@types/chai-as-promised/-/chai-as-promised-7.1.5.tgz#6e016811f6c7a64f2eed823191c3a6955094e255"
@@ -1328,6 +1333,13 @@
     "@types/node" "*"
     pg-protocol "*"
     pg-types "^2.2.0"
+
+"@types/retry-as-promised@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@types/retry-as-promised/-/retry-as-promised-2.3.4.tgz#4a9b5a062e985a5804813f1803a51fc4e74e8f60"
+  integrity sha512-mupT8I391XnYRKpBPb8UMUPVNmd4b9dF+eLioB8apgJZGuzKAl6kdLIgQ/XPgyKKkX9QMJaLQHgBttjwPTTK4Q==
+  dependencies:
+    "@types/bluebird" "*"
 
 "@types/retry@0.12.0":
   version "0.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1334,7 +1334,7 @@
     pg-protocol "*"
     pg-types "^2.2.0"
 
-"@types/retry-as-promised@^2.3.4":
+"@types/retry-as-promised@2.3.4":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/retry-as-promised/-/retry-as-promised-2.3.4.tgz#4a9b5a062e985a5804813f1803a51fc4e74e8f60"
   integrity sha512-mupT8I391XnYRKpBPb8UMUPVNmd4b9dF+eLioB8apgJZGuzKAl6kdLIgQ/XPgyKKkX9QMJaLQHgBttjwPTTK4Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7351,10 +7351,10 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
-retry-as-promised@^7.0.2:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-7.0.2.tgz#13115746736813e689d179f64b162666436bf6c2"
-  integrity sha512-grWu7vnuC5uSb3h+uehW4g0zSAMrGHOXeuQohLKmT9KMy1b/rM/gsiRGIXAvhUPJxEGgT9uhvoZ7DwESM/VPNg==
+retry-as-promised@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/retry-as-promised/-/retry-as-promised-7.0.3.tgz#ca3c13b15525a7bfbf0f56d2996f0e75649d068b"
+  integrity sha512-SEvMa4khHvpU/o6zgh7sK24qm6rxVgKnrSyzb5POeDvZx5N9Bf0s5sQsQ4Fl+HjRp0X+w2UzACGfUnXtx6cJ9Q==
 
 retry@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
I have corrected the types in the underlying `retry-as-promised` library so they can now be re-exported by sequelize to get the proper type for `retry`.

See https://github.com/DefinitelyTyped/DefinitelyTyped/pull/63267 for details.

