### PR TITLE
feat(types): add noAlias option to avoid generating arrow alias in …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@sequelize/monorepo",
-  "private": true,
+  "name": "@clairejs/sequelize",
+  "version": "1.0.0",
   "scripts": {
     "prepare": "husky install",
     "publish-all": "lerna publish --conventional-commits --no-private --yes --create-release github",

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -1189,7 +1189,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
           continue;
         }
 
-        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo, { replacements: options.replacements, minifyAliases: options.minifyAliases });
+        const joinQueries = this.generateInclude(include, { externalAs: mainTable.as, internalAs: mainTable.as }, topLevelInfo, { replacements: options.replacements, minifyAliases: options.minifyAliases, noAlias: include?.noAlias });
 
         subJoinQueries = subJoinQueries.concat(joinQueries.subQuery);
         mainJoinQueries = mainJoinQueries.concat(joinQueries.mainQuery);
@@ -1783,7 +1783,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
 
     return {
       join: include.required ? 'INNER JOIN' : include.right && this.dialect.supports['RIGHT JOIN'] ? 'RIGHT OUTER JOIN' : 'LEFT OUTER JOIN',
-      body: this.quoteTable(tableRight, asRight),
+      body: this.quoteTable(tableRight, !options.noAlias ? asRight : tableRight),
       condition: joinOn,
       attributes: {
         main: [],

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -724,6 +724,11 @@ export interface IncludeOptions extends Filterable<any>, Projectable, Paranoid {
    * Use sub queries. This should only be used if you know for sure the query does not result in a cartesian product.
    */
   subQuery?: boolean;
+
+  /**
+   * Don't use arrow alias when generation join clauses.
+   */
+  noAlias?: boolean;
 }
 
 type OrderItemAssociation = Association | ModelStatic<Model> | { model: ModelStatic<Model>, as: string } | string;


### PR DESCRIPTION
…join clause

<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Add `noAlias` option to prevent generating arrow alias in nested join clauses.

## Todos

- [x] Add noAlias option in IncludeOptions
- [x] Check for noAlias when generating join clause
