### PR TITLE
feat: add nested col filtering

### DIFF
--- a/src/utils.d.ts
+++ b/src/utils.d.ts
@@ -48,6 +48,7 @@ export function mapWhereFieldNames(attributes: object, model: ModelType): object
 export function mapValueFieldNames(dataValues: object, fields: string[], model: ModelType): object;
 
 export function isColString(value: string): boolean;
+export function isColFilter(value: string): boolean;
 export function canTreatArrayAsAnd(arr: unknown[]): boolean;
 export function combineTableNames(tableName1: string, tableName2: string): string;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -256,6 +256,11 @@ function isColString(value) {
 }
 exports.isColString = isColString;
 
+function isColFilter(value) {
+  return typeof value === 'string' && value[0] === '#' && value[value.length - 1] === '#';
+}
+exports.isColFilter = isColFilter;
+
 function canTreatArrayAsAnd(arr) {
   return arr.some(arg => _.isPlainObject(arg) || arg instanceof Where);
 }


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Hi,

just a PR to propose a solution to filter models on nested cols without filtering includes. 

I may have done things wrong, but I was unable to use `$Nested.col$` with offset and limit (as far as I can see, because of includes left joins are not included in limit/offset sub query).

The other problem I encountered is that such nested cols in `WHERE` clause, are filtering my eager loaded includes. Instead, what I was searching for, is a way to filter main models on its associations but not its associations themselves.

Instead of opening an issue, I investigated the code to try to understand what I missed and then wrote my solution that I share here in case it can be useful.

In order to not conflict with `$Nested.col$` syntax, I introduced a `#Nested.filter#` that injects a `subQueryFilter` with `_generateSubQueryFilter`.

```js
Product.findAll({
  limit: 6,
  order: [
    ['id', 'ASC']
  ],
  where: {
    '#Prices.value#': {
      [Op.gt]: 10
    }
  },
  include: [ Price ]
})  
```
Here we get all products having at least one Price over 10, but eager loading all their Prices.
My proposal has the benefit to work with limits and offsets.

I'm obviously open to suggestions or other ways to solve my need,

Thank you for your attention and all your work :)

Marc-Olivier

## Todos

- [ ] test with other db than postgres
- [ ] ...certainly a lot of things, let me know
