### PR TITLE
meta: temp disable stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,8 +19,8 @@ jobs:
         with:
           stale-issue-label: "stale"
           stale-issue-message: 'This bug report has not been verified by maintainers yet, and has been open for 14 days without activity. It will be closed if no further activity occurs within the next 14 days. If this is still an issue, consider commenting with more information to help us verify it.'
-          days-before-issue-stale: 14
-          days-before-issue-close: 14
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           operations-per-run: 1000
           days-before-pr-stale: -1
           days-before-pr-close: -1
@@ -32,8 +32,8 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: 'This feature request has not been approved by maintainers yet, and has been open for 14 days without activity. It will be closed as "not planned" if no further activity occurs within the next 14 days.'
           stale-pr-message: 'This pull request has been marked as maybe-abandoned and has not seen any activity for 14 days. It will be closed if no further activity occurs within the next 30 days. If you would still like to work on this, please comment to let us know and the label will be removed.'
-          days-before-issue-stale: 14
-          days-before-issue-close: 14
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           operations-per-run: 1000
           days-before-pr-stale: 14
           days-before-pr-close: 30


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [X] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

It's the holiday period so we might not respond on time. We'll temporarily disable the stale bot and re-activate it again later
