### PR TITLE
preserve keys order when using getters and virtual fields

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -3182,7 +3182,7 @@ Instead of specifying a Model, either:
 
     options = options ?? EMPTY_OBJECT;
 
-    const { attributes, attributesWithGetters } = this.constructor.modelDefinition;
+    const { attributes, attributesWithGetters, rawAttributes } = this.constructor.modelDefinition;
 
     if (attributeName) {
       const attribute = attributes.get(attributeName);
@@ -3211,7 +3211,8 @@ Instead of specifying a Model, either:
       || options.plain && this._options.include
       || options.clone
     ) {
-      const values = Object.create(null);
+      let values = Object.create(null);
+      
       if (attributesWithGetters.size > 0) {
         for (const attributeName2 of attributesWithGetters) {
           if (!this._options.attributes?.includes(attributeName2)) {
@@ -3230,6 +3231,18 @@ Instead of specifying a Model, either:
           values[attributeName2] = this.get(attributeName2, options);
         }
       }
+
+      const keysOrder = Object.keys(rawAttributes)
+
+      values = Object.fromEntries(
+        Object.entries(values)
+          .sort(([keyA], [keyB]) => {
+            const indexA = keysOrder.indexOf(keyA);
+            const indexB = keysOrder.indexOf(keyB);
+            
+            return indexA - indexB;
+          })
+      );
 
       return values;
     }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ x ] Have you added new tests to prevent regressions?
- [ x ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ x ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ x ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

When a model has getters and virtual fields, when serialized to JSON these fields are placed on top of the object. This PR implements sorting for the objects keys following the order they were declared on the model schema.

I'm aware that this PR are doesn't follow most of your contributions guidelines and is likely to be closed. However, if someone with more time than me wants to implement this the "correct" way, please do it. This is a very annoying behavior of Sequelize.