### PR TITLE
fix: allow bind parameters in array literal

### DIFF
--- a/packages/core/src/utils/sql.ts
+++ b/packages/core/src/utils/sql.ts
@@ -164,7 +164,7 @@ function mapBindParametersAndReplacements(
         }
 
         // detect the bind param if it's a valid identifier and it's followed either by '::' (=cast), ')', whitespace of it's the end of the query.
-        const match = remainingString.match(/^\$(?<name>([a-z_][0-9a-z_]*|[1-9][0-9]*))(?:\)|,|$|\s|::|;)/i);
+        const match = remainingString.match(/^\$(?<name>([a-z_][0-9a-z_]*|[1-9][0-9]*))(?:\]|\)|,|$|\s|::|;)/i);
         const bindParamName = match?.groups?.name;
         if (!bindParamName) {
           continue;
@@ -281,7 +281,7 @@ function escapeValueWithBackCompat(value: unknown, dialect: AbstractDialect, esc
 }
 
 function canPrecedeNewToken(char: string | undefined): boolean {
-  return char === undefined || /[\s(>,=]/.test(char);
+  return char === undefined || /[\s([>,=]/.test(char);
 }
 
 /**

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -64,6 +64,17 @@ describe('mapBindParameters', () => {
     });
   });
 
+  it('parses bind parameters in array literal', () => {
+    const { sql } = mapBindParameters(`SELECT * FROM users WHERE ids = array[$param]::string[]`, dialect);
+
+    expectsql(sql, {
+      default: 'SELECT * FROM users WHERE ids = array[?]::string[]',
+      postgres: `SELECT * FROM users WHERE ids = array[$1]::string[]`,
+      sqlite: `SELECT * FROM users WHERE ids = array[$param]::string[]`,
+      mssql: `SELECT * FROM users WHERE ids = array[@param]::string[]`,
+    });
+  });
+
   it('parses bind parameters following JSON extraction', () => {
     const { sql } = mapBindParameters(`SELECT * FROM users WHERE json_col->>$key`, dialect);
 
@@ -88,12 +99,11 @@ describe('mapBindParameters', () => {
   });
 
   if (sequelize.dialect.supports.dataTypes.ARRAY) {
-    it('does not parse bind parameters inside ARRAY[]', () => {
+    it('parses bind parameters inside ARRAY[]', () => {
       const { sql } = mapBindParameters('SELECT * FROM users WHERE id = ARRAY[$id1]::int[];', dialect);
 
       expectsql(sql, {
-        // it's a syntax error, but we still check because we accept this in replacements.
-        default: 'SELECT * FROM users WHERE id = ARRAY[$id1]::int[];',
+        default: 'SELECT * FROM users WHERE id = ARRAY[$1]::int[];',
       });
     });
   }

--- a/packages/core/test/unit/utils/sql.test.ts
+++ b/packages/core/test/unit/utils/sql.test.ts
@@ -64,17 +64,6 @@ describe('mapBindParameters', () => {
     });
   });
 
-  it('parses bind parameters in array literal', () => {
-    const { sql } = mapBindParameters(`SELECT * FROM users WHERE ids = array[$param]::string[]`, dialect);
-
-    expectsql(sql, {
-      default: 'SELECT * FROM users WHERE ids = array[?]::string[]',
-      postgres: `SELECT * FROM users WHERE ids = array[$1]::string[]`,
-      sqlite: `SELECT * FROM users WHERE ids = array[$param]::string[]`,
-      mssql: `SELECT * FROM users WHERE ids = array[@param]::string[]`,
-    });
-  });
-
   it('parses bind parameters following JSON extraction', () => {
     const { sql } = mapBindParameters(`SELECT * FROM users WHERE json_col->>$key`, dialect);
 


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Background

Hi! I'm working on upgrading from Sequelize 6 to the latest Sequelize 7 alpha in an application. One of the things I've run into is that bind parameters can no longer go inside array literals, for example:

```js
await sequelize.query('SELECT array[$1, $2]', {
  type: 'SELECT',
  bind: [123, 456],
});
```

As of 7.0.0-alpha.12 this stopped working, and I tracked it down to #14447. It does appear to be an intentional change, since it even added a test for that case: https://github.com/sequelize/sequelize/blob/b3f853e5c2199c33dffe3a988b71a4ac5f14dc22/packages/core/test/unit/utils/sql.test.ts#L91-L98

The application does rely on being able to build array literals like that in quite a few places, so I'll have to say that there are some good use cases for this syntax, and that it feels a bit too conservative to prohibit it.

I noticed that wrapping parentheses around the value serves as a workaround, ie. `SELECT array[($1), ($2)]`, but it's fairly non-obvious.

## Description Of Change

Adjusts `mapBindParametersAndReplacements` so that it also allows `[` as a preceding character when detecting a bind parameter, as well as allowing `]` after.