### PR TITLE
feat(sqlite): split SQLite from MySQL

### DIFF
--- a/packages/core/src/dialects/sqlite/query-generator-typescript.ts
+++ b/packages/core/src/dialects/sqlite/query-generator-typescript.ts
@@ -49,6 +49,10 @@ export class SqliteQueryGeneratorTypeScript extends AbstractQueryGenerator {
     return `PRAGMA foreign_keys = ${enable ? 'ON' : 'OFF'}`;
   }
 
+  dropForeignKeyQuery(_tableName: TableNameOrModel, _foreignKey: string): string {
+    throw new Error(`dropForeignKeyQuery is not supported in ${this.dialect.name}.`);
+  }
+
   removeIndexQuery(
     tableName: TableNameOrModel,
     indexNameOrAttributes: string | string[],

--- a/packages/core/src/dialects/sqlite/query-generator-typescript.ts
+++ b/packages/core/src/dialects/sqlite/query-generator-typescript.ts
@@ -2,18 +2,18 @@ import { randomBytes } from 'node:crypto';
 import { rejectInvalidOptions } from '../../utils/check';
 import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { generateIndexName } from '../../utils/string';
+import { AbstractQueryGenerator } from '../abstract/query-generator';
 import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import type { ShowConstraintsQueryOptions } from '../abstract/query-generator.types';
 import type { ColumnsDescription } from '../abstract/query-interface.types';
-import { MySqlQueryGenerator } from '../mysql/query-generator';
 
 const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
 
 /**
  * Temporary class to ease the TypeScript migration
  */
-export class SqliteQueryGeneratorTypeScript extends MySqlQueryGenerator {
+export class SqliteQueryGeneratorTypeScript extends AbstractQueryGenerator {
   createSchemaQuery(): string {
     throw new Error(`Schemas are not supported in ${this.dialect.name}.`);
   }

--- a/packages/core/src/dialects/sqlite/query-generator-typescript.ts
+++ b/packages/core/src/dialects/sqlite/query-generator-typescript.ts
@@ -3,6 +3,7 @@ import { rejectInvalidOptions } from '../../utils/check';
 import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
+import type { RemoveColumnQueryOptions } from '../abstract/query-generator';
 import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
 import type { RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import type { ShowConstraintsQueryOptions } from '../abstract/query-generator.types';
@@ -51,6 +52,10 @@ export class SqliteQueryGeneratorTypeScript extends AbstractQueryGenerator {
 
   dropForeignKeyQuery(_tableName: TableNameOrModel, _foreignKey: string): string {
     throw new Error(`dropForeignKeyQuery is not supported in ${this.dialect.name}.`);
+  }
+
+  removeColumnQuery(_table: TableNameOrModel, _attributeName: string, _options?: RemoveColumnQueryOptions): string {
+    throw new Error(`removeColumnQuery is not supported in ${this.dialect.name}.`);
   }
 
   removeIndexQuery(

--- a/packages/core/src/dialects/sqlite/query-generator.js
+++ b/packages/core/src/dialects/sqlite/query-generator.js
@@ -4,18 +4,13 @@ import { removeNullishValuesFromHash } from '../../utils/format';
 import { EMPTY_OBJECT } from '../../utils/object.js';
 import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { rejectInvalidOptions } from '../../utils/check';
-import {
-  ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-  REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-} from '../abstract/query-generator';
+import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS, CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 
 const { Transaction } = require('../../transaction');
 const _ = require('lodash');
 const { SqliteQueryGeneratorTypeScript } = require('./query-generator-typescript');
 
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
-const REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 // TODO: add support for 'uniqueKeys' by improving the createTableQuery implementation so it also generates a CREATE UNIQUE INDEX query
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set();
 
@@ -274,39 +269,6 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
     }
 
     return result;
-  }
-
-  // TODO: this should not implement `removeColumnQuery` but a new sqlite specific function possibly called `replaceTableQuery`
-  removeColumnQuery(tableName, attributes, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'removeColumnQuery',
-        this.dialect.name,
-        REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-        REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    attributes = this.attributesToSQL(attributes);
-
-    const table = this.extractTableDetails(tableName);
-
-    // TODO: this is unsafe, this table could already exist
-    const backupTableName = {
-      tableName: `${table.tableName}_backup`,
-      schema: table.schema,
-      delimiter: table.delimiter,
-    };
-
-    const quotedTableName = this.quoteTable(tableName);
-    const quotedBackupTableName = this.quoteTable(backupTableName);
-    const attributeNames = Object.keys(attributes).map(attr => this.quoteIdentifier(attr)).join(', ');
-
-    return `${this.createTableQuery(backupTableName, attributes)}`
-      + `INSERT INTO ${quotedBackupTableName} SELECT ${attributeNames} FROM ${quotedTableName};`
-      + `DROP TABLE ${quotedTableName};`
-      + `ALTER TABLE ${quotedBackupTableName} RENAME TO ${quotedTableName};`;
   }
 
   renameColumnQuery(tableName, attrNameBefore, attrNameAfter, attributes) {

--- a/packages/core/src/dialects/sqlite/query-interface.d.ts
+++ b/packages/core/src/dialects/sqlite/query-interface.d.ts
@@ -1,8 +1,8 @@
 import type { Sequelize } from '../../sequelize.js';
-import { AbstractQueryInterface } from '../abstract/query-interface.js';
 import type { SqliteQueryGenerator } from './query-generator.js';
+import { SqliteQueryInterfaceTypeScript } from './query-interface-typescript.js';
 
-export class SqliteQueryInterface extends AbstractQueryInterface {
+export class SqliteQueryInterface extends SqliteQueryInterfaceTypeScript {
   queryGenerator: SqliteQueryGenerator;
 
   constructor(sequelize: Sequelize, queryGenerator: SqliteQueryGenerator);

--- a/packages/core/src/dialects/sqlite/query-interface.js
+++ b/packages/core/src/dialects/sqlite/query-interface.js
@@ -230,7 +230,7 @@ export class SqliteQueryInterface extends SqliteQueryInterfaceTypeScript {
           }
         }
 
-        const sql = this.queryGenerator.removeColumnQuery(tableName, columns);
+        const sql = this.queryGenerator._replaceTableQuery(tableName, columns);
         const subQueries = sql.split(';').filter(q => q !== '');
 
         for (const subQuery of subQueries) {

--- a/packages/core/test/unit/query-generator/drop-foreign-key-query.test.ts
+++ b/packages/core/test/unit/query-generator/drop-foreign-key-query.test.ts
@@ -1,6 +1,7 @@
 import { createSequelizeInstance, expectsql, sequelize } from '../../support';
 
 const dialect = sequelize.dialect;
+const notSupportedError = new Error(`dropForeignKeyQuery is not supported in ${dialect.name}.`);
 
 describe('QueryGenerator#dropForeignKeyQuery', () => {
   const queryGenerator = sequelize.getQueryInterface().queryGenerator;
@@ -10,6 +11,7 @@ describe('QueryGenerator#dropForeignKeyQuery', () => {
       default: 'ALTER TABLE [myTable] DROP FOREIGN KEY [myColumnKey];',
       postgres: 'ALTER TABLE "myTable" DROP CONSTRAINT "myColumnKey";',
       mssql: 'ALTER TABLE [myTable] DROP [myColumnKey]',
+      sqlite: notSupportedError,
     });
   });
 
@@ -20,6 +22,7 @@ describe('QueryGenerator#dropForeignKeyQuery', () => {
       default: 'ALTER TABLE [MyModels] DROP FOREIGN KEY [myColumnKey];',
       postgres: 'ALTER TABLE "MyModels" DROP CONSTRAINT "myColumnKey";',
       mssql: 'ALTER TABLE [MyModels] DROP [myColumnKey]',
+      sqlite: notSupportedError,
     });
   });
 
@@ -28,7 +31,7 @@ describe('QueryGenerator#dropForeignKeyQuery', () => {
       default: 'ALTER TABLE [mySchema].[myTable] DROP FOREIGN KEY [myColumnKey];',
       postgres: 'ALTER TABLE "mySchema"."myTable" DROP CONSTRAINT "myColumnKey";',
       mssql: 'ALTER TABLE [mySchema].[myTable] DROP [myColumnKey]',
-      sqlite: 'ALTER TABLE `mySchema.myTable` DROP FOREIGN KEY `myColumnKey`;',
+      sqlite: notSupportedError,
     });
   });
 
@@ -37,6 +40,7 @@ describe('QueryGenerator#dropForeignKeyQuery', () => {
       default: 'ALTER TABLE [myTable] DROP FOREIGN KEY [myColumnKey];',
       postgres: 'ALTER TABLE "myTable" DROP CONSTRAINT "myColumnKey";',
       mssql: 'ALTER TABLE [myTable] DROP [myColumnKey]',
+      sqlite: notSupportedError,
     });
   });
 
@@ -48,7 +52,7 @@ describe('QueryGenerator#dropForeignKeyQuery', () => {
       default: 'ALTER TABLE [mySchema].[myTable] DROP FOREIGN KEY [myColumnKey];',
       postgres: 'ALTER TABLE "mySchema"."myTable" DROP CONSTRAINT "myColumnKey";',
       mssql: 'ALTER TABLE [mySchema].[myTable] DROP [myColumnKey]',
-      sqlite: 'ALTER TABLE `mySchema.myTable` DROP FOREIGN KEY `myColumnKey`;',
+      sqlite: notSupportedError,
     });
   });
 
