### PR TITLE
meta(mariadb): test for 10.11 instead of 11.0

### DIFF
--- a/dev/mariadb/latest/docker-compose.yml
+++ b/dev/mariadb/latest/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   mariadb-latest:
     container_name: sequelize-mariadb-latest
-    image: mariadb:11.0.2
+    image: mariadb:10.11.4
     environment:
       MYSQL_DATABASE: sequelize_test
       MYSQL_USER: sequelize_test


### PR DESCRIPTION
One test is very flaky for 11.0 and it needs further debugging and possibly is a bug within MariaDB itself. See https://github.com/sequelize/sequelize/pull/16147#issuecomment-1598349038
Since this impacts our CI quite a lot I would suggest going back to the previous 'major' version

Update; I created this all from mobile, and the GitHub app does not give me the PR template