### PR TITLE
fix(mssql): support connecting to multiple instances with configuration

### DIFF
--- a/packages/core/src/dialects/mssql/connection-manager.ts
+++ b/packages/core/src/dialects/mssql/connection-manager.ts
@@ -53,6 +53,7 @@ export class MsSqlConnectionManager extends AbstractConnectionManager<MsSqlConne
       port: typeof config.port === 'string' ? Number.parseInt(config.port, 10) : config.port,
       database: config.database,
       trustServerCertificate: true,
+      ...config.dialectOptions,
     };
 
     const authentication: TediousConnectionConfig['authentication'] = {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
When connecting to two MSSQL databases. I encountered an issue with connecting to one of them. It connects to one of them without any problem, but for the other one gives “No database service available” and “Failed to connect to database...” errors. 
example:
ConnectionError [SequelizeConnectionError]: Failed to connect to **** - 14952:error:1425F102:SSL routines:ssl_choose_client_version:unsupported protocol.

This change will fix this error. 