### PR TITLE
feat(postgres, sqlite): add conflictWhere option to upsert (v6)

### DIFF
--- a/src/dialects/abstract/index.d.ts
+++ b/src/dialects/abstract/index.d.ts
@@ -41,6 +41,7 @@ export declare type DialectSupports = {
     ignoreDuplicates: string;
     updateOnDuplicate: boolean | string;
     onConflictDoNothing: string;
+    onConflictWhere: boolean,
     conflictFields: boolean;
   };
   constraints: {

--- a/src/dialects/abstract/index.js
+++ b/src/dialects/abstract/index.js
@@ -50,6 +50,7 @@ AbstractDialect.prototype.supports = {
     ignoreDuplicates: '', /* dialect specific words for INSERT IGNORE or DO NOTHING */
     updateOnDuplicate: false, /* whether dialect supports ON DUPLICATE KEY UPDATE */
     onConflictDoNothing: '', /* dialect specific words for ON CONFLICT DO NOTHING */
+    onConflictWhere: false, /* whether dialect supports ON CONFLICT WHERE */
     conflictFields: false /* whether the dialect supports specifying conflict fields or not */
   },
   constraints: {

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -198,6 +198,13 @@ class QueryGenerator {
 
     let onDuplicateKeyUpdate = '';
 
+    if (
+      !_.isEmpty(options.conflictWhere)
+      && !this._dialect.supports.inserts.onConflictWhere
+    ) {
+      throw new Error('missing dialect support for conflictWhere option');
+    }
+
     // `options.updateOnDuplicate` is the list of field names to update if a duplicate key is hit during the insert.  It
     // contains just the field names.  This option is _usually_ explicitly set by the corresponding query-interface
     // upsert function.
@@ -206,10 +213,28 @@ class QueryGenerator {
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
         const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
-        onDuplicateKeyUpdate = ` ON CONFLICT (${conflictKeys.join(',')})`;
+
+        const fragments = [
+          'ON CONFLICT',
+          '(',
+          conflictKeys.join(','),
+          ')'
+        ];
+
+        if (!_.isEmpty(options.conflictWhere)) {
+          fragments.push(this.whereQuery(options.conflictWhere, options));
+        }
+
         // if update keys are provided, then apply them here.  if there are no updateKeys provided, then do not try to
         // do an update.  Instead, fall back to DO NOTHING.
-        onDuplicateKeyUpdate += _.isEmpty(updateKeys) ? ' DO NOTHING ' : ` DO UPDATE SET ${updateKeys.join(',')}`;
+        if (_.isEmpty(updateKeys)) {
+          fragments.push('DO NOTHING');
+        } else {
+          fragments.push('DO UPDATE SET', updateKeys.join(','));
+        }
+
+        onDuplicateKeyUpdate = ` ${Utils.joinSQLFragments(fragments)}`;
+
       } else {
         const valueKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`);
         // the rough equivalent to ON CONFLICT DO NOTHING in mysql, etc is ON DUPLICATE KEY UPDATE id = id

--- a/src/dialects/postgres/index.js
+++ b/src/dialects/postgres/index.js
@@ -60,7 +60,8 @@ PostgresDialect.prototype.supports = _.merge(
     inserts: {
       onConflictDoNothing: ' ON CONFLICT DO NOTHING',
       updateOnDuplicate: ' ON CONFLICT DO UPDATE SET',
-      conflictFields: true
+      conflictFields: true,
+      onConflictWhere: true
     },
     NUMERIC: true,
     ARRAY: true,

--- a/src/dialects/sqlite/index.js
+++ b/src/dialects/sqlite/index.js
@@ -35,7 +35,8 @@ SqliteDialect.prototype.supports = _.merge(
     inserts: {
       ignoreDuplicates: ' OR IGNORE',
       updateOnDuplicate: ' ON CONFLICT DO UPDATE SET',
-      conflictFields: true
+      conflictFields: true,
+      onConflictWhere: true
     },
     index: {
       using: false,

--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -1023,6 +1023,12 @@ export interface UpsertOptions<TAttributes = any> extends Logging, Transactionab
    */
   validate?: boolean;
   /**
+   * An optional parameter that specifies a where clause for the `ON CONFLICT` part of the query
+   * (in particular: for applying to partial unique indexes).
+   * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
+   */
+  conflictWhere?: WhereOptions<TAttributes>;
+  /**
    * Optional override for the conflict fields in the ON CONFLICT part of the query.
    * Only supported in Postgres >= 9.5 and SQLite >= 3.24.0
    */

--- a/test/integration/model/upsert.test.js
+++ b/test/integration/model/upsert.test.js
@@ -760,6 +760,167 @@ describe(Support.getTestDialectTeaser('Model'), () => {
             expect(otherMembership.id).to.not.eq(originalMembership.id);
           });
         });
+
+        if (current.dialect.supports.inserts.onConflictWhere) {
+          describe('conflictWhere', () => {
+            const Users = current.define(
+              'users',
+              {
+                name: DataTypes.STRING,
+                bio: DataTypes.STRING,
+                isUnique: DataTypes.BOOLEAN
+              },
+              {
+                indexes: [
+                  {
+                    unique: true,
+                    fields: ['name'],
+                    where: { isUnique: true }
+                  }
+                ]
+              }
+            );
+
+            beforeEach(() => Users.sync({ force: true }));
+
+            it('should insert with no other rows', async () => {
+              const [newRow] = await Users.upsert(
+                {
+                  name: 'John',
+                  isUnique: true
+                },
+                {
+                  conflictWhere: {
+                    isUnique: true
+                  }
+                }
+              );
+
+              expect(newRow).to.not.eq(null);
+              expect(newRow.name).to.eq('John');
+            });
+
+            it('should update with another unique user', async () => {
+              let [newRow] = await Users.upsert(
+                {
+                  name: 'John',
+                  isUnique: true,
+                  bio: 'before'
+                },
+                {
+                  conflictWhere: {
+                    isUnique: true
+                  }
+                }
+              );
+
+              expect(newRow).to.not.eq(null);
+              expect(newRow.name).to.eq('John');
+              expect(newRow.bio).to.eq('before');
+
+              [newRow] = await Users.upsert(
+                {
+                  name: 'John',
+                  isUnique: true,
+                  bio: 'after'
+                },
+                {
+                  conflictWhere: {
+                    isUnique: true
+                  }
+                }
+              );
+
+              expect(newRow).to.not.eq(null);
+              expect(newRow.name).to.eq('John');
+              expect(newRow.bio).to.eq('after');
+
+              const rowCount = await Users.count();
+
+              expect(rowCount).to.eq(1);
+            });
+
+            it('allows both unique and non-unique users with the same name', async () => {
+              let [newRow] = await Users.upsert(
+                {
+                  name: 'John',
+                  isUnique: true,
+                  bio: 'first'
+                },
+                {
+                  conflictWhere: {
+                    isUnique: true
+                  }
+                }
+              );
+
+              expect(newRow).to.not.eq(null);
+              expect(newRow.name).to.eq('John');
+              expect(newRow.bio).to.eq('first');
+
+              [newRow] = await Users.upsert(
+                {
+                  name: 'John',
+                  isUnique: false,
+                  bio: 'second'
+                },
+                {
+                  conflictWhere: {
+                    isUnique: true
+                  }
+                }
+              );
+
+              expect(newRow).to.not.eq(null);
+              expect(newRow.name).to.eq('John');
+              expect(newRow.bio).to.eq('second');
+
+              const rowCount = await Users.count();
+
+              expect(rowCount).to.eq(2);
+            });
+
+            it('allows for multiple unique users with different names', async () => {
+              let [newRow] = await Users.upsert(
+                {
+                  name: 'John',
+                  isUnique: true,
+                  bio: 'first'
+                },
+                {
+                  conflictWhere: {
+                    isUnique: true
+                  }
+                }
+              );
+
+              expect(newRow).to.not.eq(null);
+              expect(newRow.name).to.eq('John');
+              expect(newRow.bio).to.eq('first');
+
+              [newRow] = await Users.upsert(
+                {
+                  name: 'Bob',
+                  isUnique: false,
+                  bio: 'second'
+                },
+                {
+                  conflictWhere: {
+                    isUnique: true
+                  }
+                }
+              );
+
+              expect(newRow).to.not.eq(null);
+              expect(newRow.name).to.eq('Bob');
+              expect(newRow.bio).to.eq('second');
+
+              const rowCount = await Users.count();
+
+              expect(rowCount).to.eq(2);
+            });
+          });
+        }
       }
     });
   }

--- a/test/types/upsert.ts
+++ b/test/types/upsert.ts
@@ -43,4 +43,11 @@ sequelize.transaction(async trx => {
     validate: true,
     conflictFields: ['foo', 'bar']
   });
+
+  const res4: [TestModel, boolean | null] = await TestModel.upsert<TestModel>({}, {
+    conflictWhere: {
+      foo: 'abc',
+      bar: 'def',
+    },
+  });
 })


### PR DESCRIPTION
Adds an option to set the where clause in the `ON CONFLICT` part of postgres/sqlite upserts.  Backport of #13411.