@@ -59,7 +63,7 @@ describe('QueryGenerator#dropForeignKeyQuery', () => {
     }
 
     expectsql(() => queryGenerator.dropForeignKeyQuery({ tableName: 'myTable', schema: 'mySchema', delimiter: 'custom' }, 'myColumnKey'), {
-      sqlite: 'ALTER TABLE `mySchemacustommyTable` DROP FOREIGN KEY `myColumnKey`;',
+      sqlite: notSupportedError,
     });
   });
 });

--- a/packages/core/test/unit/query-generator/remove-column-query.test.ts
+++ b/packages/core/test/unit/query-generator/remove-column-query.test.ts
@@ -3,6 +3,7 @@ import { createSequelizeInstance, expectsql, getTestDialect, sequelize } from '.
 
 const dialect = sequelize.dialect;
 const dialectName = getTestDialect();
+const notSupportedError = new Error(`removeColumnQuery is not supported in ${dialectName}.`);
 
 describe('QueryGenerator#removeColumnQuery', () => {
   const queryGenerator = sequelize.getQueryInterface().queryGenerator;
@@ -11,7 +12,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
     expectsql(() => queryGenerator.removeColumnQuery('myTable', 'myColumn'), {
       default: 'ALTER TABLE [myTable] DROP COLUMN [myColumn];',
       'mariadb mysql snowflake': 'ALTER TABLE [myTable] DROP [myColumn];',
-      sqlite: 'CREATE TABLE IF NOT EXISTS `myTable_backup` (`0` m, `1` y, `2` C, `3` o, `4` l, `5` u, `6` m, `7` n);INSERT INTO `myTable_backup` SELECT `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7` FROM `myTable`;DROP TABLE `myTable`;ALTER TABLE `myTable_backup` RENAME TO `myTable`;',
+      sqlite: notSupportedError,
     });
   });
 
