### PR TITLE
feat(mariadb): split MariaDB from MySQL

### DIFF
--- a/packages/core/src/dialects/mariadb/data-types.db.ts
+++ b/packages/core/src/dialects/mariadb/data-types.db.ts
@@ -1,0 +1,57 @@
+import dayjs from 'dayjs';
+import type { FieldInfo } from 'mariadb';
+import { isValidTimeZone } from '../../utils/dayjs.js';
+import type { MariaDbDialect } from './index.js';
+
+/**
+ * First pass of DB value parsing: Parses based on the MariaDB Type ID.
+ * If a Sequelize DataType is specified, the value is then passed to {@link DataTypes.ABSTRACT#parseDatabaseValue}.
+ *
+ * @param dialect
+ */
+export function registerMariaDbDbDataTypeParsers(dialect: MariaDbDialect) {
+  dialect.registerDataTypeParser(['DATETIME'], (value: FieldInfo) => {
+    const valueStr = value.string();
+    if (valueStr === null) {
+      return null;
+    }
+
+    const timeZone = dialect.sequelize.options.timezone;
+    if (timeZone === '+00:00') { // default value
+      // mariadb returns a UTC date string that looks like the following:
+      // 2022-01-01 00:00:00
+      // The above does not specify a time zone offset, so Date.parse will try to parse it as a local time.
+      // Adding +00 fixes this.
+      return `${valueStr}+00`;
+    }
+
+    if (isValidTimeZone(timeZone)) {
+      return dayjs.tz(valueStr, timeZone).toISOString();
+    }
+
+    // offset format, we can just append.
+    // "2022-09-22 20:03:06" with timeZone "-04:00"
+    // becomes "2022-09-22 20:03:06-04:00"
+    return valueStr + timeZone;
+  });
+
+  // dateonly
+  dialect.registerDataTypeParser(['DATE'], (value: FieldInfo) => {
+    return value.string();
+  });
+
+  // bigint
+  dialect.registerDataTypeParser(['LONGLONG'], (value: FieldInfo) => {
+    return value.string();
+  });
+
+  dialect.registerDataTypeParser(['GEOMETRY'], (value: FieldInfo) => {
+    return value.geometry();
+  });
+
+  // For backwards compatibility, we currently return BIGINTs as strings. We will implement bigint support for all
+  // dialects in the future: https://github.com/sequelize/sequelize/issues/10468
+  dialect.registerDataTypeParser(['BIGINT'], (value: FieldInfo) => {
+    return value.string();
+  });
+}

