### PR TITLE
fix(postgres): cast VARCHAR[] columns

### DIFF
--- a/packages/core/src/dialects/postgres/data-types.ts
+++ b/packages/core/src/dialects/postgres/data-types.ts
@@ -353,8 +353,7 @@ export class ARRAY<T extends BaseTypes.AbstractDataType<any>> extends BaseTypes.
     const mappedValues = isString(type) ? values : values.map(value => type.escape(value));
 
     // Types that don't need to specify their cast
-    const unambiguousType = type instanceof BaseTypes.STRING
-      || type instanceof BaseTypes.TEXT
+    const unambiguousType = type instanceof BaseTypes.TEXT
       || type instanceof BaseTypes.INTEGER;
 
     const cast = mappedValues.length === 0 || !unambiguousType ? `::${attributeTypeToSql(type)}[]` : '';

--- a/packages/core/test/unit/data-types/arrays.test.ts
+++ b/packages/core/test/unit/data-types/arrays.test.ts
@@ -118,6 +118,25 @@ describe('DataTypes.ARRAY', () => {
       return;
     }
 
+    it('does not not add cast to array of TEXT', () => {
+      expectsql(queryGenerator.escape([
+        'foo',
+        'bar',
+      ], { type: DataTypes.ARRAY(DataTypes.TEXT) }), {
+        postgres: `ARRAY['foo','bar']`,
+      });
+    });
+
+    // Regression test for https://github.com/sequelize/sequelize/issues/16391
+    it('adds cast to array of VARCHAR', () => {
+      expectsql(queryGenerator.escape([
+        'foo',
+        'bar',
+      ], { type: DataTypes.ARRAY(DataTypes.STRING(64)) }), {
+        postgres: `ARRAY['foo','bar']::VARCHAR(64)[]`,
+      });
+    });
+
     it('escapes array of JSON', () => {
       expectsql(queryGenerator.escape([
         { some: 'nested', more: { nested: true }, answer: 42 },

--- a/packages/core/test/unit/dialects/postgres/query-generator.test.js
+++ b/packages/core/test/unit/dialects/postgres/query-generator.test.js
@@ -224,7 +224,7 @@ if (dialect.startsWith('postgres')) {
         }, {
           title: 'string in array should escape \' as \'\'',
           arguments: ['myTable', { where: { aliases: { [Op.contains]: ['Queen\'s'] } } }],
-          expectation: 'SELECT * FROM "myTable" WHERE "myTable"."aliases" @> ARRAY[\'Queen\'\'s\'];',
+          expectation: 'SELECT * FROM "myTable" WHERE "myTable"."aliases" @> ARRAY[\'Queen\'\'s\']::VARCHAR(255)[];',
         },
 
         // Variants when quoteIdentifiers is false

--- a/packages/core/test/unit/query-generator/json-path-extraction-query.test.ts
+++ b/packages/core/test/unit/query-generator/json-path-extraction-query.test.ts
@@ -34,7 +34,7 @@ describe('QueryGenerator#jsonPathExtractionQuery', () => {
         default: notSupportedError,
         mariadb: `json_compact(json_extract(\`profile\`,'$.id.username[0]."0".name'))`,
         'mysql sqlite': `json_extract(\`profile\`,'$.id.username[0]."0".name')`,
-        postgres: `"profile"#>ARRAY['id','username','0','0','name']`,
+        postgres: `"profile"#>ARRAY['id','username','0','0','name']::VARCHAR(255)[]`,
       });
     });
 
@@ -44,7 +44,7 @@ describe('QueryGenerator#jsonPathExtractionQuery', () => {
         mysql: `json_extract(\`profile\`,'$."\\\\""."\\'"."$"')`,
         mariadb: `json_compact(json_extract(\`profile\`,'$."\\\\""."\\'"."$"'))`,
         sqlite: `json_extract(\`profile\`,'$."\\""."''"."$"')`,
-        postgres: `"profile"#>ARRAY['"','''','$']`,
+        postgres: `"profile"#>ARRAY['"','''','$']::VARCHAR(255)[]`,
       });
     });
   }
@@ -75,7 +75,7 @@ describe('QueryGenerator#jsonPathExtractionQuery', () => {
         default: notSupportedError,
         mssql: `JSON_VALUE([profile], N'$.id.username[0]."0".name')`,
         'mysql mariadb sqlite': `json_unquote(json_extract(\`profile\`,'$.id.username[0]."0".name'))`,
-        postgres: `"profile"#>>ARRAY['id','username','0','0','name']`,
+        postgres: `"profile"#>>ARRAY['id','username','0','0','name']::VARCHAR(255)[]`,
       });
     });
   }

