### PR TITLE
meta: fixed typedoc 0.25 @link issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "node-hook": "1.0.0",
     "source-map-support": "0.5.21",
     "ts-node": "10.9.1",
-    "typedoc": "0.24.8",
+    "typedoc": "0.25.0",
     "typedoc-plugin-carbon-ads": "1.5.0",
     "typedoc-plugin-mdn-links": "3.1.0",
     "typedoc-plugin-missing-exports": "2.1.0",

--- a/packages/core/src/expression-builders/attribute.ts
+++ b/packages/core/src/expression-builders/attribute.ts
@@ -6,7 +6,7 @@ import type { DialectAwareFn } from './dialect-aware-fn.js';
 import type { JsonPath } from './json-path.js';
 
 /**
- * Use {@link @sequelize/core.attribute} instead.
+ * Use {@link attribute} instead.
  */
 export class Attribute extends BaseSqlExpression {
   declare private readonly brand: 'attribute';

--- a/packages/core/src/expression-builders/identifier.ts
+++ b/packages/core/src/expression-builders/identifier.ts
@@ -1,7 +1,7 @@
 import { BaseSqlExpression } from './base-sql-expression.js';
 
 /**
- * Use {@link @sequelize/core.identifier} instead.
+ * Use {@link identifier} instead.
  */
 export class Identifier extends BaseSqlExpression {
   declare private readonly brand: 'identifier';

--- a/packages/core/src/expression-builders/json-path.ts
+++ b/packages/core/src/expression-builders/json-path.ts
@@ -2,7 +2,7 @@ import type { Expression } from '../sequelize.js';
 import { BaseSqlExpression } from './base-sql-expression.js';
 
 /**
- * Do not use me directly. Use {@link @sequelize/core.jsonPath}.
+ * Do not use me directly. Use {@link jsonPath}.
  */
 export class JsonPath extends BaseSqlExpression {
   declare private readonly brand: 'jsonPath';

--- a/packages/core/src/expression-builders/json.ts
+++ b/packages/core/src/expression-builders/json.ts
@@ -4,7 +4,7 @@ import type { Attribute } from './attribute.js';
 import { attribute } from './attribute.js';
 import type { Cast } from './cast.js';
 import type { DialectAwareFn } from './dialect-aware-fn.js';
-import type { JsonPath, jsonPath } from './json-path.js';
+import type { JsonPath } from './json-path.js';
 import type { Where } from './where.js';
 import { where } from './where.js';
 
@@ -14,7 +14,7 @@ import { where } from './where.js';
  * @param conditionsOrPath A hash containing strings/numbers or other nested hash, a string using dot notation or a string using postgres/sqlite/mysql json syntax.
  * @param value An optional value to compare against. Produces a string of the form "<json path> = '<value>'".
  *
- * @deprecated use {@link where}, {@link attribute}, and/or {@link jsonPath} instead.
+ * @deprecated use {@link where}, {@link attribute}, and/or {@link @sequelize/core!index.jsonPath} instead.
  */
 export function json(
   conditionsOrPath: { [key: string]: any } | string,

--- a/packages/core/src/expression-builders/json.ts
+++ b/packages/core/src/expression-builders/json.ts
@@ -4,7 +4,7 @@ import type { Attribute } from './attribute.js';
 import { attribute } from './attribute.js';
 import type { Cast } from './cast.js';
 import type { DialectAwareFn } from './dialect-aware-fn.js';
-import type { JsonPath } from './json-path.js';
+import type { JsonPath, jsonPath } from './json-path.js';
 import type { Where } from './where.js';
 import { where } from './where.js';
 
@@ -14,7 +14,7 @@ import { where } from './where.js';
  * @param conditionsOrPath A hash containing strings/numbers or other nested hash, a string using dot notation or a string using postgres/sqlite/mysql json syntax.
  * @param value An optional value to compare against. Produces a string of the form "<json path> = '<value>'".
  *
- * @deprecated use {@link where}, {@link @sequelize/core.attribute}, and/or {@link @sequelize/core.jsonPath} instead.
+ * @deprecated use {@link where}, {@link attribute}, and/or {@link jsonPath} instead.
  */
 export function json(
   conditionsOrPath: { [key: string]: any } | string,

--- a/packages/core/src/expression-builders/list.ts
+++ b/packages/core/src/expression-builders/list.ts
@@ -1,7 +1,7 @@
 import { BaseSqlExpression } from './base-sql-expression.js';
 
 /**
- * Use {@link @sequelize/core.list} instead.
+ * Use {@link list} instead.
  */
 export class List extends BaseSqlExpression {
   declare private readonly brand: 'list';

--- a/packages/core/src/index.d.ts
+++ b/packages/core/src/index.d.ts
@@ -85,7 +85,7 @@ export { List } from './expression-builders/list.js';
 export { Value } from './expression-builders/value.js';
 export { Identifier } from './expression-builders/identifier.js';
 export { Attribute } from './expression-builders/attribute.js';
-export { JsonPath } from './expression-builders/json-path.js';
+export { JsonPath, jsonPath } from './expression-builders/json-path.js';
 export { AssociationPath } from './expression-builders/association-path.js';
 
 // All functions are available on sql.x, but these are exported for backwards compatibility

--- a/yarn.lock
+++ b/yarn.lock
@@ -1587,7 +1587,7 @@ __metadata:
     node-hook: 1.0.0
     source-map-support: 0.5.21
     ts-node: 10.9.1
-    typedoc: 0.24.8
+    typedoc: 0.25.0
     typedoc-plugin-carbon-ads: 1.5.0
     typedoc-plugin-mdn-links: 3.1.0
     typedoc-plugin-missing-exports: 2.1.0
@@ -8068,7 +8068,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:~9.0.1":
+"minimatch@npm:^9.0.0, minimatch@npm:^9.0.1, minimatch@npm:^9.0.3, minimatch@npm:~9.0.1":
   version: 9.0.3
   resolution: "minimatch@npm:9.0.3"
   dependencies:
@@ -11890,19 +11890,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc@npm:0.24.8":
-  version: 0.24.8
-  resolution: "typedoc@npm:0.24.8"
+"typedoc@npm:0.25.0":
+  version: 0.25.0
+  resolution: "typedoc@npm:0.25.0"
   dependencies:
     lunr: ^2.3.9
     marked: ^4.3.0
-    minimatch: ^9.0.0
+    minimatch: ^9.0.3
     shiki: ^0.14.1
   peerDependencies:
-    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x
+    typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x
   bin:
     typedoc: bin/typedoc
-  checksum: a46a14497f789fb3594e6c3af2e45276934ac46df40b7ed15a504ee51dc7a8013a2ffb3a54fd73abca6a2b71f97d3ec9ad356fa9aa81d29743e4645a965a2ae0
+  checksum: f0c5980017858969f037b136d9f305fa70162be891e7b169a92701cff67e1eed5c33895121265ec7da5b4a19d0042e649c103a6719c2b42736325b22fd85ff6a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Pull Request Checklist

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR fixed the typedoc `@link` tag module resolutions. 

This also unblocks #16412 

## Todos

Nothing
