### PR TITLE
meta: automatically add pending-approval to new issues

### DIFF
--- a/.github/workflows/auto-add-pending-approval.yml
+++ b/.github/workflows/auto-add-pending-approval.yml
@@ -1,0 +1,20 @@
+name: Label new issues with pending-approval
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["pending-approval"]
+            })


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Currently people can still make blank issues through the GitHub API or going to https://github.com/sequelize/sequelize/issues/new Having blank issues disabled only makes them not showing up by default, but it doesn't remove the ability to create blank issues. This is by design so we need a workaround to still add the pending-approval label to newly created issues. It seems that the issue template config does not have such an option so we're using a GitHub Action as per https://docs.github.com/en/actions/managing-issues-and-pull-requests/adding-labels-to-issues
