### PR TITLE
meta: generate `@sequelize/validator.js` docs using /src instead of /lib

### DIFF
--- a/packages/validator-js/package.json
+++ b/packages/validator-js/package.json
@@ -46,5 +46,8 @@
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
     "mocha": "10.2.0"
+  },
+  "typedoc": {
+    "entryPoint": "./src/index.ts"
   }
 }


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Tiny change: PR aligns the validator package with the core package by making typedoc use the source code instead of the built files for its doc generation