### PR TITLE
meta: update build cache dependency exclusions

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
     "default": ["{projectRoot}/**/*"],
-    "prod": ["!{projectRoot}/test/**/*"]
+    "prod": ["!{projectRoot}/test/**/*", "!{projectRoot}/.mocharc.jsonc"]
   },
   "targetDefaults": {
     "build": {

--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
     "default": ["{projectRoot}/**/*"],
-    "prod": ["!{projectRoot}/test/**/*", "!{projectRoot}/.mocharc.jsonc"]
+    "prod": ["!{projectRoot}/test/**/*", "!{projectRoot}/.eslintrc.js", "!{projectRoot}/.mocharc.jsonc", "!{projectRoot}/*.md"]
   },
   "targetDefaults": {
     "build": {

--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,11 @@
   "$schema": "node_modules/nx/schemas/nx-schema.json",
   "namedInputs": {
     "default": ["{projectRoot}/**/*"],
-    "prod": ["!{projectRoot}/test/**/*", "!{projectRoot}/.eslintrc.js", "!{projectRoot}/.mocharc.jsonc", "!{projectRoot}/*.md"]
+    "prod": [
+      "{projectRoot}/src/**/*",
+      "{projectRoot}/package.json",
+      "{projectRoot}/tsconfig.json"
+    ]
   },
   "targetDefaults": {
     "build": {


### PR DESCRIPTION
<!--
Thanks for wanting to fix something on Sequelize - we already love you!
Please fill in the template below.
If unsure about something, just do as best as you're able.
-->

## Pull Request Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [x] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [x] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?

<!-- NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open. -->

## Description Of Change

Currently changing the `.mocharc.jsonc` file causes the cache of the build to differ therefore rebuilding the entire project.
This PR works to exclude any non-build dependencies so that the build cache is not impacted by test/dev changes.



## Todos

- [x] Currently the entire `test` directory and subdirectory are excluded, are there any other files the need excluding?
