### PR TITLE
meta: specifying `lodash` imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -108,9 +108,6 @@ module.exports = {
       // consistency
       'unicorn/filename-case': 'off',
 
-      // This would reduce the amount of things to bundle by eg. webpack.
-      'lodash/import-scope': 'off',
-
       // Passing a function reference to an array callback can accidentally introduce bug
       // due to array methods passing more than one parameter.
       'unicorn/no-array-callback-reference': 'off',

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -15,8 +15,19 @@ import { attributeTypeToSql } from './data-types-utils';
 import { AbstractQueryGeneratorTypeScript } from './query-generator-typescript';
 import { joinWithLogicalOperator } from './where-sql-builder';
 
+import compact from 'lodash/compact';
+import defaults from 'lodash/defaults';
+import each from 'lodash/each';
+import forOwn from 'lodash/forOwn';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import isObject from 'lodash/isObject';
+import isPlainObject from 'lodash/isPlainObject';
+import pick from 'lodash/pick';
+import reduce from 'lodash/reduce';
+import uniq from 'lodash/uniq';
+
 const util = require('node:util');
-const _ = require('lodash');
 const crypto = require('node:crypto');
 
 const DataTypes = require('../../data-types');
@@ -128,7 +139,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
    */
   insertQuery(table, valueHash, modelAttributes, options) {
     options = options || {};
-    _.defaults(options, this.options);
+    defaults(options, this.options);
 
     const modelAttributeMap = {};
     const bind = Object.create(null);
@@ -146,7 +157,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     let tmpTable = ''; // tmpTable declaration for trigger
 
     if (modelAttributes) {
-      _.each(modelAttributes, (attribute, key) => {
+      each(modelAttributes, (attribute, key) => {
         modelAttributeMap[key] = attribute;
         if (attribute.field) {
           modelAttributeMap[attribute.field] = attribute;
@@ -169,7 +180,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       outputFragment = returnValues.outputFragment || '';
     }
 
-    if (_.get(this, ['sequelize', 'options', 'dialectOptions', 'prependSearchPath']) || options.searchPath) {
+    if (get(this, ['sequelize', 'options', 'dialectOptions', 'prependSearchPath']) || options.searchPath) {
       // Not currently supported with search path (requires output of multiple queries)
       bindParam = undefined;
     }
@@ -213,7 +224,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     let onDuplicateKeyUpdate = '';
 
     if (
-      !_.isEmpty(options.conflictWhere)
+      !isEmpty(options.conflictWhere)
       && !this.dialect.supports.inserts.onConflictWhere
     ) {
       throw new Error('missing dialect support for conflictWhere option');
@@ -235,13 +246,13 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
           ')',
         ];
 
-        if (!_.isEmpty(options.conflictWhere)) {
+        if (!isEmpty(options.conflictWhere)) {
           fragments.push(this.whereQuery(options.conflictWhere, options));
         }
 
         // if update keys are provided, then apply them here.  if there are no updateKeys provided, then do not try to
         // do an update.  Instead, fall back to DO NOTHING.
-        if (_.isEmpty(updateKeys)) {
+        if (isEmpty(updateKeys)) {
           fragments.push('DO NOTHING');
         } else {
           fragments.push('DO UPDATE SET', updateKeys.join(','));
@@ -253,14 +264,14 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         // the rough equivalent to ON CONFLICT DO NOTHING in mysql, etc is ON DUPLICATE KEY UPDATE id = id
         // So, if no update values were provided, fall back to the identifier columns provided in the upsertKeys array.
         // This will be the primary key in most cases, but it could be some other constraint.
-        if (_.isEmpty(valueKeys) && options.upsertKeys) {
+        if (isEmpty(valueKeys) && options.upsertKeys) {
           valueKeys.push(...options.upsertKeys.map(attr => `${this.quoteIdentifier(attr)}=${this.quoteIdentifier(attr)}`));
         }
 
         // edge case... but if for some reason there were no valueKeys, and there were also no upsertKeys... then we
         // can no longer build the requested query without a syntax error.  Let's throw something more graceful here
         // so the devs know what the problem is.
-        if (_.isEmpty(valueKeys)) {
+        if (isEmpty(valueKeys)) {
           throw new Error('No update values found for ON DUPLICATE KEY UPDATE clause, and no identifier fields could be found to use instead.');
         }
 
@@ -337,7 +348,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     let onDuplicateKeyUpdate = '';
 
     for (const fieldValueHash of fieldValueHashes) {
-      _.forOwn(fieldValueHash, (value, key) => {
+      forOwn(fieldValueHash, (value, key) => {
         if (!allAttributes.includes(key)) {
           allAttributes.push(key);
         }
@@ -449,7 +460,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
    */
   updateQuery(tableName, attrValueHash, where, options, columnDefinitions) {
     options = options || {};
-    _.defaults(options, this.options);
+    defaults(options, this.options);
 
     attrValueHash = removeNullishValuesFromHash(attrValueHash, options.omitNull, options);
 
@@ -460,7 +471,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     let tmpTable = ''; // tmpTable declaration for trigger
     let suffix = '';
 
-    if (_.get(this, ['sequelize', 'options', 'dialectOptions', 'prependSearchPath']) || options.searchPath) {
+    if (get(this, ['sequelize', 'options', 'dialectOptions', 'prependSearchPath']) || options.searchPath) {
       // Not currently supported with search path (requires output of multiple queries)
       options.bindParam = false;
     }
@@ -486,7 +497,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     }
 
     if (columnDefinitions) {
-      _.each(columnDefinitions, (attribute, key) => {
+      each(columnDefinitions, (attribute, key) => {
         modelAttributeMap[key] = attribute;
         if (attribute.field) {
           modelAttributeMap[attribute.field] = attribute;
@@ -545,12 +556,12 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
     // TODO: this method should delegate to `updateQuery`
 
     options = options || {};
-    _.defaults(options, { returning: true });
+    defaults(options, { returning: true });
     const { model } = options;
 
     // TODO: add attribute DataType
     // TODO: add model
-    const escapeOptions = _.pick(options, ['replacements', 'model']);
+    const escapeOptions = pick(options, ['replacements', 'model']);
 
     extraAttributesToBeUpdated = removeNullishValuesFromHash(extraAttributesToBeUpdated, this.options.omitNull);
 
@@ -744,7 +755,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       this.dialect.supports.index.where && options.where ? options.where : undefined,
     );
 
-    return _.compact(ind).join(' ');
+    return compact(ind).join(' ');
   }
 
   /*
@@ -811,7 +822,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
           if (isModelStatic(item)) {
             // set
             model = item;
-          } else if (_.isPlainObject(item) && item.model && isModelStatic(item.model)) {
+          } else if (isPlainObject(item) && item.model && isModelStatic(item.model)) {
             // set
             model = item.model;
             as = item.as;
@@ -928,7 +939,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       return this.formatSqlExpression(collection, options);
     }
 
-    if (_.isPlainObject(collection) && collection.raw) {
+    if (isPlainObject(collection) && collection.raw) {
       // simple objects with raw is no longer supported
       throw new Error('The `{raw: "..."}` syntax is no longer supported.  Use `sequelize.literal` instead.');
     }
@@ -1069,11 +1080,11 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         mainJoinQueries = mainJoinQueries.concat(joinQueries.mainQuery);
 
         if (joinQueries.attributes.main.length > 0) {
-          attributes.main = _.uniq(attributes.main.concat(joinQueries.attributes.main));
+          attributes.main = uniq(attributes.main.concat(joinQueries.attributes.main));
         }
 
         if (joinQueries.attributes.subQuery.length > 0) {
-          attributes.subQuery = _.uniq(attributes.subQuery.concat(joinQueries.attributes.subQuery));
+          attributes.subQuery = uniq(attributes.subQuery.concat(joinQueries.attributes.subQuery));
         }
       }
     }
@@ -1354,7 +1365,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         attr = this.quoteIdentifier(attr, options.model);
       }
 
-      if (!_.isEmpty(options.include) && (!attr.includes('.') || options.dotNotation) && addTable) {
+      if (!isEmpty(options.include) && (!attr.includes('.') || options.dotNotation) && addTable) {
         attr = `${quotedMainTableAs}.${attr}`;
       }
 
@@ -1702,7 +1713,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
         throw new Error(`Unsupported value in "returning" option: ${NodeUtil.inspect(field)}. This option only accepts true, false, or an array of strings, col() or literal().`);
       }));
     } else if (modelAttributes) {
-      _.each(modelAttributes, attribute => {
+      each(modelAttributes, attribute => {
         if (!(attribute.type instanceof DataTypes.VIRTUAL)) {
           returnFields.push(this.quoteIdentifier(attribute.field));
           returnTypes.push(attribute.type);
@@ -1710,7 +1721,7 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
       });
     }
 
-    if (_.isEmpty(returnFields)) {
+    if (isEmpty(returnFields)) {
       returnFields.push(`*`);
     }
 
@@ -2108,8 +2119,8 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   parseConditionObject(conditions, path) {
     path = path || [];
 
-    return _.reduce(conditions, (result, value, key) => {
-      if (_.isObject(value)) {
+    return reduce(conditions, (result, value, key) => {
+      if (isObject(value)) {
         return result.concat(this.parseConditionObject(value, path.concat(key))); // Recursively parse objects
       }
 

--- a/packages/core/src/dialects/abstract/query.js
+++ b/packages/core/src/dialects/abstract/query.js
@@ -3,7 +3,11 @@
 import NodeUtil from 'node:util';
 import { AbstractDataType } from './data-types';
 
-const _ = require('lodash');
+import chain from 'lodash/chain';
+import findKey from 'lodash/findKey';
+import isEmpty from 'lodash/isEmpty';
+import reduce from 'lodash/reduce';
+
 const { QueryTypes } = require('../../query-types');
 const Dot = require('dottie');
 const deprecations = require('../../utils/deprecations');
@@ -219,7 +223,7 @@ export class AbstractQuery {
     // Map raw fields to names if a mapping is provided
     if (this.options.fieldMap) {
       const fieldMap = this.options.fieldMap;
-      results = results.map(result => _.reduce(fieldMap, (result, name, field) => {
+      results = results.map(result => reduce(fieldMap, (result, name, field) => {
         if (result[field] !== undefined && name !== field) {
           result[name] = result[field];
           delete result[field];
@@ -543,10 +547,10 @@ export class AbstractQuery {
     };
 
     const getUniqueKeyAttributes = model => {
-      let uniqueKeyAttributes = _.chain(model.uniqueKeys);
+      let uniqueKeyAttributes = chain(model.uniqueKeys);
       uniqueKeyAttributes = uniqueKeyAttributes
         .result(`${uniqueKeyAttributes.findKey()}.fields`)
-        .map(field => _.findKey(model.attributes, chr => chr.field === field))
+        .map(field => findKey(model.attributes, chr => chr.field === field))
         .value();
 
       return uniqueKeyAttributes;
@@ -578,7 +582,7 @@ export class AbstractQuery {
           for ($i = 0; $i < $length; $i++) {
             topHash += stringify(row[includeOptions.model.primaryKeyAttributes[$i]]);
           }
-        } else if (!_.isEmpty(includeOptions.model.uniqueKeys)) {
+        } else if (!isEmpty(includeOptions.model.uniqueKeys)) {
           uniqueKeyAttributes = getUniqueKeyAttributes(includeOptions.model);
           for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
             topHash += row[uniqueKeyAttributes[$i]];
@@ -629,7 +633,7 @@ export class AbstractQuery {
                   for ($i = 0; $i < $length; $i++) {
                     itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
                   }
-                } else if (!_.isEmpty(includeMap[prefix].model.uniqueKeys)) {
+                } else if (!isEmpty(includeMap[prefix].model.uniqueKeys)) {
                   uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
                   for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
                     itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];
@@ -717,7 +721,7 @@ export class AbstractQuery {
               for ($i = 0; $i < $length; $i++) {
                 itemHash += stringify(row[`${prefix}.${primaryKeyAttributes[$i]}`]);
               }
-            } else if (!_.isEmpty(includeMap[prefix].model.uniqueKeys)) {
+            } else if (!isEmpty(includeMap[prefix].model.uniqueKeys)) {
               uniqueKeyAttributes = getUniqueKeyAttributes(includeMap[prefix].model);
               for ($i = 0; $i < uniqueKeyAttributes.length; $i++) {
                 itemHash += row[`${prefix}.${uniqueKeyAttributes[$i]}`];

--- a/packages/core/src/dialects/db2/query-generator.js
+++ b/packages/core/src/dialects/db2/query-generator.js
@@ -13,7 +13,16 @@ import {
 } from '../abstract/query-generator';
 import { Db2QueryGeneratorTypeScript } from './query-generator-typescript';
 
-const _ = require('lodash');
+import defaults from 'lodash/defaults';
+import each from 'lodash/each';
+import forEach from 'lodash/forEach';
+import forOwn from 'lodash/forOwn';
+import includes from 'lodash/includes';
+import isPlainObject from 'lodash/isPlainObject';
+import isString from 'lodash/isString';
+import startsWith from 'lodash/startsWith';
+import template from 'lodash/template';
+
 const DataTypes = require('../../data-types');
 const randomBytes = require('node:crypto').randomBytes;
 const { Op } = require('../../operators');
@@ -111,7 +120,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
           const commentMatch = dataType.match(/^(.+) (COMMENT.*)$/);
           if (commentMatch && commentMatch.length > 2) {
             const commentText = commentMatch[2].replace(/COMMENT/, '').trim();
-            commentStr += _.template(commentTemplate, this._templateSettings)({
+            commentStr += template(commentTemplate, this._templateSettings)({
               table: this.quoteTable(tableName),
               comment: this.escape(commentText),
               column: this.quoteIdentifier(attr),
@@ -121,10 +130,10 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
           }
         }
 
-        if (_.includes(dataType, 'PRIMARY KEY')) {
+        if (includes(dataType, 'PRIMARY KEY')) {
           primaryKeys.push(attr);
 
-          if (_.includes(dataType, 'REFERENCES')) {
+          if (includes(dataType, 'REFERENCES')) {
             // Db2 doesn't support inline REFERENCES declarations: move to the end
             match = dataType.match(/^(.+) (REFERENCES.*)$/);
             attrStr.push(`${this.quoteIdentifier(attr)} ${match[1].replace(/PRIMARY KEY/, '')}`);
@@ -132,7 +141,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
           } else {
             attrStr.push(`${this.quoteIdentifier(attr)} ${dataType.replace(/PRIMARY KEY/, '')}`);
           }
-        } else if (_.includes(dataType, 'REFERENCES')) {
+        } else if (includes(dataType, 'REFERENCES')) {
           // Db2 doesn't support inline REFERENCES declarations: move to the end
           match = dataType.match(/^(.+) (REFERENCES.*)$/);
           attrStr.push(`${this.quoteIdentifier(attr)} ${match[1]}`);
@@ -141,7 +150,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
           if (options && options.uniqueKeys) {
             for (const ukey in options.uniqueKeys) {
               if (options.uniqueKeys[ukey].fields.includes(attr)
-                  && !_.includes(dataType, 'NOT NULL')) {
+                  && !includes(dataType, 'NOT NULL')) {
                 dataType += ' NOT NULL';
                 break;
               }
@@ -163,8 +172,8 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     }).join(', ');
 
     if (options && options.uniqueKeys) {
-      _.each(options.uniqueKeys, (columns, indexName) => {
-        if (!_.isString(indexName)) {
+      each(options.uniqueKeys, (columns, indexName) => {
+        if (!isString(indexName)) {
           indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
         }
 
@@ -182,13 +191,13 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
       }
     }
 
-    return `${_.template(query, this._templateSettings)(values).trim()};${commentStr}`;
+    return `${template(query, this._templateSettings)(values).trim()};${commentStr}`;
   }
 
   renameTableQuery(before, after) {
     const query = 'RENAME TABLE <%= before %> TO <%= after %>;';
 
-    return _.template(query, this._templateSettings)({
+    return template(query, this._templateSettings)({
       before: this.quoteTable(before),
       after: this.quoteTable(after),
     });
@@ -228,14 +237,14 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     };
 
     const query = 'ALTER TABLE <%= table %> ADD <%= attribute %>;';
-    const attribute = _.template('<%= key %> <%= definition %>', this._templateSettings)({
+    const attribute = template('<%= key %> <%= definition %>', this._templateSettings)({
       key: this.quoteIdentifier(key),
       definition: this.attributeToSQL(dataType, {
         context: 'addColumn',
       }),
     });
 
-    return _.template(query, this._templateSettings)({
+    return template(query, this._templateSettings)({
       table: this.quoteTable(table),
       attribute,
     });
@@ -254,7 +263,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
 
     const query = 'ALTER TABLE <%= tableName %> DROP COLUMN <%= attributeName %>;';
 
-    return _.template(query, this._templateSettings)({
+    return template(query, this._templateSettings)({
       tableName: this.quoteTable(tableName),
       attributeName: this.quoteIdentifier(attributeName),
     });
@@ -274,18 +283,18 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
 
       for (const definition of defs) {
         if (/REFERENCES/.test(definition)) {
-          constraintString.push(_.template('<%= fkName %> FOREIGN KEY (<%= attrName %>) <%= definition %>', this._templateSettings)({
+          constraintString.push(template('<%= fkName %> FOREIGN KEY (<%= attrName %>) <%= definition %>', this._templateSettings)({
             fkName: this.quoteIdentifier(`${attributeName}_foreign_idx`),
             attrName: this.quoteIdentifier(attributeName),
             definition: definition.replace(/.+?(?=REFERENCES)/, ''),
           }));
-        } else if (_.startsWith(definition, 'DROP ')) {
-          attrString.push(_.template('<%= attrName %> <%= definition %>', this._templateSettings)({
+        } else if (startsWith(definition, 'DROP ')) {
+          attrString.push(template('<%= attrName %> <%= definition %>', this._templateSettings)({
             attrName: this.quoteIdentifier(attributeName),
             definition,
           }));
         } else {
-          attrString.push(_.template('<%= attrName %> SET <%= definition %>', this._templateSettings)({
+          attrString.push(template('<%= attrName %> SET <%= definition %>', this._templateSettings)({
             attrName: this.quoteIdentifier(attributeName),
             definition,
           }));
@@ -303,7 +312,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
       finalQuery += `ADD CONSTRAINT ${constraintString.join(' ADD CONSTRAINT ')}`;
     }
 
-    return _.template(query, this._templateSettings)({
+    return template(query, this._templateSettings)({
       tableName: this.quoteTable(tableName),
       query: finalQuery,
     });
@@ -313,7 +322,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     const query = 'ALTER TABLE <%= tableName %> RENAME COLUMN <%= before %> TO <%= after %>;';
     const newName = Object.keys(attributes)[0];
 
-    return _.template(query, this._templateSettings)({
+    return template(query, this._templateSettings)({
       tableName: this.quoteTable(tableName),
       before: this.quoteIdentifier(attrBefore),
       after: this.quoteIdentifier(newName),
@@ -340,7 +349,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
       outputFragment = '';
     }
 
-    _.forEach(attrValueHashes, attrValueHash => {
+    forEach(attrValueHashes, attrValueHash => {
       // special case for empty objects with primary keys
       const fields = Object.keys(attrValueHash);
       const firstAttr = attributes[fields[0]];
@@ -351,7 +360,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
       }
 
       // normal case
-      _.forOwn(attrValueHash, (value, key) => {
+      forOwn(attrValueHash, (value, key) => {
         if (!allAttributes.includes(key)) {
           if (value === null && attributes[key] && attributes[key].autoIncrement) {
             return;
@@ -366,7 +375,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     }
 
     if (allAttributes.length > 0) {
-      _.forEach(attrValueHashes, attrValueHash => {
+      forEach(attrValueHashes, attrValueHash => {
         tuples.push(`(${
           // TODO: pass type of attribute & model
           allAttributes.map(key => this.escape(attrValueHash[key] ?? null, { replacements: options.replacements })).join(',')})`);
@@ -381,7 +390,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
       output: outputFragment,
     };
 
-    const generatedQuery = _.template(allQueries.join(';'), this._templateSettings)(replacements);
+    const generatedQuery = template(allQueries.join(';'), this._templateSettings)(replacements);
 
     return generatedQuery;
   }
@@ -389,7 +398,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
   updateQuery(tableName, attrValueHash, where, options, attributes) {
     const sql = super.updateQuery(tableName, attrValueHash, where, options, attributes);
     options = options || {};
-    _.defaults(options, this.options);
+    defaults(options, this.options);
     if (!options.limit) {
       sql.query = `SELECT * FROM FINAL TABLE (${removeTrailingSemicolon(sql.query)});`;
 
@@ -404,7 +413,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     const bindParam = options.bindParam || this.bindParam(bind);
 
     if (attributes) {
-      _.each(attributes, (attribute, key) => {
+      each(attributes, (attribute, key) => {
         modelAttributeMap[key] = attribute;
         if (attribute.field) {
           modelAttributeMap[attribute.field] = attribute;
@@ -425,7 +434,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
     }
 
     let query;
-    const whereOptions = _.defaults({ bindParam }, options);
+    const whereOptions = defaults({ bindParam }, options);
 
     query = `UPDATE (SELECT * FROM ${this.quoteTable(tableName)} ${this.whereQuery(where, whereOptions)} FETCH NEXT ${this.escape(options.limit, undefined, { replacements: options.replacements })} ROWS ONLY) SET ${values.join(',')}`;
     query = `SELECT * FROM FINAL TABLE (${query});`;
@@ -579,7 +588,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
   }
 
   attributeToSQL(attribute, options) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = {
         type: attribute,
       };
@@ -728,7 +737,7 @@ export class Db2QueryGenerator extends Db2QueryGeneratorTypeScript {
   }
 
   dropForeignKeyQuery(tableName, foreignKey) {
-    return _.template('ALTER TABLE <%= table %> DROP FOREIGN KEY <%= key %>;', this._templateSettings)({
+    return template('ALTER TABLE <%= table %> DROP FOREIGN KEY <%= key %>;', this._templateSettings)({
       table: this.quoteTable(tableName),
       key: this.quoteIdentifier(foreignKey),
     });

--- a/packages/core/src/dialects/db2/query-interface.js
+++ b/packages/core/src/dialects/db2/query-interface.js
@@ -4,7 +4,11 @@ import { AggregateError, BaseError, DatabaseError } from '../../errors';
 import { isWhereEmpty } from '../../utils/query-builder-utils';
 import { assertNoReservedBind } from '../../utils/sql';
 
-const _ = require('lodash');
+import clone from 'lodash/clone';
+import intersection from 'lodash/intersection';
+import isPlainObject from 'lodash/isPlainObject';
+import mapValues from 'lodash/mapValues';
+
 const { Op } = require('../../operators');
 const { AbstractQueryInterface } = require('../abstract/query-interface');
 const { QueryTypes } = require('../../query-types');
@@ -35,7 +39,7 @@ export class Db2QueryInterface extends AbstractQueryInterface {
     const attributes = Object.keys(insertValues);
     let indexFields;
 
-    options = _.clone(options);
+    options = clone(options);
 
     if (!isWhereEmpty(where)) {
       wheres.push(where);
@@ -48,7 +52,7 @@ export class Db2QueryInterface extends AbstractQueryInterface {
       if (value.unique) {
         // fields in the index may both the strings or objects with an attribute property - lets sanitize that
         indexFields = value.fields.map(field => {
-          if (_.isPlainObject(field)) {
+          if (isPlainObject(field)) {
             return field.attribute;
           }
 
@@ -59,7 +63,7 @@ export class Db2QueryInterface extends AbstractQueryInterface {
     }
 
     for (const index of indexes) {
-      if (_.intersection(attributes, index).length === index.length) {
+      if (intersection(attributes, index).length === index.length) {
         where = {};
         for (const field of index) {
           where[field] = insertValues[field];
@@ -148,7 +152,7 @@ export class Db2QueryInterface extends AbstractQueryInterface {
       options.uniqueKeys = options.uniqueKeys || model.uniqueKeys;
     }
 
-    attributes = _.mapValues(
+    attributes = mapValues(
       attributes,
       attribute => this.sequelize.normalizeAttribute(attribute),
     );

--- a/packages/core/src/dialects/db2/query.js
+++ b/packages/core/src/dialects/db2/query.js
@@ -4,8 +4,9 @@ import assert from 'node:assert';
 import { AbstractQuery } from '../abstract/query';
 import { logger } from '../../utils/logger';
 
+import forOwn from 'lodash/forOwn';
+
 const sequelizeErrors = require('../../errors');
-const _ = require('lodash');
 
 const debug = logger.debugContext('sql:db2');
 
@@ -78,7 +79,7 @@ export class Db2Query extends AbstractQuery {
 
     const params = [];
     if (parameters) {
-      _.forOwn(parameters, (value, key) => {
+      forOwn(parameters, (value, key) => {
         const param = this.getSQLTypeFromJsType(value, key);
         params.push(param);
       });
@@ -353,7 +354,7 @@ export class Db2Query extends AbstractQuery {
       }
 
       const errors = [];
-      _.forOwn(fields, (value, field) => {
+      forOwn(fields, (value, field) => {
         errors.push(new sequelizeErrors.ValidationErrorItem(
           this.getUniqueConstraintErrorMessage(field),
           'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,

--- a/packages/core/src/dialects/ibmi/query-generator.js
+++ b/packages/core/src/dialects/ibmi/query-generator.js
@@ -14,8 +14,10 @@ import {
   REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator';
 
+import each from 'lodash/each';
+import isPlainObject from 'lodash/isPlainObject';
+
 const util = require('node:util');
-const _ = require('lodash');
 const { IBMiQueryGeneratorTypeScript } = require('./query-generator-typescript');
 const DataTypes = require('../../data-types');
 
@@ -97,7 +99,7 @@ export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
       const sortedPrimaryKeys = [...primaryKeys];
       sortedPrimaryKeys.sort();
 
-      _.each(options.uniqueKeys, (columns, indexName) => {
+      each(options.uniqueKeys, (columns, indexName) => {
         // sort the columns for each unique key, so they can be easily compared
         // with the sorted primary key fields
         const sortedColumnFields = [...columns.fields];
@@ -460,7 +462,7 @@ export class IBMiQueryGenerator extends IBMiQueryGeneratorTypeScript {
   // }
 
   attributeToSQL(attribute, options) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = {
         type: attribute,
       };

--- a/packages/core/src/dialects/mariadb/query-generator.js
+++ b/packages/core/src/dialects/mariadb/query-generator.js
@@ -5,7 +5,9 @@ import { EMPTY_OBJECT } from '../../utils/object.js';
 import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
 
-const _ = require('lodash');
+import each from 'lodash/each';
+import isPlainObject from 'lodash/isPlainObject';
+
 const { MariaDbQueryGeneratorTypeScript } = require('./query-generator-typescript');
 
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
@@ -91,7 +93,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
 
     if (options.uniqueKeys) {
-      _.each(options.uniqueKeys, (columns, indexName) => {
+      each(options.uniqueKeys, (columns, indexName) => {
         if (typeof indexName !== 'string') {
           indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
         }
@@ -243,7 +245,7 @@ export class MariaDbQueryGenerator extends MariaDbQueryGeneratorTypeScript {
   }
 
   attributeToSQL(attribute, options) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = {
         type: attribute,
       };

--- a/packages/core/src/dialects/mariadb/query.js
+++ b/packages/core/src/dialects/mariadb/query.js
@@ -2,9 +2,11 @@
 
 import NodeUtil from 'node:util';
 
+import forOwn from 'lodash/forOwn';
+import zipObject from 'lodash/zipObject';
+
 const { AbstractQuery } = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
-const _ = require('lodash');
 const DataTypes = require('../../data-types');
 const { logger } = require('../../utils/logger');
 
@@ -229,13 +231,13 @@ export class MariaDbQuery extends AbstractQuery {
             message = uniqueKey.msg;
           }
 
-          fields = _.zipObject(uniqueKey.fields, values);
+          fields = zipObject(uniqueKey.fields, values);
         } else {
           fields[fieldKey] = fieldVal;
         }
 
         const errors = [];
-        _.forOwn(fields, (value, field) => {
+        forOwn(fields, (value, field) => {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
             'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -15,7 +15,11 @@ import {
   DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator';
 
-const _ = require('lodash');
+import each from 'lodash/each';
+import forOwn from 'lodash/forOwn';
+import isPlainObject from 'lodash/isPlainObject';
+import isString from 'lodash/isString';
+
 const DataTypes = require('../../data-types');
 const { TableHints } = require('../../table-hints');
 const { MsSqlQueryGeneratorTypeScript } = require('./query-generator-typescript');
@@ -197,7 +201,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
 
     if (options?.uniqueKeys) {
-      _.each(options.uniqueKeys, (columns, indexName) => {
+      each(options.uniqueKeys, (columns, indexName) => {
         if (typeof indexName !== 'string') {
           indexName = generateIndexName(tableName, columns);
         }
@@ -287,7 +291,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
 
     let commentStr = '';
 
-    if (dataType.comment && _.isString(dataType.comment)) {
+    if (dataType.comment && isString(dataType.comment)) {
       commentStr = this.commentTemplate(dataType.comment, table, key);
       // attributeToSQL will try to include `COMMENT 'Comment Text'` when it returns if the comment key
       // is present. This is needed for createTable statement where that part is extracted with regex.
@@ -402,7 +406,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
       }
 
       // normal case
-      _.forOwn(attrValueHash, (value, key) => {
+      forOwn(attrValueHash, (value, key) => {
         if (value !== null && attributes[key] && attributes[key].autoIncrement) {
           needIdentityInsertWrapper = true;
         }
@@ -611,7 +615,7 @@ export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
   }
 
   attributeToSQL(attribute, options) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = {
         type: attribute,
       };

--- a/packages/core/src/dialects/mssql/query-interface.js
+++ b/packages/core/src/dialects/mssql/query-interface.js
@@ -3,7 +3,7 @@
 import { isWhereEmpty } from '../../utils/query-builder-utils';
 import { assertNoReservedBind } from '../../utils/sql';
 
-const _ = require('lodash');
+import intersection from 'lodash/intersection';
 
 const { QueryTypes } = require('../../query-types');
 const { Op } = require('../../operators');
@@ -85,7 +85,7 @@ export class MsSqlQueryInterface extends AbstractQueryInterface {
 
     const attributes = Object.keys(insertValues);
     for (const index of uniqueColumnNames) {
-      if (_.intersection(attributes, index).length === index.length) {
+      if (intersection(attributes, index).length === index.length) {
         where = {};
         for (const field of index) {
           where[field] = insertValues[field];

--- a/packages/core/src/dialects/mssql/query.js
+++ b/packages/core/src/dialects/mssql/query.js
@@ -2,9 +2,11 @@
 
 import { getAttributeName } from '../../utils/format';
 
+import forOwn from 'lodash/forOwn';
+import zipObject from 'lodash/zipObject';
+
 const { AbstractQuery } = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
-const _ = require('lodash');
 const { logger } = require('../../utils/logger');
 
 const debug = logger.debugContext('sql:mssql');
@@ -105,7 +107,7 @@ export class MsSqlQuery extends AbstractQuery {
             request.addParameter(String(i + 1), paramType.type, paramType.value, paramType.typeOptions);
           }
         } else {
-          _.forOwn(parameters, (parameter, parameterName) => {
+          forOwn(parameters, (parameter, parameterName) => {
             const paramType = this.getSQLTypeFromJsType(parameter, connection.lib.TYPES);
             request.addParameter(parameterName, paramType.type, paramType.value, paramType.typeOptions);
           });
@@ -305,14 +307,14 @@ export class MsSqlQuery extends AbstractQuery {
       if (match[3]) {
         const values = match[3].split(',').map(part => part.trim());
         if (uniqueKey) {
-          fields = _.zipObject(uniqueKey.fields, values);
+          fields = zipObject(uniqueKey.fields, values);
         } else {
           fields[match[1]] = match[3];
         }
       }
 
       const errors = [];
-      _.forOwn(fields, (value, field) => {
+      forOwn(fields, (value, field) => {
         errors.push(new sequelizeErrors.ValidationErrorItem(
           this.getUniqueConstraintErrorMessage(field),
           'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,

--- a/packages/core/src/dialects/mysql/query-generator.js
+++ b/packages/core/src/dialects/mysql/query-generator.js
@@ -8,7 +8,9 @@ import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
 import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS, REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 
-const _ = require('lodash');
+import each from 'lodash/each';
+import isPlainObject from 'lodash/isPlainObject';
+
 const { MySqlQueryGeneratorTypeScript } = require('./query-generator-typescript');
 
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
@@ -96,7 +98,7 @@ export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
 
     if (options.uniqueKeys) {
-      _.each(options.uniqueKeys, (columns, indexName) => {
+      each(options.uniqueKeys, (columns, indexName) => {
         if (typeof indexName !== 'string') {
           indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
         }
@@ -262,7 +264,7 @@ export class MySqlQueryGenerator extends MySqlQueryGeneratorTypeScript {
   }
 
   attributeToSQL(attribute, options) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = {
         type: attribute,
       };

--- a/packages/core/src/dialects/mysql/query.js
+++ b/packages/core/src/dialects/mysql/query.js
@@ -2,9 +2,12 @@
 
 import NodeUtil from 'node:util';
 
+import forOwn from 'lodash/forOwn';
+import map from 'lodash/map';
+import zipObject from 'lodash/zipObject';
+
 const { AbstractQuery } = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
-const _ = require('lodash');
 const { logger } = require('../../utils/logger');
 
 const ER_DUP_ENTRY = 1062;
@@ -199,13 +202,13 @@ export class MySqlQuery extends AbstractQuery {
             message = uniqueKey.msg;
           }
 
-          fields = _.zipObject(uniqueKey.fields, values);
+          fields = zipObject(uniqueKey.fields, values);
         } else {
           fields[fieldKey] = fieldVal;
         }
 
         const errors = [];
-        _.forOwn(fields, (value, field) => {
+        forOwn(fields, (value, field) => {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
             'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,
@@ -274,7 +277,7 @@ export class MySqlQuery extends AbstractQuery {
       return acc;
     }, {});
 
-    return _.map(data, item => {
+    return map(data, item => {
       return ({
         primary: item.Key_name === 'PRIMARY',
         fields: item.fields,

--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -13,9 +13,14 @@ import {
   DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator';
 
+import each from 'lodash/each';
+import isEmpty from 'lodash/isEmpty';
+import isPlainObject from 'lodash/isPlainObject';
+import map from 'lodash/map';
+import reduce from 'lodash/reduce';
+
 const DataTypes = require('../../data-types');
 const { PostgresQueryGeneratorTypeScript } = require('./query-generator-typescript');
-const _ = require('lodash');
 
 /**
  * list of reserved words in PostgreSQL 10
@@ -130,7 +135,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     let attributesClause = attrStr.join(', ');
 
     if (options.uniqueKeys) {
-      _.each(options.uniqueKeys, (index, indexName) => {
+      each(options.uniqueKeys, (index, indexName) => {
         if (typeof indexName !== 'string') {
           indexName = generateIndexName(tableName, index);
         }
@@ -144,7 +149,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       });
     }
 
-    const pks = _.reduce(attributes, (acc, attribute, key) => {
+    const pks = reduce(attributes, (acc, attribute, key) => {
       if (attribute.includes('PRIMARY KEY')) {
         acc.push(this.quoteIdentifier(key));
       }
@@ -339,7 +344,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   }
 
   attributeToSQL(attribute, options) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = {
         type: attribute,
       };
@@ -566,7 +571,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   }
 
   expandOptions(options) {
-    return options === undefined || _.isEmpty(options)
+    return options === undefined || isEmpty(options)
       ? '' : options.join(' ');
   }
 
@@ -590,11 +595,11 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   }
 
   expandTriggerEventSpec(fireOnSpec) {
-    if (_.isEmpty(fireOnSpec)) {
+    if (isEmpty(fireOnSpec)) {
       throw new Error('no table change events specified to trigger on');
     }
 
-    return _.map(fireOnSpec, (fireValue, fireKey) => {
+    return map(fireOnSpec, (fireValue, fireKey) => {
       const EVENT_MAP = {
         insert: 'INSERT',
         update: 'UPDATE',

--- a/packages/core/src/dialects/snowflake/query-generator.js
+++ b/packages/core/src/dialects/snowflake/query-generator.js
@@ -14,7 +14,9 @@ import {
   REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator';
 
-const _ = require('lodash');
+import each from 'lodash/each';
+import isPlainObject from 'lodash/isPlainObject';
+
 const { SnowflakeQueryGeneratorTypeScript } = require('./query-generator-typescript');
 const { Op } = require('../../operators');
 
@@ -156,7 +158,7 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
     const pkString = primaryKeys.map(pk => this.quoteIdentifier(pk)).join(', ');
 
     if (options.uniqueKeys) {
-      _.each(options.uniqueKeys, (columns, indexName) => {
+      each(options.uniqueKeys, (columns, indexName) => {
         if (typeof indexName !== 'string') {
           indexName = `uniq_${tableName}_${columns.fields.join('_')}`;
         }
@@ -369,7 +371,7 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
   }
 
   attributeToSQL(attribute, options) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = {
         type: attribute,
       };

--- a/packages/core/src/dialects/snowflake/query.js
+++ b/packages/core/src/dialects/snowflake/query.js
@@ -1,8 +1,13 @@
 'use strict';
 
+import forOwn from 'lodash/forOwn';
+import map from 'lodash/map';
+import mapKeys from 'lodash/mapKeys';
+import reduce from 'lodash/reduce';
+import zipObject from 'lodash/zipObject';
+
 const { AbstractQuery } = require('../abstract/query');
 const sequelizeErrors = require('../../errors');
-const _ = require('lodash');
 const { logger } = require('../../utils/logger');
 
 const ER_DUP_ENTRY = 1062;
@@ -120,7 +125,7 @@ export class SnowflakeQuery extends AbstractQuery {
           attrsMap[attrName.toLowerCase()] = attrName;
         }
 
-        data = data.map(data => _.reduce(data, (prev, value, key) => {
+        data = data.map(data => reduce(data, (prev, value, key) => {
           if (value !== undefined && attrsMap[key]) {
             prev[attrsMap[key]] = value;
             delete prev[key];
@@ -130,7 +135,7 @@ export class SnowflakeQuery extends AbstractQuery {
         }, data));
       }
 
-      this.options.fieldMap = _.mapKeys(this.options.fieldMap, (v, k) => {
+      this.options.fieldMap = mapKeys(this.options.fieldMap, (v, k) => {
         return k.toUpperCase();
       });
 
@@ -212,13 +217,13 @@ export class SnowflakeQuery extends AbstractQuery {
             message = uniqueKey.msg;
           }
 
-          fields = _.zipObject(uniqueKey.fields, values);
+          fields = zipObject(uniqueKey.fields, values);
         } else {
           fields[fieldKey] = fieldVal;
         }
 
         const errors = [];
-        _.forOwn(fields, (value, field) => {
+        forOwn(fields, (value, field) => {
           errors.push(new sequelizeErrors.ValidationErrorItem(
             this.getUniqueConstraintErrorMessage(field),
             'unique violation', // sequelizeErrors.ValidationErrorItem.Origins.DB,
@@ -274,7 +279,7 @@ export class SnowflakeQuery extends AbstractQuery {
       return acc;
     }, {});
 
-    return _.map(data, item => ({
+    return map(data, item => ({
       primary: item.Key_name === 'PRIMARY',
       fields: item.fields,
       name: item.Key_name,

--- a/packages/core/src/dialects/sqlite/query-generator.js
+++ b/packages/core/src/dialects/sqlite/query-generator.js
@@ -6,8 +6,11 @@ import { defaultValueSchemable } from '../../utils/query-builder-utils';
 import { rejectInvalidOptions } from '../../utils/check';
 import { ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS, CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator';
 
+import defaults from 'lodash/defaults';
+import each from 'lodash/each';
+import isObject from 'lodash/isObject';
+
 const { Transaction } = require('../../transaction');
-const _ = require('lodash');
 const { SqliteQueryGeneratorTypeScript } = require('./query-generator-typescript');
 
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
@@ -72,7 +75,7 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
     //  CREATE UNIQUE INDEX does not have this issue, so we're using that instead
     //
     // if (options.uniqueKeys) {
-    //   _.each(options.uniqueKeys, (columns, indexName) => {
+    //   each(options.uniqueKeys, (columns, indexName) => {
     //     if (columns.customIndex) {
     //       if (typeof indexName !== 'string') {
     //         indexName = generateIndexName(tableName, columns);
@@ -139,7 +142,7 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
 
   updateQuery(tableName, attrValueHash, where, options, attributes) {
     options = options || {};
-    _.defaults(options, this.options);
+    defaults(options, this.options);
 
     attrValueHash = removeNullishValuesFromHash(attrValueHash, options.omitNull, options);
 
@@ -149,7 +152,7 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
     const bindParam = options.bindParam === undefined ? this.bindParam(bind) : options.bindParam;
 
     if (attributes) {
-      _.each(attributes, (attribute, key) => {
+      each(attributes, (attribute, key) => {
         modelAttributeMap[key] = attribute;
         if (attribute.field) {
           modelAttributeMap[attribute.field] = attribute;
@@ -195,7 +198,7 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
   }
 
   deleteQuery(tableName, where, options = EMPTY_OBJECT, model) {
-    _.defaults(options, this.options);
+    defaults(options, this.options);
 
     let whereClause = this.whereQuery(where, { ...options, model });
     if (whereClause) {
@@ -215,7 +218,7 @@ export class SqliteQueryGenerator extends SqliteQueryGeneratorTypeScript {
       const attribute = attributes[name];
       const columnName = attribute.field || attribute.columnName || name;
 
-      if (_.isObject(attribute)) {
+      if (isObject(attribute)) {
         let sql = attribute.type.toString();
 
         if (attribute.allowNull === false) {

--- a/packages/core/src/dialects/sqlite/query-interface.js
+++ b/packages/core/src/dialects/sqlite/query-interface.js
@@ -2,12 +2,13 @@
 
 import { noSchemaDelimiterParameter, noSchemaParameter } from '../../utils/deprecations';
 
+import isEmpty from 'lodash/isEmpty';
+
 const sequelizeErrors = require('../../errors');
 const { QueryTypes } = require('../../query-types');
 const { ColumnsDescription } = require('../abstract/query-interface.types');
 const { QueryOptions } = require('../abstract/query-interface');
 const { SqliteQueryInterfaceTypeScript } = require('./query-interface-typescript');
-const _ = require('lodash');
 const crypto = require('node:crypto');
 
 /**
@@ -156,7 +157,7 @@ export class SqliteQueryInterface extends SqliteQueryInterfaceTypeScript {
        * Query generators that use information_schema for retrieving table info will just return an empty result set,
        * it will not throw an error like built-ins do (e.g. DESCRIBE on MySql).
        */
-      if (_.isEmpty(data)) {
+      if (isEmpty(data)) {
         throw new Error(`No description found for table ${table.tableName}${table.schema ? ` in schema ${table.schema}` : ''}. Check the table name and schema; remember, they _are_ case sensitive.`);
       }
 

--- a/packages/core/src/dialects/sqlite/query.js
+++ b/packages/core/src/dialects/sqlite/query.js
@@ -1,8 +1,9 @@
 'use strict';
 
+import isEqual from 'lodash/isEqual';
 import isPlainObject from 'lodash/isPlainObject';
+import merge from 'lodash/merge';
 
-const _ = require('lodash');
 const { AbstractQuery } = require('../abstract/query');
 const { QueryTypes } = require('../../query-types');
 const sequelizeErrors = require('../../errors');
@@ -40,7 +41,7 @@ export class SqliteQuery extends AbstractQuery {
         ret[key] = _include.model;
 
         if (_include.include) {
-          _.merge(ret, this._collectModels(_include.include, key));
+          merge(ret, this._collectModels(_include.include, key));
         }
       }
     }
@@ -326,7 +327,7 @@ export class SqliteQuery extends AbstractQuery {
 
         if (this.model) {
           for (const index of this.model.getIndexes()) {
-            if (index.unique && _.isEqual(index.fields, fields) && index.msg) {
+            if (index.unique && isEqual(index.fields, fields) && index.msg) {
               message = index.msg;
               break;
             }

--- a/packages/core/src/instance-validator.js
+++ b/packages/core/src/instance-validator.js
@@ -6,10 +6,20 @@ import { BaseSqlExpression } from './expression-builders/base-sql-expression.js'
 import { getAllOwnKeys } from './utils/object';
 import { BelongsTo } from './associations/belongs-to';
 
-const _ = require('lodash');
+import difference from 'lodash/difference';
+import forIn from 'lodash/forIn';
+import get from 'lodash/get';
+
 const sequelizeError = require('./errors');
 const validator = require('./utils/validator-extras').validator;
 const { promisify } = require('node:util');
+
+// `lodash`.
+const _ = {
+  difference,
+  forIn,
+  get,
+};
 
 /**
  * Instance Validator.

--- a/packages/core/src/instance-validator.js
+++ b/packages/core/src/instance-validator.js
@@ -14,13 +14,6 @@ const sequelizeError = require('./errors');
 const validator = require('./utils/validator-extras').validator;
 const { promisify } = require('node:util');
 
-// `lodash`.
-const _ = {
-  difference,
-  forIn,
-  get,
-};
-
 /**
  * Instance Validator.
  *
@@ -38,7 +31,7 @@ export class InstanceValidator {
     };
 
     if (options.fields && !options.skip) {
-      options.skip = _.difference(Array.from(modelInstance.constructor.modelDefinition.attributes.keys()), options.fields);
+      options.skip = difference(Array.from(modelInstance.constructor.modelDefinition.attributes.keys()), options.fields);
     } else {
       options.skip ??= [];
     }
@@ -222,7 +215,7 @@ export class InstanceValidator {
 
     const attribute = this.modelInstance.constructor.modelDefinition.attributes.get(attributeName);
 
-    _.forIn(attribute.validate, (test, validatorType) => {
+    forIn(attribute.validate, (test, validatorType) => {
       if (['isUrl', 'isURL', 'isEmail'].includes(validatorType)) {
         // Preserve backwards compat. Validator.js now expects the second param to isURL and isEmail to be an object
         if (typeof test === 'object' && test !== null && test.msg) {
@@ -382,7 +375,7 @@ export class InstanceValidator {
       if (!association || !this.modelInstance.get(association.as)) {
         const modelDefinition = this.modelInstance.constructor.modelDefinition;
         const validators = modelDefinition.attributes.get(attributeName)?.validate;
-        const errMsg = _.get(validators, 'notNull.msg', `${this.modelInstance.constructor.name}.${attributeName} cannot be null`);
+        const errMsg = get(validators, 'notNull.msg', `${this.modelInstance.constructor.name}.${attributeName} cannot be null`);
 
         this.errors.push(new sequelizeError.ValidationErrorItem(
           errMsg,

--- a/packages/core/src/model-manager.js
+++ b/packages/core/src/model-manager.js
@@ -1,7 +1,13 @@
 'use strict';
 
+import defaults from 'lodash/defaults';
+
 const Toposort = require('toposort-class');
-const _ = require('lodash');
+
+// `lodash`.
+const _ = {
+  defaults,
+};
 
 export class ModelManager {
   constructor(sequelize) {

--- a/packages/core/src/model-manager.js
+++ b/packages/core/src/model-manager.js
@@ -4,11 +4,6 @@ import defaults from 'lodash/defaults';
 
 const Toposort = require('toposort-class');
 
-// `lodash`.
-const _ = {
-  defaults,
-};
-
 export class ModelManager {
   constructor(sequelize) {
     this.models = [];
@@ -114,7 +109,7 @@ export class ModelManager {
       throw new Error('Cyclic dependency found.');
     }
 
-    options = _.defaults(options || {}, {
+    options = defaults(options || {}, {
       reverse: true,
     });
 

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -57,34 +57,6 @@ const { InstanceValidator } = require('./instance-validator');
 const sequelizeErrors = require('./errors');
 const DataTypes = require('./data-types');
 
-// `lodash`.
-const _ = {
-  assignWith,
-  cloneDeep: cloneDeepLodash,
-  defaults: defaultsLodash,
-  difference,
-  each,
-  flattenDepth,
-  forEach,
-  forIn,
-  get,
-  isEqual,
-  isEmpty,
-  isObject,
-  isPlainObject,
-  intersection,
-  mapValues,
-  omit,
-  omitBy,
-  pick,
-  pickBy,
-  remove,
-  union,
-  uniq,
-  unionBy,
-  without,
-};
-
 // This list will quickly become dated, but failing to maintain this list just means
 // we won't throw a warning when we should. At least most common cases will forever be covered
 // so we stop throwing erroneous warnings when we shouldn't.
@@ -170,7 +142,7 @@ export class Model extends ModelTypeScript {
     this._previousDataValues = {};
     this.uniqno = 1;
     this._changed = new Set();
-    this._options = _.omit(options, ['comesFromDatabase']);
+    this._options = omit(options, ['comesFromDatabase']);
 
     /**
      * Returns true if this instance has not yet been persisted to the database
@@ -190,10 +162,10 @@ export class Model extends ModelTypeScript {
       const modelDefinition = this.constructor.modelDefinition;
 
       const defaults = modelDefinition.defaultValues.size > 0
-        ? _.mapValues(getObjectFromMap(modelDefinition.defaultValues), getDefaultValue => {
+        ? mapValues(getObjectFromMap(modelDefinition.defaultValues), getDefaultValue => {
           const value = getDefaultValue();
 
-          return value && value instanceof BaseSqlExpression ? value : _.cloneDeep(value);
+          return value && value instanceof BaseSqlExpression ? value : cloneDeepLodash(value);
         })
         : Object.create(null);
 
@@ -248,8 +220,8 @@ export class Model extends ModelTypeScript {
     }
 
     // apply paranoid when groupedLimit is used
-    if (_.get(options, 'groupedLimit.on.through.model.options.paranoid')) {
-      const throughModel = _.get(options, 'groupedLimit.on.through.model');
+    if (get(options, 'groupedLimit.on.through.model.options.paranoid')) {
+      const throughModel = get(options, 'groupedLimit.on.through.model');
       if (throughModel) {
         options.groupedLimit.through = this._paranoidClause(throughModel, options.groupedLimit.through);
       }
@@ -375,7 +347,7 @@ ${this._getAssociationDebugList()}`);
     }
 
     // normalize to IncludeOptions
-    if (!_.isPlainObject(include)) {
+    if (!isPlainObject(include)) {
       if (isModelStatic(include)) {
         include = {
           model: include,
@@ -476,7 +448,7 @@ ${associationOwner._getAssociationDebugList()}`);
 
     const visitedModels = [];
     const addAllIncludes = (parent, includes) => {
-      _.forEach(parent.associations, association => {
+      forEach(parent.associations, association => {
         if (all !== true && !all.includes(association.associationType)) {
           return;
         }
@@ -537,7 +509,7 @@ ${associationOwner._getAssociationDebugList()}`);
       include = mapFinderOptions(include, include.model);
 
       if (include.attributes.length > 0) {
-        _.each(include.model.primaryKeys, (attr, key) => {
+        each(include.model.primaryKeys, (attr, key) => {
           // Include the primary key if it's not already included - take into account that the pk might be aliased (due to a .field prop)
           if (!include.attributes.some(includeAttr => {
             if (attr.field !== key) {
@@ -577,7 +549,7 @@ ${associationOwner._getAssociationDebugList()}`);
 
       const through = include.association.through;
 
-      include.through = _.defaults(include.through || {}, {
+      include.through = defaultsLodash(include.through || {}, {
         model: through.model,
         // Through Models are a special case: we always want to load them as the name of the model, not the name of the association
         as: through.model.name,
@@ -637,7 +609,7 @@ ${associationOwner._getAssociationDebugList()}`);
       if (
         options.attributes
         && options.attributes.length > 0
-        && !_.flattenDepth(options.attributes, 2).includes(association.sourceKey)
+        && !flattenDepth(options.attributes, 2).includes(association.sourceKey)
       ) {
         options.attributes.push(association.sourceKey);
       }
@@ -645,7 +617,7 @@ ${associationOwner._getAssociationDebugList()}`);
       if (
         include.attributes
         && include.attributes.length > 0
-        && !_.flattenDepth(include.attributes, 2).includes(association.foreignKey)
+        && !flattenDepth(include.attributes, 2).includes(association.foreignKey)
       ) {
         include.attributes.push(association.foreignKey);
       }
@@ -682,7 +654,7 @@ ${associationOwner._getAssociationDebugList()}`);
   }
 
   static _baseMerge(...args) {
-    _.assignWith(...args);
+    assignWith(...args);
 
     return args[0];
   }
@@ -693,15 +665,15 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     if (Array.isArray(objValue) && Array.isArray(srcValue)) {
-      return _.union(objValue, srcValue);
+      return union(objValue, srcValue);
     }
 
     if (['where', 'having'].includes(key)) {
       return combineWheresWithAnd(objValue, srcValue);
-    } else if (key === 'attributes' && _.isPlainObject(objValue) && _.isPlainObject(srcValue)) {
-      return _.assignWith(objValue, srcValue, (objValue, srcValue) => {
+    } else if (key === 'attributes' && isPlainObject(objValue) && isPlainObject(srcValue)) {
+      return assignWith(objValue, srcValue, (objValue, srcValue) => {
         if (Array.isArray(objValue) && Array.isArray(srcValue)) {
-          return _.union(objValue, srcValue);
+          return union(objValue, srcValue);
         }
       });
     }
@@ -1051,7 +1023,7 @@ ${associationOwner._getAssociationDebugList()}`);
       let scope = null;
       let scopeName = null;
 
-      if (_.isPlainObject(option)) {
+      if (isPlainObject(option)) {
         if (option.method) {
           if (Array.isArray(option.method) && Boolean(initialModel.options.scopes[option.method[0]])) {
             scopeName = option.method[0];
@@ -1063,7 +1035,7 @@ ${associationOwner._getAssociationDebugList()}`);
         } else {
           scope = option;
         }
-      } else if (option === 'defaultScope' && _.isPlainObject(initialModel.options.defaultScope)) {
+      } else if (option === 'defaultScope' && isPlainObject(initialModel.options.defaultScope)) {
         scope = initialModel.options.defaultScope;
       } else {
         scopeName = option;
@@ -1166,11 +1138,11 @@ ${associationOwner._getAssociationDebugList()}`);
       }
 
       // the item order of these arrays is important! scope('a', 'b') is not equal to scope('b', 'a')
-      if (!_.isEqual(modelVariant._scopeNames, scopeNames)) {
+      if (!isEqual(modelVariant._scopeNames, scopeNames)) {
         continue;
       }
 
-      if (!_.isEqual(modelVariant._scope, mergedScope)) {
+      if (!isEqual(modelVariant._scope, mergedScope)) {
         continue;
       }
 
@@ -1233,11 +1205,11 @@ ${associationOwner._getAssociationDebugList()}`);
    * @returns {Promise} A promise that will resolve with the array containing the results of the SELECT query.
    */
   static async findAll(options) {
-    if (options !== undefined && !_.isPlainObject(options)) {
+    if (options !== undefined && !isPlainObject(options)) {
       throw new sequelizeErrors.QueryError('The argument passed to findAll must be an options object, use findByPk if you wish to pass a single primary key value');
     }
 
-    if (options !== undefined && options.attributes && !Array.isArray(options.attributes) && !_.isPlainObject(options.attributes)) {
+    if (options !== undefined && options.attributes && !Array.isArray(options.attributes) && !isPlainObject(options.attributes)) {
       throw new sequelizeErrors.QueryError('The attributes option must be an array of column names or an object');
     }
 
@@ -1252,7 +1224,7 @@ ${associationOwner._getAssociationDebugList()}`);
 
     setTransactionFromCls(options, this.sequelize);
 
-    _.defaults(options, { hooks: true, model: this });
+    defaultsLodash(options, { hooks: true, model: this });
 
     // set rejectOnEmpty option, defaults to model options
     options.rejectOnEmpty = Object.hasOwn(options, 'rejectOnEmpty')
@@ -1313,7 +1285,7 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     // rejectOnEmpty mode
-    if (_.isEmpty(results) && options.rejectOnEmpty) {
+    if (isEmpty(results) && options.rejectOnEmpty) {
       if (typeof options.rejectOnEmpty === 'function') {
         throw new options.rejectOnEmpty();
       }
@@ -1329,12 +1301,12 @@ ${associationOwner._getAssociationDebugList()}`);
   }
 
   static _warnOnInvalidOptions(options, validColumnNames) {
-    if (!_.isPlainObject(options)) {
+    if (!isPlainObject(options)) {
       return;
     }
 
     const unrecognizedOptions = Object.keys(options).filter(k => !validQueryKeywords.has(k));
-    const unexpectedModelAttributes = _.intersection(unrecognizedOptions, validColumnNames);
+    const unexpectedModelAttributes = intersection(unrecognizedOptions, validColumnNames);
     if (!options.where && unexpectedModelAttributes.length > 0) {
       logger.warn(`Model attributes (${unexpectedModelAttributes.join(', ')}) passed into finder method options of model ${this.name}, but the options.where object is empty. Did you forget to use options.where?`);
     }
@@ -1360,7 +1332,7 @@ ${associationOwner._getAssociationDebugList()}`);
       }
     }
 
-    attributes = _.uniq(attributes);
+    attributes = uniq(attributes);
 
     return attributes;
   }
@@ -1403,7 +1375,7 @@ ${associationOwner._getAssociationDebugList()}`);
           }, []),
           {
 
-            ..._.omit(options, 'include', 'attributes', 'order', 'where', 'limit', 'offset', 'plain', 'scope'),
+            ...omit(options, 'include', 'attributes', 'order', 'where', 'limit', 'offset', 'plain', 'scope'),
             include: include.include || [],
           },
         );
@@ -1411,8 +1383,8 @@ ${associationOwner._getAssociationDebugList()}`);
 
       const map = await include.association.get(results, {
 
-        ..._.omit(options, nonCascadingOptions),
-        ..._.omit(include, ['parent', 'association', 'as', 'originalAttributes']),
+        ...omit(options, nonCascadingOptions),
+        ...omit(include, ['parent', 'association', 'as', 'originalAttributes']),
       });
 
       for (const result of results) {
@@ -1470,7 +1442,7 @@ ${associationOwner._getAssociationDebugList()}`);
    * @returns {Promise<Model|null>}
    */
   static async findOne(options) {
-    if (options !== undefined && !_.isPlainObject(options)) {
+    if (options !== undefined && !isPlainObject(options)) {
       throw new Error('The argument passed to findOne must be an options object, use findByPk if you wish to pass a single primary key value');
     }
 
@@ -1483,7 +1455,7 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     // Bypass a possible overloaded findAll.
-    return await Model.findAll.call(this, (_.defaults(options, {
+    return await Model.findAll.call(this, (defaultsLodash(options, {
       model: this,
       plain: true,
     })));
@@ -1530,7 +1502,7 @@ ${associationOwner._getAssociationDebugList()}`);
       group = group.flat();
     }
 
-    options.attributes = _.unionBy(
+    options.attributes = unionBy(
       options.attributes,
       group,
       [[this.sequelize.fn(aggregateFunction, aggregateColumn), aggregateFunction]],
@@ -1566,7 +1538,7 @@ ${associationOwner._getAssociationDebugList()}`);
    */
   static async count(options) {
     options = cloneDeep(options) ?? {};
-    options = _.defaults(options, { hooks: true });
+    options = defaultsLodash(options, { hooks: true });
 
     setTransactionFromCls(options, this.sequelize);
 
@@ -1652,7 +1624,7 @@ ${associationOwner._getAssociationDebugList()}`);
    * @returns {Promise<{count: number | number[], rows: Model[]}>}
    */
   static async findAndCountAll(options) {
-    if (options !== undefined && !_.isPlainObject(options)) {
+    if (options !== undefined && !isPlainObject(options)) {
       throw new Error('The argument passed to findAndCountAll must be an options object, use findByPk if you wish to pass a single primary key value');
     }
 
@@ -1798,7 +1770,7 @@ ${associationOwner._getAssociationDebugList()}`);
     let instance = await this.findOne(options);
     if (instance === null) {
       values = { ...options.defaults };
-      if (_.isPlainObject(options.where)) {
+      if (isPlainObject(options.where)) {
         values = defaults(values, options.where);
       }
 
@@ -1869,7 +1841,7 @@ ${associationOwner._getAssociationDebugList()}`);
       }
 
       values = { ...options.defaults };
-      if (_.isPlainObject(options.where)) {
+      if (isPlainObject(options.where)) {
         values = defaults(values, options.where);
       }
 
@@ -1903,7 +1875,7 @@ ${associationOwner._getAssociationDebugList()}`);
         }
 
         if (errFieldsWhereIntersects) {
-          _.each(error.fields, (value, key) => {
+          each(error.fields, (value, key) => {
             const name = modelDefinition.columns.get(key).attributeName;
             if (value.toString() !== options.where[name].toString()) {
               throw new Error(`${this.name}#findOrCreate: value used for ${name} was not equal for both the find and the create calls, '${options.where[name]}' vs '${value}'`);
@@ -1950,7 +1922,7 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     let values = { ...options.defaults };
-    if (_.isPlainObject(options.where)) {
+    if (isPlainObject(options.where)) {
       values = defaults(values, options.where);
     }
 
@@ -2035,7 +2007,7 @@ ${associationOwner._getAssociationDebugList()}`);
     }
 
     // Map field names
-    const updatedDataValues = _.pick(instance.dataValues, changed);
+    const updatedDataValues = pick(instance.dataValues, changed);
     const insertValues = mapValueFieldNames(instance.dataValues, modelDefinition.attributes.keys(), this);
     const updateValues = mapValueFieldNames(updatedDataValues, options.fields, this);
     const now = new Date();
@@ -2168,8 +2140,8 @@ ${associationOwner._getAssociationDebugList()}`);
 
       if (options.updateOnDuplicate !== undefined) {
         if (Array.isArray(options.updateOnDuplicate) && options.updateOnDuplicate.length > 0) {
-          options.updateOnDuplicate = _.intersection(
-            _.without(Object.keys(model.tableAttributes), createdAtAttr),
+          options.updateOnDuplicate = intersection(
+            without(Object.keys(model.tableAttributes), createdAtAttr),
             options.updateOnDuplicate,
           );
         } else {
@@ -2233,14 +2205,14 @@ ${associationOwner._getAssociationDebugList()}`);
               return;
             }
 
-            const includeOptions = _(cloneDeep(include))
-              .omit(['association'])
-              .defaults({
+            const includeOptions = defaultsLodash(
+              omit(cloneDeep(include), ['association']),
+              {
                 connection: options.connection,
                 transaction: options.transaction,
                 logging: options.logging,
-              })
-              .value();
+              },
+            );
 
             const createdAssociationInstances = await recursiveBulkCreate(associationInstances, includeOptions);
             for (const idx in createdAssociationInstances) {
@@ -2378,14 +2350,14 @@ ${associationOwner._getAssociationDebugList()}`);
             return;
           }
 
-          const includeOptions = _(cloneDeep(include))
-            .omit(['association'])
-            .defaults({
+          const includeOptions = defaultsLodash(
+            omit(cloneDeep(include), ['association']),
+            {
               connection: options.connection,
               transaction: options.transaction,
               logging: options.logging,
-            })
-            .value();
+            },
+          );
 
           const createdAssociationInstances = await recursiveBulkCreate(associationInstances, includeOptions);
           if (include.association instanceof BelongsToMany) {
@@ -2421,14 +2393,14 @@ ${associationOwner._getAssociationDebugList()}`);
               valueSets.push(values);
             }
 
-            const throughOptions = _(cloneDeep(include))
-              .omit(['association', 'attributes'])
-              .defaults({
+            const throughOptions = defaultsLodash(
+              omit(cloneDeep(include), ['association', 'attributes']),
+              {
                 connection: options.connection,
                 transaction: options.transaction,
                 logging: options.logging,
-              })
-              .value();
+              },
+            );
             throughOptions.model = include.association.throughModel;
             const throughInstances = include.association.throughModel.bulkBuild(valueSets, throughOptions);
 
@@ -2504,14 +2476,14 @@ ${associationOwner._getAssociationDebugList()}`);
       throw new Error('Missing where or truncate attribute in the options parameter of model.destroy.');
     }
 
-    if (!options.truncate && !_.isPlainObject(options.where) && !Array.isArray(options.where) && !(options.where instanceof BaseSqlExpression)) {
+    if (!options.truncate && !isPlainObject(options.where) && !Array.isArray(options.where) && !(options.where instanceof BaseSqlExpression)) {
       throw new Error('Expected plain object, array or sequelize method in the options.where parameter of model.destroy.');
     }
 
     const modelDefinition = this.modelDefinition;
     const attributes = modelDefinition.attributes;
 
-    options = _.defaults(options, {
+    options = defaultsLodash(options, {
       hooks: true,
       individualHooks: false,
       force: false,
@@ -2681,7 +2653,7 @@ ${associationOwner._getAssociationDebugList()}`);
 
     const modelDefinition = this.modelDefinition;
 
-    options = this._paranoidClause(this, _.defaults(options, {
+    options = this._paranoidClause(this, defaultsLodash(options, {
       validate: true,
       hooks: true,
       individualHooks: false,
@@ -2693,7 +2665,7 @@ ${associationOwner._getAssociationDebugList()}`);
     options.type = QueryTypes.BULKUPDATE;
 
     // Clone values so it doesn't get modified for caller scope and ignore undefined values
-    values = _.omitBy(values, value => value === undefined);
+    values = omitBy(values, value => value === undefined);
 
     const updatedAtAttrName = modelDefinition.timestampAttributeNames.updatedAt;
 
@@ -2705,7 +2677,7 @@ ${associationOwner._getAssociationDebugList()}`);
         }
       }
     } else {
-      options.fields = _.intersection(Object.keys(values), Array.from(modelDefinition.physicalAttributes.keys()));
+      options.fields = intersection(Object.keys(values), Array.from(modelDefinition.physicalAttributes.keys()));
       if (updatedAtAttrName && !options.fields.includes(updatedAtAttrName)) {
         options.fields.push(updatedAtAttrName);
       }
@@ -2724,17 +2696,17 @@ ${associationOwner._getAssociationDebugList()}`);
       build.set(updatedAtAttrName, values[updatedAtAttrName], { raw: true });
 
       if (options.sideEffects) {
-        Object.assign(values, _.pick(build.get(), build.changed()));
-        options.fields = _.union(options.fields, Object.keys(values));
+        Object.assign(values, pick(build.get(), build.changed()));
+        options.fields = union(options.fields, Object.keys(values));
       }
 
       // TODO: instead of setting "skip", set the "fields" property on a copy of options that's passed to "validate"
       // We want to skip validations for all other fields
-      options.skip = _.difference(Array.from(modelDefinition.attributes.keys()), Object.keys(values));
+      options.skip = difference(Array.from(modelDefinition.attributes.keys()), Object.keys(values));
       const attributes = await build.validate(options);
       options.skip = undefined;
       if (attributes && attributes.dataValues) {
-        values = _.pick(attributes.dataValues, Object.keys(values));
+        values = pick(attributes.dataValues, Object.keys(values));
       }
     }
 
@@ -2771,7 +2743,7 @@ ${associationOwner._getAssociationDebugList()}`);
           // Record updates in instances dataValues
           Object.assign(instance.dataValues, values);
           // Set the changed fields on the instance
-          _.forIn(valuesUse, (newValue, attr) => {
+          forIn(valuesUse, (newValue, attr) => {
             if (newValue !== instance._previousDataValues[attr]) {
               instance.setDataValue(attr, newValue);
             }
@@ -2782,7 +2754,7 @@ ${associationOwner._getAssociationDebugList()}`);
           await this.hooks.runAsync('beforeSave', instance, options);
           if (!different) {
             const thisChangedValues = {};
-            _.forIn(instance.dataValues, (newValue, attr) => {
+            forIn(instance.dataValues, (newValue, attr) => {
               if (newValue !== instance._previousDataValues[attr]) {
                 thisChangedValues[attr] = newValue;
               }
@@ -2791,7 +2763,7 @@ ${associationOwner._getAssociationDebugList()}`);
             if (!changedValues) {
               changedValues = thisChangedValues;
             } else {
-              different = !_.isEqual(changedValues, thisChangedValues);
+              different = !isEqual(changedValues, thisChangedValues);
             }
           }
 
@@ -2804,7 +2776,7 @@ ${associationOwner._getAssociationDebugList()}`);
           if (keys.length > 0) {
             // Hooks change values - record changes in valuesUse so they are executed
             valuesUse = changedValues;
-            options.fields = _.union(options.fields, keys);
+            options.fields = union(options.fields, keys);
           }
         } else {
           instances = await Promise.all(instances.map(async instance => {
@@ -2825,7 +2797,7 @@ ${associationOwner._getAssociationDebugList()}`);
     let result;
     if (updateDoneRowByRow) {
       result = [instances.length, instances];
-    } else if (_.isEmpty(valuesUse)
+    } else if (isEmpty(valuesUse)
        || Object.keys(valuesUse).length === 1 && valuesUse[updatedAtAttrName]) {
       // only updatedAt is being passed, then skip update
       result = [0];
@@ -2886,7 +2858,7 @@ ${associationOwner._getAssociationDebugList()}`);
   }
 
   static _expandAttributes(options) {
-    if (!_.isPlainObject(options.attributes)) {
+    if (!isPlainObject(options.attributes)) {
       return;
     }
 
@@ -3124,7 +3096,7 @@ Instead of specifying a Model, either:
 
   static _optionsMustContainWhere(options) {
     assert(options && options.where, 'Missing where attribute in the options parameter');
-    assert(_.isPlainObject(options.where) || Array.isArray(options.where) || options.where instanceof BaseSqlExpression,
+    assert(isPlainObject(options.where) || Array.isArray(options.where) || options.where instanceof BaseSqlExpression,
       'Expected plain object, array or sequelize method in the options.where parameter');
   }
 
@@ -3206,7 +3178,7 @@ Instead of specifying a Model, either:
   setDataValue(key, value) {
     const originalValue = this._previousDataValues[key];
 
-    if (!_.isEqual(value, originalValue)) {
+    if (!isEqual(value, originalValue)) {
       this.changed(key, true);
     }
 
@@ -3397,7 +3369,7 @@ Instead of specifying a Model, either:
       // custom setter should have changed value, get that changed value
       // TODO: v5 make setters return new value instead of changing internal store
       const newValue = this.dataValues[key];
-      if (!_.isEqual(newValue, originalValue)) {
+      if (!isEqual(newValue, originalValue)) {
         this._previousDataValues[key] = originalValue;
         this.changed(key, true);
       }
@@ -3418,7 +3390,7 @@ Instead of specifying a Model, either:
 
           if (key.includes('.') && jsonAttributeNames.has(key.split('.')[0])) {
             const previousNestedValue = Dottie.get(this.dataValues, key);
-            if (!_.isEqual(previousNestedValue, value)) {
+            if (!isEqual(previousNestedValue, value)) {
               Dottie.set(this.dataValues, key, value);
               this.changed(key.split('.')[0], true);
             }
@@ -3462,7 +3434,7 @@ Instead of specifying a Model, either:
           value instanceof BaseSqlExpression
           // Otherwise, check for data type type comparators
           || ((value != null && attributeType && attributeType instanceof AbstractDataType) && !attributeType.areValuesEqual(value, originalValue, options))
-          || ((value == null || !attributeType || !(attributeType instanceof AbstractDataType)) && !_.isEqual(value, originalValue))
+          || ((value == null || !attributeType || !(attributeType instanceof AbstractDataType)) && !isEqual(value, originalValue))
         )
       ) {
         this._previousDataValues[key] = originalValue;
@@ -3546,7 +3518,7 @@ Instead of specifying a Model, either:
       return this._previousDataValues[key];
     }
 
-    return _.pickBy(this._previousDataValues, (value, key) => this.changed(key));
+    return pickBy(this._previousDataValues, (value, key) => this.changed(key));
   }
 
   _setInclude(key, value, options) {
@@ -3612,7 +3584,7 @@ Instead of specifying a Model, either:
     }
 
     options = cloneDeep(options) ?? {};
-    options = _.defaults(options, {
+    options = defaultsLodash(options, {
       hooks: true,
       validate: true,
     });
@@ -3625,7 +3597,7 @@ Instead of specifying a Model, either:
       if (this.isNewRecord) {
         options.fields = Array.from(modelDefinition.attributes.keys());
       } else {
-        options.fields = _.intersection(this.changed(), Array.from(modelDefinition.attributes.keys()));
+        options.fields = intersection(this.changed(), Array.from(modelDefinition.attributes.keys()));
       }
 
       options.defaultFields = options.fields;
@@ -3659,7 +3631,7 @@ Instead of specifying a Model, either:
 
     if (options.silent === true && !(this.isNewRecord && this.get(updatedAtAttr, { raw: true }))) {
       // UpdateAtAttr might have been added as a result of Object.keys(Model.rawAttributes). In that case we have to remove it again
-      _.remove(options.fields, val => val === updatedAtAttr);
+      remove(options.fields, val => val === updatedAtAttr);
       updatedAtAttr = false;
     }
 
@@ -3702,19 +3674,19 @@ Instead of specifying a Model, either:
 
     // Run before hook
     if (options.hooks) {
-      const beforeHookValues = _.pick(this.dataValues, options.fields);
-      let ignoreChanged = _.difference(this.changed(), options.fields); // In case of update where it's only supposed to update the passed values and the hook values
+      const beforeHookValues = pick(this.dataValues, options.fields);
+      let ignoreChanged = difference(this.changed(), options.fields); // In case of update where it's only supposed to update the passed values and the hook values
       let hookChanged;
       let afterHookValues;
 
       if (updatedAtAttr && options.fields.includes(updatedAtAttr)) {
-        ignoreChanged = _.without(ignoreChanged, updatedAtAttr);
+        ignoreChanged = without(ignoreChanged, updatedAtAttr);
       }
 
       await this.constructor.hooks.runAsync(`before${hook}`, this, options);
       await this.constructor.hooks.runAsync(`beforeSave`, this, options);
       if (options.defaultFields && !this.isNewRecord) {
-        afterHookValues = _.pick(this.dataValues, _.difference(this.changed(), ignoreChanged));
+        afterHookValues = pick(this.dataValues, difference(this.changed(), ignoreChanged));
 
         hookChanged = [];
         for (const key of Object.keys(afterHookValues)) {
@@ -3723,13 +3695,13 @@ Instead of specifying a Model, either:
           }
         }
 
-        options.fields = _.uniq(options.fields.concat(hookChanged));
+        options.fields = uniq(options.fields.concat(hookChanged));
       }
 
       if (hookChanged && options.validate) {
         // Validate again
 
-        options.skip = _.difference(Array.from(modelDefinition.attributes.keys()), hookChanged);
+        options.skip = difference(Array.from(modelDefinition.attributes.keys()), hookChanged);
         await this.validate(options);
         delete options.skip;
       }
@@ -3742,15 +3714,15 @@ Instead of specifying a Model, either:
           return;
         }
 
-        const includeOptions = _(cloneDeep(include))
-          .omit(['association'])
-          .defaults({
+        const includeOptions = defaultsLodash(
+          omit(cloneDeep(include), ['association']),
+          {
             connection: options.connection,
             transaction: options.transaction,
             logging: options.logging,
             parentRecord: this,
-          })
-          .value();
+          },
+        );
 
         await instance.save(includeOptions);
 
@@ -3832,15 +3804,15 @@ Instead of specifying a Model, either:
             instances = [instances];
           }
 
-          const includeOptions = _(cloneDeep(include))
-            .omit(['association'])
-            .defaults({
+          const includeOptions = defaultsLodash(
+            omit(cloneDeep(include), ['association']),
+            {
               connection: options.connection,
               transaction: options.transaction,
               logging: options.logging,
               parentRecord: this,
-            })
-            .value();
+            },
+          );
 
           // Instances will be updated in place so we can safely treat HasOne like a HasMany
           await Promise.all(instances.map(async instance => {
@@ -3956,7 +3928,7 @@ Instead of specifying a Model, either:
    */
   async update(values, options) {
     // Clone values so it doesn't get modified for caller scope and ignore undefined values
-    values = _.omitBy(values, value => value === undefined);
+    values = omitBy(values, value => value === undefined);
 
     const changedBefore = this.changed() || [];
 
@@ -3975,11 +3947,11 @@ Instead of specifying a Model, either:
     this.set(values, setOptions);
 
     // Now we need to figure out which fields were actually affected by the setter.
-    const sideEffects = _.without(this.changed(), ...changedBefore);
-    const fields = _.union(Object.keys(values), sideEffects);
+    const sideEffects = without(this.changed(), ...changedBefore);
+    const fields = union(Object.keys(values), sideEffects);
 
     if (!options.fields) {
-      options.fields = _.intersection(fields, this.changed());
+      options.fields = intersection(fields, this.changed());
       options.defaultFields = options.fields;
     }
 
@@ -4018,7 +3990,7 @@ Instead of specifying a Model, either:
       const defaultValue = attribute.defaultValue ?? null;
       const currentValue = this.getDataValue(attributeName);
       const undefinedOrNull = currentValue == null && defaultValue == null;
-      if (undefinedOrNull || _.isEqual(currentValue, defaultValue)) {
+      if (undefinedOrNull || isEqual(currentValue, defaultValue)) {
         // only update timestamp if it wasn't already set
         this.setDataValue(attributeName, new Date());
       }
@@ -4221,7 +4193,7 @@ Instead of specifying a Model, either:
    * @returns {object}
    */
   toJSON() {
-    return _.cloneDeep(
+    return cloneDeepLodash(
       this.get({
         plain: true,
       }),
@@ -4325,7 +4297,7 @@ Instead of specifying a Model, either:
  * @private
  */
 function unpackAnd(where) {
-  if (!_.isObject(where)) {
+  if (!isObject(where)) {
     return where;
   }
 

--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import omit from 'lodash/omit';
 import { AbstractDataType } from './dialects/abstract/data-types';
 import { BaseSqlExpression } from './expression-builders/base-sql-expression.js';
 import { intersects } from './utils/array';
@@ -25,14 +24,66 @@ import { _validateIncludedElements, combineIncludes, setTransactionFromCls, thro
 import { QueryTypes } from './query-types';
 import { getComplexKeys } from './utils/where.js';
 
+import assignWith from 'lodash/assignWith';
+import cloneDeepLodash from 'lodash/cloneDeep';
+import defaultsLodash from 'lodash/defaults';
+import difference from 'lodash/difference';
+import each from 'lodash/each';
+import flattenDepth from 'lodash/flattenDepth';
+import forEach from 'lodash/forEach';
+import forIn from 'lodash/forIn';
+import get from 'lodash/get';
+import isEqual from 'lodash/isEqual';
+import isEmpty from 'lodash/isEmpty';
+import isObject from 'lodash/isObject';
+import isPlainObject from 'lodash/isPlainObject';
+import intersection from 'lodash/intersection';
+import mapValues from 'lodash/mapValues';
+import omit from 'lodash/omit';
+import omitBy from 'lodash/omitBy';
+import pick from 'lodash/pick';
+import pickBy from 'lodash/pickBy';
+import remove from 'lodash/remove';
+import union from 'lodash/union';
+import uniq from 'lodash/uniq';
+import unionBy from 'lodash/unionBy';
+import without from 'lodash/without';
+
 const assert = require('node:assert');
 const NodeUtil = require('node:util');
-const _ = require('lodash');
 const Dottie = require('dottie');
 const { logger } = require('./utils/logger');
 const { InstanceValidator } = require('./instance-validator');
 const sequelizeErrors = require('./errors');
 const DataTypes = require('./data-types');
+
+// `lodash`.
+const _ = {
+  assignWith,
+  cloneDeep: cloneDeepLodash,
+  defaults: defaultsLodash,
+  difference,
+  each,
+  flattenDepth,
+  forEach,
+  forIn,
+  get,
+  isEqual,
+  isEmpty,
+  isObject,
+  isPlainObject,
+  intersection,
+  mapValues,
+  omit,
+  omitBy,
+  pick,
+  pickBy,
+  remove,
+  union,
+  uniq,
+  unionBy,
+  without,
+};
 
 // This list will quickly become dated, but failing to maintain this list just means
 // we won't throw a warning when we should. At least most common cases will forever be covered
@@ -119,7 +170,7 @@ export class Model extends ModelTypeScript {
     this._previousDataValues = {};
     this.uniqno = 1;
     this._changed = new Set();
-    this._options = omit(options, ['comesFromDatabase']);
+    this._options = _.omit(options, ['comesFromDatabase']);
 
     /**
      * Returns true if this instance has not yet been persisted to the database

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -1,6 +1,5 @@
 'use strict';
 
-import isPlainObject from 'lodash/isPlainObject';
 import retry from 'retry-as-promised';
 import { normalizeDataType } from './dialects/abstract/data-types-utils';
 import { AssociationPath } from './expression-builders/association-path';

--- a/packages/core/src/sequelize.js
+++ b/packages/core/src/sequelize.js
@@ -28,7 +28,11 @@ import { useInflection } from './utils/string';
 import { parseConnectionString } from './utils/url';
 import { importModels } from './import-models.js';
 
-const _ = require('lodash');
+import defaults from 'lodash/defaults';
+import defaultsDeep from 'lodash/defaultsDeep';
+import isPlainObject from 'lodash/isPlainObject';
+import map from 'lodash/map';
+
 const { Model } = require('./model');
 const DataTypes = require('./data-types');
 const { ConstraintChecking, Deferrable } = require('./deferrable');
@@ -208,19 +212,19 @@ export class Sequelize extends SequelizeTypeScript {
   constructor(database, username, password, options) {
     super();
 
-    if (arguments.length === 1 && _.isPlainObject(database)) {
+    if (arguments.length === 1 && isPlainObject(database)) {
       // new Sequelize({ ... options })
       options = database;
-    } else if (arguments.length === 1 && typeof database === 'string' || arguments.length === 2 && _.isPlainObject(username)) {
+    } else if (arguments.length === 1 && typeof database === 'string' || arguments.length === 2 && isPlainObject(username)) {
       // new Sequelize(URI, { ... options })
       options = username ? { ...username } : Object.create(null);
 
-      _.defaultsDeep(options, parseConnectionString(arguments[0]));
+      defaultsDeep(options, parseConnectionString(arguments[0]));
     } else {
       // new Sequelize(database, username, password, { ... options })
       options = options ? { ...options } : Object.create(null);
 
-      _.defaults(options, {
+      defaults(options, {
         database,
         username,
         password,
@@ -271,7 +275,7 @@ export class Sequelize extends SequelizeTypeScript {
       disableClsTransactions: false,
       defaultTransactionNestMode: TransactionNestMode.reuse,
       ...options,
-      pool: _.defaults(options.pool || {}, {
+      pool: defaults(options.pool || {}, {
         max: 5,
         min: 0,
         idle: 10_000,
@@ -374,7 +378,7 @@ export class Sequelize extends SequelizeTypeScript {
     }
 
     // Map main connection config
-    this.options.replication.write = _.defaults(this.options.replication.write ?? {}, connectionConfig);
+    this.options.replication.write = defaults(this.options.replication.write ?? {}, connectionConfig);
     this.options.replication.write.port = Number(this.options.replication.write.port);
 
     if (!this.options.replication.read) {
@@ -391,7 +395,7 @@ export class Sequelize extends SequelizeTypeScript {
       readEntry.port = Number(readEntry.port);
 
       // Apply defaults to each read config
-      return _.defaults(readEntry, connectionConfig);
+      return defaults(readEntry, connectionConfig);
     });
 
     // ==========================================
@@ -665,7 +669,7 @@ Use Sequelize#query if you wish to use replacements.`);
       options.fieldMap = options.model?.fieldAttributeMap;
     }
 
-    options = _.defaults(options, {
+    options = defaults(options, {
       logging: Object.hasOwn(this.options, 'logging') ? this.options.logging : console.debug,
       searchPath: Object.hasOwn(this.options, 'searchPath') ? this.options.searchPath : 'DEFAULT',
     });
@@ -765,7 +769,7 @@ Use Sequelize#query if you wish to use replacements.`);
     // Generate SQL Query
     const query
       = `SET ${
-        _.map(variables, (v, k) => `@${k} := ${typeof v === 'string' ? `"${v}"` : v}`).join(', ')}`;
+        map(variables, (v, k) => `@${k} := ${typeof v === 'string' ? `"${v}"` : v}`).join(', ')}`;
 
     return await this.query(query, options);
   }
@@ -987,7 +991,7 @@ Use Sequelize#query if you wish to use replacements.`);
 
     const last = args.at(-1);
 
-    if (last && _.isPlainObject(last) && Object.hasOwn(last, 'logging')) {
+    if (last && isPlainObject(last) && Object.hasOwn(last, 'logging')) {
       options = last;
 
       // remove options from set of logged arguments if options.logging is equal to console.log or console.debug
@@ -1031,7 +1035,7 @@ Use Sequelize#query if you wish to use replacements.`);
   }
 
   normalizeAttribute(attribute) {
-    if (!_.isPlainObject(attribute)) {
+    if (!isPlainObject(attribute)) {
       attribute = { type: attribute };
     } else {
       attribute = { ...attribute };

--- a/packages/core/src/utils/validator-extras.js
+++ b/packages/core/src/utils/validator-extras.js
@@ -1,7 +1,9 @@
 'use strict';
 
-const _ = require('lodash');
-const validator = _.cloneDeep(require('validator'));
+import cloneDeep from 'lodash/cloneDeep';
+import forEach from 'lodash/forEach';
+
+const validator = cloneDeep(require('validator'));
 const dayjs = require('dayjs');
 
 export const extensions = {
@@ -78,7 +80,7 @@ validator.notNull = function (val) {
 };
 
 // https://github.com/chriso/validator.js/blob/6.2.0/validator.js
-_.forEach(extensions, (extend, key) => {
+forEach(extensions, (extend, key) => {
   validator[key] = extend;
 });
 

--- a/packages/core/test/integration/associations/has-many.test.js
+++ b/packages/core/test/integration/associations/has-many.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import range from 'lodash/range';
+const range = require('lodash/range');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/associations/has-many.test.js
+++ b/packages/core/test/integration/associations/has-many.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import range from 'lodash/range';
+
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -9,7 +11,6 @@ const dayjs = require('dayjs');
 const sinon = require('sinon');
 
 const current = Support.sequelize;
-const _ = require('lodash');
 const assert = require('node:assert');
 
 const dialect = Support.getTestDialect();
@@ -772,7 +773,7 @@ describe(Support.getTestDialectTeaser('HasMany'), () => {
         Task.hasMany(User);
 
         await this.sequelize.sync({ force: true });
-        const users0 = _.range(1000).map(i => ({ username: `user${i}`, num: i, status: 'live' }));
+        const users0 = range(1000).map(i => ({ username: `user${i}`, num: i, status: 'live' }));
         await User.bulkCreate(users0);
         await Task.create({ title: 'task' });
         const users = await User.findAll();

--- a/packages/core/test/integration/dialects/postgres/error.test.js
+++ b/packages/core/test/integration/dialects/postgres/error.test.js
@@ -1,14 +1,14 @@
 'use strict';
 
-import each from 'lodash/each';
+const each = require('lodash/each');
 
-const chai      = require('chai');
+const chai = require('chai');
 
-const expect    = chai.expect;
+const expect = chai.expect;
 const { DataTypes, Sequelize } = require('@sequelize/core');
-const Support   = require('../../support');
+const Support = require('../../support');
 
-const dialect   = Support.getTestDialect();
+const dialect = Support.getTestDialect();
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] ExclusionConstraintError', () => {

--- a/packages/core/test/integration/dialects/postgres/error.test.js
+++ b/packages/core/test/integration/dialects/postgres/error.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import each from 'lodash/each';
+
 const chai      = require('chai');
 
 const expect    = chai.expect;
@@ -7,7 +9,6 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const Support   = require('../../support');
 
 const dialect   = Support.getTestDialect();
-const _ = require('lodash');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] ExclusionConstraintError', () => {
@@ -36,7 +37,7 @@ if (dialect.startsWith('postgres')) {
       };
       const err = new Sequelize.ExclusionConstraintError(errDetails);
 
-      _.each(errDetails, (value, key) => {
+      each(errDetails, (value, key) => {
         expect(err[key]).to.be.deep.equal(value, `Value for key ${key} is invalid`);
       });
     });

--- a/packages/core/test/integration/dialects/postgres/query-interface.test.js
+++ b/packages/core/test/integration/dialects/postgres/query-interface.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import uniq from 'lodash/uniq';
+const uniq = require('lodash/uniq');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/dialects/postgres/query-interface.test.js
+++ b/packages/core/test/integration/dialects/postgres/query-interface.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import uniq from 'lodash/uniq';
+
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -7,7 +9,6 @@ const Support = require('../../support');
 
 const dialect = Support.getTestDialect();
 const { DataTypes } = require('@sequelize/core');
-const _ = require('lodash');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] QueryInterface', () => {
@@ -254,7 +255,7 @@ if (dialect.startsWith('postgres')) {
           )`)], { name: 'group_username_case' });
 
         const indexes = await this.queryInterface.showIndex('Group');
-        const indexColumns = _.uniq(indexes.map(index => index.name));
+        const indexColumns = uniq(indexes.map(index => index.name));
 
         expect(indexColumns).to.include('group_username_case');
       });
@@ -265,12 +266,12 @@ if (dialect.startsWith('postgres')) {
         });
 
         const indexes0 = await this.queryInterface.showIndex('Group');
-        const indexColumns0 = _.uniq(indexes0.map(index => index.name));
+        const indexColumns0 = uniq(indexes0.map(index => index.name));
 
         expect(indexColumns0).to.include('group_username_lower');
         await this.queryInterface.removeIndex('Group', 'group_username_lower');
         const indexes = await this.queryInterface.showIndex('Group');
-        const indexColumns = _.uniq(indexes.map(index => index.name));
+        const indexColumns = uniq(indexes.map(index => index.name));
         expect(indexColumns).to.be.empty;
       });
     });

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -1,11 +1,12 @@
 'use strict';
 
+import omit from 'lodash/omit';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('./support');
 const { DataTypes, Sequelize, or, and } = require('@sequelize/core');
-const _ = require('lodash');
 
 const dialect = Support.getTestDialect();
 const current = Support.sequelize;
@@ -695,7 +696,7 @@ Instead of specifying a Model, either:
       expect(tasks[0].title).to.equal('FooBar');
       expect(tasks[0].Project.title).to.equal('BarFoo');
 
-      expect(_.omit(tasks[0].get(), 'Project')).to.deep.equal({ title: 'FooBar' });
+      expect(omit(tasks[0].get(), 'Project')).to.deep.equal({ title: 'FooBar' });
       expect(tasks[0].Project.get()).to.deep.equal({ title: 'BarFoo' });
     });
 

--- a/packages/core/test/integration/include.test.js
+++ b/packages/core/test/integration/include.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import omit from 'lodash/omit';
+const omit = require('lodash/omit');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/include/findAll.test.js
+++ b/packages/core/test/integration/include/findAll.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import partition from 'lodash/partition';
-import upperFirst from 'lodash/upperFirst';
+const partition = require('lodash/partition');
+const upperFirst = require('lodash/upperFirst');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/include/findAll.test.js
+++ b/packages/core/test/integration/include/findAll.test.js
@@ -1,11 +1,13 @@
 'use strict';
 
+import partition from 'lodash/partition';
+import upperFirst from 'lodash/upperFirst';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
 const { DataTypes, Op, Sequelize } = require('@sequelize/core');
-const _ = require('lodash');
 const promiseProps = require('p-props');
 
 const sortById = function (a, b) {
@@ -469,7 +471,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             await promise;
             const instance = await model.create({});
             if (previousInstance) {
-              await previousInstance[`set${_.upperFirst(model.name)}`](instance);
+              await previousInstance[`set${upperFirst(model.name)}`](instance);
               previousInstance = instance;
 
               return;
@@ -578,7 +580,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             await promise;
             const instance = await model.create(values);
             if (previousInstance) {
-              await previousInstance[`set${_.upperFirst(model.name)}`](instance);
+              await previousInstance[`set${upperFirst(model.name)}`](instance);
               previousInstance = instance;
 
               return;
@@ -2166,7 +2168,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
       expect(userCustomers).to.be.an('array');
       expect(userCustomers).to.be.lengthOf(2);
 
-      const [nonDeletedUserCustomers, deletedUserCustomers] = _.partition(userCustomers, userCustomer => !userCustomer.deletedAt);
+      const [nonDeletedUserCustomers, deletedUserCustomers] = partition(userCustomers, userCustomer => !userCustomer.deletedAt);
 
       expect(nonDeletedUserCustomers).to.be.lengthOf(1);
       expect(deletedUserCustomers).to.be.lengthOf(1);

--- a/packages/core/test/integration/include/findOne.test.js
+++ b/packages/core/test/integration/include/findOne.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import upperFirst from 'lodash/upperFirst';
+const upperFirst = require('lodash/upperFirst');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/include/findOne.test.js
+++ b/packages/core/test/integration/include/findOne.test.js
@@ -1,11 +1,12 @@
 'use strict';
 
+import upperFirst from 'lodash/upperFirst';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
-const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('Include'), () => {
   describe('findOne', () => {
@@ -295,7 +296,7 @@ describe(Support.getTestDialectTeaser('Include'), () => {
             await promise;
             const instance = await model.create(values);
             if (previousInstance) {
-              await previousInstance[`set${_.upperFirst(model.name)}`](instance);
+              await previousInstance[`set${upperFirst(model.name)}`](instance);
               previousInstance = instance;
 
               return;

--- a/packages/core/test/integration/include/schema.test.js
+++ b/packages/core/test/integration/include/schema.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import upperFirst from 'lodash/upperFirst';
+
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -7,7 +9,6 @@ const Support = require('../support');
 const { DataTypes, Op } = require('@sequelize/core');
 
 const dialect = Support.sequelize.dialect;
-const _ = require('lodash');
 const promiseProps = require('p-props');
 
 const sortById = function (a, b) {
@@ -362,7 +363,7 @@ describe(Support.getTestDialectTeaser('Includes with schemas'), () => {
       for (const model of singles) {
         const instance = await model.create({});
         if (previousInstance) {
-          await previousInstance[`set${_.upperFirst(model.name)}`](instance);
+          await previousInstance[`set${upperFirst(model.name)}`](instance);
           previousInstance = instance;
           continue;
         }

--- a/packages/core/test/integration/include/schema.test.js
+++ b/packages/core/test/integration/include/schema.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import upperFirst from 'lodash/upperFirst';
+const upperFirst = require('lodash/upperFirst');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/model.test.js
+++ b/packages/core/test/integration/model.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-import after from 'lodash/after';
-import once from 'lodash/once';
+const after = require('lodash/after');
+const once = require('lodash/once');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/model.test.js
+++ b/packages/core/test/integration/model.test.js
@@ -1,5 +1,8 @@
 'use strict';
 
+import after from 'lodash/after';
+import once from 'lodash/once';
+
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -9,7 +12,6 @@ const { DataTypes, Sequelize, Op, AggregateError, col } = require('@sequelize/co
 const dialectName = Support.getTestDialect();
 const dialect = Support.sequelize.dialect;
 const sinon = require('sinon');
-const _ = require('lodash');
 const dayjs = require('dayjs');
 
 const current = Support.sequelize;
@@ -994,7 +996,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         await UserPub.sync({ force: true });
         await ItemPub.sync({
           force: true,
-          logging: _.after(2, _.once(sql => {
+          logging: after(2, once(sql => {
             test = true;
             switch (dialectName) {
               case 'postgres':

--- a/packages/core/test/integration/model.test.js
+++ b/packages/core/test/integration/model.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const after = require('lodash/after');
+const afterLodash = require('lodash/after');
 const once = require('lodash/once');
 
 const chai = require('chai');
@@ -996,7 +996,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
         await UserPub.sync({ force: true });
         await ItemPub.sync({
           force: true,
-          logging: after(2, once(sql => {
+          logging: afterLodash(2, once(sql => {
             test = true;
             switch (dialectName) {
               case 'postgres':

--- a/packages/core/test/integration/model/create.test.js
+++ b/packages/core/test/integration/model/create.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import range from 'lodash/range';
+
 const chai = require('chai');
 const sinon = require('sinon');
 
@@ -7,7 +9,6 @@ const expect = chai.expect;
 const Support = require('../support');
 const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 
-const _ = require('lodash');
 const delay = require('delay');
 const assert = require('node:assert');
 
@@ -209,7 +210,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         await User.sync({ force: true });
 
-        await Promise.all(_.range(50).map(i => {
+        await Promise.all(range(50).map(i => {
           return User.findOrCreate({
             where: {
               email: `unique.email.${i}@sequelizejs.com`,
@@ -233,7 +234,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         await User.sync({ force: true });
 
-        await Promise.all(_.range(50).map(i => {
+        await Promise.all(range(50).map(i => {
           return User.findOrCreate({
             where: {
               email: `unique.email.${i}@sequelizejs.com`,
@@ -242,7 +243,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
           });
         }));
 
-        await Promise.all(_.range(50).map(i => {
+        await Promise.all(range(50).map(i => {
           return User.findOrCreate({
             where: {
               email: `unique.email.${i}@sequelizejs.com`,
@@ -266,7 +267,7 @@ describe(Support.getTestDialectTeaser('Model'), () => {
 
         await User.sync({ force: true });
 
-        await Promise.all(_.range(50).map(() => {
+        await Promise.all(range(50).map(() => {
           return User.findOrCreate({
             where: {
               email: 'unique.email.1@sequelizejs.com',

--- a/packages/core/test/integration/model/create.test.js
+++ b/packages/core/test/integration/model/create.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import range from 'lodash/range';
+const range = require('lodash/range');
 
 const chai = require('chai');
 const sinon = require('sinon');

--- a/packages/core/test/integration/model/findAll.test.js
+++ b/packages/core/test/integration/model/findAll.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import forEach from 'lodash/forEach';
+
 const chai = require('chai');
 const sinon = require('sinon');
 
@@ -8,7 +10,6 @@ const Support = require('../support');
 
 const { DataTypes, Op, Sequelize } = require('@sequelize/core');
 
-const _ = require('lodash');
 const dayjs = require('dayjs');
 const promiseProps = require('p-props');
 
@@ -908,7 +909,7 @@ The following associations are defined on "Worker": "ToDos"`);
             bob: this.Person.create({ name: 'Bob', lastName: 'Becket' }),
           });
 
-          _.forEach(r, (item, itemName) => {
+          forEach(r, (item, itemName) => {
             this[itemName] = item;
           });
 
@@ -1084,7 +1085,7 @@ The following associations are defined on "Worker": "ToDos"`);
             kim: this.Person.create({ name: 'Kim', lastName: 'Z' }),
           });
 
-          _.forEach(r, (item, itemName) => {
+          forEach(r, (item, itemName) => {
             this[itemName] = item;
           });
 
@@ -1240,7 +1241,7 @@ The following associations are defined on "Worker": "ToDos"`);
             tech: this.Industry.create({ name: 'Tech' }),
           });
 
-          _.forEach(r, (item, itemName) => {
+          forEach(r, (item, itemName) => {
             this[itemName] = item;
           });
 

--- a/packages/core/test/integration/model/findAll.test.js
+++ b/packages/core/test/integration/model/findAll.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import forEach from 'lodash/forEach';
+const forEach = require('lodash/forEach');
 
 const chai = require('chai');
 const sinon = require('sinon');

--- a/packages/core/test/integration/model/findAll/groupedLimit.test.js
+++ b/packages/core/test/integration/model/findAll/groupedLimit.test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-import groupBy from 'lodash/groupBy';
-import invokeMap from 'lodash/invokeMap';
-import property from 'lodash/property';
+const groupBy = require('lodash/groupBy');
+const invokeMap = require('lodash/invokeMap');
+const property = require('lodash/property');
 
 const chai = require('chai');
 const sinon = require('sinon');

--- a/packages/core/test/integration/model/findAll/groupedLimit.test.js
+++ b/packages/core/test/integration/model/findAll/groupedLimit.test.js
@@ -1,5 +1,9 @@
 'use strict';
 
+import groupBy from 'lodash/groupBy';
+import invokeMap from 'lodash/invokeMap';
+import property from 'lodash/property';
+
 const chai = require('chai');
 const sinon = require('sinon');
 
@@ -9,7 +13,6 @@ const Support = require('../../support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
 
 const current = Support.sequelize;
-const _ = require('lodash');
 
 if (current.dialect.supports['UNION ALL']) {
   describe(Support.getTestDialectTeaser('Model'), () => {
@@ -226,12 +229,12 @@ if (current.dialect.supports['UNION ALL']) {
               },
             });
 
-            const byUser = _.groupBy(tasks, _.property('userId'));
+            const byUser = groupBy(tasks, property('userId'));
             expect(Object.keys(byUser)).to.have.length(3);
 
             expect(byUser[1]).to.have.length(1);
             expect(byUser[2]).to.have.length(3);
-            expect(_.invokeMap(byUser[2], 'get', 'id')).to.deep.equal([4, 3, 2]);
+            expect(invokeMap(byUser[2], 'get', 'id')).to.deep.equal([4, 3, 2]);
             expect(byUser[3]).to.have.length(2);
           });
         });

--- a/packages/core/test/integration/query-interface.test.js
+++ b/packages/core/test/integration/query-interface.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import uniq from 'lodash/uniq';
+const uniq = require('lodash/uniq');
 
 const chai = require('chai');
 

--- a/packages/core/test/integration/query-interface.test.js
+++ b/packages/core/test/integration/query-interface.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import uniq from 'lodash/uniq';
+
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -9,7 +11,6 @@ const { DataTypes, Sequelize } = require('@sequelize/core');
 const dialectName = Support.getTestDialect();
 const dialect = Support.sequelize.dialect;
 const current = Support.sequelize;
-const _ = require('lodash');
 
 describe(Support.getTestDialectTeaser('QueryInterface'), () => {
   beforeEach(function () {
@@ -234,11 +235,11 @@ describe(Support.getTestDialectTeaser('QueryInterface'), () => {
     it('adds, reads and removes an index to the table', async function () {
       await this.queryInterface.addIndex('Group', ['username', 'isAdmin']);
       let indexes = await this.queryInterface.showIndex('Group');
-      let indexColumns = _.uniq(indexes.map(index => index.name));
+      let indexColumns = uniq(indexes.map(index => index.name));
       expect(indexColumns).to.include('group_username_is_admin');
       await this.queryInterface.removeIndex('Group', ['username', 'isAdmin']);
       indexes = await this.queryInterface.showIndex('Group');
-      indexColumns = _.uniq(indexes.map(index => index.name));
+      indexColumns = uniq(indexes.map(index => index.name));
       expect(indexColumns).to.be.empty;
     });
 

--- a/packages/core/test/integration/sequelize.test.js
+++ b/packages/core/test/integration/sequelize.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import cloneDeep from 'lodash/cloneDeep';
+const cloneDeep = require('lodash/cloneDeep');
 
 const { expect, assert } = require('chai');
 const Support = require('./support');

--- a/packages/core/test/integration/sequelize.test.js
+++ b/packages/core/test/integration/sequelize.test.js
@@ -1,11 +1,12 @@
 'use strict';
 
+import cloneDeep from 'lodash/cloneDeep';
+
 const { expect, assert } = require('chai');
 const Support = require('./support');
 const { DataTypes, Transaction, Sequelize, literal } = require('@sequelize/core');
 
 const dialect = Support.getTestDialect();
-const _ = require('lodash');
 const { Config: config } = require('../config/config');
 const sinon = require('sinon');
 
@@ -540,7 +541,7 @@ describe(Support.getTestDialectTeaser('Sequelize'), () => {
       ]) {
 
         it('should be able to override options on the default attributes', async function () {
-          const Picture = this.sequelize.define('picture', _.cloneDeep(customAttributes));
+          const Picture = this.sequelize.define('picture', cloneDeep(customAttributes));
           await Picture.sync({ force: true });
           for (const attribute of Object.keys(customAttributes)) {
             for (const option of Object.keys(customAttributes[attribute])) {

--- a/packages/core/test/smoke/smoketests.test.js
+++ b/packages/core/test/smoke/smoketests.test.js
@@ -5,7 +5,6 @@ const chai = require('chai');
 const expect = chai.expect;
 const Support = require('../integration/support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
-const _ = require('lodash');
 const sinon = require('sinon');
 
 const dialect = Support.getTestDialect();

--- a/packages/core/test/unit/dialects/db2/query-generator.test.js
+++ b/packages/core/test/unit/dialects/db2/query-generator.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+import each from 'lodash/each';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const _ = require('lodash');
 const { Op, sql } = require('@sequelize/core');
 const { Db2QueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/db2/query-generator.js');
 const { createSequelizeInstance } = require('../../../support');
@@ -377,7 +378,7 @@ if (dialect === 'db2') {
       ],
     };
 
-    _.each(suites, (tests, suiteTitle) => {
+    each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
         for (const test of tests) {
           const query = test.expectation.query || test.expectation;

--- a/packages/core/test/unit/dialects/db2/query-generator.test.js
+++ b/packages/core/test/unit/dialects/db2/query-generator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import each from 'lodash/each';
+const each = require('lodash/each');
 
 const chai = require('chai');
 

--- a/packages/core/test/unit/dialects/mariadb/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mariadb/query-generator.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+import each from 'lodash/each';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const _ = require('lodash');
 const { Op, IndexHints } = require('@sequelize/core');
 const { MariaDbQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mariadb/query-generator.js');
 const { createSequelizeInstance } = require('../../../support');
@@ -441,7 +442,7 @@ if (dialect === 'mariadb') {
       ],
     };
 
-    _.each(suites, (tests, suiteTitle) => {
+    each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
         for (const test of tests) {
           const query = test.expectation.query || test.expectation;

--- a/packages/core/test/unit/dialects/mariadb/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mariadb/query-generator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import each from 'lodash/each';
+const each = require('lodash/each');
 
 const chai = require('chai');
 

--- a/packages/core/test/unit/dialects/mysql/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mysql/query-generator.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+import each from 'lodash/each';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const _ = require('lodash');
 const { Op, IndexHints } = require('@sequelize/core');
 const { MySqlQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/mysql/query-generator.js');
 const { createSequelizeInstance } = require('../../../support');
@@ -440,7 +441,7 @@ if (dialect === 'mysql') {
       ],
     };
 
-    _.each(suites, (tests, suiteTitle) => {
+    each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
         for (const test of tests) {
           const query = test.expectation.query || test.expectation;

--- a/packages/core/test/unit/dialects/mysql/query-generator.test.js
+++ b/packages/core/test/unit/dialects/mysql/query-generator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import each from 'lodash/each';
+const each = require('lodash/each');
 
 const chai = require('chai');
 

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+import each from 'lodash/each';
+
 const chai = require('chai');
 
 const expect = chai.expect;
@@ -15,7 +17,6 @@ const dialect = Support.getTestDialect();
 const dayjs = require('dayjs');
 
 const current = Support.sequelize;
-const _ = require('lodash');
 
 if (dialect.startsWith('postgres')) {
   describe('[POSTGRES Specific] QueryGenerator', () => {
@@ -814,7 +815,7 @@ if (dialect.startsWith('postgres')) {
       ],
     };
 
-    _.each(suites, (tests, suiteTitle) => {
+    each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
         for (const test of tests) {
           const query = test.expectation.query || test.expectation;
@@ -875,7 +876,7 @@ if (dialect.startsWith('postgres')) {
         },
       ];
 
-      _.each(tests, test => {
+      each(tests, test => {
         it(test.title, function () {
           const convertedText = this.queryGenerator.fromArray(test.arguments);
           expect(convertedText).to.deep.equal(test.expectation);
@@ -901,7 +902,7 @@ if (dialect.startsWith('postgres')) {
         ],
       };
 
-      _.each(customSchemaSuites, (customSchemaTests, customSchemaSuiteTitle) => {
+      each(customSchemaSuites, (customSchemaTests, customSchemaSuiteTitle) => {
         for (const customSchemaTest of customSchemaTests) {
           it(customSchemaTest.title, function () {
             const convertedText = customSchemaTest.arguments ? this.queryGenerator[customSchemaSuiteTitle](...customSchemaTest.arguments) : this.queryGenerator[customSchemaSuiteTitle]();

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import each from 'lodash/each';
+const each = require('lodash/each');
 
 const chai = require('chai');
 

--- a/packages/core/test/unit/dialects/snowflake/query-generator.test.js
+++ b/packages/core/test/unit/dialects/snowflake/query-generator.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+import each from 'lodash/each';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const _ = require('lodash');
 const { Op, IndexHints } = require('@sequelize/core');
 const { SnowflakeQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/snowflake/query-generator.js');
 const { createSequelizeInstance } = require('../../../support');
@@ -826,7 +827,7 @@ if (dialect === 'snowflake') {
       ],
     };
 
-    _.each(suites, (tests, suiteTitle) => {
+    each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
         for (const test of tests) {
           const query = test.expectation.query || test.expectation;

--- a/packages/core/test/unit/dialects/snowflake/query-generator.test.js
+++ b/packages/core/test/unit/dialects/snowflake/query-generator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import each from 'lodash/each';
+const each = require('lodash/each');
 
 const chai = require('chai');
 

--- a/packages/core/test/unit/dialects/sqlite/query-generator.test.js
+++ b/packages/core/test/unit/dialects/sqlite/query-generator.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+import each from 'lodash/each';
+
 const chai = require('chai');
 
 const expect = chai.expect;
 const Support = require('../../../support');
 
 const dialect = Support.getTestDialect();
-const _ = require('lodash');
 const dayjs = require('dayjs');
 const { SqliteQueryGenerator: QueryGenerator } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/sqlite/query-generator.js');
 const { createSequelizeInstance } = require('../../../support');
@@ -377,7 +378,7 @@ if (dialect === 'sqlite') {
       ],
     };
 
-    _.each(suites, (tests, suiteTitle) => {
+    each(suites, (tests, suiteTitle) => {
       describe(suiteTitle, () => {
         for (const test of tests) {
           const query = test.expectation.query || test.expectation;

--- a/packages/core/test/unit/dialects/sqlite/query-generator.test.js
+++ b/packages/core/test/unit/dialects/sqlite/query-generator.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import each from 'lodash/each';
+const each = require('lodash/each');
 
 const chai = require('chai');
 

--- a/packages/core/test/unit/hooks.test.js
+++ b/packages/core/test/unit/hooks.test.js
@@ -1,12 +1,13 @@
 'use strict';
 
+import noop from 'lodash/noop';
+
 const chai = require('chai');
 const sinon = require('sinon');
 
 const expect = chai.expect;
 const Support = require('../support');
 const { DataTypes, Sequelize } = require('@sequelize/core');
-const _ = require('lodash');
 
 const sequelize = Support.sequelize;
 
@@ -240,7 +241,7 @@ describe(Support.getTestDialectTeaser('Hooks'), () => {
 
       const Model = sequelize.define('M', {}, {
         hooks: {
-          beforeUpdate: _.noop, // Just to make sure we can define other hooks without overwriting the global one
+          beforeUpdate: noop, // Just to make sure we can define other hooks without overwriting the global one
           beforeCreate: localHook,
         },
       });

--- a/packages/core/test/unit/hooks.test.js
+++ b/packages/core/test/unit/hooks.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import noop from 'lodash/noop';
+const noop = require('lodash/noop');
 
 const chai = require('chai');
 const sinon = require('sinon');

--- a/packages/core/test/unit/sql/create-table.test.js
+++ b/packages/core/test/unit/sql/create-table.test.js
@@ -6,7 +6,6 @@ const { DataTypes } = require('@sequelize/core');
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;
 const sql       = current.dialect.queryGenerator;
-const _         = require('lodash');
 
 describe(Support.getTestDialectTeaser('SQL'), () => {
   if (current.dialect.name === 'snowflake') {

--- a/packages/core/test/unit/sql/delete.test.js
+++ b/packages/core/test/unit/sql/delete.test.js
@@ -3,7 +3,6 @@
 const Support   = require('../../support');
 const { QueryTypes, DataTypes } = require('@sequelize/core');
 const util = require('node:util');
-const _ = require('lodash');
 
 const expectsql = Support.expectsql;
 const current   = Support.sequelize;

--- a/packages/core/test/unit/sql/generateJoin.test.js
+++ b/packages/core/test/unit/sql/generateJoin.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import at from 'lodash/at';
+const at = require('lodash/at');
 
 const Support = require('../../support');
 const { DataTypes, Sequelize, Op } = require('@sequelize/core');

--- a/packages/core/test/unit/sql/generateJoin.test.js
+++ b/packages/core/test/unit/sql/generateJoin.test.js
@@ -1,10 +1,11 @@
 'use strict';
 
+import at from 'lodash/at';
+
 const Support = require('../../support');
 const { DataTypes, Sequelize, Op } = require('@sequelize/core');
 const { _validateIncludedElements } = require('@sequelize/core/_non-semver-use-at-your-own-risk_/model-internals.js');
 const util = require('node:util');
-const _ = require('lodash');
 
 const expectsql = Support.expectsql;
 const current = Support.sequelize;
@@ -21,7 +22,7 @@ describe(Support.getTestDialectTeaser('SQL'), () => {
       Sequelize.Model._conformIncludes(options, options.model);
       options = _validateIncludedElements(options);
 
-      const include = _.at(options, path)[0];
+      const include = at(options, path)[0];
 
       it(name, () => {
 


### PR DESCRIPTION
While looking at the browser bundle size, I've identified two dependencies that could be potentially reduced.

![image](https://github.com/sequelize/sequelize/assets/477167/7b739300-7276-47fe-9554-118b21207d91)

* `moment`'s timezone JSON data, which is about `750 KB`. I can see that in the latest code, `moment` was replaced with `dayjs` which has a very low bundle size so that one is supposed to be fixed.
* `validator` package being used, which is about `115 KB`.
* `lodash` is imported as a whole via `const _ = require('lodash')`, which is about `75 KB`.

How could one potentially resolve the issue of `lodash` being imported as a whole?
By only importing the functions that're actually used.

```js
import { defaults, get, pick, ... } from 'lodash-es';
```

```js
import defaults from 'lodash/defaults ';
import get from 'lodash/get';
import pick from 'lodash/pick';
```

But at the same time I can see how `lodash`'s function names, although being very convenient and short, could potentially get lost among the rest of the code, or clash with other variables' names.

Perhaps a better approach would be leaving `_` as is and then reducing its shape:

```js
import defaults from 'lodash/defaults ';
import get from 'lodash/get';
import pick from 'lodash/pick';

const _ = {
  defaults,
  get,
  pick,
};
```

Also, sometimes in the code it uses a strange notation where it calls `lodash` as a function in order to chain its methods rather than wrapping around functions:

```js
const includeOptions = _(cloneDeep(include))
  .omit(['association'])
  .defaults({
    connection: options.connection,
    transaction: options.transaction,
    logging: options.logging,
  })
  .value();
```

I guess that could be rewritten as wrapping functions instead.

* Which way of rewriting in general would you prefer?
* Would you merge a pull request that followed the replacement strategy?

[sequelize.script.js.meta.json.txt](https://github.com/sequelize/sequelize/files/11926565/sequelize.script.js.meta.json.txt) at https://bundle-buddy.com/bundle or https://esbuild.github.io/analyze/
