### PR TITLE
feat(types): restrict attributes typing

### DIFF
--- a/packages/core/src/associations/belongs-to-many.ts
+++ b/packages/core/src/associations/belongs-to-many.ts
@@ -593,6 +593,7 @@ Add your own primary key to the through model, on different attributes than the 
       ...this.through.scope,
     };
 
+    // @ts-expect-error -- the findAll call is raw, no model here
     const currentThroughRows: ThroughModel[] = await this.through.model.findAll({
       ...options,
       where,
@@ -661,6 +662,7 @@ Add your own primary key to the through model, on different attributes than the 
 
     let currentRows: any[] = [];
     if (this.through?.unique ?? true) {
+      // @ts-expect-error -- the findAll call is raw, no model here
       currentRows = await this.through.model.findAll({
         ...options,
         raw: true,
@@ -1025,7 +1027,7 @@ export interface BelongsToManyGetAssociationsMixinOptions<T extends Model> exten
   /**
    * A list of the attributes from the join table that you want to select.
    */
-  joinTableAttributes?: FindAttributeOptions;
+  joinTableAttributes?: FindAttributeOptions<Attributes<T>>;
   /**
    * Apply a scope on the related model, or remove its default scope by passing false.
    */

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -96,7 +96,7 @@ export interface Filterable<TAttributes = any> {
   where?: WhereOptions<TAttributes>;
 }
 
-export interface Projectable {
+export interface Projectable<TAttributes = any> {
   /**
    * If an array: a list of the attributes that you want to select.
    * Attributes can also be raw SQL (`literal`), `fn`, `col`, and `cast`
@@ -121,7 +121,7 @@ export interface Projectable {
    * { attributes: { exclude: ['password'] } }
    * ```
    */
-  attributes?: FindAttributeOptions;
+  attributes?: FindAttributeOptions<TAttributes>;
 }
 
 export interface Paranoid {
@@ -588,7 +588,7 @@ export interface WhereGeometryOptions {
 /**
  * Through options for Include Options
  */
-export interface IncludeThroughOptions extends Filterable<any>, Projectable {
+export interface IncludeThroughOptions extends Filterable<any>, Projectable<any> {
   /**
    * The alias for the join model, in case you want to give it a different name than the default one.
    */
@@ -620,7 +620,7 @@ export type Includeable = ModelStatic | Association | IncludeOptions | { all: tr
 /**
  * Complex include options
  */
-export interface IncludeOptions extends Filterable<any>, Projectable, Paranoid {
+export interface IncludeOptions extends Filterable<any>, Projectable<any>, Paranoid {
   /**
    * Mark the include as duplicating, will prevent a subquery from being used.
    */
@@ -753,15 +753,16 @@ export type ProjectionAlias = readonly [
   alias: string,
 ];
 
-export type FindAttributeOptions =
+export type FindAttributeOptions<TAttributes = any> =
   | Array<string | ProjectionAlias | Literal>
+  | Array<Extract<keyof TAttributes, string>>
   | {
-    exclude: string[],
-    include?: Array<string | ProjectionAlias>,
+    exclude: string[] | Array<Extract<keyof TAttributes, string>>,
+    include?: Array<string | ProjectionAlias> | Array<Extract<keyof TAttributes, string>>,
   }
   | {
-    exclude?: string[],
-    include: Array<string | ProjectionAlias>,
+    exclude?: string[] | Array<Extract<keyof TAttributes, string>>,
+    include: Array<string | ProjectionAlias> | Array<Extract<keyof TAttributes, string>>,
   };
 
 export interface IndexHint {
@@ -790,7 +791,13 @@ export interface MaxExecutionTimeHintable {
  */
 export interface FindOptions<TAttributes = any>
   extends
-  QueryOptions, Filterable<TAttributes>, Projectable, Paranoid, IndexHintable, SearchPathable, MaxExecutionTimeHintable {
+  QueryOptions,
+  Filterable<TAttributes>,
+  Projectable<TAttributes>,
+  Paranoid,
+  IndexHintable,
+  SearchPathable,
+  MaxExecutionTimeHintable {
   /**
    * A list of associations to eagerly load using a left join (a single association is also supported).
    *
@@ -923,7 +930,14 @@ export interface NonNullFindByPkOptions<M extends Model> extends Omit<NonNullFin
  * Options for Model.count method
  */
 export interface CountOptions<TAttributes = any>
-  extends Logging, Transactionable, Filterable<TAttributes>, Projectable, Paranoid, Poolable, MaxExecutionTimeHintable {
+  extends
+  Logging,
+  Transactionable,
+  Filterable<TAttributes>,
+  Projectable<TAttributes>,
+  Paranoid,
+  Poolable,
+  MaxExecutionTimeHintable {
   /**
    * Include options. See `find` for details
    */

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -754,15 +754,14 @@ export type ProjectionAlias = readonly [
 ];
 
 export type FindAttributeOptions<TAttributes = any> =
-  | Array<string | ProjectionAlias | Literal>
-  | Array<Extract<keyof TAttributes, string>>
+  | Array<Extract<keyof TAttributes, string> | ProjectionAlias | Literal>
   | {
-    exclude: string[] | Array<Extract<keyof TAttributes, string>>,
-    include?: Array<string | ProjectionAlias> | Array<Extract<keyof TAttributes, string>>,
+    exclude: Array<Extract<keyof TAttributes, string>>,
+    include?: Array<Extract<keyof TAttributes, string> | ProjectionAlias>,
   }
   | {
-    exclude?: string[] | Array<Extract<keyof TAttributes, string>>,
-    include: Array<string | ProjectionAlias> | Array<Extract<keyof TAttributes, string>>,
+    exclude?: Array<Extract<keyof TAttributes, string>>,
+    include: Array<Extract<keyof TAttributes, string> | ProjectionAlias>,
   };
 
 export interface IndexHint {

--- a/packages/core/test/integration/json.test.ts
+++ b/packages/core/test/integration/json.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import semver from 'semver';
 import type { CreationOptional, InferAttributes, InferCreationAttributes, NonAttribute } from '@sequelize/core';
 import { DataTypes, Model, Op, sql } from '@sequelize/core';
-import { Attribute, AutoIncrement, BelongsTo, PrimaryKey } from '@sequelize/core/decorators-legacy';
+import { Attribute, BelongsTo } from '@sequelize/core/decorators-legacy';
 import { beforeAll2, beforeEach2, inlineErrorCause, sequelize, setResetMode } from './support';
 
 const dialect = sequelize.dialect;
@@ -73,9 +73,6 @@ describe('JSON Querying', () => {
 
   const vars = beforeAll2(async () => {
     class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
-      @Attribute(DataTypes.INTEGER)
-      @PrimaryKey
-      @AutoIncrement
       declare id: CreationOptional<number>;
 
       @Attribute(DataTypes.JSON)
@@ -86,12 +83,9 @@ describe('JSON Querying', () => {
     }
 
     class Order extends Model<InferAttributes<Order>, InferCreationAttributes<Order>> {
-      @Attribute(DataTypes.INTEGER)
-      @PrimaryKey
-      @AutoIncrement
       declare id: CreationOptional<number>;
 
-      @BelongsTo(User, 'userId')
+      @BelongsTo(() => User, 'userId')
       declare user: NonAttribute<User>;
 
       @Attribute(DataTypes.INTEGER)
@@ -365,9 +359,6 @@ describe('JSONB Querying', () => {
 
   const vars = beforeAll2(async () => {
     class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
-      @Attribute(DataTypes.INTEGER)
-      @PrimaryKey
-      @AutoIncrement
       declare id: CreationOptional<number>;
 
       @Attribute(DataTypes.JSONB)
@@ -378,12 +369,9 @@ describe('JSONB Querying', () => {
     }
 
     class Order extends Model<InferAttributes<Order>, InferCreationAttributes<Order>> {
-      @Attribute(DataTypes.INTEGER)
-      @PrimaryKey
-      @AutoIncrement
       declare id: CreationOptional<number>;
 
-      @BelongsTo(User, 'userId')
+      @BelongsTo(() => User, 'userId')
       declare user: NonAttribute<User>;
 
       @Attribute(DataTypes.INTEGER)

--- a/packages/core/test/integration/json.test.ts
+++ b/packages/core/test/integration/json.test.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import semver from 'semver';
 import type { CreationOptional, InferAttributes, InferCreationAttributes, NonAttribute } from '@sequelize/core';
 import { DataTypes, Model, Op, sql } from '@sequelize/core';
-import { Attribute, BelongsTo } from '@sequelize/core/decorators-legacy';
+import { Attribute, AutoIncrement, BelongsTo, PrimaryKey } from '@sequelize/core/decorators-legacy';
 import { beforeAll2, beforeEach2, inlineErrorCause, sequelize, setResetMode } from './support';
 
 const dialect = sequelize.dialect;
@@ -73,6 +73,9 @@ describe('JSON Querying', () => {
 
   const vars = beforeAll2(async () => {
     class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+      @Attribute(DataTypes.INTEGER)
+      @PrimaryKey
+      @AutoIncrement
       declare id: CreationOptional<number>;
 
       @Attribute(DataTypes.JSON)
@@ -82,7 +85,12 @@ describe('JSON Querying', () => {
       declare stringJsonAttr: string;
     }
 
-    class Order extends Model<InferAttributes<Order>> {
+    class Order extends Model<InferAttributes<Order>, InferCreationAttributes<Order>> {
+      @Attribute(DataTypes.INTEGER)
+      @PrimaryKey
+      @AutoIncrement
+      declare id: CreationOptional<number>;
+
       @BelongsTo(User, 'userId')
       declare user: NonAttribute<User>;
 
@@ -357,6 +365,9 @@ describe('JSONB Querying', () => {
 
   const vars = beforeAll2(async () => {
     class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+      @Attribute(DataTypes.INTEGER)
+      @PrimaryKey
+      @AutoIncrement
       declare id: CreationOptional<number>;
 
       @Attribute(DataTypes.JSONB)
@@ -366,7 +377,12 @@ describe('JSONB Querying', () => {
       declare stringJsonbAttr: CreationOptional<string>;
     }
 
-    class Order extends Model<InferAttributes<Order>> {
+    class Order extends Model<InferAttributes<Order>, InferCreationAttributes<Order>> {
+      @Attribute(DataTypes.INTEGER)
+      @PrimaryKey
+      @AutoIncrement
+      declare id: CreationOptional<number>;
+
       @BelongsTo(User, 'userId')
       declare user: NonAttribute<User>;
 

--- a/packages/core/test/types/find-all.ts
+++ b/packages/core/test/types/find-all.ts
@@ -24,7 +24,7 @@ import { User } from './models/user';
   const customUsers = await User.findAll<User, CustomUser>({
     attributes: [
       ['bar', 'foo'],
-      'ignored',
+      'firstName',
       [col('table.id'), 'xyz'],
       [cast(col('createdAt'), 'varchar'), 'abc'],
     ],

--- a/packages/core/test/types/find-one.ts
+++ b/packages/core/test/types/find-one.ts
@@ -121,7 +121,7 @@ User.findOne({ where: { '$include1.$include2.includeAttr$': 'blah2' } });
     raw: true,
   })).toEqualTypeOf<CustomUser>();
 
-  async function passDown(params: FindOptions<User>) {
+  async function passDown(params: FindOptions<Attributes<User>>) {
     // Unknown ahead of time
     // We can't what 'rejectOnEmpty' and 'raw' are set to, so we default to these types:
     expectTypeOf(await User.findOne(params))

--- a/packages/core/test/unit/query-generator/select-query.test.ts
+++ b/packages/core/test/unit/query-generator/select-query.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import type { InferAttributes, Model } from '@sequelize/core';
+import type { CreationOptional, InferAttributes, InferCreationAttributes, Model } from '@sequelize/core';
 import { DataTypes, IndexHints, Op, TableHints, or, sql as sqlTag } from '@sequelize/core';
 import { _validateIncludedElements } from '@sequelize/core/_non-semver-use-at-your-own-risk_/model-internals.js';
 import { buildInvalidOptionReceivedError } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
@@ -10,19 +10,31 @@ const { attribute, col, cast, where, fn, literal } = sqlTag;
 describe('QueryGenerator#selectQuery', () => {
   const queryGenerator = sequelize.queryGenerator;
 
-  interface TUser extends Model<InferAttributes<TUser>> {
+  interface TUser extends Model<InferAttributes<TUser>, InferCreationAttributes<TUser>> {
+    id: CreationOptional<number>;
     username: string;
   }
 
   const User = sequelize.define<TUser>('User', {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      autoIncrement: true,
+      primaryKey: true,
+    },
     username: DataTypes.STRING,
   }, { timestamps: true });
 
-  interface TProject extends Model<InferAttributes<TProject>> {
+  interface TProject extends Model<InferAttributes<TProject>, InferCreationAttributes<TProject>> {
+    id: CreationOptional<number>;
     duration: bigint;
   }
 
   const Project = sequelize.define<TProject>('Project', {
+    id: {
+      type: DataTypes.INTEGER.UNSIGNED,
+      autoIncrement: true,
+      primaryKey: true,
+    },
     duration: DataTypes.BIGINT,
   }, { timestamps: false });
 
@@ -491,8 +503,6 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         attributes: [
           // these used to have special escaping logic, now they're always escaped like any other strings. col, fn, and literal can be used for advanced logic.
           ['count(*)', 'count'],
-          '.*',
-          '*',
           [literal('count(*)'), 'literal_count'],
           [fn('count', '*'), 'fn_count_str'],
           [fn('count', col('*')), 'fn_count_col'],
@@ -507,8 +517,6 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         default: `
           SELECT
             [count(*)] AS [count],
-            [.*],
-            [*],
             count(*) AS [literal_count],
             count('*') AS [fn_count_str],
             count(*) AS [fn_count_col],
@@ -520,8 +528,6 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         mssql: `
           SELECT
             [count(*)] AS [count],
-            [.*],
-            [*],
             count(*) AS [literal_count],
             count(N'*') AS [fn_count_str],
             count(*) AS [fn_count_col],
@@ -554,7 +560,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('raw replacements for where', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           where: ['name IN (?)', [1, 'test', 3, 'derp']],
         });
@@ -564,7 +570,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('raw replacements for nested where', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           where: [['name IN (?)', [1, 'test', 3, 'derp']]],
         });
@@ -574,7 +580,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('raw replacements for having', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           having: ['name IN (?)', [1, 'test', 3, 'derp']],
         });
@@ -584,7 +590,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('raw replacements for nested having', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           having: [['name IN (?)', [1, 'test', 3, 'derp']]],
         });
@@ -594,7 +600,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('raw string from where', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           where: `name = 'something'`,
         });
@@ -604,7 +610,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('raw string from having', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           having: `name = 'something'`,
         });
@@ -614,7 +620,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('rejects where: null', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           where: null,
         });
@@ -624,7 +630,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('rejects where: primitive', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           where: 1,
         });
@@ -634,7 +640,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     it('rejects where: array of primitives', () => {
       expect(() => {
         queryGenerator.selectQuery('User', {
-          attributes: ['*'],
+          attributes: [[col('*'), 'col_all']],
           // @ts-expect-error -- this is not a valid value anymore
           where: [''],
         });

--- a/packages/core/test/unit/query-generator/select-query.test.ts
+++ b/packages/core/test/unit/query-generator/select-query.test.ts
@@ -503,6 +503,10 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         attributes: [
           // these used to have special escaping logic, now they're always escaped like any other strings. col, fn, and literal can be used for advanced logic.
           ['count(*)', 'count'],
+          // @ts-expect-error -- test against a vulnerability CVE-2023-22578
+          '.*',
+          // @ts-expect-error -- test against a vulnerability CVE-2023-22578
+          '*',
           [literal('count(*)'), 'literal_count'],
           [fn('count', '*'), 'fn_count_str'],
           [fn('count', col('*')), 'fn_count_col'],
@@ -517,6 +521,8 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         default: `
           SELECT
             [count(*)] AS [count],
+            [.*],
+            [*],
             count(*) AS [literal_count],
             count('*') AS [fn_count_str],
             count(*) AS [fn_count_col],
@@ -528,6 +534,8 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
         mssql: `
           SELECT
             [count(*)] AS [count],
+            [.*],
+            [*],
             count(*) AS [literal_count],
             count(N'*') AS [fn_count_str],
             count(*) AS [fn_count_col],


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Updates the attributes typing for find queries so that model attributes can be selected/suggested by IDE's.
