### PR TITLE
fix(mariadb,mysql,postgres,sqlite): support specifying custom values for updateOnDupl…

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: sequelize
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/packages/core/src/dialects/abstract/query-generator.d.ts
+++ b/packages/core/src/dialects/abstract/query-generator.d.ts
@@ -39,7 +39,7 @@ type InsertOptions = ParameterOptions & SearchPathable & {
 type BulkInsertOptions = ParameterOptions & {
   hasTrigger?: boolean,
 
-  updateOnDuplicate?: string[],
+  updateOnDuplicate?: string[] | [string, string | Literal],
   ignoreDuplicates?: boolean,
   upsertKeys?: string[],
   returning?: boolean | Array<string | Literal | Col>,

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -382,7 +382,16 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       if (this.dialect.supports.inserts.updateOnDuplicate === ' ON CONFLICT DO UPDATE SET') { // postgres / sqlite
         // If no conflict target columns were specified, use the primary key names from options.upsertKeys
         const conflictKeys = options.upsertKeys.map(attr => this.quoteIdentifier(attr));
-        const updateKeys = options.updateOnDuplicate.map(attr => `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`);
+        const updateKeys = options.updateOnDuplicate.map(attr => {
+          if (Array.isArray(attr)) {
+            const [fieldName, _fieldValue] = attr;
+            const fieldValue = _fieldValue instanceof Literal ? _fieldValue.val : this.escape(_fieldValue, fieldMappedAttributes[fieldName]);
+
+            return `${this.quoteIdentifier(fieldName)}=${fieldValue}`;
+          }
+
+          return `${this.quoteIdentifier(attr)}=EXCLUDED.${this.quoteIdentifier(attr)}`;
+        });
 
         let whereClause = false;
         if (options.conflictWhere) {

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -410,9 +410,11 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
         const valueKeys = options.updateOnDuplicate.map(attr => {
           if (Array.isArray(attr)) {
-            const [fieldName, fieldValue] = attr;
+            const [fieldName, _fieldValue] = attr;
 
-            return `${this.quoteIdentifier(fieldName)} = ${(fieldValue instanceof Literal ? fieldValue.val : this.escape(fieldValue))}`;
+            const fieldValue = _fieldValue instanceof Literal ? _fieldValue.val : this.escape(_fieldValue, fieldMappedAttributes[fieldName]);
+
+            return `${this.quoteIdentifier(fieldName)} = ${fieldValue}`;
           }
 
           return `${this.quoteIdentifier(attr)}=VALUES(${this.quoteIdentifier(attr)})`;

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1,9 +1,15 @@
 'use strict';
 
-import omit from 'lodash/omit';
-import { AbstractDataType } from './dialects/abstract/data-types';
-import { BaseSqlExpression } from './expression-builders/base-sql-expression.js';
-import { intersects } from './utils/array';
+import { Association, BelongsTo, BelongsToMany, HasMany, HasOne } from './associations';
+import { EMPTY_OBJECT, cloneDeep, defaults, flattenObjectDeep, getObjectFromMap, mergeDefaults } from './utils/object';
+import { _validateIncludedElements, combineIncludes, setTransactionFromCls, throwInvalidInclude } from './model-internals';
+import { every, find } from './utils/iterators';
+import { isModelStatic, isSameInitialModel } from './utils/model-utils';
+import {
+  mapFinderOptions,
+  mapOptionFieldNames,
+  mapValueFieldNames,
+} from './utils/format';
 import {
   noDoubleNestedGroup,
   noModelDropSchema,
@@ -11,23 +17,18 @@ import {
   schemaRenamedToWithSchema,
   scopeRenamedToWithScope,
 } from './utils/deprecations';
-import { toDefaultValue } from './utils/dialect';
-import {
-  mapFinderOptions,
-  mapOptionFieldNames,
-  mapValueFieldNames,
-} from './utils/format';
-import { every, find } from './utils/iterators';
-import { cloneDeep, mergeDefaults, defaults, flattenObjectDeep, getObjectFromMap, EMPTY_OBJECT } from './utils/object';
-import { isWhereEmpty } from './utils/query-builder-utils';
-import { ModelTypeScript } from './model-typescript';
-import { isModelStatic, isSameInitialModel } from './utils/model-utils';
-import { Association, BelongsTo, BelongsToMany, HasMany, HasOne } from './associations';
+
+import { AbstractDataType } from './dialects/abstract/data-types';
 import { AssociationSecret } from './associations/helpers';
+import { BaseSqlExpression } from './expression-builders/base-sql-expression.js';
+import { ModelTypeScript } from './model-typescript';
 import { Op } from './operators';
-import { _validateIncludedElements, combineIncludes, setTransactionFromCls, throwInvalidInclude } from './model-internals';
 import { QueryTypes } from './query-types';
 import { getComplexKeys } from './utils/where.js';
+import { intersects } from './utils/array';
+import { isWhereEmpty } from './utils/query-builder-utils';
+import omit from 'lodash/omit';
+import { toDefaultValue } from './utils/dialect';
 
 const assert = require('node:assert');
 const NodeUtil = require('node:util');
@@ -2122,10 +2123,17 @@ ${associationOwner._getAssociationDebugList()}`);
 
       if (options.updateOnDuplicate !== undefined) {
         if (Array.isArray(options.updateOnDuplicate) && options.updateOnDuplicate.length > 0) {
-          options.updateOnDuplicate = _.intersection(
-            _.without(Object.keys(model.tableAttributes), createdAtAttr),
-            options.updateOnDuplicate,
-          );
+          const fields = options.updateOnDuplicate.map(item => (Array.isArray(item) && item.length >= 1 ? item[0] : item));
+          const validAttributes = _.intersection(_.without(Object.keys(model.tableAttributes), createdAtAttr), fields);
+
+          options.updateOnDuplicate = options.updateOnDuplicate.filter(item => {
+            if (Array.isArray(item) && item.length >= 1) {
+              return _.includes(validAttributes, item[0]);
+            }
+
+            return _.includes(validAttributes, item);
+          });
+
         } else {
           throw new Error('updateOnDuplicate option only supports non-empty array.');
         }
@@ -2243,8 +2251,19 @@ ${associationOwner._getAssociationDebugList()}`);
 
         // Map updateOnDuplicate attributes to fields
         if (options.updateOnDuplicate) {
-          options.updateOnDuplicate = options.updateOnDuplicate.map(attrName => {
+
+          const validColumns = options.updateOnDuplicate.map(element => {
+            const attrName = Array.isArray(element) && element.length >= 1 ? element[0] : element;
+
             return modelDefinition.getColumnName(attrName);
+          });
+
+          options.updateOnDuplicate = options.updateOnDuplicate.filter(item => {
+            if (Array.isArray(item) && item.length >= 1) {
+              return _.includes(validColumns, item[0]);
+            }
+
+            return _.includes(validColumns, item);
           });
 
           if (options.conflictAttributes) {

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -2123,6 +2123,7 @@ ${associationOwner._getAssociationDebugList()}`);
 
       if (options.updateOnDuplicate !== undefined) {
         if (Array.isArray(options.updateOnDuplicate) && options.updateOnDuplicate.length > 0) {
+
           const fields = options.updateOnDuplicate.map(item => (Array.isArray(item) && item.length >= 1 ? item[0] : item));
           const validAttributes = _.intersection(_.without(Object.keys(model.tableAttributes), createdAtAttr), fields);
 
@@ -2252,18 +2253,18 @@ ${associationOwner._getAssociationDebugList()}`);
         // Map updateOnDuplicate attributes to fields
         if (options.updateOnDuplicate) {
 
-          const validColumns = options.updateOnDuplicate.map(element => {
-            const attrName = Array.isArray(element) && element.length >= 1 ? element[0] : element;
+          options.updateOnDuplicate = options.updateOnDuplicate.map(item => {
+            const hasCustomValue = Array.isArray(item) && item.length >= 1;
 
-            return modelDefinition.getColumnName(attrName);
-          });
+            const attrName = hasCustomValue ? item[0] : item;
 
-          options.updateOnDuplicate = options.updateOnDuplicate.filter(item => {
-            if (Array.isArray(item) && item.length >= 1) {
-              return _.includes(validColumns, item[0]);
+            if (hasCustomValue) {
+              item[0] = modelDefinition.getColumnName(attrName);
+
+              return item;
             }
 
-            return _.includes(validColumns, item);
+            return modelDefinition.getColumnName(attrName);
           });
 
           if (options.conflictAttributes) {

--- a/packages/core/test/integration/model/bulk-create.test.js
+++ b/packages/core/test/integration/model/bulk-create.test.js
@@ -514,7 +514,15 @@ describe(Support.getTestDialectTeaser('Model'), () => {
               { uniqueName: 'Paul' },
               { uniqueName: 'Michael', secretValue: '50' },
             ];
-            await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', literal('secret_value + 5')]] });
+
+            if (dialectName === 'postgres') {
+              const column = `CAST(${this.User.getTableName()}.secret_value AS INTEGER) `;
+              await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', literal(`${column} + 5`)]] });
+
+            } else {
+              await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', literal('secret_value + 5')]] });
+            }
+
             const users = await this.User.findAll({ order: ['id'] });
             expect(users.length).to.equal(3);
             expect(users[0].uniqueName).to.equal('Peter');

--- a/packages/core/test/integration/model/bulk-create.test.js
+++ b/packages/core/test/integration/model/bulk-create.test.js
@@ -4,7 +4,7 @@ const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
-const { DataTypes, Op, col } = require('@sequelize/core');
+const { DataTypes, Op, col, literal } = require('@sequelize/core');
 
 const dialectName = Support.getTestDialect();
 const dialect = Support.sequelize.dialect;
@@ -476,6 +476,55 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(users[1].secretValue).to.equal('24');
           expect(users[2].uniqueName).to.equal('Michael');
           expect(users[2].secretValue).to.equal('26');
+        });
+
+        describe('[#13033] should support the updateOnDuplicate option with custom values', () => {
+          it('when custom value is not literal', async function () {
+            const data = [
+              { uniqueName: 'Peter', secretValue: '42' },
+              { uniqueName: 'Paul', secretValue: '23' },
+            ];
+
+            await this.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: ['secretValue'] });
+            const new_data = [
+              { uniqueName: 'Peter' },
+              { uniqueName: 'Paul' },
+              { uniqueName: 'Michael', secretValue: '30' },
+            ];
+            await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', '10']] });
+            const users = await this.User.findAll({ order: ['id'] });
+            expect(users.length).to.equal(3);
+            expect(users[0].uniqueName).to.equal('Peter');
+            expect(users[0].secretValue).to.equal('10');
+            expect(users[1].uniqueName).to.equal('Paul');
+            expect(users[1].secretValue).to.equal('10');
+            expect(users[2].uniqueName).to.equal('Michael');
+            expect(users[2].secretValue).to.equal('30');
+          });
+
+          it('when custom value is a sequelize literal', async function () {
+            const data = [
+              { uniqueName: 'Peter', secretValue: '10' },
+              { uniqueName: 'Paul', secretValue: '15' },
+            ];
+
+            await this.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: ['secretValue'] });
+            const new_data = [
+              { uniqueName: 'Peter' },
+              { uniqueName: 'Paul' },
+              { uniqueName: 'Michael', secretValue: '50' },
+            ];
+            await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', literal('secret_value + 5')]] });
+            const users = await this.User.findAll({ order: ['id'] });
+            expect(users.length).to.equal(3);
+            expect(users[0].uniqueName).to.equal('Peter');
+            expect(users[0].secretValue).to.equal('15');
+            expect(users[1].uniqueName).to.equal('Paul');
+            expect(users[1].secretValue).to.equal('20');
+            expect(users[2].uniqueName).to.equal('Michael');
+            expect(users[2].secretValue).to.equal('50');
+          });
+
         });
 
         describe('should support the updateOnDuplicate option with primary keys', () => {


### PR DESCRIPTION
…icate in model.bulkCreate. Fixes #13033

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

When using the updateOnDuplicate option in model.bulkCreate we're unable to specify custom values or literals.

Example code of the issue:
```SQL
    const options = {
      updateOnDuplicate: [
        'last_request_date'
        'last_resource_id',
        'retrivals_count',
        'updatedAt'
      ],
      logging:         true,
      hooks:           false,
      individualHooks: false,
      returning:       false
    };

    // Perform the batch upsert using bulkCreate with the options
    const bulk = await ActorUsage.bulkCreate(usersArray, options);

```

This code generates an ON DUPLICATE KEY UPDATE query based on the **tableAttributes**. However, the values used in the update will be the same as the ones specified in the **usersArray**, making it impossible to increment a counter or customize the update.

This PR fixes this,
Example code of the solution:
```SQL
    const options = {
      updateOnDuplicate: [
        ['last_request_date', literal('CURRENT_TIMESTAMP')],
        ['last_resource_id', resource.id],
        ['retrivals_count', literal('retrivals_count + 1')],
        'updatedAt'
      ],
      logging:         true,
      hooks:           false,
      individualHooks: false,
      returning:       false
    };

    // Perform the batch upsert using bulkCreate with the options
    const bulk = await ActorUsage.bulkCreate(usersArray, options);

```

**updateOnDuplicate** now supports specifying literals or custom values for ON DUPLICATE KEY UPDATE with a similar syntax to what Sequelize uses for sort operations in a query.

This code will generate an ON DUPLICATE KEY UPDATE query. If there are fields specified with custom values or literals, they will be used instead of defaulting to the column names in the records array.

This update allows us to specify a custom update value for a column, enabling us to customize the query by adding native SQL functions or increasing the field value (if applicable).





