### PR TITLE
fix(postgres): Escape identifier in createSchema and dropSchema

### DIFF
--- a/src/dialects/postgres/query-generator.js
+++ b/src/dialects/postgres/query-generator.js
@@ -46,14 +46,14 @@ class PostgresQueryGenerator extends AbstractQueryGenerator {
     const databaseVersion = _.get(this, 'sequelize.options.databaseVersion', 0);
 
     if (databaseVersion && semver.gte(databaseVersion, '9.2.0')) {
-      return `CREATE SCHEMA IF NOT EXISTS ${schema};`;
+      return `CREATE SCHEMA IF NOT EXISTS ${this.quoteIdentifier(schema)};`;
     }
 
-    return `CREATE SCHEMA ${schema};`;
+    return `CREATE SCHEMA ${this.quoteIdentifier(schema)};`;
   }
 
   dropSchema(schema) {
-    return `DROP SCHEMA IF EXISTS ${schema} CASCADE;`;
+    return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schema)} CASCADE;`;
   }
 
   showSchemasQuery() {

--- a/test/unit/sql/create-schema.test.js
+++ b/test/unit/sql/create-schema.test.js
@@ -10,7 +10,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     describe('dropSchema', () => {
       it('IF EXISTS', () => {
         expectsql(sql.dropSchema('foo'), {
-          postgres: 'DROP SCHEMA IF EXISTS foo CASCADE;'
+          postgres: 'DROP SCHEMA IF EXISTS "foo" CASCADE;'
         });
       });
     });
@@ -27,14 +27,14 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       it('9.2.0 or above', () => {
         current.options.databaseVersion = '9.2.0';
         expectsql(sql.createSchema('foo'), {
-          postgres: 'CREATE SCHEMA IF NOT EXISTS foo;'
+          postgres: 'CREATE SCHEMA IF NOT EXISTS "foo";'
         });
       });
 
       it('below 9.2.0', () => {
         current.options.databaseVersion = '9.0.0';
         expectsql(sql.createSchema('foo'), {
-          postgres: 'CREATE SCHEMA foo;'
+          postgres: 'CREATE SCHEMA "foo";'
         });
       });
     });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Fixes #15651. This patch backports a part of #14999 to Sequelize v6 to quote schema identifiers in PostgreSQL `createSchema()` and `dropSchema()`.

## Todos

(none)
