### PR TITLE
fix(mssql): return no result when limit is zero

### DIFF
--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -897,6 +897,8 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
   }
 
   addLimitAndOffset(options, model) {
+    const hasLimit = options.limit !== null && options.limit !== undefined;
+    const hasOffset = options.offset !== null && options.offset !== undefined;
     const offset = options.offset || 0;
     const isSubQuery = options.subQuery === undefined
       ? options.hasIncludeWhere || options.hasIncludeRequired || options.hasMultiAssociation
@@ -909,7 +911,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
       orders = this.getQueryOrders(options, model, isSubQuery);
     }
 
-    if (options.limit || options.offset) {
+    if (hasLimit || hasOffset) {
       // TODO: document why this is adding the primary key of the model in ORDER BY if options.include is set
       if (!options.order || options.order.length === 0 || options.include && orders.subQueryOrder.length === 0) {
         let primaryKey = model.primaryKeyField;
@@ -950,11 +952,11 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
         }
       }
 
-      if (options.offset || options.limit) {
+      if (hasOffset || hasLimit) {
         fragment += ` OFFSET ${this.escape(offset, options)} ROWS`;
       }
 
-      if (options.limit) {
+      if (hasLimit) {
         fragment += ` FETCH NEXT ${this.escape(options.limit, options)} ROWS ONLY`;
       }
     }

--- a/packages/core/test/integration/model/findAll.test.js
+++ b/packages/core/test/integration/model/findAll.test.js
@@ -1347,6 +1347,12 @@ The following associations are defined on "Worker": "ToDos"`);
         expect(users[0].id).to.equal(3);
       });
 
+      it('returns no results when limit is zero', async function () {
+        await this.User.bulkCreate([{ username: 'bobby' }, { username: 'tables' }]);
+        const users = await this.User.findAll({ limit: 0, offset: 0 });
+        expect(users.length).to.equal(0);
+      });
+
       it('should allow us to find IDs using capital letters', async function () {
         const User = this.sequelize.define(`User${Support.rand()}`, {
           ID: { type: DataTypes.INTEGER, primaryKey: true, autoIncrement: true },


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] ~If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?~ <!-- Put PR link here -->
- [ ] ~Did you update the typescript typings accordingly (if applicable)?~
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This is a naive attempt to fix https://github.com/sequelize/sequelize/issues/15959.

Today, the MSSQL variant of `addLimitAndOffset()` outputs nothing when the limit parameter is zero. Therefore, no pagination is applied and Sequelize returns all results. I would instead expect Sequelize to return no result, as it does with other dialects.

This fix doesn't work: `FETCH NEXT 0 ROWS ONLY` is considered as invalid by MS SQL Server as `The number of rows provided for a FETCH clause must be greater then zero`.

So I think a correct solution would be to have a condition higher in the call stack that bypasses SQL generation/execution altogether when limit is zero, and instead directly returns an empty set. Not sure where to add such a condition, any guidance/advice on that is welcome.

## Todos

- [ ] Implement a fix that works
- [ ] Revert the changes in `packages/core/src/dialects/mssql/query-generator.js`
- [ ] Add more tests?
