### PR TITLE
meta: fix update-authors CI

### DIFF
--- a/.github/workflows/authors.yml
+++ b/.github/workflows/authors.yml
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: "0" # This is required to actually get all the authors
           persist-credentials: false
       - run: "dev/update-authors.js" # Run the AUTHORS tool
-      - uses: gr2m/create-or-update-pull-request-action@df20b2c073090271599a08c55ae26e0c3522b329 # v1.9.2 # Create a PR or update the Action's existing PR
+      - uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5 # Create a PR or update the Action's existing PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Since it runs once a week I kinda forgot about this. Apparently GitHub wants `dist/index.js` of the action to be included but it's not shipped. This fixes it but I'm not sure renovate will easily pick up updates to the action. But last release was November 2022 so it doesn't get that many updates.