### PR TITLE
fix: fix crash when defining index on child model with decorators

### DIFF
--- a/packages/core/src/decorators/shared/model.ts
+++ b/packages/core/src/decorators/shared/model.ts
@@ -97,16 +97,14 @@ export function mergeAttributeOptions(
   options: Partial<AttributeOptions>,
   overrideOnConflict: boolean,
 ): Partial<AttributeOptions> {
-  for (const [optionName, optionValue] of Object.entries(options)) {
-    if (!(optionName in existingOptions)) {
-      // @ts-expect-error -- runtime type checking is enforced by model
+  for (const [optionName, optionValue] of Object.entries(options) as Array<[keyof AttributeOptions, any]>) {
+    if (existingOptions[optionName] === undefined) {
       existingOptions[optionName] = optionValue;
       continue;
     }
 
     // These are objects. We merge their properties, unless the same key is used in both values.
     if (optionName === 'validate') {
-      // @ts-expect-error -- dynamic type, not worth typing
       for (const [subOptionName, subOptionValue] of getAllOwnEntries(optionValue)) {
         if ((subOptionName in existingOptions[optionName]!) && !overrideOnConflict) {
           throw new Error(`Multiple decorators are attempting to register option ${optionName}[${JSON.stringify(subOptionName)}] of attribute ${attributeName} on model ${model.name}.`);
@@ -137,7 +135,6 @@ export function mergeAttributeOptions(
       continue;
     }
 
-    // @ts-expect-error -- dynamic type, not worth typing
     if (optionValue === existingOptions[optionName] || overrideOnConflict) {
       continue;
     }

--- a/packages/core/src/model-definition.ts
+++ b/packages/core/src/model-definition.ts
@@ -879,9 +879,8 @@ export function mergeModelOptions(
   overrideOnConflict: boolean,
 ): ModelOptions {
   // merge-able: scopes, indexes
-  for (const [optionName, optionValue] of Object.entries(options)) {
-    if (!(optionName in existingModelOptions)) {
-      // @ts-expect-error -- runtime type checking is enforced by model
+  for (const [optionName, optionValue] of Object.entries(options) as Array<[keyof ModelOptions, any]>) {
+    if (existingModelOptions[optionName] === undefined) {
       existingModelOptions[optionName] = optionValue;
       continue;
     }
@@ -936,12 +935,10 @@ export function mergeModelOptions(
       continue;
     }
 
-    // @ts-expect-error -- dynamic type, not worth typing
     if (!overrideOnConflict && optionValue !== existingModelOptions[optionName]) {
       throw new Error(`Trying to set the option ${optionName}, but a value already exists.`);
     }
 
-    // @ts-expect-error -- dynamic type, not worth typing
     existingModelOptions[optionName] = optionValue;
   }
 

--- a/packages/core/test/unit/decorators/table.test.ts
+++ b/packages/core/test/unit/decorators/table.test.ts
@@ -27,7 +27,7 @@ describe(`@Table legacy decorator`, () => {
 
     sequelize.addModels([User]);
 
-    expect(User.tableName).to.equal('custom_users');
+    expect(User.table.tableName).to.equal('custom_users');
   });
 
   // different decorators can modify the model's options
@@ -39,7 +39,7 @@ describe(`@Table legacy decorator`, () => {
 
     sequelize.addModels([User]);
 
-    expect(User.tableName).to.equal('custom_users');
+    expect(User.table.tableName).to.equal('custom_users');
     expect(User.options.timestamps).to.equal(false);
   });
 
@@ -82,6 +82,21 @@ describe(`@Table legacy decorator`, () => {
         name: 'users_id_unique',
       },
     ]);
+  });
+
+  it('does not crash when inheriting options', () => {
+    @Table.Abstract({})
+    class ParentModel extends Model {}
+
+    @Table({
+      indexes: [{
+        fields: ['id'],
+        unique: true,
+      }],
+    })
+    class User extends ParentModel {}
+
+    sequelize.addModels([User]);
   });
 
   it('merges scopes', () => {


### PR DESCRIPTION
## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Edge case we discovered while updating Sequelize in a production app: Using decorators to define an index on a model that inherits from another model causes a crash during the merging of options, due to the index option being undefined instead of being absent altogether