### PR TITLE
docs(model): Added `upsertKeys` property to `BulkCreateOptions` interface

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1159,12 +1159,9 @@ export interface BulkCreateOptions<TAttributes = any> extends Logging, Transacti
   fields?: Array<keyof TAttributes>;
 
   /**
-   * Should each row be subject to validation before it is inserted.
-   * The whole insert will fail if one row fails validation
-   *
-   * @default false
+   * Include options. See `find` for details
    */
-  validate?: boolean;
+  include?: AllowArray<Includeable>;
 
   /**
    * Run before / after create hooks for each individual Instance?
@@ -1182,20 +1179,28 @@ export interface BulkCreateOptions<TAttributes = any> extends Logging, Transacti
   ignoreDuplicates?: boolean;
 
   /**
+   * Return all columns or only the specified columns for the affected rows (only for postgres)
+   */
+  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
+
+  /**
    * Fields to update if row key already exists (on duplicate key update)? (only supported by MySQL,
    * MariaDB, SQLite >= 3.24.0 & Postgres >= 9.5).
    */
   updateOnDuplicate?: Array<keyof TAttributes>;
 
   /**
-   * Include options. See `find` for details
+   * Primary key names used as conflict target columns during insertion.
    */
-  include?: AllowArray<Includeable>;
+  upsertKeys?: string[];
 
   /**
-   * Return all columns or only the specified columns for the affected rows (only for postgres)
+   * Should each row be subject to validation before it is inserted.
+   * The whole insert will fail if one row fails validation
+   *
+   * @default false
    */
-  returning?: boolean | Array<keyof TAttributes | Literal | Col>;
+  validate?: boolean;
 }
 
 /**

--- a/test/integration/cls.test.ts
+++ b/test/integration/cls.test.ts
@@ -1,9 +1,9 @@
+import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/model-hooks.js';
 import { expect } from 'chai';
 import delay from 'delay';
 import sinon from 'sinon';
 import { DataTypes, QueryTypes, Model } from '@sequelize/core';
 import type { ModelStatic, InferAttributes, InferCreationAttributes } from '@sequelize/core';
-import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/model-hooks.js';
 import {
   beforeAll2, createSequelizeInstance,
   disableDatabaseResetForSuite,

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -1,3 +1,4 @@
+import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/model-hooks.js';
 import { expectTypeOf } from 'expect-type';
 import type {
   FindOptions,
@@ -14,7 +15,6 @@ import type {
 } from '@sequelize/core/_non-semver-use-at-your-own-risk_/associations';
 import type { AbstractQuery } from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query.js';
 import type { ValidationOptions } from '@sequelize/core/_non-semver-use-at-your-own-risk_/instance-validator';
-import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/model-hooks.js';
 import type { SemiDeepWritable } from './type-helpers/deep-writable';
 
 {

--- a/test/unit/decorators/hooks.test.ts
+++ b/test/unit/decorators/hooks.test.ts
@@ -1,6 +1,6 @@
+import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/model-hooks.js';
 import { expect } from 'chai';
 import { Model } from '@sequelize/core';
-import type { ModelHooks } from '@sequelize/core/_non-semver-use-at-your-own-risk_/model-hooks.js';
 import {
   AfterAssociate,
   AfterBulkCreate,


### PR DESCRIPTION
## Pull Request Checklist
- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change
Added documentation for the `upsertKeys` option in the `BulkCreateOptions` interface.
fix #15226