### PR TITLE
fix: use singular association name to generate FK

### DIFF
--- a/packages/core/src/associations/belongs-to.ts
+++ b/packages/core/src/associations/belongs-to.ts
@@ -20,7 +20,7 @@ import { Op } from '../operators';
 import { getColumnName } from '../utils/format.js';
 import { isSameInitialModel } from '../utils/model-utils.js';
 import { cloneDeep, removeUndefined } from '../utils/object.js';
-import { camelize, singularize } from '../utils/string.js';
+import { camelize } from '../utils/string.js';
 import { Association } from './base';
 import type { AssociationOptions, SingleAssociationAccessors } from './base';
 import { HasMany } from './has-many.js';
@@ -264,7 +264,7 @@ export class BelongsTo<
   }
 
   protected inferForeignKey(): string {
-    const associationName = singularize(this.options.as);
+    const associationName = this.options.name.singular;
     if (!associationName) {
       throw new Error('Sanity check: Could not guess the name of the association');
     }

--- a/packages/core/test/integration/associations/has-one.test.js
+++ b/packages/core/test/integration/associations/has-one.test.js
@@ -516,8 +516,11 @@ describe(Support.getTestDialectTeaser('HasOne'), () => {
         });
 
         expect(Object.keys(InternetOrders.getAttributes()).length).to.equal(2);
-        expect(InternetOrders.getAttributes().OrderId).to.be.ok;
-        expect(InternetOrders.getAttributes().OrdersId).not.to.be.ok;
+
+        // The model is named incorrectly.
+        // The modal name should always be singular, so here sequelize assumes that "Orders" is singular
+        expect(InternetOrders.getAttributes().OrdersId).to.be.ok;
+        expect(InternetOrders.getAttributes().OrderId).not.to.be.ok;
       });
     });
   });

--- a/packages/core/test/unit/associations/belongs-to.test.ts
+++ b/packages/core/test/unit/associations/belongs-to.test.ts
@@ -137,6 +137,22 @@ describe(getTestDialectTeaser('belongsTo'), () => {
     sequelize.addModels([Post, Author]);
   });
 
+  it(`uses the model's singular name to generate the foreign key name`, () => {
+    const Book = sequelize.define('Book', {}, {
+      name: {
+        singular: 'Singular',
+        plural: 'Plural',
+      },
+    });
+
+    const Log = sequelize.define('Log', {}, {});
+
+    Log.belongsTo(Book);
+
+    expect(Log.getAttributes().Plural).to.not.exist;
+    expect(Log.getAttributes().Singular).to.exist;
+  });
+
   describe('association hooks', () => {
     let Projects: ModelStatic<any>;
     let Tasks: ModelStatic<any>;

--- a/packages/core/test/unit/associations/belongs-to.test.ts
+++ b/packages/core/test/unit/associations/belongs-to.test.ts
@@ -149,8 +149,8 @@ describe(getTestDialectTeaser('belongsTo'), () => {
 
     Log.belongsTo(Book);
 
-    expect(Log.getAttributes().Plural).to.not.exist;
-    expect(Log.getAttributes().Singular).to.exist;
+    expect(Log.getAttributes().PluralId).to.not.exist;
+    expect(Log.getAttributes().SingularId).to.exist;
   });
 
   describe('association hooks', () => {


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Closes #15895

Fairly straightforward fix. Instead of inferring the singular form, use the one that was already provided in the configuration of the association, or the model