### PR TITLE
refactor: rework expectsql

### DIFF
--- a/packages/core/test/unit/sql/insert.test.js
+++ b/packages/core/test/unit/sql/insert.test.js
@@ -39,7 +39,9 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             snowflake: 'INSERT INTO "users" ("user_name") VALUES ($sequelize_1);',
             default: 'INSERT INTO `users` (`user_name`) VALUES ($sequelize_1);',
           },
-          bind: { sequelize_1: 'triggertest' },
+          bind: {
+            default: { sequelize_1: 'triggertest' },
+          },
         });
 
     });
@@ -63,7 +65,9 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             snowflake: 'INSERT INTO "ms" ("id") VALUES ($sequelize_1);',
             default: 'INSERT INTO `ms` (`id`) VALUES ($sequelize_1);',
           },
-          bind: { sequelize_1: 0 },
+          bind: {
+            default: { sequelize_1: 0 },
+          },
         });
     });
 
@@ -124,7 +128,10 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
             'missing dialect support for conflictWhere option',
           ),
           'postgres sqlite':
-            `INSERT INTO [users] ([user_name],[pass_word]) VALUES ($sequelize_1,$sequelize_2) ON CONFLICT ([user_name]) WHERE [user_name] = 'test where value' DO UPDATE SET [user_name]=EXCLUDED.[user_name],[pass_word]=EXCLUDED.[pass_word],[updated_at]=EXCLUDED.[updated_at];`,
+            `INSERT INTO [users] ([user_name],[pass_word]) VALUES ($sequelize_1,$sequelize_2)
+             ON CONFLICT ([user_name])
+               WHERE [user_name] = 'test where value'
+               DO UPDATE SET [user_name]=EXCLUDED.[user_name],[pass_word]=EXCLUDED.[pass_word],[updated_at]=EXCLUDED.[updated_at];`,
         });
       },
     );


### PR DESCRIPTION
## Description Of Change

The goal of this PR is to rewrite `expectsql` to build it on top of `expectPerDialect`. This means that `expectPerDialect` is now able to do everything `expectsql` was able to. For instance, The `toMatchSql` expectation now has a fuzzy mode that the dev can enable if they want, even if they're not using the default expectation nor a combined one

The main goal was to make `expectsql` more flexible when matching bind parameters.

Before this PR, you had to write such a match like this:

```ts
expectsql(myQueryWithBindParameters, {
  query: {
    default: 'INSERT INTO `users` (`user_name`) VALUES ($sequelize_1);',
  },
  bind: {
    default: { sequelize_1: 'triggertest' },
  },
});
```

With this PR, you can now write it like this if you want:

```ts
expectsql(myQueryWithBindParameters, {
  default: {
    query: 'INSERT INTO `users` (`user_name`) VALUES ($sequelize_1);',
    bind: { sequelize_1: 'triggertest' },
  },
});
```

As well as mix them

```ts
expectsql(myQueryWithBindParameters, {
  bind: {
    default: { sequelize_1: 'triggertest' },
  },
  mssql: 'INSERT INTO `users` (`user_name`) VALUES ($sequelize_1);'
});
```

I initially rewrote it because you could not specify more than one dialect in your `bind` keys, but maybe this goes too far? Should we keep these two interfaces separate?