### PR TITLE
fix(mysql): don't print milliseconds if date precision is 0

### DIFF
--- a/packages/core/src/dialects/abstract/data-types.ts
+++ b/packages/core/src/dialects/abstract/data-types.ts
@@ -1418,6 +1418,7 @@ export class DATE extends AbstractDataType<AcceptedDate> {
   }
 
   toSql() {
+    // TODO [>=8]: Consider making precision default to 3 instead of being dialect-dependent.
     if (this.options.precision != null) {
       return `DATETIME(${this.options.precision})`;
     }

--- a/packages/core/src/dialects/mysql/data-types.ts
+++ b/packages/core/src/dialects/mysql/data-types.ts
@@ -93,7 +93,17 @@ export class DATE extends BaseTypes.DATE {
   toBindableValue(date: AcceptedDate) {
     date = this._applyTimezone(date);
 
-    return date.format('YYYY-MM-DD HH:mm:ss.SSS');
+    // MySQL datetime precision defaults to 0
+    const precision = this.options.precision ?? 0;
+    let format = 'YYYY-MM-DD HH:mm:ss';
+    // TODO: We should normally use `S`, `SS` or `SSS` based on the precision, but
+    //  dayjs has a bug which causes `S` and `SS` to be ignored:
+    //  https://github.com/iamkun/dayjs/issues/1734
+    if (precision > 0) {
+      format += `.SSS`;
+    }
+
+    return date.format(format);
   }
 
   sanitize(value: unknown, options?: { timezone?: string }): unknown {

--- a/packages/core/src/sql-string.ts
+++ b/packages/core/src/sql-string.ts
@@ -41,7 +41,7 @@ export function bestGuessDataTypeOfVal(val: unknown, dialect: AbstractDialect): 
       }
 
       if (val instanceof Date) {
-        return new DataTypes.DATE().toDialectDataType(dialect);
+        return new DataTypes.DATE(3).toDialectDataType(dialect);
       }
 
       if (Buffer.isBuffer(val)) {

--- a/packages/core/test/integration/instance/update.test.js
+++ b/packages/core/test/integration/instance/update.test.js
@@ -88,7 +88,7 @@ describe('Model#update', () => {
       expect(user.get('createdAt')).to.equalTime(testDate);
     });
 
-    it('doesn\'t update primary keys or timestamps', async function () {
+    it(`doesn't update primary keys or timestamps`, async function () {
       const User = this.sequelize.define(`User${Support.rand()}`, {
         name: DataTypes.STRING,
         bio: DataTypes.TEXT,

--- a/packages/core/test/integration/instance/update.test.js
+++ b/packages/core/test/integration/instance/update.test.js
@@ -9,124 +9,57 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
 
-describe(Support.getTestDialectTeaser('Instance'), () => {
-  before(function () {
-    this.clock = sinon.useFakeTimers();
+describe('Model#update', () => {
+  beforeEach(async function () {
+    this.User = this.sequelize.define('User', {
+      username: { type: DataTypes.STRING },
+      uuidv1: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV1 },
+      uuidv4: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4 },
+      touchedAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
+      aNumber: { type: DataTypes.INTEGER },
+      bNumber: { type: DataTypes.INTEGER },
+      aDate: { type: DataTypes.DATE },
+
+      validateTest: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        validate: { isInt: true },
+      },
+      validateCustom: {
+        type: DataTypes.STRING,
+        allowNull: true,
+        validate: { len: { msg: 'Length failed.', args: [1, 20] } },
+      },
+      validateSideEffect: {
+        type: DataTypes.VIRTUAL,
+        allowNull: true,
+        validate: { isInt: true },
+        set(val) {
+          this.setDataValue('validateSideEffect', val);
+          this.setDataValue('validateSideAffected', val * 2);
+        },
+      },
+      validateSideAffected: {
+        type: DataTypes.INTEGER,
+        allowNull: true,
+        validate: { isInt: true },
+      },
+
+      dateAllowNullTrue: {
+        type: DataTypes.DATE,
+        allowNull: true,
+      },
+    });
+    await this.User.sync({ force: true });
   });
-  after(function () {
-    this.clock.restore();
-  });
 
-  describe('update', () => {
-    beforeEach(async function () {
-      this.User = this.sequelize.define('User', {
-        username: { type: DataTypes.STRING },
-        uuidv1: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV1 },
-        uuidv4: { type: DataTypes.UUID, defaultValue: DataTypes.UUIDV4 },
-        touchedAt: { type: DataTypes.DATE, defaultValue: DataTypes.NOW },
-        aNumber: { type: DataTypes.INTEGER },
-        bNumber: { type: DataTypes.INTEGER },
-        aDate: { type: DataTypes.DATE },
-
-        validateTest: {
-          type: DataTypes.INTEGER,
-          allowNull: true,
-          validate: { isInt: true },
-        },
-        validateCustom: {
-          type: DataTypes.STRING,
-          allowNull: true,
-          validate: { len: { msg: 'Length failed.', args: [1, 20] } },
-        },
-        validateSideEffect: {
-          type: DataTypes.VIRTUAL,
-          allowNull: true,
-          validate: { isInt: true },
-          set(val) {
-            this.setDataValue('validateSideEffect', val);
-            this.setDataValue('validateSideAffected', val * 2);
-          },
-        },
-        validateSideAffected: {
-          type: DataTypes.INTEGER,
-          allowNull: true,
-          validate: { isInt: true },
-        },
-
-        dateAllowNullTrue: {
-          type: DataTypes.DATE,
-          allowNull: true,
-        },
-      });
-      await this.User.sync({ force: true });
+  describe('Fake Timers Suite', () => {
+    before(function () {
+      this.clock = sinon.useFakeTimers();
     });
 
-    if (current.dialect.supports.transactions) {
-      it('supports transactions', async function () {
-        const sequelize = await Support.prepareTransactionTest(this.sequelize);
-        const User = sequelize.define('User', { username: DataTypes.STRING });
-
-        await User.sync({ force: true });
-        const user = await User.create({ username: 'foo' });
-        const t = await sequelize.startUnmanagedTransaction();
-        await user.update({ username: 'bar' }, { transaction: t });
-        const users1 = await User.findAll();
-        const users2 = await User.findAll({ transaction: t });
-        expect(users1[0].username).to.equal('foo');
-        expect(users2[0].username).to.equal('bar');
-        await t.rollback();
-      });
-    }
-
-    it('should update fields that are not specified on create', async function () {
-      const User = this.sequelize.define(`User${Support.rand()}`, {
-        name: DataTypes.STRING,
-        bio: DataTypes.TEXT,
-        email: DataTypes.STRING,
-      });
-
-      await User.sync({ force: true });
-
-      const user1 = await User.create({
-        name: 'snafu',
-        email: 'email',
-      }, {
-        fields: ['name', 'email'],
-      });
-
-      const user0 = await user1.update({ bio: 'swag' });
-      const user = await user0.reload();
-      expect(user.get('name')).to.equal('snafu');
-      expect(user.get('email')).to.equal('email');
-      expect(user.get('bio')).to.equal('swag');
-    });
-
-    it('should succeed in updating when values are unchanged (without timestamps)', async function () {
-      const User = this.sequelize.define(`User${Support.rand()}`, {
-        name: DataTypes.STRING,
-        bio: DataTypes.TEXT,
-        email: DataTypes.STRING,
-      }, {
-        timestamps: false,
-      });
-
-      await User.sync({ force: true });
-
-      const user1 = await User.create({
-        name: 'snafu',
-        email: 'email',
-      }, {
-        fields: ['name', 'email'],
-      });
-
-      const user0 = await user1.update({
-        name: 'snafu',
-        email: 'email',
-      });
-
-      const user = await user0.reload();
-      expect(user.get('name')).to.equal('snafu');
-      expect(user.get('email')).to.equal('email');
+    after(function () {
+      this.clock.restore();
     });
 
     it('should update timestamps with milliseconds', async function () {
@@ -153,236 +86,6 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       const testDate = new Date();
       testDate.setTime(2100);
       expect(user.get('createdAt')).to.equalTime(testDate);
-    });
-
-    it('should only save passed attributes', async function () {
-      const user = this.User.build();
-      await user.save();
-      user.set('validateTest', 5);
-      expect(user.changed('validateTest')).to.be.ok;
-
-      await user.update({
-        validateCustom: '1',
-      });
-
-      expect(user.changed('validateTest')).to.be.ok;
-      expect(user.validateTest).to.be.equal(5);
-      await user.reload();
-      expect(user.validateTest).to.not.be.equal(5);
-    });
-
-    it('should save attributes affected by setters', async function () {
-      const user = await this.User.create();
-      await user.update({ validateSideEffect: 5 });
-      expect(user.validateSideEffect).to.be.equal(5);
-      await user.reload();
-      expect(user.validateSideAffected).to.be.equal(10);
-      expect(user.validateSideEffect).not.to.be.ok;
-    });
-
-    it('fails if the update was made to a new record which is not persisted', async function () {
-      const Foo = this.sequelize.define('Foo', {
-        name: { type: DataTypes.STRING },
-      }, { noPrimaryKey: true });
-      await Foo.sync({ force: true });
-
-      const instance = Foo.build({ name: 'FooBar' }, { isNewRecord: true });
-      await expect(instance.update()).to.be.rejectedWith('You attempted to update an instance that is not persisted.');
-    });
-
-    describe('hooks', () => {
-      it('should update attributes added in hooks when default fields are used', async function () {
-        const User = this.sequelize.define(`User${Support.rand()}`, {
-          name: DataTypes.STRING,
-          bio: DataTypes.TEXT,
-          email: DataTypes.STRING,
-        });
-
-        User.beforeUpdate(instance => {
-          instance.set('email', 'B');
-        });
-
-        await User.sync({ force: true });
-
-        const user0 = await User.create({
-          name: 'A',
-          bio: 'A',
-          email: 'A',
-        });
-
-        await user0.update({
-          name: 'B',
-          bio: 'B',
-        });
-
-        const user = await User.findOne({});
-        expect(user.get('name')).to.equal('B');
-        expect(user.get('bio')).to.equal('B');
-        expect(user.get('email')).to.equal('B');
-      });
-
-      it('should update attributes changed in hooks when default fields are used', async function () {
-        const User = this.sequelize.define(`User${Support.rand()}`, {
-          name: DataTypes.STRING,
-          bio: DataTypes.TEXT,
-          email: DataTypes.STRING,
-        });
-
-        User.beforeUpdate(instance => {
-          instance.set('email', 'C');
-        });
-
-        await User.sync({ force: true });
-
-        const user0 = await User.create({
-          name: 'A',
-          bio: 'A',
-          email: 'A',
-        });
-
-        await user0.update({
-          name: 'B',
-          bio: 'B',
-          email: 'B',
-        });
-
-        const user = await User.findOne({});
-        expect(user.get('name')).to.equal('B');
-        expect(user.get('bio')).to.equal('B');
-        expect(user.get('email')).to.equal('C');
-      });
-
-      it('should validate attributes added in hooks when default fields are used', async function () {
-        const User = this.sequelize.define(`User${Support.rand()}`, {
-          name: DataTypes.STRING,
-          bio: DataTypes.TEXT,
-          email: {
-            type: DataTypes.STRING,
-            validate: {
-              isEmail: true,
-            },
-          },
-        });
-
-        User.beforeUpdate(instance => {
-          instance.set('email', 'B');
-        });
-
-        await User.sync({ force: true });
-
-        const user0 = await User.create({
-          name: 'A',
-          bio: 'A',
-          email: 'valid.email@gmail.com',
-        });
-
-        await expect(user0.update({
-          name: 'B',
-        })).to.be.rejectedWith(Sequelize.ValidationError);
-
-        const user = await User.findOne({});
-        expect(user.get('email')).to.equal('valid.email@gmail.com');
-      });
-
-      it('should validate attributes changed in hooks when default fields are used', async function () {
-        const User = this.sequelize.define(`User${Support.rand()}`, {
-          name: DataTypes.STRING,
-          bio: DataTypes.TEXT,
-          email: {
-            type: DataTypes.STRING,
-            validate: {
-              isEmail: true,
-            },
-          },
-        });
-
-        User.beforeUpdate(instance => {
-          instance.set('email', 'B');
-        });
-
-        await User.sync({ force: true });
-
-        const user0 = await User.create({
-          name: 'A',
-          bio: 'A',
-          email: 'valid.email@gmail.com',
-        });
-
-        await expect(user0.update({
-          name: 'B',
-          email: 'still.valid.email@gmail.com',
-        })).to.be.rejectedWith(Sequelize.ValidationError);
-
-        const user = await User.findOne({});
-        expect(user.get('email')).to.equal('valid.email@gmail.com');
-      });
-    });
-
-    it('should not set attributes that are not specified by fields', async function () {
-      const User = this.sequelize.define(`User${Support.rand()}`, {
-        name: DataTypes.STRING,
-        bio: DataTypes.TEXT,
-        email: DataTypes.STRING,
-      });
-
-      await User.sync({ force: true });
-
-      const user0 = await User.create({
-        name: 'snafu',
-        email: 'email',
-      });
-
-      const user = await user0.update({
-        bio: 'heyo',
-        email: 'heho',
-      }, {
-        fields: ['bio'],
-      });
-
-      expect(user.get('name')).to.equal('snafu');
-      expect(user.get('email')).to.equal('email');
-      expect(user.get('bio')).to.equal('heyo');
-    });
-
-    it('updates attributes in the database', async function () {
-      const user = await this.User.create({ username: 'user' });
-      expect(user.username).to.equal('user');
-      const user0 = await user.update({ username: 'person' });
-      expect(user0.username).to.equal('person');
-    });
-
-    it('ignores unknown attributes', async function () {
-      const user = await this.User.create({ username: 'user' });
-      const user0 = await user.update({ username: 'person', foo: 'bar' });
-      expect(user0.username).to.equal('person');
-      expect(user0.foo).not.to.exist;
-    });
-
-    it('ignores undefined attributes', async function () {
-      await this.User.sync({ force: true });
-      const user = await this.User.create({ username: 'user' });
-      const user0 = await user.update({ username: undefined });
-      expect(user0.username).to.equal('user');
-    });
-
-    // NOTE: This is a regression test for https://github.com/sequelize/sequelize/issues/12717
-    it('updates attributes for model with date pk (#12717)', async function () {
-      const Event = this.sequelize.define('Event', {
-        date: { type: DataTypes.DATE, allowNull: false, primaryKey: true },
-        name: { type: DataTypes.STRING },
-      });
-
-      await Event.sync({ force: true });
-      const event = await Event.create({
-        date: new Date(),
-        name: 'event',
-      });
-
-      expect(event.name).to.equal('event');
-      await event.update({ name: 'event updated' });
-
-      const event0 = await Event.findOne({ where: { date: event.date } });
-      expect(event0.name).to.equal('event updated');
     });
 
     it('doesn\'t update primary keys or timestamps', async function () {
@@ -415,49 +118,347 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       expect(new Date(user0.updatedAt)).to.not.equalTime(new Date(oldUpdatedAt));
       expect(user0.identifier).to.equal(oldIdentifier);
     });
+  });
 
-    it('stores and restores null values', async function () {
-      const Download = this.sequelize.define('download', {
-        startedAt: DataTypes.DATE,
-        canceledAt: DataTypes.DATE,
-        finishedAt: DataTypes.DATE,
+  if (current.dialect.supports.transactions) {
+    it('supports transactions', async function () {
+      const sequelize = await Support.prepareTransactionTest(this.sequelize);
+      const User = sequelize.define('User', { username: DataTypes.STRING });
+
+      await User.sync({ force: true });
+      const user = await User.create({ username: 'foo' });
+      const t = await sequelize.startUnmanagedTransaction();
+      await user.update({ username: 'bar' }, { transaction: t });
+      const users1 = await User.findAll();
+      const users2 = await User.findAll({ transaction: t });
+      expect(users1[0].username).to.equal('foo');
+      expect(users2[0].username).to.equal('bar');
+      await t.rollback();
+    });
+  }
+
+  it('should update fields that are not specified on create', async function () {
+    const User = this.sequelize.define(`User${Support.rand()}`, {
+      name: DataTypes.STRING,
+      bio: DataTypes.TEXT,
+      email: DataTypes.STRING,
+    });
+
+    await User.sync({ force: true });
+
+    const user1 = await User.create({
+      name: 'snafu',
+      email: 'email',
+    }, {
+      fields: ['name', 'email'],
+    });
+
+    const user0 = await user1.update({ bio: 'swag' });
+    const user = await user0.reload();
+    expect(user.get('name')).to.equal('snafu');
+    expect(user.get('email')).to.equal('email');
+    expect(user.get('bio')).to.equal('swag');
+  });
+
+  it('should succeed in updating when values are unchanged (without timestamps)', async function () {
+    const User = this.sequelize.define(`User${Support.rand()}`, {
+      name: DataTypes.STRING,
+      bio: DataTypes.TEXT,
+      email: DataTypes.STRING,
+    }, {
+      timestamps: false,
+    });
+
+    await User.sync({ force: true });
+
+    const user1 = await User.create({
+      name: 'snafu',
+      email: 'email',
+    }, {
+      fields: ['name', 'email'],
+    });
+
+    const user0 = await user1.update({
+      name: 'snafu',
+      email: 'email',
+    });
+
+    const user = await user0.reload();
+    expect(user.get('name')).to.equal('snafu');
+    expect(user.get('email')).to.equal('email');
+  });
+
+  it('should only save passed attributes', async function () {
+    const user = this.User.build();
+    await user.save();
+    user.set('validateTest', 5);
+    expect(user.changed('validateTest')).to.be.ok;
+
+    await user.update({
+      validateCustom: '1',
+    });
+
+    expect(user.changed('validateTest')).to.be.ok;
+    expect(user.validateTest).to.be.equal(5);
+    await user.reload();
+    expect(user.validateTest).to.not.be.equal(5);
+  });
+
+  it('should save attributes affected by setters', async function () {
+    const user = await this.User.create();
+    await user.update({ validateSideEffect: 5 });
+    expect(user.validateSideEffect).to.be.equal(5);
+    await user.reload();
+    expect(user.validateSideAffected).to.be.equal(10);
+    expect(user.validateSideEffect).not.to.be.ok;
+  });
+
+  it('fails if the update was made to a new record which is not persisted', async function () {
+    const Foo = this.sequelize.define('Foo', {
+      name: { type: DataTypes.STRING },
+    }, { noPrimaryKey: true });
+    await Foo.sync({ force: true });
+
+    const instance = Foo.build({ name: 'FooBar' }, { isNewRecord: true });
+    await expect(instance.update()).to.be.rejectedWith('You attempted to update an instance that is not persisted.');
+  });
+
+  describe('hooks', () => {
+    it('should update attributes added in hooks when default fields are used', async function () {
+      const User = this.sequelize.define(`User${Support.rand()}`, {
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
+        email: DataTypes.STRING,
       });
 
-      await Download.sync();
-
-      const download = await Download.create({
-        startedAt: new Date(),
+      User.beforeUpdate(instance => {
+        instance.set('email', 'B');
       });
 
+      await User.sync({ force: true });
+
+      const user0 = await User.create({
+        name: 'A',
+        bio: 'A',
+        email: 'A',
+      });
+
+      await user0.update({
+        name: 'B',
+        bio: 'B',
+      });
+
+      const user = await User.findOne({});
+      expect(user.get('name')).to.equal('B');
+      expect(user.get('bio')).to.equal('B');
+      expect(user.get('email')).to.equal('B');
+    });
+
+    it('should update attributes changed in hooks when default fields are used', async function () {
+      const User = this.sequelize.define(`User${Support.rand()}`, {
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
+        email: DataTypes.STRING,
+      });
+
+      User.beforeUpdate(instance => {
+        instance.set('email', 'C');
+      });
+
+      await User.sync({ force: true });
+
+      const user0 = await User.create({
+        name: 'A',
+        bio: 'A',
+        email: 'A',
+      });
+
+      await user0.update({
+        name: 'B',
+        bio: 'B',
+        email: 'B',
+      });
+
+      const user = await User.findOne({});
+      expect(user.get('name')).to.equal('B');
+      expect(user.get('bio')).to.equal('B');
+      expect(user.get('email')).to.equal('C');
+    });
+
+    it('should validate attributes added in hooks when default fields are used', async function () {
+      const User = this.sequelize.define(`User${Support.rand()}`, {
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
+        email: {
+          type: DataTypes.STRING,
+          validate: {
+            isEmail: true,
+          },
+        },
+      });
+
+      User.beforeUpdate(instance => {
+        instance.set('email', 'B');
+      });
+
+      await User.sync({ force: true });
+
+      const user0 = await User.create({
+        name: 'A',
+        bio: 'A',
+        email: 'valid.email@gmail.com',
+      });
+
+      await expect(user0.update({
+        name: 'B',
+      })).to.be.rejectedWith(Sequelize.ValidationError);
+
+      const user = await User.findOne({});
+      expect(user.get('email')).to.equal('valid.email@gmail.com');
+    });
+
+    it('should validate attributes changed in hooks when default fields are used', async function () {
+      const User = this.sequelize.define(`User${Support.rand()}`, {
+        name: DataTypes.STRING,
+        bio: DataTypes.TEXT,
+        email: {
+          type: DataTypes.STRING,
+          validate: {
+            isEmail: true,
+          },
+        },
+      });
+
+      User.beforeUpdate(instance => {
+        instance.set('email', 'B');
+      });
+
+      await User.sync({ force: true });
+
+      const user0 = await User.create({
+        name: 'A',
+        bio: 'A',
+        email: 'valid.email@gmail.com',
+      });
+
+      await expect(user0.update({
+        name: 'B',
+        email: 'still.valid.email@gmail.com',
+      })).to.be.rejectedWith(Sequelize.ValidationError);
+
+      const user = await User.findOne({});
+      expect(user.get('email')).to.equal('valid.email@gmail.com');
+    });
+  });
+
+  it('should not set attributes that are not specified by fields', async function () {
+    const User = this.sequelize.define(`User${Support.rand()}`, {
+      name: DataTypes.STRING,
+      bio: DataTypes.TEXT,
+      email: DataTypes.STRING,
+    });
+
+    await User.sync({ force: true });
+
+    const user0 = await User.create({
+      name: 'snafu',
+      email: 'email',
+    });
+
+    const user = await user0.update({
+      bio: 'heyo',
+      email: 'heho',
+    }, {
+      fields: ['bio'],
+    });
+
+    expect(user.get('name')).to.equal('snafu');
+    expect(user.get('email')).to.equal('email');
+    expect(user.get('bio')).to.equal('heyo');
+  });
+
+  it('updates attributes in the database', async function () {
+    const user = await this.User.create({ username: 'user' });
+    expect(user.username).to.equal('user');
+    const user0 = await user.update({ username: 'person' });
+    expect(user0.username).to.equal('person');
+  });
+
+  it('ignores unknown attributes', async function () {
+    const user = await this.User.create({ username: 'user' });
+    const user0 = await user.update({ username: 'person', foo: 'bar' });
+    expect(user0.username).to.equal('person');
+    expect(user0.foo).not.to.exist;
+  });
+
+  it('ignores undefined attributes', async function () {
+    await this.User.sync({ force: true });
+    const user = await this.User.create({ username: 'user' });
+    const user0 = await user.update({ username: undefined });
+    expect(user0.username).to.equal('user');
+  });
+
+  // NOTE: This is a regression test for https://github.com/sequelize/sequelize/issues/12717
+  it('updates attributes for model with date pk (#12717)', async function () {
+    const Event = this.sequelize.define('Event', {
+      date: { type: DataTypes.DATE, allowNull: false, primaryKey: true },
+      name: { type: DataTypes.STRING },
+    });
+
+    await Event.sync({ force: true });
+    const event = await Event.create({
+      date: new Date(),
+      name: 'event',
+    });
+
+    expect(event.name).to.equal('event');
+    await event.update({ name: 'event updated' });
+
+    const event0 = await Event.findOne({ where: { date: event.date } });
+    expect(event0.name).to.equal('event updated');
+  });
+
+  it('stores and restores null values', async function () {
+    const Download = this.sequelize.define('download', {
+      startedAt: DataTypes.DATE,
+      canceledAt: DataTypes.DATE,
+      finishedAt: DataTypes.DATE,
+    });
+
+    await Download.sync();
+
+    const download = await Download.create({
+      startedAt: new Date(),
+    });
+
+    expect(download.startedAt instanceof Date).to.be.true;
+    expect(download.canceledAt).to.not.be.ok;
+    expect(download.finishedAt).to.not.be.ok;
+
+    const download0 = await download.update({
+      canceledAt: new Date(),
+    });
+
+    expect(download0.startedAt instanceof Date).to.be.true;
+    expect(download0.canceledAt instanceof Date).to.be.true;
+    expect(download0.finishedAt).to.not.be.ok;
+
+    const downloads = await Download.findAll({
+      where: { finishedAt: null },
+    });
+
+    for (const download of downloads) {
       expect(download.startedAt instanceof Date).to.be.true;
-      expect(download.canceledAt).to.not.be.ok;
+      expect(download.canceledAt instanceof Date).to.be.true;
       expect(download.finishedAt).to.not.be.ok;
+    }
+  });
 
-      const download0 = await download.update({
-        canceledAt: new Date(),
-      });
+  it('should support logging', async function () {
+    const spy = sinon.spy();
 
-      expect(download0.startedAt instanceof Date).to.be.true;
-      expect(download0.canceledAt instanceof Date).to.be.true;
-      expect(download0.finishedAt).to.not.be.ok;
-
-      const downloads = await Download.findAll({
-        where: { finishedAt: null },
-      });
-
-      for (const download of downloads) {
-        expect(download.startedAt instanceof Date).to.be.true;
-        expect(download.canceledAt instanceof Date).to.be.true;
-        expect(download.finishedAt).to.not.be.ok;
-      }
-    });
-
-    it('should support logging', async function () {
-      const spy = sinon.spy();
-
-      const user = await this.User.create({});
-      await user.update({ username: 'yolo' }, { logging: spy });
-      expect(spy.called).to.be.ok;
-    });
+    const user = await this.User.create({});
+    await user.update({ username: 'yolo' }, { logging: spy });
+    expect(spy.called).to.be.ok;
   });
 });

--- a/packages/core/test/integration/instance/update.test.js
+++ b/packages/core/test/integration/instance/update.test.js
@@ -365,6 +365,26 @@ describe(Support.getTestDialectTeaser('Instance'), () => {
       expect(user0.username).to.equal('user');
     });
 
+    // NOTE: This is a regression test for https://github.com/sequelize/sequelize/issues/12717
+    it('updates attributes for model with date pk (#12717)', async function () {
+      const Event = this.sequelize.define('Event', {
+        date: { type: DataTypes.DATE, allowNull: false, primaryKey: true },
+        name: { type: DataTypes.STRING },
+      });
+
+      await Event.sync({ force: true });
+      const event = await Event.create({
+        date: new Date(),
+        name: 'event',
+      });
+
+      expect(event.name).to.equal('event');
+      await event.update({ name: 'event updated' });
+
+      const event0 = await Event.findOne({ where: { date: event.date } });
+      expect(event0.name).to.equal('event updated');
+    });
+
     it('doesn\'t update primary keys or timestamps', async function () {
       const User = this.sequelize.define(`User${Support.rand()}`, {
         name: DataTypes.STRING,

--- a/packages/core/test/unit/sql/insert.test.js
+++ b/packages/core/test/unit/sql/insert.test.js
@@ -143,7 +143,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
 
         const User = timezoneSequelize.define('user', {
           date: {
-            type: DataTypes.DATE,
+            type: DataTypes.DATE(3),
           },
         }, {
           timestamps: false,
@@ -170,7 +170,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
     it('formats the date correctly when inserting', () => {
       const User = current.define('user', {
         date: {
-          type: DataTypes.DATE,
+          type: DataTypes.DATE(3),
         },
       }, {
         timestamps: false,

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -73,12 +73,12 @@ TestModel.init({
   ...(dialectSupportsArray() && {
     intArrayAttr: DataTypes.ARRAY(DataTypes.INTEGER),
     intRangeAttr: DataTypes.RANGE(DataTypes.INTEGER),
-    dateRangeAttr: DataTypes.RANGE(DataTypes.DATE),
+    dateRangeAttr: DataTypes.RANGE(DataTypes.DATE(3)),
   }),
 
   stringAttr: DataTypes.STRING,
   binaryAttr: DataTypes.BLOB,
-  dateAttr: DataTypes.DATE,
+  dateAttr: DataTypes.DATE(3),
   booleanAttr: DataTypes.BOOLEAN,
   bigIntAttr: DataTypes.BIGINT,
 


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR is an updated version of PR https://github.com/sequelize/sequelize/pull/13145

Looks like the bug was fixed, so I only added a regression test

Closes https://github.com/sequelize/sequelize/pull/13145
Closes https://github.com/sequelize/sequelize/issues/12717
