### PR TITLE
meta: update typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "node-hook": "1.0.0",
     "source-map-support": "0.5.21",
     "ts-node": "10.9.1",
-    "typedoc": "0.23.28",
+    "typedoc": "0.24.7",
     "typedoc-plugin-carbon-ads": "1.4.0",
     "typedoc-plugin-mdn-links": "3.0.3",
-    "typedoc-plugin-missing-exports": "1.0.0",
+    "typedoc-plugin-missing-exports": "2.0.0",
     "typescript": "5.0.4"
   },
   "packageManager": "yarn@1.22.19",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -208,10 +208,5 @@
     "----------------------------------------- development ---------------------------------------------": "",
     "build": "../../build-packages.mjs core"
   },
-  "support": true,
-  "typedoc": {
-    "entryPoint": "./src/index.d.ts",
-    "displayName": "@sequelize/core",
-    "tsconfig": "./tsconfig.json"
-  }
+  "support": true
 }

--- a/packages/core/src/data-types.ts
+++ b/packages/core/src/data-types.ts
@@ -14,76 +14,75 @@
 import * as DataTypes from './dialects/abstract/data-types.js';
 import { classToInvokable } from './utils/class-to-invokable.js';
 
-/** This is an alias of {@link <internal>~AbstractDataType}. */
-export const ABSTRACT = DataTypes.AbstractDataType;
+export { AbstractDataType as ABSTRACT } from './dialects/abstract/data-types.js';
 
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~STRING} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const STRING = classToInvokable(DataTypes.STRING);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~CHAR} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const CHAR = classToInvokable(DataTypes.CHAR);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~TEXT} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const TEXT = classToInvokable(DataTypes.TEXT);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~TINYINT} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const TINYINT = classToInvokable(DataTypes.TINYINT);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~SMALLINT} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const SMALLINT = classToInvokable(DataTypes.SMALLINT);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~MEDIUMINT} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const MEDIUMINT = classToInvokable(DataTypes.MEDIUMINT);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~INTEGER} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const INTEGER = classToInvokable(DataTypes.INTEGER);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~BIGINT} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const BIGINT = classToInvokable(DataTypes.BIGINT);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~FLOAT} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const FLOAT = classToInvokable(DataTypes.FLOAT);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~TIME} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const TIME = classToInvokable(DataTypes.TIME);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~DATE} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const DATE = classToInvokable(DataTypes.DATE);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~DATEONLY} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const DATEONLY = classToInvokable(DataTypes.DATEONLY);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~BOOLEAN} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const BOOLEAN = classToInvokable(DataTypes.BOOLEAN);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~NOW} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const NOW = classToInvokable(DataTypes.NOW);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~BLOB} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const BLOB = classToInvokable(DataTypes.BLOB);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~DECIMAL} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const DECIMAL = classToInvokable(DataTypes.DECIMAL);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~UUID} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const UUID = classToInvokable(DataTypes.UUID);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~UUIDV1} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const UUIDV1 = classToInvokable(DataTypes.UUIDV1);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~UUIDV4} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const UUIDV4 = classToInvokable(DataTypes.UUIDV4);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~HSTORE} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const HSTORE = classToInvokable(DataTypes.HSTORE);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~JSON} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const JSON = classToInvokable(DataTypes.JSON);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~JSONB} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const JSONB = classToInvokable(DataTypes.JSONB);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~VIRTUAL} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const VIRTUAL = classToInvokable(DataTypes.VIRTUAL);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~ARRAY} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const ARRAY = classToInvokable(DataTypes.ARRAY);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~ENUM} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const ENUM = classToInvokable(DataTypes.ENUM);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~RANGE} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const RANGE = classToInvokable(DataTypes.RANGE);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~REAL} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const REAL = classToInvokable(DataTypes.REAL);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~DOUBLE} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const DOUBLE = classToInvokable(DataTypes.DOUBLE);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~GEOMETRY} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const GEOMETRY = classToInvokable(DataTypes.GEOMETRY);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~GEOGRAPHY} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const GEOGRAPHY = classToInvokable(DataTypes.GEOGRAPHY);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~CIDR} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const CIDR = classToInvokable(DataTypes.CIDR);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~INET} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const INET = classToInvokable(DataTypes.INET);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~MACADDR} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const MACADDR = classToInvokable(DataTypes.MACADDR);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~CITEXT} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const CITEXT = classToInvokable(DataTypes.CITEXT);
-/** This is a simple wrapper to make the DataType constructable without `new`. See {@link <internal>~TSVECTOR} for all available options. */
+/** This is a simple wrapper to make the DataType constructable without `new`. See the return type for all available options. */
 export const TSVECTOR = classToInvokable(DataTypes.TSVECTOR);

