### PR TITLE
fix(postgres): prevent crash if postgres connection emit multiple errors

### DIFF
--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -204,8 +204,8 @@ class ConnectionManager extends AbstractConnectionManager {
 
     // Don't let a Postgres restart (or error) to take down the whole app
     connection.on('error', error => {
-      debug(`connection error ${error.code || error.message}`);
       connection._invalid = true;
+      debug(`connection error ${error.code || error.message}`);
       this.pool.destroy(connection);
     });
 

--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -165,9 +165,10 @@ class ConnectionManager extends AbstractConnectionManager {
       }
 
       // Don't let a Postgres restart (or error) to take down the whole app
-      connection.once('error', error => {
-        connection._invalid = true;
+      connection.on('error', error => {
         debug(`connection error ${error.code || error.message}`);
+        if (connection._invalid) return;
+        connection._invalid = true;
         this.pool.destroy(connection);
       });
 

--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -167,7 +167,6 @@ class ConnectionManager extends AbstractConnectionManager {
       // Don't let a Postgres restart (or error) to take down the whole app
       connection.on('error', error => {
         debug(`connection error ${error.code || error.message}`);
-        if (connection._invalid) return;
         connection._invalid = true;
         this.pool.destroy(connection);
       });

--- a/src/dialects/postgres/connection-manager.js
+++ b/src/dialects/postgres/connection-manager.js
@@ -164,13 +164,6 @@ class ConnectionManager extends AbstractConnectionManager {
         connection.connection.on('parameterStatus', parameterHandler);
       }
 
-      // Don't let a Postgres restart (or error) to take down the whole app
-      connection.on('error', error => {
-        debug(`connection error ${error.code || error.message}`);
-        connection._invalid = true;
-        this.pool.destroy(connection);
-      });
-
       connection.connect(err => {
         responded = true;
 
@@ -207,6 +200,13 @@ class ConnectionManager extends AbstractConnectionManager {
           resolve(connection);
         }
       });
+    });
+
+    // Don't let a Postgres restart (or error) to take down the whole app
+    connection.on('error', error => {
+      debug(`connection error ${error.code || error.message}`);
+      connection._invalid = true;
+      this.pool.destroy(connection);
     });
 
     let query = '';


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

We recently observed multiple crashes due to an unhandled "server conn crashed?" exception originating from the pg library. As best as I've been able to tell, this shouldn't be possible and should have been fixed in this previous PR : https://github.com/sequelize/sequelize/pull/14731

I think that an error might be able to slip up during the connection without the error listener being properly attached or that error can be fired multiple times and is only handled once.
My fix is to attach the listener before trying to connect to the database. Also I change back the .once handler to a .on (this was changed in the PR 14731) to be able to catch multiple errors.

## Todos
