### PR TITLE
fix: restrict precision option in DATE and TIME to number

### DIFF
--- a/packages/core/src/dialects/abstract/data-types.ts
+++ b/packages/core/src/dialects/abstract/data-types.ts
@@ -655,7 +655,7 @@ export interface DecimalNumberOptions extends NumberOptions {
   /**
    * Total number of digits.
    *
-   * {@link DecimalNumberOptions#scale} must be specified if is specified.
+   * {@link DecimalNumberOptions#scale} must be specified if precision is specified.
    */
   precision?: number | undefined;
 

--- a/packages/core/src/dialects/abstract/data-types.ts
+++ b/packages/core/src/dialects/abstract/data-types.ts
@@ -655,7 +655,7 @@ export interface DecimalNumberOptions extends NumberOptions {
   /**
    * Total number of digits.
    *
-   * {@link DecimalNumberOptions#scale} must be specified if precision is specified.
+   * {@link DecimalNumberOptions#scale} must be specified if is specified.
    */
   precision?: number | undefined;
 
@@ -1323,7 +1323,7 @@ export interface TimeOptions {
   /**
    * The precision of the date.
    */
-  precision?: string | number | undefined;
+  precision?: number | undefined;
 }
 
 /**
@@ -1377,7 +1377,7 @@ export interface DateOptions {
   /**
    * The precision of the date.
    */
-  precision?: string | number | undefined;
+  precision?: number | undefined;
 }
 
 type RawDate = Date | string | number;


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Hopefully unblocks #15799 by restricting the precision option to `number | undefined`
