### PR TITLE
fix: prevent public class fields from shadowing association values

### DIFF
--- a/packages/core/src/model.js
+++ b/packages/core/src/model.js
@@ -1697,6 +1697,14 @@ ${associationOwner._getAssociationDebugList()}`);
       delete instance[attributeName];
     }
 
+    // If there are associations in the instance, we assign them as properties on the instance
+    // so that they can be accessed directly, instead of having to call `get` and `set`.
+    // class properties re-assign them to whatever value was set on the class property (or undefined if none)
+    // so this workaround re-assigns the association after the instance was created.
+    for (const associationName of Object.keys(this.modelDefinition.associations)) {
+      instance[associationName] = instance.getDataValue(associationName);
+    }
+
     return instance;
   }
 
@@ -3527,7 +3535,6 @@ Instead of specifying a Model, either:
 
     const include = this._options.includeMap[key];
     const association = include.association;
-    const accessor = key;
     const primaryKeyAttribute = include.model.primaryKeyAttribute;
     const childOptions = {
       isNewRecord: this.isNewRecord,
@@ -3548,10 +3555,10 @@ Instead of specifying a Model, either:
         }
 
         isEmpty = value && value[primaryKeyAttribute] === null || value === null;
-        this[accessor] = this.dataValues[accessor] = isEmpty ? null : include.model.build(value, childOptions);
+        this[key] = this.dataValues[key] = isEmpty ? null : include.model.build(value, childOptions);
       } else {
         isEmpty = value[0] && value[0][primaryKeyAttribute] === null;
-        this[accessor] = this.dataValues[accessor] = isEmpty ? [] : include.model.bulkBuild(value, childOptions);
+        this[key] = this.dataValues[key] = isEmpty ? [] : include.model.bulkBuild(value, childOptions);
       }
     }
   }


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Eager-loaded associations were suffering from the same issue as attributes: they get shadowed by public class fields declared on the model.

This adds a workaround. The actual solution would be to move everything from the constructor inside of the `build` method, so everything can be done after the class properties have been defined instead of before.

This will be possible to do in v8 when we ban using "new" on the model and require always using the build static method instead.