### PR TITLE
fix: throw if `where` receives an invalid value (v6)

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -2833,7 +2833,7 @@ class QueryGenerator {
       });
     }
 
-    return '1=1';
+    throw new Error(`Unsupported where option value: ${util.inspect(smth)}. Please refer to the Sequelize documentation to learn more about which values are accepted as part of the where option.`);
   }
 
   // A recursive parser for nested where conditions

--- a/test/unit/sql/get-where-conditions.test.js
+++ b/test/unit/sql/get-where-conditions.test.js
@@ -1,0 +1,14 @@
+const { expect } = require('chai');
+const { sequelize } = require('../../support');
+
+describe('QueryGenerator#getWhereConditions', () => {
+  const queryGenerator = sequelize.queryInterface.queryGenerator;
+
+  it('throws if called with invalid arguments', () => {
+    const User = sequelize.define('User');
+
+    expect(() => {
+      queryGenerator.getWhereConditions(new Date(), User.getTableName(), User);
+    }).to.throw('Unsupported where option value');
+  });
+});


### PR DESCRIPTION
Backport of https://github.com/sequelize/sequelize/pull/15375 to resolve CVE-2023-22579 and CVE-2023-22580