### PR TITLE
feat: rollback workaround #13347, improve stack traces using async stack traces instead

### DIFF
--- a/packages/core/src/dialects/db2/query.js
+++ b/packages/core/src/dialects/db2/query.js
@@ -36,152 +36,154 @@ export class Db2Query extends AbstractQuery {
 
     const complete = this._logQuery(sql, debug, parameters);
 
-    const errStack = new Error().stack;
-
-    return new Promise((resolve, reject) => {
-      // TRANSACTION SUPPORT
-      if (_.startsWith(this.sql, 'BEGIN TRANSACTION')) {
-        connection.beginTransaction(err => {
-          if (err) {
-            reject(this.formatError(err, errStack));
-          } else {
-            resolve(this.formatResults());
-          }
-        });
-      } else if (_.startsWith(this.sql, 'COMMIT TRANSACTION')) {
-        connection.commitTransaction(err => {
-          if (err) {
-            reject(this.formatError(err, errStack));
-          } else {
-            resolve(this.formatResults());
-          }
-        });
-      } else if (_.startsWith(this.sql, 'ROLLBACK TRANSACTION')) {
-        connection.rollbackTransaction(err => {
-          if (err) {
-            reject(this.formatError(err, errStack));
-          } else {
-            resolve(this.formatResults());
-          }
-        });
-      } else if (_.startsWith(this.sql, 'SAVE TRANSACTION')) {
-        connection.commitTransaction(err => {
-          if (err) {
-            reject(this.formatError(err, errStack));
-          } else {
-            connection.beginTransaction(err => {
-              if (err) {
-                reject(this.formatError(err, errStack));
-              } else {
-                resolve(this.formatResults());
-              }
-            });
-          }
-        }, this.options.transaction.name);
-      } else {
-        const params = [];
-        if (parameters) {
-          _.forOwn(parameters, (value, key) => {
-            const param = this.getSQLTypeFromJsType(value, key);
-            params.push(param);
-          });
-        }
-
-        const SQL = this.sql.toUpperCase();
-        let newSql = this.sql;
-
-        // TODO: move this to Db2QueryGenerator
-        if ((this.isSelectQuery() || _.startsWith(SQL, 'SELECT '))
-            && !SQL.includes(' FROM ', 8)) {
-          if (this.sql.charAt(this.sql.length - 1) === ';') {
-            newSql = this.sql.slice(0, -1);
-          }
-
-          newSql += ' FROM SYSIBM.SYSDUMMY1;';
-        }
-
-        connection.prepare(newSql, (err, stmt) => {
-          if (err) {
-            reject(this.formatError(err, errStack));
-          }
-
-          stmt.execute(params, (err, result, outparams) => {
-            complete();
-
-            // map the INOUT parameters to the name provided by the dev
-            // this is an internal API, not yet ready for dev consumption, hence the _unsafe_ prefix.
-            if (outparams && this.options.bindParameterOrder && this.options._unsafe_db2Outparams) {
-              for (let i = 0; i < this.options.bindParameterOrder.length; i++) {
-                const paramName = this.options.bindParameterOrder[i];
-                const paramValue = outparams[i];
-
-                this.options._unsafe_db2Outparams.set(paramName, paramValue);
-              }
-            }
-
-            if (err && err.message) {
-              err = this.filterSQLError(err, this.sql, connection);
-              if (err === null) {
-                stmt.closeSync();
-                resolve(this.formatResults([], 0));
-              }
-            }
-
-            if (err) {
-              err.sql = sql;
-              stmt.closeSync();
-              reject(this.formatError(err, errStack, connection, parameters));
-            } else {
-              let data = [];
-              let metadata = [];
-              let affectedRows = 0;
-              if (typeof result === 'object') {
-                if (_.startsWith(this.sql, 'DELETE FROM ')) {
-                  affectedRows = result.getAffectedRowsSync();
-                } else {
-                  data = result.fetchAllSync();
-                  metadata = result.getColumnMetadataSync();
-                }
-
-                result.closeSync();
-              }
-
-              stmt.closeSync();
-              const datalen = data.length;
-              if (datalen > 0) {
-                const coltypes = {};
-                for (const metadatum of metadata) {
-                  coltypes[metadatum.SQL_DESC_NAME]
-                      = metadatum.SQL_DESC_TYPE_NAME;
-                }
-
-                for (let i = 0; i < datalen; i++) {
-                  for (const column in data[i]) {
-                    const value = data[i][column];
-                    if (value === null) {
-                      continue;
-                    }
-
-                    const parse = this.sequelize.dialect.getParserForDatabaseDataType(coltypes[column]);
-                    if (parse) {
-                      data[i][column] = parse(value);
-                    }
-                  }
-                }
-
-                if (outparams && outparams.length > 0) {
-                  data.unshift(outparams);
-                }
-
-                resolve(this.formatResults(data, datalen, metadata, connection));
-              } else {
-                resolve(this.formatResults(data, affectedRows));
-              }
-            }
-          });
-        });
+    if (this.sql.startsWith('BEGIN TRANSACTION')) {
+      try {
+        await connection.beginTransaction();
+      } catch (error) {
+        throw this.formatError(error);
       }
-    });
+
+      return this.formatResults();
+    }
+
+    if (this.sql.startsWith('COMMIT TRANSACTION')) {
+      try {
+        await connection.commitTransaction();
+      } catch (error) {
+        throw this.formatError(error);
+      }
+
+      return this.formatResults();
+    }
+
+    if (this.sql.startsWith('ROLLBACK TRANSACTION')) {
+      try {
+        await connection.rollbackTransaction();
+      } catch (error) {
+        throw this.formatError(error);
+      }
+
+      return this.formatResults();
+    }
+
+    if (_.startsWith(this.sql, 'SAVE TRANSACTION')) {
+      try {
+        await connection.commitTransaction(this.options.transaction.name);
+        await connection.beginTransaction();
+      } catch (error) {
+        throw this.formatError(error);
+      }
+
+      return this.formatResults();
+    }
+
+    const params = [];
+    if (parameters) {
+      _.forOwn(parameters, (value, key) => {
+        const param = this.getSQLTypeFromJsType(value, key);
+        params.push(param);
+      });
+    }
+
+    const SQL = this.sql.toUpperCase();
+    let newSql = this.sql;
+
+    // TODO: move this to Db2QueryGenerator
+    if ((this.isSelectQuery() || _.startsWith(SQL, 'SELECT '))
+            && !SQL.includes(' FROM ', 8)) {
+      if (this.sql.charAt(this.sql.length - 1) === ';') {
+        newSql = this.sql.slice(0, -1);
+      }
+
+      newSql += ' FROM SYSIBM.SYSDUMMY1;';
+    }
+
+    let stmt;
+    try {
+      stmt = await connection.prepare(newSql);
+    } catch (error) {
+      throw this.formatError(error);
+    }
+
+    let res;
+    try {
+      res = await stmt.execute(params);
+    } catch (error) {
+      if (error.message) {
+        // eslint-disable-next-line no-ex-assign -- legacy code. TODO: reformat
+        error = this.filterSQLError(error, this.sql, connection);
+        if (error === null) {
+          stmt.closeSync();
+
+          return this.formatResults([], 0);
+        }
+      }
+
+      error.sql = sql;
+      stmt.closeSync();
+      throw this.formatError(error, connection, parameters);
+    }
+
+    const { result, outparams } = res;
+
+    complete();
+
+    // map the INOUT parameters to the name provided by the dev
+    // this is an internal API, not yet ready for dev consumption, hence the _unsafe_ prefix.
+    if (outparams && this.options.bindParameterOrder && this.options._unsafe_db2Outparams) {
+      for (let i = 0; i < this.options.bindParameterOrder.length; i++) {
+        const paramName = this.options.bindParameterOrder[i];
+        const paramValue = outparams[i];
+
+        this.options._unsafe_db2Outparams.set(paramName, paramValue);
+      }
+    }
+
+    let data = [];
+    let metadata = [];
+    let affectedRows = 0;
+    if (typeof result === 'object') {
+      if (_.startsWith(this.sql, 'DELETE FROM ')) {
+        affectedRows = result.getAffectedRowsSync();
+      } else {
+        data = result.fetchAllSync();
+        metadata = result.getColumnMetadataSync();
+      }
+
+      result.closeSync();
+    }
+
+    stmt.closeSync();
+    const datalen = data.length;
+    if (datalen > 0) {
+      const coltypes = {};
+      for (const metadatum of metadata) {
+        coltypes[metadatum.SQL_DESC_NAME]
+                      = metadatum.SQL_DESC_TYPE_NAME;
+      }
+
+      for (let i = 0; i < datalen; i++) {
+        for (const column in data[i]) {
+          const value = data[i][column];
+          if (value === null) {
+            continue;
+          }
+
+          const parse = this.sequelize.dialect.getParserForDatabaseDataType(coltypes[column]);
+          if (parse) {
+            data[i][column] = parse(value);
+          }
+        }
+      }
+
+      if (outparams && outparams.length > 0) {
+        data.unshift(outparams);
+      }
+
+      return this.formatResults(data, datalen, metadata, connection);
+    }
+
+    return this.formatResults(data, affectedRows);
   }
 
   async run(sql, parameters) {
@@ -303,7 +305,7 @@ export class Db2Query extends AbstractQuery {
     });
   }
 
