### PR TITLE
meta: prepare doesn't exist in the workspace context

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -176,7 +176,7 @@
     "test-integration": "yarn mocha \"test/integration/**/*.test.[tj]s\"",
     "test-smoke": "yarn mocha \"test/smoke/**/*.test.[tj]s\" --timeout 600000",
     "teaser": "ts-node test/teaser.ts",
-    "test": "yarn prepare && yarn test-typings && yarn teaser && yarn test-unit && yarn test-integration",
+    "test": "yarn build && yarn test-typings && yarn teaser && yarn test-unit && yarn test-integration",
     "----------------------------------------- coverage ------------------------------------------------": "",
     "cover": "rimraf coverage && yarn teaser && yarn cover-integration && yarn cover-unit && yarn merge-coverage",
     "cover-integration": "cross-env COVERAGE=true nyc --reporter=lcovonly yarn mocha \"test/integration/**/*.test.[tj]s\" && node -e \"require('fs').renameSync('coverage/lcov.info', 'coverage/integration.info')\"",


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Prior to the monorepo prepare work run husky install & then build

Prepare only exists in the root package.json file therefore I have updated this to just build.