### PR TITLE
fix(sqlite): don't use mkdirp if the file already exists

### DIFF
--- a/packages/core/src/dialects/sqlite/connection-manager.ts
+++ b/packages/core/src/dialects/sqlite/connection-manager.ts
@@ -66,9 +66,11 @@ export class SqliteConnectionManager extends AbstractConnectionManager<SqliteCon
       return this.connections.get(connectionCacheKey)!;
     }
 
-    if (!inMemory && (readWriteMode & this.lib.OPEN_CREATE) !== 0) {
+    const storageDir = path.dirname(storage);
+
+    if (!inMemory && (readWriteMode & this.lib.OPEN_CREATE) !== 0 && !fs.existsSync(storageDir)) {
       // automatic path provision for `options.storage`
-      fs.mkdirSync(path.dirname(storage), { recursive: true });
+      fs.mkdirSync(storageDir, { recursive: true });
     }
 
     const connection = await new Promise<SqliteConnection>((resolve, reject) => {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

On Windows, using fs.mkdir() on the root directory even with recursion will result in an error

https://nodejs.org/dist/latest-v16.x/docs/api/fs.html#fsmkdirpath-options-callback

Fixes #14555 
