### PR TITLE
feat: support iterables in association methods

### DIFF
--- a/packages/core/src/associations/base.ts
+++ b/packages/core/src/associations/base.ts
@@ -1,6 +1,8 @@
+import isObject from 'lodash/isObject.js';
 import type { AttributeNames, AttributeOptions, Hookable, Model, ModelStatic } from '../model';
+import { isIterable } from '../utils/check.js';
 import { cloneDeep } from '../utils/object.js';
-import type { AllowArray, PartialBy } from '../utils/types.js';
+import type { AllowIterable, Nullish, PartialBy } from '../utils/types.js';
 import { AssociationSecret } from './helpers';
 import type { NormalizeBaseAssociationOptions } from './helpers';
 
@@ -163,7 +165,9 @@ export abstract class Association<
 
     this.options = cloneDeep(options) ?? {};
 
+    source.modelDefinition.hooks.runSync('beforeDefinitionRefresh');
     source.associations[this.as] = this;
+    source.modelDefinition.hooks.runSync('afterDefinitionRefresh');
   }
 
   /**
@@ -201,6 +205,21 @@ export abstract class MultiAssociation<
     return true;
   }
 
+  protected toInstanceOrPkArray(
+    input: Nullish<AllowIterable<T | Exclude<T[TargetKey], any[]>>>,
+  ): Array<T | Exclude<T[TargetKey], any[]>> {
+    if (input == null) {
+      return [];
+    }
+
+    if (!isIterable(input) || !isObject(input)) {
+      return [input];
+    }
+
+    return [...input];
+
+  }
+
   /**
    * Normalize input
    *
@@ -209,12 +228,10 @@ export abstract class MultiAssociation<
    * @private
    * @returns built objects
    */
