### PR TITLE
feat: add timestamp & version attributes

### DIFF
--- a/packages/core/src/decorators/legacy/attribute-utils.ts
+++ b/packages/core/src/decorators/legacy/attribute-utils.ts
@@ -7,7 +7,7 @@ import type {
 } from './decorator-utils.js';
 import {
   createOptionallyParameterizedPropertyDecorator,
-  DECORATOR_NO_DEFAULT,
+  DECORATOR_NO_DEFAULT, throwMustBeAttribute,
   throwMustBeInstanceProperty,
   throwMustBeMethod,
 } from './decorator-utils.js';
@@ -52,7 +52,7 @@ export function createOptionalAttributeOptionsDecorator<T>(
     defaultValue,
     (decoratorOption, target, propertyName, propertyDescriptor) => {
       if (typeof propertyName === 'symbol') {
-        throw new TypeError('Symbol Model Attributes are not currently supported. We welcome a PR that implements this feature.');
+        throwMustBeAttribute(decoratorName, target, propertyName);
       }
 
       const attributeOptions = callback(decoratorOption, target, propertyName, propertyDescriptor);

--- a/packages/core/src/decorators/legacy/built-in-attributes.ts
+++ b/packages/core/src/decorators/legacy/built-in-attributes.ts
@@ -1,0 +1,77 @@
+import type { ModelStatic } from '../../model.js';
+import { isModelStatic } from '../../utils/model-utils.js';
+import { registerModelOptions } from '../shared/model.js';
+import type { OptionalParameterizedPropertyDecorator } from './decorator-utils.js';
+import {
+  createOptionallyParameterizedPropertyDecorator,
+  throwMustBeAttribute, throwMustBeInstanceProperty,
+  throwMustBeModel,
+} from './decorator-utils.js';
+
+function createBuiltInAttributeDecorator(
+  decoratorName: string,
+  callback: (
+    target: ModelStatic,
+    propertyName: string,
+  ) => void,
+): OptionalParameterizedPropertyDecorator<undefined> {
+  return createOptionallyParameterizedPropertyDecorator<undefined>(
+    decoratorName,
+    undefined,
+    (decoratorOption, target, propertyName) => {
+      if (typeof target === 'function') {
+        throwMustBeInstanceProperty(decoratorName, target, propertyName);
+      }
+
+      if (!isModelStatic(target.constructor)) {
+        throwMustBeModel(decoratorName, target, propertyName);
+      }
+
+      if (typeof propertyName === 'symbol') {
+        throwMustBeAttribute(decoratorName, target, propertyName);
+      }
+
+      callback(target.constructor, propertyName);
+    },
+  );
+}
+
+export const CreatedAt = createBuiltInAttributeDecorator(
+  'CreatedAt',
+  (target: ModelStatic, propertyName: string) => {
+    registerModelOptions(target, {
+      createdAt: propertyName,
+      timestamps: true,
+    });
+  },
+);
+
+export const UpdatedAt = createBuiltInAttributeDecorator(
+  'UpdatedAt',
+  (target: ModelStatic, propertyName: string) => {
+    registerModelOptions(target, {
+      updatedAt: propertyName,
+      timestamps: true,
+    });
+  },
+);
+
+export const DeletedAt = createBuiltInAttributeDecorator(
+  'DeletedAt',
+  (target: ModelStatic, propertyName: string) => {
+    registerModelOptions(target, {
+      deletedAt: propertyName,
+      timestamps: true,
+      paranoid: true,
+    });
+  },
+);
+
+export const Version = createBuiltInAttributeDecorator(
+  'Version',
+  (target: ModelStatic, propertyName: string) => {
+    registerModelOptions(target, {
+      version: propertyName,
+    });
+  },
+);

--- a/packages/core/src/decorators/legacy/decorator-utils.ts
+++ b/packages/core/src/decorators/legacy/decorator-utils.ts
@@ -107,6 +107,12 @@ export function throwMustBeMethod(decoratorName: string, target: Object, propert
   );
 }
 
+export function throwMustBeAttribute(decoratorName: string, target: Object, propertyName: string | symbol): never {
+  throw new TypeError(
+    `Decorator @${decoratorName} has been used on ${getPropertyName(target, propertyName)}, which is a symbol field. Symbol Model Attributes are not currently supported. We welcome a PR that implements this feature.`,
+  );
+}
+
 export function getPropertyName(obj: object, property: string | symbol): string {
   if (typeof obj === 'function') {
     return `${obj.name}.${String(property)}`;

--- a/packages/core/src/decorators/legacy/index.mjs
+++ b/packages/core/src/decorators/legacy/index.mjs
@@ -19,6 +19,13 @@ export const Unique = Pkg.Unique;
 export const Index = Pkg.Index;
 export const createIndexDecorator = Pkg.createIndexDecorator;
 
+// Built-in Attribute Decorators
+
+export const CreatedAt = Pkg.CreatedAt;
+export const UpdatedAt = Pkg.UpdatedAt;
+export const DeletedAt = Pkg.DeletedAt;
+export const Version = Pkg.Version;
+
 // Association Decorators
 
 export const BelongsTo = Pkg.BelongsTo;

--- a/packages/core/src/decorators/legacy/index.ts
+++ b/packages/core/src/decorators/legacy/index.ts
@@ -15,3 +15,4 @@ export * from './attribute.js';
 export * from './table.js';
 export * from './validation.js';
 export { HasOne, HasMany, BelongsTo, BelongsToMany } from './associations.js';
+export * from './built-in-attributes.js';

--- a/packages/core/src/decorators/legacy/validation.ts
+++ b/packages/core/src/decorators/legacy/validation.ts
@@ -66,13 +66,13 @@ export const ModelValidator = createOptionallyParameterizedPropertyDecorator<und
     const targetClass = isStatic ? target : target.constructor;
 
     if (!isModelStatic(targetClass)) {
-      throwMustBeModel('ValidateModel', target, propertyName);
+      throwMustBeModel('ModelValidator', target, propertyName);
     }
 
     // @ts-expect-error -- it's normal to get any here
     const property = target[propertyName];
     if (typeof property !== 'function') {
-      throwMustBeMethod('ValidateModel', target, propertyName);
+      throwMustBeMethod('ModelValidator', target, propertyName);
     }
 
     const validator = isStatic ? function validate() {

--- a/packages/core/test/unit/decorators/built-in-attributes.test.ts
+++ b/packages/core/test/unit/decorators/built-in-attributes.test.ts
@@ -20,7 +20,7 @@ describe('@CreatedAt', () => {
 });
 
 describe('@UpdatedAt', () => {
-  it('marks a column as the createdAt attribute', () => {
+  it('marks a column as the updatedAt attribute', () => {
     class Test extends Model {
       @UpdatedAt
       declare customUpdatedAt: Date;

--- a/packages/core/test/unit/decorators/built-in-attributes.test.ts
+++ b/packages/core/test/unit/decorators/built-in-attributes.test.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { Model } from '@sequelize/core';
+import { CreatedAt, DeletedAt, UpdatedAt, Version } from '@sequelize/core/decorators-legacy';
+import { sequelize } from '../../support';
+
+describe('@CreatedAt', () => {
+  it('marks a column as the createdAt attribute', () => {
+    class Test extends Model {
+      @CreatedAt
+      declare customCreatedAt: Date;
+    }
+
+    sequelize.addModels([Test]);
+
+    expect(Test.modelDefinition.timestampAttributeNames).to.deep.equal({
+      createdAt: 'customCreatedAt',
+      updatedAt: 'updatedAt',
+    });
+  });
+});
+
+describe('@UpdatedAt', () => {
+  it('marks a column as the createdAt attribute', () => {
+    class Test extends Model {
+      @UpdatedAt
+      declare customUpdatedAt: Date;
+    }
+
+    sequelize.addModels([Test]);
+
+    expect(Test.modelDefinition.timestampAttributeNames).to.deep.equal({
+      createdAt: 'createdAt',
+      updatedAt: 'customUpdatedAt',
+    });
+  });
+});
+
+describe('@DeletedAt', () => {
+  it('marks a column as the createdAt attribute', () => {
+    class Test extends Model {
+      @DeletedAt
+      declare customDeletedAt: Date | null;
+    }
+
+    sequelize.addModels([Test]);
+
+    expect(Test.modelDefinition.options.paranoid).to.be.true;
+    expect(Test.modelDefinition.timestampAttributeNames).to.deep.equal({
+      createdAt: 'createdAt',
+      updatedAt: 'updatedAt',
+      deletedAt: 'customDeletedAt',
+    });
+  });
+});
+
+describe('@Version', () => {
+  it('marks a column as the createdAt attribute', () => {
+    class Test extends Model {
+      @Version
+      declare customVersionAttribute: number;
+    }
+
+    sequelize.addModels([Test]);
+
+    expect(Test.modelDefinition.versionAttributeName).to.equal('customVersionAttribute');
+  });
+});

--- a/packages/core/test/unit/decorators/built-in-attributes.test.ts
+++ b/packages/core/test/unit/decorators/built-in-attributes.test.ts
@@ -36,7 +36,7 @@ describe('@UpdatedAt', () => {
 });
 
 describe('@DeletedAt', () => {
-  it('marks a column as the createdAt attribute', () => {
+  it('marks a column as the deletedAt attribute', () => {
     class Test extends Model {
       @DeletedAt
       declare customDeletedAt: Date | null;
@@ -54,7 +54,7 @@ describe('@DeletedAt', () => {
 });
 
 describe('@Version', () => {
-  it('marks a column as the createdAt attribute', () => {
+  it('marks a column as the version attribute', () => {
     class Test extends Model {
       @Version
       declare customVersionAttribute: number;


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR adds the 3 timestamp attribute decorators, `@CreatedAt`, `@UpdatedAt`, `@DeletedAt`, as well as the `@Version` decorator

They're used to control which attribute will be used at the timestamp and version attributes