### PR TITLE
docs: remove NPM disclosure link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,10 +13,4 @@ The following table describes the versions of this project that are currently su
 
 At Sequelize, we prioritize security issues and will try to fix them as soon as they are disclosed.
 
-If you discover a security vulnerability, please reach out to the project maintainers privately. You can find related information in [CONTACT.md](./CONTACT.md).
-
-After validating & discussing scope of security vulnerability, we will set a time-frame for patch distribution. This time-frame may vary depending upon the nature of vulnerability.
-
-Once affected versions are patched you may report security issue to any Node.js security vulnerability database. A few which we have worked with in past are listed below.
-
-- [Snyk.io](https://snyk.io/vulnerability-disclosure)
+If you discover a security vulnerability, please create a security advisory [here](https://github.com/sequelize/sequelize/security/advisories/new).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,5 +19,4 @@ After validating & discussing scope of security vulnerability, we will set a tim
 
 Once affected versions are patched you may report security issue to any Node.js security vulnerability database. A few which we have worked with in past are listed below.
 
-- [NPM](https://www.npmjs.com/advisories/report)
 - [Snyk.io](https://snyk.io/vulnerability-disclosure)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,3 +14,4 @@ The following table describes the versions of this project that are currently su
 At Sequelize, we prioritize security issues and will try to fix them as soon as they are disclosed.
 
 If you discover a security vulnerability, please create a security advisory [here](https://github.com/sequelize/sequelize/security/advisories/new).
+Otherwise, contact the project maintainers privately. You can find related information in [CONTACT.md](./CONTACT.md).


### PR DESCRIPTION
NPM seems to have removed all resources to report a vulnerability. Not sure why they did this, but the link on this page is dead now.