### PR TITLE
fix: allow literals in col option

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -2360,7 +2360,10 @@ https://github.com/sequelize/sequelize/discussions/15694`);
       if (Array.isArray(smth.col) && !factory) {
         throw new Error('Cannot call Sequelize.col() with array outside of order / group clause');
       }
-      if (smth.col.startsWith.?('*')) {
+      if (smth.col instanceof Utils.Literal) {
+        return smth.col.val;
+      }
+      if (smth.col.startsWith('*')) {
         return '*';
       }
       return this.quote(smth.col, factory);

--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -2360,7 +2360,7 @@ https://github.com/sequelize/sequelize/discussions/15694`);
       if (Array.isArray(smth.col) && !factory) {
         throw new Error('Cannot call Sequelize.col() with array outside of order / group clause');
       }
-      if (smth.col.startsWith('*')) {
+      if (smth.col.startsWith.?('*')) {
         return '*';
       }
       return this.quote(smth.col, factory);


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Was trying the solution from https://stackoverflow.com/questions/61050556/count-distinct-values-of-field-within-jsonb-in-sequelize, but it would result in error `smth.col.startsWith is not a function` because of the `sequelize.literal`.

This tiny fix solves it and allow the
