### PR TITLE
meta: install TypeScript at root level for test-typings CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Extract artifact
         run: tar -xf install-build-node-18.tar
       - name: Install TypeScript
-        run: yarn add typescript@~${{ matrix.ts-version }}
+        run: yarn add typescript@~${{ matrix.ts-version }} -W
       - name: Typing Tests
         run: yarn workspace @sequelize/core test-typings
   test-sqlite:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
       - name: Extract artifact
         run: tar -xf install-build-node-18.tar
       - name: Install TypeScript
-        run: yarn workspace @sequelize/core add typescript@~${{ matrix.ts-version }}
+        run: yarn add typescript@~${{ matrix.ts-version }}
       - name: Typing Tests
         run: yarn workspace @sequelize/core test-typings
   test-sqlite:


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

I've noticed that some dependency updates are failing to install other versions of TypeScript, and a quick Google search leaves me to think we should not add TypeScript on both the root level and on the workspace level. There should no harm in adding TypeScript to the root level here since it will not be added to the archive used for the other checks.
I hope that this fixes that.

One occurance of this; https://github.com/sequelize/sequelize/actions/runs/4590964565
Two errors that happened on that run, highlighting that it might not be directly related to the dependency being updated;
`error An unexpected error occurred: "expected workspace package to exist for \"eslint-utils\"".`
`error An unexpected error occurred: "expected workspace package to exist for \"typedoc\"".`