### PR TITLE
feat: migrate database queries to typescript

### DIFF
--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -37,6 +37,7 @@ import type {
   CreateDatabaseQueryOptions,
   DropTableQueryOptions,
   GetConstraintSnippetQueryOptions,
+  ListDatabasesQueryOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   QuoteTableOptions,
@@ -60,6 +61,7 @@ export interface RemoveIndexQueryOptions {
 
 export const CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['charset', 'collate', 'ctype', 'encoding', 'template']);
 export const DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof DropTableQueryOptions>(['cascade']);
+export const LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ListDatabasesQueryOptions>(['skip']);
 export const LIST_TABLES_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ListTablesQueryOptions>(['schema']);
 export const QUOTE_TABLE_SUPPORTABLE_OPTIONS = new Set<keyof QuoteTableOptions>(['indexHints', 'tableHints']);
 export const REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof RemoveColumnQueryOptions>(['ifExists', 'cascade']);
@@ -146,6 +148,10 @@ export class AbstractQueryGeneratorTypeScript {
     return this.sequelize.options;
   }
 
+  protected _getTechnicalDatabaseNames(): string[] {
+    return [];
+  }
+
   protected _getTechnicalSchemaNames(): string[] {
     return [];
   }
@@ -161,6 +167,14 @@ export class AbstractQueryGeneratorTypeScript {
   dropDatabaseQuery(database: string): string {
     if (this.dialect.supports.multiDatabases) {
       return `DROP DATABASE IF EXISTS ${this.quoteIdentifier(database)}`;
+    }
+
+    throw new Error(`Databases are not supported in ${this.dialect.name}.`);
+  }
+
+  listDatabasesQuery(_options?: ListDatabasesQueryOptions): string {
+    if (this.dialect.supports.multiDatabases) {
+      throw new Error(`${this.dialect.name} declares supporting databases but listDatabasesQuery is not implemented.`);
     }
 
     throw new Error(`Databases are not supported in ${this.dialect.name}.`);

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -158,6 +158,14 @@ export class AbstractQueryGeneratorTypeScript {
     throw new Error(`Databases are not supported in ${this.dialect.name}.`);
   }
 
+  dropDatabaseQuery(database: string): string {
+    if (this.dialect.supports.multiDatabases) {
+      return `DROP DATABASE IF EXISTS ${this.quoteIdentifier(database)}`;
+    }
+
+    throw new Error(`Databases are not supported in ${this.dialect.name}.`);
+  }
+
   listSchemasQuery(_options?: ListSchemasQueryOptions): string {
     if (this.dialect.supports.schemas) {
       throw new Error(`${this.dialect.name} declares supporting schema but listSchemasQuery is not implemented.`);

--- a/packages/core/src/dialects/abstract/query-generator-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-generator-typescript.ts
@@ -34,6 +34,7 @@ import type { BindParamOptions, DataType } from './data-types.js';
 import type { AbstractQueryGenerator } from './query-generator.js';
 import type {
   AddConstraintQueryOptions,
+  CreateDatabaseQueryOptions,
   DropTableQueryOptions,
   GetConstraintSnippetQueryOptions,
   ListSchemasQueryOptions,
@@ -57,6 +58,7 @@ export interface RemoveIndexQueryOptions {
   cascade?: boolean;
 }
 
+export const CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['charset', 'collate', 'ctype', 'encoding', 'template']);
 export const DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof DropTableQueryOptions>(['cascade']);
 export const LIST_TABLES_QUERY_SUPPORTABLE_OPTIONS = new Set<keyof ListTablesQueryOptions>(['schema']);
 export const QUOTE_TABLE_SUPPORTABLE_OPTIONS = new Set<keyof QuoteTableOptions>(['indexHints', 'tableHints']);
@@ -146,6 +148,14 @@ export class AbstractQueryGeneratorTypeScript {
 
   protected _getTechnicalSchemaNames(): string[] {
     return [];
+  }
+
+  createDatabaseQuery(_database: string, _options?: CreateDatabaseQueryOptions): string {
+    if (this.dialect.supports.multiDatabases) {
+      throw new Error(`${this.dialect.name} declares supporting databases but createDatabaseQuery is not implemented.`);
+    }
+
+    throw new Error(`Databases are not supported in ${this.dialect.name}.`);
   }
 
   listSchemasQuery(_options?: ListSchemasQueryOptions): string {

--- a/packages/core/src/dialects/abstract/query-generator.d.ts
+++ b/packages/core/src/dialects/abstract/query-generator.d.ts
@@ -152,7 +152,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   createSchemaQuery(schemaName: string, options?: CreateSchemaQueryOptions): string;
   dropSchemaQuery(schemaName: string): string | QueryWithBindParams;
 
-  dropDatabaseQuery(databaseName: string): string;
   listDatabasesQuery(): string;
 
   /**

--- a/packages/core/src/dialects/abstract/query-generator.d.ts
+++ b/packages/core/src/dialects/abstract/query-generator.d.ts
@@ -58,15 +58,6 @@ type ArithmeticQueryOptions = ParameterOptions & {
   returning?: boolean | Array<string | Literal | Col>,
 };
 
-// keep CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
-export interface CreateDatabaseQueryOptions {
-  collate?: string;
-  charset?: string;
-  encoding?: string;
-  ctype?: string;
-  template?: string;
-}
-
 // keep CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
 export interface CreateSchemaQueryOptions {
   collate?: string;
@@ -161,7 +152,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   createSchemaQuery(schemaName: string, options?: CreateSchemaQueryOptions): string;
   dropSchemaQuery(schemaName: string): string | QueryWithBindParams;
 
-  createDatabaseQuery(databaseName: string, options?: CreateDatabaseQueryOptions): string;
   dropDatabaseQuery(databaseName: string): string;
   listDatabasesQuery(): string;
 

--- a/packages/core/src/dialects/abstract/query-generator.d.ts
+++ b/packages/core/src/dialects/abstract/query-generator.d.ts
@@ -152,8 +152,6 @@ export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
   createSchemaQuery(schemaName: string, options?: CreateSchemaQueryOptions): string;
   dropSchemaQuery(schemaName: string): string | QueryWithBindParams;
 
-  listDatabasesQuery(): string;
-
   /**
    * Creates a function that can be used to collect bind parameters.
    *

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -48,14 +48,6 @@ export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
  * @private
  */
 export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
-  dropDatabaseQuery() {
-    if (this.dialect.supports.multiDatabases) {
-      throw new Error(`${this.dialect.name} declares supporting databases but dropDatabaseQuery is not implemented.`);
-    }
-
-    throw new Error(`Databases are not supported in ${this.dialect.name}.`);
-  }
-
   listDatabasesQuery() {
     if (this.dialect.supports.multiDatabases) {
       throw new Error(`${this.dialect.name} declares supporting databases but listDatabasesQuery is not implemented.`);

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -38,12 +38,6 @@ const { Op } = require('../../operators');
 const sequelizeError = require('../../errors');
 const { _validateIncludedElements } = require('../../model-internals');
 
-/**
- * List of possible options listed in {@link CreateDatabaseQueryOptions}.
- * It is used to validate the options passed to {@link AbstractQueryGenerator#createDatabaseQuery},
- * as not all of them are supported by all dialects.
- */
-export const CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS = new Set(['collate', 'charset', 'encoding', 'ctype', 'template']);
 export const CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS = new Set(['collate', 'charset']);
 export const CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS = new Set(['collate', 'charset', 'engine', 'rowFormat', 'comment', 'initialAutoIncrement', 'uniqueKeys']);
 export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
@@ -54,14 +48,6 @@ export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
  * @private
  */
 export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
-  createDatabaseQuery() {
-    if (this.dialect.supports.multiDatabases) {
-      throw new Error(`${this.dialect.name} declares supporting databases but createDatabaseQuery is not implemented.`);
-    }
-
-    throw new Error(`Databases are not supported in ${this.dialect.name}.`);
-  }
-
   dropDatabaseQuery() {
     if (this.dialect.supports.multiDatabases) {
       throw new Error(`${this.dialect.name} declares supporting databases but dropDatabaseQuery is not implemented.`);

--- a/packages/core/src/dialects/abstract/query-generator.js
+++ b/packages/core/src/dialects/abstract/query-generator.js
@@ -48,14 +48,6 @@ export const ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS = new Set(['ifNotExists']);
  * @private
  */
 export class AbstractQueryGenerator extends AbstractQueryGeneratorTypeScript {
-  listDatabasesQuery() {
-    if (this.dialect.supports.multiDatabases) {
-      throw new Error(`${this.dialect.name} declares supporting databases but listDatabasesQuery is not implemented.`);
-    }
-
-    throw new Error(`Databases are not supported in ${this.dialect.name}.`);
-  }
-
   createSchemaQuery() {
     if (this.dialect.supports.schemas) {
       throw new Error(`${this.dialect.name} declares supporting schema but createSchemaQuery is not implemented.`);

--- a/packages/core/src/dialects/abstract/query-generator.types.ts
+++ b/packages/core/src/dialects/abstract/query-generator.types.ts
@@ -12,6 +12,15 @@ export interface QueryWithBindParams {
   bind: BindOrReplacements;
 }
 
+// keep CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
+export interface CreateDatabaseQueryOptions {
+  charset?: string;
+  collate?: string;
+  ctype?: string;
+  encoding?: string;
+  template?: string;
+}
+
 export interface ListSchemasQueryOptions {
   /** List of schemas to exclude from output */
   skip?: string[];

--- a/packages/core/src/dialects/abstract/query-generator.types.ts
+++ b/packages/core/src/dialects/abstract/query-generator.types.ts
@@ -21,6 +21,7 @@ export interface CreateDatabaseQueryOptions {
   template?: string;
 }
 
+// keep LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS updated when modifying this
 export interface ListDatabasesQueryOptions {
   skip?: string[];
 }

--- a/packages/core/src/dialects/abstract/query-generator.types.ts
+++ b/packages/core/src/dialects/abstract/query-generator.types.ts
@@ -21,6 +21,10 @@ export interface CreateDatabaseQueryOptions {
   template?: string;
 }
 
+export interface ListDatabasesQueryOptions {
+  skip?: string[];
+}
+
 export interface ListSchemasQueryOptions {
   /** List of schemas to exclude from output */
   skip?: string[];

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -17,6 +17,7 @@ import type {
   AddConstraintOptions,
   ColumnsDescription,
   ConstraintDescription,
+  CreateDatabaseOptions,
   CreateSchemaOptions,
   DeferConstraintsOptions,
   DescribeTableOptions,
@@ -57,6 +58,18 @@ export class AbstractQueryInterfaceTypeScript {
     this.sequelize = sequelize;
     this.queryGenerator = queryGenerator;
     this.#internalQueryInterface = internalQueryInterface ?? new AbstractQueryInterfaceInternal(sequelize, queryGenerator);
+  }
+
+  /**
+   * Create a database
+   *
+   * @param database
+   * @param options
+   */
+  async createDatabase(database: string, options?: CreateDatabaseOptions): Promise<void> {
+    const sql = this.queryGenerator.createDatabaseQuery(database, options);
+
+    await this.sequelize.queryRaw(sql, options);
   }
 
   /**

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -73,6 +73,18 @@ export class AbstractQueryInterfaceTypeScript {
   }
 
   /**
+   * Drop a database
+   *
+   * @param database
+   * @param options
+   */
+  async dropDatabase(database: string, options?: QueryRawOptions): Promise<void> {
+    const sql = this.queryGenerator.dropDatabaseQuery(database);
+
+    await this.sequelize.queryRaw(sql, options);
+  }
+
+  /**
    * Returns the database version.
    *
    * @param options Query Options

--- a/packages/core/src/dialects/abstract/query-interface-typescript.ts
+++ b/packages/core/src/dialects/abstract/query-interface-typescript.ts
@@ -19,9 +19,11 @@ import type {
   ConstraintDescription,
   CreateDatabaseOptions,
   CreateSchemaOptions,
+  DatabaseDescription,
   DeferConstraintsOptions,
   DescribeTableOptions,
   FetchDatabaseVersionOptions,
+  ListDatabasesOptions,
   QiDropAllTablesOptions,
   QiDropTableOptions,
   QiShowAllTablesOptions,
@@ -82,6 +84,17 @@ export class AbstractQueryInterfaceTypeScript {
     const sql = this.queryGenerator.dropDatabaseQuery(database);
 
     await this.sequelize.queryRaw(sql, options);
+  }
+
+  /**
+   * Lists all available databases
+   *
+   * @param options
+   */
+  async listDatabases(options?: ListDatabasesOptions): Promise<DatabaseDescription[]> {
+    const sql = this.queryGenerator.listDatabasesQuery(options);
+
+    return this.sequelize.queryRaw<DatabaseDescription>(sql, { ...options, type: QueryTypes.SELECT });
   }
 
   /**

--- a/packages/core/src/dialects/abstract/query-interface.d.ts
+++ b/packages/core/src/dialects/abstract/query-interface.d.ts
@@ -186,10 +186,6 @@ export interface FunctionParam {
   direction?: string;
 }
 
-export interface DatabaseDescription {
-  name: string;
-}
-
 export interface IndexFieldDescription {
   attribute: string;
   length: number | undefined;
@@ -550,9 +546,4 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
    * Rollback (revert) a transaction that hasn't been committed
    */
   rollbackTransaction(transaction: Transaction, options?: QueryRawOptions): Promise<void>;
-
-  /**
-   * Lists all available databases
-   */
-  listDatabases(options?: QueryRawOptions): Promise<DatabaseDescription[]>;
 }

--- a/packages/core/src/dialects/abstract/query-interface.d.ts
+++ b/packages/core/src/dialects/abstract/query-interface.d.ts
@@ -552,11 +552,6 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   rollbackTransaction(transaction: Transaction, options?: QueryRawOptions): Promise<void>;
 
   /**
-   * Creates a database
-   */
-  dropDatabase(name: string, options?: QueryRawOptions): Promise<void>;
-
-  /**
    * Lists all available databases
    */
   listDatabases(options?: QueryRawOptions): Promise<DatabaseDescription[]>;

--- a/packages/core/src/dialects/abstract/query-interface.d.ts
+++ b/packages/core/src/dialects/abstract/query-interface.d.ts
@@ -180,10 +180,6 @@ export interface QueryInterfaceIndexOptions extends IndexOptions, Omit<QiOptions
 
 export interface QueryInterfaceRemoveIndexOptions extends QueryInterfaceIndexOptions, RemoveIndexQueryOptions { }
 
-export interface CreateDatabaseOptions extends CollateCharsetOptions, QueryRawOptions {
-  encoding?: string;
-}
-
 export interface FunctionParam {
   type: string;
   name?: string;
@@ -554,11 +550,6 @@ export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
    * Rollback (revert) a transaction that hasn't been committed
    */
   rollbackTransaction(transaction: Transaction, options?: QueryRawOptions): Promise<void>;
-
-  /**
-   * Creates a database
-   */
-  createDatabase(name: string, options?: CreateDatabaseOptions): Promise<void>;
 
   /**
    * Creates a database

--- a/packages/core/src/dialects/abstract/query-interface.js
+++ b/packages/core/src/dialects/abstract/query-interface.js
@@ -23,26 +23,6 @@ const { QueryTypes } = require('../../query-types');
  */
 export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
   /**
-   * Create a database
-   *
-   * @param {string} database  Database name to create
-   * @param {object} [options] Query options
-   * @param {string} [options.charset] Database default character set, MYSQL only
-   * @param {string} [options.collate] Database default collation
-   * @param {string} [options.encoding] Database default character set, PostgreSQL only
-   * @param {string} [options.ctype] Database character classification, PostgreSQL only
-   * @param {string} [options.template] The name of the template from which to create the new database, PostgreSQL only
-   *
-   * @returns {Promise}
-   */
-  async createDatabase(database, options) {
-    options = options || {};
-    const sql = this.queryGenerator.createDatabaseQuery(database, options);
-
-    return await this.sequelize.queryRaw(sql, options);
-  }
-
-  /**
    * Drop a database
    *
    * @param {string} database  Database name to drop

--- a/packages/core/src/dialects/abstract/query-interface.js
+++ b/packages/core/src/dialects/abstract/query-interface.js
@@ -22,12 +22,6 @@ const { QueryTypes } = require('../../query-types');
  * The interface that Sequelize uses to talk to all databases
  */
 export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
-  async listDatabases(options) {
-    const sql = this.queryGenerator.listDatabasesQuery();
-
-    return await this.sequelize.queryRaw(sql, { ...options, type: QueryTypes.SELECT });
-  }
-
   /**
     * Drop all schemas
     *

--- a/packages/core/src/dialects/abstract/query-interface.js
+++ b/packages/core/src/dialects/abstract/query-interface.js
@@ -22,20 +22,6 @@ const { QueryTypes } = require('../../query-types');
  * The interface that Sequelize uses to talk to all databases
  */
 export class AbstractQueryInterface extends AbstractQueryInterfaceTypeScript {
-  /**
-   * Drop a database
-   *
-   * @param {string} database  Database name to drop
-   * @param {object} [options] Query options
-   *
-   * @returns {Promise}
-   */
-  async dropDatabase(database, options) {
-    const sql = this.queryGenerator.dropDatabaseQuery(database);
-
-    return await this.sequelize.queryRaw(sql, options);
-  }
-
   async listDatabases(options) {
     const sql = this.queryGenerator.listDatabasesQuery();
 

--- a/packages/core/src/dialects/abstract/query-interface.types.ts
+++ b/packages/core/src/dialects/abstract/query-interface.types.ts
@@ -5,12 +5,17 @@ import type {
   AddConstraintQueryOptions,
   CreateDatabaseQueryOptions,
   DropTableQueryOptions,
+  ListDatabasesQueryOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   RemoveColumnQueryOptions,
   RemoveConstraintQueryOptions,
   ShowConstraintsQueryOptions,
 } from './query-generator.types';
+
+export interface DatabaseDescription {
+  name: string;
+}
 
 export interface ColumnDescription {
   type: string;
@@ -64,6 +69,9 @@ export interface ConstraintDescription {
 
 /** Options accepted by {@link AbstractQueryInterface#createDatabase} */
 export interface CreateDatabaseOptions extends CreateDatabaseQueryOptions, QueryRawOptions { }
+
+/** Options accepted by {@link AbstractQueryInterface#listDatabases} */
+export interface ListDatabasesOptions extends ListDatabasesQueryOptions, QueryRawOptions { }
 
 /** Options accepted by {@link AbstractQueryInterface#createSchema} */
 export interface CreateSchemaOptions extends CreateSchemaQueryOptions, QueryRawOptions { }

--- a/packages/core/src/dialects/abstract/query-interface.types.ts
+++ b/packages/core/src/dialects/abstract/query-interface.types.ts
@@ -3,6 +3,7 @@ import type { QueryRawOptions } from '../../sequelize';
 import type { CreateSchemaQueryOptions } from './query-generator';
 import type {
   AddConstraintQueryOptions,
+  CreateDatabaseQueryOptions,
   DropTableQueryOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
@@ -60,6 +61,9 @@ export interface ConstraintDescription {
   definition?: string;
   deferrable?: Deferrable;
 }
+
+/** Options accepted by {@link AbstractQueryInterface#createDatabase} */
+export interface CreateDatabaseOptions extends CreateDatabaseQueryOptions, QueryRawOptions { }
 
 /** Options accepted by {@link AbstractQueryInterface#createSchema} */
 export interface CreateSchemaOptions extends CreateSchemaQueryOptions, QueryRawOptions { }

--- a/packages/core/src/dialects/mssql/query-generator-typescript.ts
+++ b/packages/core/src/dialects/mssql/query-generator-typescript.ts
@@ -4,15 +4,20 @@ import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { buildJsonPath } from '../../utils/json';
 import { generateIndexName } from '../../utils/string';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import { REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS } from '../abstract/query-generator-typescript';
+import {
+  CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
+  REMOVE_INDEX_QUERY_SUPPORTABLE_OPTIONS,
+} from '../abstract/query-generator-typescript';
 import type { EscapeOptions, RemoveIndexQueryOptions, TableNameOrModel } from '../abstract/query-generator-typescript';
 import type {
+  CreateDatabaseQueryOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 import type { ConstraintType } from '../abstract/query-interface.types';
 
+const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['collate']);
 const REMOVE_INDEX_QUERY_SUPPORTED_OPTIONS = new Set<keyof RemoveIndexQueryOptions>(['ifExists']);
 
 /**
@@ -33,6 +38,24 @@ export class MsSqlQueryGeneratorTypeScript extends AbstractQueryGenerator {
       'INFORMATION_SCHEMA',
       'sys',
     ];
+  }
+
+  createDatabaseQuery(database: string, options?: CreateDatabaseQueryOptions) {
+    if (options) {
+      rejectInvalidOptions(
+        'createDatabaseQuery',
+        this.dialect.name,
+        CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
+        CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
+    return joinSQLFragments([
+      `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = ${this.escape(database)})`,
+      `CREATE DATABASE ${this.quoteIdentifier(database)}`,
+      options?.collate ? `COLLATE ${this.escape(options.collate)}` : '',
+    ]);
   }
 
   listSchemasQuery(options?: ListSchemasQueryOptions) {

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -33,10 +33,6 @@ const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
-  listDatabasesQuery() {
-    return `SELECT name FROM sys.databases;`;
-  }
-
   createSchemaQuery(schema, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -9,10 +9,8 @@ import { generateIndexName } from '../../utils/string';
 import { attributeTypeToSql, normalizeDataType } from '../abstract/data-types-utils';
 import {
   ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
   CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
   CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-  DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator';
 
 import each from 'lodash/each';
@@ -30,35 +28,11 @@ function throwMethodUndefined(methodName) {
   throw new Error(`The method "${methodName}" is not defined! Please add it to your sql dialect.`);
 }
 
-const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set(['collate']);
 const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
-const DROP_TABLE_QUERY_SUPPORTED_OPTIONS = new Set();
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
-  createDatabaseQuery(databaseName, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createDatabaseQuery',
-        this.dialect.name,
-        CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    const collation = options?.collate ? `COLLATE ${this.escape(options.collate)}` : '';
-
-    return [
-      'IF NOT EXISTS (SELECT * FROM sys.databases WHERE name =', this.escape(databaseName), ')',
-      'BEGIN',
-      'CREATE DATABASE', this.quoteIdentifier(databaseName),
-      `${collation};`,
-      'END;',
-    ].join(' ');
-  }
-
   dropDatabaseQuery(databaseName) {
     return [
       'IF EXISTS (SELECT * FROM sys.databases WHERE name =', this.escape(databaseName), ')',

--- a/packages/core/src/dialects/mssql/query-generator.js
+++ b/packages/core/src/dialects/mssql/query-generator.js
@@ -33,15 +33,6 @@ const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['uniqueKeys']);
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 
 export class MsSqlQueryGenerator extends MsSqlQueryGeneratorTypeScript {
-  dropDatabaseQuery(databaseName) {
-    return [
-      'IF EXISTS (SELECT * FROM sys.databases WHERE name =', this.escape(databaseName), ')',
-      'BEGIN',
-      'DROP DATABASE', this.quoteIdentifier(databaseName), ';',
-      'END;',
-    ].join(' ');
-  }
-
   listDatabasesQuery() {
     return `SELECT name FROM sys.databases;`;
   }

--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -36,10 +36,6 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     return `SET search_path to ${searchPath};`;
   }
 
-  listDatabasesQuery() {
-    return `SELECT datname AS name FROM pg_database;`;
-  }
-
   createSchemaQuery(schema, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -36,10 +36,6 @@ export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
     return `SET search_path to ${searchPath};`;
   }
 
-  dropDatabaseQuery(databaseName) {
-    return `DROP DATABASE IF EXISTS ${this.quoteIdentifier(databaseName)};`;
-  }
-
   listDatabasesQuery() {
     return `SELECT datname AS name FROM pg_database;`;
   }

--- a/packages/core/src/dialects/postgres/query-generator.js
+++ b/packages/core/src/dialects/postgres/query-generator.js
@@ -7,10 +7,8 @@ import { ENUM } from './data-types';
 import { quoteIdentifier } from '../../utils/dialect';
 import { rejectInvalidOptions } from '../../utils/check';
 import {
-  CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
   CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
   CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-  DROP_TABLE_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator';
 
 import each from 'lodash/each';
@@ -30,34 +28,12 @@ const { PostgresQueryGeneratorTypeScript } = require('./query-generator-typescri
  */
 const POSTGRES_RESERVED_WORDS = 'all,analyse,analyze,and,any,array,as,asc,asymmetric,authorization,binary,both,case,cast,check,collate,collation,column,concurrently,constraint,create,cross,current_catalog,current_date,current_role,current_schema,current_time,current_timestamp,current_user,default,deferrable,desc,distinct,do,else,end,except,false,fetch,for,foreign,freeze,from,full,grant,group,having,ilike,in,initially,inner,intersect,into,is,isnull,join,lateral,leading,left,like,limit,localtime,localtimestamp,natural,not,notnull,null,offset,on,only,or,order,outer,overlaps,placing,primary,references,returning,right,select,session_user,similar,some,symmetric,table,tablesample,then,to,trailing,true,union,unique,user,using,variadic,verbose,when,where,window,with'.split(',');
 
-const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set(['encoding', 'collate', 'ctype', 'template']);
 const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['comment', 'uniqueKeys']);
-const DROP_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['cascade']);
 
 export class PostgresQueryGenerator extends PostgresQueryGeneratorTypeScript {
   setSearchPath(searchPath) {
     return `SET search_path to ${searchPath};`;
-  }
-
-  createDatabaseQuery(databaseName, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createDatabaseQuery',
-        this.dialect.name,
-        CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    const quotedDatabaseName = this.quoteIdentifier(databaseName);
-    const encoding = options?.encoding ? ` ENCODING = ${this.escape(options.encoding)}` : '';
-    const collation = options?.collate ? ` LC_COLLATE = ${this.escape(options.collate)}` : '';
-    const ctype = options?.ctype ? ` LC_CTYPE = ${this.escape(options.ctype)}` : '';
-    const template = options?.template ? ` TEMPLATE = ${this.escape(options.template)}` : '';
-
-    return `CREATE DATABASE ${quotedDatabaseName}${encoding}${collation}${ctype}${template};`;
   }
 
   dropDatabaseQuery(databaseName) {

--- a/packages/core/src/dialects/snowflake/query-generator-typescript.ts
+++ b/packages/core/src/dialects/snowflake/query-generator-typescript.ts
@@ -1,13 +1,19 @@
 import { rejectInvalidOptions } from '../../utils/check';
 import { joinSQLFragments } from '../../utils/join-sql-fragments';
 import { AbstractQueryGenerator } from '../abstract/query-generator';
-import { SHOW_CONSTRAINTS_QUERY_SUPPORTABLE_OPTIONS, type TableNameOrModel } from '../abstract/query-generator-typescript';
+import type { TableNameOrModel } from '../abstract/query-generator-typescript';
+import {
+  CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
+  SHOW_CONSTRAINTS_QUERY_SUPPORTABLE_OPTIONS,
+} from '../abstract/query-generator-typescript';
 import type {
+  CreateDatabaseQueryOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 
+const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['charset', 'collate']);
 const SHOW_CONSTRAINTS_QUERY_SUPPORTED_OPTIONS = new Set<keyof ShowConstraintsQueryOptions>(['constraintName', 'constraintType']);
 
 /**
@@ -16,6 +22,24 @@ const SHOW_CONSTRAINTS_QUERY_SUPPORTED_OPTIONS = new Set<keyof ShowConstraintsQu
 export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
   protected _getTechnicalSchemaNames() {
     return ['INFORMATION_SCHEMA', 'PERFORMANCE_SCHEMA', 'SYS', 'information_schema', 'performance_schema', 'sys'];
+  }
+
+  createDatabaseQuery(database: string, options?: CreateDatabaseQueryOptions) {
+    if (options) {
+      rejectInvalidOptions(
+        'createDatabaseQuery',
+        this.dialect.name,
+        CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
+        CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
+    return joinSQLFragments([
+      `CREATE DATABASE IF NOT EXISTS ${this.quoteIdentifier(database)}`,
+      options?.charset && `DEFAULT CHARACTER SET ${this.escape(options.charset)}`,
+      options?.collate && `DEFAULT COLLATE ${this.escape(options.collate)}`,
+    ]);
   }
 
   listSchemasQuery(options?: ListSchemasQueryOptions) {

--- a/packages/core/src/dialects/snowflake/query-generator-typescript.ts
+++ b/packages/core/src/dialects/snowflake/query-generator-typescript.ts
@@ -4,16 +4,19 @@ import { AbstractQueryGenerator } from '../abstract/query-generator';
 import type { TableNameOrModel } from '../abstract/query-generator-typescript';
 import {
   CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
+  LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS,
   SHOW_CONSTRAINTS_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator-typescript';
 import type {
   CreateDatabaseQueryOptions,
+  ListDatabasesQueryOptions,
   ListSchemasQueryOptions,
   ListTablesQueryOptions,
   ShowConstraintsQueryOptions,
 } from '../abstract/query-generator.types';
 
 const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set<keyof CreateDatabaseQueryOptions>(['charset', 'collate']);
+const LIST_DATABASES_QUERY_SUPPORTED_OPTIONS = new Set<keyof ListDatabasesQueryOptions>([]);
 const SHOW_CONSTRAINTS_QUERY_SUPPORTED_OPTIONS = new Set<keyof ShowConstraintsQueryOptions>(['constraintName', 'constraintType']);
 
 /**
@@ -40,6 +43,20 @@ export class SnowflakeQueryGeneratorTypeScript extends AbstractQueryGenerator {
       options?.charset && `DEFAULT CHARACTER SET ${this.escape(options.charset)}`,
       options?.collate && `DEFAULT COLLATE ${this.escape(options.collate)}`,
     ]);
+  }
+
+  listDatabasesQuery(options?: ListDatabasesQueryOptions) {
+    if (options) {
+      rejectInvalidOptions(
+        'listDatabasesQuery',
+        this.dialect.name,
+        LIST_DATABASES_QUERY_SUPPORTABLE_OPTIONS,
+        LIST_DATABASES_QUERY_SUPPORTED_OPTIONS,
+        options,
+      );
+    }
+
+    return `SHOW DATABASES`;
   }
 
   listSchemasQuery(options?: ListSchemasQueryOptions) {

--- a/packages/core/src/dialects/snowflake/query-generator.js
+++ b/packages/core/src/dialects/snowflake/query-generator.js
@@ -7,10 +7,8 @@ import { quoteIdentifier } from '../../utils/dialect.js';
 import { rejectInvalidOptions } from '../../utils/check';
 import {
   ADD_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
-  CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
   CREATE_SCHEMA_QUERY_SUPPORTABLE_OPTIONS,
   CREATE_TABLE_QUERY_SUPPORTABLE_OPTIONS,
-  REMOVE_COLUMN_QUERY_SUPPORTABLE_OPTIONS,
 } from '../abstract/query-generator';
 
 import each from 'lodash/each';
@@ -30,10 +28,7 @@ const SNOWFLAKE_RESERVED_WORDS = 'account,all,alter,and,any,as,between,by,case,c
 const typeWithoutDefault = new Set(['BLOB', 'TEXT', 'GEOMETRY', 'JSON']);
 
 const ADD_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
-const CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS = new Set(['charset', 'collate']);
 const CREATE_SCHEMA_QUERY_SUPPORTED_OPTIONS = new Set();
-const LIST_SCHEMAS_QUERY_SUPPORTED_OPTIONS = new Set();
-const REMOVE_COLUMN_QUERY_SUPPORTED_OPTIONS = new Set();
 const CREATE_TABLE_QUERY_SUPPORTED_OPTIONS = new Set(['collate', 'charset', 'rowFormat', 'comment', 'uniqueKeys']);
 
 export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
@@ -42,26 +37,6 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
 
     this.whereSqlBuilder.setOperatorKeyword(Op.regexp, 'REGEXP');
     this.whereSqlBuilder.setOperatorKeyword(Op.notRegexp, 'NOT REGEXP');
-  }
-
-  createDatabaseQuery(databaseName, options) {
-    if (options) {
-      rejectInvalidOptions(
-        'createDatabaseQuery',
-        this.dialect.name,
-        CREATE_DATABASE_QUERY_SUPPORTABLE_OPTIONS,
-        CREATE_DATABASE_QUERY_SUPPORTED_OPTIONS,
-        options,
-      );
-    }
-
-    return joinSQLFragments([
-      'CREATE DATABASE IF NOT EXISTS',
-      this.quoteIdentifier(databaseName),
-      options?.charset && `DEFAULT CHARACTER SET ${this.escape(options.charset)}`,
-      options?.collate && `DEFAULT COLLATE ${this.escape(options.collate)}`,
-      ';',
-    ]);
   }
 
   dropDatabaseQuery(databaseName) {

--- a/packages/core/src/dialects/snowflake/query-generator.js
+++ b/packages/core/src/dialects/snowflake/query-generator.js
@@ -39,10 +39,6 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
     this.whereSqlBuilder.setOperatorKeyword(Op.notRegexp, 'NOT REGEXP');
   }
 
-  listDatabasesQuery() {
-    return `SHOW DATABASES;`;
-  }
-
   createSchemaQuery(schema, options) {
     if (options) {
       rejectInvalidOptions(

--- a/packages/core/src/dialects/snowflake/query-generator.js
+++ b/packages/core/src/dialects/snowflake/query-generator.js
@@ -39,10 +39,6 @@ export class SnowflakeQueryGenerator extends SnowflakeQueryGeneratorTypeScript {
     this.whereSqlBuilder.setOperatorKeyword(Op.notRegexp, 'NOT REGEXP');
   }
 
-  dropDatabaseQuery(databaseName) {
-    return `DROP DATABASE IF EXISTS ${this.quoteIdentifier(databaseName)};`;
-  }
-
   listDatabasesQuery() {
     return `SHOW DATABASES;`;
   }

--- a/packages/core/test/integration/query-interface/create-drop-list-database.test.ts
+++ b/packages/core/test/integration/query-interface/create-drop-list-database.test.ts
@@ -4,13 +4,11 @@ import { sequelize } from '../support';
 
 const queryInterface = sequelize.queryInterface;
 const dialect = sequelize.getDialect();
-
-const supportedByDialect = ['postgres', 'mssql', 'snowflake'].includes(dialect);
 const newDbName = 'myDB';
 
 describe('QueryInterface#{create,drop,list}Database', () => {
 
-  if (supportedByDialect) {
+  if (sequelize.dialect.supports.multiDatabases) {
     it('should create, drop, and list databases respectively', async () => {
       const preCreationDatabases: DatabaseDescription[] = await queryInterface.listDatabases();
       expect(preCreationDatabases.some(db => db.name === newDbName)).to.eq(false, 'Database already exists prior to running the test');
@@ -26,6 +24,11 @@ describe('QueryInterface#{create,drop,list}Database', () => {
 
       expect(postDeletionDatabases.some(db => db.name === newDbName)).to.eq(false, 'Database "myDB" still exists, but should have been deleted');
       expect(postDeletionDatabases.length).to.eq(preCreationDatabases.length);
+    });
+
+    it('should list all databases except technical ones', async () => {
+      const databases: DatabaseDescription[] = await queryInterface.listDatabases();
+      expect(databases).to.deep.equal([{ name: 'sequelize_test' }]);
     });
   } else {
     it('should throw, indicating that the method is not supported', async () => {

--- a/packages/core/test/integration/support.ts
+++ b/packages/core/test/integration/support.ts
@@ -271,22 +271,17 @@ export async function dropTestSchemas(customSequelize: Sequelize = sequelize) {
     return;
   }
 
-  const schemas = await customSequelize.showAllSchemas();
+  const schemas = await customSequelize.showAllSchemas({ skip: [customSequelize.config.database] });
   const schemasPromise = [];
-  for (const schema of schemas) {
-    // @ts-expect-error -- TODO: type return value of "showAllSchemas"
-    const schemaName = schema.name ? schema.name : schema;
-    if (schemaName !== customSequelize.config.database) {
-      const promise = customSequelize.dropSchema(schemaName);
-
-      if (getTestDialect() === 'db2') {
-        // https://github.com/sequelize/sequelize/pull/14453#issuecomment-1155581572
-        // DB2 can sometimes deadlock / timeout when deleting more than one schema at the same time.
-        // eslint-disable-next-line no-await-in-loop
-        await promise;
-      } else {
-        schemasPromise.push(promise);
-      }
+  for (const schemaName of schemas) {
+    const promise = customSequelize.dropSchema(schemaName);
+    if (getTestDialect() === 'db2') {
+      // https://github.com/sequelize/sequelize/pull/14453#issuecomment-1155581572
+      // DB2 can sometimes deadlock / timeout when deleting more than one schema at the same time.
+      // eslint-disable-next-line no-await-in-loop
+      await promise;
+    } else {
+      schemasPromise.push(promise);
     }
   }
 

--- a/packages/core/test/integration/support.ts
+++ b/packages/core/test/integration/support.ts
@@ -232,6 +232,7 @@ async function clearDatabaseInternal(customSequelize: Sequelize) {
   }
 
   await dropTestSchemas(customSequelize);
+  await dropTestDatabases(customSequelize);
 }
 
 export async function clearDatabase(customSequelize: Sequelize = sequelize) {
@@ -252,6 +253,16 @@ afterEach('no running queries checker', () => {
     }`);
   }
 });
+
+export async function dropTestDatabases(customSequelize: Sequelize = sequelize) {
+  if (!customSequelize.dialect.supports.multiDatabases) {
+    return;
+  }
+
+  const qi = customSequelize.queryInterface;
+  const databases = await qi.listDatabases({ skip: [customSequelize.config.database] });
+  await Promise.all(databases.map(async db => qi.dropDatabase(db.name)));
+}
 
 export async function dropTestSchemas(customSequelize: Sequelize = sequelize) {
   if (!customSequelize.dialect.supports.schemas) {

--- a/packages/core/test/unit/query-generator/create-database-query.test.ts
+++ b/packages/core/test/unit/query-generator/create-database-query.test.ts
@@ -12,18 +12,18 @@ describe('QueryGenerator#createDatabaseQuery', () => {
   it('produces a CREATE DATABASE query in supported dialects', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase'), {
       default: notSupportedError,
-      postgres: 'CREATE DATABASE "myDatabase";',
-      snowflake: 'CREATE DATABASE IF NOT EXISTS "myDatabase";',
-      mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase' ) BEGIN CREATE DATABASE [myDatabase] ; END;`,
+      postgres: 'CREATE DATABASE "myDatabase"',
+      snowflake: 'CREATE DATABASE IF NOT EXISTS "myDatabase"',
+      mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase' ) CREATE DATABASE [myDatabase]`,
     });
   });
 
   it('supports the collate option', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', { collate: 'en_US.UTF-8' }), {
       default: notSupportedError,
-      postgres: `CREATE DATABASE "myDatabase" LC_COLLATE = 'en_US.UTF-8';`,
-      snowflake: 'CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT COLLATE \'en_US.UTF-8\';',
-      mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase' ) BEGIN CREATE DATABASE [myDatabase] COLLATE N'en_US.UTF-8'; END;`,
+      postgres: `CREATE DATABASE "myDatabase" LC_COLLATE = 'en_US.UTF-8'`,
+      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT COLLATE 'en_US.UTF-8'`,
+      mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase' ) CREATE DATABASE [myDatabase] COLLATE N'en_US.UTF-8'`,
     });
   });
 
@@ -31,7 +31,7 @@ describe('QueryGenerator#createDatabaseQuery', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', { encoding: 'UTF8' }), {
       default: notSupportedError,
       'mssql snowflake': buildInvalidOptionReceivedError('createDatabaseQuery', dialectName, ['encoding']),
-      postgres: `CREATE DATABASE "myDatabase" ENCODING = 'UTF8';`,
+      postgres: `CREATE DATABASE "myDatabase" ENCODING = 'UTF8'`,
     });
   });
 
@@ -39,7 +39,7 @@ describe('QueryGenerator#createDatabaseQuery', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', { ctype: 'zh_TW.UTF-8' }), {
       default: notSupportedError,
       'mssql snowflake': buildInvalidOptionReceivedError('createDatabaseQuery', dialectName, ['ctype']),
-      postgres: `CREATE DATABASE "myDatabase" LC_CTYPE = 'zh_TW.UTF-8';`,
+      postgres: `CREATE DATABASE "myDatabase" LC_CTYPE = 'zh_TW.UTF-8'`,
     });
   });
 
@@ -47,7 +47,7 @@ describe('QueryGenerator#createDatabaseQuery', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', { template: 'template0' }), {
       default: notSupportedError,
       'mssql snowflake': buildInvalidOptionReceivedError('createDatabaseQuery', dialectName, ['template']),
-      postgres: `CREATE DATABASE "myDatabase" TEMPLATE = 'template0';`,
+      postgres: `CREATE DATABASE "myDatabase" TEMPLATE = 'template0'`,
     });
   });
 
@@ -55,7 +55,7 @@ describe('QueryGenerator#createDatabaseQuery', () => {
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', { charset: 'utf8mb4' }), {
       default: notSupportedError,
       'mssql postgres': buildInvalidOptionReceivedError('createDatabaseQuery', dialectName, ['charset']),
-      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT CHARACTER SET 'utf8mb4';`,
+      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT CHARACTER SET 'utf8mb4'`,
     });
   });
 
@@ -78,9 +78,9 @@ describe('QueryGenerator#createDatabaseQuery', () => {
 
     expectsql(() => queryGenerator.createDatabaseQuery('myDatabase', config), {
       default: notSupportedError,
-      postgres: `CREATE DATABASE "myDatabase" ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'zh_TW.UTF-8' TEMPLATE = 'template0';`,
-      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT CHARACTER SET 'utf8mb4' DEFAULT COLLATE 'en_US.UTF-8';`,
-      mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase') BEGIN CREATE DATABASE [myDatabase] COLLATE N'en_US.UTF-8'; END;`,
+      postgres: `CREATE DATABASE "myDatabase" ENCODING = 'UTF8' LC_COLLATE = 'en_US.UTF-8' LC_CTYPE = 'zh_TW.UTF-8' TEMPLATE = 'template0'`,
+      snowflake: `CREATE DATABASE IF NOT EXISTS "myDatabase" DEFAULT CHARACTER SET 'utf8mb4' DEFAULT COLLATE 'en_US.UTF-8'`,
+      mssql: `IF NOT EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase') CREATE DATABASE [myDatabase] COLLATE N'en_US.UTF-8'`,
     });
   });
 });

--- a/packages/core/test/unit/query-generator/drop-database-query.test.ts
+++ b/packages/core/test/unit/query-generator/drop-database-query.test.ts
@@ -11,16 +11,15 @@ describe('QueryGenerator#dropDatabaseQuery', () => {
   it('produces a DROP DATABASE query in supported dialects', () => {
     expectsql(() => queryGenerator.dropDatabaseQuery('myDatabase'), {
       default: notSupportedError,
-      'postgres snowflake': 'DROP DATABASE IF EXISTS [myDatabase];',
-      mssql: `IF EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase' ) BEGIN DROP DATABASE [myDatabase] ; END;`,
+      'mssql postgres snowflake': 'DROP DATABASE IF EXISTS [myDatabase]',
     });
   });
 
   it('omits quotes if quoteIdentifiers is false', async () => {
     expectsql(() => noQuoteQueryGenerator.dropDatabaseQuery('myDatabase'), {
       default: notSupportedError,
-      'postgres snowflake': 'DROP DATABASE IF EXISTS myDatabase;',
-      mssql: `IF EXISTS (SELECT * FROM sys.databases WHERE name = N'myDatabase' ) BEGIN DROP DATABASE [myDatabase] ; END;`,
+      mssql: 'DROP DATABASE IF EXISTS [myDatabase]',
+      'postgres snowflake': 'DROP DATABASE IF EXISTS myDatabase',
     });
   });
 });

--- a/packages/core/test/unit/query-generator/list-databases-query.test.ts
+++ b/packages/core/test/unit/query-generator/list-databases-query.test.ts
@@ -1,3 +1,4 @@
+import { buildInvalidOptionReceivedError } from '@sequelize/core/_non-semver-use-at-your-own-risk_/utils/check.js';
 import { expectsql, getTestDialect, sequelize } from '../../support';
 
 const dialectName = getTestDialect();
@@ -10,9 +11,18 @@ describe('QueryGenerator#listDatabasesQuery', () => {
   it('produces a query used to list schemas in supported dialects', () => {
     expectsql(() => queryGenerator.listDatabasesQuery(), {
       default: notSupportedError,
-      postgres: 'SELECT datname AS name FROM pg_database;',
-      mssql: 'SELECT name FROM sys.databases;',
-      snowflake: 'SHOW DATABASES;',
+      mssql: `SELECT [name] FROM sys.databases WHERE [name] NOT IN (N'master', N'model', N'msdb', N'tempdb')`,
+      postgres: `SELECT datname AS "name" FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres')`,
+      snowflake: 'SHOW DATABASES',
+    });
+  });
+
+  it('produces a query used to list schemas in supported dialects with skip option', () => {
+    expectsql(() => queryGenerator.listDatabasesQuery({ skip: ['sample_db'] }), {
+      default: notSupportedError,
+      mssql: `SELECT [name] FROM sys.databases WHERE [name] NOT IN (N'master', N'model', N'msdb', N'tempdb', N'sample_db')`,
+      postgres: `SELECT datname AS "name" FROM pg_database WHERE datistemplate = false AND datname NOT IN ('postgres', 'sample_db')`,
+      snowflake: buildInvalidOptionReceivedError('listDatabasesQuery', 'snowflake', ['skip']),
     });
   });
 });


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [x] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Migrate the following methods to typescript:
- `createDatabase` and `createDatabaseQuery`
- `dropDatabase` and `dropDatabaseQuery`
- `listDatabases` and `listDatabasesQuery`

Also updated the test `clearDatabaseInternal` function to support removing test databases.