### PR TITLE
docs(ibmi,snowflake): Mark IBMi and Snowflake as experimental

### DIFF
--- a/packages/core/src/dialects/ibmi/index.ts
+++ b/packages/core/src/dialects/ibmi/index.ts
@@ -45,6 +45,8 @@ export class IBMiDialect extends AbstractDialect {
   readonly TICK_CHAR_RIGHT = '"';
 
   constructor(sequelize: Sequelize) {
+    console.warn('The IBMi dialect is experimental and usage is at your own risk. Its development is exclusively community-driven and not officially supported by the maintainers.');
+
     super(sequelize, DataTypes, 'ibmi');
 
     this.connectionManager = new IBMiConnectionManager(this, sequelize);

--- a/packages/core/src/dialects/snowflake/index.ts
+++ b/packages/core/src/dialects/snowflake/index.ts
@@ -54,6 +54,8 @@ export class SnowflakeDialect extends AbstractDialect {
   readonly queryInterface: SnowflakeQueryInterface;
 
   constructor(sequelize: Sequelize) {
+    console.warn('The Snowflake dialect is experimental and usage is at your own risk. Its development is exclusively community-driven and not officially supported by the maintainers.');
+
     super(sequelize, DataTypes, 'snowflake');
     this.connectionManager = new SnowflakeConnectionManager(this, sequelize);
     this.queryGenerator = new SnowflakeQueryGenerator({

--- a/packages/core/test/unit/model/define.test.ts
+++ b/packages/core/test/unit/model/define.test.ts
@@ -304,6 +304,10 @@ describe('Model', () => {
         // must use a new sequelize instance because warnings are only logged once per instance.
         const newSequelize = createSequelizeInstance();
 
+        // @ts-expect-error -- only used in testing
+        // Needed due to "experimental" warning for ibmi and snowflake dialects
+        console.warn.restore();
+
         newSequelize.define('A', {
           age: {
             type: DataTypes.FLOAT(10, 2),

--- a/packages/core/test/unit/model/define.test.ts
+++ b/packages/core/test/unit/model/define.test.ts
@@ -306,7 +306,7 @@ describe('Model', () => {
 
         // @ts-expect-error -- only used in testing
         // Needed due to "experimental" warning for ibmi and snowflake dialects
-        console.warn.restore();
+        console.warn.reset();
 
         newSequelize.define('A', {
           age: {

--- a/packages/core/test/unit/model/define.test.ts
+++ b/packages/core/test/unit/model/define.test.ts
@@ -304,10 +304,6 @@ describe('Model', () => {
         // must use a new sequelize instance because warnings are only logged once per instance.
         const newSequelize = createSequelizeInstance();
 
-        // @ts-expect-error -- only used in testing
-        // Needed due to "experimental" warning for ibmi and snowflake dialects
-        console.warn.reset();
-
         newSequelize.define('A', {
           age: {
             type: DataTypes.FLOAT(10, 2),
@@ -317,8 +313,12 @@ describe('Model', () => {
         if (!['mysql', 'mariadb'].includes(dialectName)) {
           // @ts-expect-error -- only used in testing
           expect(console.warn.called).to.eq(true, 'console.warn was not called');
+
           // @ts-expect-error -- only used in testing
-          expect(console.warn.args[0][0]).to.contain(`does not support FLOAT with scale or precision specified. These options are ignored.`);
+          const warnings = console.warn.args.map(args => args[0]);
+          expect(warnings.some(
+            (msg: string) => msg.includes(`does not support FLOAT with scale or precision specified. These options are ignored.`),
+          )).to.eq(true, 'warning was not logged');
         } else {
           // @ts-expect-error -- only used in testing
           expect(console.warn.called).to.equal(false, 'console.warn was called but it should not have been');

--- a/yarn.lock
+++ b/yarn.lock
@@ -5105,7 +5105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-glob@npm:3.3.1":
+"fast-glob@npm:3.3.1, fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0":
   version: 3.3.1
   resolution: "fast-glob@npm:3.3.1"
   dependencies:
@@ -5115,19 +5115,6 @@ __metadata:
     merge2: ^1.3.0
     micromatch: ^4.0.4
   checksum: b6f3add6403e02cf3a798bfbb1183d0f6da2afd368f27456010c0bc1f9640aea308243d4cb2c0ab142f618276e65ecb8be1661d7c62a7b4e5ba774b9ce5432e5
-  languageName: node
-  linkType: hard
-
-"fast-glob@npm:^3.2.11, fast-glob@npm:^3.2.12, fast-glob@npm:^3.2.9, fast-glob@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "fast-glob@npm:3.3.0"
-  dependencies:
-    "@nodelib/fs.stat": ^2.0.2
-    "@nodelib/fs.walk": ^1.2.3
-    glob-parent: ^5.1.2
-    merge2: ^1.3.0
-    micromatch: ^4.0.4
-  checksum: 20df62be28eb5426fe8e40e0d05601a63b1daceb7c3d87534afcad91bdcf1e4b1743cf2d5247d6e225b120b46df0b9053a032b2691ba34ee121e033acd81f547
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR marks IBMi and Snowflake as experimental. Configuring Sequelize for one of these dialects will render a warning. This change is done due to insufficient means of running our integration tests against a publicly available instance of either of the dialects and a respective inability of verifying code changes.

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Render warning when ibmi or snowflake dialect is loaded:

```
import {Sequelize}from './packages/core';
 const s = new Sequelize({dialect: 'ibmi'})
```

-->

```
The IBMi dialect is experimental and usage is at your own risk. Its development is exclusively community-driven and not officially supported by the maintainers.
```