--- a/packages/core/test/unit/sql/literal.test.ts
+++ b/packages/core/test/unit/sql/literal.test.ts
@@ -19,7 +19,7 @@ describe('json', () => {
     };
 
     expectsql(() => queryGenerator.escape(json(conditions)), {
-      postgres: `("metadata"->'language' = '"icelandic"' AND "metadata"#>ARRAY['pg_rating','dk'] = '"G"') AND "another_json_field"->'x' = '1'`,
+      postgres: `("metadata"->'language' = '"icelandic"' AND "metadata"#>ARRAY['pg_rating','dk']::VARCHAR(255)[] = '"G"') AND "another_json_field"->'x' = '1'`,
       sqlite: `(json_extract(\`metadata\`,'$.language') = '"icelandic"' AND json_extract(\`metadata\`,'$.pg_rating.dk') = '"G"') AND json_extract(\`another_json_field\`,'$.x') = '1'`,
       mariadb: `(json_compact(json_extract(\`metadata\`,'$.language')) = '"icelandic"' AND json_compact(json_extract(\`metadata\`,'$.pg_rating.dk')) = '"G"') AND json_compact(json_extract(\`another_json_field\`,'$.x')) = '1'`,
       mysql: `(json_extract(\`metadata\`,'$.language') = CAST('"icelandic"' AS JSON) AND json_extract(\`metadata\`,'$.pg_rating.dk') = CAST('"G"' AS JSON)) AND json_extract(\`another_json_field\`,'$.x') = CAST('1' AS JSON)`,
@@ -30,7 +30,7 @@ describe('json', () => {
     const path = 'metadata.pg_rating.dk';
 
     expectsql(() => queryGenerator.escape(json(path)), {
-      postgres: `"metadata"#>ARRAY['pg_rating','dk']`,
+      postgres: `"metadata"#>ARRAY['pg_rating','dk']::VARCHAR(255)[]`,
       mariadb: `json_compact(json_extract(\`metadata\`,'$.pg_rating.dk'))`,
       'sqlite mysql': `json_extract(\`metadata\`,'$.pg_rating.dk')`,
     });
@@ -38,7 +38,7 @@ describe('json', () => {
 
   it('supports numbers in the dot notation', () => {
     expectsql(() => queryGenerator.escape(json('profile.id.0.1')), {
-      postgres: `"profile"#>ARRAY['id','0','1']`,
+      postgres: `"profile"#>ARRAY['id','0','1']::VARCHAR(255)[]`,
       mariadb: `json_compact(json_extract(\`profile\`,'$.id."0"."1"'))`,
       'sqlite mysql': `json_extract(\`profile\`,'$.id."0"."1"')`,
     });
@@ -49,7 +49,7 @@ describe('json', () => {
     const value = 'U';
 
     expectsql(() => queryGenerator.escape(json(path, value)), {
-      postgres: `"metadata"#>ARRAY['pg_rating','is'] = '"U"'`,
+      postgres: `"metadata"#>ARRAY['pg_rating','is']::VARCHAR(255)[] = '"U"'`,
       sqlite: `json_extract(\`metadata\`,'$.pg_rating.is') = '"U"'`,
       mariadb: `json_compact(json_extract(\`metadata\`,'$.pg_rating.is')) = '"U"'`,
       mysql: `json_extract(\`metadata\`,'$.pg_rating.is') = CAST('"U"' AS JSON)`,
@@ -147,6 +147,7 @@ describe('fn', () => {
 
     expectsql(out, {
       default: `concat(ARRAY['abc'])`,
+      postgres: `concat(ARRAY['abc']::VARCHAR(255)[])`,
     });
   });
 });

--- a/packages/core/test/unit/sql/where.test.ts
+++ b/packages/core/test/unit/sql/where.test.ts
@@ -1,4 +1,7 @@
 import util from 'node:util';
+import type {
+  FormatWhereOptions,
+} from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator-typescript.js';
 import { expect } from 'chai';
 import { expectTypeOf } from 'expect-type';
 import attempt from 'lodash/attempt';
@@ -15,9 +18,6 @@ import type {
   WhereOptions,
 } from '@sequelize/core';
 import { DataTypes, Model, Op, and, json, or, sql } from '@sequelize/core';
-import type {
-  FormatWhereOptions,
-} from '@sequelize/core/_non-semver-use-at-your-own-risk_/dialects/abstract/query-generator-typescript.js';
 import { createTester, expectsql, getTestDialectTeaser, sequelize } from '../../support';
 
 const { literal, col, where, fn, cast, attribute } = sql;
@@ -247,6 +247,7 @@ describe(getTestDialectTeaser('SQL'), () => {
       for (const [arrayOperator, arraySqlOperator] of arrayOperators) {
         testSql({ [attributeName]: { [operator]: { [arrayOperator]: testWithValues } } }, {
           default: `[${attributeName}] ${sqlOperator} ${arraySqlOperator} (ARRAY[${testWithValues.map(v => util.inspect(v)).join(',')}])`,
+          postgres: `"${attributeName}" ${sqlOperator} ${arraySqlOperator} (ARRAY[${testWithValues.map(v => util.inspect(v)).join(',')}]${attributeName === 'stringAttr' ? '::VARCHAR(255)[]' : ''})`,
         });
 
         testSql({ [attributeName]: { [operator]: { [arrayOperator]: literal('literal') } } }, {
@@ -2039,7 +2040,7 @@ Caused by: "undefined" cannot be escaped`),
           });
 
           testSql({ 'jsonAttr.nested.twice': 'value' }, {
-            postgres: `"jsonAttr"#>ARRAY['nested','twice'] = '"value"'`,
+            postgres: `"jsonAttr"#>ARRAY['nested','twice']::VARCHAR(255)[] = '"value"'`,
             sqlite: `json_extract(\`jsonAttr\`,'$.nested.twice') = '"value"'`,
             mariadb: `json_compact(json_extract(\`jsonAttr\`,'$.nested.twice')) = '"value"'`,
             mysql: `json_extract(\`jsonAttr\`,'$.nested.twice') = CAST('"value"' AS JSON)`,
@@ -2057,7 +2058,7 @@ Caused by: "undefined" cannot be escaped`),
           testSql({
             'jsonAttr.nested': { twice: 'value' },
           }, {
-            postgres: `"jsonAttr"#>ARRAY['nested','twice'] = '"value"'`,
+            postgres: `"jsonAttr"#>ARRAY['nested','twice']::VARCHAR(255)[] = '"value"'`,
             sqlite: `json_extract(\`jsonAttr\`,'$.nested.twice') = '"value"'`,
             mariadb: `json_compact(json_extract(\`jsonAttr\`,'$.nested.twice')) = '"value"'`,
             mysql: `json_extract(\`jsonAttr\`,'$.nested.twice') = CAST('"value"' AS JSON)`,
@@ -2117,7 +2118,7 @@ Caused by: "undefined" cannot be escaped`),
           testSql({
             '$association.jsonAttr$.nested.deep::STRING': 'value',
           }, {
-            postgres: `CAST("association"."jsonAttr"#>ARRAY['nested','deep'] AS STRING) = 'value'`,
+            postgres: `CAST("association"."jsonAttr"#>ARRAY['nested','deep']::VARCHAR(255)[] AS STRING) = 'value'`,
             mariadb: `CAST(json_compact(json_extract(\`association\`.\`jsonAttr\`,'$.nested.deep')) AS STRING) = 'value'`,
             'sqlite mysql': `CAST(json_extract(\`association\`.\`jsonAttr\`,'$.nested.deep') AS STRING) = 'value'`,
           });
@@ -2131,7 +2132,7 @@ Caused by: "undefined" cannot be escaped`),
           });
 
           testSql({ 'jsonAttr.nested.attribute': 4 }, {
-            postgres: `"jsonAttr"#>ARRAY['nested','attribute'] = '4'`,
+            postgres: `"jsonAttr"#>ARRAY['nested','attribute']::VARCHAR(255)[] = '4'`,
             sqlite: `json_extract(\`jsonAttr\`,'$.nested.attribute') = '4'`,
             mariadb: `json_compact(json_extract(\`jsonAttr\`,'$.nested.attribute')) = '4'`,
             mysql: `json_extract(\`jsonAttr\`,'$.nested.attribute') = CAST('4' AS JSON)`,
@@ -2156,7 +2157,7 @@ Caused by: "undefined" cannot be escaped`),
           });
 
           testSql({ 'jsonAttr.0.attribute': 4 }, {
-            postgres: `"jsonAttr"#>ARRAY['0','attribute'] = '4'`,
+            postgres: `"jsonAttr"#>ARRAY['0','attribute']::VARCHAR(255)[] = '4'`,
             sqlite: `json_extract(\`jsonAttr\`,'$."0".attribute') = '4'`,
             mariadb: `json_compact(json_extract(\`jsonAttr\`,'$."0".attribute')) = '4'`,
             mysql: `json_extract(\`jsonAttr\`,'$."0".attribute') = CAST('4' AS JSON)`,
@@ -2179,7 +2180,7 @@ Caused by: "undefined" cannot be escaped`),
           });
 
           testSql({ 'jsonAttr[0].nested.attribute': 4 }, {
-            postgres: `"jsonAttr"#>ARRAY['0','nested','attribute'] = '4'`,
+            postgres: `"jsonAttr"#>ARRAY['0','nested','attribute']::VARCHAR(255)[] = '4'`,
 
             // these tests cannot be deduplicated because [0] will be replaced by `0` by expectsql
             sqlite: `json_extract(\`jsonAttr\`,'$[0].nested.attribute') = '4'`,
@@ -2189,7 +2190,7 @@ Caused by: "undefined" cannot be escaped`),
 
           // aliases attribute -> column correctly
           testSql({ 'aliasedJsonAttr.nested.attribute': 4 }, {
-            postgres: `"aliased_json"#>ARRAY['nested','attribute'] = '4'`,
+            postgres: `"aliased_json"#>ARRAY['nested','attribute']::VARCHAR(255)[] = '4'`,
             sqlite: `json_extract(\`aliased_json\`,'$.nested.attribute') = '4'`,
             mariadb: `json_compact(json_extract(\`aliased_json\`,'$.nested.attribute')) = '4'`,
             mysql: `json_extract(\`aliased_json\`,'$.nested.attribute') = CAST('4' AS JSON)`,
@@ -2210,7 +2211,7 @@ Caused by: "undefined" cannot be escaped`),
           });
 
           testSql({ 'jsonAttr.nested.key:unquote': 0 }, {
-            postgres: `"jsonAttr"#>>ARRAY['nested','key'] = 0`,
+            postgres: `"jsonAttr"#>>ARRAY['nested','key']::VARCHAR(255)[] = 0`,
             mssql: `JSON_VALUE([jsonAttr], N'$.nested.key') = 0`,
             'sqlite mysql mariadb': `json_unquote(json_extract([jsonAttr],'$.nested.key')) = 0`,
           });
@@ -2351,7 +2352,7 @@ Caused by: "undefined" cannot be escaped`),
             },
           },
         }, {
-          postgres: `"User"."jsonbAttr"#>ARRAY['nested','attribute'] = '"value"'`,
+          postgres: `"User"."jsonbAttr"#>ARRAY['nested','attribute']::VARCHAR(255)[] = '"value"'`,
         }, {
           mainAlias: 'User',
         });
@@ -2371,7 +2372,7 @@ Caused by: "undefined" cannot be escaped`),
             [Op.in]: [3, 7],
           },
         }, {
-          postgres: `"jsonbAttr"#>ARRAY['nested','attribute'] IN ('3', '7')`,
+          postgres: `"jsonbAttr"#>ARRAY['nested','attribute']::VARCHAR(255)[] IN ('3', '7')`,
         });
 
         testSql({
@@ -2403,7 +2404,7 @@ Caused by: "undefined" cannot be escaped`),
             },
           },
         }, {
-          postgres: `"User"."jsonbAttr"#>ARRAY['name','last'] = '"Simpson"' AND "User"."jsonbAttr"->'employment' != '"None"'`,
+          postgres: `"User"."jsonbAttr"#>ARRAY['name','last']::VARCHAR(255)[] = '"Simpson"' AND "User"."jsonbAttr"->'employment' != '"None"'`,
         }, {
           mainAlias: 'User',
         });
@@ -2419,7 +2420,7 @@ Caused by: "undefined" cannot be escaped`),
             },
           },
         }, {
-          postgres: `"jsonbAttr"#>ARRAY['nested','attribute'] > ${queryGen.escape(jsonDt)}`,
+          postgres: `"jsonbAttr"#>ARRAY['nested','attribute']::VARCHAR(255)[] > ${queryGen.escape(jsonDt)}`,
         });
 
         testSql({
@@ -2429,7 +2430,7 @@ Caused by: "undefined" cannot be escaped`),
             },
           },
         }, {
-          postgres: `"jsonbAttr"#>ARRAY['nested','attribute'] = 'true'`,
+          postgres: `"jsonbAttr"#>ARRAY['nested','attribute']::VARCHAR(255)[] = 'true'`,
         });
 
         testSql({


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Fix the issue described in #16391. Turns out #15598 introduced the concept of an unambiguous type in the Postgres dialect [here](https://github.com/sequelize/sequelize/pull/15598/files#diff-e9bfe30ec00f5e83c73554b39259414f80e608e8f1196ce9e969d776cc892085R361), but mistakingly classified `STRING` arrays as unambigious so that the cast was omitted.