### PR TITLE
feat: Allow different additional attributes in N:M join table

### DIFF
--- a/packages/core/src/associations/belongs-to-many.ts
+++ b/packages/core/src/associations/belongs-to-many.ts
@@ -843,7 +843,7 @@ The number of ${this.target.name} to associate (${newTargets.length}), and the n
 
     for (const changedTarget of changedTargets) {
       // @ts-expect-error -- gets the content of the "through" table for this association that is set on the model
-      let throughAttributes = changedTarget[this.through.model.name];
+      let throughAttributes = changedTarget.newInstance[this.through.model.name];
       const attributes = {
         ...defaultAttributesArray[multipleAttributes ? changedTarget.index : 0],
         ...throughAttributes,

--- a/packages/core/test/integration/associations/belongs-to-many.test.js
+++ b/packages/core/test/integration/associations/belongs-to-many.test.js
@@ -3498,8 +3498,8 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
         expect(projects.length).to.equal(3);
         projects.forEach(project => {
-          expect(project.UserProject.status).to.equal('great');
-          expect(project.UserProject.data).to.equal(123);
+          expect(project.userProject.status).to.equal('great');
+          expect(project.userProject.data).to.equal(123);
         });
       });
 
@@ -3512,7 +3512,7 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
           ],
         });
 
-        expect(promise).to.be.rejectedWith(AssociationError);
+        await expect(promise).to.be.rejectedWith(AssociationError);
       });
 
       it('should accept an array to be used for each association accordingly with "add" mixin', async function () {
@@ -3527,13 +3527,13 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
         expect(projects.length).to.equal(3);
         expect(
-          projects.find(project => project.id === this.projects[0].id)?.UserProject,
+          projects.find(project => project.id === this.projects[0].id)?.userProject,
         ).to.exist.and.to.include({ status: 'great', data: 123 });
         expect(
-          projects.find(project => project.id === this.projects[1].id)?.UserProject,
+          projects.find(project => project.id === this.projects[1].id)?.userProject,
         ).to.exist.and.to.include({ status: 'fine', data: 456 });
         expect(
-          projects.find(project => project.id === this.projects[2].id)?.UserProject,
+          projects.find(project => project.id === this.projects[2].id)?.userProject,
         ).to.exist.and.to.include({ status: 'wrong', data: 789 });
       });
 
@@ -3556,13 +3556,13 @@ describe(Support.getTestDialectTeaser('BelongsToMany'), () => {
 
         expect(projects.length).to.equal(3);
         expect(
-          projects.find(project => project.id === this.projects[0].id)?.UserProject,
+          projects.find(project => project.id === this.projects[0].id)?.userProject,
         ).to.exist.and.to.include({ status: 'great', data: 123 });
         expect(
-          projects.find(project => project.id === this.projects[1].id)?.UserProject,
+          projects.find(project => project.id === this.projects[1].id)?.userProject,
         ).to.exist.and.to.include({ status: 'fine', data: 456 });
         expect(
-          projects.find(project => project.id === this.projects[2].id)?.UserProject,
+          projects.find(project => project.id === this.projects[2].id)?.userProject,
         ).to.exist.and.to.include({ status: 'wrong', data: 789 });
       });
     });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change
Closes #13730
<!-- Please provide a description of the change here. -->

## Todos

- [x] Update documentation if feature is correctly implemented<!-- e.g. #1 feature: Extend the type script definition -->
- [x] Improve variable naming if necessary<!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [x] Check if another error class is better suited than AssociationError <!-- ... -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Many-to-many association methods now accept join-table attributes either as a single configuration applied to all targets or as an array supplying per-target attributes; per-target attributes are applied to the corresponding join rows.
  * Added validation that per-target attribute arrays match the number of associations and surface an error when they do not.

* **Tests**
  * Added tests covering single and per-target join attributes, mismatch validation, and correct persistence of per-target values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->