@@ -20,6 +21,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
       default: buildInvalidOptionReceivedError('removeColumnQuery', dialectName, ['ifExists']),
       mariadb: 'ALTER TABLE `myTable` DROP IF EXISTS `myColumn`;',
       'postgres mssql': 'ALTER TABLE [myTable] DROP COLUMN IF EXISTS [myColumn];',
+      sqlite: notSupportedError,
     });
   });
 
@@ -29,7 +31,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
     expectsql(() => queryGenerator.removeColumnQuery(MyModel, 'myColumn'), {
       default: 'ALTER TABLE [MyModels] DROP COLUMN [myColumn];',
       'mariadb mysql snowflake': 'ALTER TABLE [MyModels] DROP [myColumn];',
-      sqlite: 'CREATE TABLE IF NOT EXISTS `MyModels_backup` (`0` m, `1` y, `2` C, `3` o, `4` l, `5` u, `6` m, `7` n);INSERT INTO `MyModels_backup` SELECT `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7` FROM `MyModels`;DROP TABLE `MyModels`;ALTER TABLE `MyModels_backup` RENAME TO `MyModels`;',
+      sqlite: notSupportedError,
     });
   });
 
@@ -37,7 +39,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
     expectsql(() => queryGenerator.removeColumnQuery({ tableName: 'myTable', schema: 'mySchema' }, 'myColumn'), {
       default: 'ALTER TABLE [mySchema].[myTable] DROP COLUMN [myColumn];',
       'mariadb mysql snowflake': 'ALTER TABLE [mySchema].[myTable] DROP [myColumn];',
-      sqlite: 'CREATE TABLE IF NOT EXISTS `mySchema.myTable_backup` (`0` m, `1` y, `2` C, `3` o, `4` l, `5` u, `6` m, `7` n);INSERT INTO `mySchema.myTable_backup` SELECT `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7` FROM `mySchema.myTable`;DROP TABLE `mySchema.myTable`;ALTER TABLE `mySchema.myTable_backup` RENAME TO `mySchema.myTable`;',
+      sqlite: notSupportedError,
     });
   });
 