--- a/packages/core/src/dialects/abstract/data-types.ts
+++ b/packages/core/src/dialects/abstract/data-types.ts
@@ -2429,7 +2429,6 @@ export interface GeometryOptions {
  * User.create({username: 'username', geometry: point })
  * ```
  *
- * @see {@link <internal>~GEOGRAPHY}
  * @category DataTypes
  */
 export class GEOMETRY extends AbstractDataType<GeoJson> {

--- a/packages/core/src/dialects/abstract/index.ts
+++ b/packages/core/src/dialects/abstract/index.ts
@@ -498,12 +498,12 @@ export abstract class AbstractDialect {
    * For instance, when implementing "parse" for a Date type,
    * prefer returning a String rather than a Date object.
    *
-   * The {@link AbstractDataType#parseDatabaseValue} method will then be called on the DataType instance defined by the user,
+   * The {@link DataTypes.ABSTRACT#parseDatabaseValue} method will then be called on the DataType instance defined by the user,
    * which can decide on a more specific JS type (e.g. parse the date string & return a Date instance or a Temporal instance).
    *
    * You typically do not need to implement this method. This is used to provide default parsers when no DataType
    * is provided (e.g. raw queries that don't specify a model). Sequelize already provides a default parser for most types.
-   * For a custom Data Type, implementing {@link AbstractDataType#parseDatabaseValue} is typically what you want.
+   * For a custom Data Type, implementing {@link DataTypes.ABSTRACT#parseDatabaseValue} is typically what you want.
    *
    * @param databaseDataTypes Dialect-specific DB data type identifiers that will use this parser.
    * @param parser The parser function to call when parsing the data type. Parameters are dialect-specific.

--- a/packages/core/src/dialects/abstract/query.js
+++ b/packages/core/src/dialects/abstract/query.js
@@ -289,7 +289,7 @@ export class AbstractQuery {
   }
 
   /**
-   * Calls {@link AbstractDataType#parseDatabaseValue} on all attributes returned by the database, if a model is specified.
+   * Calls {@link DataTypes.ABSTRACT#parseDatabaseValue} on all attributes returned by the database, if a model is specified.
    *
    * This method mutates valueArrays.
    *

--- a/packages/core/src/dialects/mssql/data-types.db.ts
+++ b/packages/core/src/dialects/mssql/data-types.db.ts
@@ -3,7 +3,7 @@ import type { MssqlDialect } from './index.js';
 
 /**
  * First pass of DB value parsing: Parses based on the MSSQL Type ID.
- * If a Sequelize DataType is specified, the value is then passed to {@link AbstractDataType#parseDatabaseValue}.
+ * If a Sequelize DataType is specified, the value is then passed to {@link DataTypes.ABSTRACT#parseDatabaseValue}.
  *
  * @param dialect
  */

--- a/packages/core/src/dialects/mysql/data-types.db.ts
+++ b/packages/core/src/dialects/mysql/data-types.db.ts
@@ -7,7 +7,7 @@ import type { MysqlDialect } from './index.js';
 
 /**
  * First pass of DB value parsing: Parses based on the MySQL Type ID.
- * If a Sequelize DataType is specified, the value is then passed to {@link AbstractDataType#parseDatabaseValue}.
+ * If a Sequelize DataType is specified, the value is then passed to {@link DataTypes.ABSTRACT#parseDatabaseValue}.
  *
  * @param dialect
  */

--- a/packages/core/src/dialects/postgres/data-types-db.ts
+++ b/packages/core/src/dialects/postgres/data-types-db.ts
@@ -9,7 +9,7 @@ import type { PostgresDialect } from './index.js';
 
 /**
  * First pass of DB value parsing: Parses based on the Postgres Type ID.
- * If a Sequelize DataType is specified, the value is then passed to {@link AbstractDataType#parseDatabaseValue}.
+ * If a Sequelize DataType is specified, the value is then passed to {@link DataTypes.ABSTRACT#parseDatabaseValue}.
  *
  * @param dialect
  */

--- a/packages/core/src/errors/validation-error.ts
+++ b/packages/core/src/errors/validation-error.ts
@@ -33,7 +33,7 @@ export enum ValidationErrorItemOrigin {
   FUNCTION = 'FUNCTION',
 
   /**
-   * specifies validation errors that originate from {@link <internal>~AbstractDataType#validate} constraint validation.
+   * specifies validation errors that originate from {@link DataTypes.ABSTRACT#validate} constraint validation.
    */
   DATATYPE = 'DATATYPE',
 }

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -29,6 +29,7 @@ export type {
   TimeOptions,
   VirtualOptions,
   RangeOptions,
+  BindParamOptions,
 } from './dialects/abstract/data-types.js';
 export type {
   GeoJson,
@@ -61,6 +62,7 @@ export { useInflection } from './utils/string';
 export { isModelStatic, isSameInitialModel } from './utils/model-utils';
 export type { Validator } from './utils/validator-extras';
 export { Deferrable } from './deferrable';
+export { AbstractDialect } from './dialects/abstract/index.js';
 export { AbstractQueryGenerator } from './dialects/abstract/query-generator.js';
 export { importModels } from './import-models.js';
 export { ModelDefinition } from './model-definition.js';

--- a/packages/core/src/instance-validator.d.ts
+++ b/packages/core/src/instance-validator.d.ts
@@ -1,5 +1,6 @@
 import type { Hookable } from './model';
 
+// TODO: move this to "validate". "validate" should accept either ValidationOptions or a boolean
 export interface ValidationOptions extends Hookable {
   /**
    * An array of strings. All properties that are in this array will not be validated

--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -185,7 +185,7 @@ type AllowAnyAll<T> =
 
 // number is always allowed because -Infinity & +Infinity are valid
 /**
- * This type represents a valid input when describing a {@link <internal>~RANGE}.
+ * This type represents a valid input when describing a {@link DataTypes.RANGE}.
  */
 export type Rangable<T> = readonly [
   lower: T | InputRangePart<T> | number | null,
@@ -193,7 +193,7 @@ export type Rangable<T> = readonly [
 ] | EmptyRange;
 
 /**
- * This type represents the output of the {@link <internal>~RANGE} data type.
+ * This type represents the output of the {@link DataTypes.RANGE} data type.
  */
 // number is always allowed because -Infinity & +Infinity are valid
 export type Range<T> = readonly [

--- a/packages/core/typedoc.json
+++ b/packages/core/typedoc.json
@@ -1,0 +1,5 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/decorators/legacy/index.ts", "src/index.d.ts"],
+  "excludeExternals": true
+}

--- a/packages/validator-js/package.json
+++ b/packages/validator-js/package.json
@@ -46,8 +46,5 @@
     "chai": "4.3.7",
     "chai-as-promised": "7.1.1",
     "mocha": "10.2.0"
-  },
-  "typedoc": {
-    "entryPoint": "./src/index.ts"
   }
 }

--- a/packages/validator-js/typedoc.json
+++ b/packages/validator-js/typedoc.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["../../typedoc.base.json"],
+  "entryPoints": ["src/index.ts"]
+}

--- a/typedoc.base.json
+++ b/typedoc.base.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://typedoc.org/schema.json"
+}

--- a/typedoc.js
+++ b/typedoc.js
@@ -6,5 +6,5 @@ module.exports = {
   plugin: ['typedoc-plugin-missing-exports', 'typedoc-plugin-mdn-links', 'typedoc-plugin-carbon-ads'],
   carbonPlacement: 'sequelizeorg',
   carbonServe: 'CEAI627Y',
-  // treatWarningsAsErrors: true,
+  treatWarningsAsErrors: true,
 };

--- a/typedoc.js
+++ b/typedoc.js
@@ -1,11 +1,10 @@
 module.exports = {
   entryPointStrategy: 'packages',
-  entryPoints: ['packages/core', 'packages/validator-js'],
+  entryPoints: ['packages/*'],
   out: './.typedoc-build',
   readme: 'none',
   plugin: ['typedoc-plugin-missing-exports', 'typedoc-plugin-mdn-links', 'typedoc-plugin-carbon-ads'],
   carbonPlacement: 'sequelizeorg',
   carbonServe: 'CEAI627Y',
-  excludeExternals: true,
-  treatWarningsAsErrors: true,
+  // treatWarningsAsErrors: true,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6422,7 +6422,7 @@ markdownlint@~0.28.2:
     markdown-it "13.0.1"
     markdownlint-micromark "0.1.2"
 
-marked@^4.2.12:
+marked@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
   integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
@@ -6544,7 +6544,7 @@ minimatch@^6.1.6:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimatch@^7.1.3, minimatch@^7.4.2:
+minimatch@^7.4.2:
   version "7.4.6"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-7.4.6.tgz#845d6f254d8f4a5e4fd6baf44d5f10c8448365fb"
   integrity sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==
@@ -9651,19 +9651,19 @@ typedoc-plugin-mdn-links@3.0.3:
   resolved "https://registry.yarnpkg.com/typedoc-plugin-mdn-links/-/typedoc-plugin-mdn-links-3.0.3.tgz#da8d1a9750d57333e6c21717b38bfc13d4058de2"
   integrity sha512-NXhIpwQnsg7BcyMCHVqj3tUK+DL4g3Bt96JbFl4APzTGFkA+iM6GfZ/fn3TAqJ8O0CXG5R9BfWxolw1m1omNuQ==
 
-typedoc-plugin-missing-exports@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-1.0.0.tgz#7212a2cfaba7b48264df4b4110f3a5684b5c49a1"
-  integrity sha512-7s6znXnuAj1eD9KYPyzVzR1lBF5nwAY8IKccP5sdoO9crG4lpd16RoFpLsh2PccJM+I2NASpr0+/NMka6ThwVA==
+typedoc-plugin-missing-exports@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.0.0.tgz#9bdc4e30b0c7f24e9f1cb8890db4d01f608717c5"
+  integrity sha512-t0QlKCm27/8DaheJkLo/gInSNjzBXgSciGhoLpL6sLyXZibm7SuwJtHvg4qXI2IjJfFBgW9mJvvszpoxMyB0TA==
 
-typedoc@0.23.28:
-  version "0.23.28"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.23.28.tgz#3ce9c36ef1c273fa849d2dea18651855100d3ccd"
-  integrity sha512-9x1+hZWTHEQcGoP7qFmlo4unUoVJLB0H/8vfO/7wqTnZxg4kPuji9y3uRzEu0ZKez63OJAUmiGhUrtukC6Uj3w==
+typedoc@0.24.7:
+  version "0.24.7"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.24.7.tgz#7eeb272a1894b3789acc1a94b3f2ae8e7330ee39"
+  integrity sha512-zzfKDFIZADA+XRIp2rMzLe9xZ6pt12yQOhCr7cD7/PBTjhPmMyMvGrkZ2lPNJitg3Hj1SeiYFNzCsSDrlpxpKw==
   dependencies:
     lunr "^2.3.9"
-    marked "^4.2.12"
-    minimatch "^7.1.3"
+    marked "^4.3.0"
+    minimatch "^9.0.0"
     shiki "^0.14.1"
 
 typescript@5.0.4, typescript@^5.0.4:


### PR DESCRIPTION
## Pull Request Checklist

TypeDoc 0.24 is out, which supports monorepos.

This means all modules will be properly listed in our API definition now:

![image](https://github.com/sequelize/sequelize/assets/1280915/1ce8cfa9-0e0f-4302-9e34-134be0b31dd6)

URLs changed, we will need to update the documentation to align with this update