### PR TITLE
feat: remove escape options from data types

### DIFF
--- a/packages/core/src/dialects/abstract/data-types-utils.ts
+++ b/packages/core/src/dialects/abstract/data-types-utils.ts
@@ -1,7 +1,7 @@
 import NodeUtils from 'node:util';
 import { BaseError, ValidationErrorItem } from '../../errors/index.js';
 import type { Model } from '../../model.js';
-import type { DataType, DataTypeClass, DataTypeClassOrInstance, DataTypeInstance, ToSqlOptions } from './data-types.js';
+import type { DataType, DataTypeClass, DataTypeClassOrInstance, DataTypeInstance } from './data-types.js';
 import { AbstractDataType } from './data-types.js';
 import type { AbstractDialect } from './index.js';
 
@@ -51,10 +51,10 @@ export function dataTypeClassOrInstanceToInstance(Type: DataTypeClassOrInstance)
 }
 
 export function validateDataType(
-  type: AbstractDataType<any>,
-  attributeName: string,
-  modelInstance: Model<any> | null,
   value: unknown,
+  type: AbstractDataType<any>,
+  attributeName: string = '[unnamed]',
+  modelInstance: Model<any> | null = null,
 ): ValidationErrorItem | null {
   try {
     type.validate(value);
@@ -77,13 +77,13 @@ export function validateDataType(
   }
 }
 
-export function attributeTypeToSql(type: AbstractDataType<any> | string, options: ToSqlOptions): string {
+export function attributeTypeToSql(type: AbstractDataType<any> | string): string {
   if (typeof type === 'string') {
     return type;
   }
 
   if (type instanceof AbstractDataType) {
-    return type.toSql(options);
+    return type.toSql();
   }
 
   throw new Error('attributeTypeToSql received a type that is neither a string or an instance of AbstractDataType');

--- a/packages/core/src/dialects/abstract/data-types.ts
+++ b/packages/core/src/dialects/abstract/data-types.ts
@@ -9,7 +9,7 @@ import { ValidationErrorItem } from '../../errors';
 import type { Falsy } from '../../generic/falsy';
 import type { GeoJson, GeoJsonType } from '../../geo-json.js';
 import { assertIsGeoJson } from '../../geo-json.js';
-import type { NormalizedAttributeOptions, ModelStatic, Rangable, RangePart } from '../../model.js';
+import type { ModelStatic, Rangable, RangePart } from '../../model.js';
 import type { Sequelize } from '../../sequelize.js';
 import { makeBufferFromTypedArray } from '../../utils/buffer.js';
 import { isPlainObject, isString } from '../../utils/check.js';
@@ -21,6 +21,7 @@ import { validator as Validator } from '../../utils/validator-extras';
 import type { HstoreRecord } from '../postgres/hstore.js';
 import { buildRangeParser } from '../postgres/range.js';
 import {
+  attributeTypeToSql,
   dataTypeClassOrInstanceToInstance,
   isDataType,
   isDataTypeClass,
@@ -62,18 +63,9 @@ export type DataType =
   | string
   | DataTypeClassOrInstance;
 
-export interface ToSqlOptions {
-  dialect: AbstractDialect;
-}
+export type NormalizedDataType = string | DataTypeInstance;
 
-export interface StringifyOptions {
-  dialect: AbstractDialect;
-  operation?: string;
-  timezone?: string | undefined;
-  field?: NormalizedAttributeOptions;
-}
-
-export interface BindParamOptions extends StringifyOptions {
+export interface BindParamOptions {
   bindParam(value: unknown): string;
 }
 
@@ -218,16 +210,15 @@ export abstract class AbstractDataType<
    * The resulting value will be inlined as-is with no further escaping.
    *
    * @param value The value to escape.
-   * @param options Options.
    */
-  escape(value: AcceptedType, options: StringifyOptions): string {
-    const asBindValue = this.toBindableValue(value, options);
+  escape(value: AcceptedType): string {
+    const asBindValue = this.toBindableValue(value);
 
     if (!isString(asBindValue)) {
       throw new Error(`${this.constructor.name}#stringify has been overridden to return a non-string value, so ${this.constructor.name}#escape must be implemented to handle that value correctly.`);
     }
 
-    return options.dialect.escapeString(asBindValue);
+    return this._getDialect().escapeString(asBindValue);
   }
 
   /**
@@ -246,7 +237,7 @@ export abstract class AbstractDataType<
    */
   getBindParamSql(value: AcceptedType, options: BindParamOptions): string {
     // TODO: rename "options.bindParam" to "options.collectBindParam"
-    return options.bindParam(this.toBindableValue(value, options));
+    return options.bindParam(this.toBindableValue(value));
   }
 
   /**
@@ -255,15 +246,14 @@ export abstract class AbstractDataType<
    * will handle escaping.
    *
    * @param value The value to convert.
-   * @param _options Options.
    */
-  toBindableValue(value: AcceptedType, _options: StringifyOptions): unknown {
+  toBindableValue(value: AcceptedType): unknown {
     return String(value);
   }
 
   toString(): string {
     try {
-      return this.toSql({ dialect: this.usageContext?.sequelize.dialect! });
+      return this.toSql();
     } catch {
       // best effort introspection (dialect may not be available)
       return this.constructor.toString();
@@ -278,7 +268,7 @@ export abstract class AbstractDataType<
    * Returns a SQL declaration of this data type.
    * e.g. 'VARCHAR(255)', 'TEXT', etc…
    */
-  abstract toSql(options: ToSqlOptions): string;
+  abstract toSql(): string;
 
   /**
    * Override this method to emit an error or a warning if the Data Type, as it is configured, is not compatible
@@ -334,6 +324,16 @@ export abstract class AbstractDataType<
     // there is a convention that all DataTypes must accept a single "options" parameter as one of their signatures, but it's impossible to enforce in typing
     // @ts-expect-error -- see ^
     return this._construct(this.options);
+  }
+
+  withUsageContext(usageContext: DataTypeUseContext): this {
+    const out = this.clone().attachUsageContext(usageContext);
+
+    if (this.#dialect) {
+      out.#dialect = this.#dialect;
+    }
+
+    return out;
   }
 
   /**
@@ -426,7 +426,7 @@ export class STRING extends AbstractDataType<string | Buffer> {
     }
   }
 
-  toSql(_options: ToSqlOptions): string {
+  toSql(): string {
     // TODO: STRING should use an unlimited length type by default - https://github.com/sequelize/sequelize/issues/14259
     return joinSQLFragments([
       `VARCHAR(${this.options.length ?? 255})`,
@@ -471,12 +471,12 @@ export class STRING extends AbstractDataType<string | Buffer> {
     return new this({ binary: true });
   }
 
-  escape(value: string | Buffer, options: StringifyOptions): string {
+  escape(value: string | Buffer): string {
     if (Buffer.isBuffer(value)) {
-      return options.dialect.escapeBuffer(value);
+      return this._getDialect().escapeBuffer(value);
     }
 
-    return options.dialect.escapeString(value);
+    return this._getDialect().escapeString(value);
   }
 
   toBindableValue(value: string | Buffer): unknown {
@@ -683,10 +683,10 @@ export class BaseNumberDataType<Options extends NumberOptions = NumberOptions> e
     throw new Error(`getNumberSqlTypeName has not been implemented in ${this.constructor.name}`);
   }
 
-  toSql(_options: ToSqlOptions): string {
+  toSql(): string {
     let result: string = this.getNumberSqlTypeName();
 
-    if (this.options.unsigned && this._supportsNativeUnsigned(_options.dialect)) {
+    if (this.options.unsigned && this._supportsNativeUnsigned(this._getDialect())) {
       result += ' UNSIGNED';
     }
 
@@ -715,11 +715,11 @@ export class BaseNumberDataType<Options extends NumberOptions = NumberOptions> e
     }
   }
 
-  escape(value: AcceptedNumber, options: StringifyOptions): string {
-    return this.toBindableValue(value, options);
+  escape(value: AcceptedNumber): string {
+    return String(this.toBindableValue(value));
   }
 
-  toBindableValue(num: AcceptedNumber, _options: StringifyOptions): string {
+  toBindableValue(num: AcceptedNumber): string | number {
     // This should be unnecessary but since this directly returns the passed string its worth the added validation.
     this.validate(num);
 
@@ -733,7 +733,7 @@ export class BaseNumberDataType<Options extends NumberOptions = NumberOptions> e
       return `${sign}Infinity`;
     }
 
-    return String(num);
+    return num;
   }
 
   getBindParamSql(value: AcceptedNumber, options: BindParamOptions): string {
@@ -809,13 +809,13 @@ export class BaseIntegerDataType extends BaseNumberDataType<IntegerOptions> {
     return _dialect.supports.dataTypes.INTS.unsigned;
   }
 
-  toSql(options: ToSqlOptions): string {
+  toSql(): string {
     let result: string = this.getNumberSqlTypeName();
     if (this.options.length != null) {
       result += `(${this.options.length})`;
     }
 
-    if (this.options.unsigned && this._supportsNativeUnsigned(options.dialect)) {
+    if (this.options.unsigned && this._supportsNativeUnsigned(this._getDialect())) {
       result += ' UNSIGNED';
     }
 
@@ -1072,13 +1072,13 @@ export class BaseDecimalNumberDataType extends BaseNumberDataType<DecimalNumberO
     }
   }
 
-  toSql(options: ToSqlOptions): string {
+  toSql(): string {
     let sql = this.getNumberSqlTypeName();
     if (!this.isUnconstrained()) {
       sql += `(${this.options.precision}, ${this.options.scale})`;
     }
 
-    if (this.options.unsigned && this._supportsNativeUnsigned(options.dialect)) {
+    if (this.options.unsigned && this._supportsNativeUnsigned(this._getDialect())) {
       sql += ' UNSIGNED';
     }
 
@@ -1307,7 +1307,7 @@ export class BOOLEAN extends AbstractDataType<boolean> {
   }
 
   toBindableValue(value: boolean | Falsy): unknown {
-    return value ? 'true' : 'false';
+    return Boolean(value);
   }
 }
 
@@ -1464,24 +1464,23 @@ export class DATE extends AbstractDataType<AcceptedDate> {
     return false;
   }
 
-  protected _applyTimezone(date: AcceptedDate, options: { timezone?: string | undefined }) {
-    if (options.timezone) {
-      if (isValidTimeZone(options.timezone)) {
-        return dayjs(date).tz(options.timezone);
+  protected _applyTimezone(date: AcceptedDate) {
+    const timezone = this._getDialect().sequelize.options.timezone;
+
+    if (timezone) {
+      if (isValidTimeZone(timezone)) {
+        return dayjs(date).tz(timezone);
       }
 
-      return dayjs(date).utcOffset(options.timezone);
+      return dayjs(date).utcOffset(timezone);
     }
 
     return dayjs(date);
   }
 
-  toBindableValue(
-    date: AcceptedDate,
-    options: StringifyOptions,
-  ) {
+  toBindableValue(date: AcceptedDate) {
     // Z here means current timezone, _not_ UTC
-    return this._applyTimezone(date, options).format('YYYY-MM-DD HH:mm:ss.SSS Z');
+    return this._applyTimezone(date).format('YYYY-MM-DD HH:mm:ss.SSS Z');
   }
 }
 
@@ -1507,7 +1506,7 @@ export class DATEONLY extends AbstractDataType<AcceptedDate> {
     return 'DATE';
   }
 
-  toBindableValue(date: AcceptedDate, _options: StringifyOptions) {
+  toBindableValue(date: AcceptedDate) {
     return dayjs.utc(date).format('YYYY-MM-DD');
   }
 
@@ -1751,10 +1750,10 @@ export class BLOB extends AbstractDataType<AcceptedBlob> {
     return value;
   }
 
-  escape(value: string | Buffer, options: StringifyOptions) {
+  escape(value: string | Buffer) {
     const buf = typeof value === 'string' ? Buffer.from(value, 'binary') : value;
 
-    return options.dialect.escapeBuffer(buf);
+    return this._getDialect().escapeBuffer(buf);
   }
 
   getBindParamSql(value: AcceptedBlob, options: BindParamOptions) {
@@ -2210,8 +2209,8 @@ sequelize.define('MyModel', {
     }
   }
 
-  toSql(options: ToSqlOptions): string {
-    throw new Error(`ENUM has not been implemented in the ${options.dialect.name} dialect.`);
+  toSql(): string {
+    throw new Error(`ENUM has not been implemented in the ${this._getDialect().name} dialect.`);
   }
 }
 
@@ -2220,7 +2219,7 @@ export interface ArrayOptions {
 }
 
 interface NormalizedArrayOptions {
-  type: AbstractDataType<any>;
+  type: NormalizedDataType;
 }
 
 /**
@@ -2244,7 +2243,7 @@ export class ARRAY<T extends AbstractDataType<any>> extends AbstractDataType<Arr
   /**
    * @param typeOrOptions type of array values
    */
-  constructor(typeOrOptions: DataTypeClassOrInstance | ArrayOptions) {
+  constructor(typeOrOptions: DataType | ArrayOptions) {
     super();
 
     const rawType = isDataType(typeOrOptions) ? typeOrOptions : typeOrOptions?.type;
@@ -2254,12 +2253,12 @@ export class ARRAY<T extends AbstractDataType<any>> extends AbstractDataType<Arr
     }
 
     this.options = {
-      type: dataTypeClassOrInstanceToInstance(rawType),
+      type: isString(rawType) ? rawType : dataTypeClassOrInstanceToInstance(rawType),
     };
   }
 
-  toSql(options: ToSqlOptions): string {
-    return `${this.options.type.toSql(options)}[]`;
+  toSql(): string {
+    return `${attributeTypeToSql(this.options.type)}[]`;
   }
 
   validate(value: any) {
@@ -2269,8 +2268,14 @@ export class ARRAY<T extends AbstractDataType<any>> extends AbstractDataType<Arr
       );
     }
 
+    if (isString(this.options.type)) {
+      return;
+    }
+
+    const subType: AbstractDataType<any> = this.options.type;
+
     for (const item of value) {
-      this.options.type.validate(item);
+      subType.validate(item);
     }
   }
 
@@ -2279,7 +2284,13 @@ export class ARRAY<T extends AbstractDataType<any>> extends AbstractDataType<Arr
       return value;
     }
 
-    return value.map(item => this.options.type.sanitize(item));
+    if (isString(this.options.type)) {
+      return;
+    }
+
+    const subType: AbstractDataType<any> = this.options.type;
+
+    return value.map(item => subType.sanitize(item));
   }
 
   parseDatabaseValue(value: unknown[]): unknown {
@@ -2288,11 +2299,23 @@ export class ARRAY<T extends AbstractDataType<any>> extends AbstractDataType<Arr
       throw new Error(`DataTypes.ARRAY Received a non-array value from database: ${util.inspect(value)}`);
     }
 
-    return value.map(item => this.options.type.parseDatabaseValue(item));
+    if (isString(this.options.type)) {
+      return value;
+    }
+
+    const subType: AbstractDataType<any> = this.options.type;
+
+    return value.map(item => subType.parseDatabaseValue(item));
   }
 
-  toBindableValue(value: Array<AcceptableTypeOf<T>>, _options: StringifyOptions): unknown {
-    return value.map(val => this.options.type.toBindableValue(val, _options));
+  toBindableValue(value: Array<AcceptableTypeOf<T>>): unknown {
+    if (isString(this.options.type)) {
+      return value;
+    }
+
+    const subType: AbstractDataType<any> = this.options.type;
+
+    return value.map(val => subType.toBindableValue(val));
   }
 
   protected _checkOptionSupport(dialect: AbstractDialect) {
@@ -2310,13 +2333,17 @@ export class ARRAY<T extends AbstractDataType<any>> extends AbstractDataType<Arr
       replacement = replacement.clone();
     }
 
-    replacement.options.type = replacement.options.type.toDialectDataType(dialect);
+    if (!isString(replacement.options.type)) {
+      replacement.options.type = replacement.options.type.toDialectDataType(dialect);
+    }
 
     return replacement;
   }
 
   attachUsageContext(usageContext: DataTypeUseContext): this {
-    this.options.type.attachUsageContext(usageContext);
+    if (!isString(this.options.type)) {
+      this.options.type.attachUsageContext(usageContext);
+    }
 
     return super.attachUsageContext(usageContext);
   }

--- a/packages/core/src/dialects/abstract/query-interface.d.ts
+++ b/packages/core/src/dialects/abstract/query-interface.d.ts
@@ -497,7 +497,7 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   /**
    * Inserts a new record
    */
-  insert(instance: Model | null, tableName: string, values: object, options?: QiInsertOptions): Promise<object>;
+  insert(instance: Model | null, tableName: TableName, values: object, options?: QiInsertOptions): Promise<object>;
 
   /**
    * Inserts or Updates a record in the database

--- a/packages/core/src/dialects/db2/data-types.ts
+++ b/packages/core/src/dialects/db2/data-types.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import maxBy from 'lodash/maxBy.js';
 import * as BaseTypes from '../abstract/data-types.js';
-import type { AcceptedDate, ToSqlOptions } from '../abstract/data-types.js';
+import type { AcceptedDate } from '../abstract/data-types.js';
 import type { AbstractDialect } from '../abstract/index.js';
 
 function removeUnsupportedIntegerOptions(dataType: BaseTypes.BaseIntegerDataType, dialect: AbstractDialect) {
@@ -36,7 +36,7 @@ export class BLOB extends BaseTypes.BLOB {
 }
 
 export class STRING extends BaseTypes.STRING {
-  toSql(options: ToSqlOptions) {
+  toSql() {
     const length = this.options.length ?? 255;
 
     if (this.options.binary) {
@@ -44,7 +44,7 @@ export class STRING extends BaseTypes.STRING {
         return `VARCHAR(${length}) FOR BIT DATA`;
       }
 
-      throw new Error(`${options.dialect.name} does not support the BINARY option for data types with a length greater than 4000.`);
+      throw new Error(`${this._getDialect().name} does not support the BINARY option for data types with a length greater than 4000.`);
     }
 
     if (length <= 4000) {

--- a/packages/core/src/dialects/ibmi/query-generator.js
+++ b/packages/core/src/dialects/ibmi/query-generator.js
@@ -318,7 +318,7 @@ export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
       const format = (value === null && options.where);
 
       // use default escape mechanism instead of the DataType's.
-      return SqlString.escape(value, this.options.timezone, this.dialect, format);
+      return SqlString.escape(value, this.dialect, format);
     }
 
     if (!attribute.type.belongsToDialect(this.dialect)) {

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -457,6 +457,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
   }
 
   upsertQuery(tableName, insertValues, updateValues, where, model, options) {
+    // TODO: support TableNameWithSchema objects
     const targetTableAlias = this.quoteTable(`${tableName}_target`);
     const sourceTableAlias = this.quoteTable(`${tableName}_source`);
     const primaryKeysColumns = [];

--- a/packages/core/src/dialects/mysql/data-types.ts
+++ b/packages/core/src/dialects/mysql/data-types.ts
@@ -7,8 +7,6 @@ import { isValidTimeZone } from '../../utils/dayjs';
 import * as BaseTypes from '../abstract/data-types.js';
 import type {
   AcceptedDate,
-  StringifyOptions,
-  ToSqlOptions,
   BindParamOptions,
 } from '../abstract/data-types.js';
 
@@ -92,8 +90,8 @@ export class BOOLEAN extends BaseTypes.BOOLEAN {
 }
 
 export class DATE extends BaseTypes.DATE {
-  toBindableValue(date: AcceptedDate, options: StringifyOptions) {
-    date = this._applyTimezone(date, options);
+  toBindableValue(date: AcceptedDate) {
+    date = this._applyTimezone(date);
 
     return date.format('YYYY-MM-DD HH:mm:ss.SSS');
   }
@@ -119,8 +117,8 @@ export class UUID extends BaseTypes.UUID {
 }
 
 export class GEOMETRY extends BaseTypes.GEOMETRY {
-  toBindableValue(value: GeoJson, options: StringifyOptions) {
-    return `ST_GeomFromText(${options.dialect.escapeString(
+  toBindableValue(value: GeoJson) {
+    return `ST_GeomFromText(${this._getDialect().escapeString(
       wkx.Geometry.parseGeoJSON(value).toWkt(),
     )})`;
   }
@@ -137,7 +135,9 @@ export class GEOMETRY extends BaseTypes.GEOMETRY {
 }
 
 export class ENUM<Member extends string> extends BaseTypes.ENUM<Member> {
-  toSql(options: ToSqlOptions) {
-    return `ENUM(${this.options.values.map(value => options.dialect.escapeString(value)).join(', ')})`;
+  toSql() {
+    const dialect = this._getDialect();
+
+    return `ENUM(${this.options.values.map(value => dialect.escapeString(value)).join(', ')})`;
   }
 }

--- a/packages/core/src/dialects/postgres/data-types.ts
+++ b/packages/core/src/dialects/postgres/data-types.ts
@@ -1,14 +1,15 @@
 import assert from 'node:assert';
 import wkx from 'wkx';
 import type { Rangable } from '../../model.js';
-import { isString } from '../../utils/check.js';
+import { isBigInt, isNumber, isString } from '../../utils/check.js';
+import * as BaseTypes from '../abstract/data-types';
 import type {
   AcceptableTypeOf,
-  StringifyOptions,
   BindParamOptions,
   AcceptedDate,
+  AbstractDataType,
 } from '../abstract/data-types';
-import * as BaseTypes from '../abstract/data-types';
+import { attributeTypeToSql } from '../abstract/data-types-utils.js';
 import type { AbstractDialect } from '../abstract/index.js';
 import * as Hstore from './hstore';
 import { PostgresQueryGenerator } from './query-generator';
@@ -24,7 +25,7 @@ function removeUnsupportedIntegerOptions(dataType: BaseTypes.BaseIntegerDataType
 }
 
 export class DATEONLY extends BaseTypes.DATEONLY {
-  toBindableValue(value: AcceptableTypeOf<BaseTypes.DATEONLY>, options: StringifyOptions) {
+  toBindableValue(value: AcceptableTypeOf<BaseTypes.DATEONLY>) {
     if (value === Number.POSITIVE_INFINITY) {
       return 'infinity';
     }
@@ -33,12 +34,12 @@ export class DATEONLY extends BaseTypes.DATEONLY {
       return '-infinity';
     }
 
-    return super.toBindableValue(value, options);
+    return super.toBindableValue(value);
   }
 
   sanitize(value: unknown): unknown {
     if (value === Number.POSITIVE_INFINITY
-        || value === Number.NEGATIVE_INFINITY) {
+      || value === Number.NEGATIVE_INFINITY) {
       return value;
     }
 
@@ -87,7 +88,7 @@ export class DATE extends BaseTypes.DATE {
 
   validate(value: any) {
     if (value === Number.POSITIVE_INFINITY
-        || value === Number.NEGATIVE_INFINITY) {
+      || value === Number.NEGATIVE_INFINITY) {
       // valid
       return;
     }
@@ -95,10 +96,7 @@ export class DATE extends BaseTypes.DATE {
     super.validate(value);
   }
 
-  toBindableValue(
-    value: AcceptedDate,
-    options: StringifyOptions,
-  ): string {
+  toBindableValue(value: AcceptedDate): string {
     if (value === Number.POSITIVE_INFINITY) {
       return 'infinity';
     }
@@ -107,7 +105,7 @@ export class DATE extends BaseTypes.DATE {
       return '-infinity';
     }
 
-    return super.toBindableValue(value, options);
+    return super.toBindableValue(value);
   }
 
   sanitize(value: unknown) {
@@ -258,8 +256,8 @@ export class GEOMETRY extends BaseTypes.GEOMETRY {
     return wkx.Geometry.parse(b).toGeoJSON({ shortCrs: true });
   }
 
-  toBindableValue(value: AcceptableTypeOf<BaseTypes.GEOMETRY>, options: StringifyOptions): string {
-    return `ST_GeomFromGeoJSON(${options.dialect.escapeString(JSON.stringify(value))})`;
+  toBindableValue(value: AcceptableTypeOf<BaseTypes.GEOMETRY>): string {
+    return `ST_GeomFromGeoJSON(${this._getDialect().escapeString(JSON.stringify(value))})`;
   }
 
   getBindParamSql(value: AcceptableTypeOf<BaseTypes.GEOMETRY>, options: BindParamOptions) {
@@ -282,11 +280,8 @@ export class GEOGRAPHY extends BaseTypes.GEOGRAPHY {
     return result;
   }
 
-  toBindableValue(
-    value: AcceptableTypeOf<BaseTypes.GEOGRAPHY>,
-    options: StringifyOptions,
-  ) {
-    return `ST_GeomFromGeoJSON(${options.dialect.escapeString(JSON.stringify(value))})`;
+  toBindableValue(value: AcceptableTypeOf<BaseTypes.GEOGRAPHY>) {
+    return `ST_GeomFromGeoJSON(${this._getDialect().escapeString(JSON.stringify(value))})`;
   }
 
   getBindParamSql(value: AcceptableTypeOf<BaseTypes.GEOGRAPHY>, options: BindParamOptions) {
@@ -305,91 +300,78 @@ export class HSTORE extends BaseTypes.HSTORE {
 }
 
 export class RANGE<T extends BaseTypes.BaseNumberDataType | DATE | DATEONLY = INTEGER> extends BaseTypes.RANGE<T> {
-  toBindableValue(values: Rangable<AcceptableTypeOf<T>>, options: StringifyOptions) {
+  toBindableValue(values: Rangable<AcceptableTypeOf<T>>): string {
     if (!Array.isArray(values)) {
-      return this.options.subtype.toBindableValue(values, options);
+      throw new TypeError('Range values must be an array');
     }
 
     return RangeParser.stringify(values, rangePart => {
-      const out = this.options.subtype.toBindableValue(rangePart, options);
+      let out = this.options.subtype.toBindableValue(rangePart);
+
+      if (isNumber(out) || isBigInt(out)) {
+        out = String(out);
+      }
 
       if (!isString(out)) {
-        throw new Error('DataTypes.RANGE only accepts types that can be stringified.');
+        throw new Error('DataTypes.RANGE only accepts types that are represented by either strings, numbers or bigints.');
       }
 
       return out;
     });
   }
 
-  escape(values: Rangable<AcceptableTypeOf<T>>, options: StringifyOptions): string {
-    const value = this.toBindableValue(values, options);
-    if (!Array.isArray(values)) {
-      return `'${value}'::${this.#toCastType()}`;
-    }
+  escape(values: Rangable<AcceptableTypeOf<T>>): string {
+    const value = this.toBindableValue(values);
+    const dialect = this._getDialect();
 
-    return `'${value}'`;
+    return dialect.escapeString(value);
   }
 
   getBindParamSql(
     values: Rangable<AcceptableTypeOf<T>>,
     options: BindParamOptions,
   ): string {
-    const value = this.toBindableValue(values, options);
-    if (!Array.isArray(values)) {
-      return `${options.bindParam(value ?? '')}::${this.#toCastType()}`;
-    }
+    const value = this.toBindableValue(values);
 
-    return options.bindParam(value);
+    return `${options.bindParam(value)}::${this.toSql()}`;
   }
 
   toSql() {
     const subTypeClass = this.options.subtype.constructor as typeof BaseTypes.AbstractDataType;
 
-    return RANGE.typeMap.subTypes[subTypeClass.getDataTypeId().toLowerCase()];
+    return RANGE.typeMap[subTypeClass.getDataTypeId().toLowerCase()];
   }
 
-  #toCastType(): string {
-    const subTypeClass = this.options.subtype.constructor as typeof BaseTypes.AbstractDataType;
-
-    return RANGE.typeMap.castTypes[subTypeClass.getDataTypeId().toLowerCase()];
-  }
-
-  static typeMap: { subTypes: Record<string, string>, castTypes: Record<string, string> } = {
-    subTypes: {
-      integer: 'int4range',
-      decimal: 'numrange',
-      date: 'tstzrange',
-      dateonly: 'daterange',
-      bigint: 'int8range',
-    },
-    castTypes: {
-      integer: 'int4',
-      decimal: 'numeric',
-      date: 'timestamptz',
-      dateonly: 'date',
-      bigint: 'int8',
-    },
+  static typeMap: Record<string, string> = {
+    integer: 'int4range',
+    decimal: 'numrange',
+    date: 'tstzrange',
+    dateonly: 'daterange',
+    bigint: 'int8range',
   };
 }
 
 export class ARRAY<T extends BaseTypes.AbstractDataType<any>> extends BaseTypes.ARRAY<T> {
-  escape(
-    values: Array<AcceptableTypeOf<T>>,
-    options: StringifyOptions,
-  ) {
+  escape(values: Array<AcceptableTypeOf<T>>) {
     const type = this.options.type;
 
-    return `ARRAY[${values.map((value: any) => {
-      return type.escape(value, options);
-    }).join(',')}]::${type.toSql(options)}[]`;
+    const mappedValues = isString(type) ? values : values.map(value => type.escape(value));
+
+    return `ARRAY[${mappedValues.join(',')}]::${attributeTypeToSql(type)}[]`;
   }
 
   getBindParamSql(
     values: Array<AcceptableTypeOf<T>>,
     options: BindParamOptions,
   ) {
+    if (isString(this.options.type)) {
+      return options.bindParam(values);
+    }
+
+    const subType: AbstractDataType<any> = this.options.type;
+
     return options.bindParam(values.map((value: any) => {
-      return this.options.type.toBindableValue(value, options);
+      return subType.toBindableValue(value);
     }));
   }
 }

--- a/packages/core/src/dialects/snowflake/data-types.ts
+++ b/packages/core/src/dialects/snowflake/data-types.ts
@@ -1,6 +1,6 @@
 import maxBy from 'lodash/maxBy.js';
 import * as BaseTypes from '../abstract/data-types.js';
-import type { AcceptedDate, StringifyOptions } from '../abstract/data-types.js';
+import type { AcceptedDate } from '../abstract/data-types.js';
 import type { AbstractDialect } from '../abstract/index.js';
 
 export class DATE extends BaseTypes.DATE {
@@ -8,8 +8,8 @@ export class DATE extends BaseTypes.DATE {
     return `TIMESTAMP${this.options.precision != null ? `(${this.options.precision})` : ''}`;
   }
 
-  toBindableValue(date: AcceptedDate, options: StringifyOptions) {
-    date = this._applyTimezone(date, options);
+  toBindableValue(date: AcceptedDate) {
+    date = this._applyTimezone(date);
 
     return date.format('YYYY-MM-DD HH:mm:ss.SSS');
   }
@@ -38,8 +38,8 @@ export class TEXT extends BaseTypes.TEXT {
 }
 
 export class JSON extends BaseTypes.JSON {
-  escape(value: unknown, options: StringifyOptions) {
-    return options.operation === 'where' && typeof value === 'string' ? value : globalThis.JSON.stringify(value);
+  escape(value: unknown) {
+    return globalThis.JSON.stringify(value);
   }
 }
 

--- a/packages/core/src/instance-validator.js
+++ b/packages/core/src/instance-validator.js
@@ -387,7 +387,7 @@ export class InstanceValidator {
 
     const type = attribute.type;
     if (value != null && !(value instanceof BaseSqlExpression) && type instanceof AbstractDataType) {
-      const error = validateDataType(type, attributeName, this.modelInstance, value);
+      const error = validateDataType(value, type, attributeName, this.modelInstance);
       if (error) {
         this.errors.push(error);
       }

--- a/packages/core/src/model-definition.ts
+++ b/packages/core/src/model-definition.ts
@@ -505,7 +505,7 @@ Timestamp attributes are managed automatically by Sequelize, and their nullabili
         if (builtAttribute.type instanceof AbstractDataType) {
           // @ts-expect-error -- defaultValue is not readOnly yet!
           builtAttribute.type
-            = builtAttribute.type.clone().attachUsageContext({
+            = builtAttribute.type.withUsageContext({
               // TODO: Repository Pattern - replace with ModelDefinition
               model: this.#model,
               attributeName,
@@ -520,7 +520,7 @@ Timestamp attributes are managed automatically by Sequelize, and their nullabili
               = new builtAttribute.defaultValue();
           }
 
-          this.#defaultValues.set(attributeName, () => toDefaultValue(builtAttribute.defaultValue, this.sequelize.dialect));
+          this.#defaultValues.set(attributeName, () => toDefaultValue(builtAttribute.defaultValue));
         }
 
         // TODO: remove "notNull" & "isNull" validators

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -11,7 +11,7 @@ import type {
   HasOneOptions,
 } from './associations/index';
 import type { Deferrable } from './deferrable';
-import type { AbstractDataType, DataType } from './dialects/abstract/data-types.js';
+import type { DataType, NormalizedDataType } from './dialects/abstract/data-types.js';
 import type {
   IndexOptions,
   TableName,
@@ -1876,7 +1876,7 @@ export interface NormalizedAttributeOptions<M extends Model = Model> extends Rea
   /**
    * Like {@link AttributeOptions.type}, but normalized.
    */
-  readonly type: string | AbstractDataType<any>;
+  readonly type: NormalizedDataType;
   readonly references?: NormalizedAttributeReferencesOptions;
 }
 
@@ -2436,7 +2436,7 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   ): Promise<M>;
   static findByPk<M extends Model>(
     this: ModelStatic<M>,
-    identifier?: unknown,
+    identifier: unknown,
     options?: FindByPkOptions<M>
   ): Promise<M | null>;
 

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -165,23 +165,23 @@ export class Model extends ModelTypeScript {
       const { createdAt: createdAtAttrName, updatedAt: updatedAtAttrName, deletedAt: deletedAtAttrName } = modelDefinition.timestampAttributeNames;
 
       if (createdAtAttrName && defaults[createdAtAttrName]) {
-        this.dataValues[createdAtAttrName] = toDefaultValue(defaults[createdAtAttrName], this.sequelize.dialect);
+        this.dataValues[createdAtAttrName] = toDefaultValue(defaults[createdAtAttrName]);
         delete defaults[createdAtAttrName];
       }
 
       if (updatedAtAttrName && defaults[updatedAtAttrName]) {
-        this.dataValues[updatedAtAttrName] = toDefaultValue(defaults[updatedAtAttrName], this.sequelize.dialect);
+        this.dataValues[updatedAtAttrName] = toDefaultValue(defaults[updatedAtAttrName]);
         delete defaults[updatedAtAttrName];
       }
 
       if (deletedAtAttrName && defaults[deletedAtAttrName]) {
-        this.dataValues[deletedAtAttrName] = toDefaultValue(defaults[deletedAtAttrName], this.sequelize.dialect);
+        this.dataValues[deletedAtAttrName] = toDefaultValue(defaults[deletedAtAttrName]);
         delete defaults[deletedAtAttrName];
       }
 
       for (const key in defaults) {
         if (values[key] === undefined) {
-          this.set(key, toDefaultValue(defaults[key], this.sequelize.dialect), { raw: true });
+          this.set(key, toDefaultValue(defaults[key]), { raw: true });
           delete values[key];
         }
       }
@@ -2808,7 +2808,7 @@ ${associationOwner._getAssociationDebugList()}`);
 
     const attribute = attributes.get(attributeName);
     if (attribute?.defaultValue) {
-      return toDefaultValue(attribute.defaultValue, this.sequelize.dialect);
+      return toDefaultValue(attribute.defaultValue);
     }
   }
 
@@ -3888,7 +3888,7 @@ Instead of specifying a Model, either:
       throw new Error('You attempted to update an instance that is not persisted.');
     }
 
-    options = options || {};
+    options = options || EMPTY_OBJECT;
     if (Array.isArray(options)) {
       options = { fields: options };
     }

--- a/packages/core/src/sql-string.ts
+++ b/packages/core/src/sql-string.ts
@@ -3,7 +3,7 @@ import type { AbstractDataType } from './dialects/abstract/data-types.js';
 import type { AbstractDialect } from './dialects/abstract/index.js';
 import { logger } from './utils/logger';
 
-function arrayToList(array: unknown[], timeZone: string | undefined, dialect: AbstractDialect, format: boolean) {
+function arrayToList(array: unknown[], dialect: AbstractDialect, format: boolean) {
   // TODO: rewrite
   // eslint-disable-next-line unicorn/no-array-reduce
   return array.reduce((sql: string, val, i) => {
@@ -12,9 +12,9 @@ function arrayToList(array: unknown[], timeZone: string | undefined, dialect: Ab
     }
 
     if (Array.isArray(val)) {
-      sql += `(${arrayToList(val, timeZone, dialect, format)})`;
+      sql += `(${arrayToList(val, dialect, format)})`;
     } else {
-      sql += escape(val, timeZone, dialect, format);
+      sql += escape(val, dialect, format);
     }
 
     return sql;
@@ -84,7 +84,6 @@ function bestGuessDataTypeOfVal(val: unknown, dialect: AbstractDialect): Abstrac
 
 export function escape(
   val: unknown,
-  timeZone: string | undefined,
   dialect: AbstractDialect,
   format: boolean = false,
 ): string {
@@ -101,13 +100,10 @@ export function escape(
   }
 
   if (Array.isArray(val) && (dialectName !== 'postgres' || format)) {
-    return arrayToList(val, timeZone, dialect, format);
+    return arrayToList(val, dialect, format);
   }
 
   const dataType = bestGuessDataTypeOfVal(val, dialect);
 
-  return dataType.escape(val, {
-    dialect,
-    timezone: timeZone,
-  });
+  return dataType.escape(val);
 }

--- a/packages/core/src/utils/dialect.ts
+++ b/packages/core/src/utils/dialect.ts
@@ -2,15 +2,14 @@ import { randomUUID } from 'node:crypto';
 import NodeUtil from 'node:util';
 import isPlainObject from 'lodash/isPlainObject';
 import { v1 as uuidv1 } from 'uuid';
-import type { AbstractDialect } from '../dialects/abstract';
 import * as DataTypes from '../dialects/abstract/data-types.js';
 import { isString } from './check.js';
 
-export function toDefaultValue(value: unknown, dialect: AbstractDialect): unknown {
+export function toDefaultValue(value: unknown): unknown {
   if (typeof value === 'function') {
     const tmp = value();
     if (tmp instanceof DataTypes.AbstractDataType) {
-      return tmp.toSql({ dialect });
+      return tmp.toSql();
     }
 
     return tmp;

--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -203,7 +203,7 @@ function mapBindParametersAndReplacements(
         throw new Error(`Named replacement ":${replacementName}" has no entry in the replacement map.`);
       }
 
-      const escapedReplacement = escapeSqlValue(replacementValue, undefined, dialect, true);
+      const escapedReplacement = escapeSqlValue(replacementValue, dialect, true);
 
       // add everything before the bind parameter name
       output += sqlString.slice(previousSliceEnd, i);
@@ -244,7 +244,7 @@ function mapBindParametersAndReplacements(
         throw new Error(`Positional replacement (?) ${replacementIndex} has no entry in the replacement map (replacements[${replacementIndex}] is undefined).`);
       }
 
-      const escapedReplacement = escapeSqlValue(replacementValue, undefined, dialect, true);
+      const escapedReplacement = escapeSqlValue(replacementValue, dialect, true);
 
       // add everything before the bind parameter name
       output += sqlString.slice(previousSliceEnd, i);

--- a/packages/core/test/integration/model.test.js
+++ b/packages/core/test/integration/model.test.js
@@ -451,7 +451,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
       await this.sequelize.sync();
       await this.sequelize.sync(); // The second call should not try to create the indices again
-      const args = await this.sequelize.queryInterface.showIndex(Model.tableName);
+      const args = await this.sequelize.queryInterface.showIndex(Model.table);
       let primary;
       let idx1;
       let idx2;

--- a/packages/core/test/integration/model/attributes/types.test.js
+++ b/packages/core/test/integration/model/attributes/types.test.js
@@ -63,7 +63,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         });
 
         it('should be ignored in table creation', async function () {
-          const fields = await this.sequelize.getQueryInterface().describeTable(this.User.tableName);
+          const fields = await this.sequelize.getQueryInterface().describeTable(this.User.table);
           expect(Object.keys(fields).length).to.equal(2);
         });
 

--- a/packages/core/test/integration/model/create.test.js
+++ b/packages/core/test/integration/model/create.test.js
@@ -541,7 +541,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               },
             })).to.be.rejectedWith(Sequelize.UniqueConstraintError);
 
-            expect(error instanceof Sequelize.UniqueConstraintError).to.be.ok;
             expect(error.fields).to.be.ok;
           })(),
           (async () => {
@@ -554,7 +553,6 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               },
             })).to.be.rejectedWith(Sequelize.UniqueConstraintError);
 
-            expect(error instanceof Sequelize.UniqueConstraintError).to.be.ok;
             expect(error.fields).to.be.ok;
           })(),
         ]);

--- a/packages/core/test/integration/model/searchPath.test.js
+++ b/packages/core/test/integration/model/searchPath.test.js
@@ -53,14 +53,10 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       beforeEach('build restaurant tables', async function () {
         const Restaurant = this.Restaurant;
 
-        try {
-          await current.createSchema('schema_one');
-          await current.createSchema('schema_two');
-          await Restaurant.sync({ force: true, searchPath: SEARCH_PATH_ONE });
-          await Restaurant.sync({ force: true, searchPath: SEARCH_PATH_TWO });
-        } catch (error) {
-          expect(error).to.be.null;
-        }
+        await current.createSchema('schema_one');
+        await current.createSchema('schema_two');
+        await Restaurant.sync({ force: true, searchPath: SEARCH_PATH_ONE });
+        await Restaurant.sync({ force: true, searchPath: SEARCH_PATH_TWO });
       });
 
       afterEach('drop schemas', async () => {
@@ -241,16 +237,12 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         beforeEach(async function () {
           const Location = this.Location;
 
-          try {
-            await Location.sync({ force: true });
-            await Location.create({ name: 'HQ' });
-            const obj = await Location.findOne({ where: { name: 'HQ' } });
-            expect(obj).to.not.be.null;
-            expect(obj.name).to.equal('HQ');
-            locationId = obj.id;
-          } catch (error) {
-            expect(error).to.be.null;
-          }
+          await Location.sync({ force: true });
+          await Location.create({ name: 'HQ' });
+          const obj = await Location.findOne({ where: { name: 'HQ' } });
+          expect(obj).to.not.be.null;
+          expect(obj.name).to.equal('HQ');
+          locationId = obj.id;
         });
 
         it('should be able to insert and retrieve associated data into the table in schema_one', async function () {
@@ -300,12 +292,8 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         beforeEach(async function () {
           const Employee = this.Employee;
 
-          try {
-            await Employee.sync({ force: true, searchPath: SEARCH_PATH_ONE });
-            await Employee.sync({ force: true, searchPath: SEARCH_PATH_TWO });
-          } catch (error) {
-            expect(error).to.be.null;
-          }
+          await Employee.sync({ force: true, searchPath: SEARCH_PATH_ONE });
+          await Employee.sync({ force: true, searchPath: SEARCH_PATH_TWO });
         });
 
         it('should be able to insert and retrieve associated data into the table in schema_one', async function () {

--- a/packages/core/test/support.ts
+++ b/packages/core/test/support.ts
@@ -47,7 +47,11 @@ function withInlineCause(cb: (() => any)): () => void {
   };
 }
 
-function inlineErrorCause(error: Error) {
+function inlineErrorCause(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return String(error);
+  }
+
   let message = error.message;
 
   // eslint-disable-next-line @typescript-eslint/prefer-ts-expect-error
@@ -332,9 +336,9 @@ export function expectPerDialect<Out>(
   if (expectation instanceof Error) {
     assert(result instanceof Error, `Expected method to error with "${expectation.message}", but it returned ${inspect(result)}.`);
 
-    expect(result.message).to.equal(expectation.message);
+    expect(inlineErrorCause(result)).to.include(expectation.message);
   } else {
-    assert(!(result instanceof Error), `Did not expect query to error, but it errored with ${result instanceof Error ? result.message : ''}`);
+    assert(!(result instanceof Error), `Did not expect query to error, but it errored with ${inlineErrorCause(result)}`);
 
     assertMatchesExpectation(result, expectation);
   }
@@ -483,9 +487,9 @@ export function expectsql(
   if (expectation instanceof Error) {
     assert(query instanceof Error, `Expected query to error with "${expectation.message}", but it is equal to ${JSON.stringify(query)}.`);
 
-    expect(query.message).to.equal(expectation.message);
+    expect(inlineErrorCause(query)).to.include(expectation.message);
   } else {
-    assert(!(query instanceof Error), `Expected query to equal ${minifySql(expectation)}, but it errored with ${query instanceof Error ? query.message : ''}`);
+    assert(!(query instanceof Error), `Expected query to equal:\n${minifySql(expectation)}\n\nBut it errored with:\n${inlineErrorCause(query)}`);
 
     expect(minifySql(isObject(query) ? query.query : query)).to.equal(minifySql(expectation));
   }

--- a/packages/core/test/types/models/user.ts
+++ b/packages/core/test/types/models/user.ts
@@ -85,7 +85,7 @@ User.init(
 );
 
 User.afterSync(() => {
-  sequelize.getQueryInterface().addIndex(User.tableName, {
+  sequelize.getQueryInterface().addIndex(User.table, {
     fields: ['lastName'],
     using: 'BTREE',
     name: 'lastNameIdx',

--- a/packages/core/test/unit/data-types/_utils.ts
+++ b/packages/core/test/unit/data-types/_utils.ts
@@ -7,7 +7,7 @@ export const testDataTypeSql = createTester((it, description: string, dataType: 
     let result: Error | string;
 
     try {
-      result = typeof dataType === 'string' ? dataType : sequelize.normalizeDataType(dataType).toSql({ dialect: sequelize.dialect });
+      result = typeof dataType === 'string' ? dataType : sequelize.normalizeDataType(dataType).toSql();
     } catch (error) {
       assert(error instanceof Error);
       result = error;

--- a/packages/core/test/unit/data-types/misc-data-types.test.ts
+++ b/packages/core/test/unit/data-types/misc-data-types.test.ts
@@ -6,7 +6,6 @@ import { expectsql, sequelize, getTestDialect } from '../../support';
 import { testDataTypeSql } from './_utils';
 
 const dialectName = getTestDialect();
-const dialect = sequelize.dialect;
 
 describe('DataTypes.BOOLEAN', () => {
   testDataTypeSql('BOOLEAN', DataTypes.BOOLEAN, {
@@ -49,7 +48,7 @@ describe('DataTypes.ENUM', () => {
     const enumType = User.getAttributes().anEnum.type;
     assert(typeof enumType !== 'string');
 
-    expectsql(enumType.toSql({ dialect }), {
+    expectsql(enumType.toSql(), {
       postgres: '"public"."enum_Users_anEnum"',
       'mysql mariadb': `ENUM('value 1', 'value 2')`,
       // SQL Server does not support enums, we use text + a check constraint instead

--- a/packages/core/test/unit/data-types/temporal-types.test.ts
+++ b/packages/core/test/unit/data-types/temporal-types.test.ts
@@ -80,8 +80,8 @@ describe('DataTypes.DATE', () => {
   describe('toBindableValue', () => {
     if (dialect.supports.dataTypes.DATETIME.infinity) {
       it('stringifies numeric Infinity/-Infinity', () => {
-        expect(type.toBindableValue(Number.POSITIVE_INFINITY, { dialect })).to.equal('infinity');
-        expect(type.toBindableValue(Number.NEGATIVE_INFINITY, { dialect })).to.equal('-infinity');
+        expect(type.toBindableValue(Number.POSITIVE_INFINITY)).to.equal('infinity');
+        expect(type.toBindableValue(Number.NEGATIVE_INFINITY)).to.equal('-infinity');
       });
     }
   });
@@ -99,8 +99,8 @@ describe('DataTypes.DATEONLY', () => {
   describe('validate', () => {
     if (dialect.supports.dataTypes.DATEONLY.infinity) {
       it('DATEONLY should stringify Infinity/-Infinity to infinity/-infinity', () => {
-        expect(type.toBindableValue(Number.POSITIVE_INFINITY, { dialect })).to.equal('infinity');
-        expect(type.toBindableValue(Number.NEGATIVE_INFINITY, { dialect })).to.equal('-infinity');
+        expect(type.toBindableValue(Number.POSITIVE_INFINITY)).to.equal('infinity');
+        expect(type.toBindableValue(Number.NEGATIVE_INFINITY)).to.equal('-infinity');
       });
     }
   });

--- a/packages/core/test/unit/query-generator/add-column-query.test.ts
+++ b/packages/core/test/unit/query-generator/add-column-query.test.ts
@@ -12,7 +12,7 @@ describe('QueryGenerator#addColumnQuery', () => {
   }, { timestamps: false });
 
   it('generates a ADD COLUMN query in supported dialects', () => {
-    expectsql(() => queryGenerator.addColumnQuery(User.tableName, 'age', {
+    expectsql(() => queryGenerator.addColumnQuery(User.table, 'age', {
       type: DataTypes.INTEGER,
     }), {
       default: `ALTER TABLE [Users] ADD [age] INTEGER;`,
@@ -22,7 +22,7 @@ describe('QueryGenerator#addColumnQuery', () => {
   });
 
   it('generates a ADD COLUMN IF NOT EXISTS query in supported dialects', () => {
-    expectsql(() => queryGenerator.addColumnQuery(User.tableName, 'age', {
+    expectsql(() => queryGenerator.addColumnQuery(User.table, 'age', {
       type: DataTypes.INTEGER,
     }, { ifNotExists: true }), {
       default: buildInvalidOptionReceivedError('addColumnQuery', dialectName, ['ifNotExists']),

--- a/packages/core/test/unit/query-generator/arithmetic-query.test.ts
+++ b/packages/core/test/unit/query-generator/arithmetic-query.test.ts
@@ -80,7 +80,7 @@ describe('QueryGenerator#arithmeticQuery', () => {
   it('parses named replacements in literals', async () => {
     const sql = queryGenerator.arithmeticQuery(
       '+',
-      User.tableName,
+      User.table,
       // where
       literal('id = :id'),
       // increment by field

--- a/packages/core/test/unit/query-generator/bulk-insert-query.test.ts
+++ b/packages/core/test/unit/query-generator/bulk-insert-query.test.ts
@@ -9,7 +9,7 @@ describe('QueryGenerator#bulkInsertQuery', () => {
   }, { timestamps: false });
 
   it('parses named replacements in literals', async () => {
-    const sql = queryGenerator.bulkInsertQuery(User.tableName, [{
+    const sql = queryGenerator.bulkInsertQuery(User.table, [{
       firstName: literal(':injection'),
     }], {
       replacements: {

--- a/packages/core/test/unit/query-generator/delete-query.test.ts
+++ b/packages/core/test/unit/query-generator/delete-query.test.ts
@@ -11,7 +11,7 @@ describe('QueryGenerator#deleteQuery', () => {
   // you'll find more replacement tests in query-generator tests
   it('parses named replacements in literals', async () => {
     const query = queryGenerator.deleteQuery(
-      User.tableName,
+      User.table,
       literal('name = :name'),
       {
         limit: literal(':limit'),

--- a/packages/core/test/unit/query-generator/insert-query.test.ts
+++ b/packages/core/test/unit/query-generator/insert-query.test.ts
@@ -11,7 +11,7 @@ describe('QueryGenerator#insertQuery', () => {
 
   // you'll find more replacement tests in query-generator tests
   it('parses named replacements in literals', () => {
-    const { query, bind } = queryGenerator.insertQuery(User.tableName, {
+    const { query, bind } = queryGenerator.insertQuery(User.table, {
       firstName: literal(':name'),
     }, {}, {
       replacements: {
@@ -29,7 +29,7 @@ describe('QueryGenerator#insertQuery', () => {
   });
 
   it('supports named bind parameters in literals', () => {
-    const { query, bind } = queryGenerator.insertQuery(User.tableName, {
+    const { query, bind } = queryGenerator.insertQuery(User.table, {
       firstName: 'John',
       lastName: literal('$lastName'),
       username: 'jd',
@@ -48,7 +48,7 @@ describe('QueryGenerator#insertQuery', () => {
   });
 
   it('parses positional bind parameters in literals', () => {
-    const { query, bind } = queryGenerator.insertQuery(User.tableName, {
+    const { query, bind } = queryGenerator.insertQuery(User.table, {
       firstName: 'John',
       lastName: literal('$1'),
       username: 'jd',
@@ -67,7 +67,7 @@ describe('QueryGenerator#insertQuery', () => {
   });
 
   it('parses bind parameters in literals even with bindParams: false', () => {
-    const { query, bind } = queryGenerator.insertQuery(User.tableName, {
+    const { query, bind } = queryGenerator.insertQuery(User.table, {
       firstName: 'John',
       lastName: literal('$1'),
       username: 'jd',
@@ -86,7 +86,7 @@ describe('QueryGenerator#insertQuery', () => {
 
   describe('returning', () => {
     it('supports returning: true', () => {
-      const { query } = queryGenerator.insertQuery(User.tableName, {
+      const { query } = queryGenerator.insertQuery(User.table, {
         firstName: 'John',
       }, User.getAttributes(), {
         returning: true,
@@ -105,7 +105,7 @@ describe('QueryGenerator#insertQuery', () => {
     });
 
     it('supports array of strings (column names)', () => {
-      const { query } = queryGenerator.insertQuery(User.tableName, {
+      const { query } = queryGenerator.insertQuery(User.table, {
         firstName: 'John',
       }, User.getAttributes(), {
         returning: ['*', 'myColumn'],
@@ -127,7 +127,7 @@ describe('QueryGenerator#insertQuery', () => {
     it('supports array of literals', () => {
 
       expectsql(() => {
-        return queryGenerator.insertQuery(User.tableName, {
+        return queryGenerator.insertQuery(User.table, {
           firstName: 'John',
         }, User.getAttributes(), {
           returning: [literal('*')],

--- a/packages/core/test/unit/query-generator/remove-column-query.test.ts
+++ b/packages/core/test/unit/query-generator/remove-column-query.test.ts
@@ -13,7 +13,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
   }, { timestamps: false });
 
   it('generates a DROP COLUMN query in supported dialects', () => {
-    expectsql(() => queryGenerator.removeColumnQuery(User.tableName, 'age'), {
+    expectsql(() => queryGenerator.removeColumnQuery(User.table, 'age'), {
       default: `ALTER TABLE [Users] DROP COLUMN [age];`,
       postgres: `ALTER TABLE "Users" DROP COLUMN "age";`,
       snowflake: `ALTER TABLE "Users" DROP "age";`,
@@ -23,7 +23,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
   });
 
   it('generates a DROP COLUMN IF EXISTS query in supported dialects', () => {
-    expectsql(() => queryGenerator.removeColumnQuery(User.tableName, 'age', { ifExists: true }), {
+    expectsql(() => queryGenerator.removeColumnQuery(User.table, 'age', { ifExists: true }), {
       default: buildInvalidOptionReceivedError('removeColumnQuery', dialectName, ['ifExists']),
       mariadb: 'ALTER TABLE `Users` DROP IF EXISTS `age`;',
       mssql: 'ALTER TABLE [Users] DROP COLUMN IF EXISTS [age];',

--- a/packages/core/test/unit/query-generator/select-query.test.ts
+++ b/packages/core/test/unit/query-generator/select-query.test.ts
@@ -36,7 +36,7 @@ describe('QueryGenerator#selectQuery', () => {
   });
 
   it('supports offset without limit', () => {
-    const sql = queryGenerator.selectQuery(User.tableName, {
+    const sql = queryGenerator.selectQuery(User.table, {
       model: User,
       attributes: ['id'],
       offset: 1,
@@ -55,7 +55,7 @@ describe('QueryGenerator#selectQuery', () => {
   });
 
   it('supports querying for bigint values', () => {
-    const sql = queryGenerator.selectQuery(Project.tableName, {
+    const sql = queryGenerator.selectQuery(Project.table, {
       model: Project,
       attributes: ['id'],
       where: {
@@ -76,7 +76,7 @@ describe('QueryGenerator#selectQuery', () => {
   });
 
   it('supports cast in attributes', () => {
-    const sql = queryGenerator.selectQuery(User.tableName, {
+    const sql = queryGenerator.selectQuery(User.table, {
       model: User,
       attributes: [
         'id',
@@ -93,7 +93,7 @@ describe('QueryGenerator#selectQuery', () => {
     it('parses named replacements in literals', () => {
       // The goal of this test is to test that :replacements are parsed in literals in as many places as possible
 
-      const sql = queryGenerator.selectQuery(User.tableName, {
+      const sql = queryGenerator.selectQuery(User.table, {
         model: User,
         attributes: [[fn('uppercase', literal(':attr')), 'id'], literal(':attr2')],
         where: {
@@ -170,7 +170,7 @@ describe('QueryGenerator#selectQuery', () => {
     it('does not parse replacements in strings in literals', () => {
       // The goal of this test is to test that :replacements are parsed in literals in as many places as possible
 
-      const sql = queryGenerator.selectQuery(User.tableName, {
+      const sql = queryGenerator.selectQuery(User.table, {
         model: User,
         attributes: [literal('id')],
         where: literal(`id = ':id'`),
@@ -185,7 +185,7 @@ describe('QueryGenerator#selectQuery', () => {
     });
 
     it('parses named replacements in literals in includes', () => {
-      const sql = queryGenerator.selectQuery(User.tableName, {
+      const sql = queryGenerator.selectQuery(User.table, {
         model: User,
         attributes: ['id'],
         include: _validateIncludedElements({
@@ -256,7 +256,7 @@ describe('QueryGenerator#selectQuery', () => {
     });
 
     it(`parses named replacements in belongsToMany includes' through tables`, () => {
-      const sql = queryGenerator.selectQuery(Project.tableName, {
+      const sql = queryGenerator.selectQuery(Project.table, {
         model: Project,
         attributes: ['id'],
         include: _validateIncludedElements({
@@ -309,7 +309,7 @@ describe('QueryGenerator#selectQuery', () => {
     });
 
     it('parses named replacements in literals in includes (subQuery)', () => {
-      const sql = queryGenerator.selectQuery(User.tableName, {
+      const sql = queryGenerator.selectQuery(User.table, {
         model: User,
         attributes: ['id'],
         include: _validateIncludedElements({
@@ -428,7 +428,7 @@ describe('QueryGenerator#selectQuery', () => {
 
     it('rejects positional replacements, because their execution order is hard to determine', () => {
       expect(
-        () => queryGenerator.selectQuery(User.tableName, {
+        () => queryGenerator.selectQuery(User.table, {
           model: User,
           where: {
             username: {
@@ -443,7 +443,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     });
 
     it(`always escapes the attribute if it's provided as a string`, () => {
-      const sql = queryGenerator.selectQuery(User.tableName, {
+      const sql = queryGenerator.selectQuery(User.table, {
         model: User,
         attributes: [
           // these used to have special escaping logic, now they're always escaped like any other strings. col, fn, and literal can be used for advanced logic.
@@ -491,7 +491,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
     });
 
     it('supports a "having" option', () => {
-      const sql = queryGenerator.selectQuery(User.tableName, {
+      const sql = queryGenerator.selectQuery(User.table, {
         model: User,
         attributes: [
           literal('*'),
@@ -509,7 +509,7 @@ Only named replacements (:name) are allowed in literal() because we cannot guara
 
   describe('minifyAliases', () => {
     it('minifies custom attributes', () => {
-      const sql = queryGenerator.selectQuery(User.tableName, {
+      const sql = queryGenerator.selectQuery(User.table, {
         minifyAliases: true,
         model: User,
         attributes: [

--- a/packages/core/test/unit/query-generator/update-query.test.ts
+++ b/packages/core/test/unit/query-generator/update-query.test.ts
@@ -11,11 +11,9 @@ describe('QueryGenerator#updateQuery', () => {
 
   // you'll find more replacement tests in query-generator tests
   it('parses named replacements in literals', async () => {
-    const { query, bind } = queryGenerator.updateQuery(User.tableName, {
+    const { query, bind } = queryGenerator.updateQuery(User.table, {
       firstName: literal(':name'),
-    }, {
-      where: literal('name = :name'),
-    }, {
+    }, literal('name = :name'), {
       replacements: {
         name: 'Zoe',
       },
@@ -30,7 +28,7 @@ describe('QueryGenerator#updateQuery', () => {
   });
 
   it('generates extra bind params', async () => {
-    const { query, bind } = queryGenerator.updateQuery(User.tableName, {
+    const { query, bind } = queryGenerator.updateQuery(User.table, {
       firstName: 'John',
       lastName: literal('$1'),
       username: 'jd',
@@ -48,13 +46,11 @@ describe('QueryGenerator#updateQuery', () => {
   });
 
   it('does not generate extra bind params with bindParams: false', async () => {
-    const { query, bind } = queryGenerator.updateQuery(User.tableName, {
+    const { query, bind } = queryGenerator.updateQuery(User.table, {
       firstName: 'John',
       lastName: literal('$1'),
       username: 'jd',
-    }, {
-      where: literal('first_name = $2'),
-    }, {
+    }, literal('first_name = $2'), {
       bindParam: false,
     });
 

--- a/packages/core/test/unit/query-interface/bulk-delete.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-delete.test.ts
@@ -17,7 +17,7 @@ describe('QueryInterface#bulkDelete', () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
     await sequelize.getQueryInterface().bulkDelete(
-      User.tableName,
+      User.table,
       { firstName: ':id' },
       {
         replacements: {

--- a/packages/core/test/unit/query-interface/bulk-insert.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-insert.test.ts
@@ -17,7 +17,7 @@ describe('QueryInterface#bulkInsert', () => {
     const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
 
     const users = range(1000).map(i => ({ firstName: `user${i}` }));
-    await sequelize.getQueryInterface().bulkInsert(User.tableName, users);
+    await sequelize.getQueryInterface().bulkInsert(User.table, users);
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0).args[0];
@@ -34,7 +34,7 @@ describe('QueryInterface#bulkInsert', () => {
     const transaction = new Transaction(sequelize, {});
 
     const users = range(2000).map(i => ({ firstName: `user${i}` }));
-    await sequelize.getQueryInterface().bulkInsert(User.tableName, users, { transaction });
+    await sequelize.getQueryInterface().bulkInsert(User.table, users, { transaction });
 
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0).args[0];
@@ -50,7 +50,7 @@ describe('QueryInterface#bulkInsert', () => {
   it('does not parse replacements outside of raw sql', async () => {
     const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
 
-    await sequelize.getQueryInterface().bulkInsert(User.tableName, [{
+    await sequelize.getQueryInterface().bulkInsert(User.table, [{
       firstName: ':injection',
     }], {
       replacements: {

--- a/packages/core/test/unit/query-interface/bulk-update.test.ts
+++ b/packages/core/test/unit/query-interface/bulk-update.test.ts
@@ -17,7 +17,7 @@ describe('QueryInterface#bulkUpdate', () => {
     const stub = sinon.stub(sequelize, 'queryRaw').resolves([[], 0]);
 
     await sequelize.getQueryInterface().bulkUpdate(
-      User.tableName,
+      User.table,
       {
         // values
         firstName: ':injection',
@@ -51,7 +51,7 @@ describe('QueryInterface#bulkUpdate', () => {
     sinon.stub(sequelize, 'queryRaw');
 
     await expect(sequelize.getQueryInterface().bulkUpdate(
-      User.tableName,
+      User.table,
       {
         firstName: literal('$sequelize_test'),
       },
@@ -68,7 +68,7 @@ describe('QueryInterface#bulkUpdate', () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
     await sequelize.getQueryInterface().bulkUpdate(
-      User.tableName,
+      User.table,
       {
         firstName: 'newName',
       },
@@ -98,7 +98,7 @@ describe('QueryInterface#bulkUpdate', () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
     await sequelize.getQueryInterface().bulkUpdate(
-      User.tableName,
+      User.table,
       {
         firstName: 'newName',
       },

--- a/packages/core/test/unit/query-interface/decrement.test.ts
+++ b/packages/core/test/unit/query-interface/decrement.test.ts
@@ -18,9 +18,9 @@ describe('QueryInterface#decrement', () => {
 
     await sequelize.getQueryInterface().decrement(
       User,
-      User.tableName,
+      User.table,
       // where
-      { id: ':id' },
+      { firstName: ':firstName' },
       // incrementAmountsByField
       { age: ':age' },
       // extraAttributesToBeUpdated
@@ -39,9 +39,9 @@ describe('QueryInterface#decrement', () => {
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
     expectsql(firstCall.args[0] as string, {
-      default: `UPDATE [Users] SET [age]=[age]- ':age',[name]=':name' WHERE [id] = ':id'`,
-      postgres: `UPDATE "Users" SET "age"="age"- ':age',"name"=':name' WHERE "id" = ':id' RETURNING ":data"`,
-      mssql: `UPDATE [Users] SET [age]=[age]- N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [id] = N':id'`,
+      default: `UPDATE [Users] SET [age]=[age]- ':age',[name]=':name' WHERE [firstName] = ':firstName'`,
+      postgres: `UPDATE "Users" SET "age"="age"- ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
+      mssql: `UPDATE [Users] SET [age]=[age]- N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [firstName] = N':firstName'`,
     });
     expect(firstCall.args[1]?.bind).to.be.undefined;
   });

--- a/packages/core/test/unit/query-interface/delete.test.ts
+++ b/packages/core/test/unit/query-interface/delete.test.ts
@@ -20,7 +20,7 @@ describe('QueryInterface#delete', () => {
 
     await sequelize.getQueryInterface().delete(
       instance,
-      User.tableName,
+      User.table,
       { firstName: ':id' },
       {
         replacements: {

--- a/packages/core/test/unit/query-interface/increment.test.ts
+++ b/packages/core/test/unit/query-interface/increment.test.ts
@@ -18,9 +18,9 @@ describe('QueryInterface#increment', () => {
 
     await sequelize.getQueryInterface().increment(
       User,
-      User.tableName,
+      User.table,
       // where
-      { id: ':id' },
+      { firstName: ':firstName' },
       // incrementAmountsByField
       { age: ':age' },
       // extraAttributesToBeUpdated
@@ -39,9 +39,9 @@ describe('QueryInterface#increment', () => {
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
     expectsql(firstCall.args[0] as string, {
-      default: `UPDATE [Users] SET [age]=[age]+ ':age',[name]=':name' WHERE [id] = ':id'`,
-      postgres: `UPDATE "Users" SET "age"="age"+ ':age',"name"=':name' WHERE "id" = ':id' RETURNING ":data"`,
-      mssql: `UPDATE [Users] SET [age]=[age]+ N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [id] = N':id'`,
+      default: `UPDATE [Users] SET [age]=[age]+ ':age',[name]=':name' WHERE [firstName] = ':firstName'`,
+      postgres: `UPDATE "Users" SET "age"="age"+ ':age',"name"=':name' WHERE "firstName" = ':firstName' RETURNING ":data"`,
+      mssql: `UPDATE [Users] SET [age]=[age]+ N':age',[name]=N':name' OUTPUT INSERTED.[:data] WHERE [firstName] = N':firstName'`,
     });
     expect(firstCall.args[1]?.bind).to.be.undefined;
   });

--- a/packages/core/test/unit/query-interface/insert.test.ts
+++ b/packages/core/test/unit/query-interface/insert.test.ts
@@ -16,7 +16,7 @@ describe('QueryInterface#insert', () => {
   it('does not parse replacements outside of raw sql', async () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
-    await sequelize.getQueryInterface().insert(null, User.tableName, {
+    await sequelize.getQueryInterface().insert(null, User.table, {
       firstName: 'Zoe',
     }, {
       returning: [':data'],
@@ -42,7 +42,7 @@ describe('QueryInterface#insert', () => {
   it('throws if a bind parameter name starts with the reserved "sequelize_" prefix', async () => {
     sinon.stub(sequelize, 'queryRaw');
 
-    await expect(sequelize.getQueryInterface().insert(null, User.tableName, {
+    await expect(sequelize.getQueryInterface().insert(null, User.table, {
       firstName: literal('$sequelize_test'),
     }, {
       bind: {
@@ -54,7 +54,7 @@ describe('QueryInterface#insert', () => {
   it('merges user-provided bind parameters with sequelize-generated bind parameters (object bind)', async () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
-    await sequelize.getQueryInterface().insert(null, User.tableName, {
+    await sequelize.getQueryInterface().insert(null, User.table, {
       firstName: literal('$firstName'),
       lastName: 'Doe',
     }, {
@@ -80,7 +80,7 @@ describe('QueryInterface#insert', () => {
   it('merges user-provided bind parameters with sequelize-generated bind parameters (array bind)', async () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
-    await sequelize.getQueryInterface().insert(null, User.tableName, {
+    await sequelize.getQueryInterface().insert(null, User.table, {
       firstName: literal('$1'),
       lastName: 'Doe',
     }, {

--- a/packages/core/test/unit/query-interface/raw-select.test.ts
+++ b/packages/core/test/unit/query-interface/raw-select.test.ts
@@ -16,7 +16,7 @@ describe('QueryInterface#rawSelect', () => {
   it('does not parse user-provided data as replacements', async () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
-    await sequelize.getQueryInterface().rawSelect(User.tableName, {
+    await sequelize.getQueryInterface().rawSelect(User.table, {
       // @ts-expect-error -- we'll fix the typings when we migrate query-generator to TypeScript
       attributes: ['id'],
       where: {

--- a/packages/core/test/unit/query-interface/select.test.ts
+++ b/packages/core/test/unit/query-interface/select.test.ts
@@ -16,7 +16,7 @@ describe('QueryInterface#select', () => {
   it('does not parse user-provided data as replacements', async () => {
     const stub = sinon.stub(sequelize, 'queryRaw');
 
-    await sequelize.getQueryInterface().select(User, User.tableName, {
+    await sequelize.getQueryInterface().select(User, User.table, {
       // @ts-expect-error -- we'll fix the typings when we migrate query-generator to TypeScript
       attributes: ['id'],
       where: {

--- a/packages/core/test/unit/query-interface/update.test.ts
+++ b/packages/core/test/unit/query-interface/update.test.ts
@@ -20,9 +20,9 @@ describe('QueryInterface#update', () => {
 
     await sequelize.getQueryInterface().update(
       instance,
-      User.tableName,
+      User.table,
       { firstName: ':name' },
-      { id: ':id' },
+      { firstName: ':firstName' },
       {
         returning: [':data'],
         replacements: {
@@ -35,14 +35,14 @@ describe('QueryInterface#update', () => {
     expect(stub.callCount).to.eq(1);
     const firstCall = stub.getCall(0);
     expectsql(firstCall.args[0] as string, {
-      default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [id] = $sequelize_2',
-      postgres: 'UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "id" = $sequelize_2 RETURNING ":data"',
-      mssql: 'UPDATE [Users] SET [firstName]=$sequelize_1 OUTPUT INSERTED.[:data] WHERE [id] = $sequelize_2',
-      db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "id" = $sequelize_2);`,
+      default: 'UPDATE [Users] SET [firstName]=$sequelize_1 WHERE [firstName] = $sequelize_2',
+      postgres: 'UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "firstName" = $sequelize_2 RETURNING ":data"',
+      mssql: 'UPDATE [Users] SET [firstName]=$sequelize_1 OUTPUT INSERTED.[:data] WHERE [firstName] = $sequelize_2',
+      db2: `SELECT * FROM FINAL TABLE (UPDATE "Users" SET "firstName"=$sequelize_1 WHERE "firstName" = $sequelize_2);`,
     });
     expect(firstCall.args[1]?.bind).to.deep.eq({
       sequelize_1: ':name',
-      sequelize_2: ':id',
+      sequelize_2: ':firstName',
     });
   });
 
@@ -53,7 +53,7 @@ describe('QueryInterface#update', () => {
 
     await expect(sequelize.getQueryInterface().update(
       instance,
-      User.tableName,
+      User.table,
       { firstName: 'newName' },
       { id: literal('$sequelize_test') },
       {
@@ -71,7 +71,7 @@ describe('QueryInterface#update', () => {
 
     await sequelize.getQueryInterface().update(
       instance,
-      User.tableName,
+      User.table,
       { firstName: 'newName' },
       { id: { [Op.eq]: literal('$id') } },
       {
@@ -101,7 +101,7 @@ describe('QueryInterface#update', () => {
 
     await sequelize.getQueryInterface().update(
       instance,
-      User.tableName,
+      User.table,
       { firstName: 'newName' },
       { id: { [Op.eq]: literal('$1') } },
       {

--- a/packages/core/test/unit/query-interface/upsert.test.ts
+++ b/packages/core/test/unit/query-interface/upsert.test.ts
@@ -230,17 +230,17 @@ describe('QueryInterface#upsert', () => {
       default: 'INSERT INTO `Users` (`firstName`,`counter`) VALUES ($sequelize_1,`counter` + 1) ON DUPLICATE KEY UPDATE `counter`=`counter` + 1;',
       postgres: 'INSERT INTO "Users" ("firstName","counter") VALUES ($sequelize_1,`counter` + 1) ON CONFLICT ("id") DO UPDATE SET "counter"=EXCLUDED."counter";',
       mssql: `
-        MERGE INTO [Users] WITH(HOLDLOCK) AS [Users_target] 
-        USING (VALUES(N'Jonh', \`counter\` + 1)) AS [Users_source]([firstName], [counter]) 
-        ON [Users_target].[id] = [Users_source].[id] WHEN MATCHED THEN UPDATE SET [Users_target].[counter] = \`counter\` + 1 
+        MERGE INTO [Users] WITH(HOLDLOCK) AS [Users_target]
+        USING (VALUES(N'Jonh', \`counter\` + 1)) AS [Users_source]([firstName], [counter])
+        ON [Users_target].[id] = [Users_source].[id] WHEN MATCHED THEN UPDATE SET [Users_target].[counter] = \`counter\` + 1
         WHEN NOT MATCHED THEN INSERT ([firstName], [counter]) VALUES(N'Jonh', \`counter\` + 1) OUTPUT $action, INSERTED.*;
         `,
       sqlite: 'INSERT INTO `Users` (`firstName`,`counter`) VALUES ($sequelize_1,`counter` + 1) ON CONFLICT (`id`) DO UPDATE SET `counter`=EXCLUDED.`counter`;',
       snowflake: 'INSERT INTO "Users" ("firstName","counter") VALUES ($sequelize_1,`counter` + 1);',
       db2: `
-        MERGE INTO "Users" AS "Users_target" 
-        USING (VALUES('Jonh', \`counter\` + 1)) AS "Users_source"("firstName", "counter") 
-        ON "Users_target"."id" = "Users_source"."id" WHEN MATCHED THEN UPDATE SET "Users_target"."counter" = \`counter\` + 1 
+        MERGE INTO "Users" AS "Users_target"
+        USING (VALUES('Jonh', \`counter\` + 1)) AS "Users_source"("firstName", "counter")
+        ON "Users_target"."id" = "Users_source"."id" WHEN MATCHED THEN UPDATE SET "Users_target"."counter" = \`counter\` + 1
         WHEN NOT MATCHED THEN INSERT ("firstName", "counter") VALUES('Jonh', \`counter\` + 1);
         `,
       ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "Users" ("firstName","counter") VALUES ($sequelize_1,`counter` + 1))',

--- a/packages/core/test/unit/sql/insert.test.js
+++ b/packages/core/test/unit/sql/insert.test.js
@@ -29,7 +29,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         returning: true,
         hasTrigger: true,
       };
-      expectsql(sql.insertQuery(User.tableName, { user_name: 'triggertest' }, User.getAttributes(), options),
+      expectsql(sql.insertQuery(User.table, { user_name: 'triggertest' }, User.getAttributes(), options),
         {
           query: {
             ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("user_name") VALUES ($sequelize_1))',
@@ -53,7 +53,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         },
       });
 
-      expectsql(sql.insertQuery(M.tableName, { id: 0 }, M.getAttributes()),
+      expectsql(sql.insertQuery(M.table, { id: 0 }, M.getAttributes()),
         {
           query: {
             mssql: 'SET IDENTITY_INSERT [ms] ON; INSERT INTO [ms] ([id]) VALUES ($sequelize_1); SET IDENTITY_INSERT [ms] OFF;',
@@ -104,7 +104,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
         try {
           result = sql.insertQuery(
-            User.tableName,
+            User.table,
             { user_name: 'testuser', pass_word: '12345' },
             User.fieldRawAttributesMap,
             {
@@ -149,7 +149,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
           timestamps: false,
         });
 
-        expectsql(timezoneSequelize.dialect.queryGenerator.insertQuery(User.tableName, { date: new Date(Date.UTC(2015, 0, 20)) }, User.getAttributes(), {}),
+        expectsql(timezoneSequelize.dialect.queryGenerator.insertQuery(User.table, { date: new Date(Date.UTC(2015, 0, 20)) }, User.getAttributes(), {}),
           {
             query: {
               default: 'INSERT INTO [users] ([date]) VALUES ($sequelize_1);',
@@ -176,7 +176,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         timestamps: false,
       });
 
-      expectsql(current.dialect.queryGenerator.insertQuery(User.tableName, { date: new Date(Date.UTC(2015, 0, 20)) }, User.getAttributes(), {}),
+      expectsql(current.dialect.queryGenerator.insertQuery(User.table, { date: new Date(Date.UTC(2015, 0, 20)) }, User.getAttributes(), {}),
         {
           query: {
             ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("date") VALUES ($sequelize_1))',
@@ -208,7 +208,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         timestamps: false,
       });
 
-      expectsql(current.dialect.queryGenerator.insertQuery(User.tableName, { date: new Date(Date.UTC(2015, 0, 20, 1, 2, 3, 89)) }, User.getAttributes(), {}),
+      expectsql(current.dialect.queryGenerator.insertQuery(User.table, { date: new Date(Date.UTC(2015, 0, 20, 1, 2, 3, 89)) }, User.getAttributes(), {}),
         {
           query: {
             ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("date") VALUES ($sequelize_1))',
@@ -243,7 +243,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         timestamps: false,
       });
 
-      expectsql(sql.insertQuery(User.tableName, { user_name: 'null\0test' }, User.getAttributes()),
+      expectsql(sql.insertQuery(User.table, { user_name: 'null\0test' }, User.getAttributes()),
         {
           query: {
             ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("user_name") VALUES ($sequelize_1))',
@@ -286,7 +286,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       // mapping primary keys to their "field" override values
       const primaryKeys = User.primaryKeyAttributes.map(attr => User.getAttributes()[attr].field || attr);
 
-      expectsql(sql.bulkInsertQuery(User.tableName, [{ user_name: 'testuser', pass_word: '12345' }], { updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'], upsertKeys: primaryKeys }, User.fieldRawAttributesMap),
+      expectsql(sql.bulkInsertQuery(User.table, [{ user_name: 'testuser', pass_word: '12345' }], { updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'], upsertKeys: primaryKeys }, User.fieldRawAttributesMap),
         {
           default: 'INSERT INTO `users` (`user_name`,`pass_word`) VALUES (\'testuser\',\'12345\');',
           ibmi: 'SELECT * FROM FINAL TABLE (INSERT INTO "users" ("user_name","pass_word") VALUES (\'testuser\',\'12345\'))',
@@ -309,7 +309,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         },
       });
 
-      expectsql(sql.bulkInsertQuery(M.tableName, [{ id: 0 }, { id: null }], {}, M.fieldRawAttributesMap),
+      expectsql(sql.bulkInsertQuery(M.table, [{ id: 0 }, { id: null }], {}, M.fieldRawAttributesMap),
         {
           query: {
             mssql: 'SET IDENTITY_INSERT [ms] ON; INSERT INTO [ms] DEFAULT VALUES;INSERT INTO [ms] ([id]) VALUES (0),(NULL); SET IDENTITY_INSERT [ms] OFF;',
@@ -363,7 +363,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
         try {
           result = sql.bulkInsertQuery(
-            User.tableName,
+            User.table,
             [{ user_name: 'testuser', pass_word: '12345' }],
             {
               updateOnDuplicate: ['user_name', 'pass_word', 'updated_at'],

--- a/packages/core/test/unit/sql/update.test.js
+++ b/packages/core/test/unit/sql/update.test.js
@@ -24,7 +24,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       const options = {
         returning: false,
       };
-      expectsql(sql.updateQuery(User.tableName, { user_name: 'triggertest' }, { id: 2 }, options, User.getAttributes()),
+      expectsql(sql.updateQuery(User.table, { user_name: 'triggertest' }, { id: 2 }, options, User.getAttributes()),
         {
           query: {
             db2: 'SELECT * FROM FINAL TABLE (UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2);',
@@ -52,7 +52,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         returning: true,
         hasTrigger: true,
       };
-      expectsql(sql.updateQuery(User.tableName, { user_name: 'triggertest' }, { id: 2 }, options, User.getAttributes()),
+      expectsql(sql.updateQuery(User.table, { user_name: 'triggertest' }, { id: 2 }, options, User.getAttributes()),
         {
           query: {
             ibmi: 'UPDATE "users" SET "user_name"=$sequelize_1 WHERE "id" = $sequelize_2',
@@ -80,7 +80,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
         timestamps: false,
       });
 
-      expectsql(sql.updateQuery(User.tableName, { username: 'new.username' }, { username: 'username' }, { limit: 1 }), {
+      expectsql(sql.updateQuery(User.table, { username: 'new.username' }, { username: 'username' }, { limit: 1 }), {
         query: {
           ibmi: 'UPDATE "Users" SET "username"=$sequelize_1 WHERE "username" = $sequelize_2',
           mssql: 'UPDATE TOP(1) [Users] SET [username]=$sequelize_1 WHERE [username] = $sequelize_2',

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -61,7 +61,7 @@ describe('mapBindParameters', () => {
     });
   });
 
-  it('parses bind parameters following JSONB indexing', () => {
+  it('parses bind parameters following JSON extraction', () => {
     const { sql } = mapBindParameters(`SELECT * FROM users WHERE json_col->>$key`, dialect);
 
     expectsql(sql, {
@@ -391,7 +391,7 @@ describe('injectReplacements (named replacements)', () => {
     });
   });
 
-  it('parses named replacements following JSONB indexing', () => {
+  it('parses named replacements following JSON extraction', () => {
     const sql = injectReplacements(`SELECT * FROM users WHERE json_col->>:key`, dialect, {
       key: 'name',
     });
@@ -608,7 +608,7 @@ describe('injectReplacements (positional replacements)', () => {
     });
   });
 
-  it('parses named replacements following JSONB indexing', () => {
+  it('parses named replacements following JSON extraction', () => {
     const sql = injectReplacements(`SELECT * FROM users WHERE json_col->>?`, dialect, ['name']);
 
     expectsql(sql, {

--- a/packages/core/test/unit/utils/utils.test.ts
+++ b/packages/core/test/unit/utils/utils.test.ts
@@ -9,8 +9,6 @@ import { underscoredIf, camelizeIf, pluralize, singularize } from '@sequelize/co
 import { parseConnectionString } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/url.js';
 import { sequelize, getTestDialect, expectsql } from '../../support';
 
-const dialect = sequelize.dialect;
-
 describe('Utils', () => {
   describe('underscore', () => {
     describe('underscoredIf', () => {
@@ -200,22 +198,22 @@ describe('Utils', () => {
 
   describe('toDefaultValue', () => {
     it('return plain data types', () => {
-      expect(() => toDefaultValue(DataTypes.UUIDV4, dialect)).to.throw();
+      expect(() => toDefaultValue(DataTypes.UUIDV4)).to.throw();
     });
     it('return uuid v1', () => {
-      expect(/^[\da-z-]{36}$/.test(toDefaultValue(DataTypes.UUIDV1(), dialect) as string)).to.be.equal(true);
+      expect(/^[\da-z-]{36}$/.test(toDefaultValue(DataTypes.UUIDV1()) as string)).to.be.equal(true);
     });
     it('return uuid v4', () => {
-      expect(/^[\da-z-]{36}/.test(toDefaultValue(DataTypes.UUIDV4(), dialect) as string)).to.be.equal(true);
+      expect(/^[\da-z-]{36}/.test(toDefaultValue(DataTypes.UUIDV4()) as string)).to.be.equal(true);
     });
     it('return now', () => {
-      expect(Object.prototype.toString.call(toDefaultValue(DataTypes.NOW(), dialect))).to.be.equal('[object Date]');
+      expect(Object.prototype.toString.call(toDefaultValue(DataTypes.NOW()))).to.be.equal('[object Date]');
     });
     it('return plain string', () => {
-      expect(toDefaultValue('Test', dialect)).to.equal('Test');
+      expect(toDefaultValue('Test')).to.equal('Test');
     });
     it('return plain object', () => {
-      expect(toDefaultValue({}, dialect)).to.deep.equal({});
+      expect(toDefaultValue({})).to.deep.equal({});
     });
   });
 


### PR DESCRIPTION
This PR moves the Data Types refactor out of #15598

Escape options won't be provided to data types anymore, but each data type as access to the dialect by using `this._getDialect()`

The RANGE data type will not accept non-range values anymore. Prior to this PR, the RANGE data type would accept non-range values and stringify them as regular values instead of ranges. This doesn't really make any sense, as they're not interchangeable.

I've also imported a few test refactors from #15598