### PR TITLE
meta: move `types` condition to the front

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,9 +21,9 @@
   "type": "commonjs",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./lib/index.mjs",
-      "require": "./lib/index.js",
-      "types": "./types/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./decorators-legacy": {
       "types": "./types/decorators/legacy/index.d.ts",

--- a/packages/validator-js/package.json
+++ b/packages/validator-js/package.json
@@ -25,9 +25,9 @@
   "types": "./types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./types/index.d.ts",
       "import": "./lib/index.mjs",
-      "require": "./lib/index.js",
-      "types": "./types/index.d.ts"
+      "require": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
## Description Of Change

I moved `types` condition to the front. `package.json#exports` are **order-sensitive** - they are always matched from the top to the bottom. When a match is found then it should be used and no further matching should occur. 

Right now, the current setup works in TypeScript but it's considered a bug and it should not be relied upon, see the thread and the comment [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260). For that reason, I would like to fix all popular packages that misconfigured their `exports` this way so the bug can be fixed in TypeScript.

Note that some of your entrypoints were already using this more correct order (see [those](https://github.com/sequelize/sequelize/blob/e83ff36c3c55c2aee12188861d1cf26720017277/packages/core/package.json#L28-L36)).