### PR TITLE
fix: accept & ignore "undefined" as a value in where

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -2826,7 +2826,7 @@ class QueryGenerator {
       }
       throw new Error('Support for literal replacements in the `where` object has been removed.');
     }
-    if (smth === null) {
+    if (smth == null) {
       return this.whereItemsQuery(smth, {
         model: factory,
         prefix: prepend && tableName

--- a/test/unit/sql/get-where-conditions.test.js
+++ b/test/unit/sql/get-where-conditions.test.js
@@ -11,4 +11,16 @@ describe('QueryGenerator#getWhereConditions', () => {
       queryGenerator.getWhereConditions(new Date(), User.getTableName(), User);
     }).to.throw('Unsupported where option value');
   });
+
+  it('ignores undefined', () => {
+    const User = sequelize.define('User');
+
+    expect(queryGenerator.getWhereConditions(undefined, User.getTableName(), User)).to.eq('');
+  });
+
+  it('ignores null', () => {
+    const User = sequelize.define('User');
+
+    expect(queryGenerator.getWhereConditions(undefined, User.getTableName(), User)).to.eq('');
+  });
 });


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/sequelize/sequelize/pull/15699 where "undefined" became an invalid value in `where`. This PR treats undefined the same as if the where property was missing

Closes #15702