### PR TITLE
meta: move platformAutomerge in renovate packageRules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,7 @@
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
       "automerge": true,
-      "platformAutomerge": true,
+      "platformAutomerge": true
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,11 +8,11 @@
   "automergeStrategy": "squash",
   "semanticCommitType": "meta",
   "ignorePaths": ["dev/**/oldest/docker-compose.yml"],
-  "platformAutomerge": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest", "lockFileMaintenance"],
-      "automerge": true
+      "automerge": true,
+      "platformAutomerge": true,
     }
   ]
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Not sure if this fixes it, but it's worth a try. Now 'automerge' and 'platformAutomerge' are at the same place

