### PR TITLE
fix: fix unnamed dollar string detection (v7)

### DIFF
--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -69,7 +69,7 @@ function mapBindParametersAndReplacements(
 
       const remainingString = sqlString.slice(i, sqlString.length);
 
-      const dollarStringStartMatch = remainingString.match(/^\$(?<name>[a-z_][0-9a-z_])?(\$)/i);
+      const dollarStringStartMatch = remainingString.match(/^\$(?<name>[a-z_][0-9a-z_]*)?(\$)/i);
       const tagName = dollarStringStartMatch?.groups?.name ?? '';
 
       if (currentDollarStringTagName === tagName) {
@@ -148,6 +148,7 @@ function mapBindParametersAndReplacements(
       const dollarStringStartMatch = remainingString.match(/^\$(?<name>[a-z_][0-9a-z_]*)?\$/i);
       if (dollarStringStartMatch) {
         currentDollarStringTagName = dollarStringStartMatch.groups?.name ?? '';
+        i += dollarStringStartMatch[0].length - 1;
 
         continue;
       }

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -678,7 +678,7 @@ describe('injectReplacements (positional replacements)', () => {
     });
   });
 
-  it('does consider the token to be a bind parameter if it is located after a $ quoted string', () => {
+  it('does consider the token to be a replacement if it is located after a $ quoted string', () => {
     const sql = injectReplacements(`SELECT $$ abc $$ AS string FROM users WHERE id = ?`, dialect, [1]);
 
     expectsql(sql, {

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -670,6 +670,14 @@ describe('injectReplacements (positional replacements)', () => {
     });
   });
 
+  it('does not consider the token to be a replacement if it is in an unnamed $ quoted string', () => {
+    const sql = injectReplacements(`SELECT $$ ? $$`, dialect, [1]);
+
+    expectsql(sql, {
+      default: `SELECT $$ ? $$`,
+    });
+  });
+
   it('does consider the token to be a bind parameter if it is located after a $ quoted string', () => {
     const sql = injectReplacements(`SELECT $$ abc $$ AS string FROM users WHERE id = ?`, dialect, [1]);
 


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Fixes an issue reported here: https://github.com/sequelize/sequelize/issues/15301#issuecomment-1322151016

Basically unnamed `$$` quoted strings were ending too quickly. The parser considered the string to be delimited like this:

```sql
SELECT $$ id $$
--     ^ start of string
--      ^ end of string
```

instead of this:

```sql
SELECT $$ id $$
--     ^ start of string
--           ^ end of string
```