### PR TITLE
meta: fix mariadb flaky test

### DIFF
--- a/dev/mariadb/latest/docker-compose.yml
+++ b/dev/mariadb/latest/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   mariadb-latest:
     container_name: sequelize-mariadb-latest
-    image: mariadb:10.11.4
+    image: mariadb:11.0.2
     environment:
       MYSQL_DATABASE: sequelize_test
       MYSQL_USER: sequelize_test

--- a/packages/core/test/integration/model/findAll/groupedLimit.test.js
+++ b/packages/core/test/integration/model/findAll/groupedLimit.test.js
@@ -127,6 +127,7 @@ if (current.dialect.supports['UNION ALL']) {
               },
               order: [
                 Sequelize.fn('ABS', Sequelize.col('age')),
+                // Two users have the same abs(age), so we need to make sure that the order is deterministic
                 'id',
               ],
               include: [this.User.Tasks],

--- a/packages/core/test/integration/model/findAll/groupedLimit.test.js
+++ b/packages/core/test/integration/model/findAll/groupedLimit.test.js
@@ -117,7 +117,7 @@ if (current.dialect.supports['UNION ALL']) {
             }
           });
 
-          it('works with computed order', async function () {
+          it('works with computed orders', async function () {
             const users = await this.User.findAll({
               attributes: ['id'],
               groupedLimit: {
@@ -128,29 +128,6 @@ if (current.dialect.supports['UNION ALL']) {
               order: [
                 Sequelize.fn('ABS', Sequelize.col('age')),
                 // Two users have the same abs(age), so we need to make sure that the order is deterministic
-                'id',
-              ],
-              include: [this.User.Tasks],
-            });
-
-            /*
-             project1 - 1, 3, 4
-             project2 - 3, 5, 4
-           */
-            // Flaky test
-            expect(users.map(u => u.get('id'))).to.deep.equal([1, 3, 5, 4]);
-          });
-
-          it('works with multiple orders', async function () {
-            const users = await this.User.findAll({
-              attributes: ['id'],
-              groupedLimit: {
-                limit: 3,
-                on: this.User.Projects,
-                values: this.projects.map(item => item.get('id')),
-              },
-              order: [
-                Sequelize.fn('ABS', Sequelize.col('age')),
                 ['id', 'DESC'],
               ],
               include: [this.User.Tasks],

--- a/packages/core/test/integration/model/findAll/groupedLimit.test.js
+++ b/packages/core/test/integration/model/findAll/groupedLimit.test.js
@@ -117,7 +117,7 @@ if (current.dialect.supports['UNION ALL']) {
             }
           });
 
-          it('[Flaky] works with computed order', async function () {
+          it('works with computed order', async function () {
             const users = await this.User.findAll({
               attributes: ['id'],
               groupedLimit: {

--- a/packages/core/test/integration/model/findAll/groupedLimit.test.js
+++ b/packages/core/test/integration/model/findAll/groupedLimit.test.js
@@ -127,6 +127,7 @@ if (current.dialect.supports['UNION ALL']) {
               },
               order: [
                 Sequelize.fn('ABS', Sequelize.col('age')),
+                'id',
               ],
               include: [this.User.Tasks],
             });


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR fixes a flaky test. Users with ID 4 and 7 have the same absolute age, so the sort order was undetermined.

I added the primary key as a secondary sort order to fix this issue. This seems to have fixed the issue: It failed 9 times out of 10 before, and has not failed since. Tested with MariaDB 11.