### PR TITLE
fix: throw an error if the user tries to register the same model twice

### DIFF
--- a/packages/core/src/model-definition.ts
+++ b/packages/core/src/model-definition.ts
@@ -759,6 +759,10 @@ Specify a different name for either index to resolve this issue.`);
 const modelDefinitions = new WeakMap</* model class */ Function, ModelDefinition>();
 
 export function registerModelDefinition(model: ModelStatic, modelDefinition: ModelDefinition): void {
+  if (modelDefinitions.has(model)) {
+    throw new Error(`Model ${model.name} has already been initialized. Models can only belong to one Sequelize instance. Registering the same model with multiple Sequelize instances is not yet supported. Please see https://github.com/sequelize/sequelize/issues/15389`);
+  }
+
   modelDefinitions.set(model, modelDefinition);
 }
 

--- a/packages/core/test/unit/model/init.test.ts
+++ b/packages/core/test/unit/model/init.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { Model } from '@sequelize/core';
+import { sequelize } from '../../support';
 
 describe('Uninitialized model', () => {
   class Test extends Model {}
@@ -10,5 +11,17 @@ describe('Uninitialized model', () => {
 
   it('throws when .sequelize is accessed', () => {
     expect(() => Test.sequelize).to.throw(/has not been initialized/);
+  });
+});
+
+describe('Initialized model', () => {
+  it('throws if initialized twice', () => {
+    class Test extends Model {}
+
+    Test.init({}, { sequelize });
+
+    expect(() => {
+      Test.init({}, { sequelize });
+    }).to.throw(/already been initialized/);
   });
 });


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Closes https://github.com/sequelize/sequelize/issues/11734. Registering the same model twice is not supported. [Repository mode](https://github.com/sequelize/sequelize/issues/15389) can eventually add support for this in the future