### PR TITLE
fix: rename `clsTransactionNestMode` ➡️ `defaultTransactionNestMode`; `ClsTransactionOptions` ➡️ `ManagedTransactionOptions`

### DIFF
--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -53,7 +53,7 @@ export {
   IsolationLevel,
   TransactionNestMode,
   Transaction,
-  type ClsTransactionOptions,
+  type ManagedTransactionOptions,
   type TransactionOptions,
   type NormalizedTransactionOptions,
 } from './transaction';

--- a/packages/core/src/sequelize-typescript.ts
+++ b/packages/core/src/sequelize-typescript.ts
@@ -20,7 +20,7 @@ import { validModelHooks } from './model-hooks.js';
 import { setTransactionFromCls } from './model-internals.js';
 import type { ModelManager } from './model-manager.js';
 import type { ConnectionOptions, NormalizedOptions, Options, QueryRawOptions, Sequelize } from './sequelize.js';
-import type { ClsTransactionOptions, TransactionOptions } from './transaction.js';
+import type { ManagedTransactionOptions, TransactionOptions } from './transaction.js';
 import {
   Transaction,
   TransactionNestMode,
@@ -346,12 +346,12 @@ export abstract class SequelizeTypeScript {
    * @param options Transaction Options
    * @param callback Async callback during which the transaction will be active
    */
-  transaction<T>(options: ClsTransactionOptions, callback: TransactionCallback<T>): Promise<T>;
+  transaction<T>(options: ManagedTransactionOptions, callback: TransactionCallback<T>): Promise<T>;
   async transaction<T>(
-    optionsOrCallback: ClsTransactionOptions | TransactionCallback<T>,
+    optionsOrCallback: ManagedTransactionOptions | TransactionCallback<T>,
     maybeCallback?: TransactionCallback<T>,
   ): Promise<T> {
-    let options: ClsTransactionOptions;
+    let options: ManagedTransactionOptions;
     let callback: TransactionCallback<T>;
     if (typeof optionsOrCallback === 'function') {
       callback = optionsOrCallback;
@@ -365,7 +365,7 @@ export abstract class SequelizeTypeScript {
       throw new Error('sequelize.transaction requires a callback. If you wish to start an unmanaged transaction, please use sequelize.startUnmanagedTransaction instead');
     }
 
-    const nestMode: TransactionNestMode = options.nestMode ?? this.options.clsTransactionNestMode;
+    const nestMode: TransactionNestMode = options.nestMode ?? this.options.defaultTransactionNestMode;
 
     // @ts-expect-error -- will be fixed once this class has been merged back with the Sequelize class
     const normalizedOptions = normalizeTransactionOptions(this, options);

--- a/packages/core/src/sequelize.d.ts
+++ b/packages/core/src/sequelize.d.ts
@@ -446,11 +446,11 @@ export interface Options extends Logging {
 
   /**
    * How nested transaction blocks behave by default.
-   * See {@link ClsTransactionOptions#nestMode} for more information.
+   * See {@link ManagedTransactionOptions#nestMode} for more information.
    *
    * @default TransactionNestMode.reuse
    */
-  clsTransactionNestMode?: TransactionNestMode;
+  defaultTransactionNestMode?: TransactionNestMode;
 }
 
 export interface NormalizedOptions extends RequiredBy<Options,
@@ -461,7 +461,7 @@ export interface NormalizedOptions extends RequiredBy<Options,
   | 'dialect'
   | 'timezone'
   | 'disableClsTransactions'
-  | 'clsTransactionNestMode'
+  | 'defaultTransactionNestMode'
 > {
   readonly replication: NormalizedReplicationOptions;
 }

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -269,7 +269,7 @@ export class Sequelize extends SequelizeTypeScript {
       minifyAliases: false,
       logQueryParameters: false,
       disableClsTransactions: false,
-      clsTransactionNestMode: TransactionNestMode.reuse,
+      defaultTransactionNestMode: TransactionNestMode.reuse,
       ...options,
       pool: _.defaults(options.pool || {}, {
         max: 5,

--- a/packages/core/src/transaction.ts
+++ b/packages/core/src/transaction.ts
@@ -544,7 +544,7 @@ export type NormalizedTransactionOptions = StrictRequiredBy<Omit<TransactionOpti
 /**
  * Options accepted by {@link Sequelize#transaction}.
  */
-export interface ClsTransactionOptions extends TransactionOptions {
+export interface ManagedTransactionOptions extends TransactionOptions {
   /**
    * How the transaction block should behave if a parent transaction block exists.
    */

--- a/packages/core/test/integration/sequelize/transaction.test.ts
+++ b/packages/core/test/integration/sequelize/transaction.test.ts
@@ -136,9 +136,9 @@ describe(getTestDialectTeaser('Sequelize#transaction'), () => {
       });
     }
 
-    it(`defaults nestMode to sequelize's clsTransactionNestMode option`, async () => {
+    it(`defaults nestMode to sequelize's defaultTransactionNestMode option`, async () => {
       const customSequelize = await createSingleTransactionalTestSequelizeInstance({
-        clsTransactionNestMode: TransactionNestMode.savepoint,
+        defaultTransactionNestMode: TransactionNestMode.savepoint,
       });
 
       await customSequelize.transaction(async transaction1 => {


### PR DESCRIPTION
## Pull Request Checklist

This is a tiny PR to fix an issue I noticed while writing the new transaction documentation. The new transaction options included CLS in their name but they had nothing to do with CLS, they're related to managed transactions with or without CLS.