### PR TITLE
feat: throw if same model name is registered again

### DIFF
--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -502,6 +502,10 @@ export class Sequelize extends SequelizeTypeScript {
     options.modelName = modelName;
     options.sequelize = this;
 
+    if (this.isDefined(modelName)) {
+      throw new Error(`${modelName} is already defined`);
+    }
+
     const model = class extends Model {};
 
     model.init(attributes, options);

--- a/packages/core/test/unit/model/define.test.js
+++ b/packages/core/test/unit/model/define.test.js
@@ -38,6 +38,13 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       }).to.throw('An attribute called \'id\' was defined in model \'foos\' but primaryKey is not set. This is likely to be an error, which can be fixed by setting its \'primaryKey\' option to true. If this is intended, explicitly set its \'primaryKey\' option to false');
     });
 
+    it('throws if the user tries to register a model with a model name that is already registered', () => {
+      expect(() => {
+        current.define('i_am_already_there', {});
+        current.define('i_am_already_there', {});
+      }).to.throw(`i_am_already_there is already defined`);
+    });
+
     it('allows creating an "id" field as the primary key', () => {
       const Bar = current.define('bar', {
         id: {


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

If the user tries to register models with a name that was already registered previously this should make the `sequelize.define` throw.

```js
sequelize.define('model_already_present', { /* MODEL DEFINITION */ });

// This will throw!
sequelize.define('model_already_present', { /* MODEL DEFINITION */ });
```

Closes #15641 