### PR TITLE
use old definition when updating column

### DIFF
--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -247,8 +247,17 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
 
       if (attributes[attributeName].startsWith('ENUM(')) {
         attrSql += this.pgEnum(tableName, attributeName, attributes[attributeName]);
-        definition = definition.replace(/^ENUM\(.+\)/, this.pgEnumName(tableName, attributeName, { schema: false }));
-        definition += ` USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(tableName, attributeName)})`;
+        const oldDefinition = definition;
+        definition = definition.replace(
+          /^ENUM\(.+\)/,
+          this.pgEnumName(tableName, attributeName, { schema: false })
+        );
+        definition += ` USING (${this.quoteIdentifier(
+          attributeName
+        )}::${oldDefinition.replace(
+          /^ENUM\(.+\)/,
+          this.pgEnumName(tableName, attributeName, { schema: false })
+        )})`;
       }
 
       if (/UNIQUE;*$/.test(definition)) {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
