### PR TITLE
fix:use definition when generating update query

### DIFF
--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -248,7 +248,7 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
       if (attributes[attributeName].startsWith('ENUM(')) {
         attrSql += this.pgEnum(tableName, attributeName, attributes[attributeName]);
         definition = definition.replace(/^ENUM\(.+\)/, this.pgEnumName(tableName, attributeName, { schema: false }));
-        definition += ` USING (${this.quoteIdentifier(attributeName)}::${this.pgEnumName(tableName, attributeName)})`;
+        definition += ` USING (${this.quoteIdentifier(attributeName)}::${definition})`;
       }
 
       if (/UNIQUE;*$/.test(definition)) {

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -124,6 +124,12 @@ if (dialect.startsWith('postgres')) {
           }],
           expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1" USING ("col_1"::"public"."enum_myTable_col_1");ALTER TABLE "myTable" ALTER COLUMN "col_2" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_2" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_2" AS ENUM(''value 3'', ''value 4''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_2" TYPE "public"."enum_myTable_col_2" USING ("col_2"::"public"."enum_myTable_col_2");`,
         },
+        {
+          arguments: ['myTable', {
+            col_1: 'ARRAY(ENUM(\'value 1\', \'value 2\')) NOT NULL',
+          }],
+          expectation: `ALTER TABLE "myTable" ALTER COLUMN "col_1" SET NOT NULL;ALTER TABLE "myTable" ALTER COLUMN "col_1" DROP DEFAULT;DO 'BEGIN CREATE TYPE "public"."enum_myTable_col_1" AS ENUM(''value 1'', ''value 2''); EXCEPTION WHEN duplicate_object THEN null; END';ALTER TABLE "myTable" ALTER COLUMN "col_1" TYPE "public"."enum_myTable_col_1"[] USING ("col_1"::"public"."enum_myTable_col_1"[]);`
+        },
       ],
 
       selectQuery: [


### PR DESCRIPTION


## Pull Request Checklist

##Issue being addressed 
When trying to execute a migration that updates a column of a table of type ARRAY(ENUM(...)) sequelize would ry to update it to type ENUM(...)
The specific example is 
` await queryInterface.addColumn(
			'Proposals',
			'transferType',
			{
				type: Sequelize.ARRAY(
					Sequelize.ENUM('SHOPPER_LOCATION', 'TRAVELLER_LOCATION')
				),
				allowNull: true,
			},
			{ logging: true }
		);
await queryInterface.changeColumn(
			'Proposals',
			'transferType',
			{
				// log SQL statement to console
				type: Sequelize.ARRAY(
					Sequelize.ENUM('SHOPPER_LOCATION', 'TRAVELLER_LOCATION')
				),
				allowNull: false,
			},
			{ logging: true }
		);
`
Running this would generate the query 
`ALTER TABLE 
  "Proposals" ALTER COLUMN "transferType" 
SET 
  NOT NULL;
ALTER TABLE 
  "Proposals" ALTER COLUMN "transferType" 
DROP 
  DEFAULT;
DO 'BEGIN CREATE TYPE "public"."enum_Proposals_transferType" AS ENUM(''SHOPPER_LOCATION'', ''TRAVELLER_LOCATION''); EXCEPTION WHEN duplicate_object THEN null; END';
ALTER TABLE 
  "Proposals" ALTER COLUMN "transferType" TYPE "public"."enum_Proposals_transferType" [] USING (
    "transferType" :: "public"."enum_Proposals_transferType" 
  );`
but the required query is 

`ALTER TABLE 
  "Proposals" ALTER COLUMN "transferType" 
SET 
  NOT NULL;
ALTER TABLE 
  "Proposals" ALTER COLUMN "transferType" 
DROP 
  DEFAULT;
DO 'BEGIN CREATE TYPE "public"."enum_Proposals_transferType" AS ENUM(''SHOPPER_LOCATION'', ''TRAVELLER_LOCATION''); EXCEPTION WHEN duplicate_object THEN null; END';
ALTER TABLE 
  "Proposals" ALTER COLUMN "transferType" TYPE "public"."enum_Proposals_transferType" [] USING (
    "transferType" :: "public"."enum_Proposals_transferType" []
  );`
## Description Of Change
When generating the query for updating a column of type enum the definition is used instead of using the enum only so that the array definition ([])  is also reflected in the generated query


