### PR TITLE
fix(ibmi): close connection after query execution

### DIFF
--- a/packages/core/src/dialects/ibmi/query.js
+++ b/packages/core/src/dialects/ibmi/query.js
@@ -25,7 +25,7 @@ export class IBMiQuery extends AbstractQuery {
       throw this.formatError(error);
     } finally {
       if (this.connection) {
-        await this.connection.close5();
+        await this.connection.close();
       }
     }
 

--- a/packages/core/src/dialects/ibmi/query.js
+++ b/packages/core/src/dialects/ibmi/query.js
@@ -23,6 +23,10 @@ export class IBMiQuery extends AbstractQuery {
       results = await this.connection.query(this.sql, parameters);
     } catch (error) {
       throw this.formatError(error);
+    } finally {
+      if (this.connection) {
+        await this.connection.close5();
+      }
     }
 
     complete();


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions? Not applicable
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

While using Sequelize against the IBM i, I noticed connections (jobs) on the system are not being closed until the application closes. Since a connection pool isn't used, this is a problem. Connections need to be disposed of. This pull request simply adds a finally on the try catch around the query and closes the connection. Tested against our IBM i (7.4).

## Todos

