### PR TITLE
feat: measure time taken to acquire a connection from the pool and pass it to afterPoolAcquire hook

### DIFF
--- a/src/dialects/abstract/connection-manager.js
+++ b/src/dialects/abstract/connection-manager.js
@@ -285,10 +285,11 @@ class ConnectionManager {
     try {
 
       await this.sequelize.runHooks('beforePoolAcquire', options);
-
+      const start = Date.now();
       result = await this.pool.acquire(options.type, options.useMaster);
+      const timeTakenToAcquireInMs = Date.now() - start;
 
-      await this.sequelize.runHooks('afterPoolAcquire', result, options);
+      await this.sequelize.runHooks('afterPoolAcquire', result, options, timeTakenToAcquireInMs);
 
     } catch (error) {
       if (error instanceof TimeoutError) throw new errors.ConnectionAcquireTimeoutError(error);

--- a/src/hooks.d.ts
+++ b/src/hooks.d.ts
@@ -78,7 +78,7 @@ export interface SequelizeHooks<
   beforeConnect(config: DeepWriteable<Config>): HookReturn;
   afterConnect(connection: unknown, config: Config): HookReturn;
   beforePoolAcquire(config: GetConnectionOptions): HookReturn;
-  afterPoolAcquire(connection: Connection, config: GetConnectionOptions): HookReturn;
+  afterPoolAcquire(connection: Connection, config: GetConnectionOptions, timeTakenToAcquireInMs: number): HookReturn;
   beforeDisconnect(connection: unknown): HookReturn;
   afterDisconnect(connection: unknown): HookReturn;
 }

--- a/src/hooks.js
+++ b/src/hooks.js
@@ -44,7 +44,7 @@ const hookTypes = {
   beforeDisconnect: { params: 1, noModel: true },
   afterDisconnect: { params: 1, noModel: true },
   beforePoolAcquire: { params: 1, noModel: true },
-  afterPoolAcquire: { params: 2, noModel: true },
+  afterPoolAcquire: { params: 3, noModel: true },
   beforeSync: { params: 1 },
   afterSync: { params: 1 },
   beforeBulkSync: { params: 1 },
@@ -556,7 +556,8 @@ exports.applyTo = applyTo;
  * A hook that is run after a connection to the pool
  *
  * @param {string}   name
- * @param {Function} fn   A callback function that is called with the connection object and the config passed to connection
+ * @param {Function} fn   A callback function that is called with the connection object, the config passed to connection
+ * and the time taken, in milliseconds, to acquire the connection from the pool.
  * @name afterPoolAcquire
  * @memberof Sequelize
  */

--- a/src/sequelize.d.ts
+++ b/src/sequelize.d.ts
@@ -736,8 +736,8 @@ export class Sequelize extends Hooks {
    * @param name
    * @param fn   A callback function that is called with options
    */
-  public static afterPoolAcquire(name: string, fn: (connection: Connection, options: GetConnectionOptions) => void): void;
-  public static afterPoolAcquire(fn: (connection: Connection, options: GetConnectionOptions) => void): void;
+  public static afterPoolAcquire(name: string, fn: (connection: Connection, options: GetConnectionOptions, timeTakenToAcquireInMs: number) => void): void;
+  public static afterPoolAcquire(fn: (connection: Connection, options: GetConnectionOptions, timeTakenToAcquireInMs: number) => void): void;
 
 
   /**

--- a/test/types/hooks.ts
+++ b/test/types/hooks.ts
@@ -98,17 +98,19 @@ import { SemiDeepWritable } from "./type-helpers/deep-writable";
     expectTypeOf(args).toMatchTypeOf<[GetConnectionOptions | undefined]>();
   });
 
-  Sequelize.afterPoolAcquire('name', (connection: Connection, options?: GetConnectionOptions) => {
+  Sequelize.afterPoolAcquire('name', (connection: Connection, options?: GetConnectionOptions, timeTakenToAcquireInMs?: number) => {
     expectTypeOf(connection).toMatchTypeOf<Connection>();
     expectTypeOf(options).toMatchTypeOf<GetConnectionOptions | undefined>();
+    expectTypeOf(timeTakenToAcquireInMs).toMatchTypeOf<number | undefined>();
   });
 
-  Sequelize.afterPoolAcquire((connection: Connection, options?: GetConnectionOptions) => {
+  Sequelize.afterPoolAcquire((connection: Connection, options?: GetConnectionOptions, timeTakenToAcquireInMs?: number) => {
     expectTypeOf(connection).toMatchTypeOf<Connection>();
     expectTypeOf(options).toMatchTypeOf<GetConnectionOptions | undefined>();
+    expectTypeOf(timeTakenToAcquireInMs).toMatchTypeOf<number | undefined>();
   });
 
-  Sequelize.addHook('afterPoolAcquire', (...args: [Connection | GetConnectionOptions | undefined]) => {
-    expectTypeOf(args).toMatchTypeOf<[Connection | GetConnectionOptions | undefined]>();
+  Sequelize.addHook('afterPoolAcquire', (...args: [Connection | GetConnectionOptions | number | undefined]) => {
+    expectTypeOf(args).toMatchTypeOf<[Connection | GetConnectionOptions | number | undefined]>();
   });
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Measures the time taken, in milliseconds, to acquire a connection from the pool. The measured time is then passed to the afterPoolAcquire hook as its 3rd argument

This measurement is useful to help debug situations where a query has been delayed b/c of the amount of time taken to acquire a connection from the pool.

main change: https://github.com/sequelize/sequelize/pull/16249