-  protected toInstanceArray(input: AllowArray<T | Exclude<T[TargetKey], any[]>>): T[] {
-    if (!Array.isArray(input)) {
-      input = [input];
-    }
+  protected toInstanceArray(input: AllowIterable<T | Exclude<T[TargetKey], any[]>> | null): T[] {
+    const normalizedInput = this.toInstanceOrPkArray(input);
 
-    return input.map(element => {
+    return normalizedInput.map(element => {
       if (element instanceof this.target) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- needed for TS < 5.0
         return element as T;

--- a/packages/core/src/associations/belongs-to-many.ts
+++ b/packages/core/src/associations/belongs-to-many.ts
@@ -30,7 +30,7 @@ import type { Sequelize } from '../sequelize';
 import { isModelStatic, isSameInitialModel } from '../utils/model-utils.js';
 import { removeUndefined } from '../utils/object.js';
 import { camelize } from '../utils/string.js';
-import type { AllowArray } from '../utils/types.js';
+import type { AllowIterable } from '../utils/types.js';
 import { MultiAssociation } from './base';
 import type {
   Association,
@@ -528,14 +528,12 @@ Add your own primary key to the through model, on different attributes than the 
    */
   async has(
     sourceInstance: SourceModel,
-    targetInstancesOrPks: AllowArray<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
+    targetInstancesOrPks: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
     options?: BelongsToManyHasAssociationMixinOptions<TargetModel>,
   ): Promise<boolean> {
-    if (!Array.isArray(targetInstancesOrPks)) {
-      targetInstancesOrPks = [targetInstancesOrPks];
-    }
+    const targets = this.toInstanceOrPkArray(targetInstancesOrPks);
 
-    const targetPrimaryKeys: Array<TargetModel[TargetKey]> = targetInstancesOrPks.map(instance => {
+    const targetPrimaryKeys: Array<TargetModel[TargetKey]> = targets.map(instance => {
       if (instance instanceof this.target) {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- needed for TS < 5.0
         return (instance as TargetModel).get(this.targetKey);
@@ -578,7 +576,7 @@ Add your own primary key to the through model, on different attributes than the 
    */
   async set(
     sourceInstance: SourceModel,
-    newInstancesOrPrimaryKeys: AllowArray<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
+    newInstancesOrPrimaryKeys: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
     options: BelongsToManySetAssociationsMixinOptions<TargetModel> = {},
   ): Promise<void> {
     const sourceKey = this.sourceKey;
@@ -586,7 +584,7 @@ Add your own primary key to the through model, on different attributes than the 
     const foreignKey = this.foreignKey;
     const otherKey = this.otherKey;
 
-    const newInstances = newInstancesOrPrimaryKeys === null ? [] : this.toInstanceArray(newInstancesOrPrimaryKeys);
+    const newInstances = this.toInstanceArray(newInstancesOrPrimaryKeys);
 
     const where: WhereOptions = {
       [foreignKey]: sourceInstance.get(sourceKey),
@@ -644,15 +642,13 @@ Add your own primary key to the through model, on different attributes than the 
    */
   async add(
     sourceInstance: SourceModel,
-    newInstancesOrPrimaryKeys: AllowArray<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
+    newInstancesOrPrimaryKeys: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
     options?: BelongsToManyAddAssociationsMixinOptions<TargetModel>,
   ): Promise<void> {
-    // If newInstances is null or undefined, no-op
-    if (!newInstancesOrPrimaryKeys) {
+    const newInstances = this.toInstanceArray(newInstancesOrPrimaryKeys);
+    if (newInstances.length === 0) {
       return;
     }
-
-    const newInstances = this.toInstanceArray(newInstancesOrPrimaryKeys);
 
     const where: WhereOptions = {
       [this.foreignKey]: sourceInstance.get(this.sourceKey),
@@ -778,10 +774,13 @@ Add your own primary key to the through model, on different attributes than the 
    */
   async remove(
     sourceInstance: SourceModel,
-    targetInstanceOrPks: AllowArray<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
+    targetInstanceOrPks: AllowIterable<TargetModel | Exclude<TargetModel[TargetKey], any[]>>,
     options?: BelongsToManyRemoveAssociationMixinOptions,
   ): Promise<void> {
     const targetInstance = this.toInstanceArray(targetInstanceOrPks);
+    if (targetInstance.length === 0) {
+      return;
+    }
 
     const where: WhereOptions = {
       [this.foreignKey]: sourceInstance.get(this.sourceKey),
@@ -1095,7 +1094,7 @@ export interface BelongsToManySetAssociationsMixinOptions<TargetModel extends Mo
  * @see Model.belongsToMany
  */
 export type BelongsToManySetAssociationsMixin<TModel extends Model, TModelPrimaryKey> = (
-  newAssociations?: Array<TModel | TModelPrimaryKey>,
+  newAssociations?: Iterable<TModel | TModelPrimaryKey> | null,
   options?: BelongsToManySetAssociationsMixinOptions<TModel>
 ) => Promise<void>;
 
@@ -1127,7 +1126,7 @@ export interface BelongsToManyAddAssociationsMixinOptions<TModel extends Model>
  * @see Model.belongsToMany
  */
 export type BelongsToManyAddAssociationsMixin<T extends Model, TModelPrimaryKey> = (
-  newAssociations?: Array<T | TModelPrimaryKey>,
+  newAssociations?: Iterable<T | TModelPrimaryKey>,
   options?: BelongsToManyAddAssociationsMixinOptions<T>
 ) => Promise<void>;
 
@@ -1240,7 +1239,7 @@ export interface BelongsToManyRemoveAssociationsMixinOptions extends InstanceDes
  * @see Model.belongsToMany
  */
 export type BelongsToManyRemoveAssociationsMixin<TModel, TModelPrimaryKey> = (
-  associationsToRemove?: Array<TModel | TModelPrimaryKey>,
+  associationsToRemove?: Iterable<TModel | TModelPrimaryKey>,
   options?: BelongsToManyRemoveAssociationsMixinOptions
 ) => Promise<void>;
 
@@ -1294,7 +1293,7 @@ export interface BelongsToManyHasAssociationsMixinOptions<T extends Model>
  * @see Model.belongsToMany
  */
 export type BelongsToManyHasAssociationsMixin<TModel extends Model, TModelPrimaryKey> = (
-  targets: Array<TModel | TModelPrimaryKey>,
+  targets: Iterable<TModel | TModelPrimaryKey>,
   options?: BelongsToManyHasAssociationsMixinOptions<TModel>
 ) => Promise<boolean>;
 

--- a/packages/core/src/associations/has-many.ts
+++ b/packages/core/src/associations/has-many.ts
@@ -22,7 +22,7 @@ import { Op } from '../operators';
 import { isPlainObject } from '../utils/check.js';
 import { isSameInitialModel } from '../utils/model-utils.js';
 import { removeUndefined } from '../utils/object.js';
-import type { AllowArray } from '../utils/types.js';
+import type { AllowIterable } from '../utils/types.js';
 import { MultiAssociation } from './base';
 import type { Association, AssociationOptions, MultiAssociationAccessors, MultiAssociationOptions } from './base';
 import { BelongsTo } from './belongs-to.js';
@@ -302,27 +302,25 @@ export class HasMany<
    * Check if one or more rows are associated with `this`.
    *
    * @param sourceInstance the source instance
-   * @param targetInstances Can be an array of instances or their primary keys
+   * @param targets A list of instances or their primary keys
    * @param options Options passed to getAssociations
    */
   async has(
     sourceInstance: S,
-    targetInstances: AllowArray<T | Exclude<T[TargetPrimaryKey], any[]>>,
+    targets: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]>>,
     options?: HasManyHasAssociationsMixinOptions<T>,
   ): Promise<boolean> {
-    if (!Array.isArray(targetInstances)) {
-      targetInstances = [targetInstances];
-    }
+    const normalizedTargets = this.toInstanceOrPkArray(targets);
 
     const where = {
-      [Op.or]: targetInstances.map(instance => {
+      [Op.or]: normalizedTargets.map(instance => {
         if (instance instanceof this.target) {
-
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- needed for TS < 5.0
           return (instance as T).where();
         }
 
         return {
+          // TODO: support composite foreign keys
           // @ts-expect-error -- TODO: what if the target has no primary key?
           [this.target.primaryKeyAttribute]: instance,
         };
@@ -332,6 +330,7 @@ export class HasMany<
     const findOptions: HasManyGetAssociationsMixinOptions<T> = {
       ...options,
       scope: false,
+      // TODO: support composite foreign keys
       // @ts-expect-error -- TODO: what if the target has no primary key?
       attributes: [this.target.primaryKeyAttribute],
       raw: true,
@@ -346,33 +345,33 @@ export class HasMany<
 
     const associatedObjects = await this.get(sourceInstance, findOptions);
 
-    return associatedObjects.length === targetInstances.length;
+    return associatedObjects.length === normalizedTargets.length;
   }
 
   /**
    * Set the associated models by passing an array of persisted instances or their primary keys. Everything that is not in the passed array will be un-associated
    *
    * @param sourceInstance source instance to associate new instances with
-   * @param rawTargetInstances An array of persisted instances or primary key of instances to associate with this. Pass `null` to remove all associations.
+   * @param targets An array of persisted instances or primary key of instances to associate with this. Pass `null` to remove all associations.
    * @param options Options passed to `target.findAll` and `update`.
    */
   async set(
     sourceInstance: S,
-    rawTargetInstances: AllowArray<T | Exclude<T[TargetPrimaryKey], any[]>> | null,
+    targets: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]>> | null,
     options?: HasManySetAssociationsMixinOptions<T>,
   ): Promise<void> {
-    const targetInstances = rawTargetInstances === null ? [] : this.toInstanceArray(rawTargetInstances);
+    const normalizedTargets = this.toInstanceArray(targets);
 
     const oldAssociations = await this.get(sourceInstance, { ...options, scope: false, raw: true });
     const promises: Array<Promise<any>> = [];
     const obsoleteAssociations = oldAssociations.filter(old => {
-      return !targetInstances.some(obj => {
+      return !normalizedTargets.some(obj => {
         // @ts-expect-error -- old is a raw result
         return obj.get(this.target.primaryKeyAttribute) === old[this.target.primaryKeyAttribute];
       });
     });
 
-    const unassociatedObjects = targetInstances.filter(obj => {
+    const unassociatedObjects = normalizedTargets.filter(obj => {
       return !oldAssociations.some(old => {
         // @ts-expect-error -- old is a raw result
         return obj.get(this.target.primaryKeyAttribute) === old[this.target.primaryKeyAttribute];
@@ -422,7 +421,7 @@ export class HasMany<
    */
   async add(
     sourceInstance: S,
-    rawTargetInstances: AllowArray<T | Exclude<T[TargetPrimaryKey], any[]>>,
+    rawTargetInstances: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]>>,
     options: HasManyAddAssociationsMixinOptions<T> = {},
   ): Promise<void> {
     const targetInstances = this.toInstanceArray(rawTargetInstances);
@@ -451,30 +450,27 @@ export class HasMany<
    * Un-associate one or several target rows.
    *
    * @param sourceInstance instance to un associate instances with
-   * @param targetInstances Can be an Instance or its primary key, or a mixed array of instances and primary keys
+   * @param targets Can be an Instance or its primary key, or a mixed array of instances and primary keys
    * @param options Options passed to `target.update`
    */
   async remove(
     sourceInstance: S,
-    targetInstances: AllowArray<T | Exclude<T[TargetPrimaryKey], any[]>>,
+    targets: AllowIterable<T | Exclude<T[TargetPrimaryKey], any[]>>,
     options: HasManyRemoveAssociationsMixinOptions<T> = {},
   ): Promise<void> {
-    if (targetInstances == null) {
+    if (targets == null) {
       return;
     }
 
-    if (!Array.isArray(targetInstances)) {
-      targetInstances = [targetInstances];
-    }
-
-    if (targetInstances.length === 0) {
+    const normalizedTargets = this.toInstanceOrPkArray(targets);
+    if (normalizedTargets.length === 0) {
       return;
     }
 
     const where: WhereOptions = {
       [this.foreignKey]: sourceInstance.get(this.sourceKey),
       // @ts-expect-error -- TODO: what if the target has no primary key?
-      [this.target.primaryKeyAttribute]: targetInstances.map(targetInstance => {
+      [this.target.primaryKeyAttribute]: normalizedTargets.map(targetInstance => {
         if (targetInstance instanceof this.target) {
           // @ts-expect-error -- TODO: what if the target has no primary key?
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- needed for TS < 5.0
@@ -648,7 +644,7 @@ export interface HasManySetAssociationsMixinOptions<T extends Model>
  * @see Model.hasMany
  */
 export type HasManySetAssociationsMixin<T extends Model, TModelPrimaryKey> = (
-  newAssociations?: Array<T | TModelPrimaryKey> | null,
+  newAssociations?: Iterable<T | TModelPrimaryKey> | null,
   options?: HasManySetAssociationsMixinOptions<T>,
 ) => Promise<void>;
 
@@ -675,7 +671,7 @@ export interface HasManyAddAssociationsMixinOptions<T extends Model>
  * @see Model.hasMany
  */
 export type HasManyAddAssociationsMixin<T extends Model, TModelPrimaryKey> = (
-  newAssociations?: Array<T | TModelPrimaryKey>,
+  newAssociations?: Iterable<T | TModelPrimaryKey>,
   options?: HasManyAddAssociationsMixinOptions<T>
 ) => Promise<void>;
 
@@ -795,7 +791,7 @@ export interface HasManyRemoveAssociationsMixinOptions<T extends Model>
  * @see Model.hasMany
  */
 export type HasManyRemoveAssociationsMixin<T extends Model, TModelPrimaryKey> = (
-  oldAssociateds?: Array<T | TModelPrimaryKey>,
+  oldAssociateds?: Iterable<T | TModelPrimaryKey>,
   options?: HasManyRemoveAssociationsMixinOptions<T>
 ) => Promise<void>;
 
@@ -852,7 +848,7 @@ export interface HasManyHasAssociationsMixinOptions<T extends Model>
 //       we should also add a "HasManyHasAnyAssociationsMixin"
 //       and "HasManyHasAssociationsMixin" should instead return a Map of id -> boolean or WeakMap of instance -> boolean
 export type HasManyHasAssociationsMixin<TModel extends Model, TModelPrimaryKey> = (
-  targets: Array<TModel | TModelPrimaryKey>,
+  targets: Iterable<TModel | TModelPrimaryKey>,
   options?: HasManyHasAssociationsMixinOptions<TModel>
 ) => Promise<boolean>;
 

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -188,18 +188,18 @@ export class AbstractQueryGeneratorTypeScript {
     throw new Error(`listTablesQuery has not been implemented in ${this.dialect.name}.`);
   }
 
-  removeColumnQuery(tableName: TableNameOrModel, attributeName: string, options?: RemoveColumnQueryOptions): string {
-    const REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveColumnQueryOptions>();
-
-    if (this.dialect.supports.removeColumn.cascade) {
-      REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS.add('cascade');
-    }
-
-    if (this.dialect.supports.removeColumn.ifExists) {
-      REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS.add('ifExists');
-    }
-
+  removeColumnQuery(tableName: TableNameOrModel, columnName: string, options?: RemoveColumnQueryOptions): string {
     if (options) {
+      const REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveColumnQueryOptions>();
+
+      if (this.dialect.supports.removeColumn.cascade) {
+        REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS.add('cascade');
+      }
+
+      if (this.dialect.supports.removeColumn.ifExists) {
+        REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS.add('ifExists');
+      }
+
       rejectInvalidOptions(
         'removeColumnQuery',
         this.dialect.name,
@@ -214,7 +214,7 @@ export class AbstractQueryGeneratorTypeScript {
       this.quoteTable(tableName),
       'DROP COLUMN',
       options?.ifExists ? 'IF EXISTS' : '',
-      this.quoteIdentifier(attributeName),
+      this.quoteIdentifier(columnName),
       options?.cascade ? 'CASCADE' : '',
     ]);
   }

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -270,16 +270,16 @@ export class AbstractQueryInterfaceTypeScript {
    * Removes a column from a table
    *
    * @param tableName
-   * @param attributeName
+   * @param columnName
    * @param options
    */
   async removeColumn(
     tableName: TableNameOrModel,
-    attributeName: string,
+    columnName: string,
     options?: RemoveColumnOptions,
   ): Promise<void> {
     const queryOptions = { ...options, raw: true };
-    const sql = this.queryGenerator.removeColumnQuery(tableName, attributeName, queryOptions);
+    const sql = this.queryGenerator.removeColumnQuery(tableName, columnName, queryOptions);
 
     await this.sequelize.queryRaw(sql, queryOptions);
   }

--- a/packages/core/src/dialects/sqlite/query-generator-typescript.ts
+++ b/packages/core/src/dialects/sqlite/query-generator-typescript.ts
@@ -67,7 +67,7 @@ export class SqliteQueryGeneratorTypeScript extends AbstractQueryGenerator {
     return `PRAGMA foreign_keys = ${enable ? 'ON' : 'OFF'}`;
   }
 
-  removeColumnQuery(_table: TableNameOrModel, _attributeName: string, _options?: RemoveColumnQueryOptions): string {
+  removeColumnQuery(_table: TableNameOrModel, _columnName: string, _options?: RemoveColumnQueryOptions): string {
     throw new Error(`removeColumnQuery is not supported in ${this.dialect.name}.`);
   }
 

--- a/packages/core/src/dialects/sqlite/query-interface.js
+++ b/packages/core/src/dialects/sqlite/query-interface.js
@@ -22,9 +22,9 @@ export class SqliteQueryInterface extends SqliteQueryInterfaceTypeScript {
    *
    * @override
    */
-  async removeColumn(tableName, attributeName, options) {
+  async removeColumn(tableName, columnName, options) {
     const fields = await this.describeTable(tableName, options);
-    delete fields[attributeName];
+    delete fields[columnName];
 
     return this.alterTableInternal(tableName, fields, options);
   }

--- a/packages/core/src/utils/check.ts
+++ b/packages/core/src/utils/check.ts
@@ -10,6 +10,11 @@ export function isNodeError(val: unknown): val is NodeJS.ErrnoException {
   return val instanceof Error && 'code' in val;
 }
 
+export function isIterable(val: unknown): val is Iterable<unknown> {
+  // @ts-expect-error -- TS does not allow accessing Symbol.iterator like this.
+  return val != null && val[Symbol.iterator];
+}
+
 /**
  * Some dialects emit an Error with a string code, that are not ErrnoException.
  * This serves as a more generic check for those cases.

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -71,6 +71,8 @@ export type NonUndefinedKeys<T, K extends keyof T> = {
 
 export type AllowArray<T> = T | T[];
 
+export type AllowIterable<T> = T | Iterable<T>;
+
 export type AllowLowercase<T extends string> = T | Lowercase<T>;
 
 export type AllowReadonlyArray<T> = T | readonly T[];

--- a/packages/core/test/integration/associations/belongs-to-many-mixins.test.ts
+++ b/packages/core/test/integration/associations/belongs-to-many-mixins.test.ts
@@ -1,0 +1,271 @@
+import { expect } from 'chai';
+import type {
+  BelongsToManyAddAssociationsMixin,
+  BelongsToManyCountAssociationsMixin,
+  BelongsToManyCreateAssociationMixin,
+  BelongsToManyGetAssociationsMixin,
+  BelongsToManyHasAssociationsMixin,
+  BelongsToManyRemoveAssociationsMixin,
+  BelongsToManySetAssociationsMixin,
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+} from '@sequelize/core';
+import { Model } from '@sequelize/core';
+import { BelongsToMany } from '@sequelize/core/decorators-legacy';
+import { beforeAll2, sequelize, setResetMode } from '../support';
+
+describe('belongsToMany Mixins', () => {
+  setResetMode('destroy');
+
+  const vars = beforeAll2(async () => {
+    class Article extends Model<InferAttributes<Article>, InferCreationAttributes<Article>> {
+      declare id: CreationOptional<number>;
+
+      @BelongsToMany(() => User, { through: 'UserArticle' })
+      declare authors?: User[];
+
+      declare getAuthors: BelongsToManyGetAssociationsMixin<User>;
+      declare setAuthors: BelongsToManySetAssociationsMixin<User, User['id']>;
+      declare addAuthors: BelongsToManyAddAssociationsMixin<User, User['id']>;
+      declare removeAuthors: BelongsToManyRemoveAssociationsMixin<User, User['id']>;
+      declare createAuthor: BelongsToManyCreateAssociationMixin<User>;
+      declare hasAuthors: BelongsToManyHasAssociationsMixin<User, User['id']>;
+      declare countAuthors: BelongsToManyCountAssociationsMixin<User>;
+    }
+
+    class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+      declare id: CreationOptional<number>;
+    }
+
+    sequelize.addModels([Article, User]);
+    await sequelize.sync({ force: true });
+
+    return { Article, User };
+  });
+
+  describe('setAssociations', () => {
+    it('associates target models to the source model', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      expect(await article.getAuthors()).to.be.empty;
+
+      await article.setAuthors([user]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+    });
+
+    it('supports any iterable', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      expect(await article.getAuthors()).to.be.empty;
+
+      await article.setAuthors(new Set([user]));
+
+      expect(await article.getAuthors()).to.have.length(1);
+    });
+
+    it('unlinks the previous associations', async () => {
+      const { User, Article } = vars;
+
+      const [article, user1, user2] = await Promise.all([
+        Article.create(),
+        User.create(),
+        User.create(),
+      ]);
+
+      expect(await article.getAuthors()).to.be.empty;
+
+      await article.setAuthors([user1]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+
+      await article.setAuthors([user2]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+      expect(await article.hasAuthors([user2])).to.be.true;
+    });
+
+    it('clears associations when the parameter is null', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      await article.setAuthors([user]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+
+      await article.setAuthors(null);
+
+      expect(await article.getAuthors()).to.be.empty;
+    });
+
+    it('supports passing the primary key instead of an object', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      expect(await article.getAuthors()).to.be.empty;
+
+      await article.setAuthors([user.id]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+    });
+  });
+
+  describe('addAssociations', () => {
+    it('associates target models to the source model', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      expect(await article.getAuthors()).to.be.empty;
+
+      await article.addAuthors([user]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+    });
+
+    it('supports any iterable', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      expect(await article.getAuthors()).to.be.empty;
+
+      await article.addAuthors(new Set([user]));
+
+      expect(await article.getAuthors()).to.have.length(1);
+    });
+
+    it('supports passing the primary key instead of an object', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      expect(await article.getAuthors()).to.be.empty;
+
+      await article.addAuthors([user.id]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+    });
+  });
+
+  describe('removeAssociations', () => {
+    it('unlinks the target models from the source model', async () => {
+      const { User, Article } = vars;
+
+      const [article, user1, user2] = await Promise.all([
+        Article.create(),
+        User.create(),
+        User.create(),
+      ]);
+
+      await article.setAuthors([user1, user2]);
+
+      expect(await article.getAuthors()).to.have.length(2);
+
+      await article.removeAuthors([user1]);
+
+      expect(await article.getAuthors()).to.have.length(1);
+      expect(await article.hasAuthors([user1])).to.be.false;
+    });
+
+    it('supports any iterable', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      await article.setAuthors([user]);
+      await article.removeAuthors(new Set([user]));
+
+      expect(await article.getAuthors()).to.have.length(0);
+    });
+
+    it('supports passing the primary key instead of an object', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      await article.setAuthors([user]);
+      await article.removeAuthors([user.id]);
+
+      expect(await article.getAuthors()).to.have.length(0);
+    });
+  });
+
+  describe('hasAssociations', () => {
+    it('returns true if the target model is associated to the source model', async () => {
+      const { User, Article } = vars;
+
+      const [article, user1, user2] = await Promise.all([
+        Article.create(),
+        User.create(),
+        User.create(),
+      ]);
+
+      await article.setAuthors([user1]);
+
+      expect(await article.hasAuthors([user1])).to.be.true;
+      expect(await article.hasAuthors([user2])).to.be.false;
+      expect(await article.hasAuthors([user1, user2])).to.be.false;
+    });
+
+    it('supports any iterable', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      await article.setAuthors([user]);
+
+      expect(await article.hasAuthors(new Set([user]))).to.be.true;
+    });
+
+    it('supports passing the primary key instead of an object', async () => {
+      const { User, Article } = vars;
+
+      const [article, user] = await Promise.all([
+        Article.create(),
+        User.create(),
+      ]);
+
+      await article.setAuthors([user]);
+
+      expect(await article.hasAuthors([user.id])).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

This PR adds the possibility of using any iterable (instead of only arrays) in addX, setX, hasX, and removeX hasMany and belongsToMany association methods.

This means that it will now be possible to write the following:

```ts
const books = new Set([1, 2, 3]);

await user.addBooks(books);
```

Whereas before you add to convert the set to an array first

---

The changes done in query-generator & query-interface are misc small issues that were not caught during previous reviews