### PR TITLE
meta: update Slack invitation link

### DIFF
--- a/CONTACT.md
+++ b/CONTACT.md
@@ -11,4 +11,4 @@ You can use the information below to contact maintainers directly. We will try t
 
 ## Via Slack
 
-Most of the team is also reachable privately through [our Slack](https://join.slack.com/t/sequelize/shared_invite/zt-1igt9hx8h-tGWU4AI1bRPvkRdEK5wnuQ)
+Most of the team is also reachable privately through [our Slack](https://sequelize.org/slack)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ We are happy to see that you might be interested in contributing to Sequelize! T
 - Reviewing (i.e. commenting on) open Pull Requests, to help their creators improve it if needed and allow maintainers to take less time looking into them
 - Helping to clarify issues opened by others, commenting and asking for clarification
 - Answering [questions tagged with `sequelize.js` on StackOverflow](https://stackoverflow.com/questions/tagged/sequelize.js)
-- Helping people in our [public Slack channel](https://sequelize.slack.com/) (note: if you don't have access, get yourself an invite automatically via [this link](https://join.slack.com/t/sequelize/shared_invite/zt-1igt9hx8h-tGWU4AI1bRPvkRdEK5wnuQ))
+- Helping people in our [public Slack channel](https://sequelize.slack.com/) (note: if you don't have access, get yourself an invite automatically via [this link](https://sequelize.org/slack))
 
 Sequelize is strongly moved by contributions from people like you. All maintainers also work on their free time here.
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Please find upgrade information to major versions here:
 - [Databases Compatibility Table](https://sequelize.org/releases/)
 - [Changelog](https://github.com/sequelize/sequelize/releases)
 - [Discussions](https://github.com/sequelize/sequelize/discussions)
-- [Slack](https://join.slack.com/t/sequelize/shared_invite/zt-1igt9hx8h-tGWU4AI1bRPvkRdEK5wnuQ)
+- [Slack](https://sequelize.org/slack)
 - [Stack Overflow](https://stackoverflow.com/questions/tagged/sequelize.js)
 
 ### :wrench: Tools


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions? --> I set up uptimerobot to track the newly introduced link
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Update Slack invitation link with a generic and cloudflare controlled one.

## Todos

- [x] We need to do the same for v6
