### PR TITLE
fix: merge error stacks

### DIFF
--- a/src/errors/database-error.ts
+++ b/src/errors/database-error.ts
@@ -39,7 +39,11 @@ class DatabaseError
     this.parameters = parent.parameters ?? {};
 
     if (options.stack) {
-      this.stack = options.stack;
+      this.stack = [
+       this.stack,
+        'From original error:',
+        options.stack.split('\n').slice(1).join('\n')
+      ].join('\n');
     }
   }
 }

--- a/src/errors/database-error.ts
+++ b/src/errors/database-error.ts
@@ -40,9 +40,9 @@ class DatabaseError
 
     if (options.stack) {
       this.stack = [
-       this.stack,
+        this.stack,
         'From original error:',
-        options.stack.split('\n').slice(1).join('\n')
+        options.stack.split('\n').slice(1).join('\n'),
       ].join('\n');
     }
   }

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -235,9 +235,9 @@ class ValidationError extends BaseError {
     if (stack) {
       this.stack = [
         this.stack,
-         'From original error:',
-         stack.split('\n').slice(1).join('\n')
-       ].join('\n');
+        'From original error:',
+        stack.split('\n').slice(1).join('\n'),
+      ].join('\n');
     }
   }
 

--- a/src/errors/validation-error.ts
+++ b/src/errors/validation-error.ts
@@ -232,9 +232,12 @@ class ValidationError extends BaseError {
         .join(',\n');
     }
 
-    // Allow overriding the stack if the original stacktrace is uninformative
     if (stack) {
-      this.stack = stack;
+      this.stack = [
+        this.stack,
+         'From original error:',
+         stack.split('\n').slice(1).join('\n')
+       ].join('\n');
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Another attempt in fixing #14807, using [this comment](https://github.com/sequelize/sequelize/pull/15348#pullrequestreview-1203570410) by @ephys 
Now it will merge the two error stacks, with a different title to the empty error stack.

The tests have not actually changed, only the block for checking the Node version has been removed since Node 14 is the oldest supported version.

Once this has been approved I will also backport this to v6

cc @plutownium

Fixes #14807
Closes #15348 

<!-- Please provide a description of the change here. -->
