### PR TITLE
fix: change beforeUpsert so changes to values are used in DB query

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1987,6 +1987,11 @@ ${associationOwner._getAssociationDebugList()}`);
     const createdAtAttr = modelDefinition.timestampAttributeNames.createdAt;
     const updatedAtAttr = modelDefinition.timestampAttributeNames.updatedAt;
     const hasPrimary = this.primaryKeyField in values || this.primaryKeyAttribute in values;
+
+    if (options.hooks) {
+      await this.hooks.runAsync('beforeUpsert', values, options);
+    }
+
     const instance = this.build(values);
 
     options.model = this;
@@ -2034,11 +2039,6 @@ ${associationOwner._getAssociationDebugList()}`);
       delete insertValues[this.primaryKeyField];
       delete updateValues[this.primaryKeyField];
     }
-
-    if (options.hooks) {
-      await this.hooks.runAsync('beforeUpsert', values, options);
-    }
-
     const result = await this.queryInterface.upsert(
       this.getTableName(options),
       insertValues,

--- a/packages/core/test/integration/hooks/upsert.test.js
+++ b/packages/core/test/integration/hooks/upsert.test.js
@@ -85,6 +85,39 @@ if (Support.sequelize.dialect.supports.upserts) {
           expect(hookCalled).to.equal(1);
         });
       });
+
+      describe('preserves changes to values on insert', () => {
+        it('beforeUpsert', async function () {
+          let hookCalled = 0;
+          const valuesOriginal = { mood: 'sad', username: 'leafninja' };
+
+          this.User.beforeUpsert(values => {
+            values.mood = 'happy';
+            hookCalled++;
+          });
+
+          const [user] = await this.User.upsert(valuesOriginal);
+          expect(user.mood).to.equal('happy');
+          expect(hookCalled).to.equal(1);
+        });
+      });
+
+      describe('preserves changes to values on update', () => {
+        it('beforeUpsert', async function () {
+          let hookCalled = 0;
+
+          this.User.beforeUpsert(values => {
+            values.mood = 'happy';
+            hookCalled++;
+          });
+
+          const user0 = await this.User.create({ mood: 'sad', username: 'leafninja' });
+          const [user] = await this.User.upsert({ mood: 'upset', username: 'leafninja' });
+
+          expect(user.mood).to.equal('happy');
+          expect(hookCalled).to.equal(1);
+        });
+      });
     });
   });
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Closes #8829

Move `beforeUpsert` hook call earlier in `upsert` execution so that changes to `values` are included in `insertValues` and `updateValues` passed to queryInterface.

## Todos

- [ ] <!-- e.g. #1 feature: Extend the type script definition -->
- [ ] <!-- e.g. #2 test: Does this also work with MySQL 8? -->
- [ ] <!-- ... -->
