### PR TITLE
fix(types): Document option raw on Model's get function

### DIFF
--- a/src/model.d.ts
+++ b/src/model.d.ts
@@ -3095,14 +3095,15 @@ export abstract class Model<TModelAttributes extends {} = any, TCreationAttribut
   /**
    * If no key is given, returns all values of the instance, also invoking virtual getters.
    *
-   * If key is given and a field or virtual getter is present for the key it will call that getter - else it
-   * will return the value for key.
+   * If key is given and a field or virtual getter is present for the key it will call that getter,
+   * unless the raw flag is true in the options - else it will return the value for key.
    *
    * @param options.plain If set to true, included instances will be returned as plain objects
+   * @param options.raw If set to true, field and virtual setters will be ignored
    */
   public get(options?: { plain?: boolean; clone?: boolean }): TModelAttributes;
   public get<K extends keyof this>(key: K, options?: { plain?: boolean; clone?: boolean }): this[K];
-  public get(key: string, options?: { plain?: boolean; clone?: boolean }): unknown;
+  public get(key: string, options?: { plain?: boolean; clone?: boolean; raw?: boolean }): unknown;
 
   /**
    * Set is used to update values on the instance (the sequelize representation of the instance that is,


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [x] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This function is documented in the js version of the file[1], but was not reflected in the type definitions. Since this bypasses getters I opted to only add it to the signature that returns unknown

[1]: https://github.com/sequelize/sequelize/blob/a3213f053bcc4534073e56def64f22392edaf28c/src/model.js#L3636
