### PR TITLE
feat: drop Node 16 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.15, 20]
+        node-version: [18, 20]
     name: Upload install and build artifact (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.15, 20]
+        node-version: [18, 20]
     name: Unit test all dialects (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
+        node-version: [18.15, 20]
     name: Upload install and build artifact (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18, 20]
+        node-version: [18.15, 20]
     name: Unit test all dialects (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 20]
+        node-version: [18, 20]
     name: Upload install and build artifact (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 20]
+        node-version: [18, 20]
     name: Upload install and build artifact on Windows (Node ${{ matrix.node-version }})
     runs-on: windows-latest
     steps:
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 20]
+        node-version: [18, 20]
     name: Unit test all dialects (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: lint
@@ -155,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 20]
+        node-version: [18, 20]
     name: sqlite (Node ${{ matrix.node-version }})
     runs-on: ubuntu-latest
     needs: [ unit-test, test-typings ]
@@ -178,7 +178,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16, 20]
+        node-version: [18, 20]
         postgres-version: [oldest, latest]
         minify-aliases: [true, false]
         native: [true, false]
@@ -209,7 +209,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16,20]
+        node-version: [18,20]
         database-version: [oldest, latest]
         dialect: [mysql, mariadb, mssql, db2]
     name: ${{ matrix.dialect }} ${{ matrix.database-version }} (Node ${{ matrix.node-version }})

--- a/build-packages.mjs
+++ b/build-packages.mjs
@@ -65,8 +65,8 @@ await Promise.all([
   build({
     // Adds source mapping
     sourcemap: true,
-    // The compiled code should be usable in node v16
-    target: 'node16',
+    // The compiled code should be usable in node v18
+    target: 'node18',
     // The source code's format is commonjs.
     format: 'cjs',
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,7 +37,7 @@
     "./package.json": "./package.json"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.0.0"
   },
   "files": [
     "lib",

--- a/packages/core/test/unit/utils/utils.test.ts
+++ b/packages/core/test/unit/utils/utils.test.ts
@@ -154,9 +154,9 @@ describe('Utils', () => {
 
   describe('url', () => {
     it('should return the correct options after parsed', () => {
-      const options = parseConnectionString('pg://wpx%20ss:wpx%20ss@21.77.77:4001/database ss');
+      const options = parseConnectionString('pg://wpx%20ss:wpx%20ss@104.129.90.48:4001/database ss');
       expect(options.dialect).to.equal('pg');
-      expect(options.host).to.equal('21.77.77');
+      expect(options.host).to.equal('104.129.90.48');
       expect(options.port).to.equal('4001');
       expect(options.database).to.equal('database ss');
       expect(options.username).to.equal('wpx ss');

--- a/test/register-esbuild.js
+++ b/test/register-esbuild.js
@@ -29,13 +29,13 @@ function compileFor(loader) {
   return (source, sourcefile) => {
     const { code, map } = esbuild.transformSync(source, {
       sourcemap: true,
-      target: 'node16',
+      target: 'node18',
       format: 'cjs',
       sourcefile,
       loader,
       tsconfigRaw: {
         compilerOptions: {
-          target: 'node16',
+          target: 'node18',
           useDefineForClassFields: true,
         },
       },


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [X] Did you update the typescript typings accordingly (if applicable)?
- [X] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [X] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

<!-- Please provide a description of the change here. -->

Node 16 is [EOL since September 11th, 2023](https://nodejs.org/en/blog/announcements/nodejs16-eol). With this PR we're dropping support for Node 16 in our CI.
