### PR TITLE
meta: reduce disabling import/order lint rule

### DIFF
--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2267,7 +2267,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   static withSchema<M extends Model>(
     this: ModelStatic<M>,
-    schema: string | SchemaOptions,
+    schema: string | SchemaOptions | null,
   ): ModelStatic<M>;
 
   /**
@@ -2276,7 +2276,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   static schema<M extends Model>(
     this: ModelStatic<M>,
-    schema: string,
+    schema: string | null,
     options?: { schemaDelimiter?: string } | string
   ): ModelStatic<M>;
 

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -2267,7 +2267,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   static withSchema<M extends Model>(
     this: ModelStatic<M>,
-    schema: string | SchemaOptions | null,
+    schema: Nullish<string | SchemaOptions>,
   ): ModelStatic<M>;
 
   /**
@@ -2276,7 +2276,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   static schema<M extends Model>(
     this: ModelStatic<M>,
-    schema: string | null,
+    schema: Nullish<string>,
     options?: { schemaDelimiter?: string } | string
   ): ModelStatic<M>;
 
@@ -2302,7 +2302,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   static withScope<M extends Model>(
     this: ModelStatic<M>,
-    scopes?: AllowReadonlyArray<string | ScopeOptions> | WhereAttributeHash<M>,
+    scopes?: Nullish<AllowReadonlyArray<string | ScopeOptions> | WhereAttributeHash<M>>,
   ): ModelStatic<M>;
 
   /**
@@ -2311,7 +2311,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
    */
   static scope<M extends Model>(
     this: ModelStatic<M>,
-    scopes?: AllowReadonlyArray<string | ScopeOptions> | WhereAttributeHash<M>,
+    scopes?: Nullish<AllowReadonlyArray<string | ScopeOptions> | WhereAttributeHash<M>>,
   ): ModelStatic<M>;
 
   /**

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error -- lodash/_baseIsNative is not recognized as a separate module for @types/lodash
+import baseIsNative from 'lodash/_baseIsNative';
 import cloneDeepWith from 'lodash/cloneDeepWith';
 import forOwn from 'lodash/forOwn';
 import getValue from 'lodash/get';
@@ -10,10 +12,7 @@ import omitBy from 'lodash/omitBy.js';
 import { getComplexKeys } from './format';
 import type { MapView } from './immutability.js';
 import { combinedIterator, map } from './iterators.js';
-// eslint-disable-next-line import/order -- caused by temporarily mixing require with import
 import { camelize } from './string';
-
-const baseIsNative = require('lodash/_baseIsNative');
 
 /**
  * Deeply merges object `b` into `a`.

--- a/packages/core/test/unit/model/schema.test.ts
+++ b/packages/core/test/unit/model/schema.test.ts
@@ -1,16 +1,12 @@
 import assert from 'node:assert';
-import { literal } from '@sequelize/core';
-// eslint-disable-next-line import/order
 import { expect } from 'chai';
+import { literal } from '@sequelize/core';
+import { sequelize, getTestDialectTeaser } from '../../support';
 
-const Support = require('../../support');
-
-const current = Support.sequelize;
-
-describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
-  if (current.dialect.supports.schemas) {
-    const Project = current.define('project');
-    const Company = current.define('company', {}, {
+describe(`${getTestDialectTeaser('Model')}Schemas`, () => {
+  if (sequelize.dialect.supports.schemas) {
+    const Project = sequelize.define('project');
+    const Company = sequelize.define('company', {}, {
       schema: 'default',
       schemaDelimiter: '&',
     });
@@ -19,7 +15,7 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
 
     describe('schema', () => {
       it('should work with no default schema', () => {
-        expect(Project.table.schema).to.equal(current.dialect.getDefaultSchema());
+        expect(Project.table.schema).to.equal(sequelize.dialect.getDefaultSchema());
       });
 
       it('should apply default schema from define', () => {
@@ -45,7 +41,7 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('should be able nullify schema', () => {
-        expect(Company.schema(null).table.schema).to.equal(current.dialect.getDefaultSchema());
+        expect(Company.schema(null).table.schema).to.equal(sequelize.dialect.getDefaultSchema());
       });
 
       it('should support multiple, coexistent schema models', () => {
@@ -67,12 +63,12 @@ describe(`${Support.getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('should be able to override the default schema delimiter', () => {
-        expect(Company.schema(Company.table.schema, '^').table.delimiter).to.equal('^');
+        expect(Company.schema(Company.table.schema!, '^').table.delimiter).to.equal('^');
       });
 
       it('should support multiple, coexistent schema delimiter models', () => {
-        const schema1 = Company.schema(Company.table.schema, '$');
-        const schema2 = Company.schema(Company.table.schema, '#');
+        const schema1 = Company.schema(Company.table.schema!, '$');
+        const schema2 = Company.schema(Company.table.schema!, '#');
 
         expect(schema1.table.delimiter).to.equal('$');
         expect(schema2.table.delimiter).to.equal('#');

--- a/packages/core/test/unit/model/schema.test.ts
+++ b/packages/core/test/unit/model/schema.test.ts
@@ -63,12 +63,12 @@ describe(`${getTestDialectTeaser('Model')}Schemas`, () => {
       });
 
       it('should be able to override the default schema delimiter', () => {
-        expect(Company.schema(Company.table.schema!, '^').table.delimiter).to.equal('^');
+        expect(Company.schema(Company.table.schema, '^').table.delimiter).to.equal('^');
       });
 
       it('should support multiple, coexistent schema delimiter models', () => {
-        const schema1 = Company.schema(Company.table.schema!, '$');
-        const schema2 = Company.schema(Company.table.schema!, '#');
+        const schema1 = Company.schema(Company.table.schema, '$');
+        const schema2 = Company.schema(Company.table.schema, '#');
 
         expect(schema1.table.delimiter).to.equal('$');
         expect(schema2.table.delimiter).to.equal('#');

--- a/packages/core/test/unit/model/scope.test.ts
+++ b/packages/core/test/unit/model/scope.test.ts
@@ -2,14 +2,12 @@ import assert from 'node:assert';
 import { expect } from 'chai';
 import type { FindOptions } from '@sequelize/core';
 import { DataTypes, Op, Sequelize, col, where, literal } from '@sequelize/core';
-// eslint-disable-next-line import/order
-import { resetSequelizeInstance } from '../../support';
+// eslint-disable-next-line import/order -- sequelize cannot be imported right now since there will be too many typing errors
+import { resetSequelizeInstance, getTestDialectTeaser } from '../../support';
 
-const Support = require('../../support');
+const sequelize = require('../../support').sequelize;
 
-const sequelize = Support.sequelize;
-
-describe(Support.getTestDialectTeaser('Model'), () => {
+describe(getTestDialectTeaser('Model'), () => {
   beforeEach(() => {
     resetSequelizeInstance();
   });

--- a/packages/core/test/unit/model/scope.test.ts
+++ b/packages/core/test/unit/model/scope.test.ts
@@ -265,13 +265,13 @@ describe(getTestDialectTeaser('Model'), () => {
         ],
       });
 
-      expect(Company.options.scopes.alsoUsers).to.deep.equal({
+      expect(Company.options.scopes!.alsoUsers).to.deep.equal({
         include: [
           { model: User, association: Company.associations.users, as: 'users', where: { something: 42 } },
         ],
       });
 
-      expect(Company.options.scopes.users).to.deep.equal({
+      expect(Company.options.scopes!.users).to.deep.equal({
         include: [
           { model: User, association: Company.associations.users, as: 'users' },
         ],
@@ -365,7 +365,6 @@ describe(getTestDialectTeaser('Model'), () => {
       };
 
       const TestModel = sequelize.define('testModel', {}, {
-        mergeWhereScopesWithAndOperator: true,
         scopes: testModelScopes,
       });
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

This PR reduces the amount of times that we disable the `import/order` lint rule to 1. One thing I am not sure of is the changes I made to the withSchema/schema typings. I included `null` in there since we have a test for that case, but maybe we would like to remove that functionality and use a different method to remove the custom scope?

I didn't fix the last one since that would be more work to be done properly.
