### PR TITLE
fix(postgres): adds support for minifying through join aliases

### DIFF
--- a/src/dialects/abstract/query-generator.js
+++ b/src/dialects/abstract/query-generator.js
@@ -1881,11 +1881,7 @@ https://github.com/sequelize/sequelize/discussions/15694`);
       }
     }
 
-    if (this.options.minifyAliases && asRight.length > 63) {
-      const alias = `%${topLevelInfo.options.includeAliases.size}`;
-
-      topLevelInfo.options.includeAliases.set(alias, asRight);
-    }
+    this.aliasAs(asRight, topLevelInfo);
 
     return {
       join: include.required ? 'INNER JOIN' : include.right && this._dialect.supports['RIGHT JOIN'] ? 'RIGHT OUTER JOIN' : 'LEFT OUTER JOIN',
@@ -2027,6 +2023,8 @@ https://github.com/sequelize/sequelize/discussions/15694`);
       throughWhere = this.getWhereConditions(through.where, this.sequelize.literal(this.quoteIdentifier(throughAs)), through.model);
     }
 
+    this.aliasAs(includeAs.internalAs, topLevelInfo);
+
     // Generate a wrapped join so that the through table join can be dependent on the target join
     joinBody = `( ${this.quoteTable(throughTable, throughAs)} INNER JOIN ${this.quoteTable(include.model.getTableName(), includeAs.internalAs)} ON ${targetJoinOn}`;
     if (throughWhere) {
@@ -2052,6 +2050,18 @@ https://github.com/sequelize/sequelize/discussions/15694`);
       condition: joinCondition,
       attributes
     };
+  }
+
+  /*
+   * Appends to the alias cache if the alias 64+ characters long and minifyAliases is true.
+   * This helps to avoid character limits in PostgreSQL.
+   */
+  aliasAs(as, topLevelInfo) {
+    if (this.options.minifyAliases && as.length >= 64) {
+      const alias = `%${topLevelInfo.options.includeAliases.size}`;
+
+      topLevelInfo.options.includeAliases.set(alias, as);
+    }
   }
 
   /*


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

A fix was added to support minification of aliases to avoid character limits for PostgreSQL queries, but it did not account for through joins. I've abstracted the aliasing function and used it in both join generator functions.

## Todos

- [ ] Add new tests (need to know where to look)
