### PR TITLE
feat: measure time taken to acquire a connection from the pool and pass it to afterPoolAcquire hook

### DIFF
--- a/packages/core/src/dialects/abstract/connection-manager.ts
+++ b/packages/core/src/dialects/abstract/connection-manager.ts
@@ -185,9 +185,11 @@ export class AbstractConnectionManager<TConnection extends Connection = Connecti
 
       await this.sequelize.hooks.runAsync('beforePoolAcquire', options);
 
+      const start = Date.now();
       const result = await this.pool.acquire(options?.type, options?.useMaster);
+      const timeTakenToAcquireInMs = Date.now() - start;
 
-      await this.sequelize.hooks.runAsync('afterPoolAcquire', result, options);
+      await this.sequelize.hooks.runAsync('afterPoolAcquire', result, options, timeTakenToAcquireInMs);
 
       debug('connection acquired');
 

--- a/packages/core/src/sequelize-typescript.ts
+++ b/packages/core/src/sequelize-typescript.ts
@@ -91,7 +91,7 @@ export interface SequelizeHooks extends ModelHooks {
   /**
    * A hook that is run after a connection to the pool
    */
-  afterPoolAcquire(connection: Connection, options?: GetConnectionOptions): AsyncHookReturn;
+  afterPoolAcquire(connection: Connection, options?: GetConnectionOptions, timeTakenToAcquireInMs?: number): AsyncHookReturn;
 }
 
 export interface StaticSequelizeHooks {

--- a/packages/core/test/types/hooks.ts
+++ b/packages/core/test/types/hooks.ts
@@ -168,18 +168,20 @@ sequelize.addHook('beforePoolAcquire', (...args: [GetConnectionOptions | undefin
   expectTypeOf(args).toMatchTypeOf<[GetConnectionOptions | undefined]>();
 });
 
-sequelize.afterPoolAcquire('name', (connection: Connection, options?: GetConnectionOptions) => {
+sequelize.afterPoolAcquire('name', (connection: Connection, options?: GetConnectionOptions, timeTakenToAcquireInMs?: number) => {
   expectTypeOf(connection).toMatchTypeOf<Connection>();
   expectTypeOf(options).toMatchTypeOf<GetConnectionOptions | undefined>();
+  expectTypeOf(timeTakenToAcquireInMs).toMatchTypeOf<number | undefined>();
 });
 
-sequelize.afterPoolAcquire((connection: Connection, options?: GetConnectionOptions) => {
+sequelize.afterPoolAcquire((connection: Connection, options?: GetConnectionOptions, timeTakenToAcquireInMs?: number) => {
   expectTypeOf(connection).toMatchTypeOf<Connection>();
   expectTypeOf(options).toMatchTypeOf<GetConnectionOptions | undefined>();
+  expectTypeOf(timeTakenToAcquireInMs).toMatchTypeOf<number | undefined>();
 });
 
-sequelize.addHook('afterPoolAcquire', (...args: [Connection | GetConnectionOptions | undefined]) => {
-  expectTypeOf(args).toMatchTypeOf<[Connection | GetConnectionOptions | undefined]>();
+sequelize.addHook('afterPoolAcquire', (...args: [Connection | GetConnectionOptions | number | undefined]) => {
+  expectTypeOf(args).toMatchTypeOf<[Connection | GetConnectionOptions | number | undefined]>();
 });
 
 sequelize.beforeQuery((options, query) => {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Measures the time taken, in milliseconds, to acquire a connection from the pool. The measured time is then passed to the afterPoolAcquire hook as its 3rd argument

This measurement is useful to help debug situations where a query has been delayed b/c of the amount of time taken to acquire a connection from the pool.

v6 backport: https://github.com/sequelize/sequelize/pull/16248
