### PR TITLE
fix(findAndCountAll): count all rows without associations

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -2140,11 +2140,16 @@ Specify a different name for either index to resolve this issue.`);
     options.dataType = new DataTypes.INTEGER();
     options.includeIgnoreAttributes = false;
 
-    // No limit, offset or order for the options max be given to count()
+    // No limit, offset, order or include for the options max be given to count()
     // Set them to null to prevent scopes setting those values
     options.limit = null;
     options.offset = null;
     options.order = null;
+
+    // if options.withoutAssociations is true, it will ignore `options.include`
+    if (options.withoutAssociations) {
+      options.include = null;
+    }
 
     const result = await this.aggregate(col, 'count', options);
 
@@ -2157,7 +2162,7 @@ Specify a different name for either index to resolve this issue.`);
       }));
     }
 
-    return result;
+    return result || 0; // return 0 if count is null
   }
 
   /**
@@ -2213,6 +2218,10 @@ Specify a different name for either index to resolve this issue.`);
     if (countOptions.attributes) {
       countOptions.attributes = undefined;
     }
+
+    // findAndCountAll should count all rows
+    // without the associations included.
+    countOptions.withoutAssociations = true;
 
     const [count, rows] = await Promise.all([
       this.count(countOptions),

--- a/test/integration/include.test.js
+++ b/test/integration/include.test.js
@@ -949,7 +949,7 @@ Instead of specifying a Model, either:
         ],
       });
 
-      expect(result.count).to.eql(1);
+      expect(result.count).to.eql(3);
 
       expect(result.rows.length).to.eql(1);
       expect(result.rows[0].Item.test).to.eql('def');

--- a/test/integration/include/findAndCountAll.test.js
+++ b/test/integration/include/findAndCountAll.test.js
@@ -53,7 +53,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       ])]);
 
       // Find all projects with tasks and employees
-      const availableProjects = 3;
+      const availableProjects = 6;
       const limit = 2;
 
       const result = await Project.findAndCountAll({
@@ -165,7 +165,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         limit: 5,
       });
 
-      expect(result.count).to.be.equal(2);
+      expect(result.count).to.be.equal(5);
       expect(result.rows.length).to.be.equal(2);
     });
 
@@ -230,7 +230,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       expect(items.length).to.equal(2);
 
       const result = result0;
-      expect(result.count).to.equal(4);
+      expect(result.count).to.equal(5);
 
       // The first two of those should be returned due to the limit (Foo
       // instances 2 and 3)
@@ -256,8 +256,8 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         distinct: true,
       });
 
-      // There should be 2 instances matching the query (Instances 1 and 2), see the findAll statement
-      expect(result.count).to.equal(2);
+      // It should count all the Foo data.
+      expect(result.count).to.equal(5);
 
       // The first one of those should be returned due to the limit (Foo instance 1)
       expect(result.rows.length).to.equal(1);
@@ -332,7 +332,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
         ],
       });
 
-      expect(result.count).to.equal(2);
+      expect(result.count).to.equal(4);
       expect(result.rows.length).to.equal(1);
     });
 

--- a/test/integration/model/count.test.js
+++ b/test/integration/model/count.test.js
@@ -36,6 +36,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       await this.User.bulkCreate([
         { username: 'foo' },
         { username: 'bar' },
+        { username: 'baz' },
       ]);
 
       const user = await this.User.findOne();
@@ -107,14 +108,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       ]);
 
       const count0 = await this.User.count({ col: 'username' });
-      expect(count0).to.be.eql(3);
+
+      expect(count0).to.be.eql(3); // COUNT(DISTINCT username)
 
       const count = await this.User.count({
         col: 'age',
         distinct: true,
       });
 
-      expect(count).to.be.eql(2);
+      expect(count).to.be.eql(2); // COUNT(DISTINCT age)
     });
 
     it('should be able to specify NO column for COUNT() with DISTINCT', async function () {
@@ -167,7 +169,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         include: [this.Project],
       });
 
-      expect(count0).to.be.eql(3);
+      expect(count0).to.be.eql(3); // COUNT(DISTINCT username)
 
       const count = await this.User.count({
         col: 'age',
@@ -175,7 +177,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         include: [this.Project],
       });
 
-      expect(count).to.be.eql(2);
+      expect(count).to.be.eql(2); // COUNT(DISTINCT age)
     });
 
     it('should work correctly with include and whichever raw option', async function () {

--- a/test/integration/model/findAll.test.js
+++ b/test/integration/model/findAll.test.js
@@ -1340,7 +1340,7 @@ The following associations are defined on "Worker": "ToDos"`);
         expect(users[0].id).to.be.above(users[2].id);
       });
 
-      it('handles offset and limit', async function () {
+      it('handles offset and limit in findAll', async function () {
         await this.User.bulkCreate([{ username: 'bobby' }, { username: 'tables' }]);
         const users = await this.User.findAll({ limit: 2, offset: 2 });
         expect(users.length).to.equal(2);
@@ -1494,11 +1494,11 @@ The following associations are defined on "Worker": "ToDos"`);
       expect(info.rows.length).to.equal(2);
     });
 
-    it('handles offset', async function () {
+    it('handles offset in findAndCountAll', async function () {
       const info = await this.User.findAndCountAll({ offset: 1 });
-      expect(info.count).to.equal(3);
       expect(Array.isArray(info.rows)).to.be.ok;
-      expect(info.rows.length).to.equal(2);
+      expect(info.count).to.equal(3); // return count result
+      expect(info.rows.length).to.equal(2); // return findAll result
     });
 
     it('handles limit', async function () {
@@ -1508,10 +1508,10 @@ The following associations are defined on "Worker": "ToDos"`);
       expect(info.rows.length).to.equal(1);
     });
 
-    it('handles offset and limit', async function () {
+    it('handles offset and limit in findAndCountAll', async function () {
       const info = await this.User.findAndCountAll({ offset: 1, limit: 1 });
-      expect(info.count).to.equal(3);
       expect(Array.isArray(info.rows)).to.be.ok;
+      expect(info.count).to.equal(3);
       expect(info.rows.length).to.equal(1);
     });
 
@@ -1537,7 +1537,7 @@ The following associations are defined on "Worker": "ToDos"`);
       await election.setCitizen(alice);
       await election.setVoters([alice, bob]);
       const elections = await Election.findAndCountAll({
-        offset: 5,
+        offset: 1,
         limit: 1,
         where: {
           name: 'Some election',
@@ -1547,8 +1547,22 @@ The following associations are defined on "Worker": "ToDos"`);
           { model: Citizen, as: 'Voters' }, // Election voters
         ],
       });
-      expect(elections.count).to.equal(1);
-      expect(elections.rows.length).to.equal(0);
+      const otherElections = await Election.findAndCountAll({
+        offset: 0,
+        limit: 1,
+        where: {
+          name: 'Some other election',
+        },
+        include: [
+          'Citizen', // Election creator
+          { model: Citizen, as: 'Voters' }, // Election voters
+        ],
+      });
+
+      expect(elections.count).to.equal(1); // return count result
+      expect(elections.rows.length).to.equal(0); // return findAll result
+      expect(otherElections.count).to.equal(1);
+      expect(otherElections.rows.length).to.equal(1);
     });
 
     it('handles attributes', async function () {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? false<!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Closes #10557 

```
BREAKING CHANGE: findAndCountAll by default will only `find` and `countAll` (meaning count without association). `where` will still work for count. 

But users need to remove their temporary solution code that generates the same response. Otherwise, it will be shared with this change.
```

## Follow Up PR

- Migrate `model.js` to include this option and add information about it to the sequelize-website documentation.
