### PR TITLE
meta: increase delay for flaky tests

### DIFF
--- a/packages/core/test/integration/pool.test.ts
+++ b/packages/core/test/integration/pool.test.ts
@@ -209,7 +209,7 @@ describe(getTestDialectTeaser('Pooling'), () => {
       await cm.releaseConnection(secondConnection);
     });
 
-    it('[Flaky] should get new connection beyond idle range', async () => {
+    it('should get new connection beyond idle range', async () => {
       const sequelize = createSingleTestSequelizeInstance({
         pool: { max: 1, idle: 100, evict: 10 },
       });
@@ -225,7 +225,7 @@ describe(getTestDialectTeaser('Pooling'), () => {
       await cm.releaseConnection(firstConnection);
 
       // Wait a little and then get next available connection
-      await delay(110);
+      await delay(150);
 
       const secondConnection = await cm.getConnection();
 

--- a/packages/core/test/integration/transaction.test.js
+++ b/packages/core/test/integration/transaction.test.js
@@ -797,7 +797,7 @@ describe(Support.getTestDialectTeaser('Transaction'), () => {
       const newTransactionFunc = async function () {
         const t = await sequelize.startUnmanagedTransaction({ type: Transaction.TYPES.EXCLUSIVE, retry: { match: ['NO_MATCH'] } });
         // introduce delay to force the busy state race condition to fail
-        await delay(1000);
+        await delay(1500);
         await User.create({ id: null, username: `test ${t.id}` }, { transaction: t });
 
         return t.commit();


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

These two tests are flaky and I hope that with a longer delay they fail less often. I'll keep a look out for failing CI checks in the coming weeks to see if these return
