### PR TITLE
meta: test on postgres >12 that a password of null fails

### DIFF
--- a/packages/core/test/integration/sequelize.test.js
+++ b/packages/core/test/integration/sequelize.test.js
@@ -8,7 +8,6 @@ const dialect = Support.getTestDialect();
 const _ = require('lodash');
 const { Config: config } = require('../config/config');
 const sinon = require('sinon');
-const semver = require('semver');
 
 const current = Support.sequelize;
 
@@ -381,11 +380,6 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       });
 
       it('fails with incorrect database credentials (1)', async function () {
-        // TODO: remove this once fixed in https://github.com/brianc/node-postgres/issues/1927 or when password is not allowed to be null in our postgres implementation
-        if (dialect === 'postgres' && semver.gte(this.sequelize.getDatabaseVersion(), '12.0.0')) {
-          return;
-        }
-
         this.sequelizeWithInvalidCredentials = Support.createSequelizeInstance({
           database: 'omg',
           username: 'bar',
@@ -405,6 +399,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
                 'role "bar" does not exist',
                 'FATAL:  role "bar" does not exist',
                 'password authentication failed for user "bar"',
+                'SASL: SCRAM-SERVER-FIRST-MESSAGE: client password must be a string',
               ].some(fragment => error.message.includes(fragment)));
 
               break;


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

This is now possible with the bugfixes in pg 8.9.0