### PR TITLE
fix: align `QueryInterface` type export with value exports

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,7 +18,7 @@ export const and = Pkg.and;
 export const or = Pkg.or;
 
 // export * from './lib/query-interface';
-export const QueryInterface = Pkg.QueryInterface;
+export const AbstractQueryInterface = Pkg.AbstractQueryInterface;
 
 // export * from './lib/model';
 export const Model = Pkg.Model;

--- a/src/sequelize.js
+++ b/src/sequelize.js
@@ -1280,7 +1280,7 @@ Sequelize.prototype.Validator = Sequelize.Validator = Validator;
 
 Sequelize.Model = Model;
 
-Sequelize.QueryInterface = AbstractQueryInterface;
+Sequelize.AbstractQueryInterface = AbstractQueryInterface;
 Sequelize.BelongsTo = BelongsTo;
 Sequelize.HasOne = HasOne;
 Sequelize.HasMany = HasMany;


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
Fix the export/typing issues pointed out in [this comment](https://github.com/sequelize/sequelize/pull/15339#discussion_r1045288006).


Definitely a hacky solution, so if there's no better one I'd like to revisit this later. I'm not super familiar with our import/export system and how typings interact across the codebase, so any feedback is welcome
<!-- Please provide a description of the change here. -->
