### PR TITLE
meta(mysql): sleep 5 seconds before trying to connect

### DIFF
--- a/dev/mysql/latest/start.sh
+++ b/dev/mysql/latest/start.sh
@@ -7,6 +7,8 @@ docker compose -p sequelize-mysql-latest up -d
 
 ./../../wait-until-healthy.sh sequelize-mysql-latest
 
+sleep 5s
+
 docker exec sequelize-mysql-latest \
   mysql --host 127.0.0.1 --port 3306 -uroot -psequelize_test -e "GRANT ALL ON *.* TO 'sequelize_test'@'%' with grant option; FLUSH PRIVILEGES;"
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

It's not really fixing it, but hopefully this additional time prevents us from not able to connect even though the Docker container is healthy. If this causes `mysql latest` to not fail anymore we can look into a better solution to detect the database is ready for connections.
