### PR TITLE
fix(sqlite): add support for schemas in addConstraint

### DIFF
--- a/packages/core/src/dialects/sqlite/query-generator.js
+++ b/packages/core/src/dialects/sqlite/query-generator.js
@@ -288,6 +288,16 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
   }
 
   describeCreateTableQuery(tableName) {
+    if (typeof tableName === 'object') {
+      if (tableName.schema) {
+        tableName = `${tableName.schema}.${tableName.tableName}`;
+      } else if (tableName.tableName) {
+        tableName = `${tableName.tableName}`;
+      } else {
+        throw new Error('Table must be a string or an object containing tableName and optional schema');
+      }
+    }
+
     return `SELECT sql FROM sqlite_master WHERE tbl_name='${tableName}';`;
   }
 

--- a/packages/core/test/unit/dialects/sqlite/query-generator.test.js
+++ b/packages/core/test/unit/dialects/sqlite/query-generator.test.js
@@ -382,6 +382,23 @@ if (dialect === 'sqlite') {
           expectation: 'PRAGMA foreign_key_check(`schema.myTable`);',
         },
       ],
+      describeCreateTableQuery: [
+        {
+          title: 'Properly handles schemas in addConstraint',
+          arguments: [{ schema: 'schema', tableName: 'myTable' }],
+          expectation: 'SELECT sql FROM sqlite_master WHERE tbl_name=\'schema.myTable\';',
+        },
+        {
+          title: 'Properly handles tables specified as objects in the default schema in addConstraint',
+          arguments: [{ tableName: 'myTable' }],
+          expectation: 'SELECT sql FROM sqlite_master WHERE tbl_name=\'myTable\';',
+        },
+        {
+          title: 'Properly handles tables in the default schema in addConstraint',
+          arguments: ['myTable'],
+          expectation: 'SELECT sql FROM sqlite_master WHERE tbl_name=\'myTable\';',
+        },
+      ],
     };
 
     _.each(suites, (tests, suiteTitle) => {


### PR DESCRIPTION

## Pull Request Checklist

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

In my code, the following migration code fails with an error when running on SQLite.

```
await queryInterface.addConstraint({schema: 'app', tableName: 'mytable'}, ...)
```

It works in other dialects, and is the correct way to add constraints to tables in schemata.

It appears that SQLite uses its own method of getting the table metadata that does not respect the schema property. This modifies that method and adds support for the schema property.

Unit tests are provided to make sure this matches current behavior (which is that the tableName is a simple string), as well as the case that the tableName is an object with only the tableName property.

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
