### PR TITLE
fix: build on windows machines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,23 @@ jobs:
           name: install-build-artifact-node-${{ matrix.node-version }}
           path: install-build-node-${{ matrix.node-version }}.tar
           retention-days: 1
+  install-and-build-on-windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [16, 20]
+    name: Upload install and build artifact on Windows (Node ${{ matrix.node-version }})
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - uses: actions/setup-node@e33196f7422957bea03ed53f6fbb155025ffc7b8 # v3.7.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - name: Install dependencies and build sequelize
+        run: yarn install --immutable
+      - name: Build sequelize
+        run: yarn build
   lint:
     name: Lint code
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - name: Install dependencies and build sequelize
+      - name: Install dependencies
         run: yarn install --immutable
       - name: Build sequelize
         run: yarn build
@@ -51,7 +51,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: yarn
-      - name: Install dependencies and build sequelize
+      - name: Install dependencies
         run: yarn install --immutable
       - name: Build sequelize
         run: yarn build

--- a/build-packages.mjs
+++ b/build-packages.mjs
@@ -14,6 +14,10 @@ import glob from 'fast-glob';
 
 const exec = promisify(childProcess.exec);
 
+// On Windows, `fileURLToPath()` returns a path with "back slashes" ("\").
+// But `fast-glob` doesn't find any files when `sourceDir` contains "back slashes"
+// (Windows) instead of "forward slashes" (Linux).
+// To fix that, convert all "back slashes" to "forward slashes".
 const rootDir = path.dirname(fileURLToPath(import.meta.url)).replaceAll('\\', '/');
 const packages = await fs.readdir(`${rootDir}/packages`);
 
@@ -32,8 +36,6 @@ const typesDir = path.join(packageDir, 'types');
 
 const [sourceFiles] = await Promise.all([
   // Find all .js and .ts files from /src.
-  // `fast-glob` doesn't find any files when `sourceDir` contains "forward slashes"
-  // (Windows) instead of "back slashes" (Linux).
   glob(`${sourceDir}/**/*.{mjs,cjs,js,mts,cts,ts}`, { onlyFiles: true, absolute: false }),
   // Delete /lib for a full rebuild.
   rmDir(libDir),

--- a/build-packages.mjs
+++ b/build-packages.mjs
@@ -31,8 +31,10 @@ const libDir = path.join(packageDir, 'lib');
 const typesDir = path.join(packageDir, 'types');
 
 const [sourceFiles] = await Promise.all([
-  // Find all .js and .ts files from /src
-  glob(`${sourceDir}/**/*.{mjs,cjs,js,mts,cts,ts}`, { onlyFiles: true, absolute: false }),
+  // Find all .js and .ts files from /src.
+  // `fast-glob` doesn't find any files when `sourceDir` contains "forward slashes"
+  // (Windows) instead of "back slashes" (Linux).
+  glob(`${sourceDir.replaceAll('\\', '/')}/**/*.{mjs,cjs,js,mts,cts,ts}`, { onlyFiles: true, absolute: false }),
   // Delete /lib for a full rebuild.
   rmDir(libDir),
   // Delete /types for a full rebuild.

--- a/build-packages.mjs
+++ b/build-packages.mjs
@@ -14,7 +14,7 @@ import glob from 'fast-glob';
 
 const exec = promisify(childProcess.exec);
 
-const rootDir = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.dirname(fileURLToPath(import.meta.url)).replaceAll('\\', '/');
 const packages = await fs.readdir(`${rootDir}/packages`);
 
 const packageName = process.argv[2];
@@ -34,7 +34,7 @@ const [sourceFiles] = await Promise.all([
   // Find all .js and .ts files from /src.
   // `fast-glob` doesn't find any files when `sourceDir` contains "forward slashes"
   // (Windows) instead of "back slashes" (Linux).
-  glob(`${sourceDir.replaceAll('\\', '/')}/**/*.{mjs,cjs,js,mts,cts,ts}`, { onlyFiles: true, absolute: false }),
+  glob(`${sourceDir}/**/*.{mjs,cjs,js,mts,cts,ts}`, { onlyFiles: true, absolute: false }),
   // Delete /lib for a full rebuild.
   rmDir(libDir),
   // Delete /types for a full rebuild.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -202,7 +202,7 @@
     "test-db2": "cross-env DIALECT=db2 yarn test",
     "test-ibmi": "cross-env DIALECT=ibmi yarn test",
     "----------------------------------------- development ---------------------------------------------": "",
-    "build": "../../build-packages.mjs core"
+    "build": "node ../../build-packages.mjs core"
   },
   "support": true
 }


### PR DESCRIPTION
When I recently forked the repo, while attempting to run `npm run build` command in order to build the package, the build didn't run on my Windows machine.
The reasons turned out to be:

* `fast-glob` package [not recognizing](https://github.com/mrmlnc/fast-glob/issues/237) backslashes.
* The `build` script not specifying the executable to run the `.mjs` file with.

After applying the changes in this PR, the build process has finished without errors.