### PR TITLE
fix(mssql): force transactions if attempting to insert more than 1,000 rows

### DIFF
--- a/src/dialects/mssql/query-interface.js
+++ b/src/dialects/mssql/query-interface.js
@@ -54,23 +54,13 @@ export class MsSqlQueryInterface extends AbstractQueryInterface {
     * @override
     */
   async bulkInsert(tableName, records, options, attributes) {
-    options = { ...options, type: QueryTypes.INSERT };
-
     // If more than 1,000 rows are inserted outside of a transaction, we can't guarantee safe rollbacks.
     // See https://github.com/sequelize/sequelize/issues/15426
-    if ((records.length <= 1000) || options.transaction) {
-      const sql = this.queryGenerator.bulkInsertQuery(tableName, records, options, attributes);
-
-      // unlike bind, replacements are handled by QueryGenerator, not QueryRaw
-      delete options.replacements;
-
-      const results = await this.sequelize.queryRaw(sql, options);
-
-      return results[0];
+    if (records.length > 1000 && !options.transaction) {
+      throw new Error(`MSSQL doesn't allow for inserting more than 1,000 rows at a time, so Sequelize executes the insert as multiple queries. Please run this in a transaction to ensure safe rollbacks`);
     }
 
-    throw new Error('MSSQL doesn\'t allow for inserting more than 1,000 rows at a time. Please run this in a transaction to ensure safe rollbacks');
-
+    await super.bulkInsert(tableName, records, options, attributes);
   }
 
   /**

--- a/src/dialects/mssql/query-interface.js
+++ b/src/dialects/mssql/query-interface.js
@@ -60,7 +60,7 @@ export class MsSqlQueryInterface extends AbstractQueryInterface {
       throw new Error(`MSSQL doesn't allow for inserting more than 1,000 rows at a time, so Sequelize executes the insert as multiple queries. Please run this in a transaction to ensure safe rollbacks`);
     }
 
-    await super.bulkInsert(tableName, records, options, attributes);
+    return super.bulkInsert(tableName, records, options, attributes);
   }
 
   /**

--- a/test/integration/dialects/mssql/regressions.test.js
+++ b/test/integration/dialects/mssql/regressions.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const chai = require('chai');
-const _ = require('lodash');
+const times = require('lodash/times');
 
 const expect = chai.expect;
 const sinon =  require('sinon');
@@ -251,8 +251,9 @@ if (dialect.startsWith('mssql')) {
       expect(record.status).to.equals(value);
     });
 
+    // Fixes https://github.com/sequelize/sequelize/issues/15426
     it('rolls back changes after inserting more than 1000 rows outside of a transaction', async function () {
-      const User = this.sequelize.define('user', {
+      const User = this.sequelize.define('User', {
         username: {
           type: DataTypes.STRING,
           allowNull: false,
@@ -263,7 +264,7 @@ if (dialect.startsWith('mssql')) {
 
       try {
         await User.bulkCreate([
-          ..._.times(1000, () => ({ username: 'John' })),
+          ...times(1000, () => ({ username: 'John' })),
           { username: null },
         ]);
       } catch {

--- a/test/unit/query-interface/bulk-insert.test.ts
+++ b/test/unit/query-interface/bulk-insert.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import range from 'lodash/range';
 import sinon from 'sinon';
-import { DataTypes } from '@sequelize/core';
+import { DataTypes, Transaction } from '@sequelize/core';
 import { expectPerDialect, sequelize, toMatchRegex, toMatchSql } from '../../support';
 
 describe('QueryInterface#bulkInsert', () => {
@@ -31,9 +31,10 @@ describe('QueryInterface#bulkInsert', () => {
 
   it('uses minimal insert queries when rows >1000', async () => {
     const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
+    const transaction = new Transaction(sequelize, {});
 
     const users = range(2000).map(i => ({ firstName: `user${i}` }));
-    await sequelize.getQueryInterface().bulkInsert(User.tableName, users);
+    await sequelize.getQueryInterface().bulkInsert(User.tableName, users, { transaction });
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0).args[0];


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
Force a transaction to be used if we're attempting to insert more than 1,000 rows in a single `bulkInsert`. This allows us to safely rollback everything in case it fails.

This fixes https://github.com/sequelize/sequelize/issues/15426.
