### PR TITLE
meta(db2): remove node:util

### DIFF
--- a/src/dialects/db2/query.js
+++ b/src/dialects/db2/query.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const util = require('node:util');
+const util = require('util');
 
 const AbstractQuery = require('../abstract/query');
 const sequelizeErrors = require('../../errors');

--- a/src/dialects/db2/query.js
+++ b/src/dialects/db2/query.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const util = require('node:util');
+
 const AbstractQuery = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
 const parserStore = require('../parserStore')('db2');

--- a/src/dialects/db2/query.js
+++ b/src/dialects/db2/query.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const util = require('node:util');
-
 const AbstractQuery = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
 const parserStore = require('../parserStore')('db2');


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Since DB2 is showing that it passes even when erroring and we haven't fixed the failing tests on v6 yet, this slipped past our radar. `node:util` is not supported for Node 10
