### PR TITLE
fix(function): bulkCreate custom values or literals

### DIFF
--- a/test/integration/model/bulk-create.test.js
+++ b/test/integration/model/bulk-create.test.js
@@ -4,6 +4,7 @@ const chai = require('chai'),
   Sequelize = require('sequelize'),
   AggregateError = require('sequelize/lib/errors/aggregate-error'),
   Op = Sequelize.Op,
+  literal = Sequelize.literal,
   expect = chai.expect,
   Support = require('../support'),
   DataTypes = require('sequelize/lib/data-types'),
@@ -462,6 +463,64 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           expect(users[1].secretValue).to.equal('24');
           expect(users[2].uniqueName).to.equal('Michael');
           expect(users[2].secretValue).to.equal('26');
+        });
+
+
+        describe('[#13033] should support the updateOnDuplicate option with custom values', () => {
+          it('when custom value is not literal', async function() {
+            const data = [
+              { uniqueName: 'Peter', secretValue: '42' },
+              { uniqueName: 'Paul', secretValue: '23' }
+            ];
+
+            await this.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: ['secretValue'] });
+            const new_data = [
+              { uniqueName: 'Peter' },
+              { uniqueName: 'Paul' },
+              { uniqueName: 'Michael', secretValue: '30' }
+            ];
+            await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', '10']] });
+            const users = await this.User.findAll({ order: ['id'] });
+            expect(users.length).to.equal(3);
+            expect(users[0].uniqueName).to.equal('Peter');
+            expect(users[0].secretValue).to.equal('10');
+            expect(users[1].uniqueName).to.equal('Paul');
+            expect(users[1].secretValue).to.equal('10');
+            expect(users[2].uniqueName).to.equal('Michael');
+            expect(users[2].secretValue).to.equal('30');
+          });
+
+          it('when custom value is a sequelize literal', async function() {
+            const data = [
+              { uniqueName: 'Peter', secretValue: '10' },
+              { uniqueName: 'Paul', secretValue: '15' }
+            ];
+
+            await this.User.bulkCreate(data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: ['secretValue'] });
+            const new_data = [
+              { uniqueName: 'Peter' },
+              { uniqueName: 'Paul' },
+              { uniqueName: 'Michael', secretValue: '50' }
+            ];
+
+            if (dialect === 'postgres') {
+              const column = `CAST(${this.User.getTableName()}.secret_value AS INTEGER) `;
+              await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', literal(`${column} + 5`)]] });
+
+            } else {
+              await this.User.bulkCreate(new_data, { fields: ['uniqueName', 'secretValue'], updateOnDuplicate: [['secretValue', literal('secret_value + 5')]] });
+            }
+
+            const users = await this.User.findAll({ order: ['id'] });
+            expect(users.length).to.equal(3);
+            expect(users[0].uniqueName).to.equal('Peter');
+            expect(users[0].secretValue).to.equal('15');
+            expect(users[1].uniqueName).to.equal('Paul');
+            expect(users[1].secretValue).to.equal('20');
+            expect(users[2].uniqueName).to.equal('Michael');
+            expect(users[2].secretValue).to.equal('50');
+          });
+
         });
 
         describe('should support the updateOnDuplicate option with primary keys', () => {


### PR DESCRIPTION
Custom values or literals in 'updateOnDuplicate' for 'model.bulkCreate'.

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

When utilizing the updateOnDuplicate option in the model.bulkCreate method, we are unable to specify custom values or literals.

Here is an example code demonstrating the issue:
```SQL
    const options = {
      updateOnDuplicate: [
        'last_request_date'
        'last_resource_id',
        'retrivals_count',
        'updatedAt'
      ],
      logging:         true,
      hooks:           false,
      individualHooks: false,
      returning:       false
    };

    // Perform the batch upsert using bulkCreate with the options
    const bulk = await ActorUsage.bulkCreate(usersArray, options);

```

This code generates an ON DUPLICATE KEY UPDATE query based on the **tableAttributes**. However, the values used in the update will be the same as the ones specified in the **usersArray**, making it impossible to increment a counter or customize the update.

This pull request fixes this issue by allowing for custom values or literals to be specified in the update. Here is an example code showcasing the solution:

```SQL
    const options = {
      updateOnDuplicate: [
        ['last_request_date', literal('CURRENT_TIMESTAMP')],
        ['last_resource_id', resource.id],
        ['retrivals_count', literal('retrivals_count + 1')],
        'updatedAt'
      ],
      logging:         true,
      hooks:           false,
      individualHooks: false,
      returning:       false
    };

    // Perform the batch upsert using bulkCreate with the options
    const bulk = await ActorUsage.bulkCreate(usersArray, options);

```

Now, with the latest update, updateOnDuplicate option supports specifying literals or custom values for ON DUPLICATE KEY UPDATE with a similar syntax to what Sequelize uses for sort operations in a query.

This change will generate an ON DUPLICATE KEY UPDATE query with custom values. 

If there are fields specified with custom values or literals, they will be used instead of defaulting to the column names in the records array.

This update allows to specify a custom update value for a column, enabling customization of the query by adding native SQL functions or increasing the field value (if applicable).


Fixes issue https://github.com/sequelize/sequelize/issues/13033

