### PR TITLE
feat: move pg-hstore to prod dependencies

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,7 +56,7 @@
     "inflection": "^2.0.0",
     "lodash": "^4.17.21",
     "pg-connection-string": "^2.5.0",
-    "pg-hstore": "2.3.4",
+    "pg-hstore": "^2.3.4",
     "retry-as-promised": "^7.0.3",
     "semver": "^7.3.7",
     "sequelize-pool": "^8.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -56,6 +56,7 @@
     "inflection": "^2.0.0",
     "lodash": "^4.17.21",
     "pg-connection-string": "^2.5.0",
+    "pg-hstore": "2.3.4",
     "retry-as-promised": "^7.0.3",
     "semver": "^7.3.7",
     "sequelize-pool": "^8.0.0",
@@ -102,7 +103,6 @@
     "p-settle": "4.1.1",
     "p-timeout": "4.1.0",
     "pg": "8.10.0",
-    "pg-hstore": "2.3.4",
     "rimraf": "4.4.1",
     "sinon": "15.0.3",
     "sinon-chai": "3.7.0",
@@ -112,9 +112,6 @@
   },
   "peerDependenciesMeta": {
     "pg": {
-      "optional": true
-    },
-    "pg-hstore": {
       "optional": true
     },
     "mysql2": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7603,7 +7603,7 @@ pg-connection-string@^2.5.0:
   resolved "https://registry.yarnpkg.com/pg-connection-string/-/pg-connection-string-2.5.0.tgz#538cadd0f7e603fc09a12590f3b8a452c2c0cf34"
   integrity sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ==
 
-pg-hstore@2.3.4:
+pg-hstore@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/pg-hstore/-/pg-hstore-2.3.4.tgz#4425e3e2a3e15d2a334c35581186c27cf2e9b8dd"
   integrity sha512-N3SGs/Rf+xA1M2/n0JBiXFDVMzdekwLZLAO0g7mpDY9ouX+fDI7jS6kTq3JujmYbtNSJ53TJ0q4G98KVZSM4EA==


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

`pg-hstore` used to be lazily loaded if DataTypes.HSTORE is used. This was changed in the DataTypes PR for the following reasons:

- It's a pain to import using `require` with TypeScript
- In an indeterminate future, we'll fully migrate to ESM. Dynamic imports will be done with `import()`, which is asynchronous

This means that if you use `pg`, you must always install pg-hstore. `pg-hstore` is a tiny library, so we might as well install it by default.

Once we move dialects to their own packages, we'll move this dependency to the `@sequelize/postgresql` package