### PR TITLE
fix(types): allow Op.contains on a jsonb column

### DIFF
--- a/packages/core/src/model.d.ts
+++ b/packages/core/src/model.d.ts
@@ -382,6 +382,8 @@ export interface WhereOperators<AttributeType = any> {
   [Op.contains]?:
     // RANGE @> ELEMENT
     | AttributeType extends Range<infer RangeType> ? OperatorValues<OperatorValues<NonNullable<RangeType>>> : never
+    // jsonb @> ELEMENT
+    | AttributeType extends Record<string, unknown> ? OperatorValues<Partial<AttributeType>> : never
     // ARRAY @> ARRAY ; RANGE @> RANGE
     | WhereOperators<AttributeType>[typeof Op.overlap];
 


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [X] ~~If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)?~~ N/A
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

## Description Of Change

In the case of a jsonb column, this wasn't working properly. Previously, the below would be a TypeScript error; this fixes it. Because a jsonb column isn't a Range, we need to add a specific case for it.

```
const someJson = ...;
const e = await MyEntity.findAll({
  where: {
    myJsonbCol: { [Op.contains]: someJson },
  },
});
```