--- a/packages/core/src/dialects/mariadb/data-types.ts
+++ b/packages/core/src/dialects/mariadb/data-types.ts
@@ -28,7 +28,7 @@ export class DATE extends BaseTypes.DATE {
   toBindableValue(date: AcceptedDate) {
     date = this._applyTimezone(date);
 
-    // MySQL datetime precision defaults to 0
+    // MariaDB datetime precision defaults to 0
     const precision = this.options.precision ?? 0;
     let format = 'YYYY-MM-DD HH:mm:ss';
     // TODO: We should normally use `S`, `SS` or `SSS` based on the precision, but

--- a/packages/core/src/dialects/mariadb/data-types.ts
+++ b/packages/core/src/dialects/mariadb/data-types.ts
@@ -54,6 +54,13 @@ export class DATE extends BaseTypes.DATE {
   }
 }
 
+export class UUID extends BaseTypes.UUID {
+  // TODO: add check constraint to enforce GUID format
+  toSql() {
+    return 'CHAR(36) BINARY';
+  }
+}
+
 export class GEOMETRY extends BaseTypes.GEOMETRY {
   toBindableValue(value: GeoJson) {
     const srid = this.options.srid ? `, ${this.options.srid}` : '';

--- a/packages/core/src/dialects/mariadb/index.ts
+++ b/packages/core/src/dialects/mariadb/index.ts
@@ -1,12 +1,11 @@
-import type { FieldInfo } from 'mariadb';
 import type { Sequelize } from '../../sequelize.js';
 import { createUnspecifiedOrderedBindCollector } from '../../utils/sql';
 import type { SupportableNumericOptions } from '../abstract';
 import { AbstractDialect } from '../abstract';
-import { registerMySqlDbDataTypeParsers } from '../mysql/data-types.db.js';
 import { escapeMysqlString } from '../mysql/mysql-utils';
 import { MariaDbConnectionManager } from './connection-manager';
 import * as DataTypes from './data-types';
+import { registerMariaDbDbDataTypeParsers } from './data-types.db.js';
 import { MariaDbQuery } from './query';
 import { MariaDbQueryGenerator } from './query-generator';
 import { MariaDbQueryInterface } from './query-interface';
@@ -85,12 +84,7 @@ export class MariaDbDialect extends AbstractDialect {
       this.queryGenerator,
     );
 
-    registerMySqlDbDataTypeParsers(this);
-    // For backwards compatibility, we currently return BIGINTs as strings. We will implement bigint support for all
-    // dialects in the future: https://github.com/sequelize/sequelize/issues/10468
-    this.registerDataTypeParser(['BIGINT'], (value: FieldInfo) => {
-      return value.string();
-    });
+    registerMariaDbDbDataTypeParsers(this);
   }
 
   createBindCollector() {

--- a/packages/core/src/dialects/mariadb/query-generator.d.ts
+++ b/packages/core/src/dialects/mariadb/query-generator.d.ts
@@ -1,3 +1,3 @@
-import { MySqlQueryGenerator } from '../mysql/query-generator.js';
+import { MariaDbQueryGeneratorTypeScript } from './query-generator-typescript.js';
 
-export class MariaDbQueryGenerator extends MySqlQueryGenerator {}
+export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {}

--- a/packages/core/src/dialects/mariadb/query-generator.js
+++ b/packages/core/src/dialects/mariadb/query-generator.js
@@ -1,19 +1,147 @@
 'use strict';
 
-import { normalizeDataType } from '../abstract/data-types-utils';
-import { joinSQLFragments } from '../../utils/join-sql-fragments.js';
-import { MariaDbQueryGeneratorTypeScript } from './query-generator-typescript';
+import { joinSQLFragments } from '../../utils/join-sql-fragments';
+import { EMPTY_OBJECT } from '../../utils/object.js';
+import { defaultValueSchemable } from '../../utils/query-builder-utils';
+import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
 
 const _ = require('lodash');
+const { MariaDbQueryGeneratorTypeScript } = require('./query-generator-typescript');
+
+const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
+  createSchemaQuery(schemaName, options) {
+    return joinSQLFragments([
+      'CREATE SCHEMA IF NOT EXISTS',
+      this.quoteIdentifier(schemaName),
+      options?.charset && `DEFAULT CHARACTER SET ${this.escape(options.charset)}`,
+      options?.collate && `DEFAULT COLLATE ${this.escape(options.collate)}`,
+      ';',
+    ]);
+  }
+
+  dropSchemaQuery(schemaName) {
+    return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schemaName)};`;
+  }
 
   _getTechnicalSchemaNames() {
     return ['MYSQL', 'INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA', 'mysql', 'information_schema', 'performance_schema'];
   }
 
-  _getBeforeSelectAttributesFragment(_options) {
-    return '';
+  listSchemasQuery(options) {
+    const schemasToSkip = this._getTechnicalSchemaNames();
+
+    if (Array.isArray(options?.skip)) {
+      schemasToSkip.push(...options.skip);
+    }
+
+    return joinSQLFragments([
+      'SELECT SCHEMA_NAME as schema_name',
+      'FROM INFORMATION_SCHEMA.SCHEMATA',
+      `WHERE SCHEMA_NAME NOT IN (${schemasToSkip.map(schema => this.escape(schema)).join(', ')})`,
+      ';',
+    ]);
+  }
+
+  createTableQuery(tableName, attributes, options) {
+    options = {
+      engine: 'InnoDB',
+      charset: null,
+      rowFormat: null,
+      ...options,
+    };
+
+    const primaryKeys = [];
+    const foreignKeys = {};
+    const attrStr = [];
+
+    for (const attr in attributes) {
+      if (!Object.hasOwn(attributes, attr)) {
+        continue;
+      }
+
+      const dataType = attributes[attr];
+      let match;
+
+      if (dataType.includes('PRIMARY KEY')) {
+        primaryKeys.push(attr);
+
+        if (dataType.includes('REFERENCES')) {
+          // MySQL doesn't support inline REFERENCES declarations: move to the end
+          match = dataType.match(/^(.+) (REFERENCES.*)$/);
+          attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace('PRIMARY KEY', '')}`);
+          foreignKeys[attr] = match[2];
+        } else {
+          attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`);
+        }
+      } else if (dataType.includes('REFERENCES')) {
+        // MySQL doesn't support inline REFERENCES declarations: move to the end
+        match = dataType.match(/^(.+) (REFERENCES.*)$/);
+        attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
+        foreignKeys[attr] = match[2];
+      } else {
+        attrStr.push(`${this.quoteIdentifier(attr)} ${dataType}`);
+      }
+    }
+
+    const table = this.quoteTable(tableName);
+    let attributesClause = attrStr.join(', ');
+    const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
+
+    if (options.uniqueKeys) {
+      _.each(options.uniqueKeys, (columns, indexName) => {
+        if (typeof indexName !== 'string') {
+          indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
+        }
+
+        attributesClause += `, UNIQUE ${this.quoteIdentifier(indexName)} (${columns.fields.map(field => this.quoteIdentifier(field))
+          .join(', ')})`;
+      });
+    }
+
+    if (pkString.length > 0) {
+      attributesClause += `, PRIMARY KEY (${pkString})`;
+    }
+
+    for (const fkey in foreignKeys) {
+      if (Object.hasOwn(foreignKeys, fkey)) {
+        attributesClause += `, FOREIGN KEY (${this.quoteIdentifier(fkey)}) ${foreignKeys[fkey]}`;
+      }
+    }
+
+    return joinSQLFragments([
+      'CREATE TABLE IF NOT EXISTS',
+      table,
+      `(${attributesClause})`,
+      `ENGINE=${options.engine}`,
+      options.comment && typeof options.comment === 'string' && `COMMENT ${this.escape(options.comment)}`,
+      options.charset && `DEFAULT CHARSET=${options.charset}`,
+      options.collate && `COLLATE ${options.collate}`,
+      options.initialAutoIncrement && `AUTO_INCREMENT=${options.initialAutoIncrement}`,
+      options.rowFormat && `ROW_FORMAT=${options.rowFormat}`,
+      ';',
+    ]);
+  }
+
+  showTablesQuery(schemaName) {
+    let query = 'SELECT TABLE_NAME, TABLE_SCHEMA FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = \'BASE TABLE\'';
+    if (schemaName) {
+      query += ` AND TABLE_SCHEMA = ${this.escape(schemaName)}`;
+    } else {
+      const technicalSchemas = this._getTechnicalSchemaNames();
+
+      query += ` AND TABLE_SCHEMA NOT IN (${technicalSchemas.map(schema => this.escape(schema)).join(', ')})`;
+    }
+
+    return `${query};`;
+  }
+
+  tableExistsQuery(table) {
+    // remove first & last `, then escape as SQL string
+    const tableName = this.escape(this.quoteTable(table).slice(1, -1));
+
+    return `SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME = ${tableName} AND TABLE_SCHEMA = ${this.escape(this.sequelize.config.database)}`;
   }
 
   addColumnQuery(table, key, dataType, options = {}) {
@@ -48,6 +176,168 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
       'DROP',
       ifExists,
       this.quoteIdentifier(attributeName),
+      ';',
+    ]);
+  }
+
+  changeColumnQuery(tableName, attributes) {
+    const attrString = [];
+    const constraintString = [];
+
+    for (const attributeName in attributes) {
+      let definition = attributes[attributeName];
+      if (definition.includes('REFERENCES')) {
+        const attrName = this.quoteIdentifier(attributeName);
+        definition = definition.replace(/.+?(?=REFERENCES)/, '');
+        constraintString.push(`FOREIGN KEY (${attrName}) ${definition}`);
+      } else {
+        attrString.push(`\`${attributeName}\` \`${attributeName}\` ${definition}`);
+      }
+    }
+
+    return joinSQLFragments([
+      'ALTER TABLE',
+      this.quoteTable(tableName),
+      attrString.length && `CHANGE ${attrString.join(', ')}`,
+      constraintString.length && `ADD ${constraintString.join(', ')}`,
+      ';',
+    ]);
+  }
+
+  renameColumnQuery(tableName, attrBefore, attributes) {
+    const attrString = [];
+
+    for (const attrName in attributes) {
+      const definition = attributes[attrName];
+      attrString.push(`\`${attrBefore}\` \`${attrName}\` ${definition}`);
+    }
+
+    return joinSQLFragments([
+      'ALTER TABLE',
+      this.quoteTable(tableName),
+      'CHANGE',
+      attrString.join(', '),
+      ';',
+    ]);
+  }
+
+  truncateTableQuery(tableName) {
+    return `TRUNCATE ${this.quoteTable(tableName)}`;
+  }
+
+  deleteQuery(tableName, where, options = EMPTY_OBJECT, model) {
+    let query = `DELETE FROM ${this.quoteTable(tableName)}`;
+
+    const escapeOptions = { ...options, model };
+    const whereSql = this.whereQuery(where, escapeOptions);
+    if (whereSql) {
+      query += ` ${whereSql}`;
+    }
+
+    if (options.limit) {
+      query += ` LIMIT ${this.escape(options.limit, escapeOptions)}`;
+    }
+
+    return query;
+  }
+
+  attributeToSQL(attribute, options) {
+    if (!_.isPlainObject(attribute)) {
+      attribute = {
+        type: attribute,
+      };
+    }
+
+    const attributeString = attributeTypeToSql(attribute.type, { escape: this.escape.bind(this), dialect: this.dialect });
+    let template = attributeString;
+
+    if (attribute.allowNull === false) {
+      template += ' NOT NULL';
+    }
+
+    if (attribute.autoIncrement) {
+      template += ' auto_increment';
+    }
+
+    // BLOB/TEXT/GEOMETRY/JSON cannot have a default value
+    if (!typeWithoutDefault.has(attributeString)
+      && attribute.type._binary !== true
+      && defaultValueSchemable(attribute.defaultValue)) {
+      template += ` DEFAULT ${this.escape(attribute.defaultValue)}`;
+    }
+
+    if (attribute.unique === true) {
+      template += ' UNIQUE';
+    }
+
+    if (attribute.primaryKey) {
+      template += ' PRIMARY KEY';
+    }
+
+    if (attribute.comment) {
+      template += ` COMMENT ${this.escape(attribute.comment)}`;
+    }
+
+    if (attribute.first) {
+      template += ' FIRST';
+    }
+
+    if (attribute.after) {
+      template += ` AFTER ${this.quoteIdentifier(attribute.after)}`;
+    }
+
+    if ((!options || !options.withoutForeignKeyConstraints) && attribute.references) {
+      if (options && options.context === 'addColumn' && options.foreignKey) {
+        const fkName = this.quoteIdentifier(`${this.extractTableDetails(options.tableName).tableName}_${options.foreignKey}_foreign_idx`);
+
+        template += `, ADD CONSTRAINT ${fkName} FOREIGN KEY (${this.quoteIdentifier(options.foreignKey)})`;
+      }
+
+      template += ` REFERENCES ${this.quoteTable(attribute.references.table)}`;
+
+      if (attribute.references.key) {
+        template += ` (${this.quoteIdentifier(attribute.references.key)})`;
+      } else {
+        template += ` (${this.quoteIdentifier('id')})`;
+      }
+
+      if (attribute.onDelete) {
+        template += ` ON DELETE ${attribute.onDelete.toUpperCase()}`;
+      }
+
+      if (attribute.onUpdate) {
+        template += ` ON UPDATE ${attribute.onUpdate.toUpperCase()}`;
+      }
+    }
+
+    return template;
+  }
+
+  attributesToSQL(attributes, options) {
+    const result = {};
+
+    for (const key in attributes) {
+      const attribute = attributes[key];
+      result[attribute.field || key] = this.attributeToSQL(attribute, options);
+    }
+
+    return result;
+  }
+
+  /**
+   * Generates an SQL query that removes a foreign key from a table.
+   *
+   * @param  {string} tableName  The name of the table.
+   * @param  {string} foreignKey The name of the foreign key constraint.
+   * @returns {string}            The generated sql query.
+   * @private
+   */
+  dropForeignKeyQuery(tableName, foreignKey) {
+    return joinSQLFragments([
+      'ALTER TABLE',
+      this.quoteTable(tableName),
+      'DROP FOREIGN KEY',
+      this.quoteIdentifier(foreignKey),
       ';',
     ]);
   }

