### PR TITLE
fix: migrate removeIndexQuery to TypeScript

### DIFF
--- a/src/dialects/abstract/query-generator-typescript.ts
+++ b/src/dialects/abstract/query-generator-typescript.ts
@@ -11,11 +11,11 @@ import type { AbstractDialect } from './index.js';
 export type TableNameOrModel = TableName | ModelStatic;
 
 // keep REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
-export type RemoveIndexQueryOptions = {
-  concurrently?: boolean,
-  ifExists?: boolean,
-  cascade?: boolean,
-};
+export interface RemoveIndexQueryOptions {
+  concurrently?: boolean;
+  ifExists?: boolean;
+  cascade?: boolean;
+}
 
 export const REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['concurrently', 'ifExists', 'cascade']);
 

--- a/src/dialects/abstract/query-generator-typescript.ts
+++ b/src/dialects/abstract/query-generator-typescript.ts
@@ -10,6 +10,15 @@ import type { AbstractDialect } from './index.js';
 
 export type TableNameOrModel = TableName | ModelStatic;
 
+// keep REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
+export type RemoveIndexQueryOptions = {
+  concurrently?: boolean,
+  ifExists?: boolean,
+  cascade?: boolean,
+};
+
+export const REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS = new Set(['concurrently', 'ifExists', 'cascade']);
+
 export interface QueryGeneratorOptions {
   sequelize: Sequelize;
   dialect: AbstractDialect;
@@ -46,6 +55,14 @@ export class AbstractQueryGeneratorTypeScript {
 
   showIndexesQuery(_tableName: TableNameOrModel): string {
     throw new Error(`showIndexesQuery has not been implemented in ${this.dialect.name}.`);
+  }
+
+  removeIndexQuery(
+    _tableName: TableNameOrModel,
+    _indexNameOrAttributes: string | string [],
+    _options?: RemoveIndexQueryOptions,
+  ): string | Error {
+    throw new Error(`removeIndexQuery has not been implemented in ${this.dialect.name}.`);
   }
 
   extractTableDetails(

--- a/src/dialects/abstract/query-generator-typescript.ts
+++ b/src/dialects/abstract/query-generator-typescript.ts
@@ -61,7 +61,7 @@ export class AbstractQueryGeneratorTypeScript {
     _tableName: TableNameOrModel,
     _indexNameOrAttributes: string | string [],
     _options?: RemoveIndexQueryOptions,
-  ): string | Error {
+  ): string {
     throw new Error(`removeIndexQuery has not been implemented in ${this.dialect.name}.`);
   }
 

--- a/src/dialects/abstract/query-generator-typescript.ts
+++ b/src/dialects/abstract/query-generator-typescript.ts
@@ -17,7 +17,7 @@ export type RemoveIndexQueryOptions = {
   cascade?: boolean,
 };
 
-export const REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS = new Set(['concurrently', 'ifExists', 'cascade']);
+export const REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['concurrently', 'ifExists', 'cascade']);
 
 export interface QueryGeneratorOptions {
   sequelize: Sequelize;

--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -185,6 +185,8 @@ export interface IndexOptions {
 
 export interface QueryInterfaceIndexOptions extends IndexOptions, Omit<QiOptionsWithReplacements, 'type'> {}
 
+export interface QueryInterfaceRemoveIndexOptions extends QueryInterfaceIndexOptions, RemoveIndexQueryOptions {}
+
 export interface BaseConstraintOptions {
   name?: string;
   fields: string[];
@@ -441,12 +443,12 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   removeIndex(
     tableName: TableName,
     indexName: string,
-    options?: QueryInterfaceIndexOptions & RemoveIndexQueryOptions
+    options?: QueryInterfaceRemoveIndexOptions
   ): Promise<void>;
   removeIndex(
     tableName: TableName,
     attributes: string[],
-    options?: QueryInterfaceIndexOptions & RemoveIndexQueryOptions
+    options?: QueryInterfaceRemoveIndexOptions
   ): Promise<void>;
 
   /**

--- a/src/dialects/abstract/query-interface.d.ts
+++ b/src/dialects/abstract/query-interface.d.ts
@@ -16,7 +16,7 @@ import type { Sequelize, QueryRawOptions, QueryRawOptionsWithModel } from '../..
 import type { Transaction } from '../../transaction';
 import type { Fn, Literal, Col } from '../../utils/sequelize-method.js';
 import type { DataType } from './data-types.js';
-import type { TableNameOrModel } from './query-generator-typescript';
+import type { RemoveIndexQueryOptions, TableNameOrModel } from './query-generator-typescript';
 import type { AbstractQueryGenerator, AddColumnQueryOptions, RemoveColumnQueryOptions } from './query-generator.js';
 import { AbstractQueryInterfaceTypeScript } from './query-interface-typescript';
 
@@ -438,8 +438,16 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   /**
    * Removes an index of a table
    */
-  removeIndex(tableName: TableName, indexName: string, options?: QueryInterfaceIndexOptions): Promise<void>;
-  removeIndex(tableName: TableName, attributes: string[], options?: QueryInterfaceIndexOptions): Promise<void>;
+  removeIndex(
+    tableName: TableName,
+    indexName: string,
+    options?: QueryInterfaceIndexOptions & RemoveIndexQueryOptions
+  ): Promise<void>;
+  removeIndex(
+    tableName: TableName,
+    attributes: string[],
+    options?: QueryInterfaceIndexOptions & RemoveIndexQueryOptions
+  ): Promise<void>;
 
   /**
    * Adds constraints to a table

--- a/src/dialects/db2/query-generator-typescript.ts
+++ b/src/dialects/db2/query-generator-typescript.ts
@@ -39,11 +39,12 @@ export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
+      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(),
+        REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }

--- a/src/dialects/db2/query-generator-typescript.ts
+++ b/src/dialects/db2/query-generator-typescript.ts
@@ -5,6 +5,8 @@ import { AbstractQueryGenerator } from '../abstract/query-generator';
 import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 
+const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
+
 /**
  * Temporary class to ease the TypeScript migration
  */
@@ -39,7 +41,6 @@ export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
-      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,

--- a/src/dialects/db2/query-generator-typescript.ts
+++ b/src/dialects/db2/query-generator-typescript.ts
@@ -1,6 +1,9 @@
+import { rejectInvalidOptions } from '../../utils/check';
 import { joinSQLFragments } from '../../utils/join-sql-fragments';
+import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import type { TableNameOrModel } from '../abstract/query-generator-typescript';
+import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 
 /**
  * Temporary class to ease the TypeScript migration
@@ -32,5 +35,27 @@ export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
       table.schema !== '' ? `AND TBCREATOR = ${this.escape(table.schema)}` : 'AND TBCREATOR = USER',
       'ORDER BY NAME;',
     ]);
+  }
+
+  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+    if (options) {
+      rejectInvalidOptions(
+        'removeIndexQuery',
+        this.dialect.name,
+        REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+        new Set(),
+        options,
+      );
+    }
+
+    let indexName: string;
+    const table = this.extractTableDetails(tableName);
+    if (Array.isArray(indexNameOrAttributes)) {
+      indexName = generateIndexName(table, { fields: indexNameOrAttributes });
+    } else {
+      indexName = indexNameOrAttributes;
+    }
+
+    return `DROP INDEX ${this.quoteIdentifier(indexName)}`;
   }
 }

--- a/src/dialects/db2/query-generator-typescript.ts
+++ b/src/dialects/db2/query-generator-typescript.ts
@@ -49,8 +49,8 @@ export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
     }
 
     let indexName: string;
-    const table = this.extractTableDetails(tableName);
     if (Array.isArray(indexNameOrAttributes)) {
+      const table = this.extractTableDetails(tableName);
       indexName = generateIndexName(table, { fields: indexNameOrAttributes });
     } else {
       indexName = indexNameOrAttributes;

--- a/src/dialects/db2/query-generator-typescript.ts
+++ b/src/dialects/db2/query-generator-typescript.ts
@@ -39,7 +39,11 @@ export class Db2QueryGeneratorTypeScript extends AbstractQueryGenerator {
     ]);
   }
 
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+  removeIndexQuery(
+    tableName: TableNameOrModel,
+    indexNameOrAttributes: string | string[],
+    options?: RemoveIndexQueryOptions,
+  ) {
     if (options) {
       rejectInvalidOptions(
         'removeIndexQuery',

--- a/src/dialects/db2/query-generator.js
+++ b/src/dialects/db2/query-generator.js
@@ -598,22 +598,6 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     return `${sql} ORDER BY CONSTNAME;`;
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes) {
-    const sql = 'DROP INDEX <%= indexName %>';
-    let indexName = indexNameOrAttributes;
-
-    if (typeof indexName !== 'string') {
-      indexName = underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
-    }
-
-    const values = {
-      tableName: this.quoteIdentifiers(tableName),
-      indexName: this.quoteIdentifiers(indexName),
-    };
-
-    return _.template(sql, this._templateSettings)(values);
-  }
-
   attributeToSQL(attribute, options) {
     if (!_.isPlainObject(attribute)) {
       attribute = {

--- a/src/dialects/ibmi/query-generator-typescript.ts
+++ b/src/dialects/ibmi/query-generator-typescript.ts
@@ -51,7 +51,11 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
     ]);
   }
 
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+  removeIndexQuery(
+    tableName: TableNameOrModel,
+    indexNameOrAttributes: string | string[],
+    options?: RemoveIndexQueryOptions,
+  ) {
     if (options) {
       rejectInvalidOptions(
         'removeIndexQuery',

--- a/src/dialects/ibmi/query-generator-typescript.ts
+++ b/src/dialects/ibmi/query-generator-typescript.ts
@@ -5,6 +5,8 @@ import { AbstractQueryGenerator } from '../abstract/query-generator';
 import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 
+const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
+
 /**
  * Temporary class to ease the TypeScript migration
  */
@@ -51,7 +53,6 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
-      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,

--- a/src/dialects/ibmi/query-generator-typescript.ts
+++ b/src/dialects/ibmi/query-generator-typescript.ts
@@ -51,11 +51,12 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
+      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(['ifExists']),
+        REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }

--- a/src/dialects/ibmi/query-generator-typescript.ts
+++ b/src/dialects/ibmi/query-generator-typescript.ts
@@ -55,7 +55,7 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set<string>(['ifExists']),
+        new Set(['ifExists']),
         options,
       );
     }

--- a/src/dialects/ibmi/query-generator-typescript.ts
+++ b/src/dialects/ibmi/query-generator-typescript.ts
@@ -61,8 +61,8 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
     }
 
     let indexName: string;
-    const table = this.extractTableDetails(tableName);
     if (Array.isArray(indexNameOrAttributes)) {
+      const table = this.extractTableDetails(tableName);
       indexName = generateIndexName(table, { fields: indexNameOrAttributes });
     } else {
       indexName = indexNameOrAttributes;

--- a/src/dialects/ibmi/query-generator-typescript.ts
+++ b/src/dialects/ibmi/query-generator-typescript.ts
@@ -70,7 +70,7 @@ export class IBMiQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
     return joinSQLFragments([
       'BEGIN',
-      options?.ifExists ? `IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = '${indexName}') THEN` : '',
+      options?.ifExists ? `IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = ${this.quoteIdentifier(indexName)}) THEN` : '',
       `DROP INDEX ${this.quoteIdentifier(indexName)};`,
       'COMMIT;',
       options?.ifExists ? 'END IF;' : '',

--- a/src/dialects/ibmi/query-generator.js
+++ b/src/dialects/ibmi/query-generator.js
@@ -598,16 +598,6 @@ export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
     return sql;
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes) {
-    let indexName = indexNameOrAttributes;
-
-    if (typeof indexName !== 'string') {
-      indexName = underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
-    }
-
-    return `BEGIN IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = '${indexName}') THEN DROP INDEX "${indexName}"; COMMIT; END IF; END`;
-  }
-
   // bindParam(bind) {
   //   return value => {
   //     bind.push(value);

--- a/src/dialects/mariadb/query-generator-typescript.ts
+++ b/src/dialects/mariadb/query-generator-typescript.ts
@@ -1,0 +1,39 @@
+import { rejectInvalidOptions } from '../../utils/check';
+import { joinSQLFragments } from '../../utils/join-sql-fragments';
+import { generateIndexName } from '../../utils/string';
+import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
+import { MySqlQueryGenerator } from '../mysql/query-generator.js';
+
+/**
+ * Temporary class to ease the TypeScript migration
+ */
+export class MariaDbQueryGeneratorTypeScript extends MySqlQueryGenerator {
+  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+    if (options) {
+      rejectInvalidOptions(
+        'removeIndexQuery',
+        this.dialect.name,
+        REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+        new Set(['ifExists']),
+        options,
+      );
+    }
+
+    let indexName;
+    const table = this.extractTableDetails(tableName);
+    if (Array.isArray(indexNameOrAttributes)) {
+      indexName = generateIndexName(table, { fields: indexNameOrAttributes });
+    } else {
+      indexName = indexNameOrAttributes;
+    }
+
+    return joinSQLFragments([
+      'DROP INDEX',
+      options?.ifExists ? 'IF EXISTS' : '',
+      this.quoteIdentifier(indexName),
+      'ON',
+      this.quoteTable(tableName),
+    ]);
+  }
+}

--- a/src/dialects/mariadb/query-generator-typescript.ts
+++ b/src/dialects/mariadb/query-generator-typescript.ts
@@ -11,7 +11,11 @@ const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptio
  * Temporary class to ease the TypeScript migration
  */
 export class MariaDbQueryGeneratorTypeScript extends MySqlQueryGenerator {
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+  removeIndexQuery(
+    tableName: TableNameOrModel,
+    indexNameOrAttributes: string | string[],
+    options?: RemoveIndexQueryOptions,
+  ) {
     if (options) {
       rejectInvalidOptions(
         'removeIndexQuery',

--- a/src/dialects/mariadb/query-generator-typescript.ts
+++ b/src/dialects/mariadb/query-generator-typescript.ts
@@ -11,11 +11,12 @@ import { MySqlQueryGenerator } from '../mysql/query-generator.js';
 export class MariaDbQueryGeneratorTypeScript extends MySqlQueryGenerator {
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
+      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(['ifExists']),
+        REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }

--- a/src/dialects/mariadb/query-generator-typescript.ts
+++ b/src/dialects/mariadb/query-generator-typescript.ts
@@ -21,8 +21,8 @@ export class MariaDbQueryGeneratorTypeScript extends MySqlQueryGenerator {
     }
 
     let indexName;
-    const table = this.extractTableDetails(tableName);
     if (Array.isArray(indexNameOrAttributes)) {
+      const table = this.extractTableDetails(tableName);
       indexName = generateIndexName(table, { fields: indexNameOrAttributes });
     } else {
       indexName = indexNameOrAttributes;

--- a/src/dialects/mariadb/query-generator-typescript.ts
+++ b/src/dialects/mariadb/query-generator-typescript.ts
@@ -5,13 +5,14 @@ import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-genera
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import { MySqlQueryGenerator } from '../mysql/query-generator.js';
 
+const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
+
 /**
  * Temporary class to ease the TypeScript migration
  */
 export class MariaDbQueryGeneratorTypeScript extends MySqlQueryGenerator {
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
-      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,

--- a/src/dialects/mariadb/query-generator.js
+++ b/src/dialects/mariadb/query-generator.js
@@ -2,14 +2,11 @@
 
 import { normalizeDataType } from '../abstract/data-types-utils';
 import { joinSQLFragments } from '../../utils/join-sql-fragments.js';
-import { rejectInvalidOptions } from '../../utils/check';
-import { generateIndexName } from '../../utils/string';
-import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import { MariaDbQueryGeneratorTypeScript } from './query-generator-typescript';
 
-const { MySqlQueryGenerator } = require('../mysql/query-generator');
 const _ = require('lodash');
 
-export class MariaDbQueryGenerator extends MySqlQueryGenerator {
+export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
 
   _getTechnicalSchemaNames() {
     return ['MYSQL', 'INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA', 'mysql', 'information_schema', 'performance_schema'];
@@ -48,34 +45,6 @@ export class MariaDbQueryGenerator extends MySqlQueryGenerator {
       ifExists,
       this.quoteIdentifier(attributeName),
       ';',
-    ]);
-  }
-
-  removeIndexQuery(tableName, indexNameOrAttributes, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'removeIndexQuery',
-        this.dialect.name,
-        REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(['ifExists']),
-        options,
-      );
-    }
-
-    let indexName;
-    const table = this.extractTableDetails(tableName);
-    if (Array.isArray(indexNameOrAttributes)) {
-      indexName = generateIndexName(table, { fields: indexNameOrAttributes });
-    } else {
-      indexName = indexNameOrAttributes;
-    }
-
-    return joinSQLFragments([
-      'DROP INDEX',
-      options?.ifExists ? 'IF EXISTS' : '',
-      this.quoteIdentifier(indexName),
-      'ON',
-      this.quoteTable(tableName),
     ]);
   }
 

--- a/src/dialects/mssql/query-generator-typescript.ts
+++ b/src/dialects/mssql/query-generator-typescript.ts
@@ -52,7 +52,11 @@ export class MsSqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
     return `EXEC sys.sp_helpindex @objname = ${this.escape(this.quoteTable(tableName))};`;
   }
 
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+  removeIndexQuery(
+    tableName: TableNameOrModel,
+    indexNameOrAttributes: string | string[],
+    options?: RemoveIndexQueryOptions,
+  ) {
     if (options) {
       rejectInvalidOptions(
         'removeIndexQuery',

--- a/src/dialects/mssql/query-generator-typescript.ts
+++ b/src/dialects/mssql/query-generator-typescript.ts
@@ -62,8 +62,8 @@ export class MsSqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
     }
 
     let indexName: string;
-    const table = this.extractTableDetails(tableName);
     if (Array.isArray(indexNameOrAttributes)) {
+      const table = this.extractTableDetails(tableName);
       indexName = generateIndexName(table, { fields: indexNameOrAttributes });
     } else {
       indexName = indexNameOrAttributes;

--- a/src/dialects/mssql/query-generator-typescript.ts
+++ b/src/dialects/mssql/query-generator-typescript.ts
@@ -5,6 +5,8 @@ import { AbstractQueryGenerator } from '../abstract/query-generator';
 import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 
+const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
+
 /**
  * Temporary class to ease the TypeScript migration
  */
@@ -52,7 +54,6 @@ export class MsSqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
-      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,

--- a/src/dialects/mssql/query-generator-typescript.ts
+++ b/src/dialects/mssql/query-generator-typescript.ts
@@ -56,7 +56,7 @@ export class MsSqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set<string>(['ifExists']),
+        new Set(['ifExists']),
         options,
       );
     }

--- a/src/dialects/mssql/query-generator-typescript.ts
+++ b/src/dialects/mssql/query-generator-typescript.ts
@@ -52,11 +52,12 @@ export class MsSqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
+      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(['ifExists']),
+        REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -601,16 +601,6 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
     return `EXEC sp_helpconstraint @objname = ${this.escape(this.quoteTable(tableName))};`;
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes) {
-    let indexName = indexNameOrAttributes;
-
-    if (typeof indexName !== 'string') {
-      indexName = underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
-    }
-
-    return `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteTable(tableName)}`;
-  }
-
   attributeToSQL(attribute, options) {
     if (!_.isPlainObject(attribute)) {
       attribute = {

--- a/src/dialects/mssql/query-generator.js
+++ b/src/dialects/mssql/query-generator.js
@@ -608,7 +608,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
       indexName = underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
     }
 
-    return `DROP INDEX ${this.quoteIdentifiers(indexName)} ON ${this.quoteIdentifiers(tableName)}`;
+    return `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteTable(tableName)}`;
   }
 
   attributeToSQL(attribute, options) {

--- a/src/dialects/mysql/query-generator-typescript.ts
+++ b/src/dialects/mysql/query-generator-typescript.ts
@@ -1,5 +1,8 @@
+import { rejectInvalidOptions } from '../../utils/check';
+import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import type { TableNameOrModel } from '../abstract/query-generator-typescript';
+import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 
 /**
  * Temporary class to ease the TypeScript migration
@@ -11,5 +14,27 @@ export class MySqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   showIndexesQuery(tableName: TableNameOrModel) {
     return `SHOW INDEX FROM ${this.quoteTable(tableName)}`;
+  }
+
+  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+    if (options) {
+      rejectInvalidOptions(
+        'removeIndexQuery',
+        this.dialect.name,
+        REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+        new Set(),
+        options,
+      );
+    }
+
+    let indexName: string;
+    const table = this.extractTableDetails(tableName);
+    if (Array.isArray(indexNameOrAttributes)) {
+      indexName = generateIndexName(table, { fields: indexNameOrAttributes });
+    } else {
+      indexName = indexNameOrAttributes;
+    }
+
+    return `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteTable(tableName)}`;
   }
 }

--- a/src/dialects/mysql/query-generator-typescript.ts
+++ b/src/dialects/mysql/query-generator-typescript.ts
@@ -18,7 +18,11 @@ export class MySqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
     return `SHOW INDEX FROM ${this.quoteTable(tableName)}`;
   }
 
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+  removeIndexQuery(
+    tableName: TableNameOrModel,
+    indexNameOrAttributes: string | string[],
+    options?: RemoveIndexQueryOptions,
+  ) {
     if (options) {
       rejectInvalidOptions(
         'removeIndexQuery',

--- a/src/dialects/mysql/query-generator-typescript.ts
+++ b/src/dialects/mysql/query-generator-typescript.ts
@@ -18,11 +18,12 @@ export class MySqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
+      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(),
+        REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }

--- a/src/dialects/mysql/query-generator-typescript.ts
+++ b/src/dialects/mysql/query-generator-typescript.ts
@@ -4,6 +4,8 @@ import { AbstractQueryGenerator } from '../abstract/query-generator';
 import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 
+const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
+
 /**
  * Temporary class to ease the TypeScript migration
  */
@@ -18,7 +20,6 @@ export class MySqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
-      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>();
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,

--- a/src/dialects/mysql/query-generator-typescript.ts
+++ b/src/dialects/mysql/query-generator-typescript.ts
@@ -28,8 +28,8 @@ export class MySqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
     }
 
     let indexName: string;
-    const table = this.extractTableDetails(tableName);
     if (Array.isArray(indexNameOrAttributes)) {
+      const table = this.extractTableDetails(tableName);
       indexName = generateIndexName(table, { fields: indexNameOrAttributes });
     } else {
       indexName = indexNameOrAttributes;

--- a/src/dialects/mysql/query-generator.js
+++ b/src/dialects/mysql/query-generator.js
@@ -375,21 +375,6 @@ export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
     ]);
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes) {
-    let indexName = indexNameOrAttributes;
-
-    if (typeof indexName !== 'string') {
-      indexName = underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
-    }
-
-    return joinSQLFragments([
-      'DROP INDEX',
-      this.quoteIdentifier(indexName),
-      'ON',
-      this.quoteTable(tableName),
-    ]);
-  }
-
   attributeToSQL(attribute, options) {
     if (!_.isPlainObject(attribute)) {
       attribute = {

--- a/src/dialects/postgres/query-generator-typescript.ts
+++ b/src/dialects/postgres/query-generator-typescript.ts
@@ -75,7 +75,9 @@ export class PostgresQueryGeneratorTypeScript extends AbstractQueryGenerator {
       'DROP INDEX',
       options?.concurrently ? 'CONCURRENTLY' : '',
       options?.ifExists ? 'IF EXISTS' : '',
-      this.quoteIdentifier(indexName),
+      table?.schema && table.schema !== this.dialect.getDefaultSchema()
+        ? `${this.quoteIdentifier(table.schema)}.${this.quoteIdentifier(indexName)}`
+        : this.quoteIdentifier(indexName),
       options?.cascade && !options?.concurrently ? 'CASCADE' : '',
     ]);
   }

--- a/src/dialects/postgres/query-generator-typescript.ts
+++ b/src/dialects/postgres/query-generator-typescript.ts
@@ -71,9 +71,7 @@ export class PostgresQueryGeneratorTypeScript extends AbstractQueryGenerator {
       'DROP INDEX',
       options?.concurrently ? 'CONCURRENTLY' : '',
       options?.ifExists ? 'IF EXISTS' : '',
-      table?.schema && table.schema !== this.dialect.getDefaultSchema()
-        ? `${this.quoteIdentifier(table.schema)}.${this.quoteIdentifier(indexName)}`
-        : this.quoteIdentifier(indexName),
+      `${this.quoteIdentifier(table.schema!)}.${this.quoteIdentifier(indexName)}`,
       options?.cascade ? 'CASCADE' : '',
     ]);
   }

--- a/src/dialects/postgres/query-generator-typescript.ts
+++ b/src/dialects/postgres/query-generator-typescript.ts
@@ -1,8 +1,6 @@
-import { rejectInvalidOptions } from '../../utils/check';
 import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 
 /**
@@ -53,18 +51,8 @@ export class PostgresQueryGeneratorTypeScript extends AbstractQueryGenerator {
   }
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
-    if (options) {
-      rejectInvalidOptions(
-        'removeIndexQuery',
-        this.dialect.name,
-        REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(['concurrently', 'ifExists', 'cascade']),
-        options,
-      );
-
-      if (options.cascade && options.concurrently) {
-        throw new Error(`Cannot specify both concurrently and cascade options in removeIndexQuery for ${this.dialect.name} dialect`);
-      }
+    if (options?.cascade && options?.concurrently) {
+      throw new Error(`Cannot specify both concurrently and cascade options in removeIndexQuery for ${this.dialect.name} dialect`);
     }
 
     let indexName;

--- a/src/dialects/postgres/query-generator-typescript.ts
+++ b/src/dialects/postgres/query-generator-typescript.ts
@@ -50,7 +50,11 @@ export class PostgresQueryGeneratorTypeScript extends AbstractQueryGenerator {
     ]);
   }
 
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+  removeIndexQuery(
+    tableName: TableNameOrModel,
+    indexNameOrAttributes: string | string[],
+    options?: RemoveIndexQueryOptions,
+  ) {
     if (options?.cascade && options?.concurrently) {
       throw new Error(`Cannot specify both concurrently and cascade options in removeIndexQuery for ${this.dialect.name} dialect`);
     }

--- a/src/dialects/postgres/query-generator-typescript.ts
+++ b/src/dialects/postgres/query-generator-typescript.ts
@@ -61,6 +61,10 @@ export class PostgresQueryGeneratorTypeScript extends AbstractQueryGenerator {
         new Set(['concurrently', 'ifExists', 'cascade']),
         options,
       );
+
+      if (options.cascade && options.concurrently) {
+        throw new Error(`Cannot specify both concurrently and cascade options in removeIndexQuery for ${this.dialect.name} dialect`);
+      }
     }
 
     let indexName;
@@ -78,7 +82,7 @@ export class PostgresQueryGeneratorTypeScript extends AbstractQueryGenerator {
       table?.schema && table.schema !== this.dialect.getDefaultSchema()
         ? `${this.quoteIdentifier(table.schema)}.${this.quoteIdentifier(indexName)}`
         : this.quoteIdentifier(indexName),
-      options?.cascade && !options?.concurrently ? 'CASCADE' : '',
+      options?.cascade ? 'CASCADE' : '',
     ]);
   }
 }

--- a/src/dialects/postgres/query-generator.js
+++ b/src/dialects/postgres/query-generator.js
@@ -432,20 +432,6 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     ].join(' ');
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes, options) {
-    let indexName = indexNameOrAttributes;
-
-    if (typeof indexName !== 'string') {
-      indexName = generateIndexName(tableName, { fields: indexNameOrAttributes });
-    }
-
-    return [
-      'DROP INDEX',
-      options && options.concurrently && 'CONCURRENTLY',
-      `IF EXISTS ${this.quoteIdentifiers(indexName)}`,
-    ].filter(Boolean).join(' ');
-  }
-
   addLimitAndOffset(options) {
     let fragment = '';
     if (options.limit != null) {

--- a/src/dialects/snowflake/query-generator-typescript.ts
+++ b/src/dialects/snowflake/query-generator-typescript.ts
@@ -38,11 +38,6 @@ export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
       indexName = indexNameOrAttributes;
     }
 
-    return joinSQLFragments([
-      'DROP INDEX',
-      this.quoteIdentifier(indexName),
-      'ON',
-      this.quoteTable(tableName),
-    ]);
+    return `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteTable(tableName)}`;
   }
 }

--- a/src/dialects/snowflake/query-generator-typescript.ts
+++ b/src/dialects/snowflake/query-generator-typescript.ts
@@ -1,5 +1,4 @@
 import { rejectInvalidOptions } from '../../utils/check';
-import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
 import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';

--- a/src/dialects/snowflake/query-generator-typescript.ts
+++ b/src/dialects/snowflake/query-generator-typescript.ts
@@ -1,8 +1,5 @@
-import { rejectInvalidOptions } from '../../utils/check';
-import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
-import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
+import type { TableNameOrModel } from '../abstract/query-generator-typescript';
 
 /**
  * Temporary class to ease the TypeScript migration
@@ -15,28 +12,5 @@ export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
   showIndexesQuery() {
     // TODO [+snowflake-sdk]: check if this is the correct implementation
     return `SELECT '' FROM DUAL`;
-  }
-
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
-    // TODO [+snowflake-sdk]: check if this is the correct implementation
-    if (options) {
-      rejectInvalidOptions(
-        'removeIndexQuery',
-        this.dialect.name,
-        REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(),
-        options,
-      );
-    }
-
-    let indexName: string;
-    const table = this.extractTableDetails(tableName);
-    if (Array.isArray(indexNameOrAttributes)) {
-      indexName = generateIndexName(table, { fields: indexNameOrAttributes });
-    } else {
-      indexName = indexNameOrAttributes;
-    }
-
-    return `DROP INDEX ${this.quoteIdentifier(indexName)} ON ${this.quoteTable(tableName)}`;
   }
 }

--- a/src/dialects/snowflake/query-generator.js
+++ b/src/dialects/snowflake/query-generator.js
@@ -446,22 +446,6 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
     ]);
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes) {
-    let indexName = indexNameOrAttributes;
-
-    if (typeof indexName !== 'string') {
-      indexName = underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
-    }
-
-    return joinSQLFragments([
-      'DROP INDEX',
-      this.quoteIdentifier(indexName),
-      'ON',
-      this.quoteTable(tableName),
-      ';',
-    ]);
-  }
-
   attributeToSQL(attribute, options) {
     if (!_.isPlainObject(attribute)) {
       attribute = {

--- a/src/dialects/sqlite/query-generator-typescript.ts
+++ b/src/dialects/sqlite/query-generator-typescript.ts
@@ -23,7 +23,7 @@ export class SqliteQueryGeneratorTypeScript extends MySqlQueryGenerator {
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set<string>(['ifExists']),
+        new Set(['ifExists']),
         options,
       );
     }

--- a/src/dialects/sqlite/query-generator-typescript.ts
+++ b/src/dialects/sqlite/query-generator-typescript.ts
@@ -5,6 +5,8 @@ import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-genera
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import { MySqlQueryGenerator } from '../mysql/query-generator';
 
+const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
+
 /**
  * Temporary class to ease the TypeScript migration
  */
@@ -19,7 +21,6 @@ export class SqliteQueryGeneratorTypeScript extends MySqlQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
-      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,

--- a/src/dialects/sqlite/query-generator-typescript.ts
+++ b/src/dialects/sqlite/query-generator-typescript.ts
@@ -29,8 +29,8 @@ export class SqliteQueryGeneratorTypeScript extends MySqlQueryGenerator {
     }
 
     let indexName: string;
-    const table = this.extractTableDetails(tableName);
     if (Array.isArray(indexNameOrAttributes)) {
+      const table = this.extractTableDetails(tableName);
       indexName = generateIndexName(table, { fields: indexNameOrAttributes });
     } else {
       indexName = indexNameOrAttributes;

--- a/src/dialects/sqlite/query-generator-typescript.ts
+++ b/src/dialects/sqlite/query-generator-typescript.ts
@@ -19,7 +19,11 @@ export class SqliteQueryGeneratorTypeScript extends MySqlQueryGenerator {
     return `PRAGMA INDEX_LIST(${this.quoteTable(tableName)})`;
   }
 
-  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+  removeIndexQuery(
+    tableName: TableNameOrModel,
+    indexNameOrAttributes: string | string[],
+    options?: RemoveIndexQueryOptions,
+  ) {
     if (options) {
       rejectInvalidOptions(
         'removeIndexQuery',

--- a/src/dialects/sqlite/query-generator-typescript.ts
+++ b/src/dialects/sqlite/query-generator-typescript.ts
@@ -1,4 +1,8 @@
-import type { TableNameOrModel } from '../abstract/query-generator-typescript';
+import { rejectInvalidOptions } from '../../utils/check';
+import { joinSQLFragments } from '../../utils/join-sql-fragments';
+import { generateIndexName } from '../../utils/string';
+import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import { MySqlQueryGenerator } from '../mysql/query-generator';
 
 /**
@@ -11,5 +15,31 @@ export class SqliteQueryGeneratorTypeScript extends MySqlQueryGenerator {
 
   showIndexesQuery(tableName: TableNameOrModel) {
     return `PRAGMA INDEX_LIST(${this.quoteTable(tableName)})`;
+  }
+
+  removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
+    if (options) {
+      rejectInvalidOptions(
+        'removeIndexQuery',
+        this.dialect.name,
+        REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+        new Set<string>(['ifExists']),
+        options,
+      );
+    }
+
+    let indexName: string;
+    const table = this.extractTableDetails(tableName);
+    if (Array.isArray(indexNameOrAttributes)) {
+      indexName = generateIndexName(table, { fields: indexNameOrAttributes });
+    } else {
+      indexName = indexNameOrAttributes;
+    }
+
+    return joinSQLFragments([
+      'DROP INDEX',
+      options?.ifExists ? 'IF EXISTS' : '',
+      this.quoteIdentifier(indexName),
+    ]);
   }
 }

--- a/src/dialects/sqlite/query-generator-typescript.ts
+++ b/src/dialects/sqlite/query-generator-typescript.ts
@@ -19,11 +19,12 @@ export class SqliteQueryGeneratorTypeScript extends MySqlQueryGenerator {
 
   removeIndexQuery(tableName: TableNameOrModel, indexNameOrAttributes: string | string[], options: RemoveIndexQueryOptions) {
     if (options) {
+      const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
       rejectInvalidOptions(
         'removeIndexQuery',
         this.dialect.name,
         REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
-        new Set(['ifExists']),
+        REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS,
         options,
       );
     }

--- a/src/dialects/sqlite/query-generator.js
+++ b/src/dialects/sqlite/query-generator.js
@@ -377,16 +377,6 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
     return `${sql};`;
   }
 
-  removeIndexQuery(tableName, indexNameOrAttributes) {
-    let indexName = indexNameOrAttributes;
-
-    if (typeof indexName !== 'string') {
-      indexName = underscore(`${tableName}_${indexNameOrAttributes.join('_')}`);
-    }
-
-    return `DROP INDEX IF EXISTS ${this.quoteIdentifier(indexName)}`;
-  }
-
   describeCreateTableQuery(tableName) {
     return `SELECT sql FROM sqlite_master WHERE tbl_name='${tableName}';`;
   }

--- a/src/utils/check.ts
+++ b/src/utils/check.ts
@@ -96,7 +96,7 @@ export function rejectInvalidOptions(
   dialectName: string,
   allSupportableOptions: Set<string>,
   supportedOptions: Set<string>,
-  receivedOptions: Record<string, unknown>,
+  receivedOptions: object,
 ): void {
   const receivedOptionNames = Object.keys(pickBy(receivedOptions));
   const unsupportedOptions = receivedOptionNames.filter(optionName => {

--- a/test/types/query-interface.ts
+++ b/test/types/query-interface.ts
@@ -206,6 +206,7 @@ async function test() {
 
   await queryInterface.removeIndex('Person', 'SuperDuperIndex');
   await queryInterface.removeIndex({ schema: '<schema>', tableName: 'Person' }, 'SuperDuperIndex');
+  await queryInterface.removeIndex({ schema: '<schema>', tableName: 'Person' }, 'SuperDuperIndex', { ifExists: true });
 
   const indexes = await queryInterface.showIndex('Person');
   indexes.map(index => ({

--- a/test/unit/dialects/db2/query-generator.test.js
+++ b/test/unit/dialects/db2/query-generator.test.js
@@ -579,15 +579,6 @@ if (dialect === 'db2') {
         },
       ],
 
-      removeIndexQuery: [
-        {
-          arguments: ['User', 'user_foo_bar'],
-          expectation: 'DROP INDEX "user_foo_bar"',
-        }, {
-          arguments: ['User', ['foo', 'bar']],
-          expectation: 'DROP INDEX "user_foo_bar"',
-        },
-      ],
       getForeignKeyQuery: [
         {
           arguments: ['User', 'email'],

--- a/test/unit/dialects/mariadb/query-generator.test.js
+++ b/test/unit/dialects/mariadb/query-generator.test.js
@@ -630,15 +630,6 @@ if (dialect === 'mariadb') {
         },
       ],
 
-      removeIndexQuery: [
-        {
-          arguments: ['User', 'user_foo_bar'],
-          expectation: 'DROP INDEX `user_foo_bar` ON `User`',
-        }, {
-          arguments: ['User', ['foo', 'bar']],
-          expectation: 'DROP INDEX `user_foo_bar` ON `User`',
-        },
-      ],
       getForeignKeyQuery: [
         {
           arguments: ['User', 'email'],

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -227,5 +227,17 @@ if (current.dialect.name === 'mssql') {
       });
     });
 
+    it('removeIndexQuery', function () {
+      expectsql(this.queryGenerator.removeIndexQuery('myTable', 'myIndex'), {
+        mssql: 'DROP INDEX [myIndex] ON [myTable]',
+      });
+    });
+
+    it('removeIndexQuery with custom schema', function () {
+      expectsql(this.queryGenerator.removeIndexQuery({ tableName: 'myTable', schema: 'mySchema' }, 'myIndex'), {
+        mssql: 'DROP INDEX [myIndex] ON [mySchema].[myTable]',
+      });
+    });
+
   });
 }

--- a/test/unit/dialects/mssql/query-generator.test.js
+++ b/test/unit/dialects/mssql/query-generator.test.js
@@ -226,18 +226,5 @@ if (current.dialect.name === 'mssql') {
         mssql: 'ALTER TABLE [myTable] DROP [myColumnKey]',
       });
     });
-
-    it('removeIndexQuery', function () {
-      expectsql(this.queryGenerator.removeIndexQuery('myTable', 'myIndex'), {
-        mssql: 'DROP INDEX [myIndex] ON [myTable]',
-      });
-    });
-
-    it('removeIndexQuery with custom schema', function () {
-      expectsql(this.queryGenerator.removeIndexQuery({ tableName: 'myTable', schema: 'mySchema' }, 'myIndex'), {
-        mssql: 'DROP INDEX [myIndex] ON [mySchema].[myTable]',
-      });
-    });
-
   });
 }

--- a/test/unit/dialects/mysql/query-generator.test.js
+++ b/test/unit/dialects/mysql/query-generator.test.js
@@ -623,16 +623,6 @@ if (dialect === 'mysql') {
         },
       ],
 
-      removeIndexQuery: [
-        {
-          arguments: ['User', 'user_foo_bar'],
-          expectation: 'DROP INDEX `user_foo_bar` ON `User`',
-        }, {
-          arguments: ['User', ['foo', 'bar']],
-          expectation: 'DROP INDEX `user_foo_bar` ON `User`',
-        },
-      ],
-
       getForeignKeyQuery: [
         {
           arguments: ['User', 'email'],

--- a/test/unit/dialects/postgres/query-generator.test.js
+++ b/test/unit/dialects/postgres/query-generator.test.js
@@ -973,44 +973,6 @@ if (dialect.startsWith('postgres')) {
         },
       ],
 
-      removeIndexQuery: [
-        {
-          arguments: ['User', 'user_foo_bar'],
-          expectation: 'DROP INDEX IF EXISTS "user_foo_bar"',
-        }, {
-          arguments: ['User', ['foo', 'bar']],
-          expectation: 'DROP INDEX IF EXISTS "user_foo_bar"',
-        }, {
-          arguments: ['User', ['foo', 'bar'], { concurrently: true }],
-          expectation: 'DROP INDEX CONCURRENTLY IF EXISTS "user_foo_bar"',
-        }, {
-          arguments: ['User', 'mySchema.user_foo_bar'],
-          expectation: 'DROP INDEX IF EXISTS "mySchema"."user_foo_bar"',
-        }, {
-          arguments: ['User', 'mySchema.user_foo_bar', { concurrently: true }],
-          expectation: 'DROP INDEX CONCURRENTLY IF EXISTS "mySchema"."user_foo_bar"',
-        },
-
-        // Variants when quoteIdentifiers is false
-        {
-          arguments: ['User', 'user_foo_bar'],
-          expectation: 'DROP INDEX IF EXISTS user_foo_bar',
-          context: { options: { quoteIdentifiers: false } },
-        }, {
-          arguments: ['User', ['foo', 'bar']],
-          expectation: 'DROP INDEX IF EXISTS user_foo_bar',
-          context: { options: { quoteIdentifiers: false } },
-        }, {
-          arguments: ['User', 'mySchema.user_foo_bar'],
-          expectation: 'DROP INDEX IF EXISTS mySchema.user_foo_bar',
-          context: { options: { quoteIdentifiers: false } },
-        }, {
-          arguments: ['User', 'mySchema.user_foo_bar', { concurrently: true }],
-          expectation: 'DROP INDEX CONCURRENTLY IF EXISTS mySchema.user_foo_bar',
-          context: { options: { quoteIdentifiers: false } },
-        },
-      ],
-
       startTransactionQuery: [
         {
           arguments: [{}],

--- a/test/unit/query-generator/remove-index-query.test.ts
+++ b/test/unit/query-generator/remove-index-query.test.ts
@@ -12,7 +12,6 @@ describe('QueryGenerator#removeIndexQuery', () => {
       sqlite: 'DROP INDEX `user_foo_bar`',
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
       'db2 postgres': `DROP INDEX "user_foo_bar"`,
-
     });
   });
 
@@ -22,7 +21,6 @@ describe('QueryGenerator#removeIndexQuery', () => {
       sqlite: 'DROP INDEX `my_table_foo_bar`',
       ibmi: `BEGIN DROP INDEX "my_table_foo_bar"; COMMIT; END`,
       'db2 postgres': `DROP INDEX "my_table_foo_bar"`,
-
     });
   });
 

--- a/test/unit/query-generator/remove-index-query.test.ts
+++ b/test/unit/query-generator/remove-index-query.test.ts
@@ -11,7 +11,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
       default: `DROP INDEX [user_foo_bar] ON [myTable]`,
       sqlite: 'DROP INDEX `user_foo_bar`',
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
-      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      db2: `DROP INDEX "user_foo_bar"`,
+      postgres: `DROP INDEX "public"."user_foo_bar"`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
@@ -21,7 +22,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
       default: `DROP INDEX [my_table_foo_bar] ON [myTable]`,
       sqlite: 'DROP INDEX `my_table_foo_bar`',
       ibmi: `BEGIN DROP INDEX "my_table_foo_bar"; COMMIT; END`,
-      'db2 postgres': `DROP INDEX "my_table_foo_bar"`,
+      db2: `DROP INDEX "my_table_foo_bar"`,
+      postgres: `DROP INDEX "public"."my_table_foo_bar"`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
@@ -29,7 +31,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
   it('produces a DROP INDEX with CONCURRENTLY query from a table', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { concurrently: true }), {
       default: `DROP INDEX CONCURRENTLY [user_foo_bar] ON [myTable]`,
-      postgres: `DROP INDEX CONCURRENTLY "user_foo_bar"`,
+      postgres: `DROP INDEX CONCURRENTLY "public"."user_foo_bar"`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
       'db2 ibmi mariadb mssql mysql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently']),
     });
@@ -39,7 +41,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { ifExists: true }), {
       default: `DROP INDEX IF EXISTS [user_foo_bar] ON [myTable]`,
       sqlite: 'DROP INDEX IF EXISTS `user_foo_bar`',
-      postgres: `DROP INDEX IF EXISTS "user_foo_bar"`,
+      postgres: `DROP INDEX IF EXISTS "public"."user_foo_bar"`,
       ibmi: `BEGIN IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = "user_foo_bar") THEN DROP INDEX "user_foo_bar"; COMMIT; END IF; END`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
       'db2 mysql': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['ifExists']),
@@ -49,7 +51,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
   it('produces a DROP INDEX with CASCADE query from a table', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true }), {
       default: `DROP INDEX [user_foo_bar] ON [myTable] CASCADE`,
-      postgres: `DROP INDEX "user_foo_bar" CASCADE`,
+      postgres: `DROP INDEX "public"."user_foo_bar" CASCADE`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
       'db2 ibmi mariadb mssql mysql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade']),
     });
@@ -58,7 +60,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
   it('produces a DROP INDEX with CASCADE and IF EXISTS query from a table', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true, ifExists: true }), {
       default: `DROP INDEX IF EXISTS [user_foo_bar] ON [myTable] CASCADE`,
-      postgres: `DROP INDEX IF EXISTS "user_foo_bar" CASCADE`,
+      postgres: `DROP INDEX IF EXISTS "public"."user_foo_bar" CASCADE`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
       'db2 mysql': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade', 'ifExists']),
       'ibmi mariadb mssql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade']),
@@ -68,7 +70,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
   it('produces a DROP INDEX with CONCURRENTLY and IF EXISTS query from a table', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { concurrently: true, ifExists: true }), {
       default: `DROP INDEX CONCURRENTLY IF EXISTS [user_foo_bar] ON [myTable]`,
-      postgres: `DROP INDEX CONCURRENTLY IF EXISTS "user_foo_bar"`,
+      postgres: `DROP INDEX CONCURRENTLY IF EXISTS "public"."user_foo_bar"`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
       'db2 mysql': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently', 'ifExists']),
       'ibmi mariadb mssql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently']),
@@ -90,7 +92,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
       default: `DROP INDEX [user_foo_bar] ON [myModels]`,
       sqlite: 'DROP INDEX `user_foo_bar`',
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
-      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      db2: `DROP INDEX "user_foo_bar"`,
+      postgres: `DROP INDEX "public"."user_foo_bar"`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
@@ -111,7 +114,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
       default: `DROP INDEX [user_foo_bar] ON [myTable]`,
       sqlite: 'DROP INDEX `user_foo_bar`',
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
-      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      db2: `DROP INDEX "user_foo_bar"`,
+      postgres: `DROP INDEX "public"."user_foo_bar"`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });

--- a/test/unit/query-generator/remove-index-query.test.ts
+++ b/test/unit/query-generator/remove-index-query.test.ts
@@ -12,6 +12,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
       sqlite: 'DROP INDEX `user_foo_bar`',
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
       'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
 
@@ -21,6 +22,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
       sqlite: 'DROP INDEX `my_table_foo_bar`',
       ibmi: `BEGIN DROP INDEX "my_table_foo_bar"; COMMIT; END`,
       'db2 postgres': `DROP INDEX "my_table_foo_bar"`,
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
 
@@ -28,7 +30,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { concurrently: true }), {
       default: `DROP INDEX CONCURRENTLY [user_foo_bar] ON [myTable]`,
       postgres: `DROP INDEX CONCURRENTLY "user_foo_bar"`,
-      'db2 ibmi mariadb mssql mysql snowflake sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently']),
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
+      'db2 ibmi mariadb mssql mysql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently']),
     });
   });
 
@@ -38,7 +41,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
       sqlite: 'DROP INDEX IF EXISTS `user_foo_bar`',
       postgres: `DROP INDEX IF EXISTS "user_foo_bar"`,
       ibmi: `BEGIN IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = 'user_foo_bar') THEN DROP INDEX "user_foo_bar"; COMMIT; END IF; END`,
-      'db2 mysql snowflake': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['ifExists']),
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
+      'db2 mysql': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['ifExists']),
     });
   });
 
@@ -46,7 +50,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true }), {
       default: `DROP INDEX [user_foo_bar] ON [myTable] CASCADE`,
       postgres: `DROP INDEX "user_foo_bar" CASCADE`,
-      'db2 ibmi mariadb mssql mysql snowflake sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade']),
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
+      'db2 ibmi mariadb mssql mysql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade']),
     });
   });
 
@@ -54,7 +59,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true, ifExists: true }), {
       default: `DROP INDEX IF EXISTS [user_foo_bar] ON [myTable] CASCADE`,
       postgres: `DROP INDEX IF EXISTS "user_foo_bar" CASCADE`,
-      'db2 mysql snowflake': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade', 'ifExists']),
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
+      'db2 mysql': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade', 'ifExists']),
       'ibmi mariadb mssql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade']),
     });
   });
@@ -63,7 +69,8 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { concurrently: true, ifExists: true }), {
       default: `DROP INDEX CONCURRENTLY IF EXISTS [user_foo_bar] ON [myTable]`,
       postgres: `DROP INDEX CONCURRENTLY IF EXISTS "user_foo_bar"`,
-      'db2 mysql snowflake': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently', 'ifExists']),
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
+      'db2 mysql': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently', 'ifExists']),
       'ibmi mariadb mssql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently']),
     });
   });
@@ -72,6 +79,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true, concurrently: true }), {
       default: buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade', 'concurrently']),
       postgres: new Error(`Cannot specify both concurrently and cascade options in removeIndexQuery for ${dialect.name} dialect`),
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
 
@@ -83,6 +91,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
       sqlite: 'DROP INDEX `user_foo_bar`',
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
       'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
 
@@ -93,6 +102,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
       postgres: `DROP INDEX "mySchema"."user_foo_bar"`,
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
       db2: `DROP INDEX "user_foo_bar"`,
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
 
@@ -102,6 +112,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
       sqlite: 'DROP INDEX `user_foo_bar`',
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
       'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
 
@@ -115,6 +126,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
       postgres: `DROP INDEX "mySchema"."user_foo_bar"`,
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
       db2: 'DROP INDEX "user_foo_bar"',
+      snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
     });
   });
 });

--- a/test/unit/query-generator/remove-index-query.test.ts
+++ b/test/unit/query-generator/remove-index-query.test.ts
@@ -40,7 +40,7 @@ describe('QueryGenerator#removeIndexQuery', () => {
       default: `DROP INDEX IF EXISTS [user_foo_bar] ON [myTable]`,
       sqlite: 'DROP INDEX IF EXISTS `user_foo_bar`',
       postgres: `DROP INDEX IF EXISTS "user_foo_bar"`,
-      ibmi: `BEGIN IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = 'user_foo_bar') THEN DROP INDEX "user_foo_bar"; COMMIT; END IF; END`,
+      ibmi: `BEGIN IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = "user_foo_bar") THEN DROP INDEX "user_foo_bar"; COMMIT; END IF; END`,
       snowflake: new Error(`removeIndexQuery has not been implemented in ${dialect.name}.`),
       'db2 mysql': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['ifExists']),
     });

--- a/test/unit/query-generator/remove-index-query.test.ts
+++ b/test/unit/query-generator/remove-index-query.test.ts
@@ -68,6 +68,13 @@ describe('QueryGenerator#removeIndexQuery', () => {
     });
   });
 
+  it('throws an error for DROP INDEX with CASCADE and CONCURRENTLY query from a table', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true, concurrently: true }), {
+      default: buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade', 'concurrently']),
+      postgres: new Error(`Cannot specify both concurrently and cascade options in removeIndexQuery for ${dialect.name} dialect`),
+    });
+  });
+
   it('produces a DROP INDEX query from a model', () => {
     const MyModel = sequelize.define('myModel', {});
 

--- a/test/unit/query-generator/remove-index-query.test.ts
+++ b/test/unit/query-generator/remove-index-query.test.ts
@@ -85,8 +85,9 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGenerator.removeIndexQuery({ tableName: 'myTable', schema: 'mySchema' }, 'user_foo_bar'), {
       default: `DROP INDEX [user_foo_bar] ON [mySchema].[myTable]`,
       sqlite: 'DROP INDEX `user_foo_bar`',
+      postgres: `DROP INDEX "mySchema"."user_foo_bar"`,
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
-      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      db2: `DROP INDEX "user_foo_bar"`,
     });
   });
 
@@ -106,8 +107,9 @@ describe('QueryGenerator#removeIndexQuery', () => {
     expectsql(() => queryGeneratorSchema.removeIndexQuery('myTable', 'user_foo_bar'), {
       default: `DROP INDEX [user_foo_bar] ON [mySchema].[myTable]`,
       sqlite: 'DROP INDEX `user_foo_bar`',
+      postgres: `DROP INDEX "mySchema"."user_foo_bar"`,
       ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
-      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+      db2: 'DROP INDEX "user_foo_bar"',
     });
   });
 });

--- a/test/unit/query-generator/remove-index-query.test.ts
+++ b/test/unit/query-generator/remove-index-query.test.ts
@@ -1,0 +1,113 @@
+import { buildInvalidOptionReceivedError } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
+import { createSequelizeInstance, expectsql, sequelize } from '../../support';
+
+const dialect = sequelize.dialect;
+
+describe('QueryGenerator#removeIndexQuery', () => {
+  const queryGenerator = sequelize.getQueryInterface().queryGenerator;
+
+  it('produces a DROP INDEX query from a table', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar'), {
+      default: `DROP INDEX [user_foo_bar] ON [myTable]`,
+      sqlite: 'DROP INDEX `user_foo_bar`',
+      ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
+      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+
+    });
+  });
+
+  it('produces a DROP INDEX query from a table with attributes', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', ['foo', 'bar']), {
+      default: `DROP INDEX [my_table_foo_bar] ON [myTable]`,
+      sqlite: 'DROP INDEX `my_table_foo_bar`',
+      ibmi: `BEGIN DROP INDEX "my_table_foo_bar"; COMMIT; END`,
+      'db2 postgres': `DROP INDEX "my_table_foo_bar"`,
+
+    });
+  });
+
+  it('produces a DROP INDEX with CONCURRENTLY query from a table', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { concurrently: true }), {
+      default: `DROP INDEX CONCURRENTLY [user_foo_bar] ON [myTable]`,
+      postgres: `DROP INDEX CONCURRENTLY "user_foo_bar"`,
+      'db2 ibmi mariadb mssql mysql snowflake sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently']),
+    });
+  });
+
+  it('produces a DROP INDEX with IF EXISTS query from a table', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { ifExists: true }), {
+      default: `DROP INDEX IF EXISTS [user_foo_bar] ON [myTable]`,
+      sqlite: 'DROP INDEX IF EXISTS `user_foo_bar`',
+      postgres: `DROP INDEX IF EXISTS "user_foo_bar"`,
+      ibmi: `BEGIN IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = 'user_foo_bar') THEN DROP INDEX "user_foo_bar"; COMMIT; END IF; END`,
+      'db2 mysql snowflake': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['ifExists']),
+    });
+  });
+
+  it('produces a DROP INDEX with CASCADE query from a table', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true }), {
+      default: `DROP INDEX [user_foo_bar] ON [myTable] CASCADE`,
+      postgres: `DROP INDEX "user_foo_bar" CASCADE`,
+      'db2 ibmi mariadb mssql mysql snowflake sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade']),
+    });
+  });
+
+  it('produces a DROP INDEX with CASCADE and IF EXISTS query from a table', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { cascade: true, ifExists: true }), {
+      default: `DROP INDEX IF EXISTS [user_foo_bar] ON [myTable] CASCADE`,
+      postgres: `DROP INDEX IF EXISTS "user_foo_bar" CASCADE`,
+      'db2 mysql snowflake': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade', 'ifExists']),
+      'ibmi mariadb mssql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['cascade']),
+    });
+  });
+
+  it('produces a DROP INDEX with CONCURRENTLY and IF EXISTS query from a table', () => {
+    expectsql(() => queryGenerator.removeIndexQuery('myTable', 'user_foo_bar', { concurrently: true, ifExists: true }), {
+      default: `DROP INDEX CONCURRENTLY IF EXISTS [user_foo_bar] ON [myTable]`,
+      postgres: `DROP INDEX CONCURRENTLY IF EXISTS "user_foo_bar"`,
+      'db2 mysql snowflake': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently', 'ifExists']),
+      'ibmi mariadb mssql sqlite': buildInvalidOptionReceivedError('removeIndexQuery', dialect.name, ['concurrently']),
+    });
+  });
+
+  it('produces a DROP INDEX query from a model', () => {
+    const MyModel = sequelize.define('myModel', {});
+
+    expectsql(() => queryGenerator.removeIndexQuery(MyModel, 'user_foo_bar'), {
+      default: `DROP INDEX [user_foo_bar] ON [myModels]`,
+      sqlite: 'DROP INDEX `user_foo_bar`',
+      ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
+      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+    });
+  });
+
+  it('produces a DROP INDEX query from a table and schema', () => {
+    expectsql(() => queryGenerator.removeIndexQuery({ tableName: 'myTable', schema: 'mySchema' }, 'user_foo_bar'), {
+      default: `DROP INDEX [user_foo_bar] ON [mySchema].[myTable]`,
+      sqlite: 'DROP INDEX `user_foo_bar`',
+      ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
+      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+    });
+  });
+
+  it('produces a DROP INDEX query from a table and default schema', () => {
+    expectsql(() => queryGenerator.removeIndexQuery({ tableName: 'myTable', schema: dialect.getDefaultSchema() }, 'user_foo_bar'), {
+      default: `DROP INDEX [user_foo_bar] ON [myTable]`,
+      sqlite: 'DROP INDEX `user_foo_bar`',
+      ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
+      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+    });
+  });
+
+  it('produces a DROP INDEX query from a table and globally set schema', () => {
+    const sequelizeSchema = createSequelizeInstance({ schema: 'mySchema' });
+    const queryGeneratorSchema = sequelizeSchema.getQueryInterface().queryGenerator;
+
+    expectsql(() => queryGeneratorSchema.removeIndexQuery('myTable', 'user_foo_bar'), {
+      default: `DROP INDEX [user_foo_bar] ON [mySchema].[myTable]`,
+      sqlite: 'DROP INDEX `user_foo_bar`',
+      ibmi: `BEGIN DROP INDEX "user_foo_bar"; COMMIT; END`,
+      'db2 postgres': `DROP INDEX "user_foo_bar"`,
+    });
+  });
+});

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -297,15 +297,4 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       });
     });
   });
-
-  describe('removeIndex', () => {
-    it('naming', () => {
-      expectsql(sql.removeIndexQuery('table', ['column1', 'column2'], {}, 'table'), {
-        default: 'DROP INDEX [table_column1_column2] ON [table]',
-        ibmi: 'BEGIN DROP INDEX "table_column1_column2"; COMMIT; END',
-        sqlite: 'DROP INDEX `table_column1_column2`',
-        'db2 postgres': 'DROP INDEX "table_column1_column2"',
-      });
-    });
-  });
 });

--- a/test/unit/sql/index.test.js
+++ b/test/unit/sql/index.test.js
@@ -301,12 +301,10 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
   describe('removeIndex', () => {
     it('naming', () => {
       expectsql(sql.removeIndexQuery('table', ['column1', 'column2'], {}, 'table'), {
-        ibmi: 'BEGIN IF EXISTS (SELECT * FROM QSYS2.SYSINDEXES WHERE INDEX_NAME = \'table_column1_column2\') THEN DROP INDEX "table_column1_column2"; COMMIT; END IF; END',
-        mariadb: 'DROP INDEX `table_column1_column2` ON `table`',
-        mysql: 'DROP INDEX `table_column1_column2` ON `table`',
-        mssql: 'DROP INDEX [table_column1_column2] ON [table]',
-        db2: 'DROP INDEX "table_column1_column2"',
-        default: 'DROP INDEX IF EXISTS [table_column1_column2]',
+        default: 'DROP INDEX [table_column1_column2] ON [table]',
+        ibmi: 'BEGIN DROP INDEX "table_column1_column2"; COMMIT; END',
+        sqlite: 'DROP INDEX `table_column1_column2`',
+        'db2 postgres': 'DROP INDEX "table_column1_column2"',
       });
     });
   });


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
Update the methods used to quote the indexes and table to match the [Microsoft SQL Server docs](https://learn.microsoft.com/en-us/sql/t-sql/statements/drop-index-transact-sql?view=sql-server-ver16).