### PR TITLE
meta: publish new v7 alphas as 'latest'

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "alpha"
+    "tag": "latest"
   },
   "scripts": {
     "----------------------------------------- static analysis -----------------------------------------": "",


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

As of now, the version mentioned as latest on NPM is [alpha-10](https://www.npmjs.com/package/@sequelize/core) which is not really wanted. This should become the latest alpha so people start using that sooner. This PR fixes that.

## Todos

- [ ] Publish the new alphas as both `alpha` and `latest`? (This would require to publish it twice so requires a change in the CI file)