--- a/packages/core/src/dialects/mariadb/query-generator.js
+++ b/packages/core/src/dialects/mariadb/query-generator.js
@@ -25,6 +25,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
     return `DROP SCHEMA IF EXISTS ${this.quoteIdentifier(schemaName)};`;
   }
 
+  // TODO: typescript - protected
   _getTechnicalSchemaNames() {
     return ['MYSQL', 'INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA', 'mysql', 'information_schema', 'performance_schema'];
   }
@@ -68,7 +69,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
         primaryKeys.push(attr);
 
         if (dataType.includes('REFERENCES')) {
-          // MySQL doesn't support inline REFERENCES declarations: move to the end
+          // MariaDB doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace('PRIMARY KEY', '')}`);
           foreignKeys[attr] = match[2];
@@ -76,7 +77,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
           attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace('PRIMARY KEY', '')}`);
         }
       } else if (dataType.includes('REFERENCES')) {
-        // MySQL doesn't support inline REFERENCES declarations: move to the end
+        // MariaDB doesn't support inline REFERENCES declarations: move to the end
         match = dataType.match(/^(.+) (REFERENCES.*)$/);
         attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
         foreignKeys[attr] = match[2];

--- a/packages/core/src/dialects/mysql/data-types.db.ts
+++ b/packages/core/src/dialects/mysql/data-types.db.ts
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs';
 import wkx from 'wkx';
 import { isValidTimeZone } from '../../utils/dayjs.js';
-import type { MariaDbDialect } from '../mariadb/index.js';
 import type { MySqlTypeCastValue } from './connection-manager.js';
 import type { MysqlDialect } from './index.js';
 
@@ -11,7 +10,7 @@ import type { MysqlDialect } from './index.js';
  *
  * @param dialect
  */
-export function registerMySqlDbDataTypeParsers(dialect: MysqlDialect | MariaDbDialect) {
+export function registerMySqlDbDataTypeParsers(dialect: MysqlDialect) {
   /*
   * @see buffer_type here https://dev.mysql.com/doc/refman/5.7/en/c-api-prepared-statement-type-codes.html
   * @see hex here https://github.com/sidorares/node-mysql2/blob/master/lib/constants/types.js

--- a/packages/core/test/unit/data-types/uuid.test.ts
+++ b/packages/core/test/unit/data-types/uuid.test.ts
@@ -7,11 +7,11 @@ import { testDataTypeSql } from './_utils';
 describe('DataTypes.UUID', () => {
   describe('toSql', () => {
     testDataTypeSql('UUID', DataTypes.UUID, {
-      default: 'UUID',
+      postgres: 'UUID',
       ibmi: 'CHAR(36)',
       db2: 'CHAR(36) FOR BIT DATA',
       mssql: 'UNIQUEIDENTIFIER',
-      mysql: 'CHAR(36) BINARY',
+      'mariadb mysql': 'CHAR(36) BINARY',
       snowflake: 'VARCHAR(36)',
       sqlite: 'TEXT',
     });

--- a/packages/core/test/unit/data-types/uuid.test.ts
+++ b/packages/core/test/unit/data-types/uuid.test.ts
@@ -7,11 +7,11 @@ import { testDataTypeSql } from './_utils';
 describe('DataTypes.UUID', () => {
   describe('toSql', () => {
     testDataTypeSql('UUID', DataTypes.UUID, {
-      postgres: 'UUID',
+      default: 'UUID',
       ibmi: 'CHAR(36)',
       db2: 'CHAR(36) FOR BIT DATA',
       mssql: 'UNIQUEIDENTIFIER',
-      'mariadb mysql': 'CHAR(36) BINARY',
+      mysql: 'CHAR(36) BINARY',
       snowflake: 'VARCHAR(36)',
       sqlite: 'TEXT',
     });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR splits MariaDB from MySQL dialect so all methods are unique to each dialect.