-  formatError(err, errStack, conn, parameters) {
+  formatError(err, conn, parameters) {
     let match;
 
     if (!(err && err.message)) {
@@ -360,7 +362,7 @@ export class Db2Query extends AbstractQuery {
         ));
       });
 
-      return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
+      return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields });
     }
 
     match = err.message.match(/SQL0532N {2}A parent row cannot be deleted because the relationship "(.*)" restricts the deletion/)
@@ -371,7 +373,6 @@ export class Db2Query extends AbstractQuery {
         fields: null,
         index: match[1],
         cause: err,
-        stack: errStack,
       });
     }
 
@@ -386,11 +387,10 @@ export class Db2Query extends AbstractQuery {
         constraint,
         table,
         cause: err,
-        stack: errStack,
       });
     }
 
-    return new sequelizeErrors.DatabaseError(err, { stack: errStack });
+    return new sequelizeErrors.DatabaseError(err);
   }
 
   isDropSchemaQuery() {

--- a/packages/core/src/dialects/db2/query.js
+++ b/packages/core/src/dialects/db2/query.js
@@ -66,7 +66,8 @@ export class Db2Query extends AbstractQuery {
 
     if (this.sql.startsWith('SAVE TRANSACTION')) {
       try {
-        await connection.commitTransaction(this.options.transaction.name);
+        // TODO: This is not a savepoint! It's unsafe and this behavior should be removed.
+        await connection.commitTransaction();
         await connection.beginTransaction();
       } catch (error) {
         throw this.formatError(error);

--- a/packages/core/src/dialects/ibmi/query.js
+++ b/packages/core/src/dialects/ibmi/query.js
@@ -2,7 +2,6 @@
 
 import { find } from '../../utils/iterators';
 
-const _ = require('lodash');
 const { AbstractQuery } = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
 const { logger } = require('../../utils/logger');

--- a/packages/core/src/dialects/ibmi/query.js
+++ b/packages/core/src/dialects/ibmi/query.js
@@ -15,41 +15,35 @@ export class IBMiQuery extends AbstractQuery {
   }
 
   async run(sql, parameters) {
-    const stacktrace = new Error().stack;
     this.sql = sql.replace(/;$/, '');
 
-    return new Promise((resolve, reject) => {
-      const complete = this._logQuery(sql, debug, parameters);
-      this.connection.query(this.sql, parameters, (error, results) => {
+    const complete = this._logQuery(sql, debug, parameters);
 
-        if (error) {
-          const formattedError = this.formatError(error, stacktrace);
-          reject(formattedError);
+    let results;
+    try {
+      results = await this.connection.query(this.sql, parameters);
+    } catch (error) {
+      throw this.formatError(error);
+    }
 
-          return;
+    complete();
+
+    // parse the results to the format sequelize expects
+    for (const result of results) {
+      for (const column of results.columns) {
+        const value = result[column.name];
+        if (value == null) {
+          continue;
         }
 
-        complete();
-
-        // parse the results to the format sequelize expects
-        for (const result of results) {
-          for (const column of results.columns) {
-            const value = result[column.name];
-            if (value == null) {
-              continue;
-            }
-
-            const parse = this.sequelize.dialect.getParserForDatabaseDataType(column.dataType);
-            if (parse) {
-              result[column.name] = parse(value);
-            }
-          }
+        const parse = this.sequelize.dialect.getParserForDatabaseDataType(column.dataType);
+        if (parse) {
+          result[column.name] = parse(value);
         }
+      }
+    }
 
-        resolve(results);
-      });
-    })
-      .then(results => this.formatResults(results));
+    return this.formatResults(results);
   }
 
   /**
@@ -205,7 +199,7 @@ export class IBMiQuery extends AbstractQuery {
     return Object.values(indexes);
   }
 
-  formatError(err, stacktrace) {
+  formatError(err) {
 
     // Db2 for i uses the `odbc` connector. The `odbc` connector returns a list
     // of odbc errors, each of which has a code and a state. To determine the
@@ -234,7 +228,6 @@ export class IBMiQuery extends AbstractQuery {
           cause: err,
           sql: {},
           fields: {},
-          stack: stacktrace,
         });
       }
 
@@ -244,7 +237,6 @@ export class IBMiQuery extends AbstractQuery {
           cause: err,
           sql: {},
           fields: {},
-          stack: stacktrace,
         });
       }
 
@@ -266,7 +258,7 @@ export class IBMiQuery extends AbstractQuery {
         }
       }
 
-      return new sequelizeErrors.DatabaseError(odbcError, { stack: stacktrace });
+      return new sequelizeErrors.DatabaseError(odbcError);
     }
 
     return err;

--- a/packages/core/src/dialects/mariadb/query.js
+++ b/packages/core/src/dialects/mariadb/query.js
@@ -34,8 +34,6 @@ export class MariaDbQuery extends AbstractQuery {
 
     let results;
 
-    const errForStack = new Error();
-
     try {
       results = await connection.query(this.sql, parameters);
     } catch (error) {
@@ -54,7 +52,7 @@ export class MariaDbQuery extends AbstractQuery {
 
       error.sql = sql;
       error.parameters = parameters;
-      throw this.formatError(error, errForStack.stack);
+      throw this.formatError(error);
     } finally {
       complete();
     }
@@ -207,7 +205,7 @@ export class MariaDbQuery extends AbstractQuery {
     }
   }
 
-  formatError(err, errStack) {
+  formatError(err) {
     switch (err.errno) {
       case ER_DUP_ENTRY: {
         const match = err.message.match(
@@ -243,7 +241,7 @@ export class MariaDbQuery extends AbstractQuery {
           ));
         });
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
+        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields });
       }
 
       case ER_ROW_IS_REFERENCED:
@@ -262,12 +260,11 @@ export class MariaDbQuery extends AbstractQuery {
           value: fields && fields.length && this.instance && this.instance[fields[0]] || undefined,
           index: match ? match[2] : undefined,
           cause: err,
-          stack: errStack,
         });
       }
 
       default:
-        return new sequelizeErrors.DatabaseError(err, { stack: errStack });
+        return new sequelizeErrors.DatabaseError(err);
     }
   }
 

--- a/packages/core/src/dialects/mysql/query.js
+++ b/packages/core/src/dialects/mysql/query.js
@@ -32,7 +32,6 @@ export class MySqlQuery extends AbstractQuery {
     }
 
     let results;
-    const errForStack = new Error();
 
     try {
       if (parameters && parameters.length > 0) {
@@ -64,7 +63,7 @@ export class MySqlQuery extends AbstractQuery {
 
       error.sql = sql;
       error.parameters = parameters;
-      throw this.formatError(error, errForStack.stack);
+      throw this.formatError(error);
     } finally {
       complete();
     }
@@ -186,7 +185,7 @@ export class MySqlQuery extends AbstractQuery {
     return result;
   }
 
-  formatError(err, errStack) {
+  formatError(err) {
     const errCode = err.errno || err.code;
 
     switch (errCode) {
@@ -221,7 +220,7 @@ export class MySqlQuery extends AbstractQuery {
           ));
         });
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
+        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields });
       }
 
       case ER_ROW_IS_REFERENCED:
@@ -240,12 +239,11 @@ export class MySqlQuery extends AbstractQuery {
           value: fields && fields.length && this.instance && this.instance[fields[0]] || undefined,
           index: match ? match[2] : undefined,
           cause: err,
-          stack: errStack,
         });
       }
 
       default:
-        return new sequelizeErrors.DatabaseError(err, { stack: errStack });
+        return new sequelizeErrors.DatabaseError(err);
     }
   }
 

--- a/packages/core/src/dialects/postgres/query.js
+++ b/packages/core/src/dialects/postgres/query.js
@@ -39,7 +39,6 @@ export class PostgresQuery extends AbstractQuery {
     const complete = this._logQuery(sql, debug, parameters);
 
     let queryResult;
-    const errForStack = new Error();
 
     try {
       queryResult = await query;
@@ -59,7 +58,7 @@ export class PostgresQuery extends AbstractQuery {
 
       error.sql = sql;
       error.parameters = parameters;
-      throw this.formatError(error, errForStack.stack);
+      throw this.formatError(error);
     }
 
     complete();
@@ -310,7 +309,7 @@ export class PostgresQuery extends AbstractQuery {
     return rows;
   }
 
-  formatError(err, errStack) {
+  formatError(err) {
     let match;
     let table;
     let index;
@@ -335,7 +334,6 @@ export class PostgresQuery extends AbstractQuery {
           index,
           table,
           cause: err,
-          stack: errStack,
         });
       case '23505':
         // there are multiple different formats of error messages for this error code
@@ -365,13 +363,12 @@ export class PostgresQuery extends AbstractQuery {
             }
           }
 
-          return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
+          return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields });
         }
 
         return new sequelizeErrors.UniqueConstraintError({
           message: errMessage,
           cause: err,
-          stack: errStack,
         });
 
       case '23P01':
@@ -389,7 +386,6 @@ export class PostgresQuery extends AbstractQuery {
           fields,
           table: err.table,
           cause: err,
-          stack: errStack,
         });
 
       case '42704':
@@ -406,13 +402,12 @@ export class PostgresQuery extends AbstractQuery {
             fields,
             table,
             cause: err,
-            stack: errStack,
           });
         }
 
       // falls through
       default:
-        return new sequelizeErrors.DatabaseError(err, { stack: errStack });
+        return new sequelizeErrors.DatabaseError(err);
     }
   }
 

--- a/packages/core/src/dialects/sqlite/query.js
+++ b/packages/core/src/dialects/sqlite/query.js
@@ -49,12 +49,7 @@ export class SqliteQuery extends AbstractQuery {
     return ret;
   }
 
-  _handleQueryResponse(metaData, columnTypes, err, results, errStack) {
-    if (err) {
-      err.sql = this.sql;
-      throw this.formatError(err, errStack);
-    }
-
+  _handleQueryResponse(metaData, columnTypes, results) {
     let result = this.instance;
 
     // add the inserted row id to the instance
@@ -185,87 +180,113 @@ export class SqliteQuery extends AbstractQuery {
     const method = this.getDatabaseMethod();
     const complete = this._logQuery(sql, debug, parameters);
 
-    return new Promise((resolve, reject) => {
-      conn.serialize(async () => {
-        // TODO: remove sql type based parsing for SQLite.
-        //  It is extremely inefficient (requires a series of DESCRIBE TABLE query, which slows down all queries).
-        //  and is very unreliable.
-        //  Use Sequelize DataType parsing instead, until sqlite3 provides a clean API to know the DB type.
-        const columnTypes = {};
-        const errForStack = new Error();
-        const executeSql = () => {
-          // TODO: remove this check. A query could start with a comment:
-          if (sql.startsWith('-- ')) {
-            return resolve();
-          }
+    // TODO: remove sql type based parsing for SQLite.
+    //  It is extremely inefficient (requires a series of DESCRIBE TABLE query, which slows down all queries).
+    //  and is very unreliable.
+    //  Use Sequelize DataType parsing instead, until sqlite3 provides a clean API to know the DB type.
+    const columnTypes = {};
 
-          const query = this;
+    const executeSql = async () => {
+      // TODO: remove this check. A query could start with a comment:
+      if (sql.startsWith('-- ')) {
+        return;
+      }
 
-          // cannot use arrow function here because the function is bound to the statement
-          function afterExecute(executionError, results) {
-            try {
-              complete();
-              // `this` is passed from sqlite, we have no control over this.
+      const query = this;
 
-              resolve(query._handleQueryResponse(this, columnTypes, executionError, results, errForStack.stack));
-            } catch (error) {
-              reject(error);
-            }
-          }
+      if (!parameters) {
+        parameters = [];
+      }
 
-          if (!parameters) {
-            parameters = [];
-          }
+      if (isPlainObject(parameters)) {
+        const newParameters = Object.create(null);
 
-          if (isPlainObject(parameters)) {
-            const newParameters = Object.create(null);
-
-            for (const key of Object.keys(parameters)) {
-              newParameters[`$${key}`] = stringifyIfBigint(parameters[key]);
-            }
-
-            parameters = newParameters;
-          } else {
-            parameters = parameters.map(stringifyIfBigint);
-          }
-
-          conn[method](sql, parameters, afterExecute);
-
-          return null;
-        };
-
-        if (this.getDatabaseMethod() === 'all') {
-          let tableNames = [];
-          if (this.options && this.options.tableNames) {
-            tableNames = this.options.tableNames;
-          } else if (/from `(.*?)`/i.test(this.sql)) {
-            tableNames.push(/from `(.*?)`/i.exec(this.sql)[1]);
-          }
-
-          // If we already have the metadata for the table, there's no need to ask for it again
-          tableNames = tableNames.filter(tableName => !(tableName in columnTypes) && tableName !== 'sqlite_master');
-
-          if (tableNames.length === 0) {
-            return executeSql();
-          }
-
-          await Promise.all(tableNames.map(tableName => new Promise(resolve => {
-            tableName = tableName.replace(/`/g, '');
-            columnTypes[tableName] = {};
-
-            conn.all(`PRAGMA table_info(\`${tableName}\`)`, (err, results) => {
-              if (!err) {
-                for (const result of results) {
-                  columnTypes[tableName][result.name] = result.type;
-                }
-              }
-
-              resolve();
-            });
-          })));
+        for (const key of Object.keys(parameters)) {
+          newParameters[`$${key}`] = stringifyIfBigint(parameters[key]);
         }
 
+        parameters = newParameters;
+      } else {
+        parameters = parameters.map(stringifyIfBigint);
+      }
+
+      let response;
+      try {
+
+        if (method === 'run') {
+          response = await this.#runSeries(conn, sql, parameters);
+        } else {
+          response = await this.#allSeries(conn, sql, parameters);
+        }
+      } catch (error) {
+        error.sql = this.sql;
+        throw this.formatError(error);
+      }
+
+      complete();
+
+      return query._handleQueryResponse(response.statement, columnTypes, response.results);
+    };
+
+    if (method === 'all') {
+      let tableNames = [];
+      if (this.options && this.options.tableNames) {
+        tableNames = this.options.tableNames;
+      } else if (/from `(.*?)`/i.test(this.sql)) {
+        tableNames.push(/from `(.*?)`/i.exec(this.sql)[1]);
+      }
+
+      // If we already have the metadata for the table, there's no need to ask for it again
+      tableNames = tableNames.filter(tableName => !(tableName in columnTypes) && tableName !== 'sqlite_master');
+
+      if (tableNames.length === 0) {
         return executeSql();
+      }
+
+      await Promise.all(tableNames.map(async tableName => {
+        tableName = tableName.replace(/`/g, '');
+        columnTypes[tableName] = {};
+
+        const results = await this.#allSeries(conn, `PRAGMA table_info(\`${tableName}\`)`);
+        for (const result of results) {
+          columnTypes[tableName][result.name] = result.type;
+        }
+      }));
+    }
+
+    return executeSql();
+  }
+
+  #allSeries(connection, query, parameters) {
+    return new Promise((resolve, reject) => {
+      connection.serialize(() => {
+        connection.all(query, parameters, function (err, results) {
+          if (err) {
+            reject(err);
+
+            return;
+          }
+
+          // node-sqlite3 passes the statement object as `this` to the callback
+          resolve({ statement: this, results });
+        });
+      });
+    });
+  }
+
+  #runSeries(connection, query, parameters) {
+    return new Promise((resolve, reject) => {
+      connection.serialize(() => {
+        connection.run(query, parameters, function (err, results) {
+          if (err) {
+            reject(err);
+
+            return;
+          }
+
+          // node-sqlite3 passes the statement object as `this` to the callback
+          resolve({ statement: this, results });
+        });
       });
     });
   }
@@ -320,7 +341,7 @@ export class SqliteQuery extends AbstractQuery {
     return constraints;
   }
 
-  formatError(err, errStack) {
+  formatError(err) {
 
     switch (err.code) {
       case 'SQLITE_CONSTRAINT_UNIQUE':
@@ -331,7 +352,6 @@ export class SqliteQuery extends AbstractQuery {
         if (err.message.includes('FOREIGN KEY constraint failed')) {
           return new sequelizeErrors.ForeignKeyConstraintError({
             cause: err,
-            stack: errStack,
           });
         }
 
@@ -373,14 +393,14 @@ export class SqliteQuery extends AbstractQuery {
           }
         }
 
-        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields, stack: errStack });
+        return new sequelizeErrors.UniqueConstraintError({ message, errors, cause: err, fields });
       }
 
       case 'SQLITE_BUSY':
-        return new sequelizeErrors.TimeoutError(err, { stack: errStack });
+        return new sequelizeErrors.TimeoutError(err);
 
       default:
-        return new sequelizeErrors.DatabaseError(err, { stack: errStack });
+        return new sequelizeErrors.DatabaseError(err);
     }
   }
 

--- a/packages/core/src/dialects/sqlite/query.js
+++ b/packages/core/src/dialects/sqlite/query.js
@@ -247,7 +247,7 @@ export class SqliteQuery extends AbstractQuery {
         tableName = tableName.replace(/`/g, '');
         columnTypes[tableName] = {};
 
-        const results = await this.#allSeries(conn, `PRAGMA table_info(\`${tableName}\`)`);
+        const { results } = await this.#allSeries(conn, `PRAGMA table_info(\`${tableName}\`)`);
         for (const result of results) {
           columnTypes[tableName][result.name] = result.type;
         }

--- a/packages/core/src/dialects/sqlite/query.js
+++ b/packages/core/src/dialects/sqlite/query.js
@@ -49,7 +49,7 @@ export class SqliteQuery extends AbstractQuery {
     return ret;
   }
 
-  _handleQueryResponse(metaData, columnTypes, results) {
+  _handleQueryResponse(metaData, results) {
     let result = this.instance;
 
     // add the inserted row id to the instance
@@ -225,7 +225,7 @@ export class SqliteQuery extends AbstractQuery {
 
       complete();
 
-      return query._handleQueryResponse(response.statement, columnTypes, response.results);
+      return query._handleQueryResponse(response.statement, response.results);
     };
 
     if (method === 'all') {

--- a/packages/core/src/errors/base-error.ts
+++ b/packages/core/src/errors/base-error.ts
@@ -1,9 +1,4 @@
 import { useErrorCause } from '../utils/deprecations.js';
-import type { Nullish } from '../utils/types.js';
-
-export interface SequelizeErrorOptions {
-  stack?: Nullish<string>;
-}
 
 export interface CommonErrorProperties {
   /** The SQL that triggered the error */

--- a/packages/core/src/errors/database-error.ts
+++ b/packages/core/src/errors/database-error.ts
@@ -1,4 +1,4 @@
-import type { CommonErrorProperties, SequelizeErrorOptions } from './base-error';
+import type { CommonErrorProperties } from './base-error';
 import BaseError from './base-error';
 
 export interface DatabaseErrorParent extends Error, Pick<CommonErrorProperties, 'sql'> {
@@ -6,7 +6,7 @@ export interface DatabaseErrorParent extends Error, Pick<CommonErrorProperties, 
   readonly parameters?: object;
 }
 
-export interface DatabaseErrorSubclassOptions extends SequelizeErrorOptions {
+export interface DatabaseErrorSubclassOptions {
   cause?: DatabaseErrorParent;
 
   /**
@@ -29,18 +29,13 @@ class DatabaseError
 
   /**
    * @param parent The database specific error which triggered this one
-   * @param options
    */
-  constructor(parent: DatabaseErrorParent, options: SequelizeErrorOptions = {}) {
+  constructor(parent: DatabaseErrorParent) {
     super(parent.message, { cause: parent });
     this.name = 'SequelizeDatabaseError';
 
     this.sql = parent.sql;
     this.parameters = parent.parameters ?? {};
-
-    if (options.stack) {
-      this.stack = options.stack;
-    }
   }
 }
 

--- a/packages/core/src/errors/database/exclusion-constraint-error.ts
+++ b/packages/core/src/errors/database/exclusion-constraint-error.ts
@@ -23,7 +23,7 @@ class ExclusionConstraintError extends DatabaseError {
 
     const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
 
-    super(parent, { stack: options.stack });
+    super(parent);
     this.message = options.message || parent.message;
     this.name = 'SequelizeExclusionConstraintError';
     this.constraint = options.constraint;

--- a/packages/core/src/errors/database/foreign-key-constraint-error.ts
+++ b/packages/core/src/errors/database/foreign-key-constraint-error.ts
@@ -34,7 +34,7 @@ class ForeignKeyConstraintError extends DatabaseError {
 
     const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
 
-    super(parent, { stack: options.stack });
+    super(parent);
     this.name = 'SequelizeForeignKeyConstraintError';
     this.fields = options.fields;
     this.table = options.table;

--- a/packages/core/src/errors/database/timeout-error.ts
+++ b/packages/core/src/errors/database/timeout-error.ts
@@ -1,4 +1,3 @@
-import type { SequelizeErrorOptions } from '../base-error';
 import type { DatabaseErrorParent } from '../database-error';
 import DatabaseError from '../database-error';
 
@@ -6,8 +5,8 @@ import DatabaseError from '../database-error';
  * Thrown when a database query times out because of a deadlock
  */
 class TimeoutError extends DatabaseError {
-  constructor(parent: DatabaseErrorParent, options?: SequelizeErrorOptions) {
-    super(parent, options);
+  constructor(parent: DatabaseErrorParent) {
+    super(parent);
     this.name = 'SequelizeTimeoutError';
   }
 }

--- a/packages/core/src/errors/database/unknown-constraint-error.ts
+++ b/packages/core/src/errors/database/unknown-constraint-error.ts
@@ -25,7 +25,7 @@ class UnknownConstraintError extends DatabaseError {
 
     const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
 
-    super(parent, { stack: options.stack });
+    super(parent);
     this.name = 'SequelizeUnknownConstraintError';
     this.constraint = options.constraint;
     this.fields = options.fields;

--- a/packages/core/src/errors/validation-error.ts
+++ b/packages/core/src/errors/validation-error.ts
@@ -1,5 +1,5 @@
 import type { Model } from '..';
-import type { ErrorOptions, SequelizeErrorOptions } from './base-error';
+import type { ErrorOptions } from './base-error';
 import BaseError from './base-error';
 
 /**
@@ -210,11 +210,9 @@ class ValidationError extends BaseError {
   constructor(
     message: string,
     errors: ValidationErrorItem[] = [],
-    options: SequelizeErrorOptions & ErrorOptions = {},
+    options: ErrorOptions = {},
   ) {
-    const { stack, ...passUp } = options;
-
-    super(message, passUp);
+    super(message, options);
 
     this.name = 'SequelizeValidationError';
     this.errors = errors;
@@ -230,11 +228,6 @@ class ValidationError extends BaseError {
           (err: ValidationErrorItem) => `${err.type || err.origin}: ${err.message}`,
         )
         .join(',\n');
-    }
-
-    // Allow overriding the stack if the original stacktrace is uninformative
-    if (stack) {
-      this.stack = stack;
     }
   }
 

--- a/packages/core/src/errors/validation/unique-constraint-error.ts
+++ b/packages/core/src/errors/validation/unique-constraint-error.ts
@@ -1,11 +1,11 @@
 import { useErrorCause } from '../../utils/deprecations.js';
-import type { CommonErrorProperties, SequelizeErrorOptions } from '../base-error';
+import type { CommonErrorProperties } from '../base-error';
 import type { ValidationErrorItem } from '../validation-error';
 import ValidationError from '../validation-error';
 
 interface UniqueConstraintErrorParent extends Error, Pick<CommonErrorProperties, 'sql'> {}
 
-export interface UniqueConstraintErrorOptions extends SequelizeErrorOptions {
+export interface UniqueConstraintErrorOptions {
   cause?: UniqueConstraintErrorParent;
 
   /**
@@ -35,7 +35,7 @@ class UniqueConstraintError extends ValidationError {
     const parent = options.cause ?? options.parent ?? { sql: '', name: '', message: '' };
     const message = options.message || parent.message || 'Validation Error';
     const errors = options.errors ?? [];
-    super(message, errors, { stack: options.stack, cause: parent });
+    super(message, errors, { cause: parent });
 
     this.name = 'SequelizeUniqueConstraintError';
     this.fields = options.fields ?? {};


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Fixes https://github.com/sequelize/sequelize/issues/14807
Closes https://github.com/sequelize/sequelize/pull/15348

This PR removes the stack trace modification introduced in #13347. Instead, I've rewritten the necessary Query implementations to use an async flow that is compatible with native async stack traces. Resulting in the clean stacktraces posted here: https://github.com/sequelize/sequelize/pull/15555#issuecomment-1383136934

I think this can be backported to v6 too, there shouldn't be any breaking change (apart from the use of private methods which may not supported in node 10)