@@ -45,7 +47,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
     expectsql(() => queryGenerator.removeColumnQuery({ tableName: 'myTable', schema: dialect.getDefaultSchema() }, 'myColumn'), {
       default: 'ALTER TABLE [myTable] DROP COLUMN [myColumn];',
       'mariadb mysql snowflake': 'ALTER TABLE [myTable] DROP [myColumn];',
-      sqlite: 'CREATE TABLE IF NOT EXISTS `myTable_backup` (`0` m, `1` y, `2` C, `3` o, `4` l, `5` u, `6` m, `7` n);INSERT INTO `myTable_backup` SELECT `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7` FROM `myTable`;DROP TABLE `myTable`;ALTER TABLE `myTable_backup` RENAME TO `myTable`;',
+      sqlite: notSupportedError,
     });
   });
 
@@ -56,7 +58,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
     expectsql(() => queryGeneratorSchema.removeColumnQuery('myTable', 'myColumn'), {
       default: 'ALTER TABLE [mySchema].[myTable] DROP COLUMN [myColumn];',
       'mariadb mysql snowflake': 'ALTER TABLE [mySchema].[myTable] DROP [myColumn];',
-      sqlite: 'CREATE TABLE IF NOT EXISTS `mySchema.myTable_backup` (`0` m, `1` y, `2` C, `3` o, `4` l, `5` u, `6` m, `7` n);INSERT INTO `mySchema.myTable_backup` SELECT `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7` FROM `mySchema.myTable`;DROP TABLE `mySchema.myTable`;ALTER TABLE `mySchema.myTable_backup` RENAME TO `mySchema.myTable`;',
+      sqlite: notSupportedError,
     });
   });
 
@@ -67,7 +69,7 @@ describe('QueryGenerator#removeColumnQuery', () => {
     }
 
     expectsql(() => queryGenerator.removeColumnQuery({ tableName: 'myTable', schema: 'mySchema', delimiter: 'custom' }, 'myColumn'), {
-      sqlite: 'CREATE TABLE IF NOT EXISTS `mySchemacustommyTable_backup` (`0` m, `1` y, `2` C, `3` o, `4` l, `5` u, `6` m, `7` n);INSERT INTO `mySchemacustommyTable_backup` SELECT `0`, `1`, `2`, `3`, `4`, `5`, `6`, `7` FROM `mySchemacustommyTable`;DROP TABLE `mySchemacustommyTable`;ALTER TABLE `mySchemacustommyTable_backup` RENAME TO `mySchemacustommyTable`;',
+      sqlite: notSupportedError,
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR splits SQLite from MySQL dialect so all methods are unique to each dialect.
Also, this PR remove support for some unsupported SQLite